### PR TITLE
readline: undo previous edit when get key code `0x1F`

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -1349,6 +1349,12 @@ const { createInterface } = require('readline');
     <td></td>
   </tr>
   <tr>
+    <td><kbd>Ctrl</kbd>+<kbd>-</kbd></td>
+    <td>Undo previous change</td>
+    <td>Any keystroke emits key code <code>0x1F</code> would do this action.</td>
+    <td></td>
+  </tr>
+  <tr>
     <td><kbd>Ctrl</kbd>+<kbd>Z</kbd></td>
     <td>Moves running process into background. Type
     <code>fg</code> and press <kbd>Enter</kbd>

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -126,8 +126,6 @@ function InterfaceConstructor(input, output, completer, terminal) {
   this.isCompletionEnabled = true;
   this[kSawKeyPress] = false;
   this[kPreviousKey] = null;
-  this[kUndoStack] = [];
-  this[kRedoStack] = [];
   this.escapeCodeTimeout = ESCAPE_CODE_TIMEOUT;
   this.tabSize = 8;
 

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -7,8 +7,10 @@ const {
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
   ArrayPrototypePop,
+  ArrayPrototypePush,
   ArrayPrototypeReverse,
   ArrayPrototypeSplice,
+  ArrayPrototypeShift,
   ArrayPrototypeUnshift,
   DateNow,
   FunctionPrototypeCall,
@@ -68,6 +70,7 @@ const { StringDecoder } = require('string_decoder');
 let Readable;
 
 const kHistorySize = 30;
+const kMaxUndoRedoStackSize = 2048;
 const kMincrlfDelay = 100;
 // \r\n, \n, or \r followed by something other than \n
 const lineEnding = /\r?\n|\r(?!\n)/;
@@ -79,6 +82,7 @@ const kQuestionCancel = Symbol('kQuestionCancel');
 const ESCAPE_CODE_TIMEOUT = 500;
 
 const kAddHistory = Symbol('_addHistory');
+const kBeforeEdit = Symbol('_beforeEdit');
 const kDecoder = Symbol('_decoder');
 const kDeleteLeft = Symbol('_deleteLeft');
 const kDeleteLineLeft = Symbol('_deleteLineLeft');
@@ -98,7 +102,10 @@ const kOldPrompt = Symbol('_oldPrompt');
 const kOnLine = Symbol('_onLine');
 const kPreviousKey = Symbol('_previousKey');
 const kPrompt = Symbol('_prompt');
+const kPushToUndoStack = Symbol('_pushToUndoStack');
 const kQuestionCallback = Symbol('_questionCallback');
+const kRedo = Symbol('_redo');
+const kRedoStack = Symbol('_redoStack');
 const kRefreshLine = Symbol('_refreshLine');
 const kSawKeyPress = Symbol('_sawKeyPress');
 const kSawReturnAt = Symbol('_sawReturnAt');
@@ -106,6 +113,8 @@ const kSetRawMode = Symbol('_setRawMode');
 const kTabComplete = Symbol('_tabComplete');
 const kTabCompleter = Symbol('_tabCompleter');
 const kTtyWrite = Symbol('_ttyWrite');
+const kUndo = Symbol('_undo');
+const kUndoStack = Symbol('_undoStack');
 const kWordLeft = Symbol('_wordLeft');
 const kWordRight = Symbol('_wordRight');
 const kWriteToOutput = Symbol('_writeToOutput');
@@ -117,6 +126,8 @@ function InterfaceConstructor(input, output, completer, terminal) {
   this.isCompletionEnabled = true;
   this[kSawKeyPress] = false;
   this[kPreviousKey] = null;
+  this[kUndoStack] = [];
+  this[kRedoStack] = [];
   this.escapeCodeTimeout = ESCAPE_CODE_TIMEOUT;
   this.tabSize = 8;
 
@@ -198,6 +209,8 @@ function InterfaceConstructor(input, output, completer, terminal) {
   this[kSubstringSearch] = null;
   this.output = output;
   this.input = input;
+  this[kUndoStack] = [];
+  this[kRedoStack] = [];
   this.history = history;
   this.historySize = historySize;
   this.removeHistoryDuplicates = !!removeHistoryDuplicates;
@@ -390,6 +403,10 @@ class Interface extends InterfaceConstructor {
     }
   }
 
+  [kBeforeEdit](oldText, oldCursor) {
+    this[kPushToUndoStack](oldText, oldCursor);
+  }
+
   [kQuestionCancel]() {
     if (this[kQuestionCallback]) {
       this[kQuestionCallback] = null;
@@ -579,6 +596,7 @@ class Interface extends InterfaceConstructor {
   }
 
   [kInsertString](c) {
+    this[kBeforeEdit](this.line, this.cursor);
     if (this.cursor < this.line.length) {
       const beg = StringPrototypeSlice(this.line, 0, this.cursor);
       const end = StringPrototypeSlice(
@@ -648,6 +666,8 @@ class Interface extends InterfaceConstructor {
       return;
     }
 
+    this[kBeforeEdit](this.line, this.cursor);
+
     // Apply/show completions.
     const completionsWidth = ArrayPrototypeMap(completions, (e) =>
       getStringWidth(e)
@@ -708,6 +728,7 @@ class Interface extends InterfaceConstructor {
 
   [kDeleteLeft]() {
     if (this.cursor > 0 && this.line.length > 0) {
+      this[kBeforeEdit](this.line, this.cursor);
       // The number of UTF-16 units comprising the character to the left
       const charSize = charLengthLeft(this.line, this.cursor);
       this.line =
@@ -721,6 +742,7 @@ class Interface extends InterfaceConstructor {
 
   [kDeleteRight]() {
     if (this.cursor < this.line.length) {
+      this[kBeforeEdit](this.line, this.cursor);
       // The number of UTF-16 units comprising the character to the left
       const charSize = charLengthAt(this.line, this.cursor);
       this.line =
@@ -736,6 +758,7 @@ class Interface extends InterfaceConstructor {
 
   [kDeleteWordLeft]() {
     if (this.cursor > 0) {
+      this[kBeforeEdit](this.line, this.cursor);
       // Reverse the string and match a word near beginning
       // to avoid quadratic time complexity
       let leading = StringPrototypeSlice(this.line, 0, this.cursor);
@@ -759,6 +782,7 @@ class Interface extends InterfaceConstructor {
 
   [kDeleteWordRight]() {
     if (this.cursor < this.line.length) {
+      this[kBeforeEdit](this.line, this.cursor);
       const trailing = StringPrototypeSlice(this.line, this.cursor);
       const match = StringPrototypeMatch(trailing, /^(?:\s+|\W+|\w+)\s*/);
       this.line =
@@ -769,12 +793,14 @@ class Interface extends InterfaceConstructor {
   }
 
   [kDeleteLineLeft]() {
+    this[kBeforeEdit](this.line, this.cursor);
     this.line = StringPrototypeSlice(this.line, this.cursor);
     this.cursor = 0;
     this[kRefreshLine]();
   }
 
   [kDeleteLineRight]() {
+    this[kBeforeEdit](this.line, this.cursor);
     this.line = StringPrototypeSlice(this.line, 0, this.cursor);
     this[kRefreshLine]();
   }
@@ -789,8 +815,41 @@ class Interface extends InterfaceConstructor {
 
   [kLine]() {
     const line = this[kAddHistory]();
+    this[kUndoStack] = [];
+    this[kRedoStack] = [];
     this.clearLine();
     this[kOnLine](line);
+  }
+
+  [kPushToUndoStack](text, cursor) {
+    if (ArrayPrototypePush(this[kUndoStack], { text, cursor }) >
+        kMaxUndoRedoStackSize) {
+      ArrayPrototypeShift(this[kUndoStack]);
+    }
+  }
+
+  [kUndo]() {
+    if (this[kUndoStack].length <= 0) return;
+
+    const entry = this[kUndoStack].pop();
+
+    this.line = entry.text;
+    this.cursor = entry.cursor;
+
+    ArrayPrototypePush(this[kRedoStack], entry);
+    this[kRefreshLine]();
+  }
+
+  [kRedo]() {
+    if (this[kRedoStack].length <= 0) return;
+
+    const entry = this[kRedoStack].pop();
+
+    this.line = entry.text;
+    this.cursor = entry.cursor;
+
+    ArrayPrototypePush(this[kUndoStack], entry);
+    this[kRefreshLine]();
   }
 
   // TODO(BridgeAR): Add underscores to the search part and a red background in
@@ -802,6 +861,7 @@ class Interface extends InterfaceConstructor {
   // one.
   [kHistoryNext]() {
     if (this.historyIndex >= 0) {
+      this[kBeforeEdit](this.line, this.cursor);
       const search = this[kSubstringSearch] || '';
       let index = this.historyIndex - 1;
       while (
@@ -824,6 +884,7 @@ class Interface extends InterfaceConstructor {
 
   [kHistoryPrev]() {
     if (this.historyIndex < this.history.length && this.history.length) {
+      this[kBeforeEdit](this.line, this.cursor);
       const search = this[kSubstringSearch] || '';
       let index = this.historyIndex + 1;
       while (
@@ -945,6 +1006,13 @@ class Interface extends InterfaceConstructor {
       if (this.history.length === this.historyIndex) {
         this.historyIndex = -1;
       }
+    }
+
+    // Undo
+    if (typeof key.sequence === 'string' &&
+        StringPrototypeCodePointAt(key.sequence, 0) === 0x1f) {
+      this[kUndo]();
+      return;
     }
 
     // Ignore escape key, fixes

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -721,6 +721,28 @@ function assertCursorRowsAndCols(rli, rows, cols) {
   rli.close();
 }
 
+// Undo
+{
+  const [rli, fi] = getInterface({ terminal: true, prompt: '' });
+  fi.emit('data', 'the quick brown fox');
+  assertCursorRowsAndCols(rli, 0, 19);
+
+  // Delete right line from the 5th char
+  fi.emit('keypress', '.', { ctrl: true, shift: false, name: 'b' });
+  fi.emit('keypress', '.', { ctrl: true, shift: false, name: 'b' });
+  fi.emit('keypress', '.', { ctrl: true, shift: false, name: 'b' });
+  fi.emit('keypress', '.', { ctrl: true, shift: false, name: 'b' });
+  fi.emit('keypress', ',', { ctrl: true, shift: false, name: 'k' });
+  fi.emit('keypress', ',', { ctrl: true, shift: false, name: 'u' });
+  assertCursorRowsAndCols(rli, 0, 0);
+  fi.emit('keypress', ',', { sequence: '\x1F' });
+  assert.strictEqual(rli.line, 'the quick brown');
+  fi.emit('keypress', ',', { sequence: '\x1F' });
+  assert.strictEqual(rli.line, 'the quick brown fox');
+  fi.emit('data', '\n');
+  rli.close();
+}
+
 // Clear the whole screen
 {
   const [rli, fi] = getInterface({ terminal: true, prompt: '' });


### PR DESCRIPTION
1. Undo previous edit on keystroke `ctrl -` (emit `0x1F`)
2. unit tests
3. documentation

Fix: #41308

By now, we have `ctrl -` to perform `undo`. In many terminals, all of `ctrl -`, `ctrl _`, `ctrl /` and `ctrl ?` send key code `0x1F`, so we cannot distinguish if we are pressing `shift` to perform `redo`.

My questions are:
1. If we could use a new keyboard shortcut, which one would be appropriate?
2. Or, how could I set my terminal, e.g. iterm2 or the macOS default Terminal.app, to send key code other than `0x1F` on keystroke `ctrl _`?

Could someone help me out? Thanks!