### PR TITLE
test: improve test coverage of dns/promises

### DIFF
--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -274,6 +274,7 @@ dns.lookup('', {
   await dnsPromises.lookup('', {
     hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL
   });
+  await dnsPromises.lookup('', { verbatim: true });
 })().then(common.mustCall());
 
 {


### PR DESCRIPTION
This improves a test coverage in lib/internal/dns/promises.
ref: https://coverage.nodejs.org/coverage-0b4e9ae656e93e5f/lib/internal/dns/promises.js.html#L128

This test confirms the following:
- whether `dnsPromises.lookup` can receive `verbatim` option
