### PR TITLE
tools: lint deprecation codes

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1815,6 +1815,10 @@ Type: End-of-Life
 `runInAsyncIdScope` doesn't emit the `'before'` or `'after'` event and can thus
 cause a lot of issues. See <https://github.com/nodejs/node/issues/14328>.
 
+<!-- md-lint skip-deprecation DEP0087 -->
+
+<!-- md-lint skip-deprecation DEP0088 -->
+
 ### DEP0089: `require('assert')`
 
 <!-- YAML
@@ -2255,9 +2259,9 @@ Type: End-of-Life
 The `crypto._toBuf()` function was not designed to be used by modules outside
 of Node.js core and was removed.
 
-### DEP0115: `crypto.prng()`, `crypto.pseudoRandomBytes()`, `crypto.rng()`
-
 <!--lint disable nodejs-yaml-comments -->
+
+### DEP0115: `crypto.prng()`, `crypto.pseudoRandomBytes()`, `crypto.rng()`
 
 <!-- YAML
 changes:
@@ -2269,9 +2273,9 @@ changes:
                  with `--pending-deprecation` support.
 -->
 
-<!--lint enable nodejs-yaml-comments -->
-
 Type: Documentation-only (supports [`--pending-deprecation`][])
+
+<!--lint enable nodejs-yaml-comments -->
 
 In recent versions of Node.js, there is no difference between
 [`crypto.randomBytes()`][] and `crypto.pseudoRandomBytes()`. The latter is

--- a/test/doctool/test-deprecation-codes.js
+++ b/test/doctool/test-deprecation-codes.js
@@ -1,0 +1,28 @@
+'use strict';
+
+require('../common');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const script = path.join(
+  __dirname,
+  '..',
+  '..',
+  'tools',
+  'doc',
+  'deprecationCodes.mjs'
+);
+
+const mdPath = path.join(
+  __dirname,
+  '..',
+  '..',
+  'doc',
+  'api',
+  'deprecations.md'
+);
+
+const cp = spawn(process.execPath, [script, mdPath], { encoding: 'utf-8', stdio: 'inherit' });
+
+cp.on('error', (err) => { throw err; });
+cp.on('exit', (code) => process.exit(code));

--- a/test/parallel/test-eslint-documented-deprecation-codes.js
+++ b/test/parallel/test-eslint-documented-deprecation-codes.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../common');
-if (!common.hasCrypto || !common.hasIntl)
+if (!common.hasCrypto)
   common.skip('missing crypto');
+if (!common.hasIntl)
+  common.skip('missing Intl');
 common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;

--- a/test/parallel/test-eslint-documented-deprecation-codes.js
+++ b/test/parallel/test-eslint-documented-deprecation-codes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../common');
-if (!common.hasCrypto)
+if (!common.hasCrypto || !common.hasIntl)
   common.skip('missing crypto');
 common.skipIfEslintMissing();
 

--- a/test/parallel/test-eslint-documented-deprecation-codes.js
+++ b/test/parallel/test-eslint-documented-deprecation-codes.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+common.skipIfEslintMissing();
+
+const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
+const rule = require('../../tools/eslint-rules/documented-deprecation-codes');
+
+const mdFile = 'doc/api/deprecations.md';
+
+const invalidCode = 'UNDOCUMENTED INVALID CODE';
+
+new RuleTester().run('documented-deprecation-codes', rule, {
+  valid: [
+    `
+    deprecate(function() {
+        return this.getHeaders();
+      }, 'OutgoingMessage.prototype._headers is deprecated', 'DEP0066')
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+        deprecate(function foo(){}, 'bar', '${invalidCode}');
+      `,
+      errors: [
+        {
+          message: `"${invalidCode}" does not match the expected pattern`,
+          line: 2
+        },
+        {
+          message: `"${invalidCode}" is not documented in ${mdFile}`,
+          line: 2
+        },
+      ]
+    },
+  ]
+});

--- a/tools/doc/deprecationCodes.mjs
+++ b/tools/doc/deprecationCodes.mjs
@@ -37,8 +37,8 @@ const testHeading = (headingNode, expectedDeprecationCode) => {
 const testYAMLComment = (commentNode) => {
   try {
     assert.match(
-      commentNode?.value?.substring(0, 19),
-      /<!-- YAML\r?\nchanges:\r?\n/,
+      commentNode?.value?.substring(0, 20),
+      /^<!-- YAML\r?\nchanges:\r?\n/,
       'Missing or ill-formed YAML comment.'
     );
   } catch (e) {

--- a/tools/doc/deprecationCodes.mjs
+++ b/tools/doc/deprecationCodes.mjs
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import { resolve } from 'path';
+import assert from 'assert';
+
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+
+const source = resolve(process.argv[2]);
+
+const skipDeprecationComment = /^<!-- md-lint skip-deprecation (DEP\d{4}) -->$/;
+
+const generateDeprecationCode = (codeAsNumber) =>
+  `DEP${codeAsNumber.toString().padStart(4, '0')}`;
+
+const addMarkdownPathToErrorStack = (error, node) => {
+  const { line, column } = node.position.start;
+  const [header, ...lines] = error.stack.split('\n');
+  error.stack =
+          header +
+          `\n    at <anonymous> (${source}:${line}:${column})\n` +
+          lines.join('\n');
+  return error;
+};
+
+const testHeading = (headingNode, expectedDeprecationCode) => {
+  try {
+    assert.strictEqual(
+      headingNode?.children[0]?.value.substring(0, 9),
+      `${expectedDeprecationCode}: `,
+      'Ill-formed or out-of-order deprecation code.'
+    );
+  } catch (e) {
+    throw addMarkdownPathToErrorStack(e, headingNode);
+  }
+};
+
+const testYAMLComment = (commentNode) => {
+  try {
+    assert.strictEqual(
+      commentNode?.value?.substring(0, 19),
+      '<!-- YAML\nchanges:\n',
+      'Missing or ill-formed YAML comment.'
+    );
+  } catch (e) {
+    throw addMarkdownPathToErrorStack(e, commentNode);
+  }
+};
+
+const testDeprecationType = (paragraphNode) => {
+  try {
+    assert.strictEqual(
+      paragraphNode?.children[0]?.value?.substring(0, 6),
+      'Type: ',
+      'Missing deprecation type.'
+    );
+  } catch (e) {
+    throw addMarkdownPathToErrorStack(e, paragraphNode);
+  }
+};
+
+const tree = unified()
+  .use(remarkParse)
+  .parse(fs.readFileSync(source));
+
+let expectedDeprecationCodeNumber = 0;
+for (let i = 0; i < tree.children.length; i++) {
+  const node = tree.children[i];
+  if (node.type === 'html' && skipDeprecationComment.test(node.value)) {
+    const expectedDeprecationCode =
+          generateDeprecationCode(++expectedDeprecationCodeNumber);
+    const deprecationCodeAsText = node.value.match(skipDeprecationComment)[1];
+
+    try {
+      assert.strictEqual(
+        deprecationCodeAsText,
+        expectedDeprecationCode,
+        'Deprecation codes are not ordered correctly.'
+      );
+    } catch (e) {
+      throw addMarkdownPathToErrorStack(e, node);
+    }
+  }
+  if (node.type === 'heading' && node.depth === 3) {
+    const expectedDeprecationCode =
+          generateDeprecationCode(++expectedDeprecationCodeNumber);
+
+    testHeading(node, expectedDeprecationCode);
+
+    testYAMLComment(tree.children[i + 1]);
+    testDeprecationType(tree.children[i + 2]);
+  }
+}

--- a/tools/doc/deprecationCodes.mjs
+++ b/tools/doc/deprecationCodes.mjs
@@ -37,7 +37,7 @@ const testHeading = (headingNode, expectedDeprecationCode) => {
 const testYAMLComment = (commentNode) => {
   try {
     assert.match(
-      commentNode?.value?.substring(0, 20),
+      commentNode?.value?.substring(0, 21),
       /^<!-- YAML\r?\nchanges:\r?\n/,
       'Missing or ill-formed YAML comment.'
     );

--- a/tools/doc/deprecationCodes.mjs
+++ b/tools/doc/deprecationCodes.mjs
@@ -36,9 +36,9 @@ const testHeading = (headingNode, expectedDeprecationCode) => {
 
 const testYAMLComment = (commentNode) => {
   try {
-    assert.strictEqual(
+    assert.match(
       commentNode?.value?.substring(0, 19),
-      '<!-- YAML\nchanges:\n',
+      /<!-- YAML\r?\nchanges:\r?\n/,
       'Missing or ill-formed YAML comment.'
     );
   } catch (e) {

--- a/tools/eslint-rules/documented-deprecation-codes.js
+++ b/tools/eslint-rules/documented-deprecation-codes.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { isDefiningDeprecation } = require('./rules-utils.js');
+
+const patternToMatch = /^DEP\d+$/;
+
+const mdFile = 'doc/api/deprecations.md';
+const doc = fs.readFileSync(path.resolve(__dirname, '../..', mdFile), 'utf8');
+
+function isInDoc(code) {
+  return doc.includes(`### ${code}:`);
+}
+
+function getDeprecationCode(node) {
+  return node.expression.arguments[2].value;
+}
+
+module.exports = {
+  create: function(context) {
+    return {
+      ExpressionStatement: function(node) {
+        if (!isDefiningDeprecation(node) || !getDeprecationCode(node)) return;
+        const code = getDeprecationCode(node);
+        if (!patternToMatch.test(code)) {
+          const message = `"${code}" does not match the expected pattern`;
+          context.report({ node, message });
+        }
+        if (!isInDoc(code)) {
+          const message = `"${code}" is not documented in ${mdFile}`;
+          context.report({ node, message });
+        }
+      },
+    };
+  },
+};

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -20,6 +20,14 @@ module.exports.isDefiningError = function(node) {
          node.expression.arguments.length !== 0;
 };
 
+module.exports.isDefiningDeprecation = function(node) {
+  return node.expression &&
+         node.expression.type === 'CallExpression' &&
+         node.expression.callee &&
+         node.expression.callee.name.endsWith('deprecate') &&
+         node.expression.arguments.length !== 0;
+};
+
 /**
  * Returns true if any of the passed in modules are used in
  * require calls.


### PR DESCRIPTION
Tentative to resurrect https://github.com/nodejs/node/pull/33433. Now that the CQ is using the "Squash and Merge" GitHub feature, using placeholders for deprecation codes should no longer be allowed IMHO. I think instead we should rely on a lint rule that ensures deprecation codes are uniq and in order.

Backporting to LTS lines out-of-order deprecation codes should still be possible by adding `skip-deprecation` comments.

Blocked on https://github.com/nodejs/node/pull/41990.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
