### PR TITLE
http2: emit `response` event instead of `trailers` event

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -395,7 +395,7 @@ function onSessionHeaders(handle, id, cat, flags, headers, sensitiveHeaders) {
     } else if (cat === NGHTTP2_HCAT_PUSH_RESPONSE) {
       event = 'push';
       // cat === NGHTTP2_HCAT_HEADERS:
-    } else if (!endOfStream && status !== undefined && status >= 200) {
+    } else if (status >= 200) {
       event = 'response';
     } else {
       event = endOfStream ? 'trailers' : 'headers';

--- a/test/parallel/test-http2-info-headers-and-end.js
+++ b/test/parallel/test-http2-info-headers-and-end.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+const assert = require('assert');
+
+const server = http2.createServer((request, response) => {
+  response.writeContinue();
+  response.end();
+});
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  {
+    const req = client.request({ ':path': '/' });
+
+    req.on('headers', common.mustCall((headers) => {
+      assert.notStrictEqual(headers, undefined);
+      assert.strictEqual(headers[':status'], 100);
+    }));
+
+    req.on('response', common.mustCall((headers) => {
+      assert.notStrictEqual(headers, undefined);
+      assert.strictEqual(headers[':status'], 200);
+    }));
+
+    req.on('trailers', common.mustNotCall());
+
+    req.resume();
+    req.on('end', () => {
+      client.close();
+      server.close();
+    });
+    req.end();
+  }
+}));


### PR DESCRIPTION
Fix https://github.com/nodejs/node/issues/41251.

Should emit `response` event if `cat == NGHTTP2_HCAT_HEADERS` and status >= 200.


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
