### PR TITLE
doc: clarify that import also uses main

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1093,8 +1093,11 @@ added: v0.4.0
 }
 ```
 
-The `"main"` field defines the CommonJS or ESM script that is used as the
-package entry point.
+The `"main"` field defines the entry point of a package when
+imported by name via a `node_modules` lookup.  Its value
+is a path.
+When a package has an [`"exports"`][] field, this will take precedence over the
+`"main"` field when importing the package by name.
 
 When the value is a directory, [it may only be loaded via
 `require()`](modules.md#folders-as-modules).

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1093,8 +1093,11 @@ added: v0.4.0
 }
 ```
 
-The `"main"` field defines the script that is used when the [package directory
-is loaded](modules.md#folders-as-modules). Its value is a path.
+The `"main"` field defines the CommonJS or ESM script that is used as the
+package entry point.
+
+When the value is a directory, [it may only be loaded via
+`require()`](modules.md#folders-as-modules).
 
 ```cjs
 require('./path/to/directory'); // This resolves to ./path/to/directory/main.js.

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1094,8 +1094,7 @@ added: v0.4.0
 ```
 
 The `"main"` field defines the script that is used when the [package directory
-is loaded via `require()`](modules.md#folders-as-modules). Its value
-is a path.
+is loaded](modules.md#folders-as-modules). Its value is a path.
 
 ```cjs
 require('./path/to/directory'); // This resolves to ./path/to/directory/main.js.

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1099,8 +1099,8 @@ is a path.
 When a package has an [`"exports"`][] field, this will take precedence over the
 `"main"` field when importing the package by name.
 
-When the value is a directory, [it may only be loaded via
-`require()`](modules.md#folders-as-modules).
+It also defines the script that is used when the [package directory
+is loaded via `require()`](modules.md#folders-as-modules).
 
 ```cjs
 require('./path/to/directory'); // This resolves to ./path/to/directory/main.js.

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1093,21 +1093,18 @@ added: v0.4.0
 }
 ```
 
-The `"main"` field defines the entry point of a package when
-imported by name via a `node_modules` lookup.  Its value
-is a path.
+The `"main"` field defines the entry point of a package when imported by name
+via a `node_modules` lookup.  Its value is a path.
+
 When a package has an [`"exports"`][] field, this will take precedence over the
 `"main"` field when importing the package by name.
 
-It also defines the script that is used when the [package directory
-is loaded via `require()`](modules.md#folders-as-modules).
+It also defines the script that is used when the [package directory is loaded
+via `require()`](modules.md#folders-as-modules).
 
 ```cjs
 require('./path/to/directory'); // This resolves to ./path/to/directory/main.js.
 ```
-
-When a package has an [`"exports"`][] field, this will take precedence over the
-`"main"` field when importing the package by name.
 
 ### `"packageManager"`
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
The docs currently make it sound like `main` is only used when a package is included via `require()`. However, if you `import` a package, it still uses the `main` field