### PR TITLE
test: improve test coverage of internal/worker/io

### DIFF
--- a/test/parallel/test-broadcastchannel-custom-inspect.js
+++ b/test/parallel/test-broadcastchannel-custom-inspect.js
@@ -1,0 +1,40 @@
+'use strict';
+
+require('../common');
+const { BroadcastChannel } = require('worker_threads');
+const { inspect } = require('util');
+const assert = require('assert');
+
+// This test checks BroadcastChannel custom inspect outputs
+
+{
+  const bc = new BroadcastChannel('name');
+  assert.throws(() => bc[inspect.custom].call(), {
+    code: 'ERR_INVALID_THIS',
+  });
+  bc.close();
+}
+
+{
+  const bc = new BroadcastChannel('name');
+  assert.strictEqual(inspect(bc, { depth: -1 }), 'BroadcastChannel');
+  bc.close();
+}
+
+{
+  const bc = new BroadcastChannel('name');
+  assert.strictEqual(
+    inspect(bc),
+    "BroadcastChannel { name: 'name', active: true }"
+  );
+  bc.close();
+}
+
+{
+  const bc = new BroadcastChannel('name');
+  assert.strictEqual(
+    inspect(bc, { depth: null }),
+    "BroadcastChannel { name: 'name', active: true }"
+  );
+  bc.close();
+}


### PR DESCRIPTION
This improves a test coverage in `internal/worker/io`.
ref: https://coverage.nodejs.org/coverage-74b9baa4265a8f0d/lib/internal/worker/io.js.html#L415

This tests custom inspect outputs of `BroadcastChannel` class.