### PR TITLE
zlib: move from `instanceof` check  to `new.target` check

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -728,7 +728,7 @@ Zlib.prototype.params = function params(level, strategy, callback) {
 // generic zlib
 // minimal 2-byte header
 function Deflate(opts) {
-  if (!(this instanceof Deflate))
+  if (!new.target)
     return new Deflate(opts);
   ReflectApply(Zlib, this, [opts, DEFLATE]);
 }
@@ -736,7 +736,7 @@ ObjectSetPrototypeOf(Deflate.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Deflate, Zlib);
 
 function Inflate(opts) {
-  if (!(this instanceof Inflate))
+  if (!new.target)
     return new Inflate(opts);
   ReflectApply(Zlib, this, [opts, INFLATE]);
 }
@@ -744,7 +744,7 @@ ObjectSetPrototypeOf(Inflate.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Inflate, Zlib);
 
 function Gzip(opts) {
-  if (!(this instanceof Gzip))
+  if (!new.target)
     return new Gzip(opts);
   ReflectApply(Zlib, this, [opts, GZIP]);
 }
@@ -752,7 +752,7 @@ ObjectSetPrototypeOf(Gzip.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Gzip, Zlib);
 
 function Gunzip(opts) {
-  if (!(this instanceof Gunzip))
+  if (!new.target)
     return new Gunzip(opts);
   ReflectApply(Zlib, this, [opts, GUNZIP]);
 }
@@ -761,7 +761,7 @@ ObjectSetPrototypeOf(Gunzip, Zlib);
 
 function DeflateRaw(opts) {
   if (opts && opts.windowBits === 8) opts.windowBits = 9;
-  if (!(this instanceof DeflateRaw))
+  if (!new.target)
     return new DeflateRaw(opts);
   ReflectApply(Zlib, this, [opts, DEFLATERAW]);
 }
@@ -769,7 +769,7 @@ ObjectSetPrototypeOf(DeflateRaw.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(DeflateRaw, Zlib);
 
 function InflateRaw(opts) {
-  if (!(this instanceof InflateRaw))
+  if (!new.target)
     return new InflateRaw(opts);
   ReflectApply(Zlib, this, [opts, INFLATERAW]);
 }
@@ -777,7 +777,7 @@ ObjectSetPrototypeOf(InflateRaw.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(InflateRaw, Zlib);
 
 function Unzip(opts) {
-  if (!(this instanceof Unzip))
+  if (!new.target)
     return new Unzip(opts);
   ReflectApply(Zlib, this, [opts, UNZIP]);
 }
@@ -853,7 +853,7 @@ ObjectSetPrototypeOf(Brotli.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Brotli, Zlib);
 
 function BrotliCompress(opts) {
-  if (!(this instanceof BrotliCompress))
+  if (!new.target)
     return new BrotliCompress(opts);
   ReflectApply(Brotli, this, [opts, BROTLI_ENCODE]);
 }
@@ -861,7 +861,7 @@ ObjectSetPrototypeOf(BrotliCompress.prototype, Brotli.prototype);
 ObjectSetPrototypeOf(BrotliCompress, Brotli);
 
 function BrotliDecompress(opts) {
-  if (!(this instanceof BrotliDecompress))
+  if (!new.target)
     return new BrotliDecompress(opts);
   ReflectApply(Brotli, this, [opts, BROTLI_DECODE]);
 }


### PR DESCRIPTION
This change is done due to a feature request made [here](https://github.com/nodejs/node/issues/42042) which has better performance and it includes only changes in zlib to allow other first time contributors such as myself to contribute.

Refs: https://github.com/nodejs/node/issues/42042