### PR TITLE
stream: resume stream on drain

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -853,8 +853,7 @@ function pipeOnDrain(src, dest) {
 
     if ((!state.awaitDrainWriters || state.awaitDrainWriters.size === 0) &&
       EE.listenerCount(src, 'data')) {
-      state.flowing = true;
-      flow(src);
+      src.resume();
     }
   };
 }

--- a/test/parallel/test-stream-readable-pause-and-resume.js
+++ b/test/parallel/test-stream-readable-pause-and-resume.js
@@ -56,3 +56,20 @@ function readAndPause() {
     assert(readable.isPaused());
   });
 }
+
+{
+  const { PassThrough } = require('stream');
+
+  const source3 = new PassThrough();
+  const target3 = new PassThrough();
+
+  const chunk = Buffer.allocUnsafe(1000);
+  let chunks = 1;
+  while (target3.write(chunk)) chunks++;
+
+  source3.pipe(target3);
+  target3.on('drain', common.mustCall(() => {
+    assert(!source3.isPaused());
+  }));
+  target3.on('data', () => {});
+}

--- a/test/parallel/test-stream-readable-pause-and-resume.js
+++ b/test/parallel/test-stream-readable-pause-and-resume.js
@@ -64,8 +64,7 @@ function readAndPause() {
   const target3 = new PassThrough();
 
   const chunk = Buffer.allocUnsafe(1000);
-  let chunks = 1;
-  while (target3.write(chunk)) chunks++;
+  while (target3.write(chunk));
 
   source3.pipe(target3);
   target3.on('drain', common.mustCall(() => {


### PR DESCRIPTION
Previously we would just resume "flowing" the stream without
reseting the "paused" state. Fixes this by properly using
pause/resume methods for .pipe.

Fixes: https://github.com/nodejs/node/issues/41785

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
