### PR TITLE
http: correct JSDoc declaration of parameter with properties

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -46,12 +46,11 @@ let maxHeaderSize;
 
 /**
  * Returns a new instance of `http.Server`.
- * @param {{
- *   IncomingMessage?: IncomingMessage;
- *   ServerResponse?: ServerResponse;
- *   insecureHTTPParser?: boolean;
- *   maxHeaderSize?: number;
- *   }} [opts]
+ * @param {Object} [opts]
+ * @param {IncomingMessage} [opts.IncomingMessage]
+ * @param {ServerResponse} [opts.ServerResponse]
+ * @param {boolean} [opts.insecureHTTPParser]
+ * @param {number} [opts.maxHeaderSize]
  * @param {Function} [requestListener]
  * @returns {Server}
  */

--- a/lib/http.js
+++ b/lib/http.js
@@ -46,7 +46,7 @@ let maxHeaderSize;
 
 /**
  * Returns a new instance of `http.Server`.
- * @param {Object} [opts]
+ * @param {object} [opts]
  * @param {IncomingMessage} [opts.IncomingMessage]
  * @param {ServerResponse} [opts.ServerResponse]
  * @param {boolean} [opts.insecureHTTPParser]


### PR DESCRIPTION
Use JSDoc declaration of parameter with properties as described in
https://jsdoc.app/tags-param.html#parameters-with-properties.

(I discoverecd this problem while experimenting with a tool to generate
markdown documentation from JSDoc comments. It did not recognize the
question mark and after looking around, it appears to be non-standard.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
