### PR TITLE
doc: deprecate `buffer.slice`

### DIFF
--- a/benchmark/buffers/buffer-slice.js
+++ b/benchmark/buffers/buffer-slice.js
@@ -3,7 +3,7 @@ const common = require('../common.js');
 const SlowBuffer = require('buffer').SlowBuffer;
 
 const bench = common.createBenchmark(main, {
-  type: ['fast', 'slow'],
+  type: ['fast', 'slow', 'subarray'],
   n: [1e6]
 });
 
@@ -11,10 +11,14 @@ const buf = Buffer.allocUnsafe(1024);
 const slowBuf = new SlowBuffer(1024);
 
 function main({ n, type }) {
-  const b = type === 'fast' ? buf : slowBuf;
+  const b = type === 'slow' ? slowBuf : buf;
+  const fn = type === 'subarray' ? 
+    () => b.subarray(10, 256) :
+    () => b.slice(10, 256);
+
   bench.start();
   for (let i = 0; i < n; i++) {
-    b.slice(10, 256);
+    fn();
   }
   bench.end(n);
 }

--- a/benchmark/buffers/buffer-slice.js
+++ b/benchmark/buffers/buffer-slice.js
@@ -12,7 +12,7 @@ const slowBuf = new SlowBuffer(1024);
 
 function main({ n, type }) {
   const b = type === 'slow' ? slowBuf : buf;
-  const fn = type === 'subarray' ? 
+  const fn = type === 'subarray' ?
     () => b.subarray(10, 256) :
     () => b.slice(10, 256);
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -254,7 +254,7 @@ In particular:
   without copying. This behavior can be surprising, and only exists for legacy
   compatibility. [`TypedArray.prototype.subarray()`][] can be used to achieve
   the behavior of [`Buffer.prototype.slice()`][`buf.slice()`] on both `Buffer`s
-  and other `TypedArray`s.
+  and other `TypedArray`s and should be preferred.
 * [`buf.toString()`][] is incompatible with its `TypedArray` equivalent.
 * A number of methods, e.g. [`buf.indexOf()`][], support additional arguments.
 
@@ -2056,7 +2056,7 @@ If `value` is:
 * a string, `value` is interpreted according to the character encoding in
   `encoding`.
 * a `Buffer` or [`Uint8Array`][], `value` will be used in its entirety.
-  To compare a partial `Buffer`, use [`buf.slice()`][].
+  To compare a partial `Buffer`, use [`buf.subarray`][].
 * a number, `value` will be interpreted as an unsigned 8-bit integer
   value between `0` and `255`.
 
@@ -3389,6 +3389,9 @@ console.log(buf.subarray(-5, -2).toString());
 <!-- YAML
 added: v0.3.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41596
+    description: The buf.slice() method has been deprecated.
   - version:
     - v7.1.0
     - v6.9.2
@@ -3406,10 +3409,10 @@ changes:
   **Default:** [`buf.length`][].
 * Returns: {Buffer}
 
+> Stability: 0 - Deprecated: Use [`buf.subarray`][] instead.
+
 Returns a new `Buffer` that references the same memory as the original, but
 offset and cropped by the `start` and `end` indices.
-
-This is the same behavior as `buf.subarray()`.
 
 This method is not compatible with the `Uint8Array.prototype.slice()`,
 which is a superclass of `Buffer`. To copy the slice, use
@@ -5355,6 +5358,7 @@ introducing security vulnerabilities into an application.
 [`buf.keys()`]: #bufkeys
 [`buf.length`]: #buflength
 [`buf.slice()`]: #bufslicestart-end
+[`buf.subarray`]: #bufsubarraystart-end
 [`buf.toString()`]: #buftostringencoding-start-end
 [`buf.values()`]: #bufvalues
 [`buffer.constants.MAX_LENGTH`]: #bufferconstantsmax_length

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3040,6 +3040,22 @@ const w = new Writable({
 });
 ```
 
+### DEP0158: `buffer.slice(start, end)`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41596
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+This method was deprecated because it is not compatible with
+`Uint8Array.prototype.slice()`, which is a superclass of `Buffer`.
+
+Use [`buffer.subarray`][] which does the same thing instead.
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
@@ -3062,6 +3078,7 @@ const w = new Writable({
 [`WriteStream.open()`]: fs.md#class-fswritestream
 [`assert`]: assert.md
 [`asyncResource.runInAsyncScope()`]: async_context.md#asyncresourceruninasyncscopefn-thisarg-args
+[`buffer.subarray`]: buffer.md#bufsubarraystart-end
 [`child_process`]: child_process.md
 [`clearInterval()`]: timers.md#clearintervaltimeout
 [`clearTimeout()`]: timers.md#cleartimeouttimeout

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1112,12 +1112,16 @@ function adjustOffset(offset, length) {
   return NumberIsNaN(offset) ? 0 : length;
 }
 
-Buffer.prototype.slice = function slice(start, end) {
+Buffer.prototype.subarray = function subarray(start, end) {
   const srcLength = this.length;
   start = adjustOffset(start, srcLength);
   end = end !== undefined ? adjustOffset(end, srcLength) : srcLength;
   const newLength = end > start ? end - start : 0;
   return new FastBuffer(this.buffer, this.byteOffset + start, newLength);
+};
+
+Buffer.prototype.slice = function slice(start, end) {
+  return this.subarray(start, end);
 };
 
 function swap(b, n, m) {


### PR DESCRIPTION
Opening a PR to have the discussion about this particular idea (doc-deprecating buffer.slice).

References: https://github.com/nodejs/node/issues/41588

For the why - `buffer.slice()` returns a mutable slice whereas `typedArray.slice()` and `array.slice()` return a copy. This is confusing behavior and is the result of buffers predating Uint8Array availability.

cc @addaleax @jasnell @sindresorhus @nodejs/buffer 

Also ccing some people who are usually helpful at giving useful comments when I make PRs that touch docs: @trott @aduh95 @VoltrexMaster  