### PR TITLE
src: remove separate definitions for static constexpr members

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -151,9 +151,6 @@ void AsyncWrap::EmitAfter(Environment* env, double async_id) {
        env->async_hooks_after_function());
 }
 
-// TODO(addaleax): Remove once we're on C++17.
-constexpr double AsyncWrap::kInvalidAsyncId;
-
 static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -482,8 +482,6 @@ InternalFieldInfo* BlobBindingData::Serialize(int index) {
   return info;
 }
 
-constexpr FastStringKey BlobBindingData::type_name;
-
 void Blob::RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(Blob::New);
   registry->Register(Blob::ToArrayBuffer);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2449,9 +2449,6 @@ InternalFieldInfo* BindingData::Serialize(int index) {
   return info;
 }
 
-// TODO(addaleax): Remove once we're on C++17.
-constexpr FastStringKey BindingData::type_name;
-
 void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -3135,9 +3135,6 @@ void Http2State::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("root_buffer", root_buffer);
 }
 
-// TODO(addaleax): Remove once we're on C++17.
-constexpr FastStringKey Http2State::type_name;
-
 // Set up the process.binding('http2') binding.
 void Initialize(Local<Object> target,
                 Local<Value> unused,

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -107,9 +107,6 @@ class BindingData : public BaseObject {
   SET_MEMORY_INFO_NAME(BindingData)
 };
 
-// TODO(addaleax): Remove once we're on C++17.
-constexpr FastStringKey BindingData::type_name;
-
 // helper class for the Parser
 struct StringPtr {
   StringPtr() {

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -448,8 +448,6 @@ static void ReallyExit(const FunctionCallbackInfo<Value>& args) {
 
 namespace process {
 
-constexpr FastStringKey BindingData::type_name;
-
 BindingData::BindingData(Environment* env, v8::Local<v8::Object> object)
     : SnapshotableObject(env, object, type_int) {
   Local<ArrayBuffer> ab = ArrayBuffer::New(env->isolate(), kBufferSize);

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -142,9 +142,6 @@ void BindingData::MemoryInfo(MemoryTracker* tracker) const {
                       heap_code_statistics_buffer);
 }
 
-// TODO(addaleax): Remove once we're on C++17.
-constexpr FastStringKey BindingData::type_name;
-
 void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Local<Integer> result =


### PR DESCRIPTION
This is no longer necessary (and actually deprecated) since C++17.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
