### PR TITLE
doc: suggest worker threads in cluster docs

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -6,9 +6,10 @@
 
 <!-- source_link=lib/cluster.js -->
 
-A single instance of Node.js runs in a single thread. To take advantage of
-multi-core systems, the user will sometimes want to launch a cluster of Node.js
-processes to handle the load.
+Clusters of Node.js processes can be used to run multiple instances of Node.js
+that can distribute workloads among their application threads. When process
+isolation is not needed, use the [`worker_threads`][] module instead, which
+allows running multiple application threads within a single Node.js instance.
 
 The cluster module allows easy creation of child processes that all share
 server ports.
@@ -1122,3 +1123,4 @@ socket.on('data', (id) => {
 [`process` event: `'message'`]: process.md#event-message
 [`server.close()`]: net.md#event-close
 [`worker.exitedAfterDisconnect`]: #workerexitedafterdisconnect
+[`worker_threads`]: worker_threads.md


### PR DESCRIPTION
The current documentation is incorrect in that it says "A single instance of Node.js runs in a single thread," which is not true due to the addition of worker threads (https://github.com/nodejs/node/pull/20876).

This patch removes the incorrect statement and instead suggests that applications consider using worker threads when process isolation is not needed.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
