### PR TITLE
tools: improve section tag additions in HTML doc generator

### DIFF
--- a/tools/doc/html.mjs
+++ b/tools/doc/html.mjs
@@ -73,10 +73,14 @@ function processContent(content) {
   }
   // `++level` to convert the string to a number and increment it.
   content = content.replace(/(?<=<\/?h)[1-5](?=[^<>]*>)/g, (level) => ++level);
-  // Wrap h3 tags in section tags.
+  // Wrap h3 tags in section tags unless they are immediately preceded by a
+  // section tag. The latter happens when GFM footnotes are generated. We don't
+  // want to add another section tag to the footnotes section at the end of the
+  // document because that will result in an empty section element. While not an
+  // HTML error, it's enough for validator.w3.org to print a warning.
   let firstTime = true;
   return content
-    .replace(/<h3/g, (heading) => {
+    .replace(/(?<!<section [^>]+>)<h3/g, (heading) => {
       if (firstTime) {
         firstTime = false;
         return '<section>' + heading;


### PR DESCRIPTION
There is an edge case involving GFM footnotes where our current code
adds an empty section which results in a warning (but not an error) in
HTML validators. This change causes the HTML generator to skip the
unnecessary addition of a section tag in that one edge case.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
