### PR TITLE
stream: need to cleanup event listeners if last stream is readable

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2575,7 +2575,9 @@ run().catch(console.error);
 
 `stream.pipeline()` leaves dangling event listeners on the streams
 after the `callback` has been invoked. In the case of reuse of streams after
-failure, this can cause event listener leaks and swallowed errors.
+failure, this can cause event listener leaks and swallowed errors. If the last
+stream is readable, dangling event listeners will be removed so that the last
+stream can be consumed later.
 
 `stream.pipeline()` closes all the streams when an error is raised.
 The `IncomingRequest` usage with `pipeline` could lead to an unexpected behavior

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -31,6 +31,7 @@ const {
 
 const {
   isIterable,
+  isReadable,
   isReadableNodeStream,
   isNodeStream,
 } = require('internal/streams/utils');
@@ -50,7 +51,7 @@ function destroyer(stream, reading, writing) {
   });
 
   return {
-    callback: (err) => {
+    destroy: (err) => {
       if (finished) return;
       finished = true;
       destroyImpl.destroyer(stream, err || new ERR_STREAM_DESTROYED('pipe'));
@@ -164,7 +165,7 @@ function pipelineImpl(streams, callback, opts) {
 
   // Need to cleanup event listeners if last stream is readable
   // https://github.com/nodejs/node/issues/35452
-  const lastStreamCleanup = streams[streams.length - 1].readable && [];
+  const lastStreamCleanup = [];
 
   validateAbortSignal(outerSignal, 'options.signal');
 
@@ -202,9 +203,7 @@ function pipelineImpl(streams, callback, opts) {
 
     if (final) {
       if (!error) {
-        while (lastStreamCleanup && lastStreamCleanup.length) {
-          lastStreamCleanup.shift()();
-        }
+        lastStreamCleanup.forEach((fn) => fn());
       }
       process.nextTick(callback, error, value);
     }
@@ -220,10 +219,10 @@ function pipelineImpl(streams, callback, opts) {
 
     if (isNodeStream(stream)) {
       if (end) {
-        const { callback, cleanup } = destroyer(stream, reading, writing);
-        destroys.push(callback);
+        const { destroy, cleanup } = destroyer(stream, reading, writing);
+        destroys.push(destroy);
 
-        if (lastStreamCleanup && isLastStream) {
+        if (isReadable(stream) && isLastStream) {
           lastStreamCleanup.push(cleanup);
         }
       }
@@ -239,7 +238,7 @@ function pipelineImpl(streams, callback, opts) {
         }
       }
       stream.on('error', onError);
-      if (lastStreamCleanup && isLastStream) {
+      if (isReadable(stream) && isLastStream) {
         lastStreamCleanup.push(() => {
           stream.removeListener('error', onError);
         });
@@ -309,13 +308,17 @@ function pipelineImpl(streams, callback, opts) {
 
         ret = pt;
 
-        destroys.push(destroyer(ret, false, true).callback);
+        const { destroy, cleanup } = destroyer(ret, false, true);
+        destroys.push(destroy);
+        if (isLastStream) {
+          lastStreamCleanup.push(cleanup);
+        }
       }
     } else if (isNodeStream(stream)) {
       if (isReadableNodeStream(ret)) {
         finishCount += 2;
         const cleanup = pipe(ret, stream, finish, { end });
-        if (lastStreamCleanup && isLastStream) {
+        if (isReadable(stream) && isLastStream) {
           lastStreamCleanup.push(cleanup);
         }
       } else if (isIterable(ret)) {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -45,14 +45,17 @@ function destroyer(stream, reading, writing) {
     finished = true;
   });
 
-  eos(stream, { readable: reading, writable: writing }, (err) => {
+  const cleanup = eos(stream, { readable: reading, writable: writing }, (err) => {
     finished = !err;
   });
 
-  return (err) => {
-    if (finished) return;
-    finished = true;
-    destroyImpl.destroyer(stream, err || new ERR_STREAM_DESTROYED('pipe'));
+  return {
+    callback: (err) => {
+      if (finished) return;
+      finished = true;
+      destroyImpl.destroyer(stream, err || new ERR_STREAM_DESTROYED('pipe'));
+    },
+    cleanup
   };
 }
 
@@ -159,6 +162,10 @@ function pipelineImpl(streams, callback, opts) {
   const signal = ac.signal;
   const outerSignal = opts?.signal;
 
+  // Need to cleanup event listeners if last stream is readable
+  // https://github.com/nodejs/node/issues/35452
+  const lastStreamCleanup = streams[streams.length - 1].readable && [];
+
   validateAbortSignal(outerSignal, 'options.signal');
 
   function abort() {
@@ -194,6 +201,11 @@ function pipelineImpl(streams, callback, opts) {
     ac.abort();
 
     if (final) {
+      if (!error) {
+        while (lastStreamCleanup && lastStreamCleanup.length) {
+          lastStreamCleanup.shift()();
+        }
+      }
       process.nextTick(callback, error, value);
     }
   }
@@ -204,14 +216,20 @@ function pipelineImpl(streams, callback, opts) {
     const reading = i < streams.length - 1;
     const writing = i > 0;
     const end = reading || opts?.end !== false;
+    const isLastStream = i === streams.length - 1;
 
     if (isNodeStream(stream)) {
       if (end) {
-        destroys.push(destroyer(stream, reading, writing));
+        const { callback, cleanup } = destroyer(stream, reading, writing);
+        destroys.push(callback);
+
+        if (lastStreamCleanup && isLastStream) {
+          lastStreamCleanup.push(cleanup);
+        }
       }
 
       // Catch stream errors that occur after pipe/pump has completed.
-      stream.on('error', (err) => {
+      function onError(err) {
         if (
           err &&
           err.name !== 'AbortError' &&
@@ -219,7 +237,13 @@ function pipelineImpl(streams, callback, opts) {
         ) {
           finish(err);
         }
-      });
+      }
+      stream.on('error', onError);
+      if (lastStreamCleanup && isLastStream) {
+        lastStreamCleanup.push(() => {
+          stream.removeListener('error', onError);
+        });
+      }
     }
 
     if (i === 0) {
@@ -285,12 +309,15 @@ function pipelineImpl(streams, callback, opts) {
 
         ret = pt;
 
-        destroys.push(destroyer(ret, false, true));
+        destroys.push(destroyer(ret, false, true).callback);
       }
     } else if (isNodeStream(stream)) {
       if (isReadableNodeStream(ret)) {
         finishCount += 2;
-        pipe(ret, stream, finish, { end });
+        const cleanup = pipe(ret, stream, finish, { end });
+        if (lastStreamCleanup && isLastStream) {
+          lastStreamCleanup.push(cleanup);
+        }
       } else if (isIterable(ret)) {
         finishCount++;
         pump(ret, stream, finish, { end });
@@ -345,7 +372,7 @@ function pipe(src, dst, finish, { end }) {
       finish(err);
     }
   });
-  eos(dst, { readable: false, writable: true }, finish);
+  return eos(dst, { readable: false, writable: true }, finish);
 }
 
 module.exports = { pipelineImpl, pipeline };

--- a/test/parallel/test-stream-pipeline-listeners.js
+++ b/test/parallel/test-stream-pipeline-listeners.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const common = require('../common');
+const { pipeline, Duplex, PassThrough, Writable } = require('stream');
+const assert = require('assert');
+
+const a = new PassThrough();
+a.end('foobar');
+
+const b = new Duplex({
+  write(chunk, encoding, callback) {
+    callback();
+  }
+});
+
+process.on('uncaughtException', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'no way');
+}, 1));
+
+pipeline(a, b, common.mustCall((error) => {
+  if (error) {
+    assert.ifError(error);
+  }
+
+  // Ensure that listeners is removed if last stream is readble
+  // And other stream's listeners unchanged
+  assert(a.listenerCount('error') > 0);
+  assert.strictEqual(b.listenerCount('error'), 0);
+  setTimeout(() => {
+    assert.strictEqual(b.listenerCount('error'), 0);
+    b.destroy(new Error('no way'));
+  }, 100);
+}));
+
+// If last stream is not readable, will not throw and remove listeners
+const c = new PassThrough();
+c.end('foobar');
+const d = new Writable({
+  write(chunk, encoding, callback) {
+    callback();
+  }
+});
+pipeline(c, d, common.mustCall((error) => {
+  if (error) {
+    assert.ifError(error);
+  }
+
+  assert(c.listenerCount('error') > 0);
+  assert(d.listenerCount('error') > 0);
+  setTimeout(() => {
+    assert(d.listenerCount('error') > 0);
+    d.destroy(new Error('no way'));
+  }, 100);
+}));

--- a/test/parallel/test-stream-pipeline-listeners.js
+++ b/test/parallel/test-stream-pipeline-listeners.js
@@ -4,26 +4,24 @@ const common = require('../common');
 const { pipeline, Duplex, PassThrough, Writable } = require('stream');
 const assert = require('assert');
 
+process.on('uncaughtException', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'no way');
+}, 2));
+
+// Ensure that listeners is removed if last stream is readble
+// And other stream's listeners unchanged
 const a = new PassThrough();
 a.end('foobar');
-
 const b = new Duplex({
   write(chunk, encoding, callback) {
     callback();
   }
 });
-
-process.on('uncaughtException', common.mustCall((err) => {
-  assert.strictEqual(err.message, 'no way');
-}, 1));
-
 pipeline(a, b, common.mustCall((error) => {
   if (error) {
     assert.ifError(error);
   }
 
-  // Ensure that listeners is removed if last stream is readble
-  // And other stream's listeners unchanged
   assert(a.listenerCount('error') > 0);
   assert.strictEqual(b.listenerCount('error'), 0);
   setTimeout(() => {
@@ -32,23 +30,47 @@ pipeline(a, b, common.mustCall((error) => {
   }, 100);
 }));
 
-// If last stream is not readable, will not throw and remove listeners
+// Async generators
 const c = new PassThrough();
 c.end('foobar');
-const d = new Writable({
+const d = pipeline(
+  c,
+  async function* (source) {
+    for await (const chunk of source) {
+      yield String(chunk).toUpperCase();
+    }
+  },
+  common.mustCall((error) => {
+    if (error) {
+      assert.ifError(error);
+    }
+
+    assert(c.listenerCount('error') > 0);
+    assert.strictEqual(d.listenerCount('error'), 0);
+    setTimeout(() => {
+      assert.strictEqual(b.listenerCount('error'), 0);
+      d.destroy(new Error('no way'));
+    }, 100);
+  })
+);
+
+// If last stream is not readable, will not throw and remove listeners
+const e = new PassThrough();
+e.end('foobar');
+const f = new Writable({
   write(chunk, encoding, callback) {
     callback();
   }
 });
-pipeline(c, d, common.mustCall((error) => {
+pipeline(e, f, common.mustCall((error) => {
   if (error) {
     assert.ifError(error);
   }
 
-  assert(c.listenerCount('error') > 0);
-  assert(d.listenerCount('error') > 0);
+  assert(e.listenerCount('error') > 0);
+  assert(f.listenerCount('error') > 0);
   setTimeout(() => {
-    assert(d.listenerCount('error') > 0);
-    d.destroy(new Error('no way'));
+    assert(f.listenerCount('error') > 0);
+    f.destroy(new Error('no way'));
   }, 100);
 }));


### PR DESCRIPTION
fix: https://github.com/nodejs/node/issues/35452

```javascript
const {pipeline, Duplex, PassThrough, Writable} = require('stream');

const a = new PassThrough();
a.end('foobar');

const b = new Duplex({
    write(chunk, encoding, callback) {
        callback();
    }
});

pipeline(a, b, error => {
    if (error) {
        throw error;
    }
    console.log(b.listenerCount('error'));
    setTimeout(() => {
        console.log(b.listenerCount('error'));
        b.destroy(new Error('no way'));
    }, 100);
});
```

output:

```
0
0
node:events:505
      throw er; // Unhandled 'error' event
      ^

Error: no way
```

@ronag @mcollina 