### PR TITLE
loader: fix package resolution for edge case

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -457,7 +457,7 @@ function trySelf(parentPath, request) {
   try {
     return finalizeEsmResolution(packageExportsResolve(
       pathToFileURL(pkgPath + '/package.json'), expansion, pkg,
-      pathToFileURL(parentPath), cjsConditions).resolved, parentPath, pkgPath);
+      pathToFileURL(parentPath), cjsConditions), parentPath, pkgPath);
   } catch (e) {
     if (e.code === 'ERR_MODULE_NOT_FOUND')
       throw createEsmNotFoundErr(request, pkgPath + '/package.json');
@@ -481,7 +481,7 @@ function resolveExports(nmPath, request) {
     try {
       return finalizeEsmResolution(packageExportsResolve(
         pathToFileURL(pkgPath + '/package.json'), '.' + expansion, pkg, null,
-        cjsConditions).resolved, null, pkgPath);
+        cjsConditions), null, pkgPath);
     } catch (e) {
       if (e.code === 'ERR_MODULE_NOT_FOUND')
         throw createEsmNotFoundErr(request, pkgPath + '/package.json');

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -55,9 +55,7 @@ const protocolHandlers = ObjectAssign(ObjectCreate(null), {
 
     return format;
   },
-  'file:'(parsed, ignoreErrors) {
-    return getFileProtocolModuleFormat(parsed, ignoreErrors);
-  },
+  'file:': getFileProtocolModuleFormat,
   'node:'() { return 'builtin'; },
 });
 
@@ -95,7 +93,7 @@ function defaultGetFormatWithoutErrors(url, context) {
   const parsed = new URL(url);
   if (!ObjectPrototypeHasOwnProperty(protocolHandlers, parsed.protocol))
     return null;
-  return protocolHandlers[parsed.protocol](parsed, url, true);
+  return protocolHandlers[parsed.protocol](parsed, true);
 }
 
 function defaultGetFormat(url, context) {

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -109,6 +109,6 @@ function defaultGetFormat(url, context) {
 module.exports = {
   defaultGetFormat,
   extensionFormatMap,
+  getModuleFileFormat,
   legacyExtensionFormatMap,
-  getModuleFileFormat
 };

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -56,17 +56,7 @@ const protocolHandlers = ObjectAssign(ObjectCreate(null), {
     return format;
   },
   'file:'(parsed, url) {
-    const ext = extname(parsed.pathname);
-    let format;
-
-    if (ext === '.js') {
-      format = getPackageType(parsed.href) === 'module' ? 'module' : 'commonjs';
-    } else {
-      format = extensionFormatMap[ext] ??
-        throwIfNotExperimentalSpecifierResolution(ext, url);
-    }
-
-    return format || null;
+    return getPackageFormat(parsed, true, url) || null;
   },
   'node:'() { return 'builtin'; },
 });
@@ -91,6 +81,23 @@ function getLegacyExtensionFormat(ext) {
   return legacyExtensionFormatMap[ext];
 }
 
+function getPackageFormat(url, throwIfNotResolved, urlForThrow) {
+  let format;
+
+  const ext = extname(url.pathname);
+  if (ext === '.js') {
+    format = getPackageType(url) === 'module' ? 'module' : 'commonjs';
+  } else {
+    format = extensionFormatMap[ext] ??
+      (throwIfNotResolved ?
+        throwIfNotExperimentalSpecifierResolution(ext, urlForThrow) :
+        getLegacyExtensionFormat(ext)
+      );
+  }
+
+  return format;
+}
+
 function defaultGetFormat(url, context) {
   const parsed = new URL(url);
 
@@ -103,5 +110,5 @@ module.exports = {
   defaultGetFormat,
   extensionFormatMap,
   legacyExtensionFormatMap,
-  getLegacyExtensionFormat
+  getPackageFormat
 };

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -79,13 +79,14 @@ function throwIfNotExperimentalSpecifierResolution(ext, url) {
 }
 
 function getLegacyExtensionFormat(ext) {
-  if (experimentalSpecifierResolution === 'node') {
-    if (!experimentalSpecifierResolutionWarned) {
-      process.emitWarning(
-        'The Node.js specifier resolution in ESM is experimental.',
-        'ExperimentalWarning');
-      experimentalSpecifierResolutionWarned = true;
-    }
+  if (
+    experimentalSpecifierResolution === 'node' &&
+    !experimentalSpecifierResolutionWarned
+  ) {
+    process.emitWarning(
+      'The Node.js specifier resolution in ESM is experimental.',
+      'ExperimentalWarning');
+    experimentalSpecifierResolutionWarned = true;
   }
   return legacyExtensionFormatMap[ext];
 }

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -62,26 +62,33 @@ const protocolHandlers = ObjectAssign(ObjectCreate(null), {
     if (ext === '.js') {
       format = getPackageType(parsed.href) === 'module' ? 'module' : 'commonjs';
     } else {
-      format = extensionFormatMap[ext];
-    }
-    if (!format) {
-      if (experimentalSpecifierResolution === 'node') {
-        if (!experimentalSpecifierResolutionWarned) {
-          process.emitWarning(
-            'The Node.js specifier resolution in ESM is experimental.',
-            'ExperimentalWarning');
-          experimentalSpecifierResolutionWarned = true;
-        }
-        format = legacyExtensionFormatMap[ext];
-      } else {
-        throw new ERR_UNKNOWN_FILE_EXTENSION(ext, fileURLToPath(url));
-      }
+      format = extensionFormatMap[ext] ??
+        throwIfNotExperimentalSpecifierResolution(ext, url);
     }
 
     return format || null;
   },
   'node:'() { return 'builtin'; },
 });
+
+function throwIfNotExperimentalSpecifierResolution(ext, url) {
+  if (experimentalSpecifierResolution !== 'node') {
+    throw new ERR_UNKNOWN_FILE_EXTENSION(ext, fileURLToPath(url));
+  }
+  return getLegacyExtensionFormat(ext);
+}
+
+function getLegacyExtensionFormat(ext) {
+  if (experimentalSpecifierResolution === 'node') {
+    if (!experimentalSpecifierResolutionWarned) {
+      process.emitWarning(
+        'The Node.js specifier resolution in ESM is experimental.',
+        'ExperimentalWarning');
+      experimentalSpecifierResolutionWarned = true;
+    }
+  }
+  return legacyExtensionFormatMap[ext];
+}
 
 function defaultGetFormat(url, context) {
   const parsed = new URL(url);
@@ -95,5 +102,5 @@ module.exports = {
   defaultGetFormat,
   extensionFormatMap,
   legacyExtensionFormatMap,
-  experimentalSpecifierResolutionWarned
+  getLegacyExtensionFormat
 };

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -56,7 +56,7 @@ const protocolHandlers = ObjectAssign(ObjectCreate(null), {
     return format;
   },
   'file:'(parsed, url) {
-    return getPackageFormat(parsed, true, url) || null;
+    return getModuleFileFormat(parsed, true, url) || null;
   },
   'node:'() { return 'builtin'; },
 });
@@ -81,7 +81,7 @@ function getLegacyExtensionFormat(ext) {
   return legacyExtensionFormatMap[ext];
 }
 
-function getPackageFormat(url, throwIfNotResolved, urlForThrow) {
+function getModuleFileFormat(url, throwIfNotResolved, urlForThrow) {
   let format;
 
   const ext = extname(url.pathname);
@@ -110,5 +110,5 @@ module.exports = {
   defaultGetFormat,
   extensionFormatMap,
   legacyExtensionFormatMap,
-  getPackageFormat
+  getModuleFileFormat
 };

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -32,6 +32,8 @@ const legacyExtensionFormatMap = {
   '.node': 'commonjs'
 };
 
+let experimentalSpecifierResolutionWarned = false;
+
 if (experimentalWasmModules)
   extensionFormatMap['.wasm'] = legacyExtensionFormatMap['.wasm'] = 'wasm';
 
@@ -64,9 +66,12 @@ const protocolHandlers = ObjectAssign(ObjectCreate(null), {
     }
     if (!format) {
       if (experimentalSpecifierResolution === 'node') {
-        process.emitWarning(
-          'The Node.js specifier resolution in ESM is experimental.',
-          'ExperimentalWarning');
+        if (!experimentalSpecifierResolutionWarned) {
+          process.emitWarning(
+            'The Node.js specifier resolution in ESM is experimental.',
+            'ExperimentalWarning');
+          experimentalSpecifierResolutionWarned = true;
+        }
         format = legacyExtensionFormatMap[ext];
       } else {
         throw new ERR_UNKNOWN_FILE_EXTENSION(ext, fileURLToPath(url));
@@ -90,4 +95,5 @@ module.exports = {
   defaultGetFormat,
   extensionFormatMap,
   legacyExtensionFormatMap,
+  experimentalSpecifierResolutionWarned
 };

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -55,18 +55,11 @@ const protocolHandlers = ObjectAssign(ObjectCreate(null), {
 
     return format;
   },
-  'file:'(parsed, url) {
-    return getModuleFileFormat(parsed, true, url) || null;
+  'file:'(parsed, ignoreErrors) {
+    return getFileProtocolModuleFormat(parsed, ignoreErrors);
   },
   'node:'() { return 'builtin'; },
 });
-
-function throwIfNotExperimentalSpecifierResolution(ext, url) {
-  if (experimentalSpecifierResolution !== 'node') {
-    throw new ERR_UNKNOWN_FILE_EXTENSION(ext, fileURLToPath(url));
-  }
-  return getLegacyExtensionFormat(ext);
-}
 
 function getLegacyExtensionFormat(ext) {
   if (
@@ -81,34 +74,40 @@ function getLegacyExtensionFormat(ext) {
   return legacyExtensionFormatMap[ext];
 }
 
-function getModuleFileFormat(url, throwIfNotResolved, urlForThrow) {
-  let format;
-
+function getFileProtocolModuleFormat(url, ignoreErrors) {
   const ext = extname(url.pathname);
   if (ext === '.js') {
-    format = getPackageType(url) === 'module' ? 'module' : 'commonjs';
+    return getPackageType(url) === 'module' ? 'module' : 'commonjs';
   } else {
-    format = extensionFormatMap[ext] ??
-      (throwIfNotResolved ?
-        throwIfNotExperimentalSpecifierResolution(ext, urlForThrow) :
-        getLegacyExtensionFormat(ext)
-      );
+    const format = extensionFormatMap[ext];
+    if (format) return format;
+    if (experimentalSpecifierResolution !== 'node') {
+      // Explicit undefined return indicates load hook should rerun format check
+      if (ignoreErrors)
+        return undefined;
+      throw new ERR_UNKNOWN_FILE_EXTENSION(ext, fileURLToPath(url));
+    }
+    return getLegacyExtensionFormat(ext) ?? null;
   }
+}
 
-  return format;
+function defaultGetFormatWithoutErrors(url, context) {
+  const parsed = new URL(url);
+  if (!ObjectPrototypeHasOwnProperty(protocolHandlers, parsed.protocol))
+    return null;
+  return protocolHandlers[parsed.protocol](parsed, url, true);
 }
 
 function defaultGetFormat(url, context) {
   const parsed = new URL(url);
-
   return ObjectPrototypeHasOwnProperty(protocolHandlers, parsed.protocol) ?
-    protocolHandlers[parsed.protocol](parsed, url) :
+    protocolHandlers[parsed.protocol](parsed, false) :
     null;
 }
 
 module.exports = {
   defaultGetFormat,
+  defaultGetFormatWithoutErrors,
   extensionFormatMap,
-  getModuleFileFormat,
   legacyExtensionFormatMap,
 };

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -78,17 +78,17 @@ function getFileProtocolModuleFormat(url, ignoreErrors) {
   const ext = extname(url.pathname);
   if (ext === '.js') {
     return getPackageType(url) === 'module' ? 'module' : 'commonjs';
-  } else {
-    const format = extensionFormatMap[ext];
-    if (format) return format;
-    if (experimentalSpecifierResolution !== 'node') {
-      // Explicit undefined return indicates load hook should rerun format check
-      if (ignoreErrors)
-        return undefined;
-      throw new ERR_UNKNOWN_FILE_EXTENSION(ext, fileURLToPath(url));
-    }
-    return getLegacyExtensionFormat(ext) ?? null;
   }
+
+  const format = extensionFormatMap[ext];
+  if (format) return format;
+  if (experimentalSpecifierResolution !== 'node') {
+    // Explicit undefined return indicates load hook should rerun format check
+    if (ignoreErrors)
+      return undefined;
+    throw new ERR_UNKNOWN_FILE_EXTENSION(ext, fileURLToPath(url));
+  }
+  return getLegacyExtensionFormat(ext) ?? null;
 }
 
 function defaultGetFormatWithoutErrors(url, context) {

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -18,7 +18,7 @@ async function defaultLoad(url, context) {
   } = context;
   const { importAssertions } = context;
 
-  if (!format || !translators.has(format)) {
+  if (format === undefined) {
     format = defaultGetFormat(url);
   }
 

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -2,7 +2,6 @@
 
 const { defaultGetFormat } = require('internal/modules/esm/get_format');
 const { defaultGetSource } = require('internal/modules/esm/get_source');
-const { translators } = require('internal/modules/esm/translators');
 const { validateAssertions } = require('internal/modules/esm/assert');
 
 /**

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -17,7 +17,7 @@ async function defaultLoad(url, context) {
   } = context;
   const { importAssertions } = context;
 
-  if (format === undefined) {
+  if (format == null) {
     format = defaultGetFormat(url);
   }
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -941,8 +941,12 @@ function moduleResolve(specifier, base, conditions, preserveSymlinks) {
     resolved = packageImportsResolve(specifier, base, conditions);
   } else {
     try {
-      resolved = new URL(specifier);
-    } catch {
+      ({ resolved, format } =
+        amendFormatToUrl(new URL(specifier)));
+    } catch (err) {
+      if (err.code === 'ERR_INVALID_URL_SCHEME') {
+        throwIfUnsupportedURLProtocol(new URL(specifier));
+      }
       ({ resolved, format } =
         amendFormatToUrl(
           packageResolve(
@@ -1007,6 +1011,13 @@ function resolveAsCommonJS(specifier, parentURL) {
     return found;
   } catch {
     return false;
+  }
+}
+
+function throwIfUnsupportedURLProtocol(url) {
+  if (url.protocol !== 'file:' && url.protocol !== 'data:' &&
+      url.protocol !== 'node:') {
+    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(url);
   }
 }
 
@@ -1082,9 +1093,7 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
     throw error;
   }
 
-  if (url.protocol !== 'file:' && url.protocol !== 'data:' &&
-      url.protocol !== 'node:')
-    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(url);
+  throwIfUnsupportedURLProtocol(url);
 
   return {
     url: `${url}`,

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -469,30 +469,34 @@ function resolvePackageTargetString(
 
   const composeResult = (resolved) => {
     let format;
-    try {
-      const ext = extname(resolved.pathname);
-      if (ext === '.js') {
+
+    const ext = extname(resolved.pathname);
+    if (ext === '.js') {
+      try {
         format = getPackageType(resolved);
-      } else {
-        format = extensionFormatMap[ext];
-      }
-      if (!format) {
-        if (experimentalSpecifierResolution === 'node') {
-          process.emitWarning(
-            'The Node.js specifier resolution in ESM is experimental.',
-            'ExperimentalWarning');
-          format = legacyExtensionFormatMap[ext];
+      } catch (err) {
+        if (err.code === 'ERR_INVALID_FILE_URL_PATH') {
+          const invalidModuleErr = new ERR_INVALID_MODULE_SPECIFIER(
+            resolved, 'must not include encoded "/" or "\\" characters', base);
+          invalidModuleErr.cause = err;
+          throw invalidModuleErr;
         }
+        throw err;
       }
-    } catch (err) {
-      if (err.code === 'ERR_INVALID_FILE_URL_PATH') {
-        const invalidModuleErr = new ERR_INVALID_MODULE_SPECIFIER(
-          resolved, 'must not include encoded "/" or "\\" characters', base);
-        invalidModuleErr.cause = err;
-        throw invalidModuleErr;
-      }
-      throw err;
+    } else {
+      format = extensionFormatMap[ext];
     }
+
+    if (format == null && experimentalSpecifierResolution === 'node') {
+      if (!experimentalSpecifierResolutionWarned) {
+        process.emitWarning(
+          'The Node.js specifier resolution in ESM is experimental.',
+          'ExperimentalWarning');
+        experimentalSpecifierResolutionWarned = true;
+      }
+      format = legacyExtensionFormatMap[ext];
+    }
+
     return { resolved, ...(format !== 'none') && { format } };
   };
 
@@ -1123,6 +1127,9 @@ module.exports = {
 };
 
 // cycle
-const { defaultGetFormat,
-        extensionFormatMap,
-        legacyExtensionFormatMap } = require('internal/modules/esm/get_format');
+let {
+  defaultGetFormat,
+  extensionFormatMap,
+  legacyExtensionFormatMap,
+  experimentalSpecifierResolutionWarned,
+} = require('internal/modules/esm/get_format');

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -107,7 +107,7 @@ function emitTrailingSlashPatternDeprecation(match, pjsonUrl, base) {
  * @returns {void}
  */
 function emitLegacyIndexDeprecation(url, packageJSONUrl, base, main) {
-  const format = defaultGetFormat(url);
+  const format = defaultGetFormatWithoutErrors(url);
   if (format !== 'module')
     return;
   const path = fileURLToPath(url);
@@ -916,12 +916,6 @@ function shouldBeTreatedAsRelativeOrAbsolutePath(specifier) {
   return isRelativeSpecifier(specifier);
 }
 
-function amendFormatToUrl(resolved) {
-  const format = getModuleFileFormat(resolved, false);
-
-  return { resolved, ...(format !== null) && { format } };
-}
-
 /**
  * @param {string} specifier
  * @param {string | URL | undefined} base
@@ -933,39 +927,22 @@ function moduleResolve(specifier, base, conditions, preserveSymlinks) {
   // Order swapped from spec for minor perf gain.
   // Ok since relative URLs cannot parse as URLs.
   let resolved;
-  let format;
-
   if (shouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
     resolved = new URL(specifier, base);
   } else if (specifier[0] === '#') {
     resolved = packageImportsResolve(specifier, base, conditions);
   } else {
     try {
-      ({ resolved, format } =
-        amendFormatToUrl(new URL(specifier)));
-    } catch (err) {
-      if (err.code === 'ERR_INVALID_URL_SCHEME') {
-        throwIfUnsupportedURLProtocol(new URL(specifier));
-      }
-      ({ resolved, format } =
-        amendFormatToUrl(
-          packageResolve(
-            specifier,
-            base,
-            conditions
-          )));
+      resolved = new URL(specifier);
+    }
+    catch {
+      resolved = packageResolve(specifier, base, conditions);
     }
   }
   if (resolved.protocol !== 'file:') {
-    return {
-      url: resolved
-    };
+    return resolved;
   }
-
-  return {
-    url: finalizeResolution(resolved, base, preserveSymlinks),
-    ...(format != null) && { format }
-  };
+  return finalizeResolution(resolved, base, preserveSymlinks);
 }
 
 /**
@@ -1061,15 +1038,13 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
 
   conditions = getConditionsSet(conditions);
   let url;
-  let format;
   try {
-    ({ url, format } =
-      moduleResolve(
-        specifier,
-        parentURL,
-        conditions,
-        isMain ? preserveSymlinksMain : preserveSymlinks
-      ));
+    url = moduleResolve(
+      specifier,
+      parentURL,
+      conditions,
+      isMain ? preserveSymlinksMain : preserveSymlinks
+    );
   } catch (error) {
     // Try to give the user a hint of what would have been the
     // resolved CommonJS module
@@ -1097,7 +1072,7 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
 
   return {
     url: `${url}`,
-    ...(format != null) && { format }
+    format: defaultGetFormatWithoutErrors(url)
   };
 }
 
@@ -1113,6 +1088,5 @@ module.exports = {
 
 // cycle
 const {
-  defaultGetFormat,
-  getModuleFileFormat,
+  defaultGetFormatWithoutErrors,
 } = require('internal/modules/esm/get_format');

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -934,8 +934,7 @@ function moduleResolve(specifier, base, conditions, preserveSymlinks) {
   } else {
     try {
       resolved = new URL(specifier);
-    }
-    catch {
+    } catch {
       resolved = packageResolve(specifier, base, conditions);
     }
   }

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -467,7 +467,7 @@ function resolvePackageTargetString(
   const composeResult = (resolved) => {
     let format;
     try {
-      // extension has higher priority than package.json type descriptor
+      // Extension has higher priority than package.json type descriptor
       if (StringPrototypeEndsWith(resolved.href, '.mjs')) {
         format = 'module';
       } else {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -464,29 +464,6 @@ const patternRegEx = /\*/g;
 function resolvePackageTargetString(
   target, subpath, match, packageJSONUrl, base, pattern, internal, conditions) {
 
-  const composeResult = (resolved) => {
-    let format;
-
-    const ext = extname(resolved.pathname);
-    if (ext === '.js') {
-      try {
-        format = getPackageType(resolved) === 'module' ? 'module' : 'commonjs';
-      } catch (err) {
-        if (err.code === 'ERR_INVALID_FILE_URL_PATH') {
-          const invalidModuleErr = new ERR_INVALID_MODULE_SPECIFIER(
-            resolved, 'must not include encoded "/" or "\\" characters', base);
-          invalidModuleErr.cause = err;
-          throw invalidModuleErr;
-        }
-        throw err;
-      }
-    } else {
-      format = extensionFormatMap[ext] ?? getLegacyExtensionFormat(ext);
-    }
-
-    return { resolved, ...(format !== 'none') && { format } };
-  };
-
   if (subpath !== '' && !pattern && target[target.length - 1] !== '/')
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
 
@@ -519,7 +496,7 @@ function resolvePackageTargetString(
   if (!StringPrototypeStartsWith(resolvedPath, packagePath))
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
 
-  if (subpath === '') return composeResult(resolved);
+  if (subpath === '') return resolved;
 
   if (RegExpPrototypeTest(invalidSegmentRegEx, subpath)) {
     const request = pattern ?
@@ -528,12 +505,16 @@ function resolvePackageTargetString(
   }
 
   if (pattern) {
-    return composeResult(new URL(RegExpPrototypeSymbolReplace(patternRegEx,
-                                                              resolved.href,
-                                                              () => subpath)));
+    return new URL(
+      RegExpPrototypeSymbolReplace(
+        patternRegEx,
+        resolved.href,
+        () => subpath
+      )
+    );
   }
 
-  return composeResult(new URL(subpath, resolved));
+  return new URL(subpath, resolved);
 }
 
 /**
@@ -550,7 +531,13 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
                               base, pattern, internal, conditions) {
   if (typeof target === 'string') {
     return resolvePackageTargetString(
-      target, subpath, packageSubpath, packageJSONUrl, base, pattern, internal,
+      target,
+      subpath,
+      packageSubpath,
+      packageJSONUrl,
+      base,
+      pattern,
+      internal,
       conditions);
   } else if (ArrayIsArray(target)) {
     if (target.length === 0)
@@ -760,7 +747,7 @@ function packageImportsResolve(name, base, conditions) {
           packageJSONUrl, imports[name], '', name, base, false, true, conditions
         );
         if (resolveResult != null) {
-          return resolveResult.resolved;
+          return resolveResult;
         }
       } else {
         let bestMatch = '';
@@ -792,7 +779,7 @@ function packageImportsResolve(name, base, conditions) {
                                                      bestMatch, base, true,
                                                      true, conditions);
           if (resolveResult != null) {
-            return resolveResult.resolved;
+            return resolveResult;
           }
         }
       }
@@ -856,7 +843,7 @@ function parsePackageName(specifier, base) {
  */
 function packageResolve(specifier, base, conditions) {
   if (NativeModule.canBeRequiredByUsers(specifier))
-    return { resolved: new URL('node:' + specifier) };
+    return new URL('node:' + specifier);
 
   const { packageName, packageSubpath, isScoped } =
     parsePackageName(specifier, base);
@@ -895,19 +882,14 @@ function packageResolve(specifier, base, conditions) {
         packageJSONUrl, packageSubpath, packageConfig, base, conditions);
     }
     if (packageSubpath === '.') {
-      return {
-        resolved: legacyMainResolve(
-          packageJSONUrl,
-          packageConfig,
-          base),
-        ...(packageConfig.type !== 'none') && { format: packageConfig.type }
-      };
+      return legacyMainResolve(
+        packageJSONUrl,
+        packageConfig,
+        base
+      );
     }
 
-    return {
-      resolved: new URL(packageSubpath, packageJSONUrl),
-      ...(packageConfig.type !== 'none') && { format: packageConfig.type }
-    };
+    return new URL(packageSubpath, packageJSONUrl);
     // Cross-platform root check.
   } while (packageJSONPath.length !== lastPath.length);
 
@@ -952,6 +934,29 @@ function moduleResolve(specifier, base, conditions, preserveSymlinks) {
   // Ok since relative URLs cannot parse as URLs.
   let resolved;
   let format;
+  const amendFormatToUrl = (resolved) => {
+    let format;
+
+    const ext = extname(resolved.pathname);
+    if (ext === '.js') {
+      try {
+        format = getPackageType(resolved) === 'module' ? 'module' : 'commonjs';
+      } catch (err) {
+        if (err.code === 'ERR_INVALID_FILE_URL_PATH') {
+          const invalidModuleErr = new ERR_INVALID_MODULE_SPECIFIER(
+            resolved, 'must not include encoded "/" or "\\" characters', base);
+          invalidModuleErr.cause = err;
+          throw invalidModuleErr;
+        }
+        throw err;
+      }
+    } else {
+      format = extensionFormatMap[ext] ?? getLegacyExtensionFormat(ext);
+    }
+
+    return { resolved, ...(format !== 'none') && { format } };
+  };
+
   if (shouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
     resolved = new URL(specifier, base);
   } else if (specifier[0] === '#') {
@@ -960,7 +965,13 @@ function moduleResolve(specifier, base, conditions, preserveSymlinks) {
     try {
       resolved = new URL(specifier);
     } catch {
-      ({ resolved, format } = packageResolve(specifier, base, conditions));
+      ({ resolved, format } =
+        amendFormatToUrl(
+          packageResolve(
+            specifier,
+            base,
+            conditions
+          )));
     }
   }
   if (resolved.protocol !== 'file:') {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -1071,7 +1071,7 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
 
   return {
     url: `${url}`,
-    format: defaultGetFormatWithoutErrors(url)
+    format: defaultGetFormatWithoutErrors(url),
   };
 }
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -531,13 +531,7 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
                               base, pattern, internal, conditions) {
   if (typeof target === 'string') {
     return resolvePackageTargetString(
-      target,
-      subpath,
-      packageSubpath,
-      packageJSONUrl,
-      base,
-      pattern,
-      internal,
+      target, subpath, packageSubpath, packageJSONUrl, base, pattern, internal,
       conditions);
   } else if (ArrayIsArray(target)) {
     if (target.length === 0)

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -62,9 +62,6 @@ const userConditions = getOptionValue('--conditions');
 const noAddons = getOptionValue('--no-addons');
 const addonConditions = noAddons ? [] : ['node-addons'];
 
-const experimentalSpecifierResolution =
-  getOptionValue('--experimental-specifier-resolution');
-
 const DEFAULT_CONDITIONS = ObjectFreeze([
   'node',
   'import',
@@ -484,17 +481,7 @@ function resolvePackageTargetString(
         throw err;
       }
     } else {
-      format = extensionFormatMap[ext];
-    }
-
-    if (format == null && experimentalSpecifierResolution === 'node') {
-      if (!experimentalSpecifierResolutionWarned) {
-        process.emitWarning(
-          'The Node.js specifier resolution in ESM is experimental.',
-          'ExperimentalWarning');
-        experimentalSpecifierResolutionWarned = true;
-      }
-      format = legacyExtensionFormatMap[ext];
+      format = extensionFormatMap[ext] ?? getLegacyExtensionFormat(ext);
     }
 
     return { resolved, ...(format !== 'none') && { format } };
@@ -1127,9 +1114,8 @@ module.exports = {
 };
 
 // cycle
-let {
+const {
   defaultGetFormat,
   extensionFormatMap,
-  legacyExtensionFormatMap,
-  experimentalSpecifierResolutionWarned,
+  getLegacyExtensionFormat,
 } = require('internal/modules/esm/get_format');

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -467,7 +467,12 @@ function resolvePackageTargetString(
   const composeResult = (resolved) => {
     let format;
     try {
-      format = getPackageType(resolved);
+      // extension has higher priority than package.json type descriptor
+      if (StringPrototypeEndsWith(resolved.href, '.mjs')) {
+        format = 'module';
+      } else {
+        format = getPackageType(resolved);
+      }
     } catch (err) {
       if (err.code === 'ERR_INVALID_FILE_URL_PATH') {
         const invalidModuleErr = new ERR_INVALID_MODULE_SPECIFIER(

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -37,7 +37,7 @@ const { getOptionValue } = require('internal/options');
 const policy = getOptionValue('--experimental-policy') ?
   require('internal/process/policy') :
   null;
-const { sep, relative, resolve } = require('path');
+const { sep, relative, resolve, extname } = require('path');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const typeFlag = getOptionValue('--input-type');
@@ -61,6 +61,9 @@ const packageJsonReader = require('internal/modules/package_json_reader');
 const userConditions = getOptionValue('--conditions');
 const noAddons = getOptionValue('--no-addons');
 const addonConditions = noAddons ? [] : ['node-addons'];
+
+const experimentalSpecifierResolution =
+  getOptionValue('--experimental-specifier-resolution');
 
 const DEFAULT_CONDITIONS = ObjectFreeze([
   'node',
@@ -467,11 +470,19 @@ function resolvePackageTargetString(
   const composeResult = (resolved) => {
     let format;
     try {
-      // Extension has higher priority than package.json type descriptor
-      if (StringPrototypeEndsWith(resolved.href, '.mjs')) {
-        format = 'module';
-      } else {
+      const ext = extname(resolved.pathname);
+      if (ext === '.js') {
         format = getPackageType(resolved);
+      } else {
+        format = extensionFormatMap[ext];
+      }
+      if (!format) {
+        if (experimentalSpecifierResolution === 'node') {
+          process.emitWarning(
+            'The Node.js specifier resolution in ESM is experimental.',
+            'ExperimentalWarning');
+          format = legacyExtensionFormatMap[ext];
+        }
       }
     } catch (err) {
       if (err.code === 'ERR_INVALID_FILE_URL_PATH') {
@@ -1112,4 +1123,6 @@ module.exports = {
 };
 
 // cycle
-const { defaultGetFormat } = require('internal/modules/esm/get_format');
+const { defaultGetFormat,
+        extensionFormatMap,
+        legacyExtensionFormatMap } = require('internal/modules/esm/get_format');

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -470,7 +470,7 @@ function resolvePackageTargetString(
     const ext = extname(resolved.pathname);
     if (ext === '.js') {
       try {
-        format = getPackageType(resolved);
+        format = getPackageType(resolved) === 'module' ? 'module' : 'commonjs';
       } catch (err) {
         if (err.code === 'ERR_INVALID_FILE_URL_PATH') {
           const invalidModuleErr = new ERR_INVALID_MODULE_SPECIFIER(

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -923,7 +923,7 @@ function shouldBeTreatedAsRelativeOrAbsolutePath(specifier) {
 }
 
 function amendFormatToUrl(resolved) {
-  const format = getPackageFormat(resolved, false);
+  const format = getModuleFileFormat(resolved, false);
 
   return { resolved, ...(format !== null) && { format } };
 }
@@ -1111,5 +1111,5 @@ module.exports = {
 // cycle
 const {
   defaultGetFormat,
-  getPackageFormat,
+  getModuleFileFormat,
 } = require('internal/modules/esm/get_format');

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -37,7 +37,7 @@ const { getOptionValue } = require('internal/options');
 const policy = getOptionValue('--experimental-policy') ?
   require('internal/process/policy') :
   null;
-const { sep, relative, resolve, extname } = require('path');
+const { sep, relative, resolve } = require('path');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const typeFlag = getOptionValue('--input-type');
@@ -922,6 +922,12 @@ function shouldBeTreatedAsRelativeOrAbsolutePath(specifier) {
   return isRelativeSpecifier(specifier);
 }
 
+function amendFormatToUrl(resolved) {
+  const format = getPackageFormat(resolved, false);
+
+  return { resolved, ...(format !== null) && { format } };
+}
+
 /**
  * @param {string} specifier
  * @param {string | URL | undefined} base
@@ -934,28 +940,6 @@ function moduleResolve(specifier, base, conditions, preserveSymlinks) {
   // Ok since relative URLs cannot parse as URLs.
   let resolved;
   let format;
-  const amendFormatToUrl = (resolved) => {
-    let format;
-
-    const ext = extname(resolved.pathname);
-    if (ext === '.js') {
-      try {
-        format = getPackageType(resolved) === 'module' ? 'module' : 'commonjs';
-      } catch (err) {
-        if (err.code === 'ERR_INVALID_FILE_URL_PATH') {
-          const invalidModuleErr = new ERR_INVALID_MODULE_SPECIFIER(
-            resolved, 'must not include encoded "/" or "\\" characters', base);
-          invalidModuleErr.cause = err;
-          throw invalidModuleErr;
-        }
-        throw err;
-      }
-    } else {
-      format = extensionFormatMap[ext] ?? getLegacyExtensionFormat(ext);
-    }
-
-    return { resolved, ...(format !== 'none') && { format } };
-  };
 
   if (shouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
     resolved = new URL(specifier, base);
@@ -1127,6 +1111,5 @@ module.exports = {
 // cycle
 const {
   defaultGetFormat,
-  extensionFormatMap,
-  getLegacyExtensionFormat,
+  getPackageFormat,
 } = require('internal/modules/esm/get_format');

--- a/test/es-module/test-esm-resolve-type.js
+++ b/test/es-module/test-esm-resolve-type.js
@@ -98,86 +98,172 @@ try {
     }
   };
 
-  // Create a dummy dual package
-  //
-  /**
-   * this creates following directory structure:
-   *
-   * ./node_modules:
-   *   |-> my-dual-package
-   *       |-> es
-   *           |-> index.js
-   *           |-> package.json [2]
-   *       |-> lib
-   *           |-> index.js
-   *       |->package.json [1]
-   *
-   * [1] - main package.json of the package
-   *     - it contains:
-   *             - type: 'commonjs'
-   *             - main: 'lib/mainfile.js'
-   *             - conditional exports for 'require' (lib/index.js) and
-   *                                       'import' (es/index.js)
-   * [2] - package.json add-on for the import case
-   *     - it only contains:
-   *             - type: 'module'
-   *
-   * in case the package is consumed as an ESM by importing it:
-   *    import * as my-package from 'my-dual-package'
-   * it will cause the resolve method to return:
-   *  {
-   *     url: '<base_path>/node_modules/my-dual-package/es/index.js',
-   *     format: 'module'
-   *  }
-   *
-   *  following testcase ensures that resolve works correctly in this case
-   *  returning the information as specified above. Source for 'url' value
-   *  is [1], source for 'format' value is [2]
-   */
+  function testDualPackageWithJsMainScriptAndModuleType() {
+    // Create a dummy dual package
+    //
+    /**
+     * this creates following directory structure:
+     *
+     * ./node_modules:
+     *   |-> my-dual-package
+     *       |-> es
+     *           |-> index.js
+     *           |-> package.json [2]
+     *       |-> lib
+     *           |-> index.js
+     *       |->package.json [1]
+     *
+     * [1] - main package.json of the package
+     *     - it contains:
+     *             - type: 'commonjs'
+     *             - main: 'lib/mainfile.js'
+     *             - conditional exports for 'require' (lib/index.js) and
+     *                                       'import' (es/index.js)
+     * [2] - package.json add-on for the import case
+     *     - it only contains:
+     *             - type: 'module'
+     *
+     * in case the package is consumed as an ESM by importing it:
+     *    import * as my-package from 'my-dual-package'
+     * it will cause the resolve method to return:
+     *  {
+     *     url: '<base_path>/node_modules/my-dual-package/es/index.js',
+     *     format: 'module'
+     *  }
+     *
+     *  following testcase ensures that resolve works correctly in this case
+     *  returning the information as specified above. Source for 'url' value
+     *  is [1], source for 'format' value is [2]
+     */
 
-  const moduleName = 'my-dual-package';
+    const moduleName = 'my-dual-package';
 
-  const mDir = rel(`node_modules/${moduleName}`);
-  const esSubDir = rel(`node_modules/${moduleName}/es`);
-  const cjsSubDir = rel(`node_modules/${moduleName}/lib`);
-  const pkg = rel(`node_modules/${moduleName}/package.json`);
-  const esmPkg = rel(`node_modules/${moduleName}/es/package.json`);
-  const esScript = rel(`node_modules/${moduleName}/es/index.js`);
-  const cjsScript = rel(`node_modules/${moduleName}/lib/index.js`);
+    const mDir = rel(`node_modules/${moduleName}`);
+    const esSubDir = rel(`node_modules/${moduleName}/es`);
+    const cjsSubDir = rel(`node_modules/${moduleName}/lib`);
+    const pkg = rel(`node_modules/${moduleName}/package.json`);
+    const esmPkg = rel(`node_modules/${moduleName}/es/package.json`);
+    const esScript = rel(`node_modules/${moduleName}/es/index.js`);
+    const cjsScript = rel(`node_modules/${moduleName}/lib/index.js`);
 
-  createDir(nmDir);
-  createDir(mDir);
-  createDir(esSubDir);
-  createDir(cjsSubDir);
+    createDir(nmDir);
+    createDir(mDir);
+    createDir(esSubDir);
+    createDir(cjsSubDir);
 
-  const mainPkgJsonContent = {
-    type: 'commonjs',
-    main: 'lib/index.js',
-    exports: {
-      '.': {
-        'require': './lib/index.js',
-        'import': './es/index.js'
-      },
-      './package.json': './package.json',
-    }
-  };
-  const esmPkgJsonContent = {
-    type: 'module'
-  };
+    const mainPkgJsonContent = {
+      type: 'commonjs',
+      main: 'lib/index.js',
+      exports: {
+        '.': {
+          'require': './lib/index.js',
+          'import': './es/index.js'
+        },
+        './package.json': './package.json',
+      }
+    };
+    const esmPkgJsonContent = {
+      type: 'module'
+    };
 
-  fs.writeFileSync(pkg, JSON.stringify(mainPkgJsonContent));
-  fs.writeFileSync(esmPkg, JSON.stringify(esmPkgJsonContent));
-  fs.writeFileSync(esScript,
-                   'export function esm-resolve-tester() {return 42}');
-  fs.writeFileSync(cjsScript,
-                   `module.exports = { 
-                     esm-resolve-tester: () => {return 42}}`
-  );
+    fs.writeFileSync(pkg, JSON.stringify(mainPkgJsonContent));
+    fs.writeFileSync(esmPkg, JSON.stringify(esmPkgJsonContent));
+    fs.writeFileSync(esScript,
+                     'export function esm-resolve-tester() {return 42}');
+    fs.writeFileSync(cjsScript,
+                     `module.exports = { 
+                        esm-resolve-tester: () => {return 42}}`
+    );
 
-  // test the resolve
-  const resolveResult = resolve(`${moduleName}`);
-  assert.strictEqual(resolveResult.format, 'module');
-  assert.ok(resolveResult.url.includes('my-dual-package/es/index.js'));
+    // test the resolve
+    const resolveResult = resolve(`${moduleName}`);
+    assert.strictEqual(resolveResult.format, 'module');
+    assert.ok(resolveResult.url.includes('my-dual-package/es/index.js'));
+  }
+
+  function testDualPackageWithMjsMainScriptAndCJSType() {
+
+    // Additional test for following scenario
+    /**
+     * this creates following directory structure:
+     *
+     * ./node_modules:
+     *   |-> dual-mjs-pjson
+     *       |-> subdir
+     *           |-> index.mjs [3]
+     *           |-> package.json [2]
+     *           |-> index.js
+     *       |->package.json [1]
+     *
+     * [1] - main package.json of the package
+     *     - it contains:
+     *             - type: 'commonjs'
+     *             - main: 'subdir/index.js'
+     *             - conditional exports for 'require' (subdir/index.js) and
+     *                                       'import' (subdir/index.mjs)
+     * [2] - package.json add-on for the import case
+     *     - it only contains:
+     *             - type: 'commonjs'
+     * [3] - main script for the `import` case
+     *
+     * in case the package is consumed as an ESM by importing it:
+     *    import * as my-package from 'dual-mjs-pjson'
+     * it will cause the resolve method to return:
+     *  {
+     *     url: '<base_path>/node_modules/dual-mjs-pjson/subdir/index.mjs',
+     *     format: 'module'
+     *  }
+     *
+     *  following testcase ensures that resolve works correctly in this case
+     *  returning the information as specified above. Source for 'url' value
+     *  is [1], source for 'format' value is the file extension of [3]
+     */
+    const moduleName = 'dual-mjs-pjson';
+
+    const mDir = rel(`node_modules/${moduleName}`);
+    const subDir = rel(`node_modules/${moduleName}/subdir`);
+    const pkg = rel(`node_modules/${moduleName}/package.json`);
+    const subdirPkg = rel(`node_modules/${moduleName}/subdir/package.json`);
+    const esScript = rel(`node_modules/${moduleName}/subdir/index.mjs`);
+    const cjsScript = rel(`node_modules/${moduleName}/subdir/index.js`);
+
+    createDir(nmDir);
+    createDir(mDir);
+    createDir(subDir);
+
+    const mainPkgJsonContent = {
+      type: 'commonjs',
+      main: 'lib/index.js',
+      exports: {
+        '.': {
+          'require': './subdir/index.js',
+          'import': './subdir/index.mjs'
+        },
+        './package.json': './package.json',
+      }
+    };
+    const subdirPkgJsonContent = {
+      type: 'commonjs'
+    };
+
+    fs.writeFileSync(pkg, JSON.stringify(mainPkgJsonContent));
+    fs.writeFileSync(subdirPkg, JSON.stringify(subdirPkgJsonContent));
+    fs.writeFileSync(esScript,
+                     'export function esm-resolve-tester() {return 42}');
+    fs.writeFileSync(cjsScript,
+                     `module.exports = { 
+                      esm-resolve-tester: () => {return 42}}`
+    );
+
+    // test the resolve
+    const resolveResult = resolve(`${moduleName}`);
+    assert.strictEqual(resolveResult.format, 'module');
+    assert.ok(resolveResult.url.includes(`${moduleName}/subdir/index.mjs`));
+  }
+
+  testDualPackageWithJsMainScriptAndModuleType();
+  testDualPackageWithMjsMainScriptAndCJSType();
+
 } finally {
   process.chdir(previousCwd);
   fs.rmSync(nmDir, { recursive: true, force: true });

--- a/test/es-module/test-esm-resolve-type.js
+++ b/test/es-module/test-esm-resolve-type.js
@@ -184,12 +184,15 @@ try {
   testDualPackageWithJsMainScriptAndModuleType();
 
   // TestParameters are ModuleName, mainRequireScript, mainImportScript,
-  // mainPackageType, subdirPkgJsonType, expectedResolvedFormat
+  // mainPackageType, subdirPkgJsonType, expectedResolvedFormat, mainSuffix
   [ [ 'mjs-mod-mod', 'index.js', 'index.mjs', 'module', 'module', 'module'],
     [ 'mjs-com-com', 'idx.js', 'idx.mjs', 'commonjs', 'commonjs', 'module'],
     [ 'mjs-mod-com', 'index.js', 'imp.mjs', 'module', 'commonjs', 'module'],
     [ 'js-com-com', 'index.js', 'imp.js', 'commonjs', 'commonjs', 'commonjs'],
     [ 'js-com-mod', 'index.js', 'imp.js', 'commonjs', 'module', 'module'],
+    [ 'qmod', 'index.js', 'imp.js', 'commonjs', 'module', 'module', '?k=v'],
+    [ 'hmod', 'index.js', 'imp.js', 'commonjs', 'module', 'module', '#Key'],
+    [ 'qhmod', 'index.js', 'imp.js', 'commonjs', 'module', 'module', '?k=v#h'],
     [ 'ts-mod-com', 'index.js', 'imp.ts', 'module', 'commonjs', undefined],
   ].forEach((testVariant) => {
     const [
@@ -198,7 +201,8 @@ try {
       mainImportScript,
       mainPackageType,
       subdirPackageType,
-      expectedResolvedFormat ] = testVariant;
+      expectedResolvedFormat,
+      mainSuffix ] = testVariant;
 
     const mDir = rel(`node_modules/${moduleName}`);
     const subDir = rel(`node_modules/${moduleName}/subdir`);
@@ -211,13 +215,14 @@ try {
     createDir(mDir);
     createDir(subDir);
 
+    const mainScript = mainImportScript + (mainSuffix ?? '');
     const mainPkgJsonContent = {
       type: mainPackageType,
       main: `./subdir/${mainRequireScript}`,
       exports: {
         '.': {
           'require': `./subdir/${mainRequireScript}`,
-          'import': `./subdir/${mainImportScript}`
+          'import': `./subdir/${mainScript}`
         },
         './package.json': './package.json',
       }

--- a/test/es-module/test-esm-resolve-type.js
+++ b/test/es-module/test-esm-resolve-type.js
@@ -35,10 +35,11 @@ try {
    * ensure that resolving by full path does not return the format
    * with the defaultResolver
    */
-  [ [ '/es-modules/package-type-module/index.js', undefined ],
-    [ '/es-modules/package-type-commonjs/index.js', undefined ],
-    [ '/es-modules/package-without-type/index.js', undefined ],
-    [ '/es-modules/package-without-pjson/index.js', undefined ],
+  [
+    [ '/es-modules/package-type-module/index.js', 'module' ],
+    [ '/es-modules/package-type-commonjs/index.js', 'commonjs' ],
+    [ '/es-modules/package-without-type/index.js', 'commonjs' ],
+    [ '/es-modules/package-without-pjson/index.js', 'commonjs' ],
   ].forEach((testVariant) => {
     const [ testScript, expectedType ] = testVariant;
     const resolvedPath = path.resolve(fixtures.path(testScript));

--- a/test/es-module/test-esm-resolve-type.js
+++ b/test/es-module/test-esm-resolve-type.js
@@ -183,6 +183,7 @@ try {
     [ 'mjs-mod-mod', 'index.js', 'index.mjs', 'module', 'module', 'module'],
     [ 'mjs-com-com', 'idx.js', 'idx.mjs', 'commonjs', 'commonjs', 'module'],
     [ 'mjs-mod-com', 'index.js', 'imp.mjs', 'module', 'commonjs', 'module'],
+    [ 'cjs-mod-mod', 'index.cjs', 'imp.cjs', 'module', 'module', 'commonjs'],
     [ 'js-com-com', 'index.js', 'imp.js', 'commonjs', 'commonjs', 'commonjs'],
     [ 'js-com-mod', 'index.js', 'imp.js', 'commonjs', 'module', 'module'],
     [ 'qmod', 'index.js', 'imp.js', 'commonjs', 'module', 'module', '?k=v'],

--- a/test/es-module/test-esm-resolve-type.js
+++ b/test/es-module/test-esm-resolve-type.js
@@ -145,11 +145,11 @@ try {
 
     const mainPkgJsonContent = {
       type: 'commonjs',
-      main: 'lib/index.js',
       exports: {
         '.': {
           'require': './lib/index.js',
-          'import': './es/index.js'
+          'import': './es/index.js',
+          'default': './lib/index.js'
         },
         './package.json': './package.json',
       }
@@ -212,11 +212,11 @@ try {
 
     const mainPkgJsonContent = {
       type: mainPackageType,
-      main: `./subdir/${mainRequireScript}`,
       exports: {
         '.': {
           'require': `./subdir/${mainRequireScript}${mainSuffix}`,
-          'import': `./subdir/${mainImportScript}${mainSuffix}`
+          'import': `./subdir/${mainImportScript}${mainSuffix}`,
+          'default': `./subdir/${mainRequireScript}${mainSuffix}`
         },
         './package.json': './package.json',
       }


### PR DESCRIPTION
this commit solves a regression introduced with PR-40980.
if a `resolve` call results in a script with .mjs extension the `format`
is automatically set to `module`. This avoids the case where an additional
`package.json` in the same directory as the `.mjs` file would declare the
`type` to `commonjs`

the PR also contains a new test that covers this functionality.
It fixes the issue observed with https://github.com/nodejs/node/pull/41167 during backport of https://github.com/nodejs/node/pull/40980

relevant comment for this situation: https://github.com/nodejs/node/pull/41167#issuecomment-996251066

[@nodejs/loaders](https://github.com/orgs/nodejs/teams/loaders)



<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

the issue was that for the case of `yargs` the type was solved wrongly to `commonjs` because of: [this](https://github.com/yargs/yargs/blob/main/helpers/package.json#L2) when importing `yargs/helpers`.
That happened because `package.json` had priority over the extension. With this PR the `package.json` information only applies if the extension of the script is `.js`

Refs: https://github.com/nodejs/node/pull/40980
Refs: https://github.com/yargs/yargs/issues/2068