### PR TITLE
test: mark wpt/test-user-timing test flaky

### DIFF
--- a/test/wpt/wpt.status
+++ b/test/wpt/wpt.status
@@ -7,12 +7,18 @@ prefix wpt
 [true] # This section applies to all platforms
 
 [$system==win32]
+# https://github.com/nodejs/node/issues/40449
+test-user-timing: PASS,FLAKY
 
 [$system==linux]
 
 [$system==macos]
+# https://github.com/nodejs/node/issues/40449
+test-user-timing: PASS,FLAKY
 
 [$arch==arm || $arch==arm64]
+# https://github.com/nodejs/node/issues/40449
+test-user-timing: PASS,FLAKY
 
 [$system==solaris] # Also applies to SmartOS
 

--- a/test/wpt/wpt.status
+++ b/test/wpt/wpt.status
@@ -5,20 +5,16 @@ prefix wpt
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
-
-[$system==win32]
 # https://github.com/nodejs/node/issues/40449
 test-user-timing: PASS,FLAKY
+
+[$system==win32]
 
 [$system==linux]
 
 [$system==macos]
-# https://github.com/nodejs/node/issues/40449
-test-user-timing: PASS,FLAKY
 
 [$arch==arm || $arch==arm64]
-# https://github.com/nodejs/node/issues/40449
-test-user-timing: PASS,FLAKY
 
 [$system==solaris] # Also applies to SmartOS
 


### PR DESCRIPTION
- The RH team had a team day looking at helping move
  the CI closer to green. This is one of the flaky tests
  with the most reported failures and has been open
  since October. Marking flaky.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
