### PR TITLE
lib: throw error in structuredClone when no arguments are passed

### DIFF
--- a/lib/internal/structured_clone.js
+++ b/lib/internal/structured_clone.js
@@ -1,12 +1,20 @@
 'use strict';
 
 const {
+  codes: { ERR_MISSING_ARGS },
+} = require('internal/errors');
+
+const {
   MessageChannel,
   receiveMessageOnPort,
 } = require('internal/worker/io');
 
 let channel;
 function structuredClone(value, options = undefined) {
+  if (arguments.length === 0) {
+    throw new ERR_MISSING_ARGS('input');
+  }
+
   // TODO: Improve this with a more efficient solution that avoids
   // instantiating a MessageChannel
   channel ??= new MessageChannel();
@@ -17,5 +25,5 @@ function structuredClone(value, options = undefined) {
 }
 
 module.exports = {
-  structuredClone
+  structuredClone,
 };

--- a/lib/internal/structured_clone.js
+++ b/lib/internal/structured_clone.js
@@ -12,7 +12,7 @@ const {
 let channel;
 function structuredClone(value, options = undefined) {
   if (arguments.length === 0) {
-    throw new ERR_MISSING_ARGS('input');
+    throw new ERR_MISSING_ARGS('value');
   }
 
   // TODO: Improve this with a more efficient solution that avoids

--- a/test/parallel/test-structuredClone-global.js
+++ b/test/parallel/test-structuredClone-global.js
@@ -5,10 +5,12 @@
 require('../common');
 
 const {
-  structuredClone: _structuredClone
+  structuredClone: _structuredClone,
 } = require('internal/structured_clone');
+
 const {
-  strictEqual
+  strictEqual,
+  throws,
 } = require('assert');
 
 strictEqual(globalThis.structuredClone, _structuredClone);
@@ -17,3 +19,5 @@ strictEqual(globalThis.structuredClone, undefined);
 
 // Restore the value for the known globals check.
 structuredClone = _structuredClone;
+
+throws(() => _structuredClone(), /TypeError/);

--- a/test/parallel/test-structuredClone-global.js
+++ b/test/parallel/test-structuredClone-global.js
@@ -20,4 +20,4 @@ strictEqual(globalThis.structuredClone, undefined);
 // Restore the value for the known globals check.
 structuredClone = _structuredClone;
 
-throws(() => _structuredClone(), /TypeError/);
+throws(() => _structuredClone(), /ERR_MISSING_ARGS/);


### PR DESCRIPTION
Throw `TypeError` on `structuredClone()`.

Fixes: #41450
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
