### PR TITLE
lib: move kEnumerableProperty to internal/util

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -25,6 +25,7 @@ const {
 } = require('internal/event_target');
 const {
   customInspectSymbol,
+  kEnumerableProperty,
 } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
 const {
@@ -260,7 +261,7 @@ function ClonedAbortSignal() {
 ClonedAbortSignal.prototype[kDeserialize] = () => {};
 
 ObjectDefineProperties(AbortSignal.prototype, {
-  aborted: { enumerable: true }
+  aborted: kEnumerableProperty,
 });
 
 ObjectDefineProperty(AbortSignal.prototype, SymbolToStringTag, {
@@ -329,8 +330,8 @@ class AbortController {
 }
 
 ObjectDefineProperties(AbortController.prototype, {
-  signal: { enumerable: true },
-  abort: { enumerable: true }
+  signal: kEnumerableProperty,
+  abort: kEnumerableProperty,
 });
 
 ObjectDefineProperty(AbortController.prototype, SymbolToStringTag, {

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -5,7 +5,6 @@ const {
   JSONParse,
   JSONStringify,
   ObjectDefineProperties,
-  ObjectGetOwnPropertyDescriptor,
   SafeSet,
   SymbolToStringTag,
   StringPrototypeRepeat,
@@ -60,6 +59,7 @@ const {
 } = require('internal/crypto/util');
 
 const {
+  kEnumerableProperty,
   lazyDOMException,
 } = require('internal/util');
 
@@ -703,10 +703,7 @@ ObjectDefineProperties(
       writable: false,
       value: 'Crypto',
     },
-    subtle: {
-      ...ObjectGetOwnPropertyDescriptor(Crypto.prototype, 'subtle'),
-      enumerable: true,
-    },
+    subtle: kEnumerableProperty,
     getRandomValues: {
       enumerable: true,
       configurable: true,

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -30,7 +30,8 @@ const kEncoder = Symbol('encoder');
 
 const {
   getConstructorOf,
-  customInspectSymbol: inspect
+  customInspectSymbol: inspect,
+  kEnumerableProperty,
 } = require('internal/util');
 
 const {
@@ -358,9 +359,9 @@ class TextEncoder {
 
 ObjectDefineProperties(
   TextEncoder.prototype, {
-    'encode': { enumerable: true },
-    'encodeInto': { enumerable: true },
-    'encoding': { enumerable: true },
+    'encode': kEnumerableProperty,
+    'encodeInto': kEnumerableProperty,
+    'encoding': kEnumerableProperty,
     [SymbolToStringTag]: { configurable: true, value: 'TextEncoder' },
   });
 
@@ -569,7 +570,7 @@ ObjectDefineProperties(
 );
 
 ObjectDefineProperties(TextDecoder.prototype, {
-  decode: { enumerable: true },
+  decode: kEnumerableProperty,
   [inspect]: { enumerable: false },
   [SymbolToStringTag]: {
     configurable: true,

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -8,7 +8,6 @@ const {
   FunctionPrototypeCall,
   NumberIsInteger,
   ObjectAssign,
-  ObjectCreate,
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
@@ -36,7 +35,7 @@ const {
 } = require('internal/errors');
 const { validateObject, validateString } = require('internal/validators');
 
-const { customInspectSymbol } = require('internal/util');
+const { customInspectSymbol, kEnumerableProperty } = require('internal/util');
 const { inspect } = require('util');
 
 const kIsEventTarget = SymbolFor('nodejs.event_target');
@@ -297,9 +296,6 @@ class Event {
   static AT_TARGET = 2;
   static BUBBLING_PHASE = 3;
 }
-
-const kEnumerableProperty = ObjectCreate(null);
-kEnumerableProperty.enumerable = true;
 
 ObjectDefineProperties(
   Event.prototype, {

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -43,6 +43,7 @@ const {
   getConstructorOf,
   removeColors,
   toUSVString,
+  kEnumerableProperty,
 } = require('internal/util');
 
 const {
@@ -517,18 +518,18 @@ class URLSearchParams {
 }
 
 ObjectDefineProperties(URLSearchParams.prototype, {
-  append: { enumerable: true },
-  delete: { enumerable: true },
-  get: { enumerable: true },
-  getAll: { enumerable: true },
-  has: { enumerable: true },
-  set: { enumerable: true },
-  sort: { enumerable: true },
-  entries: { enumerable: true },
-  forEach: { enumerable: true },
-  keys: { enumerable: true },
-  values: { enumerable: true },
-  toString: { enumerable: true },
+  append: kEnumerableProperty,
+  delete: kEnumerableProperty,
+  get: kEnumerableProperty,
+  getAll: kEnumerableProperty,
+  has: kEnumerableProperty,
+  set: kEnumerableProperty,
+  sort: kEnumerableProperty,
+  entries: kEnumerableProperty,
+  forEach: kEnumerableProperty,
+  keys: kEnumerableProperty,
+  values: kEnumerableProperty,
+  toString: kEnumerableProperty,
   [SymbolToStringTag]: { configurable: true, value: 'URLSearchParams' },
 
   // https://heycam.github.io/webidl/#es-iterable-entries
@@ -1044,20 +1045,20 @@ class URL {
 ObjectDefineProperties(URL.prototype, {
   [kFormat]: { configurable: false, writable: false },
   [SymbolToStringTag]: { configurable: true, value: 'URL' },
-  toString: { enumerable: true },
-  href: { enumerable: true },
-  origin: { enumerable: true },
-  protocol: { enumerable: true },
-  username: { enumerable: true },
-  password: { enumerable: true },
-  host: { enumerable: true },
-  hostname: { enumerable: true },
-  port: { enumerable: true },
-  pathname: { enumerable: true },
-  search: { enumerable: true },
-  searchParams: { enumerable: true },
-  hash: { enumerable: true },
-  toJSON: { enumerable: true },
+  toString: kEnumerableProperty,
+  href: kEnumerableProperty,
+  origin: kEnumerableProperty,
+  protocol: kEnumerableProperty,
+  username: kEnumerableProperty,
+  password: kEnumerableProperty,
+  host: kEnumerableProperty,
+  hostname: kEnumerableProperty,
+  port: kEnumerableProperty,
+  pathname: kEnumerableProperty,
+  search: kEnumerableProperty,
+  searchParams: kEnumerableProperty,
+  hash: kEnumerableProperty,
+  toJSON: kEnumerableProperty,
 });
 
 function update(url, params) {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -497,6 +497,9 @@ const lazyDOMException = hideStackFrames((message, name) => {
   return new _DOMException(message, name);
 });
 
+const kEnumerableProperty = ObjectCreate(null);
+kEnumerableProperty.enumerable = true;
+
 module.exports = {
   assertCrypto,
   cachedResult,
@@ -535,5 +538,7 @@ module.exports = {
   // Used by the buffer module to capture an internal reference to the
   // default isEncoding implementation, just in case userland overrides it.
   kIsEncodingSymbol: Symbol('kIsEncodingSymbol'),
-  kVmBreakFirstLineSymbol: Symbol('kVmBreakFirstLineSymbol')
+  kVmBreakFirstLineSymbol: Symbol('kVmBreakFirstLineSymbol'),
+
+  kEnumerableProperty,
 };

--- a/lib/internal/webstreams/compression.js
+++ b/lib/internal/webstreams/compression.js
@@ -16,13 +16,11 @@ const {
   newReadableWritablePairFromDuplex,
 } = require('internal/webstreams/adapters');
 
-const {
-  customInspect,
-  kEnumerableProperty,
-} = require('internal/webstreams/util');
+const { customInspect } = require('internal/webstreams/util');
 
 const {
   customInspectSymbol: kInspect,
+  kEnumerableProperty,
 } = require('internal/util');
 
 let zlib;

--- a/lib/internal/webstreams/encoding.js
+++ b/lib/internal/webstreams/encoding.js
@@ -14,10 +14,7 @@ const {
   TransformStream,
 } = require('internal/webstreams/transformstream');
 
-const {
-  customInspect,
-  kEnumerableProperty,
-} = require('internal/webstreams/util');
+const { customInspect } = require('internal/webstreams/util');
 
 const {
   codes: {
@@ -26,7 +23,8 @@ const {
 } = require('internal/errors');
 
 const {
-  customInspectSymbol: kInspect
+  customInspectSymbol: kInspect,
+  kEnumerableProperty,
 } = require('internal/util');
 
 const kHandle = Symbol('kHandle');

--- a/lib/internal/webstreams/queuingstrategies.js
+++ b/lib/internal/webstreams/queuingstrategies.js
@@ -14,6 +14,7 @@ const {
 
 const {
   customInspectSymbol: kInspect,
+  kEnumerableProperty,
 } = require('internal/util');
 
 const {
@@ -21,7 +22,6 @@ const {
   isBrandCheck,
   kType,
   kState,
-  kEnumerableProperty,
 } = require('internal/webstreams/util');
 
 const {

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -50,6 +50,7 @@ const {
 const {
   createDeferredPromise,
   customInspectSymbol: kInspect,
+  kEnumerableProperty,
 } = require('internal/util');
 
 const {
@@ -109,7 +110,6 @@ const {
   nonOpStart,
   kType,
   kState,
-  kEnumerableProperty,
 } = require('internal/webstreams/util');
 
 const {

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -27,6 +27,7 @@ const {
 const {
   createDeferredPromise,
   customInspectSymbol: kInspect,
+  kEnumerableProperty,
 } = require('internal/util');
 
 const {
@@ -45,7 +46,6 @@ const {
   nonOpFlush,
   kType,
   kState,
-  kEnumerableProperty,
 } = require('internal/webstreams/util');
 
 const {

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -207,9 +207,6 @@ function lazyTransfer() {
   return transfer;
 }
 
-const kEnumerableProperty = ObjectCreate(null);
-kEnumerableProperty.enumerable = true;
-
 module.exports = {
   ArrayBufferViewGetBuffer,
   ArrayBufferViewGetByteLength,
@@ -237,5 +234,4 @@ module.exports = {
   nonOpWrite,
   kType,
   kState,
-  kEnumerableProperty,
 };

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -33,6 +33,7 @@ const {
 const {
   createDeferredPromise,
   customInspectSymbol: kInspect,
+  kEnumerableProperty,
 } = require('internal/util');
 
 const {
@@ -64,7 +65,6 @@ const {
   nonOpWrite,
   kType,
   kState,
-  kEnumerableProperty,
 } = require('internal/webstreams/util');
 
 const {

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -18,6 +18,8 @@ const {
   SymbolFor,
 } = primordials;
 
+const { kEnumerableProperty } = require('internal/util');
+
 const {
   handle_onclose: handleOnCloseSymbol,
   oninit: onInitSymbol,
@@ -500,9 +502,6 @@ class BroadcastChannel extends EventTarget {
     return this;
   }
 }
-
-const kEnumerableProperty = ObjectCreate(null);
-kEnumerableProperty.enumerable = true;
 
 ObjectDefineProperties(BroadcastChannel.prototype, {
   name: kEnumerableProperty,


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
