### PR TITLE
errors: do not access .stack in debug

### DIFF
--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -106,7 +106,7 @@ const prepareStackTrace = (globalThis, error, trace) => {
         }
       }
     } catch (err) {
-      debug(err.stack);
+      debug(err);
     }
     return `${str}${t}`;
   }), '');

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -79,7 +79,7 @@ function maybeCacheSourceMap(filename, content, cjsModuleInstance) {
   } catch (err) {
     // This is most likely an [eval]-wrapper, which is currently not
     // supported.
-    debug(err.stack);
+    debug(err);
     return;
   }
   const match = StringPrototypeMatch(
@@ -119,7 +119,7 @@ function dataFromUrl(sourceURL, sourceMappingURL) {
         return null;
     }
   } catch (err) {
-    debug(err.stack);
+    debug(err);
     // If no scheme is present, we assume we are dealing with a file path.
     const mapURL = new URL(sourceMappingURL, sourceURL).href;
     return sourceMapFromFile(mapURL);
@@ -144,7 +144,7 @@ function sourceMapFromFile(mapURL) {
     const data = JSONParse(content);
     return sourcesToAbsolute(mapURL, data);
   } catch (err) {
-    debug(err.stack);
+    debug(err);
     return null;
   }
 }
@@ -163,7 +163,7 @@ function sourceMapFromDataUrl(sourceURL, url) {
       const parsedData = JSONParse(decodedData);
       return sourcesToAbsolute(sourceURL, parsedData);
     } catch (err) {
-      debug(err.stack);
+      debug(err);
       return null;
     }
   } else {


### PR DESCRIPTION
Preparing the stack was causing performance issues for some users (see: #41541). `.message` should be sufficient for debugging purposes when developing (let's switch to this).

Refs: #41541

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
