### PR TITLE
process: deprecate multipleResolves

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3070,6 +3070,20 @@ Type: End-of-Life
 This error code was removed due to adding more confusion to
 the errors used for value type validation.
 
+### DEPXXXX: `process.on('multipleResolves, handler)`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41872
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+This event was deprecated because it did not work with V8 promise combinators
+which diminished its usefulness.
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3070,7 +3070,7 @@ Type: End-of-Life
 This error code was removed due to adding more confusion to
 the errors used for value type validation.
 
-### DEPXXXX: `process.on('multipleResolves, handler)`
+### DEPXXXX: `process.on('multipleResolves', handler)`
 
 <!-- YAML
 changes:

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -181,7 +181,10 @@ See [Advanced serialization for `child_process`][] for more details.
 
 <!-- YAML
 added: v10.12.0
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated
 
 * `type` {string} The resolution type. One of `'resolve'` or `'reject'`.
 * `promise` {Promise} The promise that resolved or rejected more than once.
@@ -199,6 +202,9 @@ This is useful for tracking potential errors in an application while using the
 `Promise` constructor, as multiple resolutions are silently swallowed. However,
 the occurrence of this event does not necessarily indicate an error. For
 example, [`Promise.race()`][] can trigger a `'multipleResolves'` event.
+
+Because of the unreliability of the event in cases like the
+[`Promise.race()`][] example above it has been deprecated.
 
 ```mjs
 import process from 'process';


### PR DESCRIPTION
Deprecate the process multipleResolves event to detect when a promise is
resolved more than once because it never really worked.

Fixes: https://github.com/nodejs/node/issues/41554

Start with a doc-deprecation but I would prefer to follow up with a semver-major runtime warning