### PR TITLE
test: improve test coverage of internal/blob

### DIFF
--- a/test/parallel/test-blob-buffer-too-large.js
+++ b/test/parallel/test-blob-buffer-too-large.js
@@ -8,7 +8,8 @@ const { Blob } = require('buffer');
 try {
   new Blob([new Uint8Array(0xffffffff), [1]]);
 } catch (e) {
-  if (e.message === 'Array buffer allocation failed') {
+  if (e.message === 'Array buffer allocation failed' ||
+      e.message === 'Invalid typed array length: 4294967295') {
     common.skip(
       'Insufficient memory on this platform for oversized buffer test.'
     );

--- a/test/parallel/test-blob-buffer-too-large.js
+++ b/test/parallel/test-blob-buffer-too-large.js
@@ -5,11 +5,16 @@ const common = require('../common');
 const assert = require('assert');
 const { Blob } = require('buffer');
 
+if (common.isFreeBSD)
+  common.skip('Oversized buffer make the FreeBSD CI runner crash');
+
 try {
   new Blob([new Uint8Array(0xffffffff), [1]]);
 } catch (e) {
-  if (e.message === 'Array buffer allocation failed' ||
-      e.message === 'Invalid typed array length: 4294967295') {
+  if (
+    e.message === 'Array buffer allocation failed' ||
+    e.message === 'Invalid typed array length: 4294967295'
+  ) {
     common.skip(
       'Insufficient memory on this platform for oversized buffer test.'
     );

--- a/test/parallel/test-blob-buffer-too-large.js
+++ b/test/parallel/test-blob-buffer-too-large.js
@@ -1,0 +1,18 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Blob } = require('buffer');
+
+try {
+  new Blob([new Uint8Array(0xffffffff), [1]]);
+} catch (e) {
+  if (e.message === 'Array buffer allocation failed') {
+    common.skip(
+      'Insufficient memory on this platform for oversized buffer test.'
+    );
+  } else {
+    assert.strictEqual(e.code, 'ERR_BUFFER_TOO_LARGE');
+  }
+}

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -231,8 +231,10 @@ assert.throws(() => new Blob({}), {
     });
   });
 
-  assert.throws(() => new Blob([new Uint8Array(0xffffffff), [1]]), {
-    code: 'ERR_BUFFER_TOO_LARGE',
+  const overSizeArray = Array(17).fill(new Uint8Array(0xfffffff));
+
+  assert.throws(() => new Blob(overSizeArray), {
+    code: "ERR_BUFFER_TOO_LARGE",
   });
 }
 

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -198,6 +198,8 @@ assert.throws(() => new Blob({}), {
   const b = new Blob();
   assert.strictEqual(inspect(b, { depth: null }),
                      'Blob { size: 0, type: \'\' }');
+  assert.strictEqual(inspect(b, { depth: 1 }),
+                     'Blob { size: 0, type: \'\' }');
   assert.strictEqual(inspect(b, { depth: -1 }), '[Blob]');
 }
 
@@ -228,7 +230,35 @@ assert.throws(() => new Blob({}), {
       code: 'ERR_INVALID_ARG_VALUE',
     });
   });
+
+  assert.throws(() => new Blob([new Uint8Array(0xffffffff), [1]]), {
+    code: 'ERR_BUFFER_TOO_LARGE',
+  });
 }
+
+{
+  assert.throws(() => Reflect.get(Blob.prototype, 'type', {}), {
+    code: 'ERR_INVALID_THIS',
+  });
+  assert.throws(() => Reflect.get(Blob.prototype, 'size', {}), {
+    code: 'ERR_INVALID_THIS',
+  });
+  assert.throws(() => Blob.prototype.slice(Blob.prototype, 0, 1), {
+    code: 'ERR_INVALID_THIS',
+  });
+  assert.throws(() => Blob.prototype.stream.call(), {
+    code: 'ERR_INVALID_THIS',
+  });
+}
+
+(async () => {
+  assert.rejects(async () => Blob.prototype.arrayBuffer.call(), {
+    code: 'ERR_INVALID_THIS',
+  });
+  assert.rejects(async () => Blob.prototype.text.call(), {
+    code: 'ERR_INVALID_THIS',
+  });
+})().then(common.mustCall());
 
 (async () => {
   const blob = new Blob([

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -237,7 +237,7 @@ assert.throws(() => new Blob({}), {
       code: 'ERR_BUFFER_TOO_LARGE',
     });
   } catch (e) {
-    if (e.message !== 'Array buffer allocation failed') throw (e);
+    if (e.message !== 'Array buffer allocation failed') throw e;
     common.skip(
       'Insufficient memory on this platform for oversized buffer test.'
     );

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -231,11 +231,17 @@ assert.throws(() => new Blob({}), {
     });
   });
 
-  const overSizeArray = Array(17).fill(new Uint8Array(0xfffffff));
-
-  assert.throws(() => new Blob(overSizeArray), {
-    code: "ERR_BUFFER_TOO_LARGE",
-  });
+  try {
+    const overSizedArray = [new Uint8Array(0xffffffff), [1]];
+    assert.throws(() => new Blob(overSizedArray), {
+      code: 'ERR_BUFFER_TOO_LARGE',
+    });
+  } catch (e) {
+    if (e.message !== 'Array buffer allocation failed') throw (e);
+    common.skip(
+      'Insufficient memory on this platform for oversized buffer test.'
+    );
+  }
 }
 
 {

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -230,18 +230,6 @@ assert.throws(() => new Blob({}), {
       code: 'ERR_INVALID_ARG_VALUE',
     });
   });
-
-  try {
-    const overSizedArray = [new Uint8Array(0xffffffff), [1]];
-    assert.throws(() => new Blob(overSizedArray), {
-      code: 'ERR_BUFFER_TOO_LARGE',
-    });
-  } catch (e) {
-    if (e.message !== 'Array buffer allocation failed') throw e;
-    common.skip(
-      'Insufficient memory on this platform for oversized buffer test.'
-    );
-  }
 }
 
 {


### PR DESCRIPTION
This improves a test coverage in `lib/internal/blob`
ref: https://coverage.nodejs.org/coverage-74b9baa4265a8f0d/lib/internal/blob.js.html

This added following tests.
- executing inspect to Blob with `depth` option
- creating new Blob instance with over size argument
- causing `ERR_INVALID_THIS` errors in some methods