### PR TITLE
doc: add caveats and example to crypto.timingSafeEqual

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5339,12 +5339,13 @@ Particular care must be taken if `crypto.timingSafeEqual` is used in scenarios
 where one or both arguments may vary in length, as its algorithm is only
 constant-time with respect to a byte length that is consistent. For example, if
 you are comparing a known secret to an input of unknown length, do not truncate
-the longer of the two to match the length of the shorter one. Doing so may seem
-more efficient, but it can leak timing information. In this case, you might
-instead choose to always size `a` and `b` to the length of the input; this
-means that `crypto.timingSafeEqual` may not always execute in the same amount
-of time, but its variance will be strictly dependent on the attacker's input
-rather than on the length of your secret.
+whichever of the two happens to be longer to match the length of the shorter
+one. Doing so may seem more efficient, but it can leak timing information. In
+this case, you might instead choose to _always_ size `a` and `b` to the length
+of the input, regardless of whether it's longer or shorter than the secret.
+This would mean that `crypto.timingSafeEqual` might not always execute in the
+same amount of time across calls, but its variance will be strictly dependent
+on the attacker's input rather than on the length of your secret.
 
 In the above scenario you'll also need to check that the original input is of
 the same length as the secret, but this should be done _in addition_ to calling


### PR DESCRIPTION
 #41507 recently added documentation about an error case for `crypto.timingSafeEqual`, but even with that addition I think there are a few extra caveats to `timingSafeEqual`'s use that are worth mentioning. I've tried to be as clear as possible in this addition without going outside the scope of documentation for a single function (ie. into the realm of broader crypto best practices). I've also added a short example for the function.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
