### PR TITLE
crypto: adjust types for getRandomValues

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -357,7 +357,7 @@ added: v15.0.0
 <!--lint disable maximum-line-length remark-lint-->
 
 * `typedArray` {Buffer|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|BigInt64Array|BigUint64Array}
-* Returns: {Buffer|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|BigInt64Array|BigUint64Array} Returns `typedArray`.
+* Returns: {Buffer|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|BigInt64Array|BigUint64Array}
 
 <!--lint enable maximum-line-length remark-lint-->
 

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -354,11 +354,17 @@ Provides access to the `SubtleCrypto` API.
 added: v15.0.0
 -->
 
-* `typedArray` {Buffer|TypedArray|DataView|ArrayBuffer}
-* Returns: {Buffer|TypedArray|DataView|ArrayBuffer} Returns `typedArray`.
+<!--lint disable maximum-line-length remark-lint-->
+
+* `typedArray` {Buffer|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|BigInt64Array|BigUint64Array}
+* Returns: {Buffer|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|BigInt64Array|BigUint64Array} Returns `typedArray`.
+
+<!--lint enable maximum-line-length remark-lint-->
 
 Generates cryptographically strong random values. The given `typedArray` is
 filled with random values, and a reference to `typedArray` is returned.
+
+The given `typedArray` must be an integer-based instance of {TypedArray}.
 
 An error will be thrown if the given `typedArray` is larger than 65,536 bytes.
 

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -354,17 +354,14 @@ Provides access to the `SubtleCrypto` API.
 added: v15.0.0
 -->
 
-<!--lint disable maximum-line-length remark-lint-->
-
-* `typedArray` {Buffer|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|BigInt64Array|BigUint64Array}
-* Returns: {Buffer|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|BigInt64Array|BigUint64Array}
-
-<!--lint enable maximum-line-length remark-lint-->
+* `typedArray` {Buffer|TypedArray}
+* Returns: {Buffer|TypedArray}
 
 Generates cryptographically strong random values. The given `typedArray` is
 filled with random values, and a reference to `typedArray` is returned.
 
-The given `typedArray` must be an integer-based instance of {TypedArray}.
+The given `typedArray` must be an integer-based instance of {TypedArray},
+i.e. `Float32Array` and `Float64Array` are not accepted.
 
 An error will be thrown if the given `typedArray` is larger than 65,536 bytes.
 

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -50,6 +50,7 @@ const {
 const {
   isArrayBufferView,
   isAnyArrayBuffer,
+  isTypedArray,
   isFloat32Array,
   isFloat64Array,
 } = require('internal/util/types');
@@ -307,7 +308,7 @@ function onJobDone(buf, callback, error) {
 // not allowed to exceed 65536 bytes, and can only
 // be an integer-type TypedArray.
 function getRandomValues(data) {
-  if (!isArrayBufferView(data) ||
+  if (!isTypedArray(data) ||
       isFloat32Array(data) ||
       isFloat64Array(data)) {
     // Ordinarily this would be an ERR_INVALID_ARG_TYPE. However,

--- a/test/parallel/test-webcrypto-random.js
+++ b/test/parallel/test-webcrypto-random.js
@@ -13,6 +13,7 @@ const { getRandomValues } = require('crypto').webcrypto;
   undefined, null, '', 1, {}, [],
   new Float32Array(1),
   new Float64Array(1),
+  new DataView(new ArrayBuffer(1)),
 ].forEach((i) => {
   assert.throws(
     () => getRandomValues(i),
@@ -32,6 +33,7 @@ const intTypedConstructors = [
   Uint8Array,
   Uint16Array,
   Uint32Array,
+  Uint8ClampedArray,
   BigInt64Array,
   BigUint64Array,
 ];
@@ -47,7 +49,7 @@ for (const ctor of intTypedConstructors) {
 {
   const buf = new Uint16Array(10);
   const before = Buffer.from(buf).toString('hex');
-  getRandomValues(new DataView(buf.buffer));
+  getRandomValues(buf);
   const after = Buffer.from(buf).toString('hex');
   assert.notStrictEqual(before, after);
 }

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -16,7 +16,10 @@ const jsGlobalTypes = [
   'AggregateError', 'Array', 'ArrayBuffer', 'DataView', 'Date', 'Error',
   'EvalError', 'Function', 'Map', 'Object', 'Promise', 'RangeError',
   'ReferenceError', 'RegExp', 'Set', 'SharedArrayBuffer', 'SyntaxError',
-  'TypeError', 'TypedArray', 'URIError', 'Uint8Array',
+  'TypeError', 'TypedArray', 'URIError', 'Int8Array', 'Uint8Array',
+  'Uint8ClampedArray', 'Int16Array', 'Uint16Array', 'Int32Array',
+  'Uint32Array', 'Float32Array', 'Float64Array', 'BigInt64Array',
+  'BigUint64Array',
 ];
 
 const customTypesMap = {

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -16,10 +16,7 @@ const jsGlobalTypes = [
   'AggregateError', 'Array', 'ArrayBuffer', 'DataView', 'Date', 'Error',
   'EvalError', 'Function', 'Map', 'Object', 'Promise', 'RangeError',
   'ReferenceError', 'RegExp', 'Set', 'SharedArrayBuffer', 'SyntaxError',
-  'TypeError', 'TypedArray', 'URIError', 'Int8Array', 'Uint8Array',
-  'Uint8ClampedArray', 'Int16Array', 'Uint16Array', 'Int32Array',
-  'Uint32Array', 'Float32Array', 'Float64Array', 'BigInt64Array',
-  'BigUint64Array',
+  'TypeError', 'TypedArray', 'URIError', 'Uint8Array',
 ];
 
 const customTypesMap = {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/41480

Prevents Web Crypto API's getRandomValues from accepting DataView

WIP/draft at this moment.

I'm not sure if `new DataView(buf.buffer)` in this test was intentional:
https://github.com/nodejs/node/blob/6b7b0b72887b5050b71ea7eca940e3eac2bb9a07/test/parallel/test-webcrypto-random.js#L47-L53
