### PR TITLE
doc: add overhead hints for heap snapshot generation

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -71,6 +71,13 @@ This JSON stream format is intended to be used with tools such as
 Chrome DevTools. The JSON schema is undocumented and specific to the
 V8 engine. Therefore, the schema may change from one version of V8 to the next.
 
+Creating a heap snapshot requires memory about twice the size of the heap at
+the time the snapshot is created. This results in the risk of OOM killers
+terminating the process.
+
+Generating a snapshot is a synchronous operation which blocks the event loop
+for a duration depending on the heap size.
+
 ```js
 // Print heap snapshot to the console
 const v8 = require('v8');
@@ -289,6 +296,13 @@ engine, and may change from one version of V8 to the next.
 A heap snapshot is specific to a single V8 isolate. When using
 [worker threads][], a heap snapshot generated from the main thread will
 not contain any information about the workers, and vice versa.
+
+Creating a heap snapshot requires memory about twice the size of the heap at
+the time the snapshot is created. This results in the risk of OOM killers
+terminating the process.
+
+Generating a snapshot is a synchronous operation which blocks the event loop
+for a duration depending on the heap size.
 
 ```js
 const { writeHeapSnapshot } = require('v8');


### PR DESCRIPTION
Added some hints that creation of an heap snapshot has significant overhead on memory requirement and event loop utilization.

