### PR TITLE
test: use spawnSync() full name

### DIFF
--- a/test/parallel/test-cli-bad-options.js
+++ b/test/parallel/test-cli-bad-options.js
@@ -4,7 +4,7 @@ require('../common');
 // Tests that node exits consistently on bad option syntax.
 
 const assert = require('assert');
-const spawn = require('child_process').spawnSync;
+const { spawnSync } = require('child_process');
 
 if (process.features.inspector) {
   requiresArgument('--inspect-port');
@@ -15,7 +15,7 @@ if (process.features.inspector) {
 requiresArgument('--eval');
 
 function requiresArgument(option) {
-  const r = spawn(process.execPath, [option], { encoding: 'utf8' });
+  const r = spawnSync(process.execPath, [option], { encoding: 'utf8' });
 
   assert.strictEqual(r.status, 9);
 


### PR DESCRIPTION
test-cli-bad-options.js uses `spawnSync()` but renames it as `spawn()`
which caused me a bit of confusion for a bit until I realized what was
going on. Rename the variable `spawnSync()` for
readability/maintainability.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
