### PR TITLE
doc: improve Web Crypto headings related to ECC

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -48,7 +48,7 @@ async function generateAesKey(length = 256) {
 }
 ```
 
-#### Elliptic curve key pairs
+#### ECDSA key pairs
 
 ```js
 const { subtle } = require('crypto').webcrypto;
@@ -66,7 +66,7 @@ async function generateEcKey(namedCurve = 'P-521') {
 }
 ```
 
-#### ED25519/ED448/X25519/X448 Elliptic curve key pairs
+#### ED25519/ED448/X25519/X448 key pairs
 
 ```js
 const { subtle } = require('crypto').webcrypto;


### PR DESCRIPTION
- The heading "Elliptic curve key pairs" is much less specific than the code in the section with that title is. ECDSA is just one algorithm that uses elliptic curves. Unlike other crypto standards, Web Crypto does not represent ECC keys independent of the associated algorithm.
- ED25519/ED448/X25519/X448 are not curves (the curve names are Curve25519 and Curve448), so remove the words "Elliptic curves" to avoid confusion. Again, these are specific algorithms.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
