### PR TITLE
tools: remove conditional assignment in custom ESLint rule

### DIFF
--- a/tools/eslint-rules/no-duplicate-requires.js
+++ b/tools/eslint-rules/no-duplicate-requires.js
@@ -10,18 +10,19 @@ const { isRequireCall, isString } = require('./rules-utils.js');
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const secondLevelTypes = [
+  'FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression',
+  'ClassBody', 'MethodDefinition',
+];
 
 function isTopLevel(node) {
-  do {
-    if (node.type === 'FunctionDeclaration' ||
-        node.type === 'FunctionExpression' ||
-        node.type === 'ArrowFunctionExpression' ||
-        node.type === 'ClassBody' ||
-        node.type === 'MethodDefinition') {
-      return false;
+  while (!secondLevelTypes.includes(node.type)) {
+    node = node.parent;
+    if (!node) {
+      return true;
     }
-  } while (node = node.parent);
-  return true;
+  }
+  return false;
 }
 
 module.exports = (context) => {


### PR DESCRIPTION
These changes no-duplicate-require.js so that it doesn't use an
assignment in a conditional, which can be easy to misread as a
comparison rather than an assignment. It also means we change a do/while
(which we don't use much in our code) to the much more common while
construct.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
