### PR TITLE
build: prevent concurrent CI and CQ workflow runs

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -8,7 +8,7 @@ on:
     # ./doc/contributing/commit-queue.md
     - cron: '*/5 * * * *'
 
-concurrency: auto-start-ci
+concurrency: ${{ github.workflow }}
 
 env:
   NODE_VERSION: lts/*

--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -8,6 +8,8 @@ on:
     # ./doc/contributing/commit-queue.md
     - cron: '*/5 * * * *'
 
+concurrency: auto-start-ci
+
 env:
   NODE_VERSION: lts/*
 

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -13,7 +13,7 @@ on:
   schedule:
     - cron: '*/5 * * * *'
 
-concurrency: commit-queue
+concurrency: ${{ github.workflow }}
 
 env:
   NODE_VERSION: lts/*

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -13,6 +13,8 @@ on:
   schedule:
     - cron: '*/5 * * * *'
 
+concurrency: commit-queue
+
 env:
   NODE_VERSION: lts/*
 


### PR DESCRIPTION
Use concurrency groups to prevent new runs from being started while a
previous job is already running. This can happen when a lot of unrelated
jobs are pending because of runner exhaustion.

