### PR TITLE
build: introduce a stale issues workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,13 @@
+name: Close stale issues and PRs
+on:
+  schedule:
+    - cron: 30 1 * * *
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: This issue has been open for many days with no activity. It will be closed soon. To keep it open, remove the stale label or leave a comment.
+          stale-pr-message: This pull request has been open for many days with no activity. It will be closed soon. To keep it open, remove the stale label or leave a comment.


### PR DESCRIPTION
Closes: https://github.com/nodejs/node/issues/29232

It's time. Good grief, is it way past time.

Let's go with the default settings like in this PR. That will initially result in a bit of a stale-ocalypse as a few hundred issues and PRs get labeled stale all at once. Let it happen!

Only things that have no activity for 60 days will get marked stale. Then, if no one comments or removes the `stale` label for 7 full days after that, the issue or pull request will be closed. Let it happen! 

And even if a few things get closed that shouldn't get closed, it's easy enough to re-open them. Let it happen!

And of course, we can always adjust or remove the workflow if it doesn't work out. But good grief, let's stop talking about this and just do it already.

I have opinions on this, obviously.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
