### PR TITLE
buffer: fix atob/btoa no-arg case

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -96,6 +96,7 @@ const {
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_BUFFER_SIZE,
     ERR_OUT_OF_RANGE,
+    ERR_MISSING_ARGS,
     ERR_UNKNOWN_ENCODING
   },
   hideStackFrames
@@ -1218,6 +1219,9 @@ function btoa(input) {
   // The implementation here has not been performance optimized in any way and
   // should not be.
   // Refs: https://github.com/nodejs/node/pull/38433#issuecomment-828426932
+  if (arguments.length === 0) {
+    throw new ERR_MISSING_ARGS('input');
+  }
   input = `${input}`;
   for (let n = 0; n < input.length; n++) {
     if (input[n].charCodeAt(0) > 0xff)
@@ -1234,6 +1238,9 @@ function atob(input) {
   // The implementation here has not been performance optimized in any way and
   // should not be.
   // Refs: https://github.com/nodejs/node/pull/38433#issuecomment-828426932
+  if (arguments.length === 0) {
+    throw new ERR_MISSING_ARGS('input');
+  }
   input = `${input}`;
   for (let n = 0; n < input.length; n++) {
     if (!kBase64Digits.includes(input[n]))

--- a/test/parallel/test-btoa-atob-global.js
+++ b/test/parallel/test-btoa-atob-global.js
@@ -1,9 +1,0 @@
-'use strict';
-
-require('../common');
-
-const { strictEqual } = require('assert');
-const buffer = require('buffer');
-
-strictEqual(globalThis.atob, buffer.atob);
-strictEqual(globalThis.btoa, buffer.btoa);

--- a/test/parallel/test-btoa-atob.js
+++ b/test/parallel/test-btoa-atob.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+
+const { strictEqual, throws } = require('assert');
+const buffer = require('buffer');
+
+// Exported on the global object
+strictEqual(globalThis.atob, buffer.atob);
+strictEqual(globalThis.btoa, buffer.btoa);
+
+// Throws type error on no argument passed
+throws(() => buffer.atob(), /TypeError/);
+throws(() => buffer.btoa(), /TypeError/);


### PR DESCRIPTION
Throw `TypeError` on `atob()` and `btoa()`.

Fixes: https://github.com/nodejs/node/issues/41450