### PR TITLE
test: remove lint rule for setTimeout() arguments

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -31,8 +31,6 @@ rules:
       message: "Use an object as second argument of `assert.throws()`."
     - selector: "CallExpression:matches([callee.name='throws'], [callee.property.name='throws'])[arguments.length<2]"
       message: "`assert.throws()` must be invoked with at least two arguments."
-    - selector: "CallExpression[callee.name='setTimeout'][arguments.length<2]"
-      message: "`setTimeout()` must be invoked with at least two arguments."
     - selector: "CallExpression[callee.name='setInterval'][arguments.length<2]"
       message: "`setInterval()` must be invoked with at least two arguments."
     - selector: "ThrowStatement > CallExpression[callee.name=/Error$/]"

--- a/test/parallel/test-stream-construct-async-error.js
+++ b/test/parallel/test-stream-construct-async-error.js
@@ -12,7 +12,6 @@ const assert = require('assert');
 {
   class Foo extends Duplex {
     async _destroy(err, cb) {
-      // eslint-disable-next-line no-restricted-syntax
       await setTimeout(common.platformTimeout(1));
       throw new Error('boom');
     }
@@ -31,7 +30,6 @@ const assert = require('assert');
 {
   class Foo extends Duplex {
     async _destroy(err, cb) {
-      // eslint-disable-next-line no-restricted-syntax
       await setTimeout(common.platformTimeout(1));
     }
   }
@@ -46,7 +44,6 @@ const assert = require('assert');
 {
   class Foo extends Duplex {
     async _construct() {
-      // eslint-disable-next-line no-restricted-syntax
       await setTimeout(common.platformTimeout(1));
     }
 
@@ -64,7 +61,6 @@ const assert = require('assert');
 {
   class Foo extends Duplex {
     async _construct(callback) {
-      // eslint-disable-next-line no-restricted-syntax
       await setTimeout(common.platformTimeout(1));
       callback();
     }
@@ -88,7 +84,6 @@ const assert = require('assert');
     });
 
     async _final() {
-      // eslint-disable-next-line no-restricted-syntax
       await setTimeout(common.platformTimeout(1));
     }
   }
@@ -105,7 +100,6 @@ const assert = require('assert');
     });
 
     async _final(callback) {
-      // eslint-disable-next-line no-restricted-syntax
       await setTimeout(common.platformTimeout(1));
       callback();
     }
@@ -123,7 +117,6 @@ const assert = require('assert');
     });
 
     async _final() {
-      // eslint-disable-next-line no-restricted-syntax
       await setTimeout(common.platformTimeout(1));
       throw new Error('boom');
     }

--- a/test/parallel/test-stream-some-find-every.mjs
+++ b/test/parallel/test-stream-some-find-every.mjs
@@ -59,7 +59,6 @@ function oneTo5Async() {
 
 {
   async function checkDestroyed(stream) {
-    // eslint-disable-next-line no-restricted-syntax
     await setTimeout();
     assert.strictEqual(stream.destroyed, true);
   }
@@ -109,7 +108,6 @@ function oneTo5Async() {
   // Concurrency doesn't affect which value is found.
   const found = await Readable.from([1, 2]).find(async (val) => {
     if (val === 1) {
-      // eslint-disable-next-line no-restricted-syntax
       await setTimeout(100);
     }
     return true;

--- a/test/parallel/test-stream-writable-final-async.js
+++ b/test/parallel/test-stream-writable-final-async.js
@@ -9,7 +9,6 @@ const { setTimeout } = require('timers/promises');
 {
   class Foo extends Duplex {
     async _final(callback) {
-      // eslint-disable-next-line no-restricted-syntax
       await setTimeout(common.platformTimeout(1));
       callback();
     }


### PR DESCRIPTION
With the introduction of the promises API for setTimeout(), the
requirement that it have two parameters may not be sensible anymore in
tests.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
