### PR TITLE
doc: remove SameValue comparison reference

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -686,8 +686,7 @@ are recursively evaluated also by the following rules.
 
 ### Comparison details
 
-* Primitive values are compared using the [SameValue Comparison][], used by
-  [`Object.is()`][].
+* Primitive values are compared using [`Object.is()`][].
 * [Type tags][Object.prototype.toString()] of objects should be the same.
 * [`[[Prototype]]`][prototype-spec] of objects are compared using
   the [`===` operator][].
@@ -741,7 +740,7 @@ assert.deepStrictEqual(date, fakeDate);
 // - Date {}
 
 assert.deepStrictEqual(NaN, NaN);
-// OK, because of the SameValue comparison
+// OK because Object.is(NaN, NaN) is true.
 
 // Different unwrapped numbers:
 assert.deepStrictEqual(new Number(1), new Number(2));
@@ -757,7 +756,7 @@ assert.deepStrictEqual(new String('foo'), Object('foo'));
 assert.deepStrictEqual(-0, -0);
 // OK
 
-// Different zeros using the SameValue Comparison:
+// Different zeros:
 assert.deepStrictEqual(0, -0);
 // AssertionError: Expected inputs to be strictly deep-equal:
 // + actual - expected
@@ -833,7 +832,7 @@ assert.deepStrictEqual(date, fakeDate);
 // - Date {}
 
 assert.deepStrictEqual(NaN, NaN);
-// OK, because of the SameValue comparison
+// OK because Object.is(NaN, NaN) is true.
 
 // Different unwrapped numbers:
 assert.deepStrictEqual(new Number(1), new Number(2));
@@ -849,7 +848,7 @@ assert.deepStrictEqual(new String('foo'), Object('foo'));
 assert.deepStrictEqual(-0, -0);
 // OK
 
-// Different zeros using the SameValue Comparison:
+// Different zeros:
 assert.deepStrictEqual(0, -0);
 // AssertionError: Expected inputs to be strictly deep-equal:
 // + actual - expected
@@ -1734,7 +1733,7 @@ changes:
 * `message` {string|Error}
 
 Tests strict inequality between the `actual` and `expected` parameters as
-determined by the [SameValue Comparison][].
+determined by [`Object.is()`][].
 
 ```mjs
 import assert from 'assert/strict';
@@ -2026,7 +2025,7 @@ changes:
 * `message` {string|Error}
 
 Tests strict equality between the `actual` and `expected` parameters as
-determined by the [SameValue Comparison][].
+determined by [`Object.is()`][].
 
 ```mjs
 import assert from 'assert/strict';
@@ -2446,7 +2445,6 @@ argument.
 
 [Object wrappers]: https://developer.mozilla.org/en-US/docs/Glossary/Primitive#Primitive_wrapper_objects_in_JavaScript
 [Object.prototype.toString()]: https://tc39.github.io/ecma262/#sec-object.prototype.tostring
-[SameValue Comparison]: https://tc39.github.io/ecma262/#sec-samevalue
 [`!=` operator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Inequality
 [`===` operator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality
 [`==` operator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Equality


### PR DESCRIPTION
Referring to `Object.is()` will be more clear and direct. The
`Object.is()` reference in turn refers to `SameValue` so people can dig
deeper there if they want or need to.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
