### PR TITLE
esm: use `[stdin]` as module URL when reading stdin

### DIFF
--- a/lib/internal/main/eval_stdin.js
+++ b/lib/internal/main/eval_stdin.js
@@ -5,6 +5,9 @@
 const {
   prepareMainThreadExecution
 } = require('internal/bootstrap/pre_execution');
+const {
+  pathToFileURL,
+} = require('internal/url');
 
 const { getOptionValue } = require('internal/options');
 
@@ -24,7 +27,7 @@ readStdin((code) => {
 
   const print = getOptionValue('--print');
   if (getOptionValue('--input-type') === 'module')
-    evalModule(code, print);
+    evalModule(code, print, pathToFileURL(`${process.cwd()}/[stdin]`).href);
   else
     evalScript('[stdin]',
                code,

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -90,7 +90,7 @@ class ESMLoader {
   /**
    * The index for assigning unique URLs to anonymous module evaluation
    */
-  evalIndex = 0;
+  #evalIndex = 0;
 
   /**
    * Registry of loaded modules, akin to `require.cache`
@@ -202,7 +202,7 @@ class ESMLoader {
 
   async eval(
     source,
-    url = pathToFileURL(`${process.cwd()}/[eval${++this.evalIndex}]`).href
+    url = pathToFileURL(`${process.cwd()}/[eval${++this.#evalIndex}]`).href
   ) {
     const evalInstance = (url) => {
       const { ModuleWrap, callbackMap } = internalBinding('module_wrap');

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -39,13 +39,13 @@ function tryGetCwd() {
   }
 }
 
-function evalModule(source, print) {
+function evalModule(source, print, url = undefined) {
   if (print) {
     throw new ERR_EVAL_ESM_CANNOT_PRINT();
   }
   const { loadESM } = require('internal/process/esm_loader');
   const { handleMainPromise } = require('internal/modules/run_main');
-  return handleMainPromise(loadESM((loader) => loader.eval(source)));
+  return handleMainPromise(loadESM((loader) => loader.eval(source, url)));
 }
 
 function evalScript(name, body, breakFirstLine, print) {


### PR DESCRIPTION
To align with CJS behavior.

Refs: https://github.com/nodejs/node/pull/41924#issuecomment-1036310450
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
