### PR TITLE
doc: fix deprecation number

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3071,7 +3071,7 @@ Type: End-of-Life
 This error code was removed due to adding more confusion to
 the errors used for value type validation.
 
-### DEPXXXX: `process.on('multipleResolves', handler)`
+### DEP0160: `process.on('multipleResolves', handler)`
 
 <!-- YAML
 changes:

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -129,7 +129,7 @@ function promiseRejectHandler(type, promise, reason) {
 const multipleResolvesDeprecate = deprecate(
   () => {},
   'The multipleResolves event has been deprecated.',
-  'DEPXXXX'
+  'DEP0160'
 );
 function resolveError(type, promise, reason) {
   // We have to wrap this in a next tick. Otherwise the error could be caught by

--- a/test/parallel/test-warn-multipleResolves.mjs
+++ b/test/parallel/test-warn-multipleResolves.mjs
@@ -3,7 +3,7 @@ import { expectWarning, mustCall } from '../common/index.mjs';
 expectWarning(
   'DeprecationWarning',
   'The multipleResolves event has been deprecated.',
-  'DEPXXXX',
+  'DEP0160',
 );
 
 process.on('multipleResolves', mustCall());


### PR DESCRIPTION
Can we please agree to stop doing placeholders for deprecation numbers? I'm under the impression it does more harm than good (does it do any good?).

Refs: https://github.com/nodejs/node/pull/41872

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
