### PR TITLE
doc: use example.com for examples

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -22,7 +22,7 @@ HTTP message headers are represented by an object like this:
 { 'content-length': '123',
   'content-type': 'text/plain',
   'connection': 'keep-alive',
-  'host': 'mysite.com',
+  'host': 'example.com',
   'accept': '*/*' }
 ```
 
@@ -47,7 +47,7 @@ list like the following:
   'content-LENGTH', '123',
   'content-type', 'text/plain',
   'CONNECTION', 'keep-alive',
-  'Host', 'mysite.com',
+  'Host', 'example.com',
   'accepT', '*/*' ]
 ```
 


### PR DESCRIPTION
As per [RFC6761](https://datatracker.ietf.org/doc/html/rfc6761), use [example.com](https://example.com/) for example/dummy domains. [mysite.com](http://mysite.com) that's currently used in `http` docs is an actual business.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
