### PR TITLE
repl: remove preview when press escape

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -986,7 +986,9 @@ function REPLServer(prompt,
       clearPreview(key);
       if (!reverseSearch(d, key)) {
         ttyWrite(d, key);
-        showPreview();
+        if (key.name !== 'escape') {
+          showPreview();
+        }
       }
       return;
     }

--- a/test/parallel/test-repl-history-navigation.js
+++ b/test/parallel/test-repl-history-navigation.js
@@ -393,7 +393,7 @@ const tests = [
       // 10. Word right. Cleanup
       '\x1B[0K', '\x1B[3G', '\x1B[7C', ' // n', '\x1B[10G',
       // 11. ESCAPE
-      '\x1B[0K', ' // n', '\x1B[10G', '\x1B[0K',
+      '\x1B[0K',
       // 12. ENTER
       '\r\n',
       'Uncaught ReferenceError: functio is not defined\n',


### PR DESCRIPTION
Fix: https://github.com/nodejs/node/issues/42040

This change makes the preview part disappear when pressing `ESCAPE`. 

---

According to https://github.com/nodejs/node/commit/80913e655fef0950be61b5fb97261956f9d2c5bb, when pressing `ESCAPE` before `ENTER`, the preview part will not be included.

without `ESCAPE`:
```
> var add = x => y => x+y
var add = x => y => x+yield  <- ENTER
```
![image](https://user-images.githubusercontent.com/9262426/154804128-5fee8a7e-b543-40d2-ab85-0e6dcda51f4b.png)


with `ESCAPE`:
```
> var add = x => y => x+y
> var add = x => y => x+y <- ESCAPE
var add = x => y => x+y  <- ENTER
```
![image](https://user-images.githubusercontent.com/9262426/154804107-ac537a89-5b66-4663-a75c-349babb947f9.png)

but **it's confusing that the preview part is not removed after pressing `ESCAPE`**, this change makes it more intuitive.
