### PR TITLE
test: fix failure in `test/sequential/test-heapdump.js`

### DIFF
--- a/test/sequential/test-heapdump.js
+++ b/test/sequential/test-heapdump.js
@@ -25,13 +25,13 @@ process.chdir(tmpdir.path);
 }
 
 {
-  const readonlyFile = 'ro';
-  fs.writeFileSync(readonlyFile, Buffer.alloc(0), { mode: 0o444 });
+  const directory = 'directory';
+  fs.mkdirSync(directory);
   assert.throws(() => {
-    writeHeapSnapshot(readonlyFile);
+    writeHeapSnapshot(directory);
   }, (e) => {
     assert.ok(e, 'writeHeapSnapshot should error');
-    assert.strictEqual(e.code, 'EACCES');
+    assert.strictEqual(e.code, 'EISDIR');
     assert.strictEqual(e.syscall, 'open');
     return true;
   });

--- a/test/sequential/test-heapdump.js
+++ b/test/sequential/test-heapdump.js
@@ -31,7 +31,9 @@ process.chdir(tmpdir.path);
     writeHeapSnapshot(directory);
   }, (e) => {
     assert.ok(e, 'writeHeapSnapshot should error');
-    assert.strictEqual(e.code, 'EISDIR');
+    // TODO(RaisinTen): This should throw EISDIR on Windows too.
+    assert.strictEqual(e.code,
+                       process.platform === 'win32' ? 'EACCES' : 'EISDIR');
     assert.strictEqual(e.syscall, 'open');
     return true;
   });


### PR DESCRIPTION
The test was failing when it was being run with superuser privileges,
so this changes the test from attempting to write to a read-only file to
attempting to write to a file with the same name as that of an existing
directory, as that is a more reliable way of making
`v8.writeHeapSnapshot()` throw even when run with `sudo`.

Fixes: https://github.com/nodejs/node/issues/41643
Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
