### PR TITLE
stream: throw invalid arg type from End Of Stream

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -8,6 +8,7 @@ const {
   codes,
 } = require('internal/errors');
 const {
+  ERR_INVALID_ARG_TYPE,
   ERR_STREAM_PREMATURE_CLOSE
 } = codes;
 const { once } = require('internal/util');
@@ -56,7 +57,7 @@ function eos(stream, options, callback) {
 
   if (!isNodeStream(stream)) {
     // TODO: Webstreams.
-    // TODO: Throw INVALID_ARG_TYPE.
+    throw new ERR_INVALID_ARG_TYPE('stream', 'Stream', stream);
   }
 
   const wState = stream._writableState;

--- a/test/parallel/test-stream-end-of-streams.js
+++ b/test/parallel/test-stream-end-of-streams.js
@@ -1,0 +1,20 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const { Duplex, finished } = require('stream');
+
+assert.throws(
+  () => {
+    // Passing empty object to mock invalid stream
+    // should throw error
+    finished({}, () => {});
+  },
+  { code: 'ERR_INVALID_ARG_TYPE' }
+);
+
+const streamObj = new Duplex();
+streamObj.end();
+// Below code should not throw any errors as the
+// streamObj is `Stream`
+finished(streamObj, () => {});

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -260,7 +260,12 @@ const http = require('http');
   const streamLike = new EE();
   streamLike.readableEnded = true;
   streamLike.readable = true;
-  finished(streamLike, common.mustCall());
+  assert.throws(
+    () => {
+      finished(streamLike, () => {});
+    },
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  );
   streamLike.emit('close');
 }
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Completed another TODO task.

`Stream.finished` method has validation checks. Currently, if the `stream` input param passed to it doesn't validate the input type.

In this PR, we are adding a type check and throwing type error in case the `stream` is not a `Stream` 