### PR TITLE
stream: add iterator helper some every

### DIFF
--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -10,6 +10,7 @@ const {
   AbortError,
 } = require('internal/errors');
 const { validateInteger } = require('internal/validators');
+const { kWeakHandler } = require('internal/event_target');
 
 const {
   ArrayPrototypePush,
@@ -47,6 +48,10 @@ async function * map(fn, options) {
   const signalOpt = { signal };
 
   const abort = () => ac.abort();
+  if (options?.signal?.aborted) {
+    abort();
+  }
+
   options?.signal?.addEventListener('abort', abort);
 
   let next;
@@ -150,6 +155,40 @@ async function * map(fn, options) {
   }
 }
 
+async function some(fn, options) {
+  // https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.some
+  // Note that some does short circuit but also closes the iterator if it does
+  const ac = new AbortController();
+  if (options?.signal) {
+    if (options.signal.aborted) {
+      ac.abort();
+    }
+    options.signal.addEventListener('abort', () => ac.abort(), {
+      [kWeakHandler]: this,
+      once: true,
+    });
+  }
+  const mapped = this.map(fn, { ...options, signal: ac.signal });
+  for await (const result of mapped) {
+    if (result) {
+      ac.abort();
+      return true;
+    }
+  }
+  return false;
+}
+
+async function every(fn, options) {
+  if (typeof fn !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'fn', ['Function', 'AsyncFunction'], fn);
+  }
+  // https://en.wikipedia.org/wiki/De_Morgan%27s_laws
+  return !(await some.call(this, async (x) => {
+    return !(await fn(x));
+  }, options));
+}
+
 async function forEach(fn, options) {
   if (typeof fn !== 'function') {
     throw new ERR_INVALID_ARG_TYPE(
@@ -196,6 +235,8 @@ module.exports.streamReturningOperators = {
 };
 
 module.exports.promiseReturningOperators = {
+  every,
   forEach,
   toArray,
+  some,
 };

--- a/test/parallel/test-stream-some-every.js
+++ b/test/parallel/test-stream-some-every.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const common = require('../common');
+const {
+  Readable,
+} = require('stream');
+const assert = require('assert');
+
+function oneTo5() {
+  return Readable.from([1, 2, 3, 4, 5]);
+}
+
+function oneTo5Async() {
+  return oneTo5().map(async (x) => {
+    await Promise.resolve();
+    return x;
+  });
+}
+{
+  // Some and every work with a synchronous stream and predicate
+  (async () => {
+    assert.strictEqual(await oneTo5().some((x) => x > 3), true);
+    assert.strictEqual(await oneTo5().every((x) => x > 3), false);
+    assert.strictEqual(await oneTo5().some((x) => x > 6), false);
+    assert.strictEqual(await oneTo5().every((x) => x < 6), true);
+    assert.strictEqual(await Readable.from([]).some((x) => true), false);
+    assert.strictEqual(await Readable.from([]).every((x) => true), true);
+  })().then(common.mustCall());
+}
+
+{
+  // Some and every work with an asynchronous stream and synchronous predicate
+  (async () => {
+    assert.strictEqual(await oneTo5Async().some((x) => x > 3), true);
+    assert.strictEqual(await oneTo5Async().every((x) => x > 3), false);
+    assert.strictEqual(await oneTo5Async().some((x) => x > 6), false);
+    assert.strictEqual(await oneTo5Async().every((x) => x < 6), true);
+  })().then(common.mustCall());
+}
+
+{
+  // Some and every work on asynchronous streams with an asynchronous predicate
+  (async () => {
+    assert.strictEqual(await oneTo5().some(async (x) => x > 3), true);
+    assert.strictEqual(await oneTo5().every(async (x) => x > 3), false);
+    assert.strictEqual(await oneTo5().some(async (x) => x > 6), false);
+    assert.strictEqual(await oneTo5().every(async (x) => x < 6), true);
+  })().then(common.mustCall());
+}
+
+{
+  // Some and every short circuit
+  (async () => {
+    await oneTo5().some(common.mustCall((x) => x > 2, 3));
+    await oneTo5().every(common.mustCall((x) => x < 3, 3));
+    // When short circuit isn't possible the whole stream is iterated
+    await oneTo5().some(common.mustCall((x) => x > 6, 5));
+    // The stream is destroyed afterwards
+    const stream = oneTo5();
+    await stream.some(common.mustCall((x) => x > 2, 3));
+    assert.strictEqual(stream.destroyed, true);
+  })().then(common.mustCall());
+}
+
+{
+  // Support for AbortSignal
+  const ac = new AbortController();
+  assert.rejects(Readable.from([1, 2, 3]).some(
+    () => new Promise(() => {}),
+    { signal: ac.signal }
+  ), {
+    name: 'AbortError',
+  }).then(common.mustCall());
+  ac.abort();
+}
+{
+  // Support for pre-aborted AbortSignal
+  assert.rejects(Readable.from([1, 2, 3]).some(
+    () => new Promise(() => {}),
+    { signal: AbortSignal.abort() }
+  ), {
+    name: 'AbortError',
+  }).then(common.mustCall());
+}
+{
+  // Error cases
+  assert.rejects(async () => {
+    await Readable.from([1]).every(1);
+  }, /ERR_INVALID_ARG_TYPE/).then(common.mustCall());
+  assert.rejects(async () => {
+    await Readable.from([1]).every((x) => x, {
+      concurrency: 'Foo'
+    });
+  }, /ERR_OUT_OF_RANGE/).then(common.mustCall());
+}


### PR DESCRIPTION
This is the next one in the iterator helper proposal adding `.some` and `.every` from the TC39 iterator helpers proposal to streams.

<strike>This is the next one and should only land after https://github.com/nodejs/node/pull/41553 does (I'll rebase when it does). **So if reviewing make sure you only look at the relevant commit :)**

Marking as draft to not take CI resources until that one lands but I'd like reviews :) </strike>

I don't remember if this was in the initial work with @ronag on map so I added a co-authored-by to be on the safe side though I assume this granularity of attribution doesn't really matter to either of us very much.

cc @nodejs/streams @ronag 