### PR TITLE
lib: enable global WebCrypto by default

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -322,6 +322,7 @@ module.exports = {
     CompressionStream: 'readable',
     CountQueuingStrategy: 'readable',
     CustomEvent: 'readable',
+    crypto: 'readable',
     Crypto: 'readable',
     CryptoKey: 'readable',
     DecompressionStream: 'readable',

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -351,16 +351,6 @@ added:
 
 Expose the [CustomEvent Web API][] on the global scope.
 
-### `--experimental-global-webcrypto`
-
-<!-- YAML
-added:
-  - v17.6.0
-  - v16.15.0
--->
-
-Expose the [Web Crypto API][] on the global scope.
-
 ### `--experimental-import-meta-resolve`
 
 <!-- YAML
@@ -412,6 +402,14 @@ added: v18.0.0
 -->
 
 Disable experimental support for the [Fetch API][].
+
+### `--no-experimental-global-webcrypto`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Disable exposition of [Web Crypto API][] on the global scope.
 
 ### `--no-experimental-repl-await`
 
@@ -1839,7 +1837,6 @@ Node.js options that are allowed are:
 * `--enable-source-maps`
 * `--experimental-abortcontroller`
 * `--experimental-global-customevent`
-* `--experimental-global-webcrypto`
 * `--experimental-import-meta-resolve`
 * `--experimental-json-modules`
 * `--experimental-loader`
@@ -1872,6 +1869,7 @@ Node.js options that are allowed are:
 * `--no-addons`
 * `--no-deprecation`
 * `--no-experimental-fetch`
+* `--no-experimental-global-webcrypto`
 * `--no-experimental-repl-await`
 * `--no-extra-info-on-fatal-exception`
 * `--no-force-async-hooks-checks`

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -345,10 +345,14 @@ A browser-compatible implementation of [`CountQueuingStrategy`][].
 added:
   - v17.6.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/42083
+    description: No longer behind `--experimental-global-webcrypto` CLI flag.
 -->
 
-> Stability: 1 - Experimental. Enable this API with the
-> [`--experimental-global-webcrypto`][] CLI flag.
+> Stability: 1 - Experimental. Disable this API with the
+> [`--no-experimental-global-webcrypto`][] CLI flag.
 
 A browser-compatible implementation of {Crypto}. This global is available
 only if the Node.js binary was compiled with including support for the
@@ -360,10 +364,14 @@ only if the Node.js binary was compiled with including support for the
 added:
   - v17.6.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/42083
+    description: No longer behind `--experimental-global-webcrypto` CLI flag.
 -->
 
-> Stability: 1 - Experimental. Enable this API with the
-> [`--experimental-global-webcrypto`][] CLI flag.
+> Stability: 1 - Experimental. Disable this API with the
+> [`--no-experimental-global-webcrypto`][] CLI flag.
 
 A browser-compatible implementation of the [Web Crypto API][].
 
@@ -373,10 +381,14 @@ A browser-compatible implementation of the [Web Crypto API][].
 added:
   - v17.6.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/42083
+    description: No longer behind `--experimental-global-webcrypto` CLI flag.
 -->
 
-> Stability: 1 - Experimental. Enable this API with the
-> [`--experimental-global-webcrypto`][] CLI flag.
+> Stability: 1 - Experimental. Disable this API with the
+> [`--no-experimental-global-webcrypto`][] CLI flag.
 
 A browser-compatible implementation of {CryptoKey}. This global is available
 only if the Node.js binary was compiled with including support for the
@@ -725,10 +737,14 @@ The WHATWG [`structuredClone`][] method.
 added:
   - v17.6.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/42083
+    description: No longer behind `--experimental-global-webcrypto` CLI flag.
 -->
 
-> Stability: 1 - Experimental. Enable this API with the
-> [`--experimental-global-webcrypto`][] CLI flag.
+> Stability: 1 - Experimental. Disable this API with the
+> [`--no-experimental-global-webcrypto`][] CLI flag.
 
 A browser-compatible implementation of {SubtleCrypto}. This global is available
 only if the Node.js binary was compiled with including support for the
@@ -870,8 +886,8 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 
 [Web Crypto API]: webcrypto.md
 [`--experimental-global-customevent`]: cli.md#--experimental-global-customevent
-[`--experimental-global-webcrypto`]: cli.md#--experimental-global-webcrypto
 [`--no-experimental-fetch`]: cli.md#--no-experimental-fetch
+[`--no-experimental-global-webcrypto`]: cli.md#--no-experimental-global-webcrypto
 [`AbortController`]: https://developer.mozilla.org/en-US/docs/Web/API/AbortController
 [`ByteLengthQueuingStrategy`]: webstreams.md#class-bytelengthqueuingstrategy
 [`CompressionStream`]: webstreams.md#class-compressionstream

--- a/doc/node.1
+++ b/doc/node.1
@@ -165,6 +165,9 @@ Use this flag to enable ShadowRealm support.
 .It Fl -no-experimental-fetch
 Disable experimental support for the Fetch API.
 .
+.It Fl -no-experimental-global-webcrypto
+Disable exposition of the Web Crypto API on the global scope.
+.
 .It Fl -no-experimental-repl-await
 Disable top-level await keyword support in REPL.
 .

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -5,6 +5,7 @@ const {
   JSONParse,
   JSONStringify,
   ObjectDefineProperties,
+  ObjectDefineProperty,
   ReflectApply,
   ReflectConstruct,
   SafeSet,
@@ -27,6 +28,10 @@ const {
   validateOneOf,
   validateString,
 } = require('internal/validators');
+
+const {
+  getOptionValue,
+} = require('internal/options');
 
 const { TextDecoder, TextEncoder } = require('internal/encoding');
 
@@ -792,14 +797,19 @@ ObjectDefineProperties(
       writable: true,
       value: randomUUID,
     },
-    CryptoKey: {
-      __proto__: null,
-      enumerable: true,
-      configurable: true,
-      writable: true,
-      value: CryptoKey,
-    }
   });
+
+if (getOptionValue('--no-experimental-global-webcrypto')) {
+  // For backward compatibility, keep exposing CryptoKey in the Crypto prototype
+  // when using the flag.
+  ObjectDefineProperty(Crypto.prototype, 'CryptoKey', {
+    __proto__: null,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+    value: CryptoKey,
+  });
+}
 
 ObjectDefineProperties(
   SubtleCrypto.prototype, {

--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -4,6 +4,8 @@
 // `--interactive`.
 
 const {
+  ObjectDefineProperty,
+  RegExpPrototypeExec,
   globalThis,
 } = primordials;
 
@@ -25,9 +27,31 @@ const print = getOptionValue('--print');
 const loadESM = getOptionValue('--import').length > 0;
 if (getOptionValue('--input-type') === 'module')
   evalModule(source, print);
-else
+else {
+  // For backward compatibility, we want the identifier crypto to be the
+  // `node:crypto` module rather than WebCrypto.
+  const isUsingCryptoIdentifier =
+                             getOptionValue('--experimental-global-webcrypto') &&
+                             RegExpPrototypeExec(/\bcrypto\b/, source) !== null;
+  const shouldDefineCrypto = isUsingCryptoIdentifier && internalBinding('config').hasOpenSSL;
+
+  if (isUsingCryptoIdentifier && !shouldDefineCrypto) {
+    // This is taken from `addBuiltinLibsToObject`.
+    const object = globalThis;
+    const name = 'crypto';
+    const setReal = (val) => {
+      // Deleting the property before re-assigning it disables the
+      // getter/setter mechanism.
+      delete object[name];
+      object[name] = val;
+    };
+    ObjectDefineProperty(object, name, { __proto__: null, set: setReal });
+  }
   evalScript('[eval]',
-             source,
+             shouldDefineCrypto ? (
+               print ? `let crypto=require("node:crypto");{${source}}` : `(crypto=>{{${source}}})(require('node:crypto'))`
+             ) : source,
              getOptionValue('--inspect-brk'),
              print,
              loadESM);
+}

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -25,6 +25,7 @@ const {
 
 const {
   ERR_MANIFEST_ASSERT_INTEGRITY,
+  ERR_NO_CRYPTO,
 } = require('internal/errors').codes;
 const assert = require('internal/assert');
 
@@ -247,23 +248,29 @@ function setupFetch() {
 //               removed.
 function setupWebCrypto() {
   if (process.config.variables.node_no_browser_globals ||
-      !getOptionValue('--experimental-global-webcrypto')) {
+      getOptionValue('--no-experimental-global-webcrypto')) {
     return;
   }
 
-  let webcrypto;
-  ObjectDefineProperty(globalThis, 'crypto',
-                       { __proto__: null, ...ObjectGetOwnPropertyDescriptor({
-                         get crypto() {
-                           webcrypto ??= require('internal/crypto/webcrypto');
-                           return webcrypto.crypto;
-                         }
-                       }, 'crypto') });
   if (internalBinding('config').hasOpenSSL) {
-    webcrypto ??= require('internal/crypto/webcrypto');
+    const webcrypto = require('internal/crypto/webcrypto');
+    ObjectDefineProperty(globalThis, 'crypto',
+                         { __proto__: null, ...ObjectGetOwnPropertyDescriptor({
+                           get crypto() {
+                             return webcrypto.crypto;
+                           }
+                         }, 'crypto') });
     exposeInterface(globalThis, 'Crypto', webcrypto.Crypto);
     exposeInterface(globalThis, 'CryptoKey', webcrypto.CryptoKey);
     exposeInterface(globalThis, 'SubtleCrypto', webcrypto.SubtleCrypto);
+  } else {
+    ObjectDefineProperty(globalThis, 'crypto',
+                         { __proto__: null, ...ObjectGetOwnPropertyDescriptor({
+                           get crypto() {
+                             throw new ERR_NO_CRYPTO();
+                           }
+                         }, 'crypto') });
+
   }
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -370,7 +370,8 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--experimental-global-webcrypto",
             "expose experimental Web Crypto API on the global scope",
             &EnvironmentOptions::experimental_global_web_crypto,
-            kAllowedInEnvironment);
+            kAllowedInEnvironment,
+            true);
   AddOption("--experimental-json-modules", "", NoOp{}, kAllowedInEnvironment);
   AddOption("--experimental-loader",
             "use the specified module as a custom loader",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -110,7 +110,7 @@ class EnvironmentOptions : public Options {
   bool enable_source_maps = false;
   bool experimental_fetch = true;
   bool experimental_global_customevent = false;
-  bool experimental_global_web_crypto = false;
+  bool experimental_global_web_crypto = true;
   bool experimental_https_modules = false;
   std::string experimental_specifier_resolution;
   bool experimental_wasm_modules = false;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -357,7 +357,9 @@ if (process.env.NODE_TEST_KNOWN_GLOBALS !== '0') {
     const leaked = [];
 
     for (const val in global) {
-      if (!knownGlobals.includes(global[val])) {
+      // globalThis.crypto is a getter that throws if Node.js was compiled
+      // without OpenSSL.
+      if (val !== 'crypto' && !knownGlobals.includes(global[val])) {
         leaked.push(val);
       }
     }

--- a/test/known_issues/test-cli-print-var-crypto.js
+++ b/test/known_issues/test-cli-print-var-crypto.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+if (!common.hasCrypto) {
+  assert.fail('When Node.js is compiled without OpenSSL, overriding the global ' +
+              'crypto is allowed on string eval');
+}
+
+const child = require('child_process');
+const nodejs = `"${process.execPath}"`;
+
+// Trying to define a variable named `crypto` using `var` triggers an exception.
+
+child.exec(
+  `${nodejs} ` +
+      '-p "var crypto = {randomBytes:1};typeof crypto.randomBytes"',
+  common.mustSucceed((stdout) => {
+    assert.match(stdout, /^number/);
+  }));

--- a/test/parallel/test-assert-checktag.js
+++ b/test/parallel/test-assert-checktag.js
@@ -1,5 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
 const assert = require('assert');
 
 // Disable colored output to prevent color codes from breaking assertion

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -206,6 +206,17 @@ if (common.hasIntl) {
   expectedModules.add('NativeModule url');
 }
 
+if (common.hasCrypto) {
+  expectedModules.add('Internal Binding crypto')
+    .add('NativeModule internal/crypto/hash')
+    .add('NativeModule internal/crypto/hashnames')
+    .add('NativeModule internal/crypto/keys')
+    .add('NativeModule internal/crypto/random')
+    .add('NativeModule internal/crypto/util')
+    .add('NativeModule internal/crypto/webcrypto')
+    .add('NativeModule internal/streams/lazy_transform');
+}
+
 if (process.features.inspector) {
   expectedModules.add('Internal Binding inspector');
   expectedModules.add('NativeModule internal/inspector_async_hook');

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -288,3 +288,69 @@ child.exec(
   common.mustSucceed((stdout) => {
     assert.strictEqual(stdout, '.mjs file\n');
   }));
+
+if (common.hasCrypto) {
+  // Assert that calls to crypto utils work without require.
+  child.exec(
+    `${nodejs} ` +
+      '-e "console.log(crypto.randomBytes(16).toString(\'hex\'))"',
+    common.mustSucceed((stdout) => {
+      assert.match(stdout, /[0-9a-f]{32}/i);
+    }));
+  child.exec(
+    `${nodejs} ` +
+      '-p "crypto.randomBytes(16).toString(\'hex\')"',
+    common.mustSucceed((stdout) => {
+      assert.match(stdout, /[0-9a-f]{32}/i);
+    }));
+}
+// Assert that overriding crypto works.
+child.exec(
+  `${nodejs} ` +
+      '-p "crypto=Symbol(\'test\')"',
+  common.mustSucceed((stdout) => {
+    assert.match(stdout, /Symbol\(test\)/i);
+  }));
+child.exec(
+  `${nodejs} ` +
+    '-e "crypto = {};console.log(\'randomBytes\', typeof crypto.randomBytes)"',
+  common.mustSucceed((stdout) => {
+    assert.match(stdout, /randomBytes\sundefined/);
+  }));
+// Assert that overriding crypto with a local variable works.
+child.exec(
+  `${nodejs} ` +
+    '-e "const crypto = {};console.log(\'randomBytes\', typeof crypto.randomBytes)"',
+  common.mustSucceed((stdout) => {
+    assert.match(stdout, /randomBytes\sundefined/);
+  }));
+child.exec(
+  `${nodejs} ` +
+    '-e "let crypto = {};console.log(\'randomBytes\', typeof crypto.randomBytes)"',
+  common.mustSucceed((stdout) => {
+    assert.match(stdout, /randomBytes\sundefined/);
+  }));
+child.exec(
+  `${nodejs} ` +
+    '-e "var crypto = {};console.log(\'randomBytes\', typeof crypto.randomBytes)"',
+  common.mustSucceed((stdout) => {
+    assert.match(stdout, /randomBytes\sundefined/);
+  }));
+child.exec(
+  `${nodejs} ` +
+    '-p "const crypto = {randomBytes:1};typeof crypto.randomBytes"',
+  common.mustSucceed((stdout) => {
+    assert.match(stdout, /^number/);
+  }));
+child.exec(
+  `${nodejs} ` +
+    '-p "let crypto = {randomBytes:1};typeof crypto.randomBytes"',
+  common.mustSucceed((stdout) => {
+    assert.match(stdout, /^number/);
+  }));
+child.exec(
+  `${nodejs} --no-experimental-global-webcrypto ` +
+    '-p "var crypto = {randomBytes:1};typeof crypto.randomBytes"',
+  common.mustSucceed((stdout) => {
+    assert.match(stdout, /^number/);
+  }));

--- a/test/parallel/test-crypto-subtle-zero-length.js
+++ b/test/parallel/test-crypto-subtle-zero-length.js
@@ -15,7 +15,7 @@ const crypto = require('crypto').webcrypto;
     { name: 'AES-GCM' },
     false,
     [ 'encrypt', 'decrypt' ]);
-  assert(k instanceof crypto.CryptoKey);
+  assert(k instanceof CryptoKey);
 
   const e = await crypto.subtle.encrypt({
     name: 'AES-GCM',

--- a/test/parallel/test-global-webcrypto-classes.js
+++ b/test/parallel/test-global-webcrypto-classes.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-global-webcrypto --expose-internals
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-global-webcrypto-disbled.js
+++ b/test/parallel/test-global-webcrypto-disbled.js
@@ -1,0 +1,10 @@
+// Flags: --no-experimental-global-webcrypto
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(typeof crypto, 'undefined');
+assert.strictEqual(typeof Crypto, 'undefined');
+assert.strictEqual(typeof CryptoKey, 'undefined');
+assert.strictEqual(typeof SubtleCrypto, 'undefined');

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -57,6 +57,7 @@ builtinModules.forEach((moduleName) => {
     'setTimeout',
     'structuredClone',
     'fetch',
+    'crypto',
   ];
   assert.deepStrictEqual(new Set(Object.keys(global)), new Set(expected));
 }

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -9,7 +9,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const { types: { isCryptoKey } } = require('util');
 const {
-  webcrypto: { subtle, CryptoKey },
+  webcrypto: { subtle },
   createSecretKey,
   KeyObject,
 } = require('crypto');


### PR DESCRIPTION
Enables `--experimental-global-webcrypto` by default, and ensures that the classic `node:crypto` core module is still available in `--eval` or `--print` contexts.

Currently this PR takes the route of breaking how the REPL can access the `node:crypto` module – currently the global `crypto` in REPL refers to `node:crypto`, with this PR it now refers to the Web Crypto API.
This PR takes the route of keeping `node:crypto` available when evaluating a string from a CLI flag (e.g. `node -p 'crypto.randomBytes(16).toString("hex")'`) to avoid breaking the ecosystem (see https://github.com/nodejs/node/pull/41779#issuecomment-1041547561).

IMO it makes sense to keep the REPL global `crypto` same as when parsing files, but I don't have a strong opinion and it's easy to change if the consensus disagrees with me.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
