### PR TITLE
test: fix intl tests on small-icu builds

### DIFF
--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -106,8 +106,8 @@ if (!common.hasIntl) {
   }
   // If list is specified and doesn't contain 'en-US' then return.
   if (process.config.variables.icu_locales && !haveLocale('en-US')) {
-    common.printSkipMessage(
-      'detailed Intl tests because Node.js was built with small ICU.');
+    common.printSkipMessage('detailed Intl tests because American English is ' +
+                            'not listed as supported.');
     return;
   }
   // Number format resolved options

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -104,6 +104,12 @@ if (!common.hasIntl) {
     const numberFormat = new Intl.NumberFormat(['en']).format(12345.67890);
     assert.strictEqual(numberFormat, '12,345.679');
   }
+  // If list is specified and doesn't contain 'en-US' then return.
+  if (process.config.variables.icu_locales && !haveLocale('en-US')) {
+    common.printSkipMessage(
+      'detailed Intl tests because Node.js was built with small ICU.');
+    return;
+  }
   // Number format resolved options
   {
     const numberFormat = new Intl.NumberFormat('en-US', { style: 'percent' });


### PR DESCRIPTION
I was getting this locally:
```
=== release test-intl ===                                                     
Path: parallel/test-intl
node:assert:123
  throw new AssertionError(obj);
  ^

AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

'en' !== 'en-US'

    at Object.<anonymous> (…/test/parallel/test-intl.js:111:12)
    at Module._compile (node:internal/modules/cjs/loader:1097:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1151:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47 {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: 'en',
  expected: 'en-US',
  operator: 'strictEqual'
}

Node.js v18.0.0-pre
Command: out/Release/node …/test/parallel/test-intl.js
```
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
