### PR TITLE
webstreams: clean after the cancel algorithm of readablestream throw error

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1911,9 +1911,12 @@ function readableStreamDefaultControllerError(controller, error) {
 
 function readableStreamDefaultControllerCancelSteps(controller, reason) {
   resetQueue(controller);
-  const result = controller[kState].cancelAlgorithm(reason);
-  readableStreamDefaultControllerClearAlgorithms(controller);
-  return result;
+  try {
+    const result = controller[kState].cancelAlgorithm(reason);
+    return result;
+  } finally {
+    readableStreamDefaultControllerClearAlgorithms(controller);
+  }
 }
 
 function readableStreamDefaultControllerPullSteps(controller, readRequest) {

--- a/test/parallel/test-whatwg-readablestream.js
+++ b/test/parallel/test-whatwg-readablestream.js
@@ -81,6 +81,36 @@ const {
 }
 
 {
+  // Throw error and return rejected promise in `cancel()` method
+  // would execute same cleanup code
+  const r1 = new ReadableStream({
+    cancel: () => {
+      return Promise.reject('Cancel Error');
+    },
+  });
+  r1.cancel().finally(common.mustCall(() => {
+    const controllerState = r1[kState].controller[kState];
+
+    assert.deepEqual(controllerState.pullAlgorithm, undefined)
+    assert.deepEqual(controllerState.cancelAlgorithm, undefined)
+    assert.deepEqual(controllerState.sizeAlgorithm, undefined)
+  })).catch(() => {});
+
+  const r2 = new ReadableStream({
+    cancel() {
+      throw Error('Cancel Error');
+    }
+  });
+  r2.cancel().finally(common.mustCall(() => {
+    const controllerState = r2[kState].controller[kState];
+
+    assert.deepEqual(controllerState.pullAlgorithm, undefined)
+    assert.deepEqual(controllerState.cancelAlgorithm, undefined)
+    assert.deepEqual(controllerState.sizeAlgorithm, undefined)
+  })).catch(() => {});
+}
+
+{
   const source = {
     start: common.mustCall((controller) => {
       assert(controller instanceof ReadableStreamDefaultController);

--- a/test/parallel/test-whatwg-readablestream.js
+++ b/test/parallel/test-whatwg-readablestream.js
@@ -91,22 +91,22 @@ const {
   r1.cancel().finally(common.mustCall(() => {
     const controllerState = r1[kState].controller[kState];
 
-    assert.deepEqual(controllerState.pullAlgorithm, undefined)
-    assert.deepEqual(controllerState.cancelAlgorithm, undefined)
-    assert.deepEqual(controllerState.sizeAlgorithm, undefined)
+    assert.strictEqual(controllerState.pullAlgorithm, undefined);
+    assert.strictEqual(controllerState.cancelAlgorithm, undefined);
+    assert.strictEqual(controllerState.sizeAlgorithm, undefined);
   })).catch(() => {});
 
   const r2 = new ReadableStream({
     cancel() {
-      throw Error('Cancel Error');
+      throw new Error('Cancel Error');
     }
   });
   r2.cancel().finally(common.mustCall(() => {
     const controllerState = r2[kState].controller[kState];
 
-    assert.deepEqual(controllerState.pullAlgorithm, undefined)
-    assert.deepEqual(controllerState.cancelAlgorithm, undefined)
-    assert.deepEqual(controllerState.sizeAlgorithm, undefined)
+    assert.strictEqual(controllerState.pullAlgorithm, undefined);
+    assert.strictEqual(controllerState.cancelAlgorithm, undefined);
+    assert.strictEqual(controllerState.sizeAlgorithm, undefined);
   })).catch(() => {});
 }
 


### PR DESCRIPTION
The `readableStreamDefaultControllerClearAlgorithms()` will be executed if `cancelAlgorithm()` returns a rejected promise. However it will not be executed if  `cancelAlgorithm()` throws an error.

This PR make `readableStreamDefaultControllerClearAlgorithms()` be executed when `cancelAlgorithm()` throws an error. So [Treat throwing an exception the same as returning a rejected promise](https://streams.spec.whatwg.org/#dom-underlyingsource-cancel).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
