### PR TITLE
tools: use Set instead of `{ [key]: true }` object

### DIFF
--- a/tools/doc/alljson.mjs
+++ b/tools/doc/alljson.mjs
@@ -23,17 +23,14 @@ const results = {
 
 // Identify files that should be skipped. As files are processed, they
 // are added to this list to prevent dupes.
-const seen = {
-  'all.json': true,
-  'index.json': true
-};
+const seen = new Set(['all.json', 'index.json']);
 
 // Extract (and concatenate) the selected data from each document.
 // Expand hrefs found in json to include source HTML file.
 for (const link of toc.match(/<a.*?>/g)) {
   const href = /href="(.*?)"/.exec(link)[1];
   const json = href.replace('.html', '.json');
-  if (!jsonFiles.includes(json) || seen[json]) continue;
+  if (!jsonFiles.includes(json) || seen.has(json)) continue;
   const data = JSON.parse(
     fs.readFileSync(new URL(`./${json}`, source), 'utf8')
       .replace(/<a href=\\"#/g, `<a href=\\"${href}#`)
@@ -49,7 +46,7 @@ for (const link of toc.match(/<a.*?>/g)) {
   }
 
   // Mark source as seen.
-  seen[json] = true;
+  seen.add(json);
 }
 
 // Write results.


### PR DESCRIPTION
I forgot about `alljson.mjs` in https://github.com/nodejs/node/pull/41675...

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
