### PR TITLE
crypto: add KeyObject.prototype.equals method

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2090,7 +2090,7 @@ added: REPLACEME
 
 * `otherKeyObject`: {KeyObject} A `KeyObject` with which to
   compare `keyObject`.
-* Returns: {boolean} `true` or `false` depending on the whether the
+* Returns: {boolean} `true` or `false` depending on whether the
   keys have exactly the same type, value, and parameters.
 
 ### `keyObject.symmetricKeySize`

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2090,8 +2090,11 @@ added: REPLACEME
 
 * `otherKeyObject`: {KeyObject} A `KeyObject` with which to
   compare `keyObject`.
-* Returns: {boolean} `true` or `false` depending on whether the
-  keys have exactly the same type, value, and parameters.
+* Returns: {boolean}
+
+Returns `true` or `false` depending on whether the keys have exactly the same
+type, value, and parameters. This method is not 
+[constant time](https://en.wikipedia.org/wiki/Timing_attack).
 
 ### `keyObject.symmetricKeySize`
 

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2093,7 +2093,7 @@ added: REPLACEME
 * Returns: {boolean}
 
 Returns `true` or `false` depending on whether the keys have exactly the same
-type, value, and parameters. This method is not 
+type, value, and parameters. This method is not
 [constant time](https://en.wikipedia.org/wiki/Timing_attack).
 
 ### `keyObject.symmetricKeySize`

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2082,6 +2082,17 @@ encryption mechanism, PEM-level encryption is not supported when encrypting
 a PKCS#8 key. See [RFC 5208][] for PKCS#8 encryption and [RFC 1421][] for
 PKCS#1 and SEC1 encryption.
 
+### `keyObject.equals(otherKeyObject)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `otherKeyObject`: {KeyObject} A `KeyObject` with which to
+  compare `keyObject`.
+* Returns: {boolean} `true` or `false` depending on the whether the
+  keys have exactly the same type, value, and parameters.
+
 ### `keyObject.symmetricKeySize`
 
 <!-- YAML

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -124,6 +124,16 @@ const {
         throw new ERR_INVALID_ARG_TYPE('key', 'CryptoKey', key);
       return key[kKeyObject];
     }
+
+    equals(otherKeyObject) {
+      if (!isKeyObject(otherKeyObject)) {
+        throw new ERR_INVALID_ARG_TYPE(
+          'otherKeyObject', 'KeyObject', otherKeyObject);
+      }
+
+      return otherKeyObject.type === this.type &&
+        this[kHandle].equals(otherKeyObject[kHandle]);
+    }
   }
 
   class SecretKeyObject extends KeyObject {

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1161,9 +1161,13 @@ void KeyObjectHandle::Equals(const FunctionCallbackInfo<Value>& args) {
     case kKeyTypePublic:
       // Fall through
     case kKeyTypePrivate:
-      ret = EVP_PKEY_eq(
-        key->GetAsymmetricKey().get(),
-        key2->GetAsymmetricKey().get()) == 1;
+      if (EVP_PKEY_id(key->GetAsymmetricKey().get()) ==
+        EVP_PKEY_id(key2->GetAsymmetricKey().get())) {
+        ret = EVP_PKEY_eq(
+          key->GetAsymmetricKey().get(),
+          key2->GetAsymmetricKey().get()) == 1;
+      } else {ret = false;
+      }
       break;
     default:
       CHECK(false);

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1153,7 +1153,7 @@ void KeyObjectHandle::Equals(const FunctionCallbackInfo<Value>& args) {
         ret = CRYPTO_memcmp(
           key->GetSymmetricKey(),
           key2->GetSymmetricKey(),
-          key->GetSymmetricKeySize()) == 0;
+          size) == 0;
       else
         ret = false;
       break;

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1164,11 +1164,11 @@ void KeyObjectHandle::Equals(const FunctionCallbackInfo<Value>& args) {
       EVP_PKEY* pkey = key->GetAsymmetricKey().get();
       EVP_PKEY* pkey2 = key2->GetAsymmetricKey().get();
       if (EVP_PKEY_id(pkey) == EVP_PKEY_id(pkey2)) {
-        #if OPENSSL_VERSION_MAJOR >= 3
+#if OPENSSL_VERSION_MAJOR >= 3
           ret = EVP_PKEY_eq(pkey, pkey2) == 1;
-        #else
+#else
           ret = EVP_PKEY_cmp(pkey, pkey2) == 1;
-        #endif
+#endif
       } else {
         ret = false;
       }

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1160,16 +1160,15 @@ void KeyObjectHandle::Equals(const FunctionCallbackInfo<Value>& args) {
     }
     case kKeyTypePublic:
       // Fall through
-    case kKeyTypePrivate:
-      if (EVP_PKEY_id(key->GetAsymmetricKey().get()) ==
-        EVP_PKEY_id(key2->GetAsymmetricKey().get())) {
-        ret = EVP_PKEY_eq(
-          key->GetAsymmetricKey().get(),
-          key2->GetAsymmetricKey().get()) == 1;
-      } else {
+    case kKeyTypePrivate: {
+      EVP_PKEY* fkey = key->GetAsymmetricKey().get();
+      EVP_PKEY* fkey2 = key2->GetAsymmetricKey().get();
+      if (EVP_PKEY_id(fkey) == EVP_PKEY_id(fkey2))
+        ret = EVP_PKEY_eq(fkey, fkey2) == 1;
+      else
         ret = false;
-      }
       break;
+    }
     default:
       CHECK(false);
   }

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1165,15 +1165,16 @@ void KeyObjectHandle::Equals(const FunctionCallbackInfo<Value>& args) {
     case kKeyTypePrivate: {
       EVP_PKEY* pkey = key->GetAsymmetricKey().get();
       EVP_PKEY* pkey2 = key2->GetAsymmetricKey().get();
-      if (EVP_PKEY_id(pkey) == EVP_PKEY_id(pkey2)) {
 #if OPENSSL_VERSION_MAJOR >= 3
-          ret = EVP_PKEY_eq(pkey, pkey2) == 1;
+      int ok = EVP_PKEY_eq(pkey, pkey2);
 #else
-          ret = EVP_PKEY_cmp(pkey, pkey2) == 1;
+      int ok = EVP_PKEY_cmp(pkey, pkey2);
 #endif
-      } else {
-        ret = false;
+      if (ok == -2) {
+        Environment* env = Environment::GetCurrent(args);
+        return THROW_ERR_CRYPTO_UNSUPPORTED_OPERATION(env);
       }
+      ret = ok == 1;
       break;
     }
     default:

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1166,7 +1166,8 @@ void KeyObjectHandle::Equals(const FunctionCallbackInfo<Value>& args) {
         ret = EVP_PKEY_eq(
           key->GetAsymmetricKey().get(),
           key2->GetAsymmetricKey().get()) == 1;
-      } else {ret = false;
+      } else {
+        ret = false;
       }
       break;
     default:

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1178,7 +1178,7 @@ void KeyObjectHandle::Equals(const FunctionCallbackInfo<Value>& args) {
       break;
     }
     default:
-      CHECK(false);
+      UNREACHABLE("unsupported key type");
   }
 
   args.GetReturnValue().Set(ret);

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1161,12 +1161,17 @@ void KeyObjectHandle::Equals(const FunctionCallbackInfo<Value>& args) {
     case kKeyTypePublic:
       // Fall through
     case kKeyTypePrivate: {
-      EVP_PKEY* fkey = key->GetAsymmetricKey().get();
-      EVP_PKEY* fkey2 = key2->GetAsymmetricKey().get();
-      if (EVP_PKEY_id(fkey) == EVP_PKEY_id(fkey2))
-        ret = EVP_PKEY_eq(fkey, fkey2) == 1;
-      else
+      EVP_PKEY* pkey = key->GetAsymmetricKey().get();
+      EVP_PKEY* pkey2 = key2->GetAsymmetricKey().get();
+      if (EVP_PKEY_id(pkey) == EVP_PKEY_id(pkey2)) {
+        #if OPENSSL_VERSION_MAJOR >= 3
+          ret = EVP_PKEY_eq(pkey, pkey2) == 1;
+        #else
+          ret = EVP_PKEY_cmp(pkey, pkey2) == 1;
+        #endif
+      } else {
         ret = false;
+      }
       break;
     }
     default:

--- a/src/crypto/crypto_keys.h
+++ b/src/crypto/crypto_keys.h
@@ -189,6 +189,7 @@ class KeyObjectHandle : public BaseObject {
   static void InitEDRaw(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void InitJWK(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetKeyDetail(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Equals(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static void ExportJWK(const v8::FunctionCallbackInfo<v8::Value>& args);
 

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -885,3 +885,20 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert(!first.privateKey.equals(second.publicKey));
   assert(!first.privateKey.equals(secret));
 }
+
+{
+  const first = generateKeyPairSync('ed25519');
+  const second = generateKeyPairSync('ed448');
+
+  assert(first.publicKey.equals(first.publicKey));
+  assert(first.publicKey.equals(createPublicKey(
+    first.publicKey.export({ format: 'pem', type: 'spki' }))));
+  assert(!first.publicKey.equals(second.publicKey));
+  assert(!first.publicKey.equals(second.privateKey));
+
+  assert(first.privateKey.equals(first.privateKey));
+  assert(first.privateKey.equals(createPrivateKey(
+    first.privateKey.export({ format: 'pem', type: 'pkcs8' }))));
+  assert(!first.privateKey.equals(second.privateKey));
+  assert(!first.privateKey.equals(second.publicKey));
+}

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -890,15 +890,8 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   const first = generateKeyPairSync('ed25519');
   const second = generateKeyPairSync('ed448');
 
-  assert(first.publicKey.equals(first.publicKey));
-  assert(first.publicKey.equals(createPublicKey(
-    first.publicKey.export({ format: 'pem', type: 'spki' }))));
   assert(!first.publicKey.equals(second.publicKey));
   assert(!first.publicKey.equals(second.privateKey));
-
-  assert(first.privateKey.equals(first.privateKey));
-  assert(first.privateKey.equals(createPrivateKey(
-    first.privateKey.export({ format: 'pem', type: 'pkcs8' }))));
   assert(!first.privateKey.equals(second.privateKey));
   assert(!first.privateKey.equals(second.publicKey));
 }

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -21,6 +21,7 @@ const {
   privateDecrypt,
   privateEncrypt,
   getCurves,
+  generateKeySync,
   generateKeyPairSync,
   webcrypto,
 } = require('crypto');
@@ -845,4 +846,42 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   ).then((cryptoKey) => {
     assert(!isKeyObject(cryptoKey));
   });
+}
+
+{
+  const first = Buffer.from('Hello');
+  const second = Buffer.from('World');
+  const keyObject = createSecretKey(first);
+  assert(createSecretKey(first).equals(createSecretKey(first)));
+  assert(!createSecretKey(first).equals(createSecretKey(second)));
+
+  assert.throws(() => keyObject.equals(0), {
+    name: 'TypeError',
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: `The "otherKeyObject" argument must be an instance of KeyObject. Received type number (0)`
+  });
+
+  assert(keyObject.equals(keyObject));
+  assert(!keyObject.equals(createPublicKey(publicPem)));
+  assert(!keyObject.equals(createPrivateKey(privatePem)));
+}
+
+{
+  const first = generateKeyPairSync('ed25519');
+  const second = generateKeyPairSync('ed25519');
+  const secret = generateKeySync('aes', { length: 128 });
+
+  assert(first.publicKey.equals(first.publicKey));
+  assert(first.publicKey.equals(createPublicKey(
+    first.publicKey.export({ format: 'pem', type: 'spki' }))));
+  assert(!first.publicKey.equals(second.publicKey));
+  assert(!first.publicKey.equals(second.privateKey));
+  assert(!first.publicKey.equals(secret));
+
+  assert(first.privateKey.equals(first.privateKey));
+  assert(first.privateKey.equals(createPrivateKey(
+    first.privateKey.export({ format: 'pem', type: 'pkcs8' }))));
+  assert(!first.privateKey.equals(second.privateKey));
+  assert(!first.privateKey.equals(second.publicKey));
+  assert(!first.privateKey.equals(secret));
 }

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -858,7 +858,7 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.throws(() => keyObject.equals(0), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: `The "otherKeyObject" argument must be an instance of KeyObject. Received type number (0)`
+    message: 'The "otherKeyObject" argument must be an instance of KeyObject. Received type number (0)'
   });
 
   assert(keyObject.equals(keyObject));


### PR DESCRIPTION
This PR adds a way to compare KeyObject instances without having to export their values.