### PR TITLE
http2: fix memory leak when nghttp2 hd threshold is reached

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -401,6 +401,10 @@ class Http2Stream : public AsyncWrap,
     size_t i = 0;
     for (const auto& header : current_headers_ )
       fn(header, i++);
+    ClearHeaders();
+  }
+
+  void ClearHeaders() {
     current_headers_.clear();
   }
 
@@ -786,6 +790,8 @@ class Http2Session : public AsyncWrap,
   void HandlePingFrame(const nghttp2_frame* frame);
   void HandleAltSvcFrame(const nghttp2_frame* frame);
   void HandleOriginFrame(const nghttp2_frame* frame);
+
+  void DecrefHeaders(const nghttp2_frame* frame);
 
   // nghttp2 callbacks
   static int OnBeginHeadersCallback(

--- a/test/parallel/test-http2-options-max-headers-exceeds-nghttp2.js
+++ b/test/parallel/test-http2-options-max-headers-exceeds-nghttp2.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const h2 = require('http2');
+
+const server = h2.createServer();
+
+server.on('stream', common.mustNotCall());
+server.on('error', common.mustNotCall());
+
+server.listen(0, common.mustCall(() => {
+
+  // Setting the maxSendHeaderBlockLength > nghttp2 threshold
+  // cause a 'sessionError' and no memory leak when session destroy
+  const options = {
+    maxSendHeaderBlockLength: 100000
+  };
+
+  const client = h2.connect(`http://localhost:${server.address().port}`,
+                            options);
+  client.on('error', common.expectsError({
+    code: 'ERR_HTTP2_SESSION_ERROR',
+    name: 'Error',
+    message: 'Session closed with error code 9'
+  }));
+
+  const req = client.request({
+    // Greater than 65536 bytes
+    'test-header': 'A'.repeat(90000)
+  });
+  req.on('response', common.mustNotCall());
+
+  req.on('close', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+
+  req.on('error', common.expectsError({
+    code: 'ERR_HTTP2_SESSION_ERROR',
+    name: 'Error',
+    message: 'Session closed with error code 9'
+  }));
+  req.end();
+}));


### PR DESCRIPTION
Address: https://github.com/nodejs/node/issues/35233

nghttp2 contains a header limit as you can see here https://github.com/nghttp2/nghttp2/blob/20079b4c2f688385ba9ecf723f958d0448894879/lib/nghttp2_hd.h#L45 and when this limit is reached, the nghttp2 stops the pipelining with https://github.com/nghttp2/nghttp2/blob/master/lib/nghttp2_hd.c#L1658.

However, due to the fact of headers were processed before the error is thrown, the session still holds the memory reference for those headers and in this situation, it's never free causing the memory leak.