### PR TITLE
tls: avoid throw in onerror for bad TLSSocket obj

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -408,8 +408,10 @@ function onocspresponse(resp) {
 function onerror(err) {
   const owner = this[owner_symbol];
   debug('%s onerror %s had? %j',
-        owner._tlsOptions.isServer ? 'server' : 'client', err,
-        owner._hadError);
+        (typeof owner._tlsOptions === 'object' && owner._tlsOptions !== null) ?
+          owner._tlsOptions.isServer ? 'server' : 'client' :
+          'unknown',
+        err, owner._hadError);
 
   if (owner._hadError)
     return;
@@ -421,7 +423,7 @@ function onerror(err) {
     // When handshake fails control is not yet released,
     // so self._tlsError will return null instead of actual error
     owner.destroy(err);
-  } else if (owner._tlsOptions.isServer &&
+  } else if (owner._tlsOptions?.isServer &&
              owner._rejectUnauthorized &&
              RegExpPrototypeTest(/peer did not return a certificate/,
                                  err.message)) {


### PR DESCRIPTION
TLSWrap.onerror has a helpful debug() call built in to it. However in case of a malformed TLSSocket object, where the `_tlsOptions` value is an unexpected `undefined`, accessing `_tlsOptions.isServer` causes a TypeError to be thrown.

This commit ensures that the debug() call properly logs the state as 'unknown', instead of the two 'server' and 'client' choices previously available. Additionally, onerror branching is adjusted to allow such `undefined` options object, by use of optional chaining.

Other methods are not being adjusted, as such a case of `undefined` options is not viable during regular processing of the TLSSocket.

Fixes: nodejs/node#41501

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
