### PR TITLE
crypto: remove checkIP options argument

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2542,23 +2542,25 @@ does not contain any DNS names. This behavior is consistent with [RFC 2818][]
 If the `'subject'` option is set to `'never'`, the certificate subject is never
 considered, even if the certificate contains no subject alternative names.
 
-### `x509.checkIP(ip[, options])`
+### `x509.checkIP(ip)`
 
 <!-- YAML
 added: v15.6.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41571
+    description: The `options` argument has been removed since it had no effect.
 -->
 
 * `ip` {string}
-* `options` {Object}
-  * `subject` {string} `'always'` or `'never'`. **Default:** `'always'`.
-  * `wildcards` {boolean} **Default:** `true`.
-  * `partialWildcards` {boolean} **Default:** `true`.
-  * `multiLabelWildcards` {boolean} **Default:** `false`.
-  * `singleLabelSubdomains` {boolean} **Default:** `false`.
 * Returns: {string|undefined} Returns `ip` if the certificate matches,
   `undefined` if it does not.
 
 Checks whether the certificate matches the given IP address (IPv4 or IPv6).
+
+Only [RFC 5280][] `iPAddress` subject alternative names are considered, and they
+must match the given `ip` address exactly. Other subject alternative names as
+well as the subject field of the certificate are ignored.
 
 ### `x509.checkIssued(otherCert)`
 
@@ -5976,6 +5978,7 @@ See the [list of SSL OP Flags][] for details.
 [RFC 4055]: https://www.rfc-editor.org/rfc/rfc4055.txt
 [RFC 4122]: https://www.rfc-editor.org/rfc/rfc4122.txt
 [RFC 5208]: https://www.rfc-editor.org/rfc/rfc5208.txt
+[RFC 5280]: https://www.rfc-editor.org/rfc/rfc5280.txt
 [Web Crypto API documentation]: webcrypto.md
 [`BN_is_prime_ex`]: https://www.openssl.org/docs/man1.1.1/man3/BN_is_prime_ex.html
 [`Buffer`]: buffer.md

--- a/lib/internal/crypto/x509.js
+++ b/lib/internal/crypto/x509.js
@@ -315,6 +315,11 @@ class X509Certificate extends JSTransferable {
 
   checkIP(ip, options) {
     validateString(ip, 'ip');
+    // The options argument is currently undocumented since none of the options
+    // have any effect on the behavior of this function. However, we still parse
+    // the options argument in case OpenSSL adds flags in the future that do
+    // affect the behavior of X509_check_ip. This ensures that no invalid values
+    // are passed as the second argument in the meantime.
     return this[kHandle].checkIP(ip, getFlags(options));
   }
 


### PR DESCRIPTION
None of the supported options have any effect on `X509_check_ip_asc`.

(`iPAddress` is not a typo, it is what RFC 5280 calls subject alternative names that are IP addresses.)

Refs: https://github.com/openssl/openssl/pull/17536

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
