### PR TITLE
readline: improve code coverage for readline promises

### DIFF
--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -802,13 +802,11 @@ for (let i = 0; i < 12; i++) {
     const ac = new AbortController();
     const signal = ac.signal;
     const [rli] = getInterface({ terminal });
-    const expectedCallTimes = 1;
     signal.removeEventListener = common.mustCall(
       (event, onAbortFn) => {
         assert.strictEqual(event, 'abort');
         assert.strictEqual(onAbortFn.name, 'onAbort');
-      },
-      expectedCallTimes);
+      });
 
     rli.question('hello?', { signal }).then(common.mustCall());
 

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -797,6 +797,26 @@ for (let i = 0; i < 12; i++) {
     fi.emit('data', 'asdf\n');
   }
 
+  // Ensure that options.signal.removeEventListener was called
+  {
+    const ac = new AbortController();
+    const signal = ac.signal;
+    const [rli] = getInterface({ terminal });
+    const expectedCallTimes = 1;
+    signal.removeEventListener = common.mustCall(
+      (event, onAbortFn) => {
+        assert.strictEqual(event, 'abort');
+        assert.strictEqual(onAbortFn.name, 'onAbort');
+      },
+      expectedCallTimes);
+
+    rli.question('hello?', { signal }).then(common.mustCall());
+
+    rli.write('bar\n');
+    ac.abort();
+    rli.close();
+  }
+
   // Sending a blank line
   {
     const [rli, fi] = getInterface({ terminal });


### PR DESCRIPTION
It add tests to the readline promises module
Refs: [lib/readline/promises.js.html#L42](https://coverage.nodejs.org/coverage-7123a00b03a90862/lib/readline/promises.js.html#L42)
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
