### PR TITLE
test: use void to indicate "useless" expressions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -257,7 +257,7 @@ module.exports = {
     'no-useless-concat': 'error',
     'no-useless-constructor': 'error',
     'no-useless-return': 'error',
-    'no-void': 'error',
+    'no-void': ['error', { allowAsStatement: true }],
     'no-whitespace-before-property': 'error',
     'object-curly-newline': 'error',
     'object-curly-spacing': ['error', 'always'],

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -475,7 +475,7 @@ function getCallSite(top) {
   const err = new Error();
   Error.captureStackTrace(err, top);
   // With the V8 Error API, the stack is not formatted until it is accessed
-  err.stack; // eslint-disable-line no-unused-expressions
+  void err.stack;
   Error.prepareStackTrace = originalStackFormatter;
   return err.stack;
 }

--- a/test/message/nexttick_throw.js
+++ b/test/message/nexttick_throw.js
@@ -26,8 +26,8 @@ process.nextTick(function() {
   process.nextTick(function() {
     process.nextTick(function() {
       process.nextTick(function() {
-        // eslint-disable-next-line no-undef,no-unused-expressions
-        undefined_reference_error_maker;
+        // eslint-disable-next-line no-undef
+        void undefined_reference_error_maker;
       });
     });
   });

--- a/test/message/timeout_throw.js
+++ b/test/message/timeout_throw.js
@@ -23,6 +23,6 @@
 require('../common');
 
 setTimeout(function() {
-  // eslint-disable-next-line no-undef,no-unused-expressions
-  undefined_reference_error_maker;
+  // eslint-disable-next-line no-undef
+  void undefined_reference_error_maker;
 }, 1);

--- a/test/parallel/test-accessor-properties.js
+++ b/test/parallel/test-accessor-properties.js
@@ -17,7 +17,7 @@ const UDP = internalBinding('udp_wrap').UDP;
 {
   // Should throw instead of raise assertions
   assert.throws(() => {
-    UDP.prototype.fd; // eslint-disable-line no-unused-expressions
+    void UDP.prototype.fd;
   }, TypeError);
 
   const StreamWrapProto = Object.getPrototypeOf(TTY.prototype);
@@ -26,7 +26,7 @@ const UDP = internalBinding('udp_wrap').UDP;
   properties.forEach((property) => {
     // Should throw instead of raise assertions
     assert.throws(() => {
-      TTY.prototype[property]; // eslint-disable-line no-unused-expressions
+      void TTY.prototype[property];
     }, TypeError, `Missing expected TypeError for TTY.prototype.${property}`);
 
     // Should not throw for Object.getOwnPropertyDescriptor
@@ -42,8 +42,7 @@ const UDP = internalBinding('udp_wrap').UDP;
     const crypto = internalBinding('crypto');
 
     assert.throws(() => {
-      // eslint-disable-next-line no-unused-expressions
-      crypto.SecureContext.prototype._external;
+      void crypto.SecureContext.prototype._external;
     }, TypeError);
 
     assert.strictEqual(

--- a/test/parallel/test-buffer-backing-arraybuffer.js
+++ b/test/parallel/test-buffer-backing-arraybuffer.js
@@ -31,7 +31,7 @@ for (const { length, expectOnHeap } of tests) {
                        `for ${array.constructor.name}, length = ${length}`);
 
     // Consistency check: Accessing .buffer should create it.
-    array.buffer; // eslint-disable-line no-unused-expressions
+    void array.buffer;
     assert(arrayBufferViewHasBuffer(array));
   }
 }

--- a/test/parallel/test-buffer-constructor-deprecation-error.js
+++ b/test/parallel/test-buffer-constructor-deprecation-error.js
@@ -14,4 +14,4 @@ process.on('warning', common.mustCall());
 
 Error.prepareStackTrace = (err, trace) => new Buffer(10);
 
-new Error().stack; // eslint-disable-line no-unused-expressions
+void new Error().stack;

--- a/test/parallel/test-buffer-fakes.js
+++ b/test/parallel/test-buffer-fakes.js
@@ -14,7 +14,7 @@ assert.throws(function() {
 }, TypeError);
 
 assert.throws(function() {
-  +Buffer.prototype; // eslint-disable-line no-unused-expressions
+  void +Buffer.prototype;
 }, TypeError);
 
 assert.throws(function() {

--- a/test/parallel/test-child-process-stdin-ipc.js
+++ b/test/parallel/test-child-process-stdin-ipc.js
@@ -27,7 +27,7 @@ const spawn = require('child_process').spawn;
 
 if (process.argv[2] === 'child') {
   // Just reference stdin, it should start it
-  process.stdin; // eslint-disable-line no-unused-expressions
+  void process.stdin;
   return;
 }
 

--- a/test/parallel/test-dgram-deprecation-error.js
+++ b/test/parallel/test-dgram-deprecation-error.js
@@ -31,7 +31,7 @@ const propertyCases = propertiesToTest.map((propName) => {
         `Socket.prototype.${propName} is deprecated`,
         'DEP0112'
       );
-      sock[propName]; // eslint-disable-line no-unused-expressions
+      void sock[propName];
     },
     () => {
       // Test property setter

--- a/test/parallel/test-disable-proto-throw.js
+++ b/test/parallel/test-disable-proto-throw.js
@@ -10,8 +10,8 @@ const { Worker, isMainThread } = require('worker_threads');
 assert(Object.hasOwn(Object.prototype, '__proto__'));
 
 assert.throws(() => {
-  // eslint-disable-next-line no-proto,no-unused-expressions
-  ({}).__proto__;
+  // eslint-disable-next-line no-proto
+  void ({}).__proto__;
 }, {
   code: 'ERR_PROTO_ACCESS'
 });

--- a/test/parallel/test-error-prepare-stack-trace.js
+++ b/test/parallel/test-error-prepare-stack-trace.js
@@ -13,7 +13,7 @@ const assert = require('assert');
   try {
     throw new Error('foo');
   } catch (err) {
-    err.stack; // eslint-disable-line no-unused-expressions
+    void err.stack;
   }
   assert(prepareCalled);
 }

--- a/test/parallel/test-http-outgoing-internal-headernames-getter.js
+++ b/test/parallel/test-http-outgoing-internal-headernames-getter.js
@@ -9,5 +9,5 @@ common.expectWarning('DeprecationWarning', warn, 'DEP0066');
 {
   // Tests for _headerNames get method
   const outgoingMessage = new OutgoingMessage();
-  outgoingMessage._headerNames; // eslint-disable-line no-unused-expressions
+  void outgoingMessage._headerNames;
 }

--- a/test/parallel/test-http-outgoing-internal-headers.js
+++ b/test/parallel/test-http-outgoing-internal-headers.js
@@ -13,7 +13,7 @@ common.expectWarning('DeprecationWarning', warn, 'DEP0066');
   // Tests for _headers get method
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.getHeaders = common.mustCall();
-  outgoingMessage._headers; // eslint-disable-line no-unused-expressions
+  void outgoingMessage._headers;
 }
 
 {

--- a/test/parallel/test-http2-unbound-socket-proxy.js
+++ b/test/parallel/test-http2-unbound-socket-proxy.js
@@ -26,7 +26,7 @@ server.listen(0, common.mustCall(() => {
     // informative error.
     setImmediate(common.mustCall(() => {
       assert.throws(() => {
-        socket.example; // eslint-disable-line no-unused-expressions
+        void socket.example;
       }, {
         code: 'ERR_HTTP2_SOCKET_UNBOUND'
       });
@@ -36,8 +36,7 @@ server.listen(0, common.mustCall(() => {
         code: 'ERR_HTTP2_SOCKET_UNBOUND'
       });
       assert.throws(() => {
-        // eslint-disable-next-line no-unused-expressions
-        socket instanceof net.Socket;
+        void (socket instanceof net.Socket);
       }, {
         code: 'ERR_HTTP2_SOCKET_UNBOUND'
       });

--- a/test/parallel/test-inspector-tracing-domain.js
+++ b/test/parallel/test-inspector-tracing-domain.js
@@ -30,7 +30,7 @@ function post(message, data) {
 function generateTrace() {
   return new Promise((resolve) => setTimeout(() => {
     for (let i = 0; i < 1000000; i++) {
-      'test' + i; // eslint-disable-line no-unused-expressions
+      void ('test' + i);
     }
     resolve();
   }, 1));

--- a/test/parallel/test-internal-iterable-weak-map.js
+++ b/test/parallel/test-internal-iterable-weak-map.js
@@ -24,7 +24,7 @@ Reflect.getPrototypeOf(new Set()[Symbol.iterator]()).next =
   wm.set(_cache.moduleC, 'goodbye');
   delete _cache.moduleB;
   setImmediate(() => {
-    _cache; // eslint-disable-line no-unused-expressions
+    void _cache;
     globalThis.gc();
     const values = [...wm];
     deepStrictEqual(values, ['hello', 'goodbye']);

--- a/test/parallel/test-net-after-close.js
+++ b/test/parallel/test-net-after-close.js
@@ -32,20 +32,18 @@ const server = net.createServer(common.mustCall((s) => {
 server.listen(0, common.mustCall(() => {
   const c = net.createConnection(server.address().port);
   c.on('close', common.mustCall(() => {
-    /* eslint-disable no-unused-expressions */
     console.error('connection closed');
     assert.strictEqual(c._handle, null);
     // Calling functions / accessing properties of a closed socket should not
     // throw.
     c.setNoDelay();
     c.setKeepAlive();
-    c.bufferSize;
+    void c.bufferSize;
     c.pause();
     c.resume();
     c.address();
-    c.remoteAddress;
-    c.remotePort;
+    void c.remoteAddress;
+    void c.remotePort;
     server.close();
-    /* eslint-enable no-unused-expressions */
   }));
 }));

--- a/test/parallel/test-net-during-close.js
+++ b/test/parallel/test-net-during-close.js
@@ -28,15 +28,13 @@ const server = net.createServer(function(socket) {
 });
 
 server.listen(0, common.mustCall(function() {
-  /* eslint-disable no-unused-expressions */
   const client = net.createConnection(this.address().port);
   server.close();
   // Server connection event has not yet fired client is still attempting to
   // connect. Accessing properties should not throw in this case.
-  client.remoteAddress;
-  client.remoteFamily;
-  client.remotePort;
+  void client.remoteAddress;
+  void client.remoteFamily;
+  void client.remotePort;
   // Exit now, do not wait for the client error event.
   process.exit(0);
-  /* eslint-enable no-unused-expressions */
 }));

--- a/test/parallel/test-process-env-windows-error-reset.js
+++ b/test/parallel/test-process-env-windows-error-reset.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 
 {
   process.env.FOO = '';
-  process.env.NONEXISTENT_ENV_VAR; // eslint-disable-line no-unused-expressions
+  void process.env.NONEXISTENT_ENV_VAR;
   const foo = process.env.FOO;
 
   assert.strictEqual(foo, '');
@@ -15,7 +15,7 @@ const assert = require('assert');
 
 {
   process.env.FOO = '';
-  process.env.NONEXISTENT_ENV_VAR; // eslint-disable-line no-unused-expressions
+  void process.env.NONEXISTENT_ENV_VAR;
   const hasFoo = 'FOO' in process.env;
 
   assert.strictEqual(hasFoo, true);

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -29,7 +29,7 @@ const repl = require('repl');
 const cp = require('child_process');
 
 assert.strictEqual(repl.repl, undefined);
-repl._builtinLibs; // eslint-disable-line no-unused-expressions
+void repl._builtinLibs;
 
 common.expectWarning({
   DeprecationWarning: {

--- a/test/parallel/test-source-map-api.js
+++ b/test/parallel/test-source-map-api.js
@@ -54,8 +54,7 @@ const { readFileSync } = require('fs');
     // Require a file that throws an exception, and has a source map.
     require('../fixtures/source-map/typescript-throw.js');
   } catch (err) {
-    // eslint-disable-next-line no-unused-expressions
-    err.stack; // Force prepareStackTrace() to be called.
+    void err.stack; // Force prepareStackTrace() to be called.
   }
   assert(callSite);
   assert(sourceMap);

--- a/test/parallel/test-stdin-hang.js
+++ b/test/parallel/test-stdin-hang.js
@@ -27,6 +27,6 @@ require('../common');
 // If it does, then the test-runner will nuke it.
 
 // invoke the getter.
-process.stdin; // eslint-disable-line no-unused-expressions
+void process.stdin;
 
 console.error('Should exit normally now.');

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -7,12 +7,10 @@ const fixtures = require('../common/fixtures');
 
 if (common.isWindows) {
   if (process.argv[2] === 'child') {
-    /* eslint-disable no-unused-expressions */
-    process.stdin;
-    process.stdout;
-    process.stderr;
+    void process.stdin;
+    void process.stdout;
+    void process.stderr;
     return;
-    /* eslint-enable no-unused-expressions */
   }
   const python = process.env.PYTHON || 'python';
   const script = fixtures.path('spawn_closed_stdio.py');

--- a/test/parallel/test-stdio-pipe-access.js
+++ b/test/parallel/test-stdio-pipe-access.js
@@ -33,6 +33,6 @@ switch (who) {
                        process.stderr ] });
     break;
   case 'bottom':
-    process.stdin; // eslint-disable-line no-unused-expressions
+    void process.stdin;
     break;
 }

--- a/test/parallel/test-tls-external-accessor.js
+++ b/test/parallel/test-tls-external-accessor.js
@@ -12,11 +12,11 @@ const tls = require('tls');
   const pctx = tls.createSecureContext().context;
   const cctx = Object.create(pctx);
   assert.throws(() => cctx._external, TypeError);
-  pctx._external; // eslint-disable-line no-unused-expressions
+  void pctx._external;
 }
 {
   const pctx = tls.createSecurePair().credentials.context;
   const cctx = Object.create(pctx);
   assert.throws(() => cctx._external, TypeError);
-  pctx._external; // eslint-disable-line no-unused-expressions
+  void pctx._external;
 }

--- a/test/parallel/test-trace-events-bootstrap.js
+++ b/test/parallel/test-trace-events-bootstrap.js
@@ -16,7 +16,7 @@ const names = [
 ];
 
 if (process.argv[2] === 'child') {
-  1 + 1; // eslint-disable-line no-unused-expressions
+  void (1 + 1);
 } else {
   tmpdir.refresh();
 

--- a/test/parallel/test-trace-events-environment.js
+++ b/test/parallel/test-trace-events-environment.js
@@ -21,14 +21,12 @@ const names = new Set([
 ]);
 
 if (process.argv[2] === 'child') {
-  /* eslint-disable no-unused-expressions */
   // This is just so that the child has something to do.
-  1 + 1;
+  void (1 + 1);
   // These ensure that the RunTimers, CheckImmediate, and
   // RunAndClearNativeImmediates appear in the list.
-  setImmediate(() => { 1 + 1; });
-  setTimeout(() => { 1 + 1; }, 1);
-  /* eslint-enable no-unused-expressions */
+  setImmediate(() => { void (1 + 1); });
+  setTimeout(() => { void (1 + 1); }, 1);
 } else {
   tmpdir.refresh();
 

--- a/test/parallel/test-vm-module-errors.js
+++ b/test/parallel/test-vm-module-errors.js
@@ -86,7 +86,7 @@ async function checkModuleState() {
 
   assert.throws(() => {
     const m = new SourceTextModule('');
-    m.error; // eslint-disable-line no-unused-expressions
+    void m.error;
   }, {
     code: 'ERR_VM_MODULE_STATUS',
     message: 'Module status must be errored'
@@ -95,7 +95,7 @@ async function checkModuleState() {
   await assert.rejects(async () => {
     const m = await createEmptyLinkedModule();
     await m.evaluate();
-    m.error; // eslint-disable-line no-unused-expressions
+    void m.error;
   }, {
     code: 'ERR_VM_MODULE_STATUS',
     message: 'Module status must be errored'
@@ -103,7 +103,7 @@ async function checkModuleState() {
 
   assert.throws(() => {
     const m = new SourceTextModule('');
-    m.namespace; // eslint-disable-line no-unused-expressions
+    void m.namespace;
   }, {
     code: 'ERR_VM_MODULE_STATUS',
     message: 'Module status must not be unlinked or linking'
@@ -242,18 +242,15 @@ function checkGettersErrors() {
   const getters = ['identifier', 'context', 'namespace', 'status', 'error'];
   getters.forEach((getter) => {
     assert.throws(() => {
-      // eslint-disable-next-line no-unused-expressions
-      Module.prototype[getter];
+      void Module.prototype[getter];
     }, expectedError);
     assert.throws(() => {
-      // eslint-disable-next-line no-unused-expressions
-      SourceTextModule.prototype[getter];
+      void SourceTextModule.prototype[getter];
     }, expectedError);
   });
   // `dependencySpecifiers` getter is just part of SourceTextModule
   assert.throws(() => {
-    // eslint-disable-next-line no-unused-expressions
-    SourceTextModule.prototype.dependencySpecifiers;
+    void SourceTextModule.prototype.dependencySpecifiers;
   }, expectedError);
 }
 

--- a/test/parallel/test-worker-unsupported-things.js
+++ b/test/parallel/test-worker-unsupported-things.js
@@ -51,7 +51,7 @@ if (!process.env.HAS_STARTED_WORKER) {
 
   ['channel', 'connected'].forEach((fn) => {
     assert.throws(() => {
-      process[fn]; // eslint-disable-line no-unused-expressions
+      void process[fn];
     }, {
       code: 'ERR_WORKER_UNSUPPORTED_OPERATION',
       message: `process.${fn} is not supported in workers`


### PR DESCRIPTION
Instead of disabling the `no-unused-expressions` ESLint rule, mark
intentional "useless" expressions with `void`.

Refs: https://eslint.org/docs/rules/no-unused-expressions#options

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
