### PR TITLE
doc: fix typo in contributing guides

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -851,7 +851,7 @@ reflect the newly used value. Ensure that the release commit removes the
 `-pre` suffix for the major version being prepared.
 
 It is current TSC policy to bump major version when ABI changes. If you
-see a need to bump `NODE_MODULE_VERSION` outside of a majore release then
+see a need to bump `NODE_MODULE_VERSION` outside of a major release then
 you should consult the TSC. Commits may need to be reverted or a major
 version bump may need to happen.
 

--- a/doc/contributing/static-analysis.md
+++ b/doc/contributing/static-analysis.md
@@ -11,6 +11,6 @@ Any collaborator can ask to be added to the Node.js coverity project
 by opening an issue in the [build](https://github.com/nodejs/build) repository
 titled `Please add me to coverity`. A member of the build WG with admin
 access will verify that the requestor is an existing collaborator as listed in
-the [colloborators section](https://github.com/nodejs/node#collaborators)
+the [collaborators section](https://github.com/nodejs/node#collaborators)
 on the nodejs/node project repo. Once validated the requestor will added
 to to the coverity project.


### PR DESCRIPTION
- `doc/contributing/releases.md` majore → major
- `doc/contributing/static-analysis.md` colloborators → collaborators