### PR TITLE
lib: faster event listening

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  ArrayFrom,
   ArrayPrototypeIndexOf,
   ArrayPrototypeJoin,
   ArrayPrototypeShift,
@@ -53,8 +54,7 @@ const {
 } = primordials;
 const kRejection = SymbolFor('nodejs.rejection');
 const { inspect } = require('internal/util/inspect');
-
-let spliceOne;
+const getMappedLinkedList = require('internal/mapped_linkedlist');
 
 const {
   AbortError,
@@ -526,8 +526,8 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
       addCatch(this, result, type, args);
     }
   } else {
-    const len = handler.length;
-    const listeners = arrayClone(handler);
+    const listeners = ArrayFrom(handler);
+    const len = listeners.length;
     for (let i = 0; i < len; ++i) {
       const result = listeners[i].apply(this, args);
 
@@ -544,6 +544,10 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
 
   return true;
 };
+
+function getRealListener(listener) {
+  return listener.listener || listener;
+}
 
 function _addListener(target, type, listener, prepend) {
   let m;
@@ -575,12 +579,10 @@ function _addListener(target, type, listener, prepend) {
     events[type] = listener;
     ++target._eventsCount;
   } else {
-    if (typeof existing === 'function') {
-      // Adding the second element, need to change to array.
+    if (typeof existing === 'function')
       existing = events[type] =
-        prepend ? [listener, existing] : [existing, listener];
-      // If we've already got an array, just append.
-    } else if (prepend) {
+        getMappedLinkedList(getRealListener).push(existing);
+    if (prepend) {
       existing.unshift(listener);
     } else {
       existing.push(listener);
@@ -703,32 +705,16 @@ EventEmitter.prototype.removeListener =
           if (events.removeListener)
             this.emit('removeListener', type, list.listener || listener);
         }
-      } else if (typeof list !== 'function') {
-        let position = -1;
-
-        for (let i = list.length - 1; i >= 0; i--) {
-          if (list[i] === listener || list[i].listener === listener) {
-            position = i;
-            break;
-          }
+      } else if (typeof list !== 'function' && list?.remove(listener)) {
+        if (list.length === 0) {
+          delete events[type];
+          if (--this._eventsCount === 0)
+            this._events = ObjectCreate(null);
+        } else if (list.length === 1) {
+          events[type] = list.first;
         }
-
-        if (position < 0)
-          return this;
-
-        if (position === 0)
-          list.shift();
-        else {
-          if (spliceOne === undefined)
-            spliceOne = require('internal/util').spliceOne;
-          spliceOne(list, position);
-        }
-
-        if (list.length === 1)
-          events[type] = list[0];
-
         if (events.removeListener !== undefined)
-          this.emit('removeListener', type, listener);
+          this.emit('removeListener', type, getRealListener(listener));
       }
 
       return this;
@@ -781,8 +767,8 @@ EventEmitter.prototype.removeAllListeners =
         this.removeListener(type, listeners);
       } else if (listeners !== undefined) {
         // LIFO order
-        for (let i = listeners.length - 1; i >= 0; i--) {
-          this.removeListener(type, listeners[i]);
+        for (const listener of listeners.reverseIterator()) {
+          this.removeListener(type, listener);
         }
       }
 
@@ -800,10 +786,12 @@ function _listeners(target, type, unwrap) {
     return [];
 
   if (typeof evlistener === 'function')
-    return unwrap ? [evlistener.listener || evlistener] : [evlistener];
+    return unwrap ? [getRealListener(evlistener)] : [evlistener];
 
-  return unwrap ?
-    unwrapListeners(evlistener) : arrayClone(evlistener);
+  return ArrayFrom(unwrap ?
+    unwrapListeners(evlistener) :
+    evlistener,
+  );
 }
 
 /**
@@ -874,27 +862,10 @@ EventEmitter.prototype.eventNames = function eventNames() {
   return this._eventsCount > 0 ? ReflectOwnKeys(this._events) : [];
 };
 
-function arrayClone(arr) {
-  // At least since V8 8.3, this implementation is faster than the previous
-  // which always used a simple for-loop
-  switch (arr.length) {
-    case 2: return [arr[0], arr[1]];
-    case 3: return [arr[0], arr[1], arr[2]];
-    case 4: return [arr[0], arr[1], arr[2], arr[3]];
-    case 5: return [arr[0], arr[1], arr[2], arr[3], arr[4]];
-    case 6: return [arr[0], arr[1], arr[2], arr[3], arr[4], arr[5]];
+function *unwrapListeners(listeners) {
+  for (const item of listeners) {
+    yield typeof item.listener === 'function' ? item.listener : item;
   }
-  return ArrayPrototypeSlice(arr);
-}
-
-function unwrapListeners(arr) {
-  const ret = arrayClone(arr);
-  for (let i = 0; i < ret.length; ++i) {
-    const orig = ret[i].listener;
-    if (typeof orig === 'function')
-      ret[i] = orig;
-  }
-  return ret;
 }
 
 /**

--- a/lib/internal/mapped_linkedlist.js
+++ b/lib/internal/mapped_linkedlist.js
@@ -33,11 +33,14 @@ function unshift(root, value) {
   return node;
 }
 
-function shift(root) {
-  if (root.first) {
-    const { value } = root.first;
-    root.first = root.first.next;
+function pop(root) {
+  if (root.last) {
+    const { value } = root.last;
+    root.last = root.last.previous;
     root.length--;
+    if (!root.last) {
+      root.first = root.last;
+    }
     return value;
   }
 }
@@ -100,7 +103,7 @@ function getMappedLinkedList(getKey = (value) => value) {
       const key = getKey(value);
       const refs = map.get(key);
       if (refs) {
-        const result = shift(refs);
+        const result = pop(refs);
         if (result.previous) {
           result.previous.next = result.next;
         }

--- a/lib/internal/mapped_linkedlist.js
+++ b/lib/internal/mapped_linkedlist.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const {
+  Map,
+  SymbolIterator,
+} = primordials;
+
+function push(root, value) {
+  const node = { value };
+  if (root.last) {
+    node.previous = root.last;
+    root.last.next = node;
+  } else {
+    root.first = node;
+  }
+  root.last = node;
+  root.length++;
+
+  return node;
+}
+
+function unshift(root, value) {
+  const node = { value };
+  if (root.first) {
+    node.next = root.first;
+    root.first.previous = node;
+  } else {
+    root.last = node;
+  }
+  root.first = node;
+  root.length++;
+
+  return node;
+}
+
+function shift(root) {
+  if (root.first) {
+    const { value } = root.first;
+    root.first = root.first.next;
+    root.length--;
+    return value;
+  }
+}
+
+function getIterator(root, initialProperty, nextProperty) {
+  let node = root[initialProperty];
+
+  return {
+    next() {
+      if (!node) {
+        return { done: true };
+      }
+      const result = {
+        done: false,
+        value: node.value,
+      };
+      node = node[nextProperty];
+      return result;
+    },
+    [SymbolIterator]() {
+      return this;
+    }
+  };
+}
+
+
+function getMappedLinkedList(getKey = (value) => value) {
+  const map = new Map();
+  function addToMap(value, node, operation) {
+    const key = getKey(value);
+    let refs = map.get(key);
+    if (!refs) {
+      map.set(key, refs = { length: 0 });
+    }
+    operation(refs, node);
+  }
+  const root = { length: 0 };
+
+  return {
+    root,
+    get length() {
+      return root.length;
+    },
+    get first() {
+      return root.first?.value;
+    },
+    push(value) {
+      const node = push(root, value);
+      addToMap(value, node, push);
+
+      return this;
+    },
+    unshift(value) {
+      const node = unshift(root, value);
+      addToMap(value, node, unshift);
+
+      return this;
+    },
+    remove(value) {
+      const key = getKey(value);
+      const refs = map.get(key);
+      if (refs) {
+        const result = shift(refs);
+        if (result.previous) {
+          result.previous.next = result.next;
+        }
+        if (result === root.last) {
+          root.last = result.previous || result.next;
+        }
+        if (result.next) {
+          result.next.previous = result.previous;
+        }
+        if (result === root.first) {
+          root.first = result.next || result.previous;
+        }
+        if (refs.length === 0) {
+          map.delete(key);
+        }
+        root.length--;
+        return 1;
+      }
+      return 0;
+    },
+    [SymbolIterator]() {
+      return getIterator(root, 'first', 'next');
+    },
+    reverseIterator() {
+      return getIterator(root, 'last', 'previous');
+    },
+  };
+}
+
+module.exports = getMappedLinkedList;

--- a/lib/internal/streams/legacy.js
+++ b/lib/internal/streams/legacy.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const {
-  ArrayIsArray,
   ObjectSetPrototypeOf,
 } = primordials;
 
 const EE = require('events');
+const getMappedLinkedList = require('internal/mapped_linkedlist');
 
 function Stream(opts) {
   EE.call(this, opts);
@@ -105,10 +105,12 @@ function prependListener(emitter, event, fn) {
   // the prependListener() method. The goal is to eventually remove this hack.
   if (!emitter._events || !emitter._events[event])
     emitter.on(event, fn);
-  else if (ArrayIsArray(emitter._events[event]))
+  else if (typeof emitter._events[event] === 'function') {
+    const previous = emitter._events[event];
+    emitter._events[event] = getMappedLinkedList((l) => l.listener || l)
+      .push(fn).push(previous);
+  } else
     emitter._events[event].unshift(fn);
-  else
-    emitter._events[event] = [fn, emitter._events[event]];
 }
 
 module.exports = { Stream, prependListener };

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -64,6 +64,7 @@ const expectedModules = new Set([
   'NativeModule internal/histogram',
   'NativeModule internal/idna',
   'NativeModule internal/linkedlist',
+  'NativeModule internal/mapped_linkedlist',
   'NativeModule internal/modules/run_main',
   'NativeModule internal/modules/package_json_reader',
   'NativeModule internal/modules/cjs/helpers',

--- a/test/parallel/test-event-emitter-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-listeners-side-effects.js
@@ -47,10 +47,10 @@ e.listeners('bar');
 e.on('foo', assert.ok);
 fl = e.listeners('foo');
 
-assert(Array.isArray(e._events.foo));
-assert.strictEqual(e._events.foo.length, 2);
-assert.strictEqual(e._events.foo[0], assert.fail);
-assert.strictEqual(e._events.foo[1], assert.ok);
+const arr = Array.from(e._events.foo);
+assert.strictEqual(arr.length, 2);
+assert.strictEqual(arr[0], assert.fail);
+assert.strictEqual(arr[1], assert.ok);
 
 assert(Array.isArray(fl));
 assert.strictEqual(fl.length, 2);

--- a/test/parallel/test-http-req-close-robust-from-tampering.js
+++ b/test/parallel/test-http-req-close-robust-from-tampering.js
@@ -7,7 +7,9 @@ const { connect } = require('net');
 // cause an error.
 
 const server = createServer(common.mustCall((req, res) => {
-  req.client._events.close.forEach((fn) => { fn.bind(req)(); });
+  for (const fn of req.client._events.close) {
+    fn.apply(req);
+  }
 }));
 
 server.unref();


### PR DESCRIPTION
The current EventEmitter uses arrays to control multiple listeners,
but that means that prependListener and removeListeners operations
have an O(N) time complexity. With this change, instead of an array
we use a map + a linked list (to preserve execution order), which
gives an O(1) time complexity for those operations. This will be
especially helpful in scenarios where we have many listeners to
the same event.

**BREAKING CHANGE**: I don't know how much this is a breaking change,
because if someone is using the _events property, I think it is bad
usage that has no guarantees to keep working. Regardless, the _events
property will no longer be a function or an array, but a function
or a "MappedLinkedList". Some of the operations from the array are
present, though, like [Symbol.iterator], unshift and push, making
it possible to adapt some code that is arbritary using it

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
