### PR TITLE
string_decoder: fix crash when calling `__proto__.write()` using JS

### DIFF
--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -42,8 +42,8 @@ const {
 } = internalBinding('string_decoder');
 const internalUtil = require('internal/util');
 const {
-  ERR_ILLEGAL_CONSTRUCTOR,
   ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_THIS,
   ERR_UNKNOWN_ENCODING
 } = require('internal/errors').codes;
 const isEncoding = Buffer[internalUtil.kIsEncodingSymbol];
@@ -103,7 +103,7 @@ StringDecoder.prototype.write = function write(buf) {
                                    ['Buffer', 'TypedArray', 'DataView'],
                                    buf);
   if (!this[kNativeDecoder]) {
-    throw new ERR_ILLEGAL_CONSTRUCTOR();
+    throw new ERR_INVALID_THIS('StringDecoder');
   }
   return decode(this[kNativeDecoder], buf);
 };

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -42,6 +42,7 @@ const {
 } = internalBinding('string_decoder');
 const internalUtil = require('internal/util');
 const {
+  ERR_ILLEGAL_CONSTRUCTOR,
   ERR_INVALID_ARG_TYPE,
   ERR_UNKNOWN_ENCODING
 } = require('internal/errors').codes;
@@ -101,6 +102,9 @@ StringDecoder.prototype.write = function write(buf) {
     throw new ERR_INVALID_ARG_TYPE('buf',
                                    ['Buffer', 'TypedArray', 'DataView'],
                                    buf);
+  if (!this[kNativeDecoder]) {
+    throw new ERR_ILLEGAL_CONSTRUCTOR();
+  }
   return decode(this[kNativeDecoder], buf);
 };
 

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -210,6 +210,13 @@ if (common.enoughTestMem) {
   );
 }
 
+assert.throws(
+  () => new StringDecoder('utf8').__proto__.write(Buffer.from('abc')), // eslint-disable-line no-proto
+  {
+    code: 'ERR_ILLEGAL_CONSTRUCTOR',
+  }
+);
+
 // Test verifies that StringDecoder will correctly decode the given input
 // buffer with the given encoding to the expected output. It will attempt all
 // possible ways to write() the input buffer, see writeSequences(). The

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -213,7 +213,7 @@ if (common.enoughTestMem) {
 assert.throws(
   () => new StringDecoder('utf8').__proto__.write(Buffer.from('abc')), // eslint-disable-line no-proto
   {
-    code: 'ERR_ILLEGAL_CONSTRUCTOR',
+    code: 'ERR_INVALID_THIS',
   }
 );
 


### PR DESCRIPTION
This makes the function throw an exception from JS instead of crashing.

Fixes: https://github.com/nodejs/node/issues/41949
Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
