### PR TITLE
doc: add note regarding unfinished TLA

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -597,8 +597,7 @@ added: v14.8.0
 
 > Stability: 1 - Experimental
 
-The `await` keyword may be used in the top level (outside of async functions)
-body of an ECMAScript module.
+The `await` keyword may be used in the top level body of an ECMAScript module.
 
 Assuming an `a.mjs` with
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -591,14 +591,16 @@ would provide the exports interface for the instantiation of `module.wasm`.
 
 ## Top-level `await`
 
+<!--
+added: v14.8.0
+-->
+
 > Stability: 1 - Experimental
 
 The `await` keyword may be used in the top level (outside of async functions)
-within modules as per the [ECMAScript Top-Level `await` proposal][].
+body of an ECMAScript module.
 
 Assuming an `a.mjs` with
-
-<!-- eslint-skip -->
 
 ```js
 export const five = await Promise.resolve(5);
@@ -614,6 +616,23 @@ console.log(five); // Logs `5`
 
 ```bash
 node b.mjs # works
+```
+
+If a top level `await` expression never resolves, the `node` process will exit
+with a `13` [status code][].
+
+```js
+import { spawn } from 'child_process';
+import { execPath } from 'process';
+
+spawn(execPath, [
+  '--input-type=module',
+  '--eval',
+  // Never-resolving Promise:
+  'await new Promise(() => {})',
+]).once('exit', (code) => {
+  console.log(code); // Logs `13`
+});
 ```
 
 <i id="esm_experimental_loaders"></i>
@@ -1426,7 +1445,6 @@ success!
 [Conditional exports]: packages.md#conditional-exports
 [Core modules]: modules.md#core-modules
 [Dynamic `import()`]: https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports
-[ECMAScript Top-Level `await` proposal]: https://github.com/tc39/proposal-top-level-await/
 [ES Module Integration Proposal for WebAssembly]: https://github.com/webassembly/esm-integration
 [Import Assertions]: #import-assertions
 [Import Assertions proposal]: https://github.com/tc39/proposal-import-assertions
@@ -1461,5 +1479,6 @@ success!
 [percent-encoded]: url.md#percent-encoding-in-urls
 [resolve hook]: #resolvespecifier-context-defaultresolve
 [special scheme]: https://url.spec.whatwg.org/#special-scheme
+[status code]: process.md#exit-codes
 [the official standard format]: https://tc39.github.io/ecma262/#sec-modules
 [url.pathToFileURL]: url.md#urlpathtofileurlpath


### PR DESCRIPTION
Now that the proposal [has reached Stage 4](https://github.com/tc39/proposal-top-level-await/commit/2762cc57808dd6c965257b5deec636362b4228de), I think it's time to remove the link from our docs.

Trying to use `await` somewhere it's not allowed with a Chromium browser returns the following error: `await is only valid in async functions and the top level bodies of modules`. That's why I'm re-using the term "body" in this PR, please correct me if you think that's not correct.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
