### PR TITLE
stream: revert revert map spec compliance

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -69,7 +69,7 @@ for (const key of ObjectKeys(streamReturningOperators)) {
     value: fn,
     enumerable: false,
     configurable: true,
-    writable: true,
+    writable: false,
   });
 }
 for (const key of ObjectKeys(promiseReturningOperators)) {

--- a/test/parallel/test-stream-iterator-helpers-test262-tests.mjs
+++ b/test/parallel/test-stream-iterator-helpers-test262-tests.mjs
@@ -68,7 +68,7 @@ import assert from 'assert';
   );
   assert.strictEqual(descriptor.enumerable, false);
   assert.strictEqual(descriptor.configurable, true);
-  // assert.strictEqual(descriptor.writable, false);
+  assert.strictEqual(descriptor.writable, false);
 }
 {
   // drop/length
@@ -79,7 +79,7 @@ import assert from 'assert';
   );
   assert.strictEqual(descriptor.enumerable, false);
   assert.strictEqual(descriptor.configurable, true);
-  // assert.strictEqual(descriptor.writable, false);
+  assert.strictEqual(descriptor.writable, false);
   // drop/limit-equals-total
   const iterator = Readable.from([1, 2]).drop(2);
   const result = await iterator[Symbol.asyncIterator]().next();


### PR DESCRIPTION
Reverts nodejs/node#41931

That fix should have been semver-major in retrospect and broke Mongoose in a surprising way. I've also opened a PR to fix the issue in Mongoose.

cc @mcollina @aduh95 @ronag 

(opened a revert PR from GitHub - will amend the commit name)