### PR TITLE
perf_hooks: use arrays to store EntryBuffers

### DIFF
--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -4,12 +4,12 @@ const {
   ArrayFrom,
   ArrayIsArray,
   ArrayPrototypeFilter,
-  ArrayPrototypeFlatMap,
   ArrayPrototypeIncludes,
   ArrayPrototypePush,
   ArrayPrototypePushApply,
   ArrayPrototypeSlice,
   ArrayPrototypeSort,
+  ArrayPrototypeConcat,
   Error,
   ObjectDefineProperties,
   ObjectFreeze,
@@ -34,7 +34,6 @@ const {
 const {
   InternalPerformanceEntry,
   isPerformanceEntry,
-  kBufferNext,
 } = require('internal/perf/performance_entry');
 
 const {
@@ -89,8 +88,8 @@ const kSupportedEntryTypes = ObjectFreeze([
 ]);
 
 // Performance timeline entry Buffers
-const markEntryBuffer = createBuffer();
-const measureEntryBuffer = createBuffer();
+let markEntryBuffer = [];
+let measureEntryBuffer = [];
 const kMaxPerformanceEntryBuffers = 1e6;
 const kClearPerformanceEntryBuffers = ObjectFreeze({
   'mark': 'performance.clearMarks',
@@ -154,9 +153,7 @@ function maybeIncrementObserverCount(type) {
 class PerformanceObserverEntryList {
   constructor(entries) {
     this[kBuffer] = ArrayPrototypeSort(entries, (first, second) => {
-      if (first.startTime < second.startTime) return -1;
-      if (first.startTime > second.startTime) return 1;
-      return 0;
+      return first.startTime - second.startTime;
     });
   }
 
@@ -344,15 +341,8 @@ function enqueue(entry) {
     return;
   }
 
-  const count = buffer.count + 1;
-  buffer.count = count;
-  if (count === 1) {
-    buffer.head = entry;
-    buffer.tail = entry;
-    return;
-  }
-  buffer.tail[kBufferNext] = entry;
-  buffer.tail = entry;
+  ArrayPrototypePush(buffer, entry);
+  const count = buffer.length;
 
   if (count > kMaxPerformanceEntryBuffers &&
     !kWarnedEntryTypes.has(entryType)) {
@@ -372,63 +362,40 @@ function enqueue(entry) {
 }
 
 function clearEntriesFromBuffer(type, name) {
-  let buffer;
-  if (type === 'mark') {
-    buffer = markEntryBuffer;
-  } else if (type === 'measure') {
-    buffer = measureEntryBuffer;
-  } else {
-    return;
-  }
-  if (name === undefined) {
-    resetBuffer(buffer);
+  if (type !== 'mark' && type !== 'measure') {
     return;
   }
 
-  let head = null;
-  let tail = null;
-  let count = 0;
-  for (let entry = buffer.head; entry !== null; entry = entry[kBufferNext]) {
-    if (entry.name !== name) {
-      head = head ?? entry;
-      tail = entry;
-      continue;
-    }
-    if (tail === null) {
-      continue;
-    }
-    tail[kBufferNext] = entry[kBufferNext];
-    count++;
+  if (type === 'mark') {
+    markEntryBuffer = name === undefined ?
+      [] : ArrayPrototypeFilter(markEntryBuffer, (entry) => entry.name !== name);
+  } else {
+    measureEntryBuffer = name === undefined ?
+      [] : ArrayPrototypeFilter(measureEntryBuffer, (entry) => entry.name !== name);
   }
-  buffer.head = head;
-  buffer.tail = tail;
-  buffer.count = count;
 }
 
 function filterBufferMapByNameAndType(name, type) {
   let bufferList;
   if (type === 'mark') {
-    bufferList = [markEntryBuffer];
+    bufferList = markEntryBuffer;
   } else if (type === 'measure') {
-    bufferList = [measureEntryBuffer];
+    bufferList = measureEntryBuffer;
   } else if (type !== undefined) {
     // Unrecognized type;
     return [];
   } else {
-    bufferList = [markEntryBuffer, measureEntryBuffer];
+    bufferList = ArrayPrototypeConcat(markEntryBuffer, measureEntryBuffer);
   }
-  return ArrayPrototypeFlatMap(bufferList,
-                               (buffer) => filterBufferByName(buffer, name));
-}
+  if (name !== undefined) {
+    bufferList = ArrayPrototypeFilter(bufferList, (buffer) => buffer.name === name);
+  } else if (type !== undefined) {
+    bufferList = ArrayPrototypeSlice(bufferList);
+  }
 
-function filterBufferByName(buffer, name) {
-  const arr = [];
-  for (let entry = buffer.head; entry !== null; entry = entry[kBufferNext]) {
-    if (name === undefined || entry.name === name) {
-      ArrayPrototypePush(arr, entry);
-    }
-  }
-  return arr;
+  return ArrayPrototypeSort(bufferList, (first, second) => {
+    return first.startTime - second.startTime;
+  });
 }
 
 function observerCallback(name, type, startTime, duration, details) {
@@ -474,20 +441,6 @@ setupObservers(observerCallback);
 function hasObserver(type) {
   const observerType = getObserverType(type);
   return observerCounts[observerType] > 0;
-}
-
-function createBuffer() {
-  return {
-    head: null,
-    tail: null,
-    count: 0,
-  };
-}
-
-function resetBuffer(buffer) {
-  buffer.head = null;
-  buffer.tail = null;
-  buffer.count = 0;
 }
 
 module.exports = {

--- a/lib/internal/perf/performance_entry.js
+++ b/lib/internal/perf/performance_entry.js
@@ -22,7 +22,6 @@ const kType = Symbol('kType');
 const kStart = Symbol('kStart');
 const kDuration = Symbol('kDuration');
 const kDetail = Symbol('kDetail');
-const kBufferNext = Symbol('kBufferNext');
 
 function isPerformanceEntry(obj) {
   return obj?.[kName] !== undefined;
@@ -72,7 +71,6 @@ class InternalPerformanceEntry {
     this[kStart] = start;
     this[kDuration] = duration;
     this[kDetail] = detail;
-    this[kBufferNext] = null;
   }
 }
 
@@ -85,5 +83,4 @@ module.exports = {
   InternalPerformanceEntry,
   PerformanceEntry,
   isPerformanceEntry,
-  kBufferNext,
 };

--- a/test/parallel/test-performance-timeline.mjs
+++ b/test/parallel/test-performance-timeline.mjs
@@ -1,0 +1,35 @@
+// This file may needs to be updated to wpt:
+// https://github.com/web-platform-tests/wpt
+
+import '../common/index.mjs';
+import assert from 'assert';
+
+import { performance } from 'perf_hooks';
+import { setTimeout } from 'timers/promises';
+
+// Order by startTime
+performance.mark('one');
+await setTimeout(50);
+performance.mark('two');
+await setTimeout(50);
+performance.mark('three');
+await setTimeout(50);
+performance.measure('three', 'three');
+await setTimeout(50);
+performance.measure('two', 'two');
+await setTimeout(50);
+performance.measure('one', 'one');
+const entries = performance.getEntriesByType('measure');
+assert.deepStrictEqual(entries.map((x) => x.name), ['one', 'two', 'three']);
+const allEntries = performance.getEntries();
+assert.deepStrictEqual(allEntries.map((x) => x.name), ['one', 'one', 'two', 'two', 'three', 'three']);
+
+performance.mark('a');
+await setTimeout(50);
+performance.measure('a', 'a');
+await setTimeout(50);
+performance.mark('a');
+await setTimeout(50);
+performance.measure('a', 'one');
+const entriesByName = performance.getEntriesByName('a');
+assert.deepStrictEqual(entriesByName.map((x) => x.entryType), ['measure', 'mark', 'measure', 'mark']);


### PR DESCRIPTION
Fix: https://github.com/nodejs/node/issues/42004
Fix: https://github.com/nodejs/node/issues/42024

#### I'm not using `FixedQueue` as in https://github.com/nodejs/node/issues/42004#issuecomment-1041292872, because

1. `arrays have amortized O(1) allocation` as in https://github.com/nodejs/node/issues/42004#issuecomment-1041995152
2. `FixedQueue` lacks some API like iterating all items or deleting some items.

#### I run the performance test in https://github.com/nodejs/node/issues/42004

```
➜  time ./node slow.js name 10000
20000
./node slow.js name 10000  5.54s user 0.82s system 103% cpu 6.124 total
➜  time ./node slow.js type 10000
10000
./node slow.js type 10000  0.95s user 0.04s system 105% cpu 0.934 total
➜  time ./node fast.js name 10000
20000
./node fast.js name 10000  0.23s user 0.14s system 124% cpu 0.298 total
➜  time ./node fast.js type 10000
10000
./node fast.js type 10000  0.20s user 0.01s system 130% cpu 0.164 total
```

Get by name is faster than before but still slower than `fast.js` notably. That's because:

1. We store all entries with different names in one place, therefore need to use a filter when calling `getEntriesByName`. (Maybe this can change?)
2. We need to sort by `startTime` before output as in https://github.com/nodejs/node/issues/42024.

#### Also tested `.mark` and `.measure` performance

```javascript
const {performance} = require('perf_hooks');

let i = 1000000;
while (i--) {
    performance.mark('aaa');
    performance.measure('bbb', 'aaa');
}
```

output:
```
➜  ./node --version            
v18.0.0-pre
➜  time ./node mark.js
./node mark.js  1.25s user 0.13s system 203% cpu 0.677 total

➜  node --version                
v17.5.0
➜  time node mark.js  
node mark.js  0.84s user 0.08s system 108% cpu 0.844 total
```

There indeed a performance degradation.

I also tried init `markEntryBuffer` with a length () like `let markEntryBuffer = new Array(kMaxPerformanceEntryBuffers);`, the result is not much different.