### PR TITLE
test: validate `EventEmitterAsyncResource` methods throw on invalid this

### DIFF
--- a/test/parallel/test-eventemitter-asyncresource.js
+++ b/test/parallel/test-eventemitter-asyncresource.js
@@ -10,6 +10,7 @@ const {
 const {
   deepStrictEqual,
   strictEqual,
+  throws,
 } = require('assert');
 
 const {
@@ -130,3 +131,29 @@ function makeHook(trackedTypes) {
     ],
   ]));
 })().then(common.mustCall());
+
+// Member methods ERR_INVALID_THIS
+throws(
+  () => EventEmitterAsyncResource.prototype.emit(),
+  { code: 'ERR_INVALID_THIS' }
+);
+
+throws(
+  () => EventEmitterAsyncResource.prototype.emitDestroy(),
+  { code: 'ERR_INVALID_THIS' }
+);
+
+throws(
+  () => Reflect.get(EventEmitterAsyncResource.prototype, 'asyncId', {}),
+  { code: 'ERR_INVALID_THIS' }
+);
+
+throws(
+  () => Reflect.get(EventEmitterAsyncResource.prototype, 'triggerAsyncId', {}),
+  { code: 'ERR_INVALID_THIS' }
+);
+
+throws(
+  () => Reflect.get(EventEmitterAsyncResource.prototype, 'asyncResource', {}),
+  { code: 'ERR_INVALID_THIS' }
+);


### PR DESCRIPTION
This improves a test coverage in `lib/evnets.js`.
ref: https://coverage.nodejs.org/coverage-26f9a91cc9b178d3/lib/events.js.html#L156

This PR add a test that throwing ERR_INVALID_THIS errors in some methods.