### PR TITLE
src: do not ignore return value of BIO_reset

### DIFF
--- a/src/crypto/crypto_common.cc
+++ b/src/crypto/crypto_common.cc
@@ -302,7 +302,7 @@ Local<Value> ToV8Value(Environment* env, const BIOPointer& bio) {
           mem->data,
           NewStringType::kNormal,
           mem->length);
-  USE(BIO_reset(bio.get()));
+  CHECK_EQ(BIO_reset(bio.get()), 1);
   return ret.FromMaybe(Local<Value>());
 }
 
@@ -925,7 +925,7 @@ v8::MaybeLocal<v8::Value> GetSubjectAltNameString(
   CHECK_NOT_NULL(ext);
 
   if (!SafeX509SubjectAltNamePrint(bio, ext)) {
-    USE(BIO_reset(bio.get()));
+    CHECK_EQ(BIO_reset(bio.get()), 1);
     return v8::Null(env->isolate());
   }
 
@@ -944,7 +944,7 @@ v8::MaybeLocal<v8::Value> GetInfoAccessString(
   CHECK_NOT_NULL(ext);
 
   if (!SafeX509InfoAccessPrint(bio, ext)) {
-    USE(BIO_reset(bio.get()));
+    CHECK_EQ(BIO_reset(bio.get()), 1);
     return v8::Null(env->isolate());
   }
 
@@ -961,7 +961,7 @@ MaybeLocal<Value> GetIssuerString(
           issuer_name,
           0,
           kX509NameFlagsMultiline) <= 0) {
-    USE(BIO_reset(bio.get()));
+    CHECK_EQ(BIO_reset(bio.get()), 1);
     return Undefined(env->isolate());
   }
 
@@ -977,7 +977,7 @@ MaybeLocal<Value> GetSubject(
           X509_get_subject_name(cert),
           0,
           kX509NameFlagsMultiline) <= 0) {
-    USE(BIO_reset(bio.get()));
+    CHECK_EQ(BIO_reset(bio.get()), 1);
     return Undefined(env->isolate());
   }
 


### PR DESCRIPTION
The `USE` macro indicates that a value is intentionally ignored. Instead, `CHECK` that the function succeeds.

These are always in-memory `BIO`s so we don't expect `BIO_reset` to ever fail. Either way, we should `CHECK` that assumption.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
