### PR TITLE
[v16 backport] deps: V8: cherry-pick cc9a8a37445e

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.19',
+    'v8_embedder_string': '-node.20',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/execution/messages.cc
+++ b/deps/v8/src/execution/messages.cc
@@ -301,8 +301,10 @@ MaybeHandle<Object> ErrorUtils::FormatStackTrace(Isolate* isolate,
   Handle<FixedArray> elems = Handle<FixedArray>::cast(raw_stack);
 
   const bool in_recursion = isolate->formatting_stack_trace();
+  const bool has_overflowed = i::StackLimitCheck{isolate}.HasOverflowed();
   Handle<Context> error_context;
-  if (!in_recursion && error->GetCreationContext().ToHandle(&error_context)) {
+  if (!in_recursion && !has_overflowed &&
+      error->GetCreationContext().ToHandle(&error_context)) {
     DCHECK(error_context->IsNativeContext());
 
     if (isolate->HasPrepareStackTraceCallback()) {


### PR DESCRIPTION
Original commit message:

    fix overflow check in error formatting

    Bug: v8:12494
    Change-Id: Iba2684173296aa236f1a1c73a5606c21472eff06
    Reviewed-on: chromium-review.googlesource.com/c/v8/v8/+/3426634
    Reviewed-by: Jakob Kummerow <jkummerow@chromium.org>
    Commit-Queue: Gus Caplan <snek@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#78909}

Refs: v8/v8@cc9a8a3