### PR TITLE
doc: format changelog for v16.13.2

### DIFF
--- a/doc/changelogs/CHANGELOG_V16.md
+++ b/doc/changelogs/CHANGELOG_V16.md
@@ -99,12 +99,12 @@ Thanks to Patrik Oldsberg (rugvip) for reporting this vulnerability.
 
 ### Commits
 
-* [[`8dd4ca4537`](https://github.com/nodejs/node/commit/8dd4ca4537)] - **console**: fix prototype pollution via console.table (Tobias Nießen) [nodejs-private/node-private#307](https://github.com/nodejs-private/node-private/pull/307)
-* [[`e52882da4c`](https://github.com/nodejs/node/commit/e52882da4c)] - **crypto,tls**: implement safe x509 GeneralName format (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
-* [[`9a0a189b0b`](https://github.com/nodejs/node/commit/9a0a189b0b)] - **src**: add cve reverts and associated tests (Michael Dawson) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
-* [[`4a262d42bc`](https://github.com/nodejs/node/commit/4a262d42bc)] - **src**: remove unused x509 functions (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
-* [[`965536fe3d`](https://github.com/nodejs/node/commit/965536fe3d)] - **tls**: fix handling of x509 subject and issuer (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
-* [[`a2cbfa95ff`](https://github.com/nodejs/node/commit/a2cbfa95ff)] - **tls**: drop support for URI alternative names (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
+* \[[`8dd4ca4537`](https://github.com/nodejs/node/commit/8dd4ca4537)] - **console**: fix prototype pollution via console.table (Tobias Nießen) [nodejs-private/node-private#307](https://github.com/nodejs-private/node-private/pull/307)
+* \[[`e52882da4c`](https://github.com/nodejs/node/commit/e52882da4c)] - **crypto,tls**: implement safe x509 GeneralName format (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
+* \[[`9a0a189b0b`](https://github.com/nodejs/node/commit/9a0a189b0b)] - **src**: add cve reverts and associated tests (Michael Dawson) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
+* \[[`4a262d42bc`](https://github.com/nodejs/node/commit/4a262d42bc)] - **src**: remove unused x509 functions (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
+* \[[`965536fe3d`](https://github.com/nodejs/node/commit/965536fe3d)] - **tls**: fix handling of x509 subject and issuer (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
+* \[[`a2cbfa95ff`](https://github.com/nodejs/node/commit/a2cbfa95ff)] - **tls**: drop support for URI alternative names (Tobias Nießen) [nodejs-private/node-private#300](https://github.com/nodejs-private/node-private/pull/300)
 
 <a id="16.13.1"></a>
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Re-runs the markdown formatter that was missed in yesterday's 16.x release. The formatted changelog landed in master, but it was too late to adjust the commit in the release branch.

`master` commit: https://github.com/nodejs/node/commit/f99a2c275d940a9b55aa8a12f56c3be5984b2f64