### PR TITLE
test: mark test-worker-take-heapsnapshot flaky

### DIFF
--- a/test/pummel/pummel.status
+++ b/test/pummel/pummel.status
@@ -16,6 +16,10 @@ test-crypto-timing-safe-equal-benchmarks: PASS,FLAKY
 
 [$system==macos]
 
+[($arch==arm || $arch==arm64) && $mode==debug]
+#https://github.com/nodejs/node/issues/41204
+test-worker-take-heapsnapshot: PASS, FLAKY
+
 [$arch==arm || $arch==arm64]
 
 [$system==solaris] # Also applies to SmartOS

--- a/test/pummel/pummel.status
+++ b/test/pummel/pummel.status
@@ -17,7 +17,7 @@ test-crypto-timing-safe-equal-benchmarks: PASS,FLAKY
 [$system==macos]
 
 [($arch==arm || $arch==arm64) && $mode==debug]
-#https://github.com/nodejs/node/issues/41204
+# https://github.com/nodejs/node/issues/41204
 test-worker-take-heapsnapshot: PASS, FLAKY
 
 [$arch==arm || $arch==arm64]


### PR DESCRIPTION
- Mark test-worker-take-heapsnapshot as flaky on
  arm with debug

Refs: https://github.com/nodejs/node/issues/41204
Refs: https://github.com/nodejs/node/issues/41209

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
