### PR TITLE
tools,doc: avoid generating duplicate id attributes

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -827,9 +827,9 @@ Called when the promise receives a resolution or rejection value. This may
 occur synchronously in the case of `Promise.resolve()` or `Promise.reject()`.
 
 [HTML structured clone algorithm]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
-[Hook Callbacks]: #hook_callbacks
+[Hook Callbacks]: #hook-callbacks
 [V8]: https://developers.google.com/v8/
-[`AsyncLocalStorage`]: async_context.md#class_asynclocalstorage
+[`AsyncLocalStorage`]: async_context.md#class-asynclocalstorage
 [`Buffer`]: buffer.md
 [`DefaultDeserializer`]: #class-v8defaultdeserializer
 [`DefaultSerializer`]: #class-v8defaultserializer
@@ -839,20 +839,20 @@ occur synchronously in the case of `Promise.resolve()` or `Promise.reject()`.
 [`GetHeapSpaceStatistics`]: https://v8docs.nodesource.com/node-13.2/d5/dda/classv8_1_1_isolate.html#ac673576f24fdc7a33378f8f57e1d13a4
 [`NODE_V8_COVERAGE`]: cli.md#node_v8_coveragedir
 [`Serializer`]: #class-v8serializer
-[`after` callback]: #after_promise
+[`after` callback]: #afterpromise
 [`async_hooks`]: async_hooks.md
-[`before` callback]: #before_promise
+[`before` callback]: #beforepromise
 [`buffer.constants.MAX_LENGTH`]: buffer.md#bufferconstantsmax_length
 [`deserializer._readHostObject()`]: #deserializer_readhostobject
 [`deserializer.transferArrayBuffer()`]: #deserializertransferarraybufferid-arraybuffer
-[`init` callback]: #init_promise_parent
+[`init` callback]: #initpromise-parent
 [`serialize()`]: #v8serializevalue
 [`serializer._getSharedArrayBufferId()`]: #serializer_getsharedarraybufferidsharedarraybuffer
 [`serializer._writeHostObject()`]: #serializer_writehostobjectobject
 [`serializer.releaseBuffer()`]: #serializerreleasebuffer
 [`serializer.transferArrayBuffer()`]: #serializertransferarraybufferid-arraybuffer
 [`serializer.writeRawBytes()`]: #serializerwriterawbytesbuffer
-[`settled` callback]: #settled_promise
+[`settled` callback]: #settledpromise
 [`v8.stopCoverage()`]: #v8stopcoverage
 [`v8.takeCoverage()`]: #v8takecoverage
 [`vm.Script`]: vm.md#new-vmscriptcode-options

--- a/tools/doc/allhtml.mjs
+++ b/tools/doc/allhtml.mjs
@@ -38,7 +38,7 @@ for (const link of toc.match(/<a.*?>/g)) {
     .replace(/[\s\S]*?id="toc"[^>]*>\s*<\w+>.*?<\/\w+>\s*(<ul>\s*)?/, '')
     // Prefix TOC links with current module name
     .replace(/<a href="#(?!DEP[0-9]{4})([^"]+)"/g, (match, anchor) => {
-      return `<a href="#${moduleName}_${anchor}"`;
+      return `<a href="#all_${moduleName}_${anchor}"`;
     });
 
   apicontent += '<section>' + data.slice(match.index + match[0].length)
@@ -46,24 +46,24 @@ for (const link of toc.match(/<a.*?>/g)) {
     // Prefix all in-page anchor marks with module name
     .replace(/<a class="mark" href="#([^"]+)" id="([^"]+)"/g, (match, anchor, id) => {
       if (anchor !== id) throw new Error(`Mark does not match: ${anchor} should match ${id}`);
-      return `<a class="mark" href="#${moduleName}_${anchor}" id="${moduleName}_${anchor}"`;
+      return `<a class="mark" href="#all_${moduleName}_${anchor}" id="all_${moduleName}_${anchor}"`;
     })
     // Prefix all in-page links with current module name
     .replace(/<a href="#(?!DEP[0-9]{4})([^"]+)"/g, (match, anchor) => {
-      return `<a href="#${moduleName}_${anchor}"`;
+      return `<a href="#all_${moduleName}_${anchor}"`;
     })
     // Update footnote id attributes on anchors
     .replace(/<a href="([^"]+)" id="(user-content-fn[^"]+)"/g, (match, href, id) => {
-      return `<a href="${href}" id="${moduleName}_${id}"`;
+      return `<a href="${href}" id="all_${moduleName}_${id}"`;
     })
     // Update footnote id attributes on list items
-    .replace(/<(\S+) id="(user-content-fn-\d+)"/g, (match, tagName, id) => {
-      return `<${tagName} id="${moduleName}_${id}"`;
+    .replace(/<(\S+) id="(user-content-fn[^"]+)"/g, (match, tagName, id) => {
+      return `<${tagName} id="all_${moduleName}_${id}"`;
     })
     // Prefix all links to other docs modules with those module names
     .replace(/<a href="((\w[^#"]*)\.html)#/g, (match, href, linkModule) => {
       if (!htmlFiles.includes(href)) return match;
-      return `<a href="#${linkModule}_`;
+      return `<a href="#all_${linkModule}_`;
     })
     .trim() + '\n';
 


### PR DESCRIPTION
In all.html, we currently generate hundreds of duplicate id attributes
because of conflicts between the way allhtml.mjs prefixes in-page links
with the module name on the one hand, and the existence of legacy id
attributes hardcoded into the page on the other hand.

This prefaces the module name with `all_` to avoid the conflicts.



<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
