### PR TITLE
test: remove eslint-disable comments from fixtures

### DIFF
--- a/test/fixtures/es-module-loaders/loader-invalid-url.mjs
+++ b/test/fixtures/es-module-loaders/loader-invalid-url.mjs
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/required-modules */
 export async function resolve(specifier, { parentURL, importAssertions }, defaultResolve) {
   if (parentURL && specifier === '../fixtures/es-modules/test-esm-ok.mjs') {
     return {

--- a/test/fixtures/es-module-loaders/throw-undefined.mjs
+++ b/test/fixtures/es-module-loaders/throw-undefined.mjs
@@ -1,4 +1,3 @@
 'use strict';
-/* eslint-disable node-core/required-modules */
 
 throw undefined;

--- a/test/fixtures/es-modules/import-json-named-export.mjs
+++ b/test/fixtures/es-modules/import-json-named-export.mjs
@@ -1,2 +1,1 @@
-/* eslint-disable no-unused-vars */
 import { ofLife } from '../experimental.json' assert { type: 'json' };

--- a/test/fixtures/wpt/streams/readable-streams/general.any.js
+++ b/test/fixtures/wpt/streams/readable-streams/general.any.js
@@ -630,7 +630,6 @@ promise_test(() => {
   let pullCalled = 0;
   let cancelCalled = 0;
 
-  /* eslint-disable no-use-before-define */
   class Source {
     start(c) {
       startCalled++;

--- a/test/fixtures/wpt/streams/readable-streams/patched-global.any.js
+++ b/test/fixtures/wpt/streams/readable-streams/patched-global.any.js
@@ -22,7 +22,6 @@ test(t => {
 
   const trappedProperties = ['highWaterMark', 'size', 'start', 'type', 'mode'];
   for (const property of trappedProperties) {
-    // eslint-disable-next-line no-extend-native, accessor-pairs
     Object.defineProperty(Object.prototype, property, {
       get() { throw new Error(`${property} getter called`); },
       configurable: true

--- a/test/fixtures/wpt/streams/resources/test-utils.js
+++ b/test/fixtures/wpt/streams/resources/test-utils.js
@@ -57,7 +57,6 @@ self.garbageCollect = () => {
     // Present in some WebKit development environments
     GCController.collect();
   } else {
-    /* eslint-disable no-console */
     console.warn('Tests are running without the ability to do manual garbage collection. They will still work, but ' +
       'coverage will be suboptimal.');
     /* eslint-enable no-console */

--- a/test/fixtures/wpt/streams/transform-streams/patched-global.any.js
+++ b/test/fixtures/wpt/streams/transform-streams/patched-global.any.js
@@ -5,13 +5,11 @@
 // interfering with other tests.
 
 test(t => {
-  // eslint-disable-next-line no-extend-native, accessor-pairs
   Object.defineProperty(Object.prototype, 'highWaterMark', {
     set() { throw new Error('highWaterMark setter called'); },
     configurable: true
   });
 
-  // eslint-disable-next-line no-extend-native, accessor-pairs
   Object.defineProperty(Object.prototype, 'size', {
     set() { throw new Error('size setter called'); },
     configurable: true


### PR DESCRIPTION
We do not lint the fixtures code so eslint-disable comments are
superfluous.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
