### PR TITLE
doc: add note for handling signal events in trace events

### DIFF
--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -87,7 +87,7 @@ in your code, such as:
 ```js
 process.on('SIGINT', function onSigint() {
   console.info('Received SIGINT.');
-  process.exit();
+  process.exit(130);  // Or applicable exit code depending on OS and signal
 });
 ```
 

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -80,6 +80,17 @@ string that supports `${rotation}` and `${pid}`:
 node --trace-event-categories v8 --trace-event-file-pattern '${pid}-${rotation}.log' server.js
 ```
 
+To guarantee that the log file is properly generated after signal events like
+`SIGINT`, `SIGTERM`, or `SIGBREAK`, make sure to have the appropriate handlers
+in your code, such as:
+
+```js
+process.on('SIGINT', function onSigint() {
+  console.info('Received SIGINT.');
+  process.exit();
+});
+```
+
 The tracing system uses the same time source
 as the one used by `process.hrtime()`.
 However the trace-event timestamps are expressed in microseconds,


### PR DESCRIPTION
Keeping in mind issues like https://github.com/nodejs/node/issues/18476 and https://github.com/nodejs/node/issues/14802, I went ahead and added a note to the docs for users to handle signal events properly, so that trace events are correctly logged into files.

I'm happy to make any changes to this PR as needed since it's my first time contributing to the Node.js project.
