### PR TITLE
http,tools: JSDoc comments for HTTPRequestOptions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -350,7 +350,6 @@ module.exports = {
     'jsdoc/require-param': 'off',
     'jsdoc/check-tag-names': 'off',
     'jsdoc/require-returns': 'off',
-    'jsdoc/require-property-description': 'off',
 
     // Custom rules from eslint-plugin-node-core
     'node-core/no-unescaped-regexp-dot': 'error',

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3091,20 +3091,19 @@ changes:
   * `method` {string} A string specifying the HTTP request method. **Default:**
     `'GET'`.
   * `path` {string} Request path. Should include query string if any.
-    E.G. `'/index.html?page=12'`. An exception is thrown when the request path
-    contains illegal characters. Currently, only spaces are rejected but that
-    may change in the future. **Default:** `'/'`.
+    An exception is thrown when the request path contains spaces. **Default:**
+    `'/'`.
   * `port` {number} Port of remote server. **Default:** `defaultPort` if set,
     else `80`.
   * `protocol` {string} Protocol to use. **Default:** `'http:'`.
   * `setHost` {boolean}: Specifies whether or not to automatically add the
-    `Host` header. Defaults to `true`.
+    `Host` header. **Default:** `true`.
   * `socketPath` {string} Unix domain socket. Cannot be used if one of `host`
     or `port` is specified, as those specify a TCP Socket.
   * `timeout` {number}: A number specifying the socket timeout in milliseconds.
     This will set the timeout before the socket is connected.
-  * `signal` {AbortSignal}: An AbortSignal that may be used to abort an ongoing
-    request.
+  * `signal` {AbortSignal}: An `AbortSignal` that may be used to abort an
+    ongoing request.
 * `callback` {Function}
 * Returns: {http.ClientRequest}
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3099,7 +3099,7 @@ changes:
   * `setHost` {boolean}: Specifies whether or not to automatically add the
     `Host` header. **Default:** `true`.
   * `socketPath` {string} Unix domain socket. Cannot be used if one of `host`
-    or `port` is specified, as those specify a TCP Socket.
+    or `port` is specified, as those specify a TCP socket.
   * `timeout` {number}: A number specifying the socket timeout in milliseconds.
     This will set the timeout before the socket is connected.
   * `signal` {AbortSignal}: An `AbortSignal` that may be used to abort an

--- a/lib/http.js
+++ b/lib/http.js
@@ -137,7 +137,7 @@ function get(url, options, cb) {
   req.end();
   return req;
 }
-get('foo', {agent})
+
 module.exports = {
   _connectionListener,
   METHODS: ArrayPrototypeSort(ArrayPrototypeSlice(methods)),

--- a/lib/http.js
+++ b/lib/http.js
@@ -58,7 +58,7 @@ let maxHeaderSize;
 function createServer(opts, requestListener) {
   return new Server(opts, requestListener);
 }
-get('foo', { c})
+
 /**
  * @typedef {object} HTTPRequestOptions
  * @property {httpAgent.Agent | boolean} [agent] Controls `Agent` behavior.

--- a/lib/http.js
+++ b/lib/http.js
@@ -63,9 +63,9 @@ function createServer(opts, requestListener) {
  * @typedef {object} HTTPRequestOptions
  * @property {httpAgent.Agent | boolean} [agent] Controls `Agent` behavior.
  *   Possible values:
- *   * `undefined` (default): use `http.globalAgent` for this host and port.
- *   * `Agent` object: explicitly use the passed in `Agent`.
- *   * `false`: causes a new `Agent` with default values to be used.
+ *   - `undefined` (default): use `http.globalAgent` for this host and port.
+ *   - `Agent` object: explicitly use the passed in `Agent`.
+ *   - `false`: causes a new `Agent` with default values to be used.
  * @property {string} [auth] Basic authentication (`'user:password'`) to compute
  *   an Authorization header.
  * @property {Function} [createConnection] A function that produces a

--- a/lib/http.js
+++ b/lib/http.js
@@ -61,28 +61,39 @@ function createServer(opts, requestListener) {
 
 /**
  * @typedef {object} HTTPRequestOptions
- * @property {httpAgent.Agent | boolean} [agent]
- * @property {string} [auth]
- * @property {Function} [createConnection]
- * @property {number} [defaultPort]
- * @property {number} [family]
- * @property {object} [headers]
- * @property {number} [hints]
- * @property {string} [host]
- * @property {string} [hostname]
- * @property {boolean} [insecureHTTPParser]
- * @property {string} [localAddress]
- * @property {number} [localPort]
- * @property {Function} [lookup]
- * @property {number} [maxHeaderSize]
- * @property {string} [method]
- * @property {string} [path]
- * @property {number} [port]
- * @property {string} [protocol]
- * @property {boolean} [setHost]
- * @property {string} [socketPath]
- * @property {number} [timeout]
- * @property {AbortSignal} [signal]
+ * @property {httpAgent.Agent | boolean} [agent] Controls agent behavior.
+ * @property {string} [auth] Basic authentication ('user:password') to compute
+ * an Authorization header.
+ * @property {Function} [createConnection] A function that produces a
+ * socket/stream to use for the request when the `agent` option is not used.
+ * @property {number} [defaultPort] Default port for the protocol.
+ * @property {number} [family] IP address family to use when resolving host or
+ * hostname.
+ * @property {object} [headers] An object containing request headers.
+ * @property {number} [hints] Optional dns.lookup() hints.
+ * @property {string} [host] A domain name or IP address of the server to
+ * issue the request to.
+ * @property {string} [hostname] Alias for host.
+ * @property {boolean} [insecureHTTPParser] Use an insecure HTTP parser that
+ * accepts invalid HTTP headers when true.
+ * @property {string} [localAddress] Local interface to bind for network
+ * connections.
+ * @property {number} [localPort] Local port to connect from.
+ * @property {Function} [lookup] Custom lookup function.
+ * @property {number} [maxHeaderSize] Optionally overrides the value of
+ * --max-http-header-size (the maximum length of response headers in bytes) for
+ * responses received from the server.
+ * @property {string} [method] A string specifying the HTTP request method.
+ * @property {string} [path] Request path.
+ * @property {number} [port] Port of remote server.
+ * @property {string} [protocol] Protocol to use.
+ * @property {boolean} [setHost] Specifies whether or not to automatically add
+ * the Host header.
+ * @property {string} [socketPath] Unix domain socket.
+ * @property {number} [timeout] A number specifying the socket timeout in
+ * milliseconds.
+ * @property {AbortSignal} [signal] An AbortSignal that may be used to abort
+ * an ongoing request.
  */
 
 /**

--- a/lib/http.js
+++ b/lib/http.js
@@ -58,42 +58,60 @@ let maxHeaderSize;
 function createServer(opts, requestListener) {
   return new Server(opts, requestListener);
 }
-
+get('foo', { c})
 /**
  * @typedef {object} HTTPRequestOptions
- * @property {httpAgent.Agent | boolean} [agent] Controls agent behavior.
- * @property {string} [auth] Basic authentication ('user:password') to compute
- * an Authorization header.
+ * @property {httpAgent.Agent | boolean} [agent] Controls `Agent` behavior.
+ *   Possible values:
+ *   * `undefined` (default): use `http.globalAgent` for this host and port.
+ *   * `Agent` object: explicitly use the passed in `Agent`.
+ *   * `false`: causes a new `Agent` with default values to be used.
+ * @property {string} [auth] Basic authentication (`'user:password'`) to compute
+ *   an Authorization header.
  * @property {Function} [createConnection] A function that produces a
- * socket/stream to use for the request when the `agent` option is not used.
- * @property {number} [defaultPort] Default port for the protocol.
- * @property {number} [family] IP address family to use when resolving host or
- * hostname.
+ *   socket/stream to use for the request when the `agent` option is not used.
+ *   This can be used to avoid creating a custom `Agent` class just to override
+ *   the default `createConnection` function. See `agent.createConnection()` for
+ *   more details. Any `Duplex` stream is a valid return value.
+ * @property {number} [defaultPort] Default port for the protocol. **Default:**
+ *   `agent.defaultPort` if an `Agent` is used, else `undefined`.
+ * @property {number} [family] IP address family to use when resolving `host` or
+ *   `hostname`. Valid values are `4` or `6`. When unspecified, both IP v4 and
+ *   v6 will be used.
  * @property {object} [headers] An object containing request headers.
- * @property {number} [hints] Optional dns.lookup() hints.
+ * @property {number} [hints] Optional `dns.lookup()` hints.
  * @property {string} [host] A domain name or IP address of the server to
- * issue the request to.
- * @property {string} [hostname] Alias for host.
+ *   issue the request to. **Default:** `'localhost'`.
+ * @property {string} [hostname] Alias for `host`. To support `url.parse()`,
+ *   `hostname` will be used if both `host` and `hostname` are specified.
  * @property {boolean} [insecureHTTPParser] Use an insecure HTTP parser that
- * accepts invalid HTTP headers when true.
+ *   accepts invalid HTTP headers when `true`. Using the insecure parser should
+ *   be avoided. See `--insecure-http-parser` for more information. **Default:**
+ *   `false`
  * @property {string} [localAddress] Local interface to bind for network
- * connections.
+ *   connections.
  * @property {number} [localPort] Local port to connect from.
- * @property {Function} [lookup] Custom lookup function.
+ * @property {Function} [lookup] Custom lookup function. **Default:**
+ *   `dns.lookup()`.
  * @property {number} [maxHeaderSize] Optionally overrides the value of
- * --max-http-header-size (the maximum length of response headers in bytes) for
- * responses received from the server.
+ *   `--max-http-header-size` (the maximum length of response headers in
+ *   bytes) for responses received from the server. **Default:** 16384 (16 KB).
  * @property {string} [method] A string specifying the HTTP request method.
- * @property {string} [path] Request path.
- * @property {number} [port] Port of remote server.
- * @property {string} [protocol] Protocol to use.
+ *   **Default:** `'GET'`.
+ * @property {string} [path] Request path. Should include query string if any.
+ *   An exception is thrown when the request path contains spaces. **Default:**
+ *   `'/'`.
+ * @property {number} [port] Port of remote server. **Default:** `defaultPort`
+ *   if set, else `80`.
+ * @property {string} [protocol] Protocol to use. **Default:** `'http:'`.
  * @property {boolean} [setHost] Specifies whether or not to automatically add
- * the Host header.
- * @property {string} [socketPath] Unix domain socket.
+ *   the `Host` header. **Default:** `true`.
+ * @property {string} [socketPath] Unix domain socket. Cannot be used if one of
+ *   `host` or `port` is specified, as those specify a TCP Socket.
  * @property {number} [timeout] A number specifying the socket timeout in
- * milliseconds.
- * @property {AbortSignal} [signal] An AbortSignal that may be used to abort
- * an ongoing request.
+ *   milliseconds. This will set the timeout before the socket is connected.
+ * @property {AbortSignal} [signal] An `AbortSignal` that may be used to abort
+ *   an ongoing request.
  */
 
 /**
@@ -119,7 +137,7 @@ function get(url, options, cb) {
   req.end();
   return req;
 }
-
+get('foo', {agent})
 module.exports = {
   _connectionListener,
   METHODS: ArrayPrototypeSort(ArrayPrototypeSlice(methods)),

--- a/lib/http.js
+++ b/lib/http.js
@@ -107,7 +107,7 @@ get('foo', { c})
  * @property {boolean} [setHost] Specifies whether or not to automatically add
  *   the `Host` header. **Default:** `true`.
  * @property {string} [socketPath] Unix domain socket. Cannot be used if one of
- *   `host` or `port` is specified, as those specify a TCP Socket.
+ *   `host` or `port` is specified, as those specify a TCP socket.
  * @property {number} [timeout] A number specifying the socket timeout in
  *   milliseconds. This will set the timeout before the socket is connected.
  * @property {AbortSignal} [signal] An `AbortSignal` that may be used to abort


### PR DESCRIPTION
Applying the markdown doc information to the JSDoc comments, and enabling a lint rule requiring property descriptions in JSDoc comments.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
