### PR TITLE
benchmark: remove unreachable code from crypto/hash-stream-creation

### DIFF
--- a/benchmark/crypto/hash-stream-creation.js
+++ b/benchmark/crypto/hash-stream-creation.js
@@ -52,11 +52,7 @@ function legacyWrite(algo, message, encoding, writes, len, outEnc) {
   while (writes-- > 0) {
     const h = crypto.createHash(algo);
     h.update(message, encoding);
-    let res = h.digest(outEnc);
-
-    // Include buffer creation costs for older versions
-    if (outEnc === 'buffer' && typeof res === 'string')
-      res = Buffer.from(res, 'binary');
+    h.digest(outEnc);
   }
 
   bench.end(gbits);


### PR DESCRIPTION
`hash.digest('buffer')` has returned a Buffer and not a string since at
least Node.js 0.10.6. The benchmark, as it is written, will not work on
any version of Node.js prior to 16.x (due to `Object.hasOwn()`) and
certainly won't run on versions earlier than 0.10.6 due to const/let and
probably other things. Remove impossible-to-reach code intended to
accommodate Node.js earlier than 0.10.6.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
