### PR TITLE
lib,test: update unhandled rejections link

### DIFF
--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -181,7 +181,7 @@ function emitUnhandledRejectionWarning(uid, reason) {
       'or by rejecting a promise which was not handled with .catch(). ' +
       'To terminate the node process on unhandled promise ' +
       'rejection, use the CLI flag `--unhandled-rejections=strict` (see ' +
-      'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). ' +
+      'https://nodejs.org/api/cli.html#--unhandled-rejectionsmode). ' +
       `(rejection id: ${uid})`
   );
   try {

--- a/test/message/promise_unhandled_warn_with_error.out
+++ b/test/message/promise_unhandled_warn_with_error.out
@@ -7,4 +7,4 @@
     at *
     at *
 (Use `* --trace-warnings ...` to show where the warning was created)
-*UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
+*UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#--unhandled-rejectionsmode). (rejection id: 1)

--- a/test/parallel/test-promises-unhandled-symbol-rejections.js
+++ b/test/parallel/test-promises-unhandled-symbol-rejections.js
@@ -10,7 +10,7 @@ const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   'not handled with .catch(). To terminate the ' +
   'node process on unhandled promise rejection, ' +
   'use the CLI flag `--unhandled-rejections=strict` (see ' +
-  'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). ' +
+  'https://nodejs.org/api/cli.html#--unhandled-rejectionsmode). ' +
   '(rejection id: 1)'];
 
 common.expectWarning({


### PR DESCRIPTION
The link in the warning printed on unhandled rejection is no longer valid. This commit updates the URL to the correct target.