### PR TITLE
domain: pass opts to `EventEmitter.init`

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -446,7 +446,7 @@ Domain.prototype.bind = function(cb) {
 EventEmitter.usingDomains = true;
 
 const eventInit = EventEmitter.init;
-EventEmitter.init = function() {
+EventEmitter.init = function(opts) {
   ObjectDefineProperty(this, 'domain', {
     configurable: true,
     enumerable: false,
@@ -457,7 +457,7 @@ EventEmitter.init = function() {
     this.domain = exports.active;
   }
 
-  return FunctionPrototypeCall(eventInit, this);
+  return FunctionPrototypeCall(eventInit, this, opts);
 };
 
 const eventEmit = EventEmitter.prototype.emit;

--- a/lib/events.js
+++ b/lib/events.js
@@ -321,6 +321,8 @@ EventEmitter.setMaxListeners =
     }
   };
 
+// If you're updating this function definition, please also update any
+// re-definitions, such as the one in the Domain module (lib/domain.js).
 EventEmitter.init = function(opts) {
 
   if (this._events === undefined ||

--- a/test/parallel/test-domain-ee.js
+++ b/test/parallel/test-domain-ee.js
@@ -18,3 +18,11 @@ d.on('error', common.mustCall((err) => {
 
 d.add(e);
 e.emit('error', new Error('foobar'));
+
+{
+  // Ensure initial params pass to origin `EventEmitter.init` function
+  const e = new EventEmitter({ captureRejections: true });
+  const kCapture = Object.getOwnPropertySymbols(e)
+    .find((it) => it.description === 'kCapture');
+  assert.strictEqual(e[kCapture], true);
+}


### PR DESCRIPTION
The `domain` module override the `EventEmitter.init` but not pass the params to origin function.

Since `repl` module require `domain` module, the root cause of https://github.com/nodejs/node/issues/41391 is in `domain` module. 

Fixes: https://github.com/nodejs/node/issues/41391

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
