### PR TITLE
[v16.x backport] loader: return package format from defaultResolve if known

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3518,6 +3518,11 @@ with options `{ recursive: true, force: true }`.
 
 <!-- YAML
 added: v14.14.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41132
+    description: The `path` parameter can be a WHATWG `URL` object using `file:`
+                 protocol.
 -->
 
 * `path` {string|Buffer|URL}
@@ -5261,6 +5266,11 @@ with options `{ recursive: true, force: true }`.
 
 <!-- YAML
 added: v14.14.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41132
+    description: The `path` parameter can be a WHATWG `URL` object using `file:`
+                 protocol.
 -->
 
 * `path` {string|Buffer|URL}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1185,6 +1185,7 @@ function rm(path, options, callback) {
     callback = options;
     options = undefined;
   }
+  path = getValidatedPath(path);
 
   validateRmOptions(path, options, false, (err, options) => {
     if (err) {
@@ -1208,6 +1209,7 @@ function rm(path, options, callback) {
  * @returns {void}
  */
 function rmSync(path, options) {
+  path = getValidatedPath(path);
   options = validateRmOptionsSync(path, options, false);
 
   lazyLoadRimraf();

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -32,6 +32,8 @@ const legacyExtensionFormatMap = {
   '.node': 'commonjs'
 };
 
+let experimentalSpecifierResolutionWarned = false;
+
 if (experimentalWasmModules)
   extensionFormatMap['.wasm'] = legacyExtensionFormatMap['.wasm'] = 'wasm';
 
@@ -53,41 +55,57 @@ const protocolHandlers = ObjectAssign(ObjectCreate(null), {
 
     return format;
   },
-  'file:'(parsed, url) {
-    const ext = extname(parsed.pathname);
-    let format;
-
-    if (ext === '.js') {
-      format = getPackageType(parsed.href) === 'module' ? 'module' : 'commonjs';
-    } else {
-      format = extensionFormatMap[ext];
-    }
-    if (!format) {
-      if (experimentalSpecifierResolution === 'node') {
-        process.emitWarning(
-          'The Node.js specifier resolution in ESM is experimental.',
-          'ExperimentalWarning');
-        format = legacyExtensionFormatMap[ext];
-      } else {
-        throw new ERR_UNKNOWN_FILE_EXTENSION(ext, fileURLToPath(url));
-      }
-    }
-
-    return format || null;
-  },
+  'file:': getFileProtocolModuleFormat,
   'node:'() { return 'builtin'; },
 });
 
+function getLegacyExtensionFormat(ext) {
+  if (
+    experimentalSpecifierResolution === 'node' &&
+    !experimentalSpecifierResolutionWarned
+  ) {
+    process.emitWarning(
+      'The Node.js specifier resolution in ESM is experimental.',
+      'ExperimentalWarning');
+    experimentalSpecifierResolutionWarned = true;
+  }
+  return legacyExtensionFormatMap[ext];
+}
+
+function getFileProtocolModuleFormat(url, ignoreErrors) {
+  const ext = extname(url.pathname);
+  if (ext === '.js') {
+    return getPackageType(url) === 'module' ? 'module' : 'commonjs';
+  }
+
+  const format = extensionFormatMap[ext];
+  if (format) return format;
+  if (experimentalSpecifierResolution !== 'node') {
+    // Explicit undefined return indicates load hook should rerun format check
+    if (ignoreErrors)
+      return undefined;
+    throw new ERR_UNKNOWN_FILE_EXTENSION(ext, fileURLToPath(url));
+  }
+  return getLegacyExtensionFormat(ext) ?? null;
+}
+
+function defaultGetFormatWithoutErrors(url, context) {
+  const parsed = new URL(url);
+  if (!ObjectPrototypeHasOwnProperty(protocolHandlers, parsed.protocol))
+    return null;
+  return protocolHandlers[parsed.protocol](parsed, true);
+}
+
 function defaultGetFormat(url, context) {
   const parsed = new URL(url);
-
   return ObjectPrototypeHasOwnProperty(protocolHandlers, parsed.protocol) ?
-    protocolHandlers[parsed.protocol](parsed, url) :
+    protocolHandlers[parsed.protocol](parsed, false) :
     null;
 }
 
 module.exports = {
   defaultGetFormat,
+  defaultGetFormatWithoutErrors,
   extensionFormatMap,
   legacyExtensionFormatMap,
 };

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -2,7 +2,6 @@
 
 const { defaultGetFormat } = require('internal/modules/esm/get_format');
 const { defaultGetSource } = require('internal/modules/esm/get_source');
-const { translators } = require('internal/modules/esm/translators');
 const { validateAssertions } = require('internal/modules/esm/assert');
 
 /**
@@ -18,7 +17,7 @@ async function defaultLoad(url, context) {
   } = context;
   const { importAssertions } = context;
 
-  if (!format || !translators.has(format)) {
+  if (format == null) {
     format = defaultGetFormat(url);
   }
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -487,6 +487,23 @@ const patternRegEx = /\*/g;
 
 function resolvePackageTargetString(
   target, subpath, match, packageJSONUrl, base, pattern, internal, conditions) {
+
+  const composeResult = (resolved) => {
+    let format;
+    try {
+      format = getPackageType(resolved);
+    } catch (err) {
+      if (err.code === 'ERR_INVALID_FILE_URL_PATH') {
+        const invalidModuleErr = new ERR_INVALID_MODULE_SPECIFIER(
+          resolved, 'must not include encoded "/" or "\\" characters', base);
+        invalidModuleErr.cause = err;
+        throw invalidModuleErr;
+      }
+      throw err;
+    }
+    return { resolved, ...(format !== 'none') && { format } };
+  };
+
   if (subpath !== '' && !pattern && target[target.length - 1] !== '/')
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
 
@@ -502,7 +519,8 @@ function resolvePackageTargetString(
         const exportTarget = pattern ?
           RegExpPrototypeSymbolReplace(patternRegEx, target, () => subpath) :
           target + subpath;
-        return packageResolve(exportTarget, packageJSONUrl, conditions);
+        return packageResolve(
+          exportTarget, packageJSONUrl, conditions);
       }
     }
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
@@ -518,15 +536,18 @@ function resolvePackageTargetString(
   if (!StringPrototypeStartsWith(resolvedPath, packagePath))
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
 
-  if (subpath === '') return resolved;
+  if (subpath === '') return composeResult(resolved);
 
   if (RegExpPrototypeTest(invalidSegmentRegEx, subpath))
     throwInvalidSubpath(match + subpath, packageJSONUrl, internal, base);
 
-  if (pattern)
-    return new URL(RegExpPrototypeSymbolReplace(patternRegEx, resolved.href,
-                                                () => subpath));
-  return new URL(subpath, resolved);
+  if (pattern) {
+    return composeResult(new URL(RegExpPrototypeSymbolReplace(patternRegEx,
+                                                              resolved.href,
+                                                              () => subpath)));
+  }
+
+  return composeResult(new URL(subpath, resolved));
 }
 
 /**
@@ -552,9 +573,9 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
     let lastException;
     for (let i = 0; i < target.length; i++) {
       const targetItem = target[i];
-      let resolved;
+      let resolveResult;
       try {
-        resolved = resolvePackageTarget(
+        resolveResult = resolvePackageTarget(
           packageJSONUrl, targetItem, subpath, packageSubpath, base, pattern,
           internal, conditions);
       } catch (e) {
@@ -563,13 +584,13 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
           continue;
         throw e;
       }
-      if (resolved === undefined)
+      if (resolveResult === undefined)
         continue;
-      if (resolved === null) {
+      if (resolveResult === null) {
         lastException = null;
         continue;
       }
-      return resolved;
+      return resolveResult;
     }
     if (lastException === undefined || lastException === null)
       return lastException;
@@ -588,12 +609,12 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
       const key = keys[i];
       if (key === 'default' || conditions.has(key)) {
         const conditionalTarget = target[key];
-        const resolved = resolvePackageTarget(
+        const resolveResult = resolvePackageTarget(
           packageJSONUrl, conditionalTarget, subpath, packageSubpath, base,
           pattern, internal, conditions);
-        if (resolved === undefined)
+        if (resolveResult === undefined)
           continue;
-        return resolved;
+        return resolveResult;
       }
     }
     return undefined;
@@ -652,12 +673,15 @@ function packageExportsResolve(
       !StringPrototypeIncludes(packageSubpath, '*') &&
       !StringPrototypeEndsWith(packageSubpath, '/')) {
     const target = exports[packageSubpath];
-    const resolved = resolvePackageTarget(
+    const resolveResult = resolvePackageTarget(
       packageJSONUrl, target, '', packageSubpath, base, false, false, conditions
     );
-    if (resolved === null || resolved === undefined)
+
+    if (resolveResult == null) {
       throwExportsNotFound(packageSubpath, packageJSONUrl, base);
-    return { resolved, exact: true };
+    }
+
+    return { ...resolveResult, exact: true };
   }
 
   let bestMatch = '';
@@ -693,14 +717,25 @@ function packageExportsResolve(
   if (bestMatch) {
     const target = exports[bestMatch];
     const pattern = StringPrototypeIncludes(bestMatch, '*');
-    const resolved = resolvePackageTarget(packageJSONUrl, target,
-                                          bestMatchSubpath, bestMatch, base,
-                                          pattern, false, conditions);
-    if (resolved === null || resolved === undefined)
+    const resolveResult = resolvePackageTarget(
+      packageJSONUrl,
+      target,
+      bestMatchSubpath,
+      bestMatch,
+      base,
+      pattern,
+      false,
+      conditions);
+
+    if (resolveResult == null) {
       throwExportsNotFound(packageSubpath, packageJSONUrl, base);
-    if (!pattern)
+    }
+
+    if (!pattern) {
       emitFolderMapDeprecation(bestMatch, packageJSONUrl, true, base);
-    return { resolved, exact: pattern };
+    }
+
+    return { ...resolveResult, exact: pattern };
   }
 
   throwExportsNotFound(packageSubpath, packageJSONUrl, base);
@@ -740,11 +775,12 @@ function packageImportsResolve(name, base, conditions) {
       if (ObjectPrototypeHasOwnProperty(imports, name) &&
           !StringPrototypeIncludes(name, '*') &&
           !StringPrototypeEndsWith(name, '/')) {
-        const resolved = resolvePackageTarget(
+        const resolveResult = resolvePackageTarget(
           packageJSONUrl, imports[name], '', name, base, false, true, conditions
         );
-        if (resolved !== null)
-          return { resolved, exact: true };
+        if (resolveResult != null) {
+          return { resolved: resolveResult.resolved, exact: true };
+        }
       } else {
         let bestMatch = '';
         let bestMatchSubpath;
@@ -776,14 +812,15 @@ function packageImportsResolve(name, base, conditions) {
         if (bestMatch) {
           const target = imports[bestMatch];
           const pattern = StringPrototypeIncludes(bestMatch, '*');
-          const resolved = resolvePackageTarget(packageJSONUrl, target,
-                                                bestMatchSubpath, bestMatch,
-                                                base, pattern, true,
-                                                conditions);
-          if (resolved !== null) {
+          const resolveResult = resolvePackageTarget(
+            packageJSONUrl, target,
+            bestMatchSubpath, bestMatch,
+            base, pattern, true,
+            conditions);
+          if (resolveResult !== null) {
             if (!pattern)
               emitFolderMapDeprecation(bestMatch, packageJSONUrl, false, base);
-            return { resolved, exact: pattern };
+            return { resolved: resolveResult.resolved, exact: pattern };
           }
         }
       }
@@ -843,7 +880,7 @@ function parsePackageName(specifier, base) {
  * @param {string} specifier
  * @param {string | URL | undefined} base
  * @param {Set<string>} conditions
- * @returns {URL}
+ * @returns {resolved: URL, format? : string}
  */
 function packageResolve(specifier, base, conditions) {
   if (NativeModule.canBeRequiredByUsers(specifier))
@@ -859,8 +896,7 @@ function packageResolve(specifier, base, conditions) {
     if (packageConfig.name === packageName &&
         packageConfig.exports !== undefined && packageConfig.exports !== null) {
       return packageExportsResolve(
-        packageJSONUrl, packageSubpath, packageConfig, base, conditions
-      ).resolved;
+        packageJSONUrl, packageSubpath, packageConfig, base, conditions);
     }
   }
 
@@ -882,13 +918,26 @@ function packageResolve(specifier, base, conditions) {
 
     // Package match.
     const packageConfig = getPackageConfig(packageJSONPath, specifier, base);
-    if (packageConfig.exports !== undefined && packageConfig.exports !== null)
+    if (packageConfig.exports !== undefined && packageConfig.exports !== null) {
       return packageExportsResolve(
-        packageJSONUrl, packageSubpath, packageConfig, base, conditions
-      ).resolved;
-    if (packageSubpath === '.')
-      return legacyMainResolve(packageJSONUrl, packageConfig, base);
-    return new URL(packageSubpath, packageJSONUrl);
+        packageJSONUrl, packageSubpath, packageConfig, base, conditions);
+    }
+
+    if (packageSubpath === '.') {
+      return {
+        resolved: legacyMainResolve(
+          packageJSONUrl,
+          packageConfig,
+          base),
+        ...(packageConfig.type !== 'none') && { format: packageConfig.type }
+      };
+    }
+
+    return {
+      resolved: new URL(packageSubpath, packageJSONUrl),
+      ...(packageConfig.type !== 'none') && { format: packageConfig.type }
+    };
+
     // Cross-platform root check.
   } while (packageJSONPath.length !== lastPath.length);
 
@@ -932,6 +981,7 @@ function moduleResolve(specifier, base, conditions, preserveSymlinks) {
   // Order swapped from spec for minor perf gain.
   // Ok since relative URLs cannot parse as URLs.
   let resolved;
+  let format;
   if (shouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
     resolved = new URL(specifier, base);
   } else if (specifier[0] === '#') {
@@ -940,12 +990,15 @@ function moduleResolve(specifier, base, conditions, preserveSymlinks) {
     try {
       resolved = new URL(specifier);
     } catch {
-      resolved = packageResolve(specifier, base, conditions);
+      ({ resolved, format } = packageResolve(specifier, base, conditions));
     }
   }
   if (resolved.protocol !== 'file:')
     return resolved;
-  return finalizeResolution(resolved, base, preserveSymlinks);
+  return {
+    url: finalizeResolution(resolved, base, preserveSymlinks),
+    ...(format != null) && { format }
+  };
 }
 
 /**
@@ -1034,9 +1087,15 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
 
   conditions = getConditionsSet(conditions);
   let url;
+  let format;
   try {
-    url = moduleResolve(specifier, parentURL, conditions,
-                        isMain ? preserveSymlinksMain : preserveSymlinks);
+    ({ url, format } =
+      moduleResolve(
+        specifier,
+        parentURL,
+        conditions, 
+        isMain ? preserveSymlinksMain : preserveSymlinks
+      ));
   } catch (error) {
     // Try to give the user a hint of what would have been the
     // resolved CommonJS module
@@ -1064,7 +1123,10 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
       url.protocol !== 'node:')
     throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(url);
 
-  return { url: `${url}` };
+  return {
+    url: `${url}`,
+    ...(format != null) && { format }
+  };
 }
 
 module.exports = {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -131,7 +131,7 @@ function emitTrailingSlashPatternDeprecation(match, pjsonUrl, isExports, base) {
  * @returns {void}
  */
 function emitLegacyIndexDeprecation(url, packageJSONUrl, base, main) {
-  const format = defaultGetFormat(url);
+  const format = defaultGetFormatWithoutErrors(url);
   if (format !== 'module')
     return;
   const path = fileURLToPath(url);
@@ -488,22 +488,6 @@ const patternRegEx = /\*/g;
 function resolvePackageTargetString(
   target, subpath, match, packageJSONUrl, base, pattern, internal, conditions) {
 
-  const composeResult = (resolved) => {
-    let format;
-    try {
-      format = getPackageType(resolved);
-    } catch (err) {
-      if (err.code === 'ERR_INVALID_FILE_URL_PATH') {
-        const invalidModuleErr = new ERR_INVALID_MODULE_SPECIFIER(
-          resolved, 'must not include encoded "/" or "\\" characters', base);
-        invalidModuleErr.cause = err;
-        throw invalidModuleErr;
-      }
-      throw err;
-    }
-    return { resolved, ...(format !== 'none') && { format } };
-  };
-
   if (subpath !== '' && !pattern && target[target.length - 1] !== '/')
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
 
@@ -536,18 +520,22 @@ function resolvePackageTargetString(
   if (!StringPrototypeStartsWith(resolvedPath, packagePath))
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
 
-  if (subpath === '') return composeResult(resolved);
+  if (subpath === '') return resolved;
 
   if (RegExpPrototypeTest(invalidSegmentRegEx, subpath))
     throwInvalidSubpath(match + subpath, packageJSONUrl, internal, base);
 
   if (pattern) {
-    return composeResult(new URL(RegExpPrototypeSymbolReplace(patternRegEx,
-                                                              resolved.href,
-                                                              () => subpath)));
+    return new URL(
+      RegExpPrototypeSymbolReplace(
+        patternRegEx,
+        resolved.href,
+        () => subpath
+      )
+    );
   }
 
-  return composeResult(new URL(subpath, resolved));
+  return new URL(subpath, resolved);
 }
 
 /**
@@ -673,15 +661,15 @@ function packageExportsResolve(
       !StringPrototypeIncludes(packageSubpath, '*') &&
       !StringPrototypeEndsWith(packageSubpath, '/')) {
     const target = exports[packageSubpath];
-    const resolveResult = resolvePackageTarget(
+    const resolved = resolvePackageTarget(
       packageJSONUrl, target, '', packageSubpath, base, false, false, conditions
     );
 
-    if (resolveResult == null) {
+    if (resolved == null) {
       throwExportsNotFound(packageSubpath, packageJSONUrl, base);
     }
 
-    return { ...resolveResult, exact: true };
+    return { resolved, exact: true };
   }
 
   let bestMatch = '';
@@ -717,7 +705,7 @@ function packageExportsResolve(
   if (bestMatch) {
     const target = exports[bestMatch];
     const pattern = StringPrototypeIncludes(bestMatch, '*');
-    const resolveResult = resolvePackageTarget(
+    const resolved = resolvePackageTarget(
       packageJSONUrl,
       target,
       bestMatchSubpath,
@@ -727,7 +715,7 @@ function packageExportsResolve(
       false,
       conditions);
 
-    if (resolveResult == null) {
+    if (resolved == null) {
       throwExportsNotFound(packageSubpath, packageJSONUrl, base);
     }
 
@@ -735,7 +723,7 @@ function packageExportsResolve(
       emitFolderMapDeprecation(bestMatch, packageJSONUrl, true, base);
     }
 
-    return { ...resolveResult, exact: pattern };
+    return { resolved, exact: pattern };
   }
 
   throwExportsNotFound(packageSubpath, packageJSONUrl, base);
@@ -775,11 +763,11 @@ function packageImportsResolve(name, base, conditions) {
       if (ObjectPrototypeHasOwnProperty(imports, name) &&
           !StringPrototypeIncludes(name, '*') &&
           !StringPrototypeEndsWith(name, '/')) {
-        const resolveResult = resolvePackageTarget(
+        const resolved = resolvePackageTarget(
           packageJSONUrl, imports[name], '', name, base, false, true, conditions
         );
-        if (resolveResult != null) {
-          return { resolved: resolveResult.resolved, exact: true };
+        if (resolved != null) {
+          return { resolved, exact: true };
         }
       } else {
         let bestMatch = '';
@@ -812,15 +800,15 @@ function packageImportsResolve(name, base, conditions) {
         if (bestMatch) {
           const target = imports[bestMatch];
           const pattern = StringPrototypeIncludes(bestMatch, '*');
-          const resolveResult = resolvePackageTarget(
+          const resolved = resolvePackageTarget(
             packageJSONUrl, target,
             bestMatchSubpath, bestMatch,
             base, pattern, true,
             conditions);
-          if (resolveResult !== null) {
+          if (resolved !== null) {
             if (!pattern)
               emitFolderMapDeprecation(bestMatch, packageJSONUrl, false, base);
-            return { resolved: resolveResult.resolved, exact: pattern };
+            return { resolved, exact: pattern };
           }
         }
       }
@@ -880,7 +868,7 @@ function parsePackageName(specifier, base) {
  * @param {string} specifier
  * @param {string | URL | undefined} base
  * @param {Set<string>} conditions
- * @returns {resolved: URL, format? : string}
+ * @returns {URL}
  */
 function packageResolve(specifier, base, conditions) {
   if (NativeModule.canBeRequiredByUsers(specifier))
@@ -896,7 +884,8 @@ function packageResolve(specifier, base, conditions) {
     if (packageConfig.name === packageName &&
         packageConfig.exports !== undefined && packageConfig.exports !== null) {
       return packageExportsResolve(
-        packageJSONUrl, packageSubpath, packageConfig, base, conditions);
+        packageJSONUrl, packageSubpath, packageConfig, base, conditions
+      ).resolved;
     }
   }
 
@@ -920,24 +909,19 @@ function packageResolve(specifier, base, conditions) {
     const packageConfig = getPackageConfig(packageJSONPath, specifier, base);
     if (packageConfig.exports !== undefined && packageConfig.exports !== null) {
       return packageExportsResolve(
-        packageJSONUrl, packageSubpath, packageConfig, base, conditions);
+        packageJSONUrl, packageSubpath, packageConfig, base, conditions
+      ).resolved;
     }
 
     if (packageSubpath === '.') {
-      return {
-        resolved: legacyMainResolve(
-          packageJSONUrl,
-          packageConfig,
-          base),
-        ...(packageConfig.type !== 'none') && { format: packageConfig.type }
-      };
+      return legacyMainResolve(
+        packageJSONUrl,
+        packageConfig,
+        base
+      );
     }
 
-    return {
-      resolved: new URL(packageSubpath, packageJSONUrl),
-      ...(packageConfig.type !== 'none') && { format: packageConfig.type }
-    };
-
+    return new URL(packageSubpath, packageJSONUrl);
     // Cross-platform root check.
   } while (packageJSONPath.length !== lastPath.length);
 
@@ -981,7 +965,6 @@ function moduleResolve(specifier, base, conditions, preserveSymlinks) {
   // Order swapped from spec for minor perf gain.
   // Ok since relative URLs cannot parse as URLs.
   let resolved;
-  let format;
   if (shouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
     resolved = new URL(specifier, base);
   } else if (specifier[0] === '#') {
@@ -990,15 +973,12 @@ function moduleResolve(specifier, base, conditions, preserveSymlinks) {
     try {
       resolved = new URL(specifier);
     } catch {
-      ({ resolved, format } = packageResolve(specifier, base, conditions));
+      resolved = packageResolve(specifier, base, conditions);
     }
   }
   if (resolved.protocol !== 'file:')
     return resolved;
-  return {
-    url: finalizeResolution(resolved, base, preserveSymlinks),
-    ...(format != null) && { format }
-  };
+  return finalizeResolution(resolved, base, preserveSymlinks);
 }
 
 /**
@@ -1047,6 +1027,13 @@ function resolveAsCommonJS(specifier, parentURL) {
   }
 }
 
+function throwIfUnsupportedURLProtocol(url) {
+  if (url.protocol !== 'file:' && url.protocol !== 'data:' &&
+      url.protocol !== 'node:') {
+    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(url);
+  }
+}
+
 function defaultResolve(specifier, context = {}, defaultResolveUnused) {
   let { parentURL, conditions } = context;
   if (parentURL && policy?.manifest) {
@@ -1087,15 +1074,9 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
 
   conditions = getConditionsSet(conditions);
   let url;
-  let format;
   try {
-    ({ url, format } =
-      moduleResolve(
-        specifier,
-        parentURL,
-        conditions, 
-        isMain ? preserveSymlinksMain : preserveSymlinks
-      ));
+    url = moduleResolve(specifier, parentURL, conditions,
+                        isMain ? preserveSymlinksMain : preserveSymlinks);
   } catch (error) {
     // Try to give the user a hint of what would have been the
     // resolved CommonJS module
@@ -1119,13 +1100,11 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
     throw error;
   }
 
-  if (url.protocol !== 'file:' && url.protocol !== 'data:' &&
-      url.protocol !== 'node:')
-    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(url);
+  throwIfUnsupportedURLProtocol(url);
 
   return {
     url: `${url}`,
-    ...(format != null) && { format }
+    format: defaultGetFormatWithoutErrors(url),
   };
 }
 
@@ -1140,4 +1119,6 @@ module.exports = {
 };
 
 // cycle
-const { defaultGetFormat } = require('internal/modules/esm/get_format');
+const {
+  defaultGetFormatWithoutErrors,
+} = require('internal/modules/esm/get_format');

--- a/test/es-module/test-esm-loader-resolve-type.mjs
+++ b/test/es-module/test-esm-loader-resolve-type.mjs
@@ -1,0 +1,41 @@
+// Flags: --loader ./test/fixtures/es-module-loaders/hook-resolve-type.mjs
+import { allowGlobals } from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+
+allowGlobals(global.getModuleTypeStats);
+
+const basePath =
+  new URL('./node_modules/', import.meta.url);
+
+const rel = (file) => new URL(file, basePath);
+const createDir = (path) => {
+  if (!fs.existsSync(path)) {
+    fs.mkdirSync(path);
+  }
+};
+
+const moduleName = 'module-counter-by-type';
+
+const moduleDir = rel(`${moduleName}`);
+createDir(basePath);
+createDir(moduleDir);
+fs.cpSync(
+  fixtures.path('es-modules', moduleName),
+  moduleDir,
+  { recursive: true }
+);
+
+const { importedESM: importedESMBefore,
+        importedCJS: importedCJSBefore } = global.getModuleTypeStats();
+
+import(`${moduleName}`).finally(() => {
+  fs.rmSync(basePath, { recursive: true, force: true });
+});
+
+const { importedESM: importedESMAfter,
+        importedCJS: importedCJSAfter } = global.getModuleTypeStats();
+
+assert.strictEqual(importedESMBefore + 1, importedESMAfter);
+assert.strictEqual(importedCJSBefore, importedCJSAfter);

--- a/test/es-module/test-esm-resolve-type.js
+++ b/test/es-module/test-esm-resolve-type.js
@@ -1,0 +1,184 @@
+'use strict';
+// Flags: --expose-internals
+
+/**
+ * This test ensures defaultResolve returns the found module format in the
+ * return object in the form:
+ * { url: <url_value>, format: <'module'|'commonjs'|undefined> };
+ */
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const path = require('path');
+const fs = require('fs');
+const url = require('url');
+
+if (!common.isMainThread) {
+  common.skip(
+    'test-esm-resolve-type.js: process.chdir is not available in Workers'
+  );
+}
+
+const assert = require('assert');
+const {
+  defaultResolve: resolve
+} = require('internal/modules/esm/resolve');
+
+const rel = (file) => path.join(tmpdir.path, file);
+const previousCwd = process.cwd();
+const nmDir = rel('node_modules');
+try {
+  tmpdir.refresh();
+  process.chdir(tmpdir.path);
+  /**
+   * ensure that resolving by full path does not return the format
+   * with the defaultResolver
+   */
+  [ [ '/es-modules/package-type-module/index.js', undefined ],
+    [ '/es-modules/package-type-commonjs/index.js', undefined ],
+    [ '/es-modules/package-without-type/index.js', undefined ],
+    [ '/es-modules/package-without-pjson/index.js', undefined ],
+  ].forEach((testVariant) => {
+    const [ testScript, expectedType ] = testVariant;
+    const resolvedPath = path.resolve(fixtures.path(testScript));
+    const resolveResult = resolve(url.pathToFileURL(resolvedPath));
+    assert.strictEqual(resolveResult.format, expectedType);
+  });
+
+  /**
+   * create a test module and try to resolve it by module name.
+   * check the result is as expected
+   */
+
+  [ [ 'test-module-mainjs', 'js', 'module', 'module'],
+    [ 'test-module-mainmjs', 'mjs', 'module', 'module'],
+    [ 'test-module-cjs', 'js', 'commonjs', 'commonjs'],
+    [ 'test-module-ne', 'js', undefined, undefined],
+  ].forEach((testVariant) => {
+    const [ moduleName,
+            moduleExtenstion,
+            moduleType,
+            expectedResolvedType ] = testVariant;
+    process.chdir(previousCwd);
+    tmpdir.refresh();
+    process.chdir(tmpdir.path);
+    const createDir = (path) => {
+      if (!fs.existsSync(path)) {
+        fs.mkdirSync(path);
+      }
+    };
+
+    const mDir = rel(`node_modules/${moduleName}`);
+    const subDir = rel(`node_modules/${moduleName}/subdir`);
+    const pkg = rel(`node_modules/${moduleName}/package.json`);
+    const script = rel(`node_modules/${moduleName}/subdir/mainfile.${moduleExtenstion}`);
+
+    createDir(nmDir);
+    createDir(mDir);
+    createDir(subDir);
+    const pkgJsonContent = {
+      ...(moduleType !== undefined) && { type: moduleType },
+      main: `subdir/mainfile.${moduleExtenstion}`
+    };
+    fs.writeFileSync(pkg, JSON.stringify(pkgJsonContent));
+    fs.writeFileSync(script,
+                     'export function esm-resolve-tester() {return 42}');
+
+    const resolveResult = resolve(`${moduleName}`);
+    assert.strictEqual(resolveResult.format, expectedResolvedType);
+
+    fs.rmSync(nmDir, { recursive: true, force: true });
+  });
+
+  // Helpers
+  const createDir = (path) => {
+    if (!fs.existsSync(path)) {
+      fs.mkdirSync(path);
+    }
+  };
+
+  // Create a dummy dual package
+  //
+  /**
+   * this creates following directory structure:
+   *
+   * ./node_modules:
+   *   |-> my-dual-package
+   *       |-> es
+   *           |-> index.js
+   *           |-> package.json [2]
+   *       |-> lib
+   *           |-> index.js
+   *       |->package.json [1]
+   *
+   * [1] - main package.json of the package
+   *     - it contains:
+   *             - type: 'commonjs'
+   *             - main: 'lib/mainfile.js'
+   *             - conditional exports for 'require' (lib/index.js) and
+   *                                       'import' (es/index.js)
+   * [2] - package.json add-on for the import case
+   *     - it only contains:
+   *             - type: 'module'
+   *
+   * in case the package is consumed as an ESM by importing it:
+   *    import * as my-package from 'my-dual-package'
+   * it will cause the resolve method to return:
+   *  {
+   *     url: '<base_path>/node_modules/my-dual-package/es/index.js',
+   *     format: 'module'
+   *  }
+   *
+   *  following testcase ensures that resolve works correctly in this case
+   *  returning the information as specified above. Source for 'url' value
+   *  is [1], source for 'format' value is [2]
+   */
+
+  const moduleName = 'my-dual-package';
+
+  const mDir = rel(`node_modules/${moduleName}`);
+  const esSubDir = rel(`node_modules/${moduleName}/es`);
+  const cjsSubDir = rel(`node_modules/${moduleName}/lib`);
+  const pkg = rel(`node_modules/${moduleName}/package.json`);
+  const esmPkg = rel(`node_modules/${moduleName}/es/package.json`);
+  const esScript = rel(`node_modules/${moduleName}/es/index.js`);
+  const cjsScript = rel(`node_modules/${moduleName}/lib/index.js`);
+
+  createDir(nmDir);
+  createDir(mDir);
+  createDir(esSubDir);
+  createDir(cjsSubDir);
+
+  const mainPkgJsonContent = {
+    type: 'commonjs',
+    main: 'lib/index.js',
+    exports: {
+      '.': {
+        'require': './lib/index.js',
+        'import': './es/index.js'
+      },
+      './package.json': './package.json',
+    }
+  };
+  const esmPkgJsonContent = {
+    type: 'module'
+  };
+
+  fs.writeFileSync(pkg, JSON.stringify(mainPkgJsonContent));
+  fs.writeFileSync(esmPkg, JSON.stringify(esmPkgJsonContent));
+  fs.writeFileSync(esScript,
+                   'export function esm-resolve-tester() {return 42}');
+  fs.writeFileSync(cjsScript,
+                   `module.exports = { 
+                     esm-resolve-tester: () => {return 42}}`
+  );
+
+  // test the resolve
+  const resolveResult = resolve(`${moduleName}`);
+  assert.strictEqual(resolveResult.format, 'module');
+  assert.ok(resolveResult.url.includes('my-dual-package/es/index.js'));
+} finally {
+  process.chdir(previousCwd);
+  fs.rmSync(nmDir, { recursive: true, force: true });
+}

--- a/test/es-module/test-esm-resolve-type.js
+++ b/test/es-module/test-esm-resolve-type.js
@@ -35,10 +35,11 @@ try {
    * ensure that resolving by full path does not return the format
    * with the defaultResolver
    */
-  [ [ '/es-modules/package-type-module/index.js', undefined ],
-    [ '/es-modules/package-type-commonjs/index.js', undefined ],
-    [ '/es-modules/package-without-type/index.js', undefined ],
-    [ '/es-modules/package-without-pjson/index.js', undefined ],
+  [
+    [ '/es-modules/package-type-module/index.js', 'module' ],
+    [ '/es-modules/package-type-commonjs/index.js', 'commonjs' ],
+    [ '/es-modules/package-without-type/index.js', 'commonjs' ],
+    [ '/es-modules/package-without-pjson/index.js', 'commonjs' ],
   ].forEach((testVariant) => {
     const [ testScript, expectedType ] = testVariant;
     const resolvedPath = path.resolve(fixtures.path(testScript));
@@ -49,12 +50,14 @@ try {
   /**
    * create a test module and try to resolve it by module name.
    * check the result is as expected
+   *
+   * for test-module-ne: everything .js that is not 'module' is 'commonjs'
    */
 
   [ [ 'test-module-mainjs', 'js', 'module', 'module'],
     [ 'test-module-mainmjs', 'mjs', 'module', 'module'],
     [ 'test-module-cjs', 'js', 'commonjs', 'commonjs'],
-    [ 'test-module-ne', 'js', undefined, undefined],
+    [ 'test-module-ne', 'js', undefined, 'commonjs'],
   ].forEach((testVariant) => {
     const [ moduleName,
             moduleExtenstion,
@@ -98,86 +101,149 @@ try {
     }
   };
 
-  // Create a dummy dual package
-  //
-  /**
-   * this creates following directory structure:
-   *
-   * ./node_modules:
-   *   |-> my-dual-package
-   *       |-> es
-   *           |-> index.js
-   *           |-> package.json [2]
-   *       |-> lib
-   *           |-> index.js
-   *       |->package.json [1]
-   *
-   * [1] - main package.json of the package
-   *     - it contains:
-   *             - type: 'commonjs'
-   *             - main: 'lib/mainfile.js'
-   *             - conditional exports for 'require' (lib/index.js) and
-   *                                       'import' (es/index.js)
-   * [2] - package.json add-on for the import case
-   *     - it only contains:
-   *             - type: 'module'
-   *
-   * in case the package is consumed as an ESM by importing it:
-   *    import * as my-package from 'my-dual-package'
-   * it will cause the resolve method to return:
-   *  {
-   *     url: '<base_path>/node_modules/my-dual-package/es/index.js',
-   *     format: 'module'
-   *  }
-   *
-   *  following testcase ensures that resolve works correctly in this case
-   *  returning the information as specified above. Source for 'url' value
-   *  is [1], source for 'format' value is [2]
-   */
+  function testDualPackageWithJsMainScriptAndModuleType() {
+    // Create a dummy dual package
+    //
+    /**
+     * this creates the following directory structure:
+     *
+     * ./node_modules:
+     *   |-> my-dual-package
+     *       |-> es
+     *           |-> index.js
+     *           |-> package.json [2]
+     *       |-> lib
+     *           |-> index.js
+     *       |->package.json [1]
+     *
+     * in case the package is imported:
+     *    import * as my-package from 'my-dual-package'
+     * it will cause the resolve method to return:
+     *  {
+     *     url: '<base_path>/node_modules/my-dual-package/es/index.js',
+     *     format: 'module'
+     *  }
+     *
+     *  following testcase ensures that resolve works correctly in this case
+     *  returning the information as specified above. Source for 'url' value
+     *  is [1], source for 'format' value is [2]
+     */
 
-  const moduleName = 'my-dual-package';
+    const moduleName = 'my-dual-package';
 
-  const mDir = rel(`node_modules/${moduleName}`);
-  const esSubDir = rel(`node_modules/${moduleName}/es`);
-  const cjsSubDir = rel(`node_modules/${moduleName}/lib`);
-  const pkg = rel(`node_modules/${moduleName}/package.json`);
-  const esmPkg = rel(`node_modules/${moduleName}/es/package.json`);
-  const esScript = rel(`node_modules/${moduleName}/es/index.js`);
-  const cjsScript = rel(`node_modules/${moduleName}/lib/index.js`);
+    const mDir = rel(`node_modules/${moduleName}`);
+    const esSubDir = rel(`node_modules/${moduleName}/es`);
+    const cjsSubDir = rel(`node_modules/${moduleName}/lib`);
+    const pkg = rel(`node_modules/${moduleName}/package.json`);
+    const esmPkg = rel(`node_modules/${moduleName}/es/package.json`);
+    const esScript = rel(`node_modules/${moduleName}/es/index.js`);
+    const cjsScript = rel(`node_modules/${moduleName}/lib/index.js`);
 
-  createDir(nmDir);
-  createDir(mDir);
-  createDir(esSubDir);
-  createDir(cjsSubDir);
+    createDir(nmDir);
+    createDir(mDir);
+    createDir(esSubDir);
+    createDir(cjsSubDir);
 
-  const mainPkgJsonContent = {
-    type: 'commonjs',
-    main: 'lib/index.js',
-    exports: {
-      '.': {
-        'require': './lib/index.js',
-        'import': './es/index.js'
-      },
-      './package.json': './package.json',
-    }
-  };
-  const esmPkgJsonContent = {
-    type: 'module'
-  };
+    const mainPkgJsonContent = {
+      type: 'commonjs',
+      exports: {
+        '.': {
+          'require': './lib/index.js',
+          'import': './es/index.js',
+          'default': './lib/index.js'
+        },
+        './package.json': './package.json',
+      }
+    };
+    const esmPkgJsonContent = {
+      type: 'module'
+    };
 
-  fs.writeFileSync(pkg, JSON.stringify(mainPkgJsonContent));
-  fs.writeFileSync(esmPkg, JSON.stringify(esmPkgJsonContent));
-  fs.writeFileSync(esScript,
-                   'export function esm-resolve-tester() {return 42}');
-  fs.writeFileSync(cjsScript,
-                   `module.exports = { 
-                     esm-resolve-tester: () => {return 42}}`
-  );
+    fs.writeFileSync(pkg, JSON.stringify(mainPkgJsonContent));
+    fs.writeFileSync(esmPkg, JSON.stringify(esmPkgJsonContent));
+    fs.writeFileSync(
+      esScript,
+      'export function esm-resolve-tester() {return 42}'
+    );
+    fs.writeFileSync(
+      cjsScript,
+      'module.exports = {esm-resolve-tester: () => {return 42}}'
+    );
 
-  // test the resolve
-  const resolveResult = resolve(`${moduleName}`);
-  assert.strictEqual(resolveResult.format, 'module');
-  assert.ok(resolveResult.url.includes('my-dual-package/es/index.js'));
+    // test the resolve
+    const resolveResult = resolve(`${moduleName}`);
+    assert.strictEqual(resolveResult.format, 'module');
+    assert.ok(resolveResult.url.includes('my-dual-package/es/index.js'));
+  }
+
+  testDualPackageWithJsMainScriptAndModuleType();
+
+  // TestParameters are ModuleName, mainRequireScript, mainImportScript,
+  // mainPackageType, subdirPkgJsonType, expectedResolvedFormat, mainSuffix
+  [
+    [ 'mjs-mod-mod', 'index.js', 'index.mjs', 'module', 'module', 'module'],
+    [ 'mjs-com-com', 'idx.js', 'idx.mjs', 'commonjs', 'commonjs', 'module'],
+    [ 'mjs-mod-com', 'index.js', 'imp.mjs', 'module', 'commonjs', 'module'],
+    [ 'cjs-mod-mod', 'index.cjs', 'imp.cjs', 'module', 'module', 'commonjs'],
+    [ 'js-com-com', 'index.js', 'imp.js', 'commonjs', 'commonjs', 'commonjs'],
+    [ 'js-com-mod', 'index.js', 'imp.js', 'commonjs', 'module', 'module'],
+    [ 'qmod', 'index.js', 'imp.js', 'commonjs', 'module', 'module', '?k=v'],
+    [ 'hmod', 'index.js', 'imp.js', 'commonjs', 'module', 'module', '#Key'],
+    [ 'qhmod', 'index.js', 'imp.js', 'commonjs', 'module', 'module', '?k=v#h'],
+    [ 'ts-mod-com', 'index.js', 'imp.ts', 'module', 'commonjs', undefined],
+  ].forEach((testVariant) => {
+    const [
+      moduleName,
+      mainRequireScript,
+      mainImportScript,
+      mainPackageType,
+      subdirPackageType,
+      expectedResolvedFormat,
+      mainSuffix = '' ] = testVariant;
+
+    const mDir = rel(`node_modules/${moduleName}`);
+    const subDir = rel(`node_modules/${moduleName}/subdir`);
+    const pkg = rel(`node_modules/${moduleName}/package.json`);
+    const subdirPkg = rel(`node_modules/${moduleName}/subdir/package.json`);
+    const esScript = rel(`node_modules/${moduleName}/subdir/${mainImportScript}`);
+    const cjsScript = rel(`node_modules/${moduleName}/subdir/${mainRequireScript}`);
+
+    createDir(nmDir);
+    createDir(mDir);
+    createDir(subDir);
+
+    const mainPkgJsonContent = {
+      type: mainPackageType,
+      exports: {
+        '.': {
+          'require': `./subdir/${mainRequireScript}${mainSuffix}`,
+          'import': `./subdir/${mainImportScript}${mainSuffix}`,
+          'default': `./subdir/${mainRequireScript}${mainSuffix}`
+        },
+        './package.json': './package.json',
+      }
+    };
+    const subdirPkgJsonContent = {
+      type: `${subdirPackageType}`
+    };
+
+    fs.writeFileSync(pkg, JSON.stringify(mainPkgJsonContent));
+    fs.writeFileSync(subdirPkg, JSON.stringify(subdirPkgJsonContent));
+    fs.writeFileSync(
+      esScript,
+      'export function esm-resolve-tester() {return 42}'
+    );
+    fs.writeFileSync(
+      cjsScript,
+      'module.exports = {esm-resolve-tester: () => {return 42}}'
+    );
+
+    // test the resolve
+    const resolveResult = resolve(`${moduleName}`);
+    assert.strictEqual(resolveResult.format, expectedResolvedFormat);
+    assert.ok(resolveResult.url.endsWith(`${moduleName}/subdir/${mainImportScript}${mainSuffix}`));
+  });
+
 } finally {
   process.chdir(previousCwd);
   fs.rmSync(nmDir, { recursive: true, force: true });

--- a/test/fixtures/es-module-loaders/hook-resolve-type.mjs
+++ b/test/fixtures/es-module-loaders/hook-resolve-type.mjs
@@ -1,0 +1,21 @@
+let importedESM = 0;
+let importedCJS = 0;
+global.getModuleTypeStats = () => { return {importedESM, importedCJS} };
+
+export function load(url, context, next) {
+  return next(url, context, next);
+}
+
+export function resolve(specifier, context, next) {
+  const nextResult = next(specifier, context);
+  const { format } = nextResult;
+
+  if (format === 'module' || specifier.endsWith('.mjs')) {
+    importedESM++;
+  } else if (format == null || format === 'commonjs') {
+    importedCJS++;
+  } 
+
+  return nextResult;
+}
+

--- a/test/fixtures/es-modules/module-counter-by-type/index.js
+++ b/test/fixtures/es-modules/module-counter-by-type/index.js
@@ -1,0 +1,3 @@
+let dummy = 42;
+
+export {dummy};

--- a/test/fixtures/es-modules/module-counter-by-type/package.json
+++ b/test/fixtures/es-modules/module-counter-by-type/package.json
@@ -1,0 +1,4 @@
+{
+    "type": "module",
+    "main": "index.js"
+}

--- a/test/fixtures/es-modules/package-without-pjson/index.js
+++ b/test/fixtures/es-modules/package-without-pjson/index.js
@@ -1,0 +1,7 @@
+const identifier = 'package-without-pjson';
+
+const common = require('../common');
+common.requireNoPackageJSONAbove();
+
+console.log(identifier);
+module.exports = identifier;

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -5,6 +5,8 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const { pathToFileURL } = require('url');
+
 const { validateRmOptionsSync } = require('internal/fs/utils');
 
 tmpdir.refresh();
@@ -95,6 +97,11 @@ function removeAsync(dir) {
   makeNonEmptyDirectory(2, 10, 2, dir, false);
   removeAsync(dir);
 
+  // Same test using URL instead of a path
+  dir = nextDirPath();
+  makeNonEmptyDirectory(2, 10, 2, dir, false);
+  removeAsync(pathToFileURL(dir));
+
   // Create a flat folder including symlinks
   dir = nextDirPath();
   makeNonEmptyDirectory(1, 10, 2, dir, true);
@@ -154,6 +161,16 @@ function removeAsync(dir) {
     fs.rmSync(filePath, { force: true });
   }
 
+  // Should accept URL
+  const fileURL = pathToFileURL(path.join(tmpdir.path, 'rm-file.txt'));
+  fs.writeFileSync(fileURL, '');
+
+  try {
+    fs.rmSync(fileURL, { recursive: true });
+  } finally {
+    fs.rmSync(fileURL, { force: true });
+  }
+
   // Recursive removal should succeed.
   fs.rmSync(dir, { recursive: true });
 
@@ -199,6 +216,16 @@ function removeAsync(dir) {
     await fs.promises.rm(filePath, { recursive: true });
   } finally {
     fs.rmSync(filePath, { force: true });
+  }
+
+  // Should accept URL
+  const fileURL = pathToFileURL(path.join(tmpdir.path, 'rm-promises-file.txt'));
+  fs.writeFileSync(fileURL, '');
+
+  try {
+    await fs.promises.rm(fileURL, { recursive: true });
+  } finally {
+    fs.rmSync(fileURL, { force: true });
   }
 })().then(common.mustCall());
 


### PR DESCRIPTION
This is a backport PR for PR #40980 (cc: @danielleadams)
During merging I did one branch for PR #40980 and #41218 according to input on the backport request [thread ](https://github.com/nodejs/node/pull/41218#issuecomment-1024880812) from @Flarna 
Additionally I had to cherry-pick the commit of PR #41132 (@aduh95) as this contains a bugfix needed by #40980

Following commits have been backported:

for PR #40980: 85d4cd307957bd35e7c723d0f1d2b77175fd9b0f
for PR #41132: e5c1fd7a2a1801fd75bdde23b260488e85453eb2
for PR #41218: 34e3dd50348dd824c881c183824237532c7721c5

Since this is my first backport PR hopefully I got all the detail steps right for the tooling to work properly.

`make -j4 test` passes all the tests.
`make lint` as well

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
