### PR TITLE
crypto: expose Web Crypto API on the global scope

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -340,5 +340,6 @@ module.exports = {
     Headers: 'readable',
     Request: 'readable',
     Response: 'readable',
+    crypto: 'readable',
   },
 };

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -288,6 +288,14 @@ added: v17.5.0
 
 Enable experimental support for the [Fetch API][].
 
+### `--experimental-global-webcrypto`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Expose the [Web Crypto API][] on the global scope.
+
 ### `--experimental-import-meta-resolve`
 
 <!-- YAML
@@ -1580,6 +1588,7 @@ Node.js options that are allowed are:
 * `--enable-source-maps`
 * `--experimental-abortcontroller`
 * `--experimental-fetch`
+* `--experimental-global-webcrypto`
 * `--experimental-import-meta-resolve`
 * `--experimental-json-modules`
 * `--experimental-loader`
@@ -1982,6 +1991,7 @@ $ node --max-old-space-size=1536 index.js
 [Source Map]: https://sourcemaps.info/spec.html
 [Subresource Integrity]: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
 [V8 JavaScript code coverage]: https://v8project.blogspot.com/2017/12/javascript-code-coverage.html
+[Web Crypto API]: webcrypto.md
 [`"type"`]: packages.md#type
 [`--cpu-prof-dir`]: #--cpu-prof-dir
 [`--diagnostic-dir`]: #--diagnostic-dirdirectory

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -42,11 +42,13 @@ calling `require('crypto')` will result in an error being thrown.
 When using CommonJS, the error thrown can be caught using try/catch:
 
 ```cjs
-let crypto;
-try {
-  crypto = require('crypto');
-} catch (err) {
-  console.log('crypto support is disabled!');
+{
+  let crypto;
+  try {
+    crypto = require('crypto');
+  } catch (err) {
+    console.log('crypto support is disabled!');
+  }
 }
 ```
 

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -307,6 +307,17 @@ added: v0.1.100
 
 Used to print to stdout and stderr. See the [`console`][] section.
 
+## `crypto`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental. Enable this API with the
+> [`--experimental-global-webcrypto`][] CLI flag.
+
+A browser-compatible implementation of the [Web Crypto API][].
+
 ## `Event`
 
 <!-- YAML
@@ -598,7 +609,9 @@ The object that acts as the namespace for all W3C
 [WebAssembly][webassembly-org] related functionality. See the
 [Mozilla Developer Network][webassembly-mdn] for usage and compatibility.
 
+[Web Crypto API]: webcrypto.md
 [`--experimental-fetch`]: cli.md#--experimental-fetch
+[`--experimental-global-webcrypto`]: cli.md#--experimental-global-webcrypto
 [`AbortController`]: https://developer.mozilla.org/en-US/docs/Web/API/AbortController
 [`DOMException`]: https://developer.mozilla.org/en-US/docs/Web/API/DOMException
 [`EventTarget` and `Event` API]: events.md#eventtarget-and-event-api

--- a/doc/node.1
+++ b/doc/node.1
@@ -142,6 +142,9 @@ Enable Source Map V3 support for stack traces.
 .It Fl -experimental-fetch
 Enable experimental support for the Fetch API.
 .
+.It Fl -experimental-global-webcrypto
+Expose the Web Crypto API on the global scope.
+.
 .It Fl -experimental-import-meta-resolve
 Enable experimental ES modules support for import.meta.resolve().
 .

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -79,6 +79,8 @@ rules:
       message: "Use `const { atob } = require('buffer');` instead of the global."
     - name: btoa
       message: "Use `const { btoa } = require('buffer');` instead of the global."
+    - name: crypto
+      message: "Use `const { crypto } = require('internal/crypto/webcrypto');` instead of the global."
     - name: global
       message: "Use `const { globalThis } = primordials;` instead of `global`."
     - name: globalThis

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -36,6 +36,7 @@ function prepareMainThreadExecution(expandArgv1 = false) {
   setupInspectorHooks();
   setupWarningHandler();
   setupFetch();
+  setupWebCrypto();
 
   // Resolve the coverage directory to an absolute path, and
   // overwrite process.env so that the original path gets passed
@@ -160,6 +161,17 @@ function setupFetch() {
   exposeInterface(globalThis, 'Headers', undici.Headers);
   exposeInterface(globalThis, 'Request', undici.Request);
   exposeInterface(globalThis, 'Response', undici.Response);
+}
+
+// TODO(aduh95): move this to internal/bootstrap/browser when the CLI flag is
+//               removed.
+function setupWebCrypto() {
+  if (!getOptionValue('--experimental-global-webcrypto')) {
+    return;
+  }
+
+  const webcrypto = require('internal/crypto/webcrypto');
+  defineOperation(globalThis, 'crypto', webcrypto.crypto);
 }
 
 // Setup User-facing NODE_V8_COVERAGE environment variable that writes
@@ -503,6 +515,7 @@ module.exports = {
   setupCoverageHooks,
   setupWarningHandler,
   setupFetch,
+  setupWebCrypto,
   setupDebugEnv,
   setupPerfHooks,
   prepareMainThreadExecution,

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -18,6 +18,7 @@ const {
   setupInspectorHooks,
   setupWarningHandler,
   setupFetch,
+  setupWebCrypto,
   setupDebugEnv,
   setupPerfHooks,
   initializeDeprecations,
@@ -69,6 +70,7 @@ setupDebugEnv();
 
 setupWarningHandler();
 setupFetch();
+setupWebCrypto();
 initializeSourceMapsHandlers();
 
 // Since worker threads cannot switch cwd, we do not need to

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -319,6 +319,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental Fetch API",
             &EnvironmentOptions::experimental_fetch,
             kAllowedInEnvironment);
+  AddOption("--experimental-global-webcrypto",
+            "expose experimental Web Crypto API on the global scope",
+            &EnvironmentOptions::experimental_global_web_crypto,
+            kAllowedInEnvironment);
   AddOption("--experimental-json-modules", "", NoOp{}, kAllowedInEnvironment);
   AddOption("--experimental-loader",
             "use the specified module as a custom loader",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -108,6 +108,7 @@ class EnvironmentOptions : public Options {
   std::string dns_result_order;
   bool enable_source_maps = false;
   bool experimental_fetch = false;
+  bool experimental_global_web_crypto = false;
   bool experimental_https_modules = false;
   std::string experimental_specifier_resolution;
   bool experimental_wasm_modules = false;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -308,6 +308,9 @@ if (global.fetch) {
     global.Headers,
   );
 }
+if(global.crypto) {
+  knownGlobals.push(global.crypto)
+}
 
 function allowGlobals(...allowlist) {
   knownGlobals = knownGlobals.concat(allowlist);

--- a/test/parallel/test-global-webcrypto.js
+++ b/test/parallel/test-global-webcrypto.js
@@ -1,0 +1,11 @@
+// Flags: --experimental-global-webcrypto
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+assert.strictEqual(globalThis.crypto, crypto.webcrypto);


### PR DESCRIPTION
Expose the Web Crypto on the global scope, like it's done on browsers. When using this flag, the value of `crypto` no longer refer to `require('node:crypto')` in the REPL and in CLI eval context.

Refs: https://developer.mozilla.org/en-US/docs/Web/API/crypto_property
Refs: https://github.com/nodejs/node/pull/41782
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
