### PR TITLE
async_hooks: fix AsyncLocalStorage in unhandledRejection cases

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -443,7 +443,14 @@ function clearDefaultTriggerAsyncId() {
   async_id_fields[kDefaultTriggerAsyncId] = -1;
 }
 
-
+/**
+ * @template {Array<unknown>} T
+ * @template {unknown} R
+ * @param {number} triggerAsyncId
+ * @param { (...T: args) => R } block
+ * @param  {T} args
+ * @returns
+ */
 function defaultTriggerAsyncIdScope(triggerAsyncId, block, ...args) {
   if (triggerAsyncId === undefined)
     return block.apply(null, args);

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -444,12 +444,14 @@ function clearDefaultTriggerAsyncId() {
 }
 
 /**
+ * Sets a default top level trigger ID to be used
+ *
  * @template {Array<unknown>} T
  * @template {unknown} R
  * @param {number} triggerAsyncId
  * @param { (...T: args) => R } block
  * @param  {T} args
- * @returns
+ * @returns {R}
  */
 function defaultTriggerAsyncIdScope(triggerAsyncId, block, ...args) {
   if (triggerAsyncId === undefined)

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -27,6 +27,10 @@ const {
 const {
   pushAsyncContext,
   popAsyncContext,
+  symbols: {
+    async_id_symbol: kAsyncIdSymbol,
+    trigger_async_id_symbol: kTriggerAsyncIdSymbol
+  }
 } = require('internal/async_hooks');
 const async_hooks = require('async_hooks');
 const { isErrorStackTraceLimitWritable } = require('internal/errors');
@@ -220,41 +224,46 @@ function processPromiseRejections() {
     promiseInfo.warned = true;
     const { reason, uid, emit } = promiseInfo;
 
-    switch (unhandledRejectionsMode) {
-      case kStrictUnhandledRejections: {
-        const err = reason instanceof Error ?
-          reason : generateUnhandledRejectionError(reason);
-        triggerUncaughtException(err, true /* fromPromise */);
-        const handled = emit(reason, promise, promiseInfo);
-        if (!handled) emitUnhandledRejectionWarning(uid, reason);
-        break;
-      }
-      case kIgnoreUnhandledRejections: {
-        emit(reason, promise, promiseInfo);
-        break;
-      }
-      case kAlwaysWarnUnhandledRejections: {
-        emit(reason, promise, promiseInfo);
-        emitUnhandledRejectionWarning(uid, reason);
-        break;
-      }
-      case kThrowUnhandledRejections: {
-        const handled = emit(reason, promise, promiseInfo);
-        if (!handled) {
+    try {
+      pushAsyncContext(promise[kAsyncIdSymbol], promise[kTriggerAsyncIdSymbol], promise);
+      switch (unhandledRejectionsMode) {
+        case kStrictUnhandledRejections: {
           const err = reason instanceof Error ?
             reason : generateUnhandledRejectionError(reason);
           triggerUncaughtException(err, true /* fromPromise */);
+          const handled = emit(reason, promise, promiseInfo);
+          if (!handled) emitUnhandledRejectionWarning(uid, reason);
+          break;
         }
-        break;
-      }
-      case kWarnWithErrorCodeUnhandledRejections: {
-        const handled = emit(reason, promise, promiseInfo);
-        if (!handled) {
+        case kIgnoreUnhandledRejections: {
+          emit(reason, promise, promiseInfo);
+          break;
+        }
+        case kAlwaysWarnUnhandledRejections: {
+          emit(reason, promise, promiseInfo);
           emitUnhandledRejectionWarning(uid, reason);
-          process.exitCode = 1;
+          break;
         }
-        break;
+        case kThrowUnhandledRejections: {
+          const handled = emit(reason, promise, promiseInfo);
+          if (!handled) {
+            const err = reason instanceof Error ?
+              reason : generateUnhandledRejectionError(reason);
+            triggerUncaughtException(err, true /* fromPromise */);
+          }
+          break;
+        }
+        case kWarnWithErrorCodeUnhandledRejections: {
+          const handled = emit(reason, promise, promiseInfo);
+          if (!handled) {
+            emitUnhandledRejectionWarning(uid, reason);
+            process.exitCode = 1;
+          }
+          break;
+        }
       }
+    } finally {
+      popAsyncContext(promise[kAsyncIdSymbol]);
     }
     maybeScheduledTicksOrMicrotasks = true;
   }

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -214,49 +214,73 @@ function processPromiseRejections() {
     promiseInfo.warned = true;
     const { reason, uid, emit } = promiseInfo;
 
-    pushAsyncContext(
-      promise[kAsyncIdSymbol],
-      promise[kTriggerAsyncIdSymbol],
-      promise
-    );
-    switch (unhandledRejectionsMode) {
-      case kStrictUnhandledRejections: {
-        const err = reason instanceof Error ?
-          reason : generateUnhandledRejectionError(reason);
-        // This destroys the async stack, don't clear it after
-        triggerUncaughtException(err, true /* fromPromise */);
-        const handled = emit(reason, promise, promiseInfo);
-        if (!handled) emitUnhandledRejectionWarning(uid, reason);
-        break;
-      }
-      case kIgnoreUnhandledRejections: {
-        emit(reason, promise, promiseInfo);
-        break;
-      }
-      case kAlwaysWarnUnhandledRejections: {
-        emit(reason, promise, promiseInfo);
-        emitUnhandledRejectionWarning(uid, reason);
-        popAsyncContext(promise[kAsyncIdSymbol]);
-        break;
-      }
-      case kThrowUnhandledRejections: {
-        const handled = emit(reason, promise, promiseInfo);
-        if (!handled) {
+    let needPop = true;
+    const {
+      [kAsyncIdSymbol]: promiseAsyncId,
+      [kTriggerAsyncIdSymbol]: promiseTriggerAsyncId,
+    } = promise;
+    // We need to check if async_hooks are enabled
+    // don't use enabledHooksExist as a Promise could
+    // come from a vm.* context and not have an async id
+    if (typeof promiseAsyncId !== 'undefined') {
+      pushAsyncContext(
+        promiseAsyncId,
+        promiseTriggerAsyncId,
+        promise
+      );
+    }
+    try {
+      switch (unhandledRejectionsMode) {
+        case kStrictUnhandledRejections: {
           const err = reason instanceof Error ?
             reason : generateUnhandledRejectionError(reason);
-            // This destroys the async stack, don't clear it after
+          // This destroys the async stack, don't clear it after
           triggerUncaughtException(err, true /* fromPromise */);
+          if (typeof promiseAsyncId !== 'undefined') {
+            pushAsyncContext(
+              promise[kAsyncIdSymbol],
+              promise[kTriggerAsyncIdSymbol],
+              promise
+            );
+          }
+          const handled = emit(reason, promise, promiseInfo);
+          if (!handled) emitUnhandledRejectionWarning(uid, reason);
+          break;
         }
-        break;
-      }
-      case kWarnWithErrorCodeUnhandledRejections: {
-        const handled = emit(reason, promise, promiseInfo);
-        if (!handled) {
+        case kIgnoreUnhandledRejections: {
+          emit(reason, promise, promiseInfo);
+          break;
+        }
+        case kAlwaysWarnUnhandledRejections: {
+          emit(reason, promise, promiseInfo);
           emitUnhandledRejectionWarning(uid, reason);
-          popAsyncContext(promise[kAsyncIdSymbol]);
-          process.exitCode = 1;
+          break;
         }
-        break;
+        case kThrowUnhandledRejections: {
+          const handled = emit(reason, promise, promiseInfo);
+          if (!handled) {
+            const err = reason instanceof Error ?
+              reason : generateUnhandledRejectionError(reason);
+              // This destroys the async stack, don't clear it after
+            triggerUncaughtException(err, true /* fromPromise */);
+            needPop = false;
+          }
+          break;
+        }
+        case kWarnWithErrorCodeUnhandledRejections: {
+          const handled = emit(reason, promise, promiseInfo);
+          if (!handled) {
+            emitUnhandledRejectionWarning(uid, reason);
+            process.exitCode = 1;
+          }
+          break;
+        }
+      }
+    } finally {
+      if (needPop) {
+        if (typeof promiseAsyncId !== 'undefined') {
+          popAsyncContext(promiseAsyncId);
+        }
       }
     }
     maybeScheduledTicksOrMicrotasks = true;

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -225,7 +225,11 @@ function processPromiseRejections() {
     const { reason, uid, emit } = promiseInfo;
 
     try {
-      pushAsyncContext(promise[kAsyncIdSymbol], promise[kTriggerAsyncIdSymbol], promise);
+      pushAsyncContext(
+        promise[kAsyncIdSymbol],
+        promise[kTriggerAsyncIdSymbol],
+        promise
+      );
       switch (unhandledRejectionsMode) {
         case kStrictUnhandledRejections: {
           const err = reason instanceof Error ?

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -32,7 +32,6 @@ const {
     trigger_async_id_symbol: kTriggerAsyncIdSymbol
   }
 } = require('internal/async_hooks');
-const async_hooks = require('async_hooks');
 const { isErrorStackTraceLimitWritable } = require('internal/errors');
 
 // *Must* match Environment::TickInfo::Fields in src/env.h.
@@ -127,20 +126,11 @@ function resolveError(type, promise, reason) {
 }
 
 function unhandledRejection(promise, reason) {
-  const asyncId = async_hooks.executionAsyncId();
-  const triggerAsyncId = async_hooks.triggerAsyncId();
-  const resource = promise;
-
   const emit = (reason, promise, promiseInfo) => {
-    try {
-      pushAsyncContext(asyncId, triggerAsyncId, resource);
-      if (promiseInfo.domain) {
-        return promiseInfo.domain.emit('error', reason);
-      }
-      return process.emit('unhandledRejection', reason, promise);
-    } finally {
-      popAsyncContext(asyncId);
+    if (promiseInfo.domain) {
+      return promiseInfo.domain.emit('error', reason);
     }
+    return process.emit('unhandledRejection', reason, promise);
   };
 
   maybeUnhandledPromises.set(promise, {
@@ -224,50 +214,50 @@ function processPromiseRejections() {
     promiseInfo.warned = true;
     const { reason, uid, emit } = promiseInfo;
 
-    try {
-      pushAsyncContext(
-        promise[kAsyncIdSymbol],
-        promise[kTriggerAsyncIdSymbol],
-        promise
-      );
-      switch (unhandledRejectionsMode) {
-        case kStrictUnhandledRejections: {
+    pushAsyncContext(
+      promise[kAsyncIdSymbol],
+      promise[kTriggerAsyncIdSymbol],
+      promise
+    );
+    switch (unhandledRejectionsMode) {
+      case kStrictUnhandledRejections: {
+        const err = reason instanceof Error ?
+          reason : generateUnhandledRejectionError(reason);
+        // This destroys the async stack, don't clear it after
+        triggerUncaughtException(err, true /* fromPromise */);
+        const handled = emit(reason, promise, promiseInfo);
+        if (!handled) emitUnhandledRejectionWarning(uid, reason);
+        break;
+      }
+      case kIgnoreUnhandledRejections: {
+        emit(reason, promise, promiseInfo);
+        break;
+      }
+      case kAlwaysWarnUnhandledRejections: {
+        emit(reason, promise, promiseInfo);
+        emitUnhandledRejectionWarning(uid, reason);
+        popAsyncContext(promise[kAsyncIdSymbol]);
+        break;
+      }
+      case kThrowUnhandledRejections: {
+        const handled = emit(reason, promise, promiseInfo);
+        if (!handled) {
           const err = reason instanceof Error ?
             reason : generateUnhandledRejectionError(reason);
+            // This destroys the async stack, don't clear it after
           triggerUncaughtException(err, true /* fromPromise */);
-          const handled = emit(reason, promise, promiseInfo);
-          if (!handled) emitUnhandledRejectionWarning(uid, reason);
-          break;
         }
-        case kIgnoreUnhandledRejections: {
-          emit(reason, promise, promiseInfo);
-          break;
-        }
-        case kAlwaysWarnUnhandledRejections: {
-          emit(reason, promise, promiseInfo);
-          emitUnhandledRejectionWarning(uid, reason);
-          break;
-        }
-        case kThrowUnhandledRejections: {
-          const handled = emit(reason, promise, promiseInfo);
-          if (!handled) {
-            const err = reason instanceof Error ?
-              reason : generateUnhandledRejectionError(reason);
-            triggerUncaughtException(err, true /* fromPromise */);
-          }
-          break;
-        }
-        case kWarnWithErrorCodeUnhandledRejections: {
-          const handled = emit(reason, promise, promiseInfo);
-          if (!handled) {
-            emitUnhandledRejectionWarning(uid, reason);
-            process.exitCode = 1;
-          }
-          break;
-        }
+        break;
       }
-    } finally {
-      popAsyncContext(promise[kAsyncIdSymbol]);
+      case kWarnWithErrorCodeUnhandledRejections: {
+        const handled = emit(reason, promise, promiseInfo);
+        if (!handled) {
+          emitUnhandledRejectionWarning(uid, reason);
+          popAsyncContext(promise[kAsyncIdSymbol]);
+          process.exitCode = 1;
+        }
+        break;
+      }
     }
     maybeScheduledTicksOrMicrotasks = true;
   }

--- a/test/async-hooks/test-async-local-storage-errors.js
+++ b/test/async-hooks/test-async-local-storage-errors.js
@@ -5,18 +5,21 @@ const { AsyncLocalStorage } = require('async_hooks');
 const vm = require('vm');
 
 // err1 is emitted sync as a control - no events
-// err2 is emitted after a timeout - uncaughtExceptionMonitor + uncaughtException
+// err2 is emitted after a timeout - uncaughtExceptionMonitor
+//                                 + uncaughtException
 // err3 is emitted after some awaits -  unhandledRejection
 // err4 is emitted during handling err3 - uncaughtExceptionMonitor
-// err5 is emitted after err4 from a VM lacking hooks - unhandledRejection + uncaughtException
+// err5 is emitted after err4 from a VM lacking hooks - unhandledRejection
+//                                                    + uncaughtException
 
 const asyncLocalStorage = new AsyncLocalStorage();
-const callbackToken = {callbackToken:true};
-const awaitToken = {awaitToken:true};
+const callbackToken = { callbackToken: true };
+const awaitToken = { awaitToken: true };
 
 let i = 0;
 
-// redefining the uncaughtExceptionHandler is a bit odd, so we just do this so we can track total invocations
+// Redefining the uncaughtExceptionHandler is a bit odd, so we just do this
+// so we can track total invocations
 let underlyingExceptionHandler;
 const exceptionHandler = common.mustCall(function(...args) {
   return underlyingExceptionHandler.call(this, ...args);
@@ -31,7 +34,7 @@ const exceptionMonitor = common.mustCall((err, origin) => {
     assert.strictEqual(origin, 'unhandledRejection');
     assert.strictEqual(asyncLocalStorage.getStore(), awaitToken);
   } else {
-    assert.fail('unknown error ' + err)
+    assert.fail('unknown error ' + err);
   }
 }, 2);
 process.on('uncaughtExceptionMonitor', exceptionMonitor);
@@ -67,7 +70,7 @@ function fireErr3() {
     assert.strictEqual(err.message, 'err3');
     assert.strictEqual(asyncLocalStorage.getStore(), awaitToken);
     process.off('unhandledRejection', rejectionHandler3);
-    
+
     fireErr4();
   }, 1);
   process.on('unhandledRejection', rejectionHandler3);
@@ -78,7 +81,7 @@ function fireErr3() {
   asyncLocalStorage.run(awaitToken, awaitTest);
 }
 
-let uncaughtExceptionHandler4 = common.mustCall(
+const uncaughtExceptionHandler4 = common.mustCall(
   function(err) {
     assert.strictEqual(err.message, 'err4');
     assert.strictEqual(asyncLocalStorage.getStore(), awaitToken);
@@ -104,8 +107,8 @@ function fireErr5() {
     async function main() {
       await null;
       Promise.resolve().then(() => {
-        throw new Error("err5")
-      })
+        throw new Error('err5');
+      });
     }
     main();
   })})()`);

--- a/test/async-hooks/test-async-local-storage-errors.js
+++ b/test/async-hooks/test-async-local-storage-errors.js
@@ -2,68 +2,114 @@
 const common = require('../common');
 const assert = require('assert');
 const { AsyncLocalStorage } = require('async_hooks');
+const vm = require('vm');
+
+// err1 is emitted sync as a control - no events
+// err2 is emitted after a timeout - uncaughtExceptionMonitor + uncaughtException
+// err3 is emitted after some awaits -  unhandledRejection
+// err4 is emitted during handling err3 - uncaughtExceptionMonitor
+// err5 is emitted after err4 from a VM lacking hooks - unhandledRejection + uncaughtException
 
 const asyncLocalStorage = new AsyncLocalStorage();
-const callbackToken = {};
-const awaitToken = {};
+const callbackToken = {callbackToken:true};
+const awaitToken = {awaitToken:true};
 
 let i = 0;
-let underlyingExceptionHandler = common.mustCall(function(err) {
-  ++i;
-  assert.strictEqual(err.message, 'err2');
-  assert.strictEqual(asyncLocalStorage.getStore(), callbackToken);
 
-  // re-entrant check
-  Promise.reject(new Error('err4'));
-  underlyingExceptionHandler = common.mustCall(
-    function(err) {
-      assert.strictEqual(err.message, 'err4');
-      assert.strictEqual(asyncLocalStorage.getStore(), callbackToken);
-    }, 1);
-}, 1);
-
+// redefining the uncaughtExceptionHandler is a bit odd, so we just do this so we can track total invocations
+let underlyingExceptionHandler;
 const exceptionHandler = common.mustCall(function(...args) {
   return underlyingExceptionHandler.call(this, ...args);
 }, 2);
-
 process.setUncaughtExceptionCaptureCallback(exceptionHandler);
-
-const rejectionHandler = common.mustCall((err) => {
-  assert.strictEqual(err.message, 'err3');
-  assert.strictEqual(asyncLocalStorage.getStore(), awaitToken);
-  process.off('unhandledRejection', rejectionHandler);
-}, 1);
-process.on('unhandledRejection', rejectionHandler);
 
 const exceptionMonitor = common.mustCall((err, origin) => {
   if (err.message === 'err2') {
     assert.strictEqual(origin, 'uncaughtException');
     assert.strictEqual(asyncLocalStorage.getStore(), callbackToken);
-  }
-  if (err.message === 'err3') {
+  } else if (err.message === 'err4') {
     assert.strictEqual(origin, 'unhandledRejection');
     assert.strictEqual(asyncLocalStorage.getStore(), awaitToken);
+  } else {
+    assert.fail('unknown error ' + err)
   }
 }, 2);
 process.on('uncaughtExceptionMonitor', exceptionMonitor);
 
-async function awaitTest() {
-  await null;
-  throw new Error('err3');
+function fireErr1() {
+  underlyingExceptionHandler = common.mustCall(function(err) {
+    ++i;
+    assert.strictEqual(err.message, 'err2');
+    assert.strictEqual(asyncLocalStorage.getStore(), callbackToken);
+  }, 1);
+  try {
+    asyncLocalStorage.run(callbackToken, () => {
+      setTimeout(fireErr2, 0);
+      throw new Error('err1');
+    });
+  } catch (e) {
+    assert.strictEqual(e.message, 'err1');
+    assert.strictEqual(asyncLocalStorage.getStore(), undefined);
+  }
 }
-asyncLocalStorage.run(awaitToken, awaitTest);
 
-try {
-  asyncLocalStorage.run(callbackToken, () => {
-    setTimeout(() => {
-      process.nextTick(() => {
-        assert.strictEqual(i, 1);
-      });
-      throw new Error('err2');
-    }, 0);
-    throw new Error('err1');
+function fireErr2() {
+  process.nextTick(() => {
+    assert.strictEqual(i, 1);
+    fireErr3();
   });
-} catch (e) {
-  assert.strictEqual(e.message, 'err1');
-  assert.strictEqual(asyncLocalStorage.getStore(), undefined);
+  throw new Error('err2');
 }
+
+function fireErr3() {
+  assert.strictEqual(asyncLocalStorage.getStore(), callbackToken);
+  const rejectionHandler3 = common.mustCall((err) => {
+    assert.strictEqual(err.message, 'err3');
+    assert.strictEqual(asyncLocalStorage.getStore(), awaitToken);
+    process.off('unhandledRejection', rejectionHandler3);
+    
+    fireErr4();
+  }, 1);
+  process.on('unhandledRejection', rejectionHandler3);
+  async function awaitTest() {
+    await null;
+    throw new Error('err3');
+  }
+  asyncLocalStorage.run(awaitToken, awaitTest);
+}
+
+let uncaughtExceptionHandler4 = common.mustCall(
+  function(err) {
+    assert.strictEqual(err.message, 'err4');
+    assert.strictEqual(asyncLocalStorage.getStore(), awaitToken);
+    fireErr5();
+  }, 1);
+function fireErr4() {
+  assert.strictEqual(asyncLocalStorage.getStore(), awaitToken);
+  underlyingExceptionHandler = uncaughtExceptionHandler4;
+  // re-entrant check
+  Promise.reject(new Error('err4'));
+}
+
+function fireErr5() {
+  assert.strictEqual(asyncLocalStorage.getStore(), awaitToken);
+  underlyingExceptionHandler = () => {};
+  const rejectionHandler5 = common.mustCall((err) => {
+    assert.strictEqual(err.message, 'err5');
+    assert.strictEqual(asyncLocalStorage.getStore(), awaitToken);
+    process.off('unhandledRejection', rejectionHandler5);
+  }, 1);
+  process.on('unhandledRejection', rejectionHandler5);
+  const makeOrphan = vm.compileFunction(`(${String(() => {
+    async function main() {
+      await null;
+      Promise.resolve().then(() => {
+        throw new Error("err5")
+      })
+    }
+    main();
+  })})()`);
+  makeOrphan();
+}
+
+fireErr1();

--- a/test/async-hooks/test-async-local-storage-errors.js
+++ b/test/async-hooks/test-async-local-storage-errors.js
@@ -4,15 +4,15 @@ const assert = require('assert');
 const { AsyncLocalStorage } = require('async_hooks');
 
 const asyncLocalStorage = new AsyncLocalStorage();
-let callbackToken = {};
-let awaitToken = {};
+const callbackToken = {};
+const awaitToken = {};
 
 let i = 0;
 const exceptionHandler = common.mustCall(
   (err) => {
     ++i;
-  assert.strictEqual(err.message, 'err2');
-  assert.strictEqual(asyncLocalStorage.getStore(), callbackToken);
+    assert.strictEqual(err.message, 'err2');
+    assert.strictEqual(asyncLocalStorage.getStore(), callbackToken);
   }, 1);
 process.setUncaughtExceptionCaptureCallback(exceptionHandler);
 

--- a/test/async-hooks/test-async-local-storage-errors.js
+++ b/test/async-hooks/test-async-local-storage-errors.js
@@ -22,6 +22,18 @@ const rejectionHandler = common.mustCall((err) => {
 }, 1);
 process.on('unhandledRejection', rejectionHandler);
 
+const exceptionMonitor = common.mustCall((err, origin) => {
+  if (err.message === 'err2') {
+    assert.strictEqual(origin, 'uncaughtException');
+    assert.strictEqual(asyncLocalStorage.getStore(), callbackToken);
+  }
+  if (err.message === 'err3') {
+    assert.strictEqual(origin, 'unhandledRejection');
+    assert.strictEqual(asyncLocalStorage.getStore(), awaitToken);
+  }
+}, 2);
+process.on('uncaughtExceptionMonitor', exceptionMonitor);
+
 async function awaitTest() {
   await null;
   throw new Error('err3');

--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -18,9 +18,8 @@ const ret = spawnSync(
   ['--unhandled-rejections=none', '--stack_size=150', __filename, 'async'],
   { maxBuffer: Infinity }
 );
-const stdout = ret.stdout.toString('utf8', 0, 2048);
 assert.strictEqual(ret.status, 0,
-                   `EXIT CODE: ${ret.status}, STDERR:\n${ret.stderr}, STDOUT:\n${stdout}`);
+                   `EXIT CODE: ${ret.status}, STDERR:\n${ret.stderr}`);
 const stderr = ret.stderr.toString('utf8', 0, 2048);
 assert.doesNotMatch(stderr, /async.*hook/i);
 assert.ok(stderr.includes('Maximum call stack size exceeded'), stderr);

--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -18,8 +18,11 @@ const ret = spawnSync(
   ['--unhandled-rejections=none', '--stack_size=150', __filename, 'async'],
   { maxBuffer: Infinity }
 );
+const stdout = ret.stdout.toString('utf8', 0, 2048);
 assert.strictEqual(ret.status, 0,
-                   `EXIT CODE: ${ret.status}, STDERR:\n${ret.stderr}`);
+                   `EXIT CODE: ${ret.status}, STDERR:\n${ret.stderr}, STDOUT:\n${stdout}`);
 const stderr = ret.stderr.toString('utf8', 0, 2048);
 assert.doesNotMatch(stderr, /async.*hook/i);
 assert.ok(stderr.includes('Maximum call stack size exceeded'), stderr);
+
+console.error(stdout, stderr);

--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -24,5 +24,3 @@ assert.strictEqual(ret.status, 0,
 const stderr = ret.stderr.toString('utf8', 0, 2048);
 assert.doesNotMatch(stderr, /async.*hook/i);
 assert.ok(stderr.includes('Maximum call stack size exceeded'), stderr);
-
-console.error(stdout, stderr);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Right now async local storage doesn't properly propagate through unhandledRejections. This fixes that.