### PR TITLE
process: ignore asyncId 0 in exception handler

### DIFF
--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -20,7 +20,8 @@ const {
   clearAsyncIdStack,
   hasAsyncIdStack,
   afterHooksExist,
-  emitAfter
+  emitAfter,
+  popAsyncContext,
 } = require('internal/async_hooks');
 
 // shouldAbortOnUncaughtToggle is a typed array for faster
@@ -183,7 +184,11 @@ function createOnGlobalUncaughtException() {
     // Emit the after() hooks now that the exception has been handled.
     if (afterHooksExist()) {
       do {
-        emitAfter(executionAsyncId());
+        const asyncId = executionAsyncId();
+        if (asyncId === 0)
+          popAsyncContext(0);
+        else
+          emitAfter(asyncId);
       } while (hasAsyncIdStack());
     }
     // And completely empty the id stack, including anything that may be

--- a/test/async-hooks/init-hooks.js
+++ b/test/async-hooks/init-hooks.js
@@ -168,9 +168,6 @@ class ActivityCollector {
       }
       const err = new Error(`Found a handle whose ${hook}` +
                             ' hook was invoked but not its init hook');
-      // Don't throw if we see invocations due to an assertion in a test
-      // failing since we want to list the assertion failure instead
-      if (/process\._fatalException/.test(err.stack)) return null;
       throw err;
     }
     return h;

--- a/test/async-hooks/test-unhandled-exception-valid-ids.js
+++ b/test/async-hooks/test-unhandled-exception-valid-ids.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const initHooks = require('./init-hooks');
+
+const hooks = initHooks();
+hooks.enable();
+
+setImmediate(() => {
+  throw new Error();
+});
+
+setTimeout(() => {
+  throw new Error();
+}, 1);
+
+process.on('uncaughtException', common.mustCall(2));


### PR DESCRIPTION
Today, the global uncaught exception handler is the only place where asyncId 0 is not ignored and we still proceed to call emitAfter. This would've already failed one of our correctness tests in async_hooks if not for some other code meant to handle a different edge case.

Fixes: https://github.com/nodejs/node/issues/22982

Tests failing before the fix:

```
=== release test-timers.setInterval ===                                       
Path: async-hooks/test-timers.setInterval
Error: Found a handle whose after hook was invoked but not its init hook
    at ActivityCollector._getActivity (/Users/apapirovski/Web/nodejs/test/async-hooks/init-hooks.js:169:19)
    at ActivityCollector._after (/Users/apapirovski/Web/nodejs/test/async-hooks/init-hooks.js:200:20)
    at emitHook (node:internal/async_hooks:233:38)
    at emitAfterScript (node:internal/async_hooks:520:5)
    at process._fatalException (node:internal/process/execution:192:9)
node:assert:123
  throw new AssertionError(obj);
  ^

AssertionError [ERR_ASSERTION]: Checking invocations at stage "t1: when process exits":
     Called "before" 1 time(s), but expected 2 invocation(s).
    at checkHook (/Users/apapirovski/Web/nodejs/test/async-hooks/hook-checks.js:51:14)
    at Array.forEach (<anonymous>)
    at checkInvocations (/Users/apapirovski/Web/nodejs/test/async-hooks/hook-checks.js:28:62)
    at process.<anonymous> (/Users/apapirovski/Web/nodejs/test/async-hooks/test-timers.setInterval.js:44:3)
    at process.emit (node:events:532:35)
    at process.exit (node:internal/process/per_thread:183:15)
    at fatalError (node:internal/async_hooks:174:11)
    at emitHook (node:internal/async_hooks:237:5)
    at emitAfterScript (node:internal/async_hooks:520:5)
    at process._fatalException (node:internal/process/execution:192:9) {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: 1,
  expected: 2,
  operator: 'strictEqual'
}

Node.js v18.0.0-pre
Command: out/Release/node /Users/apapirovski/Web/nodejs/test/async-hooks/test-timers.setInterval.js
=== release test-unhandled-exception-valid-ids ===                    
Path: async-hooks/test-unhandled-exception-valid-ids
Error: Found a handle whose after hook was invoked but not its init hook
    at ActivityCollector._getActivity (/Users/apapirovski/Web/nodejs/test/async-hooks/init-hooks.js:169:19)
    at ActivityCollector._after (/Users/apapirovski/Web/nodejs/test/async-hooks/init-hooks.js:200:20)
    at emitHook (node:internal/async_hooks:233:38)
    at emitAfterScript (node:internal/async_hooks:520:5)
    at process._fatalException (node:internal/process/execution:192:9)
Command: out/Release/node /Users/apapirovski/Web/nodejs/test/async-hooks/test-unhandled-exception-valid-ids.js
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
