### PR TITLE
test: use spawnSync() full name in test-stdio-pipe-stderr

### DIFF
--- a/test/parallel/test-stdio-pipe-stderr.js
+++ b/test/parallel/test-stdio-pipe-stderr.js
@@ -4,7 +4,7 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
 const join = require('path').join;
-const spawn = require('child_process').spawnSync;
+const { spawnSync } = require('child_process');
 
 // Test that invoking node with require, and piping stderr to file,
 // does not result in exception,
@@ -21,7 +21,7 @@ const stream = fs.createWriteStream(stderrOutputPath);
 fs.writeFileSync(fakeModulePath, '', 'utf8');
 
 stream.on('open', () => {
-  spawn(process.execPath, {
+  spawnSync(process.execPath, {
     input: `require("${fakeModulePath.replace(/\\/g, '/')}")`,
     stdio: ['pipe', 'pipe', stream]
   });


### PR DESCRIPTION
test-stdio-pipe-stderr uses `spawnSync()` but renames it as `spawn()`
which can be confusing. Rename it to `spawnSync()` for
readability/maintainability.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
