### PR TITLE
src: fix out-of-bounds check of serialization indices

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -98,19 +98,19 @@ class DeserializerDelegate : public ValueDeserializer::Delegate {
     uint32_t id;
     if (!deserializer->ReadUint32(&id))
       return MaybeLocal<Object>();
-    CHECK_LE(id, host_objects_.size());
+    CHECK_LT(id, host_objects_.size());
     return host_objects_[id]->object(isolate);
   }
 
   MaybeLocal<SharedArrayBuffer> GetSharedArrayBufferFromId(
       Isolate* isolate, uint32_t clone_id) override {
-    CHECK_LE(clone_id, shared_array_buffers_.size());
+    CHECK_LT(clone_id, shared_array_buffers_.size());
     return shared_array_buffers_[clone_id];
   }
 
   MaybeLocal<WasmModuleObject> GetWasmModuleFromId(
       Isolate* isolate, uint32_t transfer_id) override {
-    CHECK_LE(transfer_id, wasm_modules_.size());
+    CHECK_LT(transfer_id, wasm_modules_.size());
     return WasmModuleObject::FromCompiledModule(
         isolate, wasm_modules_[transfer_id]);
   }


### PR DESCRIPTION
The usage of `CHECK_LE` to verify that the index is within bounds
of a vector's size allows for reading one item past the vector's end,
which is in invalid memory read. This commit fixes the off-by-one error
by changing the bounds check to use `CHECK_LT`.