### PR TITLE
tools: use Set instead of `{ [key]: true }` object

### DIFF
--- a/tools/doc/allhtml.mjs
+++ b/tools/doc/allhtml.mjs
@@ -18,14 +18,11 @@ let apicontent = '';
 
 // Identify files that should be skipped. As files are processed, they
 // are added to this list to prevent dupes.
-const seen = {
-  'all.html': true,
-  'index.html': true
-};
+const seen = new Set(['all.html', 'index.html']);
 
 for (const link of toc.match(/<a.*?>/g)) {
   const href = /href="(.*?)"/.exec(link)[1];
-  if (!htmlFiles.includes(href) || seen[href]) continue;
+  if (!htmlFiles.includes(href) || seen.has(href)) continue;
   const data = fs.readFileSync(new URL(`./${href}`, source), 'utf8');
 
   // Split the doc.
@@ -68,7 +65,7 @@ for (const link of toc.match(/<a.*?>/g)) {
     .trim() + '\n';
 
   // Mark source as seen.
-  seen[href] = true;
+  seen.add(href);
 }
 
 // Replace various mentions of index with all.


### PR DESCRIPTION
A `Set` has clearer semantics than an object whose values are always `true`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
