### PR TITLE
debugger: add debugger alias for exec(expr)

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -197,7 +197,8 @@ debug>
 * `watchers`: List all watchers and their values (automatically listed on each
   breakpoint)
 * `repl`: Open debugger's repl for evaluation in debugging script's context
-* `exec expr`: Execute an expression in debugging script's context
+* `exec expr`, `p expr`: Execute an expression in debugging script's context and
+  print its value
 
 ### Execution control
 

--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -68,6 +68,7 @@ const SHORTCUTS = {
   setBreakpoint: 'sb',
   clearBreakpoint: 'cb',
   run: 'r',
+  exec: 'p'
 };
 
 const HELP = StringPrototypeTrim(`
@@ -93,7 +94,8 @@ watch(expr)           Start watching the given expression
 unwatch(expr)         Stop watching an expression
 watchers              Print all watched expressions and their current values
 
-exec(expr)            Evaluate the expression and print the value
+exec(expr), p(expr), exec expr, p expr
+                      Evaluate the expression and print the value
 repl                  Enter a debug repl that works like exec
 
 scripts               List application scripts that are currently loaded
@@ -530,7 +532,7 @@ function createRepl(inspector) {
   function prepareControlCode(input) {
     if (input === '\n') return lastCommand;
     // Add parentheses: exec process.title => exec("process.title");
-    const match = RegExpPrototypeSymbolMatch(/^\s*exec\s+([^\n]*)/, input);
+    const match = RegExpPrototypeSymbolMatch(/^\s*(?:exec|p)\s+([^\n]*)/, input);
     if (match) {
       lastCommand = `exec(${JSONStringify(match[1])})`;
     } else {

--- a/test/sequential/test-debugger-exec.js
+++ b/test/sequential/test-debugger-exec.js
@@ -27,6 +27,14 @@ const assert = require('assert');
         'works w/o paren'
       );
     })
+    .then(() => cli.command('p [typeof heartbeat, typeof process.exit]'))
+    .then(() => {
+      assert.match(
+        cli.output,
+        /\[ 'function', 'function' \]/,
+        'works w/o paren, short'
+      );
+    })
     .then(() => cli.command('repl'))
     .then(() => {
       assert.match(
@@ -52,6 +60,14 @@ const assert = require('assert');
         cli.output,
         /\[ 'function', 'function' \]/,
         'works w/ paren'
+      );
+    })
+    .then(() => cli.command('p("[typeof heartbeat, typeof process.exit]")'))
+    .then(() => {
+      assert.match(
+        cli.output,
+        /\[ 'function', 'function' \]/,
+        'works w/ paren, short'
       );
     })
     .then(() => cli.command('cont'))


### PR DESCRIPTION
https://github.com/nodejs/node/issues/41794

we can now use `p expr` and `p(expr)`:

```
Break on start in test.js:1
> 1 const a = 1;
  2 console.log(a);
debug> n
break in test.js:2
  1 const a = 1;
> 2 console.log(a);
debug> p a
1
debug> p('a')
1
debug> 
```

if this is ok, i will add test and change docs.

@jkrems 