### PR TITLE
test: mark test-fs-rmdir-recursive flaky on win

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -15,6 +15,8 @@ test-timers-immediate-queue: PASS,FLAKY
 test-worker-memory: PASS,FLAKY
 # https://github.com/nodejs/node/issues/41206
 test-crypto-keygen: PASS,FLAKY
+# https://github.com/nodejs/node/issues/41201
+test-fs-rmdir-recursive: PASS, FLAKY
 
 [$system==linux]
 # https://github.com/nodejs/node/issues/39368


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/41201

From recent reliability reports this is now the most
common failure by far in CI runs. Mark the test as
flaky until the issue is resolved.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
