### PR TITLE
doc: remove unadvisable cluster example

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -1087,14 +1087,6 @@ for (const worker of Object.values(cluster.workers)) {
 }
 ```
 
-Using the worker's unique id is the easiest way to locate the worker.
-
-```js
-socket.on('data', (id) => {
-  const worker = cluster.workers[id];
-});
-```
-
 [Advanced serialization for `child_process`]: child_process.md#advanced-serialization
 [Child Process module]: child_process.md#child_processforkmodulepath-args-options
 [`.fork()`]: #clusterforkenv


### PR DESCRIPTION
Applications should usually keep track of workers themselves to prevent cross-referencing workers from different "groups" that are assigned to separate tasks.

Additionally, it is unreasonable to assume that the `'data'` event emitted by a `socket` object will be an integer. While the example works when the argument is a string (or `Buffer`), it can result in various issues (e.g., when `id === '__proto__'` since `cluster.workers` has a non-`null` prototype).

Refs: https://github.com/nodejs/node/commit/5f08c3cfa1ee3ece6032d1ffeda6f403e54dd5c0

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
