### PR TITLE
Inspection functions on objects doesn't receive the inspect object (docs)

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -895,7 +895,7 @@ class Box {
     this.value = value;
   }
 
-  [util.inspect.custom](depth, options, inspect) {
+  [util.inspect.custom](depth, options) {
     if (depth < 0) {
       return options.stylize('[Box]', 'special');
     }
@@ -906,7 +906,7 @@ class Box {
 
     // Five space padding because that's the size of "Box< ".
     const padding = ' '.repeat(5);
-    const inner = inspect(this.value, newOptions)
+    const inner = utils.inspect(this.value, newOptions)
                   .replace(/\n/g, `\n${padding}`);
     return `${options.stylize('Box', 'special')}< ${inner} >`;
   }


### PR DESCRIPTION
Did not found where that method is called, but I did tested on v17.1.0 and it just receives 2 parameters:

```bash
> util.inspect(box);
Uncaught TypeError: inspect is not a function
    at Box.[nodejs.util.inspect.custom] (REPL22:17:19)
    at formatValue (node:internal/util/inspect:763:19)
    at Object.inspect (node:internal/util/inspect:340:10)
```

_fixing commit message, following the guidelines..._