### PR TITLE
http2: fix no response event on continue request

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -760,7 +760,7 @@ class Http2ServerResponse extends Stream {
     }
 
     if (chunk !== null && chunk !== undefined)
-      chunk = '';  
+      chunk = '';
 
     this.write(chunk, encoding);
 

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -760,9 +760,7 @@ class Http2ServerResponse extends Stream {
     }
 
     if (chunk !== null && chunk !== undefined)
-      chunk = '';
-
-    this.write(chunk, encoding);
+      this.write(chunk, encoding);
 
     state.headRequest = stream.headRequest;
     state.ending = true;

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -760,7 +760,9 @@ class Http2ServerResponse extends Stream {
     }
 
     if (chunk !== null && chunk !== undefined)
-      this.write(chunk, encoding);
+      chunk = '';  
+
+    this.write(chunk, encoding);
 
     state.headRequest = stream.headRequest;
     state.ending = true;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -394,8 +394,10 @@ function onSessionHeaders(handle, id, cat, flags, headers, sensitiveHeaders) {
       }
     } else if (cat === NGHTTP2_HCAT_PUSH_RESPONSE) {
       event = 'push';
-      // cat === NGHTTP2_HCAT_HEADERS:
     } else if (!endOfStream && status !== undefined && status >= 200) {
+      event = 'response';
+    } else if (endOfStream && status !== undefined && status >= 200) {
+      // cat === NGHTTP2_HCAT_HEADERS
       event = 'response';
     } else {
       event = endOfStream ? 'trailers' : 'headers';

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -394,10 +394,7 @@ function onSessionHeaders(handle, id, cat, flags, headers, sensitiveHeaders) {
       }
     } else if (cat === NGHTTP2_HCAT_PUSH_RESPONSE) {
       event = 'push';
-    } else if (!endOfStream && status !== undefined && status >= 200) {
-      event = 'response';
-    } else if (endOfStream && status !== undefined && status >= 200) {
-      // cat === NGHTTP2_HCAT_HEADERS
+    } else if (status !== undefined && status >= 200) {
       event = 'response';
     } else {
       event = endOfStream ? 'trailers' : 'headers';

--- a/test/parallel/test-http2-compat-expect-continue.js
+++ b/test/parallel/test-http2-compat-expect-continue.js
@@ -6,49 +6,90 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const http2 = require('http2');
 
-const testResBody = 'other stuff!\n';
+{
+  const testResBody = 'other stuff!\n';
 
-// Checks the full 100-continue flow from client sending 'expect: 100-continue'
-// through server receiving it, sending back :status 100, writing the rest of
-// the request to finally the client receiving to.
+  // Checks the full 100-continue flow from client sending 'expect: 100-continue'
+  // through server receiving it, sending back :status 100, writing the rest of
+  // the request to finally the client receiving to.
 
-const server = http2.createServer();
+  const server = http2.createServer();
 
-let sentResponse = false;
+  let sentResponse = false;
 
-server.on('request', common.mustCall((req, res) => {
-  res.end(testResBody);
-  sentResponse = true;
-}));
-
-server.listen(0);
-
-server.on('listening', common.mustCall(() => {
-  let body = '';
-
-  const client = http2.connect(`http://localhost:${server.address().port}`);
-  const req = client.request({
-    ':method': 'POST',
-    'expect': '100-continue'
-  });
-
-  let gotContinue = false;
-  req.on('continue', common.mustCall(() => {
-    gotContinue = true;
+  server.on('request', common.mustCall((req, res) => {
+    res.end(testResBody);
+    sentResponse = true;
   }));
 
-  req.on('response', common.mustCall((headers) => {
-    assert.strictEqual(gotContinue, true);
-    assert.strictEqual(sentResponse, true);
-    assert.strictEqual(headers[':status'], 200);
-    req.end();
+  server.listen(0);
+
+  server.on('listening', common.mustCall(() => {
+    let body = '';
+
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request({
+      ':method': 'POST',
+      'expect': '100-continue'
+    });
+
+    let gotContinue = false;
+    req.on('continue', common.mustCall(() => {
+      gotContinue = true;
+    }));
+
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(gotContinue, true);
+      assert.strictEqual(sentResponse, true);
+      assert.strictEqual(headers[':status'], 200);
+      req.end();
+    }));
+
+    req.setEncoding('utf8');
+    req.on('data', common.mustCall((chunk) => { body += chunk; }));
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(body, testResBody);
+      client.close();
+      server.close();
+    }));
+  }));
+}
+
+{
+  // Checks the full 100-continue flow from client sending 'expect: 100-continue'
+  // through server receiving it and ending the request.
+
+  const server = http2.createServer();
+
+  server.on('request', common.mustCall((req, res) => {
+    res.end();
   }));
 
-  req.setEncoding('utf8');
-  req.on('data', common.mustCall((chunk) => { body += chunk; }));
-  req.on('end', common.mustCall(() => {
-    assert.strictEqual(body, testResBody);
-    client.close();
-    server.close();
+  server.listen(0);
+
+  server.on('listening', common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request({
+      ":path": "/",
+      'expect': '100-continue'
+    });
+
+    let gotContinue = false;
+    req.on('continue', common.mustCall(() => {
+      gotContinue = true;
+    }));
+
+    let gotResponse = false;
+    req.on('response', common.mustCall(() => {
+      gotResponse = true;
+    }));
+
+    req.setEncoding('utf8');
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(gotContinue, true);
+      assert.strictEqual(gotResponse, true);
+      client.close();
+      server.close();
+    }));
   }));
-}));
+}

--- a/test/parallel/test-http2-compat-expect-continue.js
+++ b/test/parallel/test-http2-compat-expect-continue.js
@@ -70,7 +70,7 @@ const http2 = require('http2');
   server.on('listening', common.mustCall(() => {
     const client = http2.connect(`http://localhost:${server.address().port}`);
     const req = client.request({
-      ":path": "/",
+      ':path': '/',
       'expect': '100-continue'
     });
 


### PR DESCRIPTION
When sending a continue request, server response with null, but it does not fires the response event type

Fixes: https://github.com/nodejs/node/issues/38258
Ref: https://github.com/nodejs/node/pull/38561

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
