### PR TITLE
events: set default handler value

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -929,7 +929,7 @@ function defineEventHandler(emitter, name) {
   // 8.1.5.1 Event handlers - basically `on[eventName]` attributes
   ObjectDefineProperty(emitter, `on${name}`, {
     get() {
-      return this[kHandlers]?.get(name)?.handler;
+      return this[kHandlers]?.get(name)?.handler ?? null;
     },
     set(value) {
       if (!this[kHandlers]) {

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -408,6 +408,13 @@ let asyncTest = Promise.resolve();
   target.onfoo = common.mustCall();
   target.dispatchEvent(new Event('foo'));
 }
+
+{
+  const target = new EventTarget();
+  defineEventHandler(target, 'foo');
+  strictEqual(target.onfoo, null);
+}
+
 {
   const target = new EventTarget();
   defineEventHandler(target, 'foo');
@@ -623,14 +630,14 @@ let asyncTest = Promise.resolve();
   strictEqual(et.constructor.name, 'EventTarget');
 }
 {
-  // Weak event handlers work
+  // Weak event listeners work
   const et = new EventTarget();
   const listener = common.mustCall();
   et.addEventListener('foo', listener, { [kWeakHandler]: et });
   et.dispatchEvent(new Event('foo'));
 }
 {
-  // Weak event handlers can be removed and weakness is not part of the key
+  // Weak event listeners can be removed and weakness is not part of the key
   const et = new EventTarget();
   const listener = common.mustNotCall();
   et.addEventListener('foo', listener, { [kWeakHandler]: et });


### PR DESCRIPTION
Event handler like BroadcastChannel.onmessage and AbortSignal.onabort
have a default value of `null` but we return `undefined`.

Return `null` and add a test.

Fixes #41963 

cc @bnoordhuis @jasnell @nodejs/events 