### PR TITLE
crypto: do not advertise unsupported algorithms

### DIFF
--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -35,8 +35,19 @@ void Hash::MemoryInfo(MemoryTracker* tracker) const {
 
 void Hash::GetHashes(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  MarkPopErrorOnReturn mark_pop_error_on_return;
   CipherPushContext ctx(env);
-  EVP_MD_do_all_sorted(array_push_back<EVP_MD>, &ctx);
+  EVP_MD_do_all_sorted(
+#if OPENSSL_VERSION_MAJOR >= 3
+    array_push_back<EVP_MD,
+                    EVP_MD_fetch,
+                    EVP_MD_free,
+                    EVP_get_digestbyname,
+                    EVP_MD_get0_name>,
+#else
+    array_push_back<EVP_MD>,
+#endif
+    &ctx);
   args.GetReturnValue().Set(ctx.ToJSArray());
 }
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/41857

`getCiphers()` diff:

```diff
--- before	2022-02-05 14:45:52.523437317 -0500
+++ after 	2022-02-05 14:45:52.523437317 -0500
@@ -70,12 +70,6 @@
 aria128
 aria192
 aria256
-bf
-bf-cbc
-bf-cfb
-bf-ecb
-bf-ofb
-blowfish
 camellia-128-cbc
 camellia-128-cfb
 camellia-128-cfb1
@@ -100,20 +94,8 @@
 camellia128
 camellia192
 camellia256
-cast
-cast-cbc
-cast5-cbc
-cast5-cfb
-cast5-ecb
-cast5-ofb
 chacha20
 chacha20-poly1305
-des
-des-cbc
-des-cfb
-des-cfb1
-des-cfb8
-des-ecb
 des-ede
 des-ede-cbc
 des-ede-cfb
@@ -126,11 +108,8 @@
 des-ede3-cfb8
 des-ede3-ecb
 des-ede3-ofb
-des-ofb
 des3
 des3-wrap
-desx
-desx-cbc
 id-aes128-CCM
 id-aes128-GCM
 id-aes128-wrap
@@ -144,29 +123,6 @@
 id-aes256-wrap
 id-aes256-wrap-pad
 id-smime-alg-CMS3DESwrap
-idea
-idea-cbc
-idea-cfb
-idea-ecb
-idea-ofb
-rc2
-rc2-128
-rc2-40
-rc2-40-cbc
-rc2-64
-rc2-64-cbc
-rc2-cbc
-rc2-cfb
-rc2-ecb
-rc2-ofb
-rc4
-rc4-40
-rc4-hmac-md5
-seed
-seed-cbc
-seed-cfb
-seed-ecb
-seed-ofb
 sm4
 sm4-cbc
 sm4-cfb
```

`getHashes()` diff:

```diff
--- before  2022-02-05 14:46:33.075661530 -0500
+++ after   2022-02-05 14:46:33.075661530 -0500
@@ -1,7 +1,4 @@
-RSA-MD4
 RSA-MD5
-RSA-MDC2
-RSA-RIPEMD160
 RSA-SHA1
 RSA-SHA1-2
 RSA-SHA224
@@ -21,17 +18,9 @@
 id-rsassa-pkcs1-v1_5-with-sha3-256
 id-rsassa-pkcs1-v1_5-with-sha3-384
 id-rsassa-pkcs1-v1_5-with-sha3-512
-md4
-md4WithRSAEncryption
 md5
 md5-sha1
 md5WithRSAEncryption
-mdc2
-mdc2WithRSA
-ripemd
-ripemd160
-ripemd160WithRSA
-rmd160
 sha1
 sha1WithRSAEncryption
 sha224
@@ -56,4 +45,3 @@
 sm3WithRSAEncryption
 ssl3-md5
 ssl3-sha1
-whirlpool
```