### PR TITLE
doc: imporve scrollbar appearance in dark mode

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -772,6 +772,10 @@ kbd {
   display: none;
 }
 
+.dark-mode{
+  color-scheme: dark;
+}
+
 .dark-mode .dark-icon {
   display: none;
 }

--- a/doc/template.html
+++ b/doc/template.html
@@ -73,7 +73,7 @@
         const mq = window.matchMedia('(prefers-color-scheme: dark)');
         if ('onchange' in mq) {
           function mqChangeListener(e) {
-            document.body.classList.toggle('dark-mode', e.matches);
+            document.documentElement.classList.toggle('dark-mode', e.matches);
           }
           mq.addEventListener('change', mqChangeListener);
           if (themeToggleButton) {
@@ -83,17 +83,17 @@
           }
         }
         if (mq.matches) {
-          document.body.classList.add('dark-mode');
+          document.documentElement.classList.add('dark-mode');
         }
       } else if (userSettings === 'true') {
-        document.body.classList.add('dark-mode');
+        document.documentElement.classList.add('dark-mode');
       }
       if (themeToggleButton) {
         themeToggleButton.hidden = false;
         themeToggleButton.addEventListener('click', function() {
           sessionStorage.setItem(
             kCustomPreference,
-            document.body.classList.toggle('dark-mode')
+            document.documentElement.classList.toggle('dark-mode')
           );
         });
       }


### PR DESCRIPTION
 imporve scrollbar appearance in dark mode by [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme)

before:
<img width="1455" alt="Screen Shot 2022-02-08 at 17 58 07" src="https://user-images.githubusercontent.com/25996236/152967129-5b6aacdd-6999-46ce-8f43-2ec415d2dc79.png">

after:
<img width="1455" alt="Screen Shot 2022-02-08 at 17 55 41" src="https://user-images.githubusercontent.com/25996236/152967141-9055d7a7-d368-489a-92ec-04d10497522e.png">

