### PR TITLE
test: improve expectWarning error message

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -549,7 +549,11 @@ function _expectWarning(name, expected, code) {
     expected.forEach(([_, code]) => assert(code, expected));
   }
   return mustCall((warning) => {
-    const [ message, code ] = expected.shift();
+    const expectedProperties = expected.shift();
+    if (!expectedProperties) {
+      assert.fail(`Unexpected extra warning received: ${warning}`);
+    }
+    const [ message, code ] = expectedProperties;
     assert.strictEqual(warning.name, name);
     if (typeof message === 'string') {
       assert.strictEqual(warning.message, message);

--- a/test/parallel/test-common-expect-warning.js
+++ b/test/parallel/test-common-expect-warning.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { spawn } = require('child_process');
+
+if (process.argv[2] !== 'child') {
+  // Expected error not emitted.
+  {
+    const child = spawn(
+      process.execPath, [__filename, 'child', 0], { encoding: 'utf8' }
+    );
+    child.on('exit', common.mustCall((status) => {
+      assert.notStrictEqual(status, 0);
+    }));
+  }
+
+  // Expected error emitted.
+  {
+    const child = spawn(
+      process.execPath, [__filename, 'child', 1], { encoding: 'utf8' }
+    );
+    child.on('exit', common.mustCall((status) => {
+      assert.strictEqual(status, 0);
+    }));
+  }
+
+  // Expected error emitted too many times.
+  {
+    const child = spawn(
+      process.execPath, [__filename, 'child', 2], { encoding: 'utf8' }
+    );
+    child.stderr.setEncoding('utf8');
+
+    let stderr = '';
+    child.stderr.on('data', (data) => {
+      stderr += data;
+    });
+    child.on('exit', common.mustCall((status) => {
+      assert.notStrictEqual(status, 0);
+      assert.match(stderr, /Unexpected extra warning received/);
+    }));
+  }
+} else {
+  const iterations = +process.argv[3];
+  common.expectWarning('fhqwhgads', 'fhqwhgads', 'fhqwhgads');
+  for (let i = 0; i < iterations; i++) {
+    process.emitWarning('fhqwhgads', 'fhqwhgads', 'fhqwhgads');
+  }
+}


### PR DESCRIPTION
expectWarning() fails with a TypeError and a message about undefined not
being iterable when the warning is emitted more times than expected.
This change produces a more useful error message.

Refs: https://github.com/nodejs/node/pull/41307/files#r775197738

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
