### PR TITLE
fix,v8: make `v8.writeHeapSnapshot` throw if `fopen`/`fclose` fail

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -267,6 +267,10 @@ disk unless [`v8.stopCoverage()`][] is invoked before the process exits.
 
 <!-- YAML
 added: v11.13.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41373
+    description: An exception will now be thrown if the file could not be written.
 -->
 
 * `filename` {string} The file path where the V8 heap snapshot is to be

--- a/src/env.cc
+++ b/src/env.cc
@@ -1643,7 +1643,7 @@ size_t Environment::NearHeapLimitCallback(void* data,
   env->isolate()->RemoveNearHeapLimitCallback(NearHeapLimitCallback,
                                               initial_heap_limit);
 
-  heap::WriteSnapshot(env->isolate(), filename.c_str());
+  heap::WriteSnapshot(env, filename.c_str());
   env->heap_limit_snapshot_taken_ += 1;
 
   // Don't take more snapshots than the number specified by

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -379,7 +379,7 @@ class DiagnosticFilename {
 };
 
 namespace heap {
-bool WriteSnapshot(v8::Isolate* isolate, const char* filename);
+bool WriteSnapshot(Environment* env, const char* filename);
 }
 
 class TraceEventScope {

--- a/test/sequential/test-heapdump.js
+++ b/test/sequential/test-heapdump.js
@@ -24,6 +24,19 @@ process.chdir(tmpdir.path);
   fs.accessSync(heapdump);
 }
 
+{
+  const readonlyFile = 'ro';
+  fs.writeFileSync(readonlyFile, Buffer.alloc(0), { mode: 0o444 });
+  assert.throws(() => {
+    writeHeapSnapshot(readonlyFile);
+  }, (e) => {
+    assert.ok(e, 'writeHeapSnapshot should error');
+    assert.strictEqual(e.code, 'EACCES');
+    assert.strictEqual(e.syscall, 'open');
+    return true;
+  });
+}
+
 [1, true, {}, [], null, Infinity, NaN].forEach((i) => {
   assert.throws(() => writeHeapSnapshot(i), {
     code: 'ERR_INVALID_ARG_TYPE',


### PR DESCRIPTION
Fixes: #41346

Alternative to #41365, this PR makes `v8.writeHeapSnapshot` throw if the file could not be written, which can happen inside read-only directories (such as those from Docker containers).

I was not able to make a readonly directory on Windows since I could still write new files to it (is it even possible on Windows?), so I created an empty readonly file instead and made the function attempt to write on it. I ran this function in both Node.js 16.13.1 and the test fails as intended.
