### PR TITLE
Docs: should give a descriptive information about the process.platform property & os.platform() function

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -301,9 +301,10 @@ added: v0.5.0
 
 * Returns: {string}
 
-Returns a string identifying the operating system platform. The value is set
-at compile time. Possible values are `'aix'`, `'darwin'`, `'freebsd'`,
-`'linux'`, `'openbsd'`, `'sunos'`, and `'win32'`.
+Returns a string identifying the operating system platform for which
+the Node.js binary was compiled. The value is set at compile time.
+Possible values are `'aix'`, `'darwin'`, `'freebsd'`,`'linux'`,
+`'openbsd'`, `'sunos'`, and `'win32'`.
 
 The return value is equivalent to [`process.platform`][].
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2613,7 +2613,7 @@ added: v0.1.16
 * {string}
 
 The `process.platform` property returns a string identifying the operating
-system platform on which the Node.js process is running.
+system platform for which the Node.js binary was compiled.
 
 Currently possible values are:
 


### PR DESCRIPTION
Process.platform & Os.platform() values are being set at the compile time for nodeJS [Ref](https://github.com/nodejs/node/blob/74b9baa4265a8f0d112dabc3efc63c2e13276488/node.gyp#L144-L145)

We should be mentioning it clearly on the docs, as we do the same for the [process.arch](https://nodejs.org/api/process.html#:~:text=which%20the%20Node.js%20binary%20was%20compiled)