### PR TITLE
tools: remove last of error-masking in commit-queue.sh

### DIFF
--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -83,10 +83,14 @@ for pr in "$@"; do
   else
     # If there's only one commit, we can use the Squash and Merge feature from GitHub.
     # TODO: use `gh pr merge` when the GitHub CLI allows to customize the commit title (https://github.com/cli/cli/issues/1023).
+    commit_title=$(git log -1 --pretty='format:%s')
+    commit_body=$(git log -1 --pretty='format:%b')
+    commit_head=$(grep 'Fetched commits as' output | cut -d. -f3 | xargs git rev-parse)
+ 
     jq -n \
-      --arg title "$(git log -1 --pretty='format:%s')" \
-      --arg body "$(git log -1 --pretty='format:%b')" \
-      --arg head "$(grep 'Fetched commits as' output | cut -d. -f3 | xargs git rev-parse)" \
+      --arg title "${commit_title}" \
+      --arg body "${commit_body}" \
+      --arg head "${commit_head}" \
       '{merge_method:"squash",commit_title:$title,commit_message:$body,sha:$head}' > output.json
     cat output.json
     if ! gh api -X PUT "repos/${OWNER}/${REPOSITORY}/pulls/${pr}/merge" --input output.json > output; then


### PR DESCRIPTION
Remove the lats of the unintentional error-masking in commit-queue.sh.

With this change, `tools/lint-sh.js . --from-npx` at last passes.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
