### PR TITLE
doc: fix documentation for `MODULE_NOT_FOUND` and `ERR_MODULE_NOT_FOUND`

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2225,9 +2225,8 @@ transferable object types has been expanded to cover more types than
 
 ### `ERR_MODULE_NOT_FOUND`
 
-> Stability: 1 - Experimental
-
-An [ES Module][] could not be resolved.
+A module file could not be resolved by the ECMAScript modules loader while
+attempting an `import` operation or when loading the program entry point.
 
 <a id="ERR_MULTIPLE_CALLBACK"></a>
 
@@ -2958,8 +2957,8 @@ changes:
     description: Added `requireStack` property.
 -->
 
-A module file could not be resolved while attempting a [`require()`][] or
-`import` operation.
+A module file could not be resolved by the CommonJS modules loader while
+attempting a [`require()`][] operation or when loading the program entry point.
 
 ## Legacy Node.js error codes
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -429,8 +429,8 @@ A required module prefixed with `'./'` is relative to the file calling
 Without a leading `'/'`, `'./'`, or `'../'` to indicate a file, the module must
 either be a core module or is loaded from a `node_modules` folder.
 
-If the given path does not exist, `require()` will throw an [`Error`][] with its
-`code` property set to `'MODULE_NOT_FOUND'`.
+If the given path does not exist, `require()` will throw a
+[`MODULE_NOT_FOUND`][] error.
 
 ## Folders as modules
 
@@ -1084,7 +1084,7 @@ This section was moved to
 [`"type"`]: packages.md#type
 [`ERR_REQUIRE_ESM`]: errors.md#err_require_esm
 [`ERR_UNSUPPORTED_DIR_IMPORT`]: errors.md#err_unsupported_dir_import
-[`Error`]: errors.md#class-error
+[`MODULE_NOT_FOUND`]: errors.md#module_not_found
 [`__dirname`]: #__dirname
 [`__filename`]: #__filename
 [`import()`]: https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports


### PR DESCRIPTION
`ERR_MODULE_NOT_FOUND` was still marked as experimental, probably an oversight from https://github.com/nodejs/node/pull/35781.
`ERR_MODULE_NOT_FOUND` is thrown wether the target specifier would be an ES module or not (we cannot really know the format of a file that doesn't exist anyway).
I've added a note regarding which module loader is involved (sorry @GeoffreyBooth), which is unfortunate but I didn't know how to explain the difference otherwise.