### PR TITLE
[v14 backport] deps: V8: cherry-pick cc9a8a37445e

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.85',
+    'v8_embedder_string': '-node.86',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/execution/messages.cc
+++ b/deps/v8/src/execution/messages.cc
@@ -858,7 +858,8 @@ MaybeHandle<Object> ErrorUtils::FormatStackTrace(Isolate* isolate,
   Handle<FixedArray> elems = Handle<FixedArray>::cast(raw_stack);
 
   const bool in_recursion = isolate->formatting_stack_trace();
-  if (!in_recursion) {
+  const bool has_overflowed = i::StackLimitCheck{isolate}.HasOverflowed();
+  if (!in_recursion && !has_overflowed) {
     Handle<Context> error_context = error->GetCreationContext();
     DCHECK(error_context->IsNativeContext());
 


### PR DESCRIPTION
Original commit message:

    fix overflow check in error formatting

    Bug: v8:12494
    Change-Id: Iba2684173296aa236f1a1c73a5606c21472eff06
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3426634
    Reviewed-by: Jakob Kummerow <jkummerow@chromium.org>
    Commit-Queue: Gus Caplan <snek@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#78909}

Refs: https://github.com/v8/v8/commit/cc9a8a37445eeffff17474020bb6038c2f9af9fc