### PR TITLE
lib: refactor to use `validateObject()` validator

### DIFF
--- a/lib/internal/source_map/source_map.js
+++ b/lib/internal/source_map/source_map.js
@@ -75,9 +75,7 @@ const {
   StringPrototypeCharAt,
 } = primordials;
 
-const {
-  ERR_INVALID_ARG_TYPE
-} = require('internal/errors').codes;
+const { validateObject } = require('internal/validators');
 
 let base64Map;
 
@@ -317,9 +315,7 @@ function decodeVLQ(stringCharIterator) {
  * @return {SourceMapV3}
  */
 function cloneSourceMapV3(payload) {
-  if (typeof payload !== 'object') {
-    throw new ERR_INVALID_ARG_TYPE('payload', ['Object'], payload);
-  }
+  validateObject(payload, 'payload');
   payload = { ...payload };
   for (const key in payload) {
     if (ObjectPrototypeHasOwnProperty(payload, key) &&


### PR DESCRIPTION
Use the `validateObject()` validator in source maps where appropriate.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
