### PR TITLE
stream: never flatten on toArray

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1900,12 +1900,10 @@ added: REPLACEME
 * `options` {Object}
   * `signal` {AbortSignal} allows cancelling the toArray operation if the
     signal is aborted.
-* Returns: {Promise} a promise containing an array (if the stream is in
-  object mode) or Buffer with the contents of the stream.
+* Returns: {Promise} a promise containing an array with the contents of the
+  stream.
 
-This method allows easily obtaining the contents of a stream. If the
-stream is in [object mode][object-mode] an array of its contents is returned.
-If the stream is not in object mode a Buffer containing its data is returned.
+This method allows easily obtaining the contents of a stream.
 
 As this method reads the entire stream into memory, it negates the benefits of
 streams. It's intended for interoperability and convenience, not as the primary

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { AbortController } = require('internal/abort_controller');
-const { Buffer } = require('buffer');
 
 const {
   codes: {
@@ -184,9 +183,6 @@ async function toArray(options) {
       throw new AbortError({ cause: options.signal.reason });
     }
     ArrayPrototypePush(result, val);
-  }
-  if (!this.readableObjectMode) {
-    return Buffer.concat(result);
   }
   return result;
 }

--- a/test/parallel/test-stream-toArray.js
+++ b/test/parallel/test-stream-toArray.js
@@ -24,14 +24,16 @@ const assert = require('assert');
 }
 
 {
-  // Works on a non-object-mode stream and flattens it
+  // Works on a non-object-mode stream
   (async () => {
+    const firstBuffer = Buffer.from([1, 2, 3]);
+    const secondBuffer = Buffer.from([4, 5, 6]);
     const stream = Readable.from(
-      [Buffer.from([1, 2, 3]), Buffer.from([4, 5, 6])]
-      , { objectMode: false });
+      [firstBuffer, secondBuffer],
+      { objectMode: false });
     const result = await stream.toArray();
-    assert.strictEqual(Buffer.isBuffer(result), true);
-    assert.deepStrictEqual(Array.from(result), [1, 2, 3, 4, 5, 6]);
+    assert.strictEqual(Array.isArray(result), true);
+    assert.deepStrictEqual(result, [firstBuffer, secondBuffer]);
   })().then(common.mustCall());
 }
 


### PR DESCRIPTION
This PR removes `toArray()` flattening behavior for non objectMode streams.

See discussion here: https://github.com/nodejs/node/pull/41612#issuecomment-1017519793 and previous discussion here: https://github.com/nodejs/node/pull/41553

cc @ronag @nodejs/streams 