### PR TITLE
lib: fix checking syntax of esm module

### DIFF
--- a/lib/internal/main/check_syntax.js
+++ b/lib/internal/main/check_syntax.js
@@ -54,7 +54,7 @@ function checkSyntax(source, filename) {
     const { defaultResolve } = require('internal/modules/esm/resolve');
     const { defaultGetFormat } = require('internal/modules/esm/get_format');
     const { url } = defaultResolve(pathToFileURL(filename).toString());
-    const { format } = defaultGetFormat(url);
+    const format = defaultGetFormat(url);
     isModule = format === 'module';
   }
   if (isModule) {

--- a/test/fixtures/syntax/good_syntax.mjs
+++ b/test/fixtures/syntax/good_syntax.mjs
@@ -1,0 +1,3 @@
+export function testFunction(req, res) {
+  return 'PASS';
+}

--- a/test/sequential/test-cli-syntax-good.js
+++ b/test/sequential/test-cli-syntax-good.js
@@ -17,6 +17,7 @@ const syntaxArgs = [
 [
   'syntax/good_syntax.js',
   'syntax/good_syntax',
+  'syntax/good_syntax.mjs',
   'syntax/good_syntax_shebang.js',
   'syntax/good_syntax_shebang',
   'syntax/illegal_if_not_wrapped.js',


### PR DESCRIPTION
A internal function `defaultGetFormat` was changed in https://github.com/nodejs/node/pull/37468. Update the call in `check_syntax.js` accordingly.


Fixes: https://github.com/nodejs/node/issues/41189
Refs: https://github.com/nodejs/node/pull/37468

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
