### PR TITLE
stream: add isReadable helper

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2238,6 +2238,19 @@ added: REPLACEME
 
 Returns whether the stream has encountered an error.
 
+### `stream.isReadable(stream)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `stream` {Readable|Duplex|ReadableStream}
+* Returns: {boolean}
+
+Returns whether the stream is readable.
+
 ### `stream.Readable.toWeb(streamReadable)`
 
 <!-- YAML

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -8,6 +8,7 @@ const {
 
 const kDestroyed = Symbol('kDestroyed');
 const kIsErrored = Symbol('kIsErrored');
+const kIsReadable = Symbol('kIsReadable');
 const kIsDisturbed = Symbol('kIsDisturbed');
 
 function isReadableNodeStream(obj, strict = false) {
@@ -116,6 +117,7 @@ function isReadableFinished(stream, strict) {
 }
 
 function isReadable(stream) {
+  if (stream[kIsReadable] != null) return stream[kIsReadable];
   const r = isReadableNodeStream(stream);
   if (r === null || typeof stream?.readable !== 'boolean') return null;
   if (isDestroyed(stream)) return false;
@@ -260,15 +262,16 @@ function isErrored(stream) {
 module.exports = {
   kDestroyed,
   isDisturbed,
-  isErrored,
   kIsDisturbed,
+  isErrored,
   kIsErrored,
+  isReadable,
+  kIsReadable,
   isClosed,
   isDestroyed,
   isDuplexNodeStream,
   isFinished,
   isIterable,
-  isReadable,
   isReadableNodeStream,
   isReadableEnded,
   isReadableFinished,

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -117,7 +117,7 @@ function isReadableFinished(stream, strict) {
 }
 
 function isReadable(stream) {
-  if (stream[kIsReadable] != null) return stream[kIsReadable];
+  if (stream && stream[kIsReadable] != null) return stream[kIsReadable];
   const r = isReadableNodeStream(stream);
   if (r === null || typeof stream?.readable !== 'boolean') return null;
   if (isDestroyed(stream)) return false;

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -83,6 +83,7 @@ const {
 const {
   kIsDisturbed,
   kIsErrored,
+  kIsReadable,
 } = require('internal/streams/utils');
 
 const {
@@ -244,6 +245,10 @@ class ReadableStream {
 
   get [kIsErrored]() {
     return this[kState].state === 'errored';
+  }
+
+  get [kIsReadable]() {
+    return this[kState].state === 'readable';
   }
 
   /**

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -41,6 +41,7 @@ const utils = require('internal/streams/utils');
 const Stream = module.exports = require('internal/streams/legacy').Stream;
 Stream.isDisturbed = utils.isDisturbed;
 Stream.isErrored = utils.isErrored;
+Stream.isReadable = utils.isReadable;
 Stream.Readable = require('internal/streams/readable');
 Stream.Writable = require('internal/streams/writable');
 Stream.Duplex = require('internal/streams/duplex');

--- a/test/parallel/test-whatwg-readablestream.js
+++ b/test/parallel/test-whatwg-readablestream.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const common = require('../common');
-const { isDisturbed, isErrored } = require('stream');
+const { isDisturbed, isErrored, isReadable } = require('stream');
 const assert = require('assert');
 const {
   isPromise,
@@ -1573,7 +1573,6 @@ class Source {
   })().then(common.mustCall());
 }
 
-
 {
   const stream = new ReadableStream({
     pull: common.mustCall((controller) => {
@@ -1586,5 +1585,20 @@ class Source {
     isErrored(stream, false);
     await reader.read().catch(common.mustCall());
     isErrored(stream, true);
+  })().then(common.mustCall());
+}
+
+{
+  const stream = new ReadableStream({
+    pull: common.mustCall((controller) => {
+      controller.error(new Error());
+    }),
+  });
+
+  const reader = stream.getReader();
+  (async () => {
+    isReadable(stream, true);
+    await reader.read().catch(common.mustCall());
+    isReadable(stream, false);
   })().then(common.mustCall());
 }


### PR DESCRIPTION
Adds an `isReadable` helper for streams and web streams.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
