### PR TITLE
src: skip costly pushing/popping if we pass zeroes as async context

### DIFF
--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -80,10 +80,10 @@ InternalCallbackScope::InternalCallbackScope(Environment* env,
 
   pushed_ids_ = true;
 
-  if (asyncContext.async_id != 0 && !skip_hooks_) {
+  if (!skip_hooks_) {
     // No need to check a return value because the application will exit if
     // an exception occurs.
-    AsyncWrap::EmitBefore(env, asyncContext.async_id);
+    AsyncWrap::EmitBefore(env, async_context_.async_id);
   }
 }
 

--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -56,6 +56,12 @@ InternalCallbackScope::InternalCallbackScope(Environment* env,
   CHECK_NOT_NULL(env);
   env->PushAsyncCallbackScope();
 
+  // Skip costly pushing/popping if we pass zeroes as async context
+  if (async_context_.async_id == 0) {
+    pushed_ids_ = false;
+    return;
+  }
+
   if (!env->can_call_into_js()) {
     failed_ = true;
     return;


### PR DESCRIPTION
Improve `MakeCallback` performance:

From uws:

> This patch reliably boosts performance by 12% of req/sec on Linux: