### PR TITLE
test: make fs watch test more stable

### DIFF
--- a/test/pummel/test-fs-watch-non-recursive.js
+++ b/test/pummel/test-fs-watch-non-recursive.js
@@ -28,7 +28,7 @@ if (common.isIBMi) {
 
 const path = require('path');
 const fs = require('fs');
-
+const assert = require('assert');
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
@@ -38,13 +38,14 @@ const filepath = path.join(testsubdir, 'watch.txt');
 
 fs.mkdirSync(testsubdir, 0o700);
 
-// Need a grace period, else the mkdirSync() above fires off an event.
-setTimeout(function() {
-  const watcher = fs.watch(testDir, { persistent: true }, common.mustNotCall());
-  setTimeout(function() {
-    fs.writeFileSync(filepath, 'test');
-  }, 100);
-  setTimeout(function() {
-    watcher.close();
-  }, 500);
-}, 50);
+const watcher = fs.watch(testDir, { persistent: true }, (event, filename) => {
+  // This function may be called with the directory depending on timing but
+  // must not be called with the file..
+  assert.strictEqual(filename, 'testsubdir');
+});
+setTimeout(() => {
+  fs.writeFileSync(filepath, 'test');
+}, 100);
+setTimeout(() => {
+  watcher.close();
+}, 500);


### PR DESCRIPTION
The test currently uses a timeout to deal with a watch event for the directory being created.

This is flaky e.g. https://ci.nodejs.org/job/node-test-binary-windows-js-suites/RUN_SUBSET=2,nodes=win10-COMPILED_BY-vs2019/lastCompletedBuild/testReport/(root)/test/pummel_test_fs_watch_non_recursive_/

Instead this changes the `common.mustNotCall` to allow calls with `testdirname` so we do not depend on timing as much.