### PR TITLE
util: display a present-but-undefined error cause

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1282,7 +1282,7 @@ function formatError(err, constructor, tag, ctx, keys) {
 
   removeDuplicateErrorKeys(ctx, keys, err, stack);
 
-  if (err.cause !== undefined &&
+  if ('cause' in err &&
       (keys.length === 0 || !keys.includes('cause'))) {
     keys.push('cause');
   }

--- a/test/message/util-inspect-error-cause.js
+++ b/test/message/util-inspect-error-cause.js
@@ -22,9 +22,13 @@ const cause5 = new Error('Object cause', {
            '    at Module._compile (node:internal/modules/cjs/loader:827:30)'
   }
 });
+const cause6 = new Error('undefined cause', {
+  cause: undefined
+});
 
 console.log(cause4);
 console.log(cause5);
+console.log(cause6);
 
 process.nextTick(() => {
   const error = new RangeError('New Stack Frames', { cause: cause2 });

--- a/test/message/util-inspect-error-cause.out
+++ b/test/message/util-inspect-error-cause.out
@@ -23,6 +23,16 @@ Error: Object cause
       '    at Module._compile (node:internal/modules/cjs/loader:827:30)'
   }
 }
+Error: undefined cause
+    at *
+    at *
+    at *
+    at *
+    at *
+    at *
+    at * {
+  [cause]: undefined
+}
 RangeError: New Stack Frames
     at *
 *[90m    at *[39m {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -665,9 +665,15 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   delete falsyCause1.stack;
   const falsyCause2 = new Error(undefined, { cause: null });
   falsyCause2.stack = '';
+  const undefinedCause = new Error('', { cause: undefined });
+  undefinedCause.stack = '';
 
   assert.strictEqual(util.inspect(falsyCause1), '[Error] { [cause]: false }');
   assert.strictEqual(util.inspect(falsyCause2), '[Error] { [cause]: null }');
+  assert.strictEqual(
+    util.inspect(undefinedCause),
+    '[Error] { [cause]: undefined }'
+  );
 }
 
 {


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/41097#issuecomment-997055761

It was a very explicit and intentional decision to differentiate an `undefined` cause from an absent cause, so let's display it.

cc @nodejs/util 