### PR TITLE
repl: #41690 REPL gives wrong autocomplete on literals

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1168,7 +1168,7 @@ const importRE = /\bimport\s*\(\s*['"`](([\w@./:-]+\/)?(?:[\w@./:-]*))(?![^'"`])
 const requireRE = /\brequire\s*\(\s*['"`](([\w@./:-]+\/)?(?:[\w@./:-]*))(?![^'"`])$/;
 const fsAutoCompleteRE = /fs(?:\.promises)?\.\s*[a-z][a-zA-Z]+\(\s*["'](.*)/;
 const simpleExpressionRE =
-    /(?:[\w$'"[{](?:\w|\$|['"\]}])*\??\.)*[a-zA-Z_$](?:\w|\$)*\??\.?$/;
+    /(?:[\w$'"`[{(](?:\w|\$|['"`\]})])*\??\.)*[a-zA-Z_$](?:\w|\$)*\??\.?$/;
 const versionedFileNamesRe = /-\d+\.\d+/;
 
 function isIdentifier(str) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1168,7 +1168,7 @@ const importRE = /\bimport\s*\(\s*['"`](([\w@./:-]+\/)?(?:[\w@./:-]*))(?![^'"`])
 const requireRE = /\brequire\s*\(\s*['"`](([\w@./:-]+\/)?(?:[\w@./:-]*))(?![^'"`])$/;
 const fsAutoCompleteRE = /fs(?:\.promises)?\.\s*[a-z][a-zA-Z]+\(\s*["'](.*)/;
 const simpleExpressionRE =
-    /(?:[a-zA-Z_$](?:\w|\$)*\??\.)*[a-zA-Z_$](?:\w|\$)*\??\.?$/;
+    /(?:[\w$'"[{](?:\w|\$|['"\]}])*\??\.)*[a-zA-Z_$](?:\w|\$)*\??\.?$/;
 const versionedFileNamesRe = /-\d+\.\d+/;
 
 function isIdentifier(str) {

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -558,6 +558,26 @@ testMe.complete('obj.', common.mustCall(function(error, data) {
 putIn.run(['.clear']);
 testMe.complete('Buffer.prototype.', common.mustCall());
 
+// Make sure repl gives correct autocomplete on literals
+testMe.complete('``.a', common.mustCall((err, data) => {
+  assert.strictEqual(data[0].includes('``.at'), true);
+}));
+testMe.complete('\'\'.a', common.mustCall((err, data) => {
+  assert.strictEqual(data[0].includes('\'\'.at'), true);
+}));
+testMe.complete('"".a', common.mustCall((err, data) => {
+  assert.strictEqual(data[0].includes('"".at'), true);
+}));
+testMe.complete('("").a', common.mustCall((err, data) => {
+  assert.strictEqual(data[0].includes('("").at'), true);
+}));
+testMe.complete('[].a', common.mustCall((err, data) => {
+  assert.strictEqual(data[0].includes('[].at'), true);
+}));
+testMe.complete('{}.a', common.mustCall((err, data) => {
+  assert.deepStrictEqual(data[0], []);
+}));
+
 const testNonGlobal = repl.start({
   input: putIn,
   output: putIn,


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/41690

The original Reg dose not match `''.at` correctly。

I changed `simpleExpressionRE` to make it match `''` part.

![image](https://user-images.githubusercontent.com/9262426/152785451-4004bb74-7e43-4e41-b53a-31fa65db65c0.png)

also `[].at`, `{}.at`, `123.at` works fine now.



