### PR TITLE
deps: V8: cherry-pick 3b6b21f595f6

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/wasm/baseline/arm/liftoff-assembler-arm.h
+++ b/deps/v8/src/wasm/baseline/arm/liftoff-assembler-arm.h
@@ -438,7 +438,7 @@ inline void EmitAnyTrue(LiftoffAssembler* assm, LiftoffRegister dst,
 
 int LiftoffAssembler::PrepareStackFrame() {
   if (!CpuFeatures::IsSupported(ARMv7)) {
-    bailout(kUnsupportedArchitecture, "Armv6 not supported");
+    bailout(kUnsupportedArchitecture, "Liftoff needs ARMv7");
     return 0;
   }
   uint32_t offset = static_cast<uint32_t>(pc_offset());

--- a/deps/v8/src/wasm/baseline/liftoff-compiler.cc
+++ b/deps/v8/src/wasm/baseline/liftoff-compiler.cc
@@ -310,6 +310,13 @@ void CheckBailoutAllowed(LiftoffBailoutReason reason, const char* detail,
   return;
 #endif
 
+#if V8_TARGET_ARCH_ARM
+  // Allow bailout for missing ARMv7 support.
+  if (!CpuFeatures::IsSupported(ARMv7) && reason == kUnsupportedArchitecture) {
+    return;
+  }
+#endif
+
 #define LIST_FEATURE(name, ...) kFeature_##name,
   constexpr WasmFeatures kExperimentalFeatures{
       FOREACH_WASM_EXPERIMENTAL_FEATURE_FLAG(LIST_FEATURE)};


### PR DESCRIPTION
Original commit message:

    [liftoff] Allow bailout for missing ARMv7

    The bailout is there explicitly in the code, so we should allow it in
    {CheckBailoutAllowed}.

    R=ahaas@chromium.org

    Bug: v8:12527
    Change-Id: Ifd906afb5f034f05c2bf7d9a28e3ab458549e7ef
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3372915
    Reviewed-by: Andreas Haas <ahaas@chromium.org>
    Commit-Queue: Clemens Backes <clemensb@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#78515}

Refs: https://github.com/v8/v8/commit/3b6b21f595f6c172b5b77bf85a3882516f7d7f1b

Fixes: https://github.com/nodejs/node/issues/41402
