### PR TITLE
build: include v8-fast-api-calls.h in bundle

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -188,6 +188,7 @@ def headers(action):
       'deps/v8/include/v8-exception.h',
       'deps/v8/include/v8-extension.h',
       'deps/v8/include/v8-external.h',
+      'deps/v8/include/v8-fast-api-calls.h',
       'deps/v8/include/v8-forward.h',
       'deps/v8/include/v8-function-callback.h',
       'deps/v8/include/v8-function.h',


### PR DESCRIPTION
This API is still experimental, but it's not really possible to experiment with it without this header.

I don't know if this is the only file that needs to be changed. I don't think I have a way to test this PR.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
