### PR TITLE
stream: avoid function call where possible

### DIFF
--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -118,17 +118,19 @@ function isReadableFinished(stream, strict) {
 
 function isReadable(stream) {
   if (stream && stream[kIsReadable] != null) return stream[kIsReadable];
-  const r = isReadableNodeStream(stream);
   if (typeof stream?.readable !== 'boolean') return null;
   if (isDestroyed(stream)) return false;
-  return r && stream.readable && !isReadableFinished(stream);
+  return isReadableNodeStream(stream) &&
+    stream.readable &&
+    !isReadableFinished(stream);
 }
 
 function isWritable(stream) {
-  const r = isWritableNodeStream(stream);
   if (typeof stream?.writable !== 'boolean') return null;
   if (isDestroyed(stream)) return false;
-  return r && stream.writable && !isWritableEnded(stream);
+  return isWritableNodeStream(stream) &&
+    stream.writable &&
+    !isWritableEnded(stream);
 }
 
 function isFinished(stream, opts) {


### PR DESCRIPTION
Instead of assigning a boolean, move the function call that assigns a
value to the boolean to the only place that boolean is checked. This
avoids the function call in cases where it is not needed.

Refs: https://github.com/nodejs/node/pull/41488#pullrequestreview-850626528

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
