### PR TITLE
doc: recommend package exports instead of requiring folders

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -442,7 +442,7 @@ Error: Cannot find module 'some-library'
 
 In all three above cases, an `import('./some-library')` call would result in a
 [`ERR_UNSUPPORTED_DIR_IMPORT`][] error. Using package [subpath exports][] or
-[subpath imports][] can provide the same containment organisation benefits as
+[subpath imports][] can provide the same containment organization benefits as
 folders as modules, and work for both `require` and `import`.
 
 ## Loading from `node_modules` folders

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -406,8 +406,8 @@ If the given path does not exist, `require()` will throw an [`Error`][] with its
 
 <!--type=misc-->
 
-It is convenient to organize programs and libraries into self-contained
-directories, and then provide a single entry point to those directories.
+> Stability: 3 - Legacy: Use [subpath exports][] or [subpath imports][] instead.
+
 There are three ways in which a folder may be passed to `require()` as
 an argument.
 
@@ -424,8 +424,6 @@ If this was in a folder at `./some-library`, then
 `require('./some-library')` would attempt to load
 `./some-library/lib/some-library.js`.
 
-This is the extent of the awareness of `package.json` files within Node.js.
-
 If there is no [`package.json`][] file present in the directory, or if the
 [`"main"`][] entry is missing or cannot be resolved, then Node.js
 will attempt to load an `index.js` or `index.node` file out of that
@@ -441,6 +439,11 @@ with the default error:
 ```console
 Error: Cannot find module 'some-library'
 ```
+
+In all three above cases, an `import('./some-library')` call would result in a
+[`ERR_UNSUPPORTED_DIR_IMPORT`][] error. Using package [subpath exports][] or
+[subpath imports][] can provide the same containment organisation benefits as
+folders as modules, and work for both `require` and `import`.
 
 ## Loading from `node_modules` folders
 
@@ -1048,6 +1051,7 @@ This section was moved to
 [GLOBAL_FOLDERS]: #loading-from-the-global-folders
 [`"main"`]: packages.md#main
 [`ERR_REQUIRE_ESM`]: errors.md#err_require_esm
+[`ERR_UNSUPPORTED_DIR_IMPORT`]: errors.md#err_unsupported_dir_import
 [`Error`]: errors.md#class-error
 [`__dirname`]: #__dirname
 [`__filename`]: #__filename
@@ -1061,3 +1065,5 @@ This section was moved to
 [exports shortcut]: #exports-shortcut
 [module resolution]: #all-together
 [native addons]: addons.md
+[subpath exports]: packages.md#subpath-exports
+[subpath imports]: packages.md#subpath-imports


### PR DESCRIPTION
Clarify that `import`ing a folder is not supported by default, and add `Legacy` status to nudge users into using the more modern and versatile `"exports"` and/or `"imports"` fields in their `package.json`.

//cc @nodejs/modules 
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
