### PR TITLE
fs: make kMaximumAccessMode more accurate

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -11,6 +11,7 @@ const {
   Number,
   NumberIsFinite,
   NumberIsInteger,
+  MathMax,
   MathMin,
   ObjectIs,
   ObjectPrototypeHasOwnProperty,
@@ -101,11 +102,11 @@ const {
   }
 } = internalBinding('constants');
 
-// The access modes can be any of F_OK, R_OK, W_OK or X_OK. Some might not be
-// available on specific systems. They can be used in combination as well
-// (F_OK | R_OK | W_OK | X_OK).
+// The access modes can be any of F_OK, R_OK, W_OK, or X_OK. Some might not be
+// available on specific systems. R_OK, W_OK, and X_OK can be used in
+// combination (R_OK | W_OK | X_OK). F_OK should be used alone.
 const kMinimumAccessMode = MathMin(F_OK, W_OK, R_OK, X_OK);
-const kMaximumAccessMode = F_OK | W_OK | R_OK | X_OK;
+const kMaximumAccessMode = MathMax(F_OK, W_OK | R_OK | X_OK);
 
 const kDefaultCopyMode = 0;
 // The copy modes can be any of COPYFILE_EXCL, COPYFILE_FICLONE or


### PR DESCRIPTION
This is a breaking change on some platforms, depending on the value of the `fs.access()` `mode` constants.

`kMaximumAccessMode` is used to validate mode values passed to
the `fs.access()` family of functions. This commit updates the
value to be the maximum of `F_OK` and `(R_OK|W_OK|X_OK)`. This is
because `F_OK` should not be used in combination with the other
values.

Refs: https://github.com/libuv/libuv/pull/3410
cc: @zsw007