### PR TITLE
tool: Fixed bug causing JSON format to be broken

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1593,7 +1593,7 @@ def configure_intl(o):
 
   # write an empty file to start with
   write(icu_config_name, do_not_edit +
-        pprint.pformat(icu_config, indent=2) + '\n')
+        pprint.pformat(icu_config, indent=2, width=1024) + '\n')
 
   # always set icu_small, node.gyp depends on it being defined.
   o['variables']['icu_small'] = b(False)
@@ -1845,7 +1845,7 @@ def configure_intl(o):
 
   # write updated icu_config.gypi with a bunch of paths
   write(icu_config_name, do_not_edit +
-        pprint.pformat(icu_config, indent=2) + '\n')
+        pprint.pformat(icu_config, indent=2, width=1024) + '\n')
   return  # end of configure_intl
 
 def configure_inspector(o):
@@ -1974,7 +1974,7 @@ if make_global_settings:
 print_verbose(output)
 
 write('config.gypi', do_not_edit +
-      pprint.pformat(output, indent=2) + '\n')
+      pprint.pformat(output, indent=2, width=1024) + '\n')
 
 write('config.status', '#!/bin/sh\nset -x\nexec ./configure ' +
       ' '.join([pipes.quote(arg) for arg in original_argv]) + '\n')


### PR DESCRIPTION
The JSON format in the current version of the `config.gypi` file can be broken because the `pprint.pformat` function splits the argument string into multiple lines if it is long enough and contains Spaces
```
./configure --v8-options="--this_is_parameter_one --this_is_parmaeter_two"
//This is the corresponding line in configure.gypi
                 'node_v8_options': '--this_is_parameter_one '
                                    '--this_is_parmaeter_two',
```
You can see that function `pprint.pformat` accidentally splits the string into two lines, causing the JSON format to be broken

I can think of three solutions

1 Abandon the line length limit

2 Use regular matches after `pprint.pformat`

3 Manually implement an appropriate print function

I chose the simplest solution for this PR and am glad to work on other solutions if the administrator thinks it is necessary