### PR TITLE
doc: fix bug in stream doc unshift example

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1586,7 +1586,7 @@ function parseHeader(stream, callback) {
     let chunk;
     while (null !== (chunk = stream.read())) {
       const str = decoder.write(chunk);
-      if (str.match(/\n\n/)) {
+      if (str.includes('\n\n')) {
         // Found the header boundary.
         const split = str.split(/\n\n/);
         header += split.shift();
@@ -1599,10 +1599,10 @@ function parseHeader(stream, callback) {
           stream.unshift(buf);
         // Now the body of the message can be read from the stream.
         callback(null, header, stream);
-      } else {
-        // Still reading the header.
-        header += str;
+        return;
       }
+      // Still reading the header.
+      header += str;
     }
   }
 }


### PR DESCRIPTION
I guess the example should only retrieve the header part, but without `return`, it will keep running.

say we have a file with content:

```
header

body1

body2

body3


```

and with the example:

```javascript
const { StringDecoder } = require('string_decoder');
const fs = require('fs');
const path = require('path');
function parseHeader(stream, callback) {
  stream.on('error', callback);
  stream.on('readable', onReadable);
  const decoder = new StringDecoder('utf8');
  let header = '';
  function onReadable() {
    let chunk;
    while (null !== (chunk = stream.read())) {
      const str = decoder.write(chunk);
      if (str.match(/\n\n/)) {
        // Found the header boundary.
        const split = str.split(/\n\n/);
        header += split.shift();
        const remaining = split.join('\n\n');
        const buf = Buffer.from(remaining, 'utf8');
        stream.removeListener('error', callback);
        // Remove the 'readable' listener before unshifting.
        stream.removeListener('readable', onReadable);
        if (buf.length)
          stream.unshift(buf);
        // Now the body of the message can be read from the stream.
        callback(null, header, stream);
        // return;
      } else {
        // Still reading the header.
        header += str;
      }
    }
  }
}

const fsStream = fs.createReadStream(path.resolve(__dirname, './sample'));
parseHeader(fsStream, (error, header, stream) => {
    console.log(error, header);
});
```

output:

```
null header
null headerbody1
null headerbody1body2
null headerbody1body2body3
```