### PR TITLE
benchmark: remove input param manipulation

### DIFF
--- a/benchmark/assert/deepequal-object.js
+++ b/benchmark/assert/deepequal-object.js
@@ -24,8 +24,7 @@ function createObj(source, add = '') {
 }
 
 function main({ size, n, method, strict }) {
-  // TODO: Fix this "hack". `n` should not be manipulated.
-  n = Math.min(Math.ceil(n / size), 20);
+  const len = Math.min(Math.ceil(n / size), 20);
 
   const source = Array.apply(null, Array(size));
   const actual = createObj(source);
@@ -39,8 +38,8 @@ function main({ size, n, method, strict }) {
   const value2 = method.includes('not') ? expectedWrong : expected;
 
   bench.start();
-  for (let i = 0; i < n; ++i) {
+  for (let i = 0; i < len; ++i) {
     fn(actual, value2);
   }
-  bench.end(n);
+  bench.end(len);
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Worked on a `TODO` which demands to avoid the manipulation of input param