### PR TITLE
doc: add unhandledRejection to strict mode

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1254,7 +1254,8 @@ occurs. One of the following modes can be chosen:
 
 * `throw`: Emit [`unhandledRejection`][]. If this hook is not set, raise the
   unhandled rejection as an uncaught exception. This is the default.
-* `strict`: Raise the unhandled rejection as an uncaught exception.
+* `strict`: Raise the unhandled rejection as an uncaught exception. If the
+  exception is handled, [`unhandledRejection`][] is emitted.
 * `warn`: Always trigger a warning, no matter if the [`unhandledRejection`][]
   hook is set or not but do not print the deprecation warning.
 * `warn-with-error-code`: Emit [`unhandledRejection`][]. If this hook is not


### PR DESCRIPTION
`lib/internal/process/promises.js` contains the following comment
about --unhandled-rejections=strict. This commit updates the
docs to reflect this:

```
// --unhandled-rejections=strict:
// Emit 'uncaughtException'. If it's not handled, print
// the error to stderr and exit the process.
// Otherwise, emit 'unhandledRejection'. If
// 'unhandledRejection' is not
// handled, emit 'UnhandledPromiseRejectionWarning'.
```

Fixes: https://github.com/nodejs/node/issues/41184

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
