### PR TITLE
test: add missing await in fs-rm/fs-rmdir tests

### DIFF
--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -185,8 +185,8 @@ function removeAsync(dir) {
   makeNonEmptyDirectory(4, 10, 2, dir, true);
 
   // Removal should fail without the recursive option set to true.
-  assert.rejects(fs.promises.rm(dir), { syscall: 'rm' });
-  assert.rejects(fs.promises.rm(dir, { recursive: false }), {
+  await assert.rejects(fs.promises.rm(dir), { syscall: 'rm' });
+  await assert.rejects(fs.promises.rm(dir, { recursive: false }), {
     syscall: 'rm'
   });
 
@@ -194,10 +194,10 @@ function removeAsync(dir) {
   await fs.promises.rm(dir, { recursive: true });
 
   // Attempted removal should fail now because the directory is gone.
-  assert.rejects(fs.promises.rm(dir), { syscall: 'stat' });
+  await assert.rejects(fs.promises.rm(dir), { syscall: 'stat' });
 
   // Should fail if target does not exist
-  assert.rejects(fs.promises.rm(
+  await assert.rejects(fs.promises.rm(
     path.join(tmpdir.path, 'noexist.txt'),
     { recursive: true }
   ), {
@@ -207,7 +207,7 @@ function removeAsync(dir) {
   });
 
   // Should not fail if target does not exist and force option is true
-  fs.promises.rm(path.join(tmpdir.path, 'noexist.txt'), { force: true });
+  await fs.promises.rm(path.join(tmpdir.path, 'noexist.txt'), { force: true });
 
   // Should delete file
   const filePath = path.join(tmpdir.path, 'rm-promises-file.txt');

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -141,8 +141,8 @@ function removeAsync(dir) {
   makeNonEmptyDirectory(4, 10, 2, dir, true);
 
   // Removal should fail without the recursive option set to true.
-  assert.rejects(fs.promises.rmdir(dir), { syscall: 'rmdir' });
-  assert.rejects(fs.promises.rmdir(dir, { recursive: false }), {
+  await assert.rejects(fs.promises.rmdir(dir), { syscall: 'rmdir' });
+  await assert.rejects(fs.promises.rmdir(dir, { recursive: false }), {
     syscall: 'rmdir'
   });
 
@@ -154,7 +154,7 @@ function removeAsync(dir) {
                        { code: 'ENOENT' });
 
   // Attempted removal should fail now because the directory is gone.
-  assert.rejects(fs.promises.rmdir(dir), { syscall: 'rmdir' });
+  await assert.rejects(fs.promises.rmdir(dir), { syscall: 'rmdir' });
 })().then(common.mustCall());
 
 // Test input validation.


### PR DESCRIPTION
Noticed that a few assertions were not being awaited, this could
potentially be leading to flakiness in tmp cleanup.

Refs: #41201