### PR TITLE
fs: fix writev empty array error behavior

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -596,6 +596,10 @@ async function writev(handle, buffers, position) {
   if (typeof position !== 'number')
     position = null;
 
+  if (buffers.length === 0) {
+    return { bytesWritten: 0, buffers };
+  }
+
   const bytesWritten = (await binding.writeBuffers(handle.fd, buffers, position,
                                                    kUsePromises)) || 0;
   return { bytesWritten, buffers };

--- a/test/parallel/test-fs-writev-promises.js
+++ b/test/parallel/test-fs-writev-promises.js
@@ -47,4 +47,13 @@ tmpdir.refresh();
     assert(Buffer.concat(bufferArr).equals(await fs.readFile(filename)));
     handle.close();
   }
+
+  {
+    // Writev with empty array behavior
+    const handle = await fs.open(getFileName(), 'w');
+    const result = await handle.writev([]);
+    assert.strictEqual(result.bytesWritten, 0);
+    assert.strictEqual(result.buffers.length, 0);
+    handle.close();
+  }
 })().then(common.mustCall());


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/41910

Alternatively - we can error on an empty array but I like this behavior better.

cc @nodejs/fs @jasnell 