### PR TITLE
doc: fix wrong indent in stream documentation

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1737,7 +1737,7 @@ async function showBoth() {
 showBoth();
 ```
 
-### `readable.map(fn[, options])`
+##### `readable.map(fn[, options])`
 
 <!-- YAML
 added:
@@ -1784,7 +1784,7 @@ for await (const result of dnsResults) {
 }
 ```
 
-### `readable.filter(fn[, options])`
+##### `readable.filter(fn[, options])`
 
 <!-- YAML
 added:
@@ -1835,7 +1835,7 @@ for await (const result of dnsResults) {
 }
 ```
 
-### `readable.forEach(fn[, options])`
+##### `readable.forEach(fn[, options])`
 
 <!-- YAML
 added: v17.5.0
@@ -1894,7 +1894,7 @@ await dnsResults.forEach((result) => {
 console.log('done'); // Stream has finished
 ```
 
-### `readable.toArray([options])`
+##### `readable.toArray([options])`
 
 <!-- YAML
 added: v17.5.0
@@ -1932,7 +1932,7 @@ const dnsResults = await Readable.from([
 }, { concurrency: 2 }).toArray();
 ```
 
-### `readable.some(fn[, options])`
+##### `readable.some(fn[, options])`
 
 <!-- YAML
 added: v17.5.0
@@ -1981,7 +1981,7 @@ console.log(anyBigFile); // `true` if any file in the list is bigger than 1MB
 console.log('done'); // Stream has finished
 ```
 
-### `readable.find(fn[, options])`
+##### `readable.find(fn[, options])`
 
 <!-- YAML
 added: v17.5.0
@@ -2031,7 +2031,7 @@ console.log(foundBigFile); // File name of large file, if any file in the list i
 console.log('done'); // Stream has finished
 ```
 
-### `readable.every(fn[, options])`
+##### `readable.every(fn[, options])`
 
 <!-- YAML
 added: v17.5.0
@@ -2080,7 +2080,7 @@ console.log(allBigFiles);
 console.log('done'); // Stream has finished
 ```
 
-### `readable.flatMap(fn[, options])`
+##### `readable.flatMap(fn[, options])`
 
 <!-- YAML
 added: v17.5.0
@@ -2129,7 +2129,7 @@ for await (const result of concatResult) {
 }
 ```
 
-### `readable.drop(limit[, options])`
+##### `readable.drop(limit[, options])`
 
 <!-- YAML
 added: v17.5.0
@@ -2151,7 +2151,7 @@ import { Readable } from 'stream';
 await Readable.from([1, 2, 3, 4]).drop(2).toArray(); // [3, 4]
 ```
 
-### `readable.take(limit[, options])`
+##### `readable.take(limit[, options])`
 
 <!-- YAML
 added: v17.5.0
@@ -2173,7 +2173,7 @@ import { Readable } from 'stream';
 await Readable.from([1, 2, 3, 4]).take(2).toArray(); // [1, 2]
 ```
 
-### `readable.asIndexedPairs([options])`
+##### `readable.asIndexedPairs([options])`
 
 <!-- YAML
 added: v17.5.0
@@ -2197,7 +2197,7 @@ const pairs = await Readable.from(['a', 'b', 'c']).asIndexedPairs().toArray();
 console.log(pairs); // [[0, 'a'], [1, 'b'], [2, 'c']]
 ```
 
-### `readable.reduce(fn[, initial[, options]])`
+##### `readable.reduce(fn[, initial[, options]])`
 
 <!-- YAML
 added: v17.5.0


### PR DESCRIPTION
looks like the indent in stream document is broken:
![image](https://user-images.githubusercontent.com/9262426/153713986-c37f6f2f-ce7c-4340-9a1c-fc0a45106d5c.png)
