### PR TITLE
crypto: rename X509_NAME_FLAGS

### DIFF
--- a/src/crypto/crypto_common.cc
+++ b/src/crypto/crypto_common.cc
@@ -41,7 +41,7 @@ using v8::Undefined;
 using v8::Value;
 
 namespace crypto {
-static constexpr int X509_NAME_FLAGS =
+static constexpr int kX509NameFlagsMultiline =
     ASN1_STRFLGS_ESC_2253 |
     ASN1_STRFLGS_ESC_CTRL |
     ASN1_STRFLGS_UTF8_CONVERT |
@@ -940,7 +940,11 @@ MaybeLocal<Value> GetIssuerString(
     const BIOPointer& bio,
     X509* cert) {
   X509_NAME* issuer_name = X509_get_issuer_name(cert);
-  if (X509_NAME_print_ex(bio.get(), issuer_name, 0, X509_NAME_FLAGS) <= 0) {
+  if (X509_NAME_print_ex(
+          bio.get(),
+          issuer_name,
+          0,
+          kX509NameFlagsMultiline) <= 0) {
     USE(BIO_reset(bio.get()));
     return Undefined(env->isolate());
   }
@@ -956,7 +960,7 @@ MaybeLocal<Value> GetSubject(
           bio.get(),
           X509_get_subject_name(cert),
           0,
-          X509_NAME_FLAGS) <= 0) {
+          kX509NameFlagsMultiline) <= 0) {
     USE(BIO_reset(bio.get()));
     return Undefined(env->isolate());
   }


### PR DESCRIPTION
Rename `X509_NAME_FLAGS` to `kX509NameFlagsMultiline`

1. to better align with the naming conventions we use for `constexpr` values,
2. to distinguish it from OpenSSL's built-in `X509` constants, and
3. to clarify what specific X509 name flags the constant represents.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
