### PR TITLE
tls: represent registeredID numerically always

### DIFF
--- a/src/crypto/crypto_common.cc
+++ b/src/crypto/crypto_common.cc
@@ -773,11 +773,10 @@ static bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen) {
 #endif
     }
   } else if (gen->type == GEN_RID) {
-    // TODO(tniessen): unlike OpenSSL's default implementation, never print the
-    // OID as text and instead always print its numeric representation, which is
-    // backward compatible in practice and more future proof (see OBJ_obj2txt).
+    // Unlike OpenSSL's default implementation, never print the OID as text and
+    // instead always print its numeric representation.
     char oline[256];
-    i2t_ASN1_OBJECT(oline, sizeof(oline), gen->d.rid);
+    OBJ_obj2txt(oline, sizeof(oline), gen->d.rid, true);
     BIO_printf(out.get(), "Registered ID:%s", oline);
   } else if (gen->type == GEN_OTHERNAME) {
     // TODO(tniessen): the format that is used here is based on OpenSSL's

--- a/test/parallel/test-x509-escaping.js
+++ b/test/parallel/test-x509-escaping.js
@@ -81,9 +81,9 @@ const { hasOpenSSL3 } = common;
     hasOpenSSL3 ?
       'DirName:"/C=DE/L=Berlin\\\\/CN=good.example.com"' :
       'DirName:/C=DE/L=Berlin/CN=good.example.com',
-    // TODO(tniessen): even OIDs that are well-known (such as the following,
-    // which is sha256WithRSAEncryption) should be represented numerically only.
-    'Registered ID:sha256WithRSAEncryption',
+    // Even OIDs that are well-known (such as the following, which is
+    // sha256WithRSAEncryption) should be represented numerically only.
+    'Registered ID:1.2.840.113549.1.1.11',
     // This is an OID that will likely never be assigned to anything, thus
     // OpenSSL should not know it.
     'Registered ID:1.3.9999.12.34',


### PR DESCRIPTION
This was considered for inclusion in https://github.com/nodejs/node/commit/466e5415a2b7b3574ab5403acb87e89a94a980d1 but was ultimately decided against to minimize breakage, and I instead added a few `TODO` comments that are resolved by this PR.

Reasons for this change:
- Whether OpenSSL represents a given OID by the associated name or numerically depends on the specific OpenSSL version. In other words, any minor OpenSSL update could change the representation when using `i2t_ASN1_OBJECT`.
- In practice, `registeredID` will not refer to any OID that is known to OpenSSL, so users are already seeing numeric representations only.
- The numeric representation has a more predictable format than the name associated with the OID.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
