### PR TITLE
doc: Clarify path search in child_process spawn

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -37,9 +37,10 @@ option if the output will not be consumed.
 
 The command lookup is performed using the `options.env.PATH` environment
 variable if `env` is in the `options` object. Otherwise, `process.env.PATH` is
-used. If `options.env` is set without `PATH`, lookup on UNIX is performed
-on a default search path search of `/usr/bin:/bin` (see execvpe/execvp), on Windows
-the current processes environment variable `PATH` is used.
+used. If `options.env` is set without `PATH`, lookup on Unix is performed
+on a default search path search of `/usr/bin:/bin` (see your operating systems
+manual for execvpe/execvp), on Windows the current processes environment
+variable `PATH` is used.
 
 On Windows, environment variables are case-insensitive. Node.js
 lexicographically sorts the `env` keys and uses the first one that

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -38,7 +38,7 @@ option if the output will not be consumed.
 The command lookup is performed using the `options.env.PATH` environment
 variable if `env` is in the `options` object. Otherwise, `process.env.PATH` is
 used. If `options.env` is set without `PATH`, lookup on Unix is performed
-on a default search path search of `/usr/bin:/bin` (see your operating systems
+on a default search path search of `/usr/bin:/bin` (see your operating system's
 manual for execvpe/execvp), on Windows the current processes environment
 variable `PATH` is used.
 

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -37,7 +37,7 @@ option if the output will not be consumed.
 
 The command lookup is performed using the `options.env.PATH` environment
 variable if `env` is in the `options` object. Otherwise, `process.env.PATH` is
-used. If `options.env` is set, but without `PATH`, lookup on UNIX is performed
+used. If `options.env` is set without `PATH`, lookup on UNIX is performed
 on a default search path search of `/usr/bin:/bin` (see execvpe/execvp), on Windows
 the current processes environment variable `PATH` is used.
 

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -36,8 +36,10 @@ identical to the behavior of pipes in the shell. Use the `{ stdio: 'ignore' }`
 option if the output will not be consumed.
 
 The command lookup is performed using the `options.env.PATH` environment
-variable if it is in the `options` object. Otherwise, `process.env.PATH` is
-used.
+variable if `env` is in the `options` object. Otherwise, `process.env.PATH` is
+used. If `options.env` is set, but without `PATH`, lookup on UNIX is performed
+on a default search path search of `/usr/bin:/bin` (see execvpe/execvp), on Windows
+the current processes environment variable `PATH` is used.
 
 On Windows, environment variables are case-insensitive. Node.js
 lexicographically sorts the `env` keys and uses the first one that


### PR DESCRIPTION
child_process: clarify path search in spawn(), explain difference between unix/win when PATH is not present in env option

The documentation about command lookup could be more clear and note differences between Windows and Linux/OSX.
Current text gives the impression that if one passes `options.env` without `PATH` that the path search will fall back on `process.env.PATH`.
However in reality, passing environment without PATH to execvp causes it to look for the binary only in `/usr/bin:/bin`.
Also Windows behaves different and more in line with the current documentation text.

References:
https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/execvp.3.html
https://linux.die.net/man/3/execvp

https://github.com/nodejs/node/blob/c61870c376e2f5b0dbaa939972c46745e21cdbdd/deps/uv/src/unix/process.c#L337
https://github.com/nodejs/node/blob/c61870c376e2f5b0dbaa939972c46745e21cdbdd/deps/uv/src/win/process.c#L1017

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
