### PR TITLE
child_process: apply hide_console_windows to spawnSync calls

### DIFF
--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -810,6 +810,9 @@ Maybe<int> SyncProcessRunner::ParseOptions(Local<Value> js_value) {
   if (js_win_hide->BooleanValue(isolate))
     uv_process_options_.flags |= UV_PROCESS_WINDOWS_HIDE;
 
+  if (env()->hide_console_windows())
+    uv_process_options_.flags |= UV_PROCESS_WINDOWS_HIDE_CONSOLE;
+
   Local<Value> js_wva =
       js_options->Get(context, env()->windows_verbatim_arguments_string())
           .ToLocalChecked();


### PR DESCRIPTION
kHideConsoleWindows should hide console windows for 
execSync and spawnSync calls as well. This fix adds on 
to https://github.com/nodejs/node/pull/39712.

I have confirmed the fix works downstream using Electron, but haven't yet built it or tested it in node itself.
Refs https://github.com/electron/electron/pull/32340 and https://github.com/microsoft/vscode/issues/138792
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
