### PR TITLE
tools: fix CQ and auto-start-ci jobs

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -55,6 +55,6 @@ jobs:
           ncu-config set repo "$(echo ${{ github.repository }} | cut -d/ -f2)"
 
       - name: Start the CI
-        run: ./tools/actions/start-ci.sh "${{ needs.get_prs_for_ci.outputs.numbers }}"
+        run: ./tools/actions/start-ci.sh ${{ needs.get_prs_for_ci.outputs.numbers }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -75,6 +75,6 @@ jobs:
           ncu-config set owner "${OWNER}"
 
       - name: Start the Commit Queue
-        run: ./tools/actions/commit-queue.sh ${{ env.OWNER }} ${{ env.REPOSITORY }} "${{ needs.get_mergeable_prs.outputs.numbers }}"
+        run: ./tools/actions/commit-queue.sh ${{ env.OWNER }} ${{ env.REPOSITORY }} ${{ needs.get_mergeable_prs.outputs.numbers }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}


### PR DESCRIPTION
My mistake, in https://github.com/nodejs/node/pull/41193 I added undesirable quotes, which break the CQ and CI GH Actions jobs.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
