### PR TITLE
test: fix names of tests marked flaky on IBM i

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -67,5 +67,5 @@ test-http-client-parse-error: PASS, FLAKY
 test-http-multi-line-headers: PASS, FLAKY
 test-http-server-unconsume: PASS, FLAKY
 test-http-upgrade-advertise: PASS, FLAKY
-test-http-client-mindhsize: PASS, FLAKY
-test-http-tls-write-error: PASS, FLAKY
+test-tls-client-mindhsize: PASS, FLAKY
+test-tls-write-error: PASS, FLAKY


### PR DESCRIPTION
Correct the names of two tests that have been marked `FLAKY` on IBM i
so they will actually be marked as such by the test runner.

Refs: https://github.com/nodejs/node/pull/41812
Refs: https://github.com/nodejs/node/issues/39683

FYI @nodejs/platform-ibmi 

https://ci.nodejs.org/job/node-test-commit-ibmi/670/nodes=ibmi73-ppc64/testReport/junit/
![image](https://user-images.githubusercontent.com/5445507/153983260-6a68c95c-bd43-4b51-9d7a-0ce0b7981bbd.png)


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
