### PR TITLE
doc: fix webstream close reject state state doc

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -425,7 +425,8 @@ added: v16.5.0
 -->
 
 * Type: {Promise} Fulfilled with `undefined` when the associated
-  {ReadableStream} is closed or this reader's lock is released.
+  {ReadableStream} is closed or rejected if the stream errors or the reader's
+  lock is released before the stream finishes closing.
 
 #### `readableStreamDefaultReader.read()`
 
@@ -552,7 +553,8 @@ added: v16.5.0
 -->
 
 * Type: {Promise} Fulfilled with `undefined` when the associated
-  {ReadableStream} is closed or this reader's lock is released.
+  {ReadableStream} is closed or rejected if the stream errors or the reader's
+  lock is released before the stream finishes closing.
 
 #### `readableStreamBYOBReader.read(view)`
 
@@ -902,9 +904,9 @@ Closes the `WritableStream` when no additional writes are expected.
 added: v16.5.0
 -->
 
-* Type: A promise that is fulfilled with `undefined` when the
-  associated {WritableStream} is closed or this writer's lock is
-  released.
+* Type: {Promise} Fulfilled with `undefined` when the associated
+  {WritableStream} is closed or rejected if the stream errors or the writer's
+  lock is released before the stream finishes closing.
 
 #### `writableStreamDefaultWriter.desiredSize`
 


### PR DESCRIPTION
The `closed` promise may reject. Document the states where it rejects
based on the spec.

Fixes: https://github.com/nodejs/node/issues/41858

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
