### PR TITLE
stream: port more test262 tests

### DIFF
--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -186,7 +186,7 @@ function asIndexedPairs(options = undefined) {
   }.call(this);
 }
 
-async function some(fn, options) {
+async function some(fn, options = undefined) {
   // eslint-disable-next-line no-unused-vars
   for await (const unused of filter.call(this, fn, options)) {
     return true;
@@ -194,7 +194,7 @@ async function some(fn, options) {
   return false;
 }
 
-async function every(fn, options) {
+async function every(fn, options = undefined) {
   if (typeof fn !== 'function') {
     throw new ERR_INVALID_ARG_TYPE(
       'fn', ['Function', 'AsyncFunction'], fn);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -69,12 +69,15 @@ for (const key of ObjectKeys(streamReturningOperators)) {
     value: fn,
     enumerable: false,
     configurable: true,
-    writable: false,
+    writable: true,
   });
 }
 for (const key of ObjectKeys(promiseReturningOperators)) {
   const op = promiseReturningOperators[key];
   function fn(...args) {
+    if (new.target) {
+      throw ERR_ILLEGAL_CONSTRUCTOR();
+    }
     return ReflectApply(op, this, args);
   }
   ObjectDefineProperty(fn, 'name', { value: op.name });
@@ -83,7 +86,7 @@ for (const key of ObjectKeys(promiseReturningOperators)) {
     value: fn,
     enumerable: false,
     configurable: true,
-    writable: false,
+    writable: true,
   });
 }
 Stream.Writable = require('internal/streams/writable');

--- a/test/parallel/test-stream-iterator-helpers-test262-tests.mjs
+++ b/test/parallel/test-stream-iterator-helpers-test262-tests.mjs
@@ -1,4 +1,4 @@
-import '../common/index.mjs';
+import { mustCall } from '../common/index.mjs';
 import { Readable } from 'stream';
 import assert from 'assert';
 
@@ -68,7 +68,7 @@ import assert from 'assert';
   );
   assert.strictEqual(descriptor.enumerable, false);
   assert.strictEqual(descriptor.configurable, true);
-  assert.strictEqual(descriptor.writable, false);
+  assert.strictEqual(descriptor.writable, true);
 }
 {
   // drop/length
@@ -79,7 +79,7 @@ import assert from 'assert';
   );
   assert.strictEqual(descriptor.enumerable, false);
   assert.strictEqual(descriptor.configurable, true);
-  assert.strictEqual(descriptor.writable, false);
+  assert.strictEqual(descriptor.writable, true);
   // drop/limit-equals-total
   const iterator = Readable.from([1, 2]).drop(2);
   const result = await iterator[Symbol.asyncIterator]().next();
@@ -111,5 +111,58 @@ import assert from 'assert';
   // drop/proto
   const proto = Object.getPrototypeOf(Readable.prototype.drop);
   assert.strictEqual(proto, Function.prototype);
+}
+{
+  // every/abrupt-iterator-close
+  const stream = Readable.from([1, 2, 3]);
+  const e = new Error();
+  await assert.rejects(stream.every(mustCall(() => {
+    throw e;
+  }, 1)), e);
+}
+{
+  // every/callable-fn
+  await assert.rejects(Readable.from([1, 2]).every({}), TypeError);
+}
+{
+  // every/callable
+  Readable.prototype.every.call(Readable.from([]), () => {});
+  // eslint-disable-next-line array-callback-return
+  Readable.from([]).every(() => {});
+  assert.throws(() => {
+    const r = Readable.from([]);
+    new r.every(() => {});
+  }, TypeError);
+}
 
+{
+  // every/false
+  const iterator = Readable.from([1, 2, 3]);
+  const result = await iterator.every((v) => v === 1);
+  assert.strictEqual(result, false);
+}
+{
+  // every/every
+  const iterator = Readable.from([1, 2, 3]);
+  const result = await iterator.every((v) => true);
+  assert.strictEqual(result, true);
+}
+
+{
+  // every/is-function
+  assert.strictEqual(typeof Readable.prototype.every, 'function');
+}
+{
+  // every/length
+  assert.strictEqual(Readable.prototype.every.length, 1);
+  // every/name
+  assert.strictEqual(Readable.prototype.every.name, 'every');
+  // every/propdesc
+  const descriptor = Object.getOwnPropertyDescriptor(
+    Readable.prototype,
+    'every'
+  );
+  assert.strictEqual(descriptor.enumerable, false);
+  assert.strictEqual(descriptor.configurable, true);
+  assert.strictEqual(descriptor.writable, true);
 }


### PR DESCRIPTION
Add some test262 tests for `every`, add some `length` checks.

Turns out properties need to be writable after all according to the
test262 tests.

cc @nodejs/streams @aduh95 