### PR TITLE
http,https: add default argument for Agent.prototype.getName

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -300,6 +300,10 @@ removed from the array on `'timeout'`.
 
 <!-- YAML
 added: v0.11.4
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41906
+    description: The `option` parameter is now optional.
 -->
 
 * `options` {Object} A set of options providing information for name generation

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -303,7 +303,7 @@ added: v0.11.4
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/41906
-    description: The `option` parameter is now optional.
+    description: The `options` parameter is now optional.
 -->
 
 * `options` {Object} A set of options providing information for name generation

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -296,7 +296,7 @@ the agent when `keepAlive` is enabled. Do not modify.
 Sockets in the `freeSockets` list will be automatically destroyed and
 removed from the array on `'timeout'`.
 
-### `agent.getName(options)`
+### `agent.getName([options])`
 
 <!-- YAML
 added: v0.11.4

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -217,7 +217,7 @@ Agent.defaultMaxSockets = Infinity;
 Agent.prototype.createConnection = net.createConnection;
 
 // Get the key for a given set of request options
-Agent.prototype.getName = function getName(options) {
+Agent.prototype.getName = function getName(options = {}) {
   let name = options.host || 'localhost';
 
   name += ':';

--- a/lib/https.js
+++ b/lib/https.js
@@ -203,7 +203,7 @@ Agent.prototype.createConnection = createConnection;
  *   }} [options]
  * @returns {string}
  */
-Agent.prototype.getName = function getName(options) {
+Agent.prototype.getName = function getName(options = {}) {
   let name = FunctionPrototypeCall(HttpAgent.prototype.getName, this, options);
 
   name += ':';

--- a/test/parallel/test-http-agent-getname.js
+++ b/test/parallel/test-http-agent-getname.js
@@ -18,7 +18,13 @@ assert.strictEqual(
   'localhost:80:192.168.1.1'
 );
 
-// empty
+// empty argument
+assert.strictEqual(
+  agent.getName(),
+  'localhost::'
+);
+
+// empty options
 assert.strictEqual(
   agent.getName({}),
   'localhost::'

--- a/test/parallel/test-https-agent-getname.js
+++ b/test/parallel/test-https-agent-getname.js
@@ -9,6 +9,12 @@ const https = require('https');
 
 const agent = new https.Agent();
 
+// empty argument
+assert.strictEqual(
+  agent.getName(),
+  'localhost::::::::::::::::::::::'
+);
+
 // empty options
 assert.strictEqual(
   agent.getName({}),


### PR DESCRIPTION
http,https: add default argument for Agent.prototype.getName


```js
const https = require('https')
let agent = new https.Agent()
console.log(agent.getName())
```

Before:
```
node:_http_agent:221
  let name = options.host || 'localhost';
                     ^

TypeError: Cannot read properties of undefined (reading 'host')
    at Agent.getName (node:_http_agent:221:22)
    at Agent.getName (node:https:207:14)
    at Object.<anonymous> (/Users/xtx/Desktop/leetcode/test.js:5:19)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```

after:
```js
localhost::::::::::::::::::::::
```