### PR TITLE
test: use Object.hasOwn() where applicable

### DIFF
--- a/test/common/report.js
+++ b/test/common/report.js
@@ -69,7 +69,7 @@ function _validateContent(report, fields = []) {
 
   checkForUnknownFields(report, sections);
   sections.forEach((section) => {
-    assert(report.hasOwnProperty(section));
+    assert(Object.hasOwn(report, section));
     assert(typeof report[section] === 'object' && report[section] !== null);
   });
 

--- a/test/doctool/test-doctool-versions.mjs
+++ b/test/doctool/test-doctool-versions.mjs
@@ -51,7 +51,7 @@ for (const version of versions) {
   assert.strictEqual(parts[parts.length - 1], 'x',
                      `'num' from ${tested} doesn't end in '.x'.`);
   const isEvenRelease = Number.parseInt(parts[expectedLength - 2]) % 2 === 0;
-  const hasLtsProperty = version.hasOwnProperty('lts');
+  const hasLtsProperty = Object.hasOwn(version, 'lts');
   if (hasLtsProperty) {
     // Odd-numbered versions of Node.js are never LTS.
     assert.ok(isEvenRelease, `${tested} should not be an 'lts' release.`);

--- a/test/parallel/test-child-process-constructor.js
+++ b/test/parallel/test-child-process-constructor.js
@@ -78,7 +78,7 @@ child.spawn({
   stdio: 'pipe'
 });
 
-assert.strictEqual(child.hasOwnProperty('pid'), true);
+assert.strictEqual(Object.hasOwn(child, 'pid'), true);
 assert(Number.isInteger(child.pid));
 
 // Try killing with invalid signal

--- a/test/parallel/test-child-process-validate-stdio.js
+++ b/test/parallel/test-child-process-validate-stdio.js
@@ -18,9 +18,9 @@ assert.throws(() => getValidStdio(600), expectedError);
   const stdio1 = [];
   const result = getValidStdio(stdio1, false);
   assert.strictEqual(stdio1.length, 3);
-  assert.strictEqual(result.hasOwnProperty('stdio'), true);
-  assert.strictEqual(result.hasOwnProperty('ipc'), true);
-  assert.strictEqual(result.hasOwnProperty('ipcFd'), true);
+  assert.strictEqual(Object.hasOwn(result, 'stdio'), true);
+  assert.strictEqual(Object.hasOwn(result, 'ipc'), true);
+  assert.strictEqual(Object.hasOwn(result, 'ipcFd'), true);
 }
 
 // Should throw if stdio has ipc and sync is true

--- a/test/parallel/test-cluster-basic.js
+++ b/test/parallel/test-cluster-basic.js
@@ -131,7 +131,7 @@ if (cluster.isWorker) {
           assert.strictEqual(Object.keys(arguments[0]).length, 4);
           assert.strictEqual(arguments[0].address, '127.0.0.1');
           assert.strictEqual(arguments[0].addressType, 4);
-          assert(arguments[0].hasOwnProperty('fd'));
+          assert(Object.hasOwn(arguments[0], 'fd'));
           assert.strictEqual(arguments[0].fd, undefined);
           const port = arguments[0].port;
           assert(Number.isInteger(port));

--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -72,7 +72,7 @@ function primary() {
   // Set up event handlers for every worker. Each worker sends a message when
   // it has received the expected number of packets. After that it disconnects.
   for (const key in cluster.workers) {
-    if (cluster.workers.hasOwnProperty(key))
+    if (Object.hasOwn(cluster.workers, key))
       setupWorker(cluster.workers[key]);
   }
 

--- a/test/parallel/test-cluster-dgram-bind-fd.js
+++ b/test/parallel/test-cluster-dgram-bind-fd.js
@@ -63,7 +63,7 @@ function primary() {
   // Set up event handlers for every worker. Each worker sends a message when
   // it has received the expected number of packets. After that it disconnects.
   for (const key in cluster.workers) {
-    if (cluster.workers.hasOwnProperty(key))
+    if (Object.hasOwn(cluster.workers, key))
       setupWorker(cluster.workers[key]);
   }
 

--- a/test/parallel/test-disable-proto-delete.js
+++ b/test/parallel/test-disable-proto-delete.js
@@ -9,14 +9,14 @@ const { Worker, isMainThread } = require('worker_threads');
 
 // eslint-disable-next-line no-proto
 assert.strictEqual(Object.prototype.__proto__, undefined);
-assert(!Object.prototype.hasOwnProperty('__proto__'));
+assert(!Object.hasOwn(Object.prototype, '__proto__'));
 
 const ctx = vm.createContext();
 const ctxGlobal = vm.runInContext('this', ctx);
 
 // eslint-disable-next-line no-proto
 assert.strictEqual(ctxGlobal.Object.prototype.__proto__, undefined);
-assert(!ctxGlobal.Object.prototype.hasOwnProperty('__proto__'));
+assert(!Object.hasOwn(ctxGlobal.Object.prototype, '__proto__'));
 
 if (isMainThread) {
   new Worker(__filename);

--- a/test/parallel/test-disable-proto-throw.js
+++ b/test/parallel/test-disable-proto-throw.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const vm = require('vm');
 const { Worker, isMainThread } = require('worker_threads');
 
-assert(Object.prototype.hasOwnProperty('__proto__'));
+assert(Object.hasOwn(Object.prototype, '__proto__'));
 
 assert.throws(() => {
   // eslint-disable-next-line no-proto,no-unused-expressions

--- a/test/parallel/test-event-emitter-check-listener-leaks.js
+++ b/test/parallel/test-event-emitter-check-listener-leaks.js
@@ -32,7 +32,7 @@ const events = require('events');
   for (let i = 0; i < 10; i++) {
     e.on('default', common.mustNotCall());
   }
-  assert.ok(!e._events.default.hasOwnProperty('warned'));
+  assert.ok(!Object.hasOwn(e._events.default, 'warned'));
   e.on('default', common.mustNotCall());
   assert.ok(e._events.default.warned);
 
@@ -40,32 +40,32 @@ const events = require('events');
   const symbol = Symbol('symbol');
   e.setMaxListeners(1);
   e.on(symbol, common.mustNotCall());
-  assert.ok(!e._events[symbol].hasOwnProperty('warned'));
+  assert.ok(!Object.hasOwn(e._events[symbol], 'warned'));
   e.on(symbol, common.mustNotCall());
-  assert.ok(e._events[symbol].hasOwnProperty('warned'));
+  assert.ok(Object.hasOwn(e._events[symbol], 'warned'));
 
   // specific
   e.setMaxListeners(5);
   for (let i = 0; i < 5; i++) {
     e.on('specific', common.mustNotCall());
   }
-  assert.ok(!e._events.specific.hasOwnProperty('warned'));
+  assert.ok(!Object.hasOwn(e._events.specific, 'warned'));
   e.on('specific', common.mustNotCall());
   assert.ok(e._events.specific.warned);
 
   // only one
   e.setMaxListeners(1);
   e.on('only one', common.mustNotCall());
-  assert.ok(!e._events['only one'].hasOwnProperty('warned'));
+  assert.ok(!Object.hasOwn(e._events['only one'], 'warned'));
   e.on('only one', common.mustNotCall());
-  assert.ok(e._events['only one'].hasOwnProperty('warned'));
+  assert.ok(Object.hasOwn(e._events['only one'], 'warned'));
 
   // unlimited
   e.setMaxListeners(0);
   for (let i = 0; i < 1000; i++) {
     e.on('unlimited', common.mustNotCall());
   }
-  assert.ok(!e._events.unlimited.hasOwnProperty('warned'));
+  assert.ok(!Object.hasOwn(e._events.unlimited, 'warned'));
 }
 
 // process-wide
@@ -76,16 +76,16 @@ const events = require('events');
   for (let i = 0; i < 42; ++i) {
     e.on('fortytwo', common.mustNotCall());
   }
-  assert.ok(!e._events.fortytwo.hasOwnProperty('warned'));
+  assert.ok(!Object.hasOwn(e._events.fortytwo, 'warned'));
   e.on('fortytwo', common.mustNotCall());
-  assert.ok(e._events.fortytwo.hasOwnProperty('warned'));
+  assert.ok(Object.hasOwn(e._events.fortytwo, 'warned'));
   delete e._events.fortytwo.warned;
 
   events.EventEmitter.defaultMaxListeners = 44;
   e.on('fortytwo', common.mustNotCall());
-  assert.ok(!e._events.fortytwo.hasOwnProperty('warned'));
+  assert.ok(!Object.hasOwn(e._events.fortytwo, 'warned'));
   e.on('fortytwo', common.mustNotCall());
-  assert.ok(e._events.fortytwo.hasOwnProperty('warned'));
+  assert.ok(Object.hasOwn(e._events.fortytwo, 'warned'));
 }
 
 // But _maxListeners still has precedence over defaultMaxListeners
@@ -94,9 +94,9 @@ const events = require('events');
   const e = new events.EventEmitter();
   e.setMaxListeners(1);
   e.on('uno', common.mustNotCall());
-  assert.ok(!e._events.uno.hasOwnProperty('warned'));
+  assert.ok(!Object.hasOwn(e._events.uno, 'warned'));
   e.on('uno', common.mustNotCall());
-  assert.ok(e._events.uno.hasOwnProperty('warned'));
+  assert.ok(Object.hasOwn(e._events.uno, 'warned'));
 
   // chainable
   assert.strictEqual(e, e.setMaxListeners(1));

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -27,8 +27,8 @@ const fs = require('fs');
 
 fs.stat('.', common.mustSucceed(function(stats) {
   assert.ok(stats.mtime instanceof Date);
-  assert.ok(stats.hasOwnProperty('blksize'));
-  assert.ok(stats.hasOwnProperty('blocks'));
+  assert.ok(Object.hasOwn(stats, 'blksize'));
+  assert.ok(Object.hasOwn(stats, 'blocks'));
   // Confirm that we are not running in the context of the internal binding
   // layer.
   // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1

--- a/test/parallel/test-http-client-default-headers-exist.js
+++ b/test/parallel/test-http-client-default-headers-exist.js
@@ -41,7 +41,7 @@ const expectedMethods = Object.keys(expectedHeaders);
 const server = http.createServer(common.mustCall((req, res) => {
   res.end();
 
-  assert(expectedHeaders.hasOwnProperty(req.method),
+  assert(Object.hasOwn(expectedHeaders, req.method),
          `${req.method} was an unexpected method`);
 
   const requestHeaders = Object.keys(req.headers);

--- a/test/parallel/test-http-server-capture-rejections.js
+++ b/test/parallel/test-http-server-capture-rejections.js
@@ -25,7 +25,7 @@ events.captureRejections = true;
 
     req.on('response', common.mustCall((res) => {
       assert.strictEqual(res.statusCode, 500);
-      assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
+      assert.strictEqual(Object.hasOwn(res.headers, 'content-type'), false);
       let data = '';
       res.setEncoding('utf8');
       res.on('data', common.mustCall((chunk) => {

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -85,8 +85,8 @@ assert.throws(() => {
 {
   const myError = new errors.codes.TEST_ERROR_1('foo');
   assert.strictEqual(myError.code, 'TEST_ERROR_1');
-  assert.strictEqual(myError.hasOwnProperty('code'), true);
-  assert.strictEqual(myError.hasOwnProperty('name'), false);
+  assert.strictEqual(Object.hasOwn(myError, 'code'), true);
+  assert.strictEqual(Object.hasOwn(myError, 'name'), false);
   assert.deepStrictEqual(Object.keys(myError), ['code']);
   const initialName = myError.name;
   myError.code = 'FHQWHGADS';

--- a/test/parallel/test-module-version.js
+++ b/test/parallel/test-module-version.js
@@ -3,7 +3,7 @@ require('../common');
 const assert = require('assert');
 
 // check for existence
-assert(process.config.variables.hasOwnProperty('node_module_version'));
+assert(Object.hasOwn(process.config.variables, 'node_module_version'));
 
 // Ensure that `node_module_version` is an Integer > 0
 assert(Number.isInteger(process.config.variables.node_module_version));

--- a/test/parallel/test-process-config.js
+++ b/test/parallel/test-process-config.js
@@ -31,7 +31,7 @@ const fs = require('fs');
 const path = require('path');
 
 // Check for existence of `process.config`.
-assert(process.hasOwnProperty('config'));
+assert(Object.hasOwn(process, 'config'));
 
 // Ensure that `process.config` is an Object.
 assert.strictEqual(Object(process.config), process.config);

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -39,7 +39,7 @@ if (process.argv[2] === 'you-are-the-child') {
 
   assert.strictEqual(Object.prototype.hasOwnProperty,
                      process.env.hasOwnProperty);
-  const has = process.env.hasOwnProperty('hasOwnProperty');
+  const has = Object.hasOwn(process.env, 'hasOwnProperty');
   assert.strictEqual(has, false);
 
   process.env.hasOwnProperty = 'asdf';

--- a/test/parallel/test-stream-duplex-writable-finished.js
+++ b/test/parallel/test-stream-duplex-writable-finished.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 // basic
 {
   // Find it on Duplex.prototype
-  assert(Duplex.prototype.hasOwnProperty('writableFinished'));
+  assert(Object.hasOwn(Duplex.prototype, 'writableFinished'));
 }
 
 // event

--- a/test/parallel/test-stream-readable-ended.js
+++ b/test/parallel/test-stream-readable-ended.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 // basic
 {
   // Find it on Readable.prototype
-  assert(Readable.prototype.hasOwnProperty('readableEnded'));
+  assert(Object.hasOwn(Readable.prototype, 'readableEnded'));
 }
 
 // event

--- a/test/parallel/test-stream-writable-finished.js
+++ b/test/parallel/test-stream-writable-finished.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 // basic
 {
   // Find it on Writable.prototype
-  assert(Writable.prototype.hasOwnProperty('writableFinished'));
+  assert(Object.hasOwn(Writable.prototype, 'writableFinished'));
 }
 
 // event

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -422,7 +422,7 @@ class TestWriter extends EE {
 
 {
   // Verify readableEncoding property
-  assert(R.prototype.hasOwnProperty('readableEncoding'));
+  assert(Object.hasOwn(R.prototype, 'readableEncoding'));
 
   const r = new R({ encoding: 'utf8' });
   assert.strictEqual(r.readableEncoding, 'utf8');
@@ -430,7 +430,7 @@ class TestWriter extends EE {
 
 {
   // Verify readableObjectMode property
-  assert(R.prototype.hasOwnProperty('readableObjectMode'));
+  assert(Object.hasOwn(R.prototype, 'readableObjectMode'));
 
   const r = new R({ objectMode: true });
   assert.strictEqual(r.readableObjectMode, true);
@@ -438,7 +438,7 @@ class TestWriter extends EE {
 
 {
   // Verify writableObjectMode property
-  assert(W.prototype.hasOwnProperty('writableObjectMode'));
+  assert(Object.hasOwn(W.prototype, 'writableObjectMode'));
 
   const w = new W({ objectMode: true });
   assert.strictEqual(w.writableObjectMode, true);


### PR DESCRIPTION
Replace Object.prototpye.hasOwnProperty() with Object.hasOwn() where
applicable.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
