### PR TITLE
build: revert fast-track changes

### DIFF
--- a/.github/workflows/comment-labeled.yml
+++ b/.github/workflows/comment-labeled.yml
@@ -23,7 +23,7 @@ jobs:
         run: gh issue comment "$NUMBER" --repo ${{ github.repository }} --body "$STALE_MESSAGE"
 
   fast-track:
-    if: github.repository == 'nodejs/node' && github.event.issue.pull_request && github.event.label.name == 'fast-track'
+    if: github.repository == 'nodejs/node' && github.event_name == 'pull_request_target' && github.event.label.name == 'fast-track'
     runs-on: ubuntu-latest
     steps:
       - name: Request Fast-Track


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/41791#discussion_r801704953

This reverts a change introduced in #41791 which prohibits `fast-track` applied label flow from functioning.