### PR TITLE
build: add corepack to the auto-updated dependencies

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -26,6 +26,7 @@ jobs:
           - id: corepack
             run: |
               make corepack-update
+              echo "NEW_VERSION=$(node deps/corepack/dist/corepack.js --version)" >> $GITHUB_ENV
           - id: lint-md-dependencies
             run: |
               cd tools/lint-md

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -23,6 +23,9 @@ jobs:
                 echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
                 ./update-eslint.sh
               fi
+          - id: corepack
+            run: |
+              make corepack-update
           - id: lint-md-dependencies
             run: |
               cd tools/lint-md

--- a/Makefile
+++ b/Makefile
@@ -1119,12 +1119,14 @@ pkg: $(PKG)
 
 .PHONY: corepack-update
 corepack-update:
-	rm -rf /tmp/node-corepack-clone
-	git clone 'https://github.com/nodejs/corepack.git' /tmp/node-corepack-clone
-	cd /tmp/node-corepack-clone && yarn pack
-	rm -rf deps/corepack && mkdir -p deps/corepack
-	cd deps/corepack && tar xf /tmp/node-corepack-clone/package.tgz --strip-components=1
+	mkdir -p /tmp/node-corepack
+	wget -q "$$(npm view corepack dist.tarball)" -O /tmp/node-corepack/package.tgz
+
+	rm -rf deps/corepack && mkdir deps/corepack
+	cd deps/corepack && tar xf /tmp/node-corepack/package.tgz --strip-components=1
 	chmod +x deps/corepack/shims/*
+
+	node deps/corepack/dist/corepack.js --version
 
 .PHONY: pkg-upload
 # Note: this is strictly for release builds on release machines only.

--- a/Makefile
+++ b/Makefile
@@ -1120,7 +1120,7 @@ pkg: $(PKG)
 .PHONY: corepack-update
 corepack-update:
 	mkdir -p /tmp/node-corepack
-	wget -q "$$(npm view corepack dist.tarball)" -O /tmp/node-corepack/package.tgz
+	curl -qLo /tmp/node-corepack/package.tgz "$$(npm view corepack dist.tarball)"
 
 	rm -rf deps/corepack && mkdir deps/corepack
 	cd deps/corepack && tar xf /tmp/node-corepack/package.tgz --strip-components=1


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This diff auto-updates Corepack when new releases are made on the npm package.

Requested in https://github.com/nodejs/admin/issues/660#issuecomment-1041463292
