### PR TITLE
[discuss] cli,doc: doc deprecate --preserve-symlinks flags

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3047,6 +3047,22 @@ const w = new Writable({
 });
 ```
 
+### DEP0XXX: `node --preserve-symlinks` and `node --preserve-symlinks-main
+<!-- YAML
+added: REPLACEME
+-->
+
+Type: Documentation-only
+
+Previously `node` supported an altered form of caching and resolution that did
+not use realpathing via `--preserve-symlinks` and `--preserve-symlinks-main`.
+
+This feature caused issues with various expectations around module resolution
+and lacked maintainence sufficient to keep supporting it. Due to this, features
+were developed that did not take it into account and led to these flags having
+inconsistent behavior.
+
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3


### PR DESCRIPTION
These flags are horribly unmaintained, and a decidedly few number of places use them (even package managers that use symlinks like pnpm and yarn don't by default and their issue trackers have hints of it being broken to users). The burden of dealing with their edge cases/design concerns isn't being kept up with even with effort to do so and testing of these flags is not existent.

I think we should at least doc deprecate them due to lack of support from the maintenance side of things unless something changes in order to allow maintainers to focus on features that are used/actively maintained when designing features.

I am not proposing we remove them at this time or anytime in the future, but we don't really test that these things work in any reliable way since they tend to break things like CITGM nor do we have real world examples of heavy usage from which to gather CI tests. We equally haven't found some person actively keeping this feature itself maintained outside of efforts to ensure they keep working to the best of our knowledge.

In addition, we likely should audit these to see security concerns and write down if they are affected by various [CWE concerns with symlinks](https://cwe.mitre.org/data/definitions/706.html).

CC: @nodejs/modules 