### PR TITLE
src: fix and cleanup URL::SerializeURL

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1578,10 +1578,10 @@ std::string URL::SerializeURL(const struct url_data* url,
     }
   }
   if (url->flags & URL_FLAGS_HAS_QUERY) {
-    output = "?" + url->query;
+    output += "?" + url->query;
   }
   if (!exclude && url->flags & URL_FLAGS_HAS_FRAGMENT) {
-    output = "#" + url->fragment;
+    output += "#" + url->fragment;
   }
   return output;
 }

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1597,7 +1597,7 @@ std::string URL::SerializeURL(const url_data& url,
   if (url.flags & URL_FLAGS_HAS_QUERY) {
     output += "?" + url.query;
   }
-  if (!exclude && url.flags & URL_FLAGS_HAS_FRAGMENT) {
+  if (!exclude && (url.flags & URL_FLAGS_HAS_FRAGMENT)) {
     output += "#" + url.fragment;
   }
   output.shrink_to_fit();

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1546,59 +1546,59 @@ void URL::Parse(const char* input,
 }  // NOLINT(readability/fn_size)
 
 // https://url.spec.whatwg.org/#url-serializing
-std::string URL::SerializeURL(const struct url_data* url,
+std::string URL::SerializeURL(const url_data& url,
                               bool exclude = false) {
   std::string output;
   output.reserve(
     10 +
-    url->scheme.size() +
-    url->username.size() +
-    url->password.size() +
-    url->host.size() +
-    url->query.size() +
-    url->fragment.size() +
-    url->href.size() +
+    url.scheme.size() +
+    url.username.size() +
+    url.password.size() +
+    url.host.size() +
+    url.query.size() +
+    url.fragment.size() +
+    url.href.size() +
     std::accumulate(
-        url->path.begin(),
-        url->path.end(),
+        url.path.begin(),
+        url.path.end(),
         0,
         [](size_t sum, const auto& str) { return sum + str.size(); }));
 
-  output += url->scheme;
-  if (url->flags & URL_FLAGS_HAS_HOST) {
+  output += url.scheme;
+  if (url.flags & URL_FLAGS_HAS_HOST) {
     output += "//";
-    if (url->flags & URL_FLAGS_HAS_USERNAME ||
-        url->flags & URL_FLAGS_HAS_PASSWORD) {
-      if (url->flags & URL_FLAGS_HAS_USERNAME) {
-        output += url->username;
+    if (url.flags & URL_FLAGS_HAS_USERNAME ||
+        url.flags & URL_FLAGS_HAS_PASSWORD) {
+      if (url.flags & URL_FLAGS_HAS_USERNAME) {
+        output += url.username;
       }
-      if (url->flags & URL_FLAGS_HAS_PASSWORD) {
-        output += ":" + url->password;
+      if (url.flags & URL_FLAGS_HAS_PASSWORD) {
+        output += ":" + url.password;
       }
       output += "@";
     }
-    output += url->host;
-    if (url->port != -1) {
-      output += ":" + std::to_string(url->port);
+    output += url.host;
+    if (url.port != -1) {
+      output += ":" + std::to_string(url.port);
     }
   }
-  if (url->flags & URL_FLAGS_CANNOT_BE_BASE) {
-    output += url->path[0];
+  if (url.flags & URL_FLAGS_CANNOT_BE_BASE) {
+    output += url.path[0];
   } else {
-    if (!(url->flags & URL_FLAGS_HAS_HOST) &&
-          url->path.size() > 1 &&
-          url->path[0].empty()) {
+    if (!(url.flags & URL_FLAGS_HAS_HOST) &&
+          url.path.size() > 1 &&
+          url.path[0].empty()) {
       output += "/.";
     }
-    for (size_t i = 1; i < url->path.size(); i++) {
-      output += "/" + url->path[i];
+    for (size_t i = 1; i < url.path.size(); i++) {
+      output += "/" + url.path[i];
     }
   }
-  if (url->flags & URL_FLAGS_HAS_QUERY) {
-    output += "?" + url->query;
+  if (url.flags & URL_FLAGS_HAS_QUERY) {
+    output += "?" + url.query;
   }
-  if (!exclude && url->flags & URL_FLAGS_HAS_FRAGMENT) {
-    output += "#" + url->fragment;
+  if (!exclude && url.flags & URL_FLAGS_HAS_FRAGMENT) {
+    output += "#" + url.fragment;
   }
   output.shrink_to_fit();
   return output;

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1550,7 +1550,7 @@ std::string URL::SerializeURL(const url_data& url,
                               bool exclude = false) {
   std::string output;
   output.reserve(
-    10 +
+    10 + // We generally insert < 10 separator characters between URL parts
     url.scheme.size() +
     url.username.size() +
     url.password.size() +

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <cstdio>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -1547,7 +1548,23 @@ void URL::Parse(const char* input,
 // https://url.spec.whatwg.org/#url-serializing
 std::string URL::SerializeURL(const struct url_data* url,
                               bool exclude = false) {
-  std::string output = url->scheme;
+  std::string output;
+  output.reserve(
+    10 +
+    url->scheme.size() +
+    url->username.size() +
+    url->password.size() +
+    url->host.size() +
+    url->query.size() +
+    url->fragment.size() +
+    url->href.size() +
+    std::accumulate(
+        url->path.begin(),
+        url->path.end(),
+        0,
+        [](size_t sum, const auto& str) { return sum + str.size(); }));
+
+  output += url->scheme;
   if (url->flags & URL_FLAGS_HAS_HOST) {
     output += "//";
     if (url->flags & URL_FLAGS_HAS_USERNAME ||
@@ -1583,6 +1600,7 @@ std::string URL::SerializeURL(const struct url_data* url,
   if (!exclude && url->flags & URL_FLAGS_HAS_FRAGMENT) {
     output += "#" + url->fragment;
   }
+  output.shrink_to_fit();
   return output;
 }
 

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1550,7 +1550,7 @@ std::string URL::SerializeURL(const url_data& url,
                               bool exclude = false) {
   std::string output;
   output.reserve(
-    10 + // We generally insert < 10 separator characters between URL parts
+    10 +  // We generally insert < 10 separator characters between URL parts
     url.scheme.size() +
     url.username.size() +
     url.password.size() +

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -94,7 +94,7 @@ class URL {
                     const struct url_data* base,
                     bool has_base);
 
-  static std::string SerializeURL(const struct url_data* url, bool exclude);
+  static std::string SerializeURL(const url_data& url, bool exclude);
 
   URL(const char* input, const size_t len) {
     Parse(input, len, kUnknownState, &context_, false, nullptr, false);
@@ -174,7 +174,7 @@ class URL {
   }
 
   std::string href() const {
-    return SerializeURL(&context_, false);
+    return SerializeURL(context_, false);
   }
 
   // Get the path of the file: URL in a format consumable by native file system
@@ -193,7 +193,7 @@ class URL {
   URL() : URL("") {}
 
  private:
-  struct url_data context_;
+  url_data context_;
 };
 
 }  // namespace url


### PR DESCRIPTION
##### src: fix query/fragment serialization in URL::SerializeURL

These are presumably typos.

##### src: reserve string allocation space early in URL::SerializeURL

This can be useful for performance when doing many string
concatenations.

##### src: use const reference instead of pointer in URL::SerializeURL

Just some general cleanup to make things C++-y instead of C-y.


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
