### PR TITLE
[v16.x] Fix JS linting warnings and errors

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -56,7 +56,7 @@ const {
 } = primordials;
 const config = internalBinding('config');
 const internalTimers = require('internal/timers');
-const { deprecate, lazyDOMExceptionClass } = require('internal/util');
+const { deprecate } = require('internal/util');
 
 setupProcessObject();
 

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -6,7 +6,6 @@ const {
   SymbolIterator,
 } = primordials;
 
-const kDestroyed = Symbol('kDestroyed');
 const kIsErrored = Symbol('kIsErrored');
 const kIsReadable = Symbol('kIsReadable');
 const kIsDisturbed = Symbol('kIsDisturbed');
@@ -110,14 +109,6 @@ function isReadableFinished(stream, strict) {
     rState.endEmitted ||
     (strict === false && rState.ended === true && rState.length === 0)
   );
-}
-
-function isDisturbed(stream) {
-  return !!(stream && (
-    stream.readableDidRead ||
-    stream.readableAborted ||
-    stream[kIsDisturbed]
-  ));
 }
 
 function isReadable(stream) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -1283,7 +1283,11 @@ Interface.prototype._ttyWrite = function(s, key) {
 /**
  * Creates an `AsyncIterator` object that iterates through
  * each line in the input stream as a string.
- * @returns {Symbol.AsyncIterator}
+ * @typedef {{
+ *   [Symbol.asyncIterator]: () => InterfaceAsyncIterator,
+ *   next: () => Promise<string>
+ * }} InterfaceAsyncIterator
+ * @returns {InterfaceAsyncIterator}
  */
 Interface.prototype[SymbolAsyncIterator] = function() {
   if (this[kLineObjectStream] === undefined) {

--- a/test/parallel/test-v8-untrusted-code-mitigations.js
+++ b/test/parallel/test-v8-untrusted-code-mitigations.js
@@ -15,4 +15,5 @@ assert.notStrictEqual(untrustedFlag, -1);
 const nextFlag = v8Options.indexOf('--', untrustedFlag + 2);
 const slice = v8Options.substring(untrustedFlag, nextFlag);
 
+// eslint-disable-next-line no-regex-spaces
 assert(slice.match(/type: bool  default: false/));


### PR DESCRIPTION
When creating https://github.com/nodejs/node/pull/41804, I ran into some linting exceptions. I'm not sure if any of these are fixed in master, but for the purposes of getting the release out, I wanted to fix them in v16.x-staging since they were easy changes.