### PR TITLE
esm: improve validation of resolved URLs

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -29,7 +29,7 @@ const {
   ERR_INVALID_RETURN_VALUE,
   ERR_UNKNOWN_MODULE_FORMAT
 } = require('internal/errors').codes;
-const { pathToFileURL, isURLInstance } = require('internal/url');
+const { pathToFileURL, isURLInstance, URL } = require('internal/url');
 const {
   isAnyArrayBuffer,
   isArrayBufferView,
@@ -558,14 +558,8 @@ class ESMLoader {
         format,
       );
     }
-    if (typeof url !== 'string') {
-      throw new ERR_INVALID_RETURN_PROPERTY_VALUE(
-        'string',
-        'loader resolve',
-        'url',
-        url,
-      );
-    }
+
+    new URL(url); // Intentionally trigger error if `url` is invalid
 
     return {
       format,

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -559,6 +559,15 @@ class ESMLoader {
       );
     }
 
+    if (typeof url !== 'string') { // non-strings can be coerced to a url string
+      throw new ERR_INVALID_RETURN_PROPERTY_VALUE(
+        'string',
+        'loader resolve',
+        'url',
+        url,
+      );
+    }
+
     new URL(url); // Intentionally trigger error if `url` is invalid
 
     return {

--- a/test/es-module/test-esm-loader-invalid-url.mjs
+++ b/test/es-module/test-esm-loader-invalid-url.mjs
@@ -4,11 +4,7 @@ import assert from 'assert';
 
 import('../fixtures/es-modules/test-esm-ok.mjs')
 .then(assert.fail, (error) => {
-  expectsError({
-    code: 'ERR_INVALID_URL',
-    message: 'Invalid URL'
-  })(error);
-
+  expectsError({ code: 'ERR_INVALID_URL' })(error);
   assert.strictEqual(error.input, '../fixtures/es-modules/test-esm-ok.mjs');
 })
 .then(mustCall());

--- a/test/fixtures/es-module-loaders/hooks-custom.mjs
+++ b/test/fixtures/es-module-loaders/hooks-custom.mjs
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url';
 import count from '../es-modules/stateful.mjs';
 
 
@@ -24,28 +25,28 @@ export function load(url, context, next) {
     format: 'module',
   });
 
-  if (url === 'esmHook/badReturnVal.mjs') return 'export function returnShouldBeObject() {}';
+  if (url.endsWith('esmHook/badReturnVal.mjs')) return 'export function returnShouldBeObject() {}';
 
-  if (url === 'esmHook/badReturnFormatVal.mjs') return {
+  if (url.endsWith('esmHook/badReturnFormatVal.mjs')) return {
     format: Array(0),
     source: '',
   }
-  if (url === 'esmHook/unsupportedReturnFormatVal.mjs') return {
+  if (url.endsWith('esmHook/unsupportedReturnFormatVal.mjs')) return {
     format: 'foo', // Not one of the allowable inputs: no translator named 'foo'
     source: '',
   }
 
-  if (url === 'esmHook/badReturnSourceVal.mjs') return {
+  if (url.endsWith('esmHook/badReturnSourceVal.mjs')) return {
     format: 'module',
     source: Array(0),
   }
 
-  if (url === 'esmHook/preknownFormat.pre') return {
+  if (url.endsWith('esmHook/preknownFormat.pre')) return {
     format: context.format,
     source: `const msg = 'hello world'; export default msg;`
   };
 
-  if (url === 'esmHook/virtual.mjs') return {
+  if (url.endsWith('esmHook/virtual.mjs')) return {
     format: 'module',
     source: `export const message = 'Woohoo!'.toUpperCase();`,
   };
@@ -62,7 +63,7 @@ export function resolve(specifier, context, next) {
 
   if (specifier.startsWith('esmHook')) return {
     format,
-    url: specifier,
+    url: pathToFileURL(specifier).href,
     importAssertions: context.importAssertions,
   };
 


### PR DESCRIPTION
Some ESM internals use type coercion on URL instances to get the href of the URL (ex `` `${url}` ``). This can result in `'undefined'`, which bypasses the current simple "is a string" validation. When that is bypassed, the resulting thrown error is a red herring, pointing to completely unrelated code.

Rather than merely switching those internals to use less errant alternatives, I think it's better to improve validation.

cc @nodejs/loaders @nodejs/modules