### PR TITLE
cluster: add schedulingPolicy to settings

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -947,6 +947,8 @@ changes:
     primary's `process.debugPort`.
   * `windowsHide` {boolean} Hide the forked processes console window that would
     normally be created on Windows systems. **Default:** `false`.
+  * `schedulingPolicy` {string} policy to distribute load among the
+    secondary processes.
 
 After calling [`.setupPrimary()`][] (or [`.fork()`][]) this settings object will
 contain the settings, including the default values.

--- a/lib/internal/cluster/primary.js
+++ b/lib/internal/cluster/primary.js
@@ -42,21 +42,23 @@ cluster.SCHED_RR = SCHED_RR;      // Primary distributes connections.
 let ids = 0;
 let debugPortOffset = 1;
 let initialized = false;
+let schedulingPolicy = SCHED_RR;
 
-// XXX(bnoordhuis) Fold cluster.schedulingPolicy into cluster.settings?
-let schedulingPolicy = process.env.NODE_CLUSTER_SCHED_POLICY;
-if (schedulingPolicy === 'rr')
-  schedulingPolicy = SCHED_RR;
-else if (schedulingPolicy === 'none')
-  schedulingPolicy = SCHED_NONE;
-else if (process.platform === 'win32') {
-  // Round-robin doesn't perform well on
-  // Windows due to the way IOCP is wired up.
-  schedulingPolicy = SCHED_NONE;
-} else
-  schedulingPolicy = SCHED_RR;
+const SCHEDULE_POLICY_NAME_MAP = new SafeMap()
+  .set('rr', SCHED_RR)
+  .set('none', SCHED_NONE);
 
-cluster.schedulingPolicy = schedulingPolicy;
+function processSchedulingPolicy(settings = {}) {
+  const schedulingPolicy = process.env.NODE_CLUSTER_SCHED_POLICY || settings.schedulingPolicy;
+  if (schedulingPolicy === 'rr' || schedulingPolicy === 'none')
+    return schedulingPolicy;
+  if (process.platform === 'win32') {
+    // Round-robin doesn't perform well on
+    // Windows due to the way IOCP is wired up.
+    return 'none';
+  }
+  return 'rr';
+}
 
 cluster.setupPrimary = function(options) {
   const settings = {
@@ -64,9 +66,12 @@ cluster.setupPrimary = function(options) {
     exec: process.argv[1],
     execArgv: process.execArgv,
     silent: false,
+    schedulingPolicy: cluster.schedulingPolicy || processSchedulingPolicy(options),
     ...cluster.settings,
     ...options
   };
+
+  assert(settings.schedulingPolicy);
 
   // Tell V8 to write profile data for each process to a separate file.
   // Without --logfile=v8-%p.log, everything ends up in a single, unusable
@@ -85,9 +90,7 @@ cluster.setupPrimary = function(options) {
     return process.nextTick(setupSettingsNT, settings);
 
   initialized = true;
-  schedulingPolicy = cluster.schedulingPolicy;  // Freeze policy.
-  assert(schedulingPolicy === SCHED_NONE || schedulingPolicy === SCHED_RR,
-         `Bad cluster.schedulingPolicy: ${schedulingPolicy}`);
+  schedulingPolicy = SCHEDULE_POLICY_NAME_MAP.get(cluster.schedulingPolicy); // Freeze policy.
 
   process.nextTick(setupSettingsNT, settings);
 

--- a/test/parallel/test-cluster-setup-primary-cumulative.js
+++ b/test/parallel/test-cluster-setup-primary-cumulative.js
@@ -34,6 +34,7 @@ assert.deepStrictEqual(cluster.settings, {
   args: process.argv.slice(2),
   exec: process.argv[1],
   execArgv: process.execArgv,
+  schedulingPolicy: 'rr',
   silent: false,
 });
 console.log('ok sets defaults');
@@ -57,6 +58,7 @@ assert.deepStrictEqual(cluster.settings, {
   args: ['foo', 'bar'],
   exec: 'overridden',
   execArgv: ['baz', 'bang'],
+  schedulingPolicy: 'rr',
   silent: false,
 });
 console.log('ok preserves current settings');


### PR DESCRIPTION
Added `schedulingPolicy` option to settings so that the cluster owners
can schedule the handler explicitly as well. They can use the name
either `rr` or `none` for setting up the schedulingPolicy of
the primary process.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
