### PR TITLE
lib: fix consistency of methods that emit warnings

### DIFF
--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -178,18 +178,16 @@ function validateHints(hints) {
 }
 
 let invalidHostnameWarningEmitted = false;
-
 function emitInvalidHostnameWarning(hostname) {
-  if (invalidHostnameWarningEmitted) {
-    return;
+  if (!invalidHostnameWarningEmitted) {
+    process.emitWarning(
+      `The provided hostname "${hostname}" is not a valid ` +
+      'hostname, and is supported in the dns module solely for compatibility.',
+      'DeprecationWarning',
+      'DEP0118'
+    );
+    invalidHostnameWarningEmitted = true;
   }
-  invalidHostnameWarningEmitted = true;
-  process.emitWarning(
-    `The provided hostname "${hostname}" is not a valid ` +
-    'hostname, and is supported in the dns module solely for compatibility.',
-    'DeprecationWarning',
-    'DEP0118'
-  );
 }
 
 let typeCoercionWarningEmitted = false;


### PR DESCRIPTION
For consistency, I refactored emitInvalidHostnameWarning method same logic as [emitTypeCoercionDeprecationWarning](https://github.com/nodejs/node/blob/f84132d177dfa7cf82d84b15c77e5a681e065231/lib/internal/dns/utils.js#L193-L203).