### PR TITLE
tools: fix `GitHub actions status when CQ is empty

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -12,8 +12,26 @@ env:
   NODE_VERSION: lts/*
 
 jobs:
-  startCI:
+  get_prs_for_ci:
     if: github.repository == 'nodejs/node'
+    runs-on: ubuntu-latest
+    outputs:
+      numbers: ${{ steps.get_prs_for_ci.outputs.numbers }}
+    steps:
+      - name: Get Pull Requests
+        id: get_prs_for_ci
+        run: >
+          gh pr list \
+                  --repo ${{ github.repository }} \
+                  --label 'request-ci' \
+                  --json 'number' \
+                  -t '::set-output name=numbers::{{ range . }}{{ .number }} {{ end }}' \
+                  --limit 100
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  startCI:
+    needs: get_prs_for_ci
+    if: needs.get_prs_for_ci.outputs.numbers != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -37,8 +55,6 @@ jobs:
           ncu-config set repo "$(echo ${{ github.repository }} | cut -d/ -f2)"
 
       - name: Start the CI
-        run: |
-          PRs=$(gh pr list --label 'request-ci' --json number --jq 'map(.number) | .[]' --limit 100)
-          ./tools/actions/start-ci.sh "$PRs"
+        run: ./tools/actions/start-ci.sh "${{ needs.get_prs_for_ci.outputs.numbers }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -17,8 +17,27 @@ env:
   NODE_VERSION: lts/*
 
 jobs:
-  commitQueue:
+  get_mergeable_prs:
     if: github.repository == 'nodejs/node'
+    runs-on: ubuntu-latest
+    outputs:
+      numbers: ${{ steps.get_mergeable_prs.outputs.numbers }}
+    steps:
+      - name: Get Pull Requests
+        id: get_mergeable_prs
+        run: >
+          gh pr list \
+                  --repo ${{ github.repository }} \
+                  --base ${{ github.ref_name }} \
+                  --label 'commit-queue' \
+                  --json 'number' \
+                  -t '::set-output name=numbers::{{ range . }}{{ .number }} {{ end }}' \
+                  --limit 100
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  commitQueue:
+    needs: get_mergeable_prs
+    if: needs.get_mergeable_prs.outputs.numbers != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -44,11 +63,10 @@ jobs:
         run: |
           echo "REPOSITORY=$(echo ${{ github.repository }} | cut -d/ -f2)" >> $GITHUB_ENV
           echo "OWNER=${{ github.repository_owner }}" >> $GITHUB_ENV
-          echo "DEFAULT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
 
       - name: Configure node-core-utils
         run: |
-          ncu-config set branch ${DEFAULT_BRANCH}
+          ncu-config set branch ${GITHUB_REF_NAME}
           ncu-config set upstream origin
           ncu-config set username "${{ secrets.GH_USER_NAME }}"
           ncu-config set token "${{ secrets.GH_USER_TOKEN }}"
@@ -57,12 +75,6 @@ jobs:
           ncu-config set owner "${OWNER}"
 
       - name: Start the Commit Queue
-        run: |
-          PRs=$(gh pr list \
-                  --base ${{ env.DEFAULT_BRANCH }} \
-                  --label 'commit-queue' \
-                  --json number --jq 'map(.number) | .[]' \
-                  --limit 100)
-          ./tools/actions/commit-queue.sh ${{ env.OWNER }} ${{ env.REPOSITORY }} "$PRs"
+        run: ./tools/actions/commit-queue.sh ${{ env.OWNER }} ${{ env.REPOSITORY }} "${{ needs.get_mergeable_prs.outputs.numbers }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}


### PR DESCRIPTION
Didn't have time to test it, I'm hoping this would solve the issue (and would also avoid pulling the repo if there are no PRs with `commit-queue` or `request-ci` labels).

Refs: https://github.com/nodejs/node/pull/40985#issuecomment-995252065

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
