### PR TITLE
tools,benchmark,lib,test: enable no-case-declarations lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -175,6 +175,7 @@ module.exports = {
     }],
     'new-parens': 'error',
     'no-async-promise-executor': 'error',
+    'no-case-declarations': 'error',
     'no-class-assign': 'error',
     'no-confusing-arrow': 'error',
     'no-const-assign': 'error',

--- a/benchmark/zlib/inflate.js
+++ b/benchmark/zlib/inflate.js
@@ -16,7 +16,7 @@ function main({ n, method, inputLen }) {
   let i = 0;
   switch (method) {
     // Performs `n` single inflate operations
-    case 'inflate':
+    case 'inflate': {
       const inflate = zlib.inflate;
       bench.start();
       (function next(err, result) {
@@ -25,14 +25,16 @@ function main({ n, method, inputLen }) {
         inflate(chunk, next);
       })();
       break;
+    }
     // Performs `n` single inflateSync operations
-    case 'inflateSync':
+    case 'inflateSync': {
       const inflateSync = zlib.inflateSync;
       bench.start();
       for (; i < n; ++i)
         inflateSync(chunk);
       bench.end(n);
       break;
+    }
     default:
       throw new Error('Unsupported inflate method');
   }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -411,7 +411,7 @@ Server.prototype.setTimeout = function setTimeout(msecs, callback) {
 
 Server.prototype[EE.captureRejectionSymbol] = function(err, event, ...args) {
   switch (event) {
-    case 'request':
+    case 'request': {
       const { 1: res } = args;
       if (!res.headersSent && !res.writableEnded) {
         // Don't leak headers.
@@ -425,6 +425,7 @@ Server.prototype[EE.captureRejectionSymbol] = function(err, event, ...args) {
         res.destroy();
       }
       break;
+    }
     default:
       net.Server.prototype[SymbolFor('nodejs.rejection')]
         .apply(this, arguments);

--- a/lib/internal/bootstrap/switches/is_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_main_thread.js
@@ -42,20 +42,22 @@ function createWritableStdioStream(fd) {
   let stream;
   // Note stream._type is used for test-module-load-list.js
   switch (guessHandleType(fd)) {
-    case 'TTY':
+    case 'TTY': {
       const tty = require('tty');
       stream = new tty.WriteStream(fd);
       stream._type = 'tty';
       break;
+    }
 
-    case 'FILE':
+    case 'FILE': {
       const SyncWriteStream = require('internal/fs/sync_write_stream');
       stream = new SyncWriteStream(fd, { autoClose: false });
       stream._type = 'fs';
       break;
+    }
 
     case 'PIPE':
-    case 'TCP':
+    case 'TCP': {
       const net = require('net');
 
       // If fd is already being used for the IPC channel, libuv will return
@@ -78,8 +80,9 @@ function createWritableStdioStream(fd) {
 
       stream._type = 'pipe';
       break;
+    }
 
-    default:
+    default: {
       // Provide a dummy black-hole output for e.g. non-console
       // Windows applications.
       const { Writable } = require('stream');
@@ -88,6 +91,7 @@ function createWritableStdioStream(fd) {
           cb();
         }
       });
+    }
   }
 
   // For supporting legacy API we put the FD here.
@@ -147,18 +151,20 @@ function getStdin() {
   const fd = 0;
 
   switch (guessHandleType(fd)) {
-    case 'TTY':
+    case 'TTY': {
       const tty = require('tty');
       stdin = new tty.ReadStream(fd);
       break;
+    }
 
-    case 'FILE':
+    case 'FILE': {
       const fs = require('fs');
       stdin = new fs.ReadStream(null, { fd: fd, autoClose: false });
       break;
+    }
 
     case 'PIPE':
-    case 'TCP':
+    case 'TCP': {
       const net = require('net');
 
       // It could be that process has been started with an IPC channel
@@ -183,13 +189,15 @@ function getStdin() {
       // Make sure the stdin can't be `.end()`-ed
       stdin._writableState.ended = true;
       break;
+    }
 
-    default:
+    default: {
       // Provide a dummy contentless input for e.g. non-console
       // Windows applications.
       const { Readable } = require('stream');
       stdin = new Readable({ read() {} });
       stdin.push(null);
+    }
   }
 
   // For supporting legacy API we put the FD here.

--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -189,7 +189,7 @@ function asyncAesGcmCipher(
   const tagByteLength = MathFloor(tagLength / 8);
   let tag;
   switch (mode) {
-    case kWebCryptoCipherDecrypt:
+    case kWebCryptoCipherDecrypt: {
       const slice = ArrayBufferIsView(data) ?
         TypedArrayPrototypeSlice : ArrayBufferPrototypeSlice;
       tag = slice(data, -tagByteLength);
@@ -206,6 +206,7 @@ function asyncAesGcmCipher(
 
       data = slice(data, 0, -tagByteLength);
       break;
+    }
     case kWebCryptoCipherEncrypt:
       tag = tagByteLength;
       break;

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -427,7 +427,7 @@ async function importGenericSecretKey(
 
       break;
     }
-    case 'raw':
+    case 'raw': {
       if (hasAnyNotIn(usagesSet, ['deriveKey', 'deriveBits'])) {
         throw lazyDOMException(
           `Unsupported key usage for a ${name} key`,
@@ -449,6 +449,7 @@ async function importGenericSecretKey(
 
       const keyObject = createSecretKey(keyData);
       return new InternalCryptoKey(keyObject, { name }, keyUsages, false);
+    }
   }
 
   throw lazyDOMException(

--- a/lib/internal/error_serdes.js
+++ b/lib/internal/error_serdes.js
@@ -120,7 +120,7 @@ let deserialize;
 function deserializeError(error) {
   if (!deserialize) deserialize = require('v8').deserialize;
   switch (error[0]) {
-    case kSerializedError:
+    case kSerializedError: {
       const { constructor, properties } = deserialize(error.subarray(1));
       const ctor = errors[constructor];
       ObjectDefineProperty(properties, SymbolToStringTag, {
@@ -128,13 +128,15 @@ function deserializeError(error) {
         enumerable: true
       });
       return ObjectCreate(ctor.prototype, properties);
+    }
     case kSerializedObject:
       return deserialize(error.subarray(1));
-    case kInspectedError:
+    case kInspectedError: {
       const buf = Buffer.from(error.buffer,
                               error.byteOffset + 1,
                               error.byteLength - 1);
       return buf.toString('utf8');
+    }
   }
   require('assert').fail('This should not happen');
 }

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -217,28 +217,31 @@ const proxySocketHandler = {
       case 'writable':
       case 'destroyed':
         return stream[prop];
-      case 'readable':
+      case 'readable': {
         if (stream.destroyed)
           return false;
         const request = stream[kRequest];
         return request ? request.readable : stream.readable;
-      case 'setTimeout':
+      }
+      case 'setTimeout': {
         const session = stream.session;
         if (session !== undefined)
           return FunctionPrototypeBind(session.setTimeout, session);
         return FunctionPrototypeBind(stream.setTimeout, stream);
+      }
       case 'write':
       case 'read':
       case 'pause':
       case 'resume':
         throw new ERR_HTTP2_NO_SOCKET_MANIPULATION();
-      default:
+      default: {
         const ref = stream.session !== undefined ?
           stream.session[kSocket] : stream;
         const value = ref[prop];
         return typeof value === 'function' ?
           FunctionPrototypeBind(value, ref) :
           value;
+      }
     }
   },
   getPrototypeOf(stream) {
@@ -258,23 +261,25 @@ const proxySocketHandler = {
       case 'destroy':
         stream[prop] = value;
         return true;
-      case 'setTimeout':
+      case 'setTimeout': {
         const session = stream.session;
         if (session !== undefined)
           session.setTimeout = value;
         else
           stream.setTimeout = value;
         return true;
+      }
       case 'write':
       case 'read':
       case 'pause':
       case 'resume':
         throw new ERR_HTTP2_NO_SOCKET_MANIPULATION();
-      default:
+      default: {
         const ref = stream.session !== undefined ?
           stream.session[kSocket] : stream;
         ref[prop] = value;
         return true;
+      }
     }
   }
 };

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -867,7 +867,7 @@ const proxySocketHandler = {
       case 'setKeepAlive':
       case 'setNoDelay':
         throw new ERR_HTTP2_NO_SOCKET_MANIPULATION();
-      default:
+      default: {
         const socket = session[kSocket];
         if (socket === undefined)
           throw new ERR_HTTP2_SOCKET_UNBOUND();
@@ -875,6 +875,7 @@ const proxySocketHandler = {
         return typeof value === 'function' ?
           FunctionPrototypeBind(value, socket) :
           value;
+      }
     }
   },
   getPrototypeOf(session) {
@@ -901,12 +902,13 @@ const proxySocketHandler = {
       case 'setKeepAlive':
       case 'setNoDelay':
         throw new ERR_HTTP2_NO_SOCKET_MANIPULATION();
-      default:
+      default: {
         const socket = session[kSocket];
         if (socket === undefined)
           throw new ERR_HTTP2_SOCKET_UNBOUND();
         socket[prop] = value;
         return true;
+      }
     }
   }
 };
@@ -1558,10 +1560,11 @@ class Http2Session extends EventEmitter {
 
   [EventEmitter.captureRejectionSymbol](err, event, ...args) {
     switch (event) {
-      case 'stream':
+      case 'stream': {
         const stream = args[0];
         stream.destroy(err);
         break;
+      }
       default:
         this.destroy(err);
     }
@@ -3184,7 +3187,7 @@ Http2Server.prototype[EventEmitter.captureRejectionSymbol] = function(
   err, event, ...args) {
 
   switch (event) {
-    case 'stream':
+    case 'stream': {
       // TODO(mcollina): we might want to match this with what we do on
       // the compat side.
       const { 0: stream } = args;
@@ -3195,7 +3198,8 @@ Http2Server.prototype[EventEmitter.captureRejectionSymbol] = function(
         stream.end();
       }
       break;
-    case 'request':
+    }
+    case 'request': {
       const { 1: res } = args;
       if (!res.headersSent && !res.finished) {
         // Don't leak headers.
@@ -3208,6 +3212,7 @@ Http2Server.prototype[EventEmitter.captureRejectionSymbol] = function(
         res.destroy();
       }
       break;
+    }
     default:
       ArrayPrototypeUnshift(args, err, event);
       ReflectApply(net.Server.prototype[EventEmitter.captureRejectionSymbol],

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -110,7 +110,7 @@ function isRecoverableError(e, code) {
                 recoverable = true;
                 break;
 
-              case 'Unterminated string constant':
+              case 'Unterminated string constant': {
                 const token = StringPrototypeSlice(this.input,
                                                    this.lastTokStart, this.pos);
                 // See https://www.ecma-international.org/ecma-262/#sec-line-terminators
@@ -118,6 +118,7 @@ function isRecoverableError(e, code) {
                                         token)) {
                   recoverable = true;
                 }
+              }
             }
             super.raise(pos, message);
           }

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2061,7 +2061,7 @@ function formatWithOptionsInternal(inspectOptions, args) {
         const nextChar = StringPrototypeCharCodeAt(first, ++i);
         if (a + 1 !== args.length) {
           switch (nextChar) {
-            case 115: // 's'
+            case 115: { // 's'
               const tempArg = args[++a];
               if (typeof tempArg === 'number') {
                 tempStr = formatNumberNoColor(tempArg, inspectOptions);
@@ -2080,10 +2080,11 @@ function formatWithOptionsInternal(inspectOptions, args) {
                 });
               }
               break;
+            }
             case 106: // 'j'
               tempStr = tryStringify(args[++a]);
               break;
-            case 100: // 'd'
+            case 100: { // 'd'
               const tempNum = args[++a];
               if (typeof tempNum === 'bigint') {
                 tempStr = formatBigIntNoColor(tempNum, inspectOptions);
@@ -2093,6 +2094,7 @@ function formatWithOptionsInternal(inspectOptions, args) {
                 tempStr = formatNumberNoColor(Number(tempNum), inspectOptions);
               }
               break;
+            }
             case 79: // 'O'
               tempStr = inspect(args[++a], inspectOptions);
               break;
@@ -2104,7 +2106,7 @@ function formatWithOptionsInternal(inspectOptions, args) {
                 depth: 4
               });
               break;
-            case 105: // 'i'
+            case 105: { // 'i'
               const tempInteger = args[++a];
               if (typeof tempInteger === 'bigint') {
                 tempStr = formatBigIntNoColor(tempInteger, inspectOptions);
@@ -2115,7 +2117,8 @@ function formatWithOptionsInternal(inspectOptions, args) {
                   NumberParseInt(tempInteger), inspectOptions);
               }
               break;
-            case 102: // 'f'
+            }
+            case 102: { // 'f'
               const tempFloat = args[++a];
               if (typeof tempFloat === 'symbol') {
                 tempStr = 'NaN';
@@ -2124,6 +2127,7 @@ function formatWithOptionsInternal(inspectOptions, args) {
                   NumberParseFloat(tempFloat), inspectOptions);
               }
               break;
+            }
             case 99: // 'c'
               a += 1;
               tempStr = '';

--- a/test/addons/worker-addon/test.js
+++ b/test/addons/worker-addon/test.js
@@ -11,7 +11,7 @@ switch (process.argv[2]) {
     require(binding);
     // fallthrough
   case 'worker-twice':
-  case 'worker':
+  case 'worker': {
     const worker = new Worker(`require(${JSON.stringify(binding)});`, {
       eval: true
     });
@@ -23,6 +23,7 @@ switch (process.argv[2]) {
       }));
     }
     return;
+  }
   case 'main-thread':
     process.env.addExtraItemToEventLoop = 'yes';
     require(binding);

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -14,13 +14,14 @@ switch (arg) {
     new async_hooks.AsyncResource(`${arg}_type`);
     return;
 
-  case 'test_callback':
+  case 'test_callback': {
     initHooks({
       onbefore: common.mustCall(() => { throw new Error(arg); })
     }).enable();
     const resource = new async_hooks.AsyncResource(`${arg}_type`);
     resource.runInAsyncScope(() => {});
     return;
+  }
 
   case 'test_callback_abort':
     initHooks({

--- a/test/common/dns.js
+++ b/test/common/dns.js
@@ -236,7 +236,7 @@ function writeDNSPacket(parsed) {
         rdLengthBuf[0] = 16;
         buffers.push(writeIPv6(rr.address));
         break;
-      case 'TXT':
+      case 'TXT': {
         const total = rr.entries.map((s) => s.length).reduce((a, b) => a + b);
         // Total length of all strings + 1 byte each for their lengths.
         rdLengthBuf[0] = rr.entries.length + total;
@@ -245,6 +245,7 @@ function writeDNSPacket(parsed) {
           buffers.push(Buffer.from(txt));
         }
         break;
+      }
       case 'MX':
         rdLengthBuf[0] = 2;
         buffers.push(new Uint16Array([rr.priority]));

--- a/test/parallel/test-child-process-spawnsync-timeout.js
+++ b/test/parallel/test-child-process-spawnsync-timeout.js
@@ -37,7 +37,7 @@ switch (process.argv[2]) {
       process.exit(1);
     }, SLEEP);
     break;
-  default:
+  default: {
     const start = Date.now();
     const ret = spawnSync(process.execPath, [__filename, 'child'],
                           { timeout: TIMER });
@@ -47,4 +47,5 @@ switch (process.argv[2]) {
     assert(end < SLEEP);
     assert(ret.status > 128 || ret.signal);
     break;
+  }
 }

--- a/test/parallel/test-cluster-basic.js
+++ b/test/parallel/test-cluster-basic.js
@@ -126,7 +126,7 @@ if (cluster.isWorker) {
           assert.strictEqual(arguments.length, 2);
           break;
 
-        case 'listening':
+        case 'listening': {
           assert.strictEqual(arguments.length, 1);
           assert.strictEqual(Object.keys(arguments[0]).length, 4);
           assert.strictEqual(arguments[0].address, '127.0.0.1');
@@ -138,7 +138,7 @@ if (cluster.isWorker) {
           assert(port >= 1);
           assert(port <= 65535);
           break;
-
+        }
         default:
           assert.strictEqual(arguments.length, 0);
           break;

--- a/test/parallel/test-fs-write-stream-err.js
+++ b/test/parallel/test-fs-write-stream-err.js
@@ -40,13 +40,14 @@ fs.write = function() {
       console.error('first write');
       // First time is ok.
       return write.apply(fs, arguments);
-    case 1:
+    case 1: {
       // Then it breaks.
       console.error('second write');
       const cb = arguments[arguments.length - 1];
       return process.nextTick(function() {
         cb(err);
       });
+    }
     default:
       // It should not be called again!
       throw new Error('BOOM!');

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -41,7 +41,7 @@ const cookies = [
 
 const s = http.createServer(common.mustCall((req, res) => {
   switch (test) {
-    case 'headers':
+    case 'headers': {
       // Check that header-related functions work before setting any headers
       const headers = res.getHeaders();
       const exoticObj = Object.create(null);
@@ -141,7 +141,7 @@ const s = http.createServer(common.mustCall((req, res) => {
       assert.strictEqual(res.hasHeader('X-TEST-HEADER2'), false);
       assert.strictEqual(res.hasHeader('X-Test-Header2'), false);
       break;
-
+    }
     case 'contentLength':
       res.setHeader('content-length', content.length);
       assert.strictEqual(res.getHeader('Content-Length'), content.length);

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -35,10 +35,11 @@ function test(res, code, key, value) {
 
 const server = http.createServer((req, res) => {
   switch (count++) {
-    case 0:
+    case 0: {
       const loc = url.parse(req.url, true).query.lang;
       test(res, 302, 'Location', `/foo?lang=${loc}`);
       break;
+    }
     case 1:
       test(res, 200, 'foo', x);
       break;

--- a/test/parallel/test-http2-response-splitting.js
+++ b/test/parallel/test-http2-response-splitting.js
@@ -32,11 +32,12 @@ server.on('stream', common.mustCall((stream, headers) => {
 
   const obj = Object.create(null);
   switch (remaining--) {
-    case 3:
+    case 3: {
       const url = new URL(makeUrl(headers));
       obj[':status'] = 302;
       obj.Location = `/foo?lang=${url.searchParams.get('lang')}`;
       break;
+    }
     case 2:
       obj.foo = x;
       break;

--- a/test/parallel/test-pending-deprecation.js
+++ b/test/parallel/test-pending-deprecation.js
@@ -29,7 +29,7 @@ switch (process.argv[2]) {
       true
     );
     break;
-  default:
+  default: {
     // Verify that the flag is off by default.
     const envvar = process.env.NODE_PENDING_DEPRECATION;
     assert.strictEqual(
@@ -61,4 +61,5 @@ switch (process.argv[2]) {
     }).on('exit', common.mustCall((code) => {
       assert.strictEqual(code, 0, message('NODE_PENDING_DEPRECATION'));
     }));
+  }
 }

--- a/test/parallel/test-stdio-pipe-access.js
+++ b/test/parallel/test-stdio-pipe-access.js
@@ -18,12 +18,13 @@ switch (who) {
                 { 'stdio': 'inherit' });
     }
     break;
-  case 'parent':
+  case 'parent': {
     const middle = spawn(process.argv0,
                          [process.argv[1], 'middle'],
                          { 'stdio': 'pipe' });
     middle.stdout.on('data', () => {});
     break;
+  }
   case 'middle':
     spawn(process.argv0,
           [process.argv[1], 'bottom'],

--- a/test/parallel/test-stdio-pipe-redirect.js
+++ b/test/parallel/test-stdio-pipe-redirect.js
@@ -13,7 +13,7 @@ const totalDots = 10000;
 const who = process.argv.length <= 2 ? 'parent' : process.argv[2];
 
 switch (who) {
-  case 'parent':
+  case 'parent': {
     const consumer = spawn(process.argv0, [process.argv[1], 'consumer'], {
       stdio: ['pipe', 'ignore', 'inherit'],
     });
@@ -23,7 +23,8 @@ switch (who) {
     process.stdin.on('data', () => {});
     producer.on('exit', process.exit);
     break;
-  case 'producer':
+  }
+  case 'producer': {
     const buffer = Buffer.alloc(writeSize, '.');
     let written = 0;
     const write = () => {
@@ -34,6 +35,7 @@ switch (who) {
     };
     write();
     break;
+  }
   case 'consumer':
     process.stdin.on('data', () => {});
     break;

--- a/test/parallel/test-trace-events-api.js
+++ b/test/parallel/test-trace-events-api.js
@@ -161,16 +161,18 @@ function testApiInChildProcess(execArgs, cb) {
       traces.forEach((trace) => {
         assert.strictEqual(trace.pid, proc.pid);
         switch (trace.ph) {
-          case 'b':
+          case 'b': {
             const expectedBegin = expectedBegins.shift();
             assert.strictEqual(trace.cat, expectedBegin.cat);
             assert.strictEqual(trace.name, expectedBegin.name);
             break;
-          case 'e':
+          }
+          case 'e': {
             const expectedEnd = expectedEnds.shift();
             assert.strictEqual(trace.cat, expectedEnd.cat);
             assert.strictEqual(trace.name, expectedEnd.name);
             break;
+          }
           default:
             assert.fail('Unexpected trace event phase');
         }

--- a/test/sequential/test-tls-securepair-client.js
+++ b/test/sequential/test-tls-securepair-client.js
@@ -77,7 +77,7 @@ function test(keyPath, certPath, check, next) {
     serverStdoutBuffer += s;
     console.log(state);
     switch (state) {
-      case 'WAIT-ACCEPT':
+      case 'WAIT-ACCEPT': {
         const matches = serverStdoutBuffer.match(/ACCEPT .*?:(\d+)/);
         if (matches) {
           const port = matches[1];
@@ -85,7 +85,7 @@ function test(keyPath, certPath, check, next) {
           startClient(port);
         }
         break;
-
+      }
       case 'WAIT-HELLO':
         if (/hello/.test(serverStdoutBuffer)) {
 

--- a/tools/doc/json.mjs
+++ b/tools/doc/json.mjs
@@ -128,7 +128,7 @@ export function jsonAPI({ filename }) {
       switch (current.type) {
         case 'ctor':
         case 'classMethod':
-        case 'method':
+        case 'method': {
           // Each item is an argument, unless the name is 'return',
           // in which case it's the return value.
           const sig = {};
@@ -142,7 +142,7 @@ export function jsonAPI({ filename }) {
           parseSignature(current.textRaw, sig);
           current.signatures = [sig];
           break;
-
+        }
         case 'property':
           // There should be only one item, which is the value.
           // Copy the data up to the section.


### PR DESCRIPTION
Don't leak identifiers into other `case` declarations. This is an ESLint recommended rule. My goal/hope is to be able to enable `eslint:recommended` at some point and have far fewer individual rules specified in `.eslintrc.js`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
