### PR TITLE
tools: fix bugs in prefer-primordials linter rule

### DIFF
--- a/test/parallel/test-eslint-prefer-primordials.js
+++ b/test/parallel/test-eslint-prefer-primordials.js
@@ -99,6 +99,34 @@ new RuleTester({
         `,
         options: [{ name: 'Function' }],
       },
+      {
+        code: 'function identifier() {}',
+        options: [{ name: 'identifier' }]
+      },
+      {
+        code: 'function* identifier() {}',
+        options: [{ name: 'identifier' }]
+      },
+      {
+        code: 'class identifier {}',
+        options: [{ name: 'identifier' }]
+      },
+      {
+        code: 'new class { identifier(){} }',
+        options: [{ name: 'identifier' }]
+      },
+      {
+        code: 'const a = { identifier: \'4\' }',
+        options: [{ name: 'identifier' }]
+      },
+      {
+        code: 'identifier:{const a = 4}',
+        options: [{ name: 'identifier' }]
+      },
+      {
+        code: 'switch(0){case identifier:}',
+        options: [{ name: 'identifier' }]
+      },
     ],
     invalid: [
       {

--- a/tools/eslint-rules/prefer-primordials.js
+++ b/tools/eslint-rules/prefer-primordials.js
@@ -58,7 +58,7 @@ function getDestructuringAssignmentParent(scope, node) {
 }
 
 const parentSelectors = [
-  // We want to select identifier that refer to another reference, not the one
+  // We want to select identifiers that refer to other references, not the ones
   // that create a new reference.
   'ClassDeclaration',
   'FunctionDeclaration',

--- a/tools/eslint-rules/prefer-primordials.js
+++ b/tools/eslint-rules/prefer-primordials.js
@@ -57,8 +57,18 @@ function getDestructuringAssignmentParent(scope, node) {
   return declaration.defs[0].node.init;
 }
 
-const identifierSelector =
-  '[type!=VariableDeclarator][type!=MemberExpression]>Identifier';
+const parentSelectors = [
+  // We want to select identifier that refer to another reference, not the one
+  // that create a new reference.
+  'ClassDeclaration',
+  'FunctionDeclaration',
+  'LabeledStatement',
+  'MemberExpression',
+  'MethodDefinition',
+  'SwitchCase',
+  'VariableDeclarator',
+];
+const identifierSelector = parentSelectors.map((selector) => `[type!=${selector}]`).join('') + '>Identifier';
 
 module.exports = {
   meta: {
@@ -90,6 +100,11 @@ module.exports = {
         reported = new Set();
       },
       [identifierSelector](node) {
+        if (node.parent.type === 'Property' && node.parent.key === node) {
+          // If the identifier is the key for this property declaration, it
+          // can't be referring to a primordials member.
+          return;
+        }
         if (reported.has(node.range[0])) {
           return;
         }


### PR DESCRIPTION
The ESLint rule would repport false positive if code is using an
identifier that happens to have the same name as a primordials member.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
