### PR TITLE
doc: add missing api entries on performance

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -55,6 +55,17 @@ added: v8.5.0
 If `name` is not provided, removes all `PerformanceMark` objects from the
 Performance Timeline. If `name` is provided, removes only the named mark.
 
+### `performance.clearMeasures([name])`
+
+<!-- YAML
+added: v16.7.0
+-->
+
+* `name` {string}
+
+If `name` is not provided, removes all `PerformanceMeasure` objects from the
+Performance Timeline. If `name` is provided, removes only the named mark.
+
 ### `performance.eventLoopUtilization([utilization1[, utilization2]])`
 
 <!-- YAML
@@ -118,6 +129,47 @@ Passing in a user-defined object instead of the result of a previous call to
 `eventLoopUtilization()` will lead to undefined behavior. The return values
 are not guaranteed to reflect any correct state of the event loop.
 
+### `performance.getEntries()`
+
+<!-- YAML
+added: v16.7.0
+-->
+
+* Returns: {PerformanceEntry\[]}
+
+Returns a list of `PerformanceEntry` objects in chronological order with
+respect to `performanceEntry.startTime`. If you are only interested in
+performance entries of certain types or that have certain names, see
+`performance.getEntriesByType()` and `performance.getEntriesByName()`.
+
+### `performance.getEntriesByName(name[, type])`
+
+<!-- YAML
+added: v16.7.0
+-->
+
+* `name` {string}
+* `type` {string}
+* Returns: {PerformanceEntry\[]}
+
+Returns a list of `PerformanceEntry` objects in chronological order
+with respect to `performanceEntry.startTime` whose `performanceEntry.name` is
+equal to `name`, and optionally, whose `performanceEntry.entryType` is equal to
+`type`.
+
+### `performance.getEntriesByType(type)`
+
+<!-- YAML
+added: v16.7.0
+-->
+
+* `type` {string}
+* Returns: {PerformanceEntry\[]}
+
+Returns a list of `PerformanceEntry` objects in chronological order
+with respect to `performanceEntry.startTime` whose `performanceEntry.entryType`
+is equal to `type`.
+
 ### `performance.mark([name[, options]])`
 
 <!-- YAML
@@ -139,6 +191,12 @@ Creates a new `PerformanceMark` entry in the Performance Timeline. A
 `performanceEntry.entryType` is always `'mark'`, and whose
 `performanceEntry.duration` is always `0`. Performance marks are used
 to mark specific significant moments in the Performance Timeline.
+
+The created `PerformanceMark` entry is put in the global performance timeline
+and can be queries with `performance.getEntries`,
+`performance.getEntriesByName`, and `performance.getEntriesByType`. When the
+observation is performed, the entries should be cleared from the global
+performance timeline manually with `performance.clearMarks`.
 
 ### `performance.measure(name[, startMarkOrOptions[, endMark]])`
 
@@ -182,6 +240,12 @@ in the Performance Timeline or any of the timestamp properties provided by the
 `PerformanceNodeTiming` class. `endMark` will be `performance.now()`
 if no parameter is passed, otherwise if the named `endMark` does not exist, an
 error will be thrown.
+
+The created `PerformanceMeasure` entry is put in the global performance timeline
+and can be queries with `performance.getEntries`,
+`performance.getEntriesByName`, and `performance.getEntriesByType`. When the
+observation is performed, the entries should be cleared from the global
+performance timeline manually with `performance.clearMeasures`.
 
 ### `performance.nodeTiming`
 
@@ -258,6 +322,9 @@ const wrapped = performance.timerify(someFunction);
 
 const obs = new PerformanceObserver((list) => {
   console.log(list.getEntries()[0].duration);
+
+  performance.clearMarks();
+  performance.clearMeasures();
   obs.disconnect();
 });
 obs.observe({ entryTypes: ['function'] });
@@ -591,6 +658,9 @@ const {
 
 const obs = new PerformanceObserver((list, observer) => {
   console.log(list.getEntries());
+
+  performance.clearMarks();
+  performance.clearMeasures();
   observer.disconnect();
 });
 obs.observe({ entryTypes: ['mark'], buffered: true });
@@ -706,6 +776,9 @@ const obs = new PerformanceObserver((perfObserverList, observer) => {
    *   }
    * ]
    */
+
+  performance.clearMarks();
+  performance.clearMeasures();
   observer.disconnect();
 });
 obs.observe({ type: 'mark' });
@@ -761,6 +834,9 @@ const obs = new PerformanceObserver((perfObserverList, observer) => {
    * ]
    */
   console.log(perfObserverList.getEntriesByName('test', 'measure')); // []
+
+  performance.clearMarks();
+  performance.clearMeasures();
   observer.disconnect();
 });
 obs.observe({ entryTypes: ['mark', 'measure'] });
@@ -806,6 +882,8 @@ const obs = new PerformanceObserver((perfObserverList, observer) => {
    *   }
    * ]
    */
+  performance.clearMarks();
+  performance.clearMeasures();
   observer.disconnect();
 });
 obs.observe({ type: 'mark' });
@@ -1155,6 +1233,7 @@ hook.enable();
 const obs = new PerformanceObserver((list, observer) => {
   console.log(list.getEntries()[0]);
   performance.clearMarks();
+  performance.clearMeasures();
   observer.disconnect();
 });
 obs.observe({ entryTypes: ['measure'], buffered: true });
@@ -1188,6 +1267,8 @@ const obs = new PerformanceObserver((list) => {
   entries.forEach((entry) => {
     console.log(`require('${entry[0]}')`, entry.duration);
   });
+  performance.clearMarks();
+  performance.clearMeasures();
   obs.disconnect();
 });
 obs.observe({ entryTypes: ['function'], buffered: true });

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -192,11 +192,11 @@ Creates a new `PerformanceMark` entry in the Performance Timeline. A
 `performanceEntry.duration` is always `0`. Performance marks are used
 to mark specific significant moments in the Performance Timeline.
 
-The created `PerformanceMark` entry is put in the global performance timeline
-and can be queries with `performance.getEntries`,
+The created `PerformanceMark` entry is put in the global Performance Timeline
+and can be queried with `performance.getEntries`,
 `performance.getEntriesByName`, and `performance.getEntriesByType`. When the
 observation is performed, the entries should be cleared from the global
-performance timeline manually with `performance.clearMarks`.
+Performance Timeline manually with `performance.clearMarks`.
 
 ### `performance.measure(name[, startMarkOrOptions[, endMark]])`
 
@@ -241,11 +241,11 @@ in the Performance Timeline or any of the timestamp properties provided by the
 if no parameter is passed, otherwise if the named `endMark` does not exist, an
 error will be thrown.
 
-The created `PerformanceMeasure` entry is put in the global performance timeline
-and can be queries with `performance.getEntries`,
+The created `PerformanceMeasure` entry is put in the global Performance Timeline
+and can be queried with `performance.getEntries`,
 `performance.getEntriesByName`, and `performance.getEntriesByType`. When the
 observation is performed, the entries should be cleared from the global
-performance timeline manually with `performance.clearMeasures`.
+Performance Timeline manually with `performance.clearMeasures`.
 
 ### `performance.nodeTiming`
 


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/40755.

These methods are required by the https://w3c.github.io/user-timing/ to clear user-created entries to prevent memory leaking. Currently, the API implementation is tested against WPT suites and we should explicitly document that Node.js supports them.