### PR TITLE
fs: fix cb/sync writev empty array behavior

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -907,7 +907,7 @@ function writev(fd, buffers, position, callback) {
   callback = maybeCallback(callback || position);
 
   if (buffers.length === 0) {
-    callback(null, 0, buffers);
+    process.nextTick(callback, null, 0, buffers);
     return;
   }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -906,6 +906,11 @@ function writev(fd, buffers, position, callback) {
   validateBufferArray(buffers);
   callback = maybeCallback(callback || position);
 
+  if (buffers.length === 0) {
+    callback(null, 0, buffers);
+    return;
+  }
+
   const req = new FSReqCallback();
   req.oncomplete = wrapper;
 
@@ -931,6 +936,10 @@ ObjectDefineProperty(writev, internalUtil.customPromisifyArgs, {
 function writevSync(fd, buffers, position) {
   fd = getValidatedFd(fd);
   validateBufferArray(buffers);
+
+  if (buffers.length === 0) {
+    return 0;
+  }
 
   const ctx = {};
 

--- a/test/parallel/test-fs-writev-sync.js
+++ b/test/parallel/test-fs-writev-sync.js
@@ -56,11 +56,21 @@ const getFileName = (i) => path.join(tmpdir.path, `writev_sync_${i}.txt`);
   assert(Buffer.concat(bufferArr).equals(fs.readFileSync(filename)));
 }
 
+// fs.writevSync with empty array of buffers
+{
+  const filename = getFileName(3);
+  const fd = fs.openSync(filename, 'w');
+  const written = fs.writevSync(fd, []);
+  assert.strictEqual(written, 0);
+  fs.closeSync(fd);
+
+}
+
 /**
  * Testing with wrong input types
  */
 {
-  const filename = getFileName(3);
+  const filename = getFileName(4);
   const fd = fs.openSync(filename, 'w');
 
   [false, 'test', {}, [{}], ['sdf'], null, undefined].forEach((i) => {

--- a/test/parallel/test-fs-writev.js
+++ b/test/parallel/test-fs-writev.js
@@ -63,14 +63,17 @@ const getFileName = (i) => path.join(tmpdir.path, `writev_${i}.txt`);
   const filename = getFileName(3);
   const fd = fs.openSync(filename, 'w');
   const bufferArr = [];
+  let afterSyncCall = false;
 
   const done = common.mustSucceed((written, buffers) => {
     assert.strictEqual(buffers.length, 0);
     assert.strictEqual(written, 0);
+    assert(afterSyncCall);
     fs.closeSync(fd);
   });
 
   fs.writev(fd, bufferArr, done);
+  afterSyncCall = true;
 }
 
 /**

--- a/test/parallel/test-fs-writev.js
+++ b/test/parallel/test-fs-writev.js
@@ -57,11 +57,27 @@ const getFileName = (i) => path.join(tmpdir.path, `writev_${i}.txt`);
   fs.writev(fd, bufferArr, done);
 }
 
+
+// fs.writev with empty array of buffers
+{
+  const filename = getFileName(3);
+  const fd = fs.openSync(filename, 'w');
+  const bufferArr = [];
+
+  const done = common.mustSucceed((written, buffers) => {
+    assert.strictEqual(buffers.length, 0);
+    assert.strictEqual(written, 0);
+    fs.closeSync(fd);
+  });
+
+  fs.writev(fd, bufferArr, done);
+}
+
 /**
  * Testing with wrong input types
  */
 {
-  const filename = getFileName(3);
+  const filename = getFileName(4);
   const fd = fs.openSync(filename, 'w');
 
   [false, 'test', {}, [{}], ['sdf'], null, undefined].forEach((i) => {


### PR DESCRIPTION
This change aligns the cb/sync behavior of writev with the promises one at https://github.com/nodejs/node/pull/41919

I suspect the old behavior was a bug since it wasn't tested or documented so I am treating this as a bug fix rather than a behavior change but I am open to changing that if people feel differently.

Refs: https://github.com/nodejs/node/issues/41910

cc @aduh95 @ronag @JungMinu 