### PR TITLE
fs: use streaming directory processing in cp()

### DIFF
--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -32,7 +32,7 @@ const {
   existsSync,
   lstatSync,
   mkdirSync,
-  readdirSync,
+  opendirSync,
   readlinkSync,
   statSync,
   symlinkSync,
@@ -275,14 +275,22 @@ function mkDirAndCopy(srcMode, src, dest, opts) {
 }
 
 function copyDir(src, dest, opts) {
-  readdirSync(src).forEach((item) => copyDirItem(item, src, dest, opts));
-}
+  const dir = opendirSync(src);
 
-function copyDirItem(item, src, dest, opts) {
-  const srcItem = join(src, item);
-  const destItem = join(dest, item);
-  const { destStat } = checkPathsSync(srcItem, destItem, opts);
-  return startCopy(destStat, srcItem, destItem, opts);
+  try {
+    let dirent;
+
+    while ((dirent = dir.readSync()) !== null) {
+      const { name } = dirent;
+      const srcItem = join(src, name);
+      const destItem = join(dest, name);
+      const { destStat } = checkPathsSync(srcItem, destItem, opts);
+
+      startCopy(destStat, srcItem, destItem, opts);
+    }
+  } finally {
+    dir.closeSync();
+  }
 }
 
 function onLink(destStat, src, dest) {

--- a/lib/internal/fs/cp/cp.js
+++ b/lib/internal/fs/cp/cp.js
@@ -41,7 +41,7 @@ const {
   copyFile,
   lstat,
   mkdir,
-  readdir,
+  opendir,
   readlink,
   stat,
   symlink,
@@ -325,11 +325,12 @@ async function mkDirAndCopy(srcMode, src, dest, opts) {
 }
 
 async function copyDir(src, dest, opts) {
-  const dir = await readdir(src);
-  for (let i = 0; i < dir.length; i++) {
-    const item = dir[i];
-    const srcItem = join(src, item);
-    const destItem = join(dest, item);
+  const dir = await opendir(src);
+
+  for await (const dirent of dir) {
+    const { name } = dirent;
+    const srcItem = join(src, name);
+    const destItem = join(dest, name);
     const { destStat } = await checkPaths(srcItem, destItem, opts);
     await startCopy(destStat, srcItem, destItem, opts);
   }

--- a/lib/internal/fs/cp/cp.js
+++ b/lib/internal/fs/cp/cp.js
@@ -327,8 +327,7 @@ async function mkDirAndCopy(srcMode, src, dest, opts) {
 async function copyDir(src, dest, opts) {
   const dir = await opendir(src);
 
-  for await (const dirent of dir) {
-    const { name } = dirent;
+  for await (const { name } of dir) {
     const srcItem = join(src, name);
     const destItem = join(dest, name);
     const { destStat } = await checkPaths(srcItem, destItem, opts);


### PR DESCRIPTION
The `readdir()` functions do not scale well, which is why `opendir()`, etc. were introduced. This is exacerbated in the current `cp()` implementation, which calls `readdir()` recursively.

This commit updates `cp()` to use the `opendir()` style iteration.