### PR TITLE
[v14.x backport] esm: make `process.exit()` default to exit code 0

### DIFF
--- a/lib/internal/modules/esm/handle_process_exit.js
+++ b/lib/internal/modules/esm/handle_process_exit.js
@@ -1,0 +1,12 @@
+'use strict';
+
+// Handle a Promise from running code that potentially does Top-Level Await.
+// In that case, it makes sense to set the exit code to a specific non-zero
+// value if the main code never finishes running.
+function handleProcessExit() {
+  process.exitCode ??= 13;
+}
+
+module.exports = {
+  handleProcessExit,
+};

--- a/lib/internal/modules/esm/handle_process_exit.js
+++ b/lib/internal/modules/esm/handle_process_exit.js
@@ -4,7 +4,7 @@
 // In that case, it makes sense to set the exit code to a specific non-zero
 // value if the main code never finishes running.
 function handleProcessExit() {
-  process.exitCode ??= 13;
+  if (process.exitCode == null) process.exitCode = 13;
 }
 
 module.exports = {

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -8,6 +8,9 @@ const CJSLoader = require('internal/modules/cjs/loader');
 const { Module, toRealPath, readPackageScope } = CJSLoader;
 const { getOptionValue } = require('internal/options');
 const path = require('path');
+const {
+  handleProcessExit,
+} = require('internal/modules/esm/handle_process_exit');
 
 function resolveMainPath(main) {
   // Note extension resolution for the main entry point can be deprecated in a
@@ -51,16 +54,13 @@ function runMainESM(mainPath) {
   }));
 }
 
-function handleMainPromise(promise) {
-  // Handle a Promise from running code that potentially does Top-Level Await.
-  // In that case, it makes sense to set the exit code to a specific non-zero
-  // value if the main code never finishes running.
-  function handler() {
-    if (process.exitCode === undefined)
-      process.exitCode = 13;
+async function handleMainPromise(promise) {
+  process.on('exit', handleProcessExit);
+  try {
+    return await promise;
+  } finally {
+    process.off('exit', handleProcessExit);
   }
-  process.on('exit', handler);
-  return PromisePrototypeFinally(promise, () => process.off('exit', handler));
 }
 
 // For backwards compatibility, we have to run a bunch of

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const {
-  PromisePrototypeFinally,
   StringPrototypeEndsWith,
 } = primordials;
 const CJSLoader = require('internal/modules/cjs/loader');

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -36,6 +36,10 @@ const {
 const format = require('internal/util/inspect').format;
 const constants = internalBinding('constants').os.signals;
 
+const {
+  handleProcessExit,
+} = require('internal/modules/esm/handle_process_exit');
+
 function assert(x, msg) {
   if (!x) throw new ERR_ASSERTION(msg || 'assertion error');
 }
@@ -165,6 +169,8 @@ function wrapProcessMethods(binding) {
   memoryUsage.rss = rss;
 
   function exit(code) {
+    process.off('exit', handleProcessExit);
+
     if (code || code === 0)
       process.exitCode = code;
 

--- a/test/es-module/test-esm-tla-unfinished.mjs
+++ b/test/es-module/test-esm-tla-unfinished.mjs
@@ -80,3 +80,21 @@ import fixtures from '../common/fixtures.js';
   assert.deepStrictEqual([status, stdout], [1, '']);
   assert.match(stderr, /Error: Xyz/);
 }
+
+{
+  // Calling process.exit() in .mjs should return status 0
+  const { status, stdout, stderr } = child_process.spawnSync(
+    process.execPath,
+    [fixtures.path('es-modules/tla/process-exit.mjs')],
+    { encoding: 'utf8' });
+  assert.deepStrictEqual([status, stdout, stderr], [0, '', '']);
+}
+
+{
+  // Calling process.exit() in worker thread shouldn't influence main thread
+  const { status, stdout, stderr } = child_process.spawnSync(
+    process.execPath,
+    [fixtures.path('es-modules/tla/unresolved-with-worker-process-exit.mjs')],
+    { encoding: 'utf8' });
+  assert.deepStrictEqual([status, stdout, stderr], [13, '', '']);
+}

--- a/test/fixtures/es-modules/tla/process-exit.mjs
+++ b/test/fixtures/es-modules/tla/process-exit.mjs
@@ -1,0 +1,1 @@
+process.exit();

--- a/test/fixtures/es-modules/tla/unresolved-with-worker-process-exit.mjs
+++ b/test/fixtures/es-modules/tla/unresolved-with-worker-process-exit.mjs
@@ -1,0 +1,8 @@
+import { Worker, isMainThread } from 'worker_threads';
+
+if (isMainThread) {
+  new Worker(new URL(import.meta.url));
+  await new Promise(() => {});
+} else {
+  process.exit();
+}

--- a/test/message/esm_display_syntax_error_import.out
+++ b/test/message/esm_display_syntax_error_import.out
@@ -6,3 +6,4 @@ SyntaxError: The requested module '../fixtures/es-module-loaders/module-named-ex
     at async ModuleJob.run (internal/modules/esm/module_job.js:*:*)
     at async Loader.import (internal/modules/esm/loader.js:*:*)
     at async Object.loadESM (internal/process/esm_loader.js:*:*)
+    at async handleMainPromise (internal/modules/run_main.js:*:*)

--- a/test/message/esm_display_syntax_error_import_module.out
+++ b/test/message/esm_display_syntax_error_import_module.out
@@ -6,3 +6,4 @@ SyntaxError: The requested module './module-named-exports.mjs' does not provide 
     at async ModuleJob.run (internal/modules/esm/module_job.js:*:*)
     at async Loader.import (internal/modules/esm/loader.js:*:*)
     at async Object.loadESM (internal/process/esm_loader.js:*:*)
+    at async handleMainPromise (internal/modules/run_main.js:*:*)

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -67,6 +67,7 @@ const expectedModules = new Set([
   'NativeModule internal/modules/esm/resolve',
   'NativeModule internal/modules/esm/transform_source',
   'NativeModule internal/modules/esm/translators',
+  'NativeModule internal/modules/esm/handle_process_exit',
   'NativeModule internal/process/esm_loader',
   'NativeModule internal/options',
   'NativeModule internal/priority_queue',


### PR DESCRIPTION
Due to a bug in top-level await implementation, it used to default to
exit code 13.

PR-URL: https://github.com/nodejs/node/pull/41388
Fixes: https://github.com/nodejs/node/issues/40808
Reviewed-By: Antoine du Hamel <duhamelantoine1995@gmail.com>
Reviewed-By: Guy Bedford <guybedford@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
