### PR TITLE
src: fix typo in js_native_api_v8.cc

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -16,7 +16,7 @@
 #define CHECK_TO_NUMBER(env, context, result, src) \
   CHECK_TO_TYPE((env), Number, (context), (result), (src), napi_number_expected)
 
-// n-api defines NAPI_AUTO_LENGHTH as the indicator that a string
+// n-api defines NAPI_AUTO_LENGTH as the indicator that a string
 // is null terminated. For V8 the equivalent is -1. The assert
 // validates that our cast of NAPI_AUTO_LENGTH results in -1 as
 // needed by V8.


### PR DESCRIPTION
* `src/js_native_api_v8.cc` NAPI_AUTO_LENGHTH → **NAPI_AUTO_LENGTH**
