### PR TITLE
process: runtime deprecate multipleResolves

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3076,11 +3076,14 @@ the errors used for value type validation.
 <!-- YAML
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41896
+    description: Runtime deprecation.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/41872
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime.
 
 This event was deprecated because it did not work with V8 promise combinators
 which diminished its usefulness.

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -20,6 +20,8 @@ const {
   setPromiseRejectCallback
 } = internalBinding('task_queue');
 
+const { deprecate } = require('internal/util');
+
 const {
   noSideEffectsToString,
   triggerUncaughtException
@@ -124,11 +126,18 @@ function promiseRejectHandler(type, promise, reason) {
   }
 }
 
+const multipleResolvesDeprecate = deprecate(
+  () => {},
+  'The multipleResolves event has been deprecated.',
+  'DEPXXXX'
+);
 function resolveError(type, promise, reason) {
   // We have to wrap this in a next tick. Otherwise the error could be caught by
   // the executed promise.
   process.nextTick(() => {
-    process.emit('multipleResolves', type, promise, reason);
+    if (process.emit('multipleResolves', type, promise, reason)) {
+      multipleResolvesDeprecate();
+    }
   });
 }
 

--- a/test/parallel/test-warn-multipleResolves.mjs
+++ b/test/parallel/test-warn-multipleResolves.mjs
@@ -1,0 +1,14 @@
+import { expectWarning, mustCall } from '../common/index.mjs';
+
+expectWarning(
+  'DeprecationWarning',
+  'The multipleResolves event has been deprecated.',
+  'DEPXXXX',
+);
+
+process.on('multipleResolves', mustCall());
+
+new Promise((resolve) => {
+  resolve();
+  resolve();
+});


### PR DESCRIPTION
Emit a runtime warning for the `multipleResolves` event, continues https://github.com/nodejs/node/pull/41872 https://github.com/nodejs/node/issues/41554

cc reviewers from the last one @jasnell @mscdex @juanarbol @RaisinTen @Mesteery and @mmarchini from the issue