### PR TITLE
perf_hooks: fix timerify

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -234,6 +234,8 @@ changes:
 
 * `fn` {Function}
 * `options` {Object}
+  * `ctor` {boolean} When true, the timerified function will used
+    `Reflect.construct()` internally to call the wrapped function.
   * `histogram` {RecordableHistogram} A histogram object created using
     `perf_hooks.createHistogram()` that will record runtime durations in
     nanoseconds.

--- a/lib/internal/perf/timerify.js
+++ b/lib/internal/perf/timerify.js
@@ -13,6 +13,7 @@ const { InternalPerformanceEntry } = require('internal/perf/performance_entry');
 const { now } = require('internal/perf/utils');
 
 const {
+  validateBoolean,
   validateFunction,
   validateObject,
 } = require('internal/validators');
@@ -60,7 +61,8 @@ function timerify(fn, options = {}) {
 
   validateObject(options, 'options');
   const {
-    histogram
+    histogram,
+    ctor = false,
   } = options;
 
   if (histogram !== undefined &&
@@ -71,13 +73,13 @@ function timerify(fn, options = {}) {
       histogram);
   }
 
-  if (fn[kTimerified]) return fn[kTimerified];
+  validateBoolean(ctor, 'options.ctor');
 
-  const constructor = isConstructor(fn);
+  if (fn[kTimerified]) return fn[kTimerified];
 
   function timerified(...args) {
     const start = now();
-    const result = constructor ?
+    const result = ctor ?
       ReflectConstruct(fn, args, fn) :
       ReflectApply(fn, this, args);
     if (!constructor && typeof result?.finally === 'function') {

--- a/test/parallel/test-performance-function.js
+++ b/test/parallel/test-performance-function.js
@@ -45,7 +45,7 @@ const {
 
 {
   class N {}
-  const n = performance.timerify(N);
+  const n = performance.timerify(N, { ctor: true });
 
   const obs = new PerformanceObserver(common.mustCall((list) => {
     const entries = list.getEntries();
@@ -121,3 +121,9 @@ const {
     });
   });
 })().then(common.mustCall());
+
+{
+  function foo() { return 1; }
+  const tfoo = performance.timerify(foo);
+  assert.strictEqual(tfoo(), 1);
+}


### PR DESCRIPTION
`timerify()` was broken by a bad `isConstructor()` check. This fixes
it. Technically probably a breaking change but this is definitely a
bug fix that gets it working correctly again.

Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
