### PR TITLE
lib: add legacy built-in functions to primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -138,6 +138,8 @@ rules:
     - name: decodeURIComponent
     - name: encodeURI
     - name: encodeURIComponent
+    - name: escape
+    - name: eval
     - name: Error
       ignore:
         - prepareStackTrace
@@ -181,6 +183,7 @@ rules:
     - name: Uint32Array
     - name: Uint8Array
     - name: Uint8ClampedArray
+    - name: unescape
     - name: URIError
     - name: WeakMap
       into: Safe

--- a/lib/internal/freeze_intrinsics.js
+++ b/lib/internal/freeze_intrinsics.js
@@ -122,7 +122,9 @@ const {
   decodeURIComponent,
   encodeURI,
   encodeURIComponent,
+  escape,
   globalThis,
+  unescape,
 } = primordials;
 
 const {
@@ -231,6 +233,7 @@ module.exports = function() {
 
     // 19 The Global Object
     // 19.2 Function Properties of the Global Object
+    // eslint-disable-next-line node-core/prefer-primordials
     eval,
     // eslint-disable-next-line node-core/prefer-primordials
     isFinite,

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -154,6 +154,15 @@ function copyPrototype(src, dest, prefix) {
   primordials[fn.name] = fn;
 });
 
+// Create copies of legacy functions
+[
+  escape,
+  eval,
+  unescape,
+].forEach((fn) => {
+  primordials[fn.name] = fn;
+});
+
 // Create copies of the namespace objects
 [
   'JSON',


### PR DESCRIPTION
Add missing built-in functions to the primordials object. 
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
