### PR TITLE
stream: revert map spec compliance

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -69,7 +69,7 @@ for (const key of ObjectKeys(streamReturningOperators)) {
     value: fn,
     enumerable: false,
     configurable: true,
-    writable: false,
+    writable: true,
   });
 }
 for (const key of ObjectKeys(promiseReturningOperators)) {

--- a/test/parallel/test-stream-iterator-helpers-test262-tests.mjs
+++ b/test/parallel/test-stream-iterator-helpers-test262-tests.mjs
@@ -68,7 +68,7 @@ import assert from 'assert';
   );
   assert.strictEqual(descriptor.enumerable, false);
   assert.strictEqual(descriptor.configurable, true);
-  assert.strictEqual(descriptor.writable, false);
+  // assert.strictEqual(descriptor.writable, false);
 }
 {
   // drop/length
@@ -79,7 +79,7 @@ import assert from 'assert';
   );
   assert.strictEqual(descriptor.enumerable, false);
   assert.strictEqual(descriptor.configurable, true);
-  assert.strictEqual(descriptor.writable, false);
+  // assert.strictEqual(descriptor.writable, false);
   // drop/limit-equals-total
   const iterator = Readable.from([1, 2]).drop(2);
   const result = await iterator[Symbol.asyncIterator]().next();


### PR DESCRIPTION
cc @ronag @mcollina 

fixes: https://github.com/nodejs/node/issues/41926

Is there a way to ask this doesn't land on 18 but only 17 and below? 

(If it's an issue I'll just make a follow up revert PR tagged with the appropriate "don't land on" tags)