### PR TITLE
tools: add double-quotes to make-v8.sh

### DIFF
--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -17,7 +17,7 @@ if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
   fi
   # set paths manually for now to use locally installed gn
   export BUILD_TOOLS=/home/iojs/build-tools
-  export LD_LIBRARY_PATH=$BUILD_TOOLS:$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH="$BUILD_TOOLS:$LD_LIBRARY_PATH"
   # Avoid linking to ccache symbolic links as ccache decides which
   # binary to run based on the name of the link (we always name them gcc/g++).
   # shellcheck disable=SC2154
@@ -28,7 +28,7 @@ if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
   rm -f "$BUILD_TOOLS/gcc"
   ln -s "$CXX_PATH" "$BUILD_TOOLS/g++"
   ln -s "$CC_PATH" "$BUILD_TOOLS/gcc"
-  export PATH=$BUILD_TOOLS:$PATH
+  export PATH="$BUILD_TOOLS:$PATH"
 
   g++ --version
   gcc --version


### PR DESCRIPTION
~Now that we maintain make-v8.sh rather than pull it from upstream, we
can make it conform to our shellcheck lint checks.~

This is not being flagged in CI because (I'm guessing) shellcheck in CI
is 0.7.0 but latest is 0.8.0.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
