### PR TITLE
src: return proper URLs from node_api_get_module_file_name

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -9,6 +9,7 @@
 #include "node_buffer.h"
 #include "node_errors.h"
 #include "node_internals.h"
+#include "node_url.h"
 #include "threadpoolwork-inl.h"
 #include "tracing/traced_value.h"
 #include "util-inl.h"
@@ -589,13 +590,13 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
   if (module->ToObject(context).ToLocal(&modobj) &&
       modobj->Get(context, node_env->filename_string()).ToLocal(&filename_js) &&
       filename_js->IsString()) {
-    node::Utf8Value filename(node_env->isolate(), filename_js);  // Cast
+    node::Utf8Value filename(node_env->isolate(), filename_js);
 
     // Turn the absolute path into a URL. Currently the absolute path is always
     // a file system path.
     // TODO(gabrielschulhof): Pass the `filename` through unchanged if/when we
     // receive it as a URL already.
-    module_filename = std::string("file://") + (*filename);
+    module_filename = node::url::URL::FromFilePath(filename.ToString()).href();
   }
 
   // Create a new napi_env for this specific module.

--- a/test/node-api/test_general/test.js
+++ b/test/node-api/test_general/test.js
@@ -1,15 +1,38 @@
 'use strict';
 
 const common = require('../../common');
+const tmpdir = require('../../common/tmpdir');
+const fs = require('fs');
+const path = require('path');
 const filename = require.resolve(`./build/${common.buildType}/test_general`);
 const test_general = require(filename);
 const assert = require('assert');
 
-// TODO(gabrielschulhof): This test may need updating if/when the filename
-// becomes a full-fledged URL.
-assert.strictEqual(test_general.filename, `file://${filename}`);
+tmpdir.refresh();
 
-const [ major, minor, patch, release ] = test_general.testGetNodeVersion();
-assert.strictEqual(process.version.split('-')[0],
-                   `v${major}.${minor}.${patch}`);
-assert.strictEqual(release, process.release.name);
+{
+  // TODO(gabrielschulhof): This test may need updating if/when the filename
+  // becomes a full-fledged URL.
+  assert.strictEqual(
+    decodeURIComponent(test_general.filename),
+    `file://${filename}`);
+}
+
+{
+  const urlTestDir = path.join(tmpdir.path, 'foo%?#bar');
+  const urlTestFile = path.join(urlTestDir, path.basename(filename));
+  fs.mkdirSync(urlTestDir, { recursive: true });
+  fs.copyFileSync(filename, urlTestFile);
+  const reportedFilename = require(urlTestFile).filename;
+  assert.doesNotMatch(reportedFilename, /foo%\?#bar/);
+  assert.strictEqual(
+    decodeURIComponent(reportedFilename),
+    `file://${urlTestFile}`);
+}
+
+{
+  const [ major, minor, patch, release ] = test_general.testGetNodeVersion();
+  assert.strictEqual(process.version.split('-')[0],
+                     `v${major}.${minor}.${patch}`);
+  assert.strictEqual(release, process.release.name);
+}

--- a/test/node-api/test_general/test.js
+++ b/test/node-api/test_general/test.js
@@ -18,12 +18,12 @@ tmpdir.refresh();
 }
 
 {
-  const urlTestDir = path.join(tmpdir.path, 'foo%?#bar');
+  const urlTestDir = path.join(tmpdir.path, 'foo%#bar');
   const urlTestFile = path.join(urlTestDir, path.basename(filename));
   fs.mkdirSync(urlTestDir, { recursive: true });
   fs.copyFileSync(filename, urlTestFile);
   const reportedFilename = require(urlTestFile).filename;
-  assert.doesNotMatch(reportedFilename, /foo%\?#bar/);
+  assert.doesNotMatch(reportedFilename, /foo%#bar/);
   assert.strictEqual(reportedFilename, url.pathToFileURL(urlTestFile).href);
 }
 

--- a/test/node-api/test_general/test.js
+++ b/test/node-api/test_general/test.js
@@ -4,6 +4,7 @@ const common = require('../../common');
 const tmpdir = require('../../common/tmpdir');
 const fs = require('fs');
 const path = require('path');
+const url = require('url');
 const filename = require.resolve(`./build/${common.buildType}/test_general`);
 const test_general = require(filename);
 const assert = require('assert');
@@ -13,9 +14,7 @@ tmpdir.refresh();
 {
   // TODO(gabrielschulhof): This test may need updating if/when the filename
   // becomes a full-fledged URL.
-  assert.strictEqual(
-    decodeURIComponent(test_general.filename),
-    `file://${filename}`);
+  assert.strictEqual(test_general.filename, url.pathToFileURL(filename).href);
 }
 
 {
@@ -25,9 +24,7 @@ tmpdir.refresh();
   fs.copyFileSync(filename, urlTestFile);
   const reportedFilename = require(urlTestFile).filename;
   assert.doesNotMatch(reportedFilename, /foo%\?#bar/);
-  assert.strictEqual(
-    decodeURIComponent(reportedFilename),
-    `file://${urlTestFile}`);
+  assert.strictEqual(reportedFilename, url.pathToFileURL(urlTestFile).href);
 }
 
 {

--- a/test/node-api/test_general/test.js
+++ b/test/node-api/test_general/test.js
@@ -25,6 +25,11 @@ tmpdir.refresh();
   const reportedFilename = require(urlTestFile).filename;
   assert.doesNotMatch(reportedFilename, /foo%#bar/);
   assert.strictEqual(reportedFilename, url.pathToFileURL(urlTestFile).href);
+  fs.rmSync(urlTestDir, {
+    force: true,
+    recursive: true,
+    maxRetries: 256
+  });
 }
 
 {


### PR DESCRIPTION
Using `file://${path}` does not properly escape special URL characters.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
