### PR TITLE
doc: make building with ninja more discoverable

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -273,6 +273,10 @@ $ ./configure
 $ make -j4
 ```
 
+We can speed up the builds by using [Ninja](https://ninja-build.org/). For more
+information, see
+[Building Node.js with Ninja](doc/contributing/building-node-with-ninja.md).
+
 The `-j4` option will cause `make` to run 4 simultaneous compilation jobs which
 may reduce build time. For more information, see the
 [GNU Make Documentation](https://www.gnu.org/software/make/manual/html_node/Parallel.html).

--- a/doc/contributing/pull-requests.md
+++ b/doc/contributing/pull-requests.md
@@ -244,6 +244,10 @@ test suite. To run the tests (including code linting) on Unix / macOS:
 ./configure && make -j4 test
 ```
 
+We can speed up the builds by using [Ninja](https://ninja-build.org/). For more
+information, see
+[Building Node.js with Ninja](building-node-with-ninja.md).
+
 And on Windows:
 
 ```text


### PR DESCRIPTION
Building with ninja would speed up the build
We have the documenation about building with ninja,
but not easily discoverable.
And present this early to the contributors.

cc: @RaisinTen 
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
