### PR TITLE
cluster: respect server.listen() backlog parameter set by workers (credit: @oyyd)

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -464,7 +464,7 @@ server.listen({
 });
 ```
 
-When `exclusive` is `true` and the underlying handle is shared, it's
+When `exclusive` is `true` and the underlying handle is shared, it is
 possible that several workers query a handle with different backlogs.
 In this case, the first `backlog` passed to the master process will be used.
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -464,6 +464,10 @@ server.listen({
 });
 ```
 
+When `exclusive` is `true` and the underlying handle is shared, it's
+possible that several workers query a handle with different backlogs.
+In this case, the first `backlog` passed to the master process will be used.
+
 Starting an IPC server as root may cause the server path to be inaccessible for
 unprivileged users. Using `readableAll` and `writableAll` will make the server
 accessible for all users.

--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -15,7 +15,7 @@ const { constants } = internalBinding('tcp_wrap');
 
 module.exports = RoundRobinHandle;
 
-function RoundRobinHandle(key, address, { port, fd, flags }) {
+function RoundRobinHandle(key, address, { port, fd, flags, backlog }) {
   this.key = key;
   this.all = new SafeMap();
   this.free = new SafeMap();
@@ -24,16 +24,17 @@ function RoundRobinHandle(key, address, { port, fd, flags }) {
   this.server = net.createServer(assert.fail);
 
   if (fd >= 0)
-    this.server.listen({ fd });
+    this.server.listen({ fd, backlog });
   else if (port >= 0) {
     this.server.listen({
       port,
       host: address,
       // Currently, net module only supports `ipv6Only` option in `flags`.
       ipv6Only: Boolean(flags & constants.UV_TCP_IPV6ONLY),
+      backlog,
     });
   } else
-    this.server.listen(address);  // UNIX socket path.
+    this.server.listen(address, backlog);  // UNIX socket path.
 
   this.server.once('listening', () => {
     this.handle = this.server._handle;

--- a/lib/net.js
+++ b/lib/net.js
@@ -1385,6 +1385,7 @@ function listenInCluster(server, address, port, addressType,
     addressType: addressType,
     fd: fd,
     flags,
+    backlog,
   };
 
   // Get the primary's server handle, and listen on it

--- a/test/parallel/test-cluster-net-listen-backlog.js
+++ b/test/parallel/test-cluster-net-listen-backlog.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+// Monkey-patch `net.Server.listen`
+const net = require('net');
+const cluster = require('cluster');
+
+// Ensures that the `backlog` is used to create a `net.Server`.
+const kExpectedBacklog = 127;
+if (cluster.isMaster) {
+  const listen = net.Server.prototype.listen;
+
+  net.Server.prototype.listen = common.mustCall(
+    function(...args) {
+      const options = args[0];
+      if (typeof options === 'object') {
+        assert(options.backlog, kExpectedBacklog);
+      } else {
+        assert(args[1], kExpectedBacklog);
+      }
+      return listen.call(this, ...args);
+    }
+  );
+
+  const worker = cluster.fork();
+  worker.on('message', () => {
+    worker.disconnect();
+  });
+} else {
+  const server = net.createServer();
+
+  server.listen({
+    host: common.localhostIPv4,
+    port: 0,
+    backlog: kExpectedBacklog,
+  }, common.mustCall(() => {
+    process.send(true);
+  }));
+}

--- a/test/parallel/test-cluster-net-listen-backlog.js
+++ b/test/parallel/test-cluster-net-listen-backlog.js
@@ -6,6 +6,11 @@ const assert = require('assert');
 const net = require('net');
 const cluster = require('cluster');
 
+// Force round-robin scheduling policy
+// as Windows defaults to SCHED_NONE
+// https://nodejs.org/docs/latest/api/cluster.html#clusterschedulingpolicy
+cluster.schedulingPolicy = cluster.SCHED_RR;
+
 // Ensures that the `backlog` is used to create a `net.Server`.
 const kExpectedBacklog = 127;
 if (cluster.isMaster) {


### PR DESCRIPTION
Re-creating the closed pull request #33827 to fix #4056, a bug where the `backlog` parameter passed in to `server.listen(handle[, backlog][, callback])` from within a Node.js worker process isn't respected. Instead, the default value of `511` is always set and unable to be overriden.

More about the [`server.listen()`](https://nodejs.org/api/net.html#serverlisten) `backlog` parameter:
> All `listen()` methods can take a `backlog` parameter to specify the maximum length of the queue of pending connections. The actual length will be determined by the OS through sysctl settings such as `tcp_max_syn_backlog` and `somaxconn` on Linux. The default value of this parameter is 511 (not 512).

This PR and all commits were authored by @oyyd. I've updated from `nodejs/master` so it won't be behind any commits, and there were no conflicts.

The original PR was closed because a test was failing on Windows. I'd like the opportunity to fix that test. If you could please run Node.js Jenkins on the PR so I can look at the error log in case the test still fails, that would be greatly appreciated.

All thanks go to @oyyd for the original PR.

Checklist:
- [x] make -j4 test (UNIX), or vcbuild test (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines
