### PR TITLE
perf_hooks: getEntriesBy[Name|Type](undefined) should not return all the entries

### DIFF
--- a/lib/internal/perf/performance.js
+++ b/lib/internal/perf/performance.js
@@ -9,6 +9,7 @@ const {
 const {
   codes: {
     ERR_ILLEGAL_CONSTRUCTOR,
+    ERR_MISSING_ARGS
   }
 } = require('internal/errors');
 
@@ -86,16 +87,18 @@ function getEntries() {
 }
 
 function getEntriesByName(name) {
-  if (name !== undefined) {
-    name = `${name}`;
+  if (arguments.length === 0) {
+    throw new ERR_MISSING_ARGS('name');
   }
+  name = `${name}`;
   return filterBufferMapByNameAndType(name, undefined);
 }
 
 function getEntriesByType(type) {
-  if (type !== undefined) {
-    type = `${type}`;
+  if (arguments.length === 0) {
+    throw new ERR_MISSING_ARGS('type');
   }
+  type = `${type}`;
   return filterBufferMapByNameAndType(undefined, type);
 }
 

--- a/test/parallel/test-performance-timeline.mjs
+++ b/test/parallel/test-performance-timeline.mjs
@@ -33,3 +33,18 @@ await setTimeout(50);
 performance.measure('a', 'one');
 const entriesByName = performance.getEntriesByName('a');
 assert.deepStrictEqual(entriesByName.map((x) => x.entryType), ['measure', 'mark', 'measure', 'mark']);
+
+// getEntriesBy[Name|Type](undefined)
+performance.mark(undefined);
+assert.strictEqual(performance.getEntriesByName(undefined).length, 1);
+assert.strictEqual(performance.getEntriesByType(undefined).length, 0);
+assert.throws(() => performance.getEntriesByName(), {
+  name: 'TypeError',
+  message: 'The "name" argument must be specified',
+  code: 'ERR_MISSING_ARGS'
+});
+assert.throws(() => performance.getEntriesByType(), {
+  name: 'TypeError',
+  message: 'The "type" argument must be specified',
+  code: 'ERR_MISSING_ARGS'
+});


### PR DESCRIPTION
Fix: https://github.com/nodejs/node/issues/42028
