### PR TITLE
doc: remove extra <td>

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -1377,7 +1377,6 @@ const { createInterface } = require('readline');
     <td>Any keystroke that emits key code <code>0x1F</code> will do this action.
     In many terminals, for example <code>xterm</code>,
     this is bound to <kbd>Ctrl</kbd>+<kbd>-</kbd>.</td>
-    <td></td>
   </tr>
   <tr>
     <td><kbd>Ctrl</kbd>+<kbd>6</kbd></td>
@@ -1386,7 +1385,6 @@ const { createInterface } = require('readline');
     We choose key code <code>0x1E</code> to perform redo.
     In <code>xterm</code>, it is bound to <kbd>Ctrl</kbd>+<kbd>6</kbd>
     by default.</td>
-    <td></td>
   </tr>
   <tr>
     <td><kbd>Ctrl</kbd>+<kbd>Z</kbd></td>


### PR DESCRIPTION
Remove extra `<td>`