### PR TITLE
test: improve util-format code coverage

### DIFF
--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -143,6 +143,13 @@ assert.strictEqual(
   '1180591620717411303424n 12345678901234567890123n'
 );
 
+assert.strictEqual(
+  util.formatWithOptions(
+    { numericSeparator: true },
+    '%i %d', 1180591620717411303424n, 12345678901234567890123n),
+  '1_180_591_620_717_411_303_424n 12_345_678_901_234_567_890_123n'
+);
+
 // Float format specifier
 assert.strictEqual(util.format('%f'), '%f');
 assert.strictEqual(util.format('%f', 42.0), '42');


### PR DESCRIPTION
Add test case for calling `util.format()` with a BigInt and a separator.

Refs: https://coverage.nodejs.org/coverage-986cf3b986c6c3e1/lib/internal/util/inspect.js.html#L2042

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
