### PR TITLE
tools: use {N} for spaces in regex

### DIFF
--- a/tools/find-inactive-collaborators.mjs
+++ b/tools/find-inactive-collaborators.mjs
@@ -49,7 +49,7 @@ const authors = await runGitCommand(
 // Get all approving reviewers of landed commits during the time period.
 const approvingReviewers = await runGitCommand(
   `git log --since="${SINCE}" | egrep "^    Reviewed-By: "`,
-  (line) => /^    Reviewed-By: ([^<]+)/.exec(line)[1].trim()
+  (line) => /^ {4}Reviewed-By: ([^<]+)/.exec(line)[1].trim()
 );
 
 async function getCollaboratorsFromReadme() {
@@ -72,7 +72,7 @@ async function getCollaboratorsFromReadme() {
       foundCollaboratorHeading = true;
     }
     if (line.startsWith('  **') && isCollaborator) {
-      const [, name, email] = /^  \*\*([^*]+)\*\* <<(.+)>>/.exec(line);
+      const [, name, email] = /^ {2}\*\*([^*]+)\*\* <<(.+)>>/.exec(line);
       const mailmap = await runGitCommand(
         `git check-mailmap '${name} <${email}>'`
       );
@@ -136,7 +136,7 @@ async function moveCollaboratorToEmeritus(peopleToMove) {
       if (line.startsWith('* ')) {
         collaboratorFirstLine = line;
       } else if (line.startsWith('  **')) {
-        const [, name, email] = /^  \*\*([^*]+)\*\* <<(.+)>>/.exec(line);
+        const [, name, email] = /^ {2}\*\*([^*]+)\*\* <<(.+)>>/.exec(line);
         if (peopleToMove.some((entry) => {
           return entry.name === name && entry.email === email;
         })) {


### PR DESCRIPTION
Spaces are hard to count. Use {N} notation to indicate how many spaces
in regular expressions in find-inactive-collaborators.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
