### PR TITLE
doc: align links in table to top

### DIFF
--- a/doc/changelogs/CHANGELOG_V16.md
+++ b/doc/changelogs/CHANGELOG_V16.md
@@ -8,11 +8,11 @@
 <th>Current</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 <a href="#16.13.1">16.13.1</a><br/>
 <a href="#16.13.0">16.13.0</a><br/>
 </td>
-<td>
+<td valign="top">
 <a href="#16.12.0">16.12.0</a><br/>
 <a href="#16.11.1">16.11.1</a><br/>
 <a href="#16.11.0">16.11.0</a><br/>


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

- The table at the start of all changelogs except for 16 has the links aligned to the top:
    - [v4 rendered][4]
    - [v6 rendered][6]
    - [v8 rendered][8]
    - [v10 rendered][10]
    - [v12 rendered][12]
    - [v14 rendered][14]
- All LTS versions except for 16 use `<td valign="top">`: 
    - [v4 source][4-highlighted]
    - [v6 source][6-highlighted]
    - [v8 source][8-highlighted]
    - [v10 source][10-highlighted]
    - [v12 source][12-highlighted]
    - [v14 source][14-highlighted]
- For version 16 they are aligned to the center:
    - [v16 rendered][16]
- 16 uses only `<td>`:
    - [v16 source][16-highlighted]

I assume this was an oversight. It's a very minor problem, but it's been annoying me for a while 🤷‍♀️

[4]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md
[6]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md
[8]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md
[10]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md
[12]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md
[14]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md
[16]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md

[4-highlighted]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md?plain=1#L11-L49
[6-highlighted]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md?plain=1#L11-L45
[8-highlighted]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md?plain=1#L11-L34
[10-highlighted]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md?plain=1#L11-L40
[12-highlighted]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md?plain=1#L11-L43
[14-highlighted]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md?plain=1#L11-L31
[16-highlighted]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md?plain=1#L11-L15
