### PR TITLE
crypto: alias webcrypto.subtle and webcrypto.getRandomValues on crypto

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5213,7 +5213,7 @@ added: REPLACEME
 
 * Type: {SubtleCrypto}
 
-A convenient alias for `crypto.webcrypto.subtle`.
+A convenient alias for [`crypto.webcrypto.subtle`][].
 
 ### `crypto.timingSafeEqual(a, b)`
 
@@ -5930,6 +5930,7 @@ See the [list of SSL OP Flags][] for details.
 [`crypto.randomFill()`]: #cryptorandomfillbuffer-offset-size-callback
 [`crypto.scrypt()`]: #cryptoscryptpassword-salt-keylen-options-callback
 [`crypto.webcrypto.getRandomValues()`]: webcrypto.md#cryptogetrandomvaluestypedarray
+[`crypto.webcrypto.subtle`]: webcrypto.md#class-subtlecrypto
 [`decipher.final()`]: #decipherfinaloutputencoding
 [`decipher.update()`]: #decipherupdatedata-inputencoding-outputencoding
 [`diffieHellman.setPublicKey()`]: #diffiehellmansetpublickeypublickey-encoding

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -4015,6 +4015,17 @@ const {
 console.log(getHashes()); // ['DSA', 'DSA-SHA', 'DSA-SHA1', ...]
 ```
 
+### `crypto.getRandomValues(typedArray)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `typedArray` {Buffer|TypedArray|DataView|ArrayBuffer}
+* Returns: {Buffer|TypedArray|DataView|ArrayBuffer} Returns `typedArray`.
+
+A convenient alias for [`crypto.webcrypto.getRandomValues()`][].
+
 ### `crypto.hkdf(digest, ikm, salt, info, keylen, callback)`
 
 <!-- YAML
@@ -5194,6 +5205,16 @@ additional properties can be passed:
 
 If the `callback` function is provided this function uses libuv's threadpool.
 
+### `crypto.subtle`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {SubtleCrypto}
+
+A convenient alias for `crypto.webcrypto.subtle`.
+
 ### `crypto.timingSafeEqual(a, b)`
 
 <!-- YAML
@@ -5908,6 +5929,7 @@ See the [list of SSL OP Flags][] for details.
 [`crypto.randomBytes()`]: #cryptorandombytessize-callback
 [`crypto.randomFill()`]: #cryptorandomfillbuffer-offset-size-callback
 [`crypto.scrypt()`]: #cryptoscryptpassword-salt-keylen-options-callback
+[`crypto.webcrypto.getRandomValues()`]: webcrypto.md#cryptogetrandomvaluestypedarray
 [`decipher.final()`]: #decipherfinaloutputencoding
 [`decipher.update()`]: #decipherupdatedata-inputencoding-outputencoding
 [`diffieHellman.setPublicKey()`]: #diffiehellmansetpublickeypublickey-encoding

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -125,9 +125,7 @@ const Certificate = require('internal/crypto/certificate');
 
 let webcrypto;
 function lazyWebCrypto() {
-  if (webcrypto === undefined) {
-    webcrypto = require('internal/crypto/webcrypto');
-  }
+  webcrypto ??= require('internal/crypto/webcrypto');
   return webcrypto;
 }
 
@@ -291,19 +289,22 @@ ObjectDefineProperties(module.exports, {
   webcrypto: {
     configurable: false,
     enumerable: true,
-    get() { return lazyWebCrypto().crypto; }
+    get() { return lazyWebCrypto().crypto; },
+    set: undefined,
   },
 
   subtle: {
     configurable: false,
     enumerable: true,
-    get() { return lazyWebCrypto().crypto.subtle; }
+    get() { return lazyWebCrypto().crypto.subtle; },
+    set: undefined,
   },
 
   getRandomValues: {
     configurable: false,
     enumerable: true,
-    get() { return lazyWebCrypto().crypto.getRandomValues; }
+    get() { return lazyWebCrypto().crypto.getRandomValues; },
+    set: undefined,
   },
 
   // Aliases for randomBytes are deprecated.

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -119,10 +119,17 @@ const {
   getHashes,
   setDefaultEncoding,
   setEngine,
-  lazyRequire,
   secureHeapUsed,
 } = require('internal/crypto/util');
 const Certificate = require('internal/crypto/certificate');
+
+let webcrypto;
+function lazyWebCrypto() {
+  if (webcrypto === undefined) {
+    webcrypto = require('internal/crypto/webcrypto');
+  }
+  return webcrypto;
+}
 
 // These helper functions are needed because the constructors can
 // use new, in which case V8 cannot inline the recursive constructor call
@@ -284,7 +291,19 @@ ObjectDefineProperties(module.exports, {
   webcrypto: {
     configurable: false,
     enumerable: true,
-    get() { return lazyRequire('internal/crypto/webcrypto').crypto; }
+    get() { return lazyWebCrypto().crypto; }
+  },
+
+  subtle: {
+    configurable: false,
+    enumerable: true,
+    get() { return lazyWebCrypto().crypto.subtle; }
+  },
+
+  getRandomValues: {
+    configurable: false,
+    enumerable: true,
+    get() { return lazyWebCrypto().crypto.getRandomValues; }
   },
 
   // Aliases for randomBytes are deprecated.


### PR DESCRIPTION
The aliases allow code written to assume that `crypto.subtle` and
`crypto.getRandomValues()` exist on the `crypto` global to just work.

Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
