### PR TITLE
util: remove unused fast path in internal debuglog

### DIFF
--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -81,7 +81,6 @@ function debuglog(set, cb) {
     if (typeof cb === 'function')
       cb(debug);
     switch (args.length) {
-      case 0: return debug();
       case 1: return debug(args[0]);
       case 2: return debug(args[0], args[1]);
       default: return debug(...new SafeArrayIterator(args));
@@ -95,7 +94,6 @@ function debuglog(set, cb) {
   };
   const logger = (...args) => {
     switch (args.length) {
-      case 0: return debug();
       case 1: return debug(args[0]);
       case 2: return debug(args[0], args[1]);
       default: return debug(...new SafeArrayIterator(args));


### PR DESCRIPTION
The internal `debuglog()` is never called with 0 parameters. Remove the
fast-path for that situation. If it ever occurs, it will fall through to
the default path.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
