### PR TITLE
vm: update measure memory rejection information

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -1060,8 +1060,9 @@ current V8 isolate, or the main context.
     exits before the next GC). With eager execution, the GC will be started
     right away to measure the memory.
     **Default:** `'default'`
-* Returns: {Promise} If the memory is successfully measured the promise will
-  resolve with an object containing information about the memory usage.
+* Returns: {Promise} If the memory is successfully measured, the promise will
+  resolve with an object containing information about the memory usage, else it
+  will be rejected with an error with `ERR_CONTEXT_NOT_INITIALIZED` code property.
 
 The format of the object that the returned Promise may resolve with is
 specific to the V8 engine and may change from one version of V8 to the next.

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -1061,8 +1061,8 @@ current V8 isolate, or the main context.
     right away to measure the memory.
     **Default:** `'default'`
 * Returns: {Promise} If the memory is successfully measured, the promise will
-  resolve with an object containing information about the memory usage, else it
-  will be rejected with an error with `ERR_CONTEXT_NOT_INITIALIZED` code property.
+  resolve with an object containing information about the memory usage.
+  Otherwise it will be rejected with an `ERR_CONTEXT_NOT_INITIALIZED` error.
 
 The format of the object that the returned Promise may resolve with is
 specific to the V8 engine and may change from one version of V8 to the next.


### PR DESCRIPTION
If in case current context is unable to allocate a promise then `ERR_CONTEXT_NOT_INITIALIZED` error will be thrown (as promise rejection) in the vm measureMemory call. Though minor change but this behavior should also be notified in the docs for the API call.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
