### PR TITLE
build: downgrade Windows 8.1 and server 2012 R2 to experimental

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -109,9 +109,9 @@ platforms. This is true regardless of entries in the table below.
 | GNU/Linux        | armv6            | kernel >= 4.14, glibc >= 2.24   | Experimental                                    | Downgraded as of Node.js 12               |
 | GNU/Linux        | ppc64le >=power8 | kernel >= 3.10.0, glibc >= 2.17 | Tier 2                                          | e.g. Ubuntu 16.04[^1], EL 7[^2]           |
 | GNU/Linux        | s390x            | kernel >= 3.10.0, glibc >= 2.17 | Tier 2                                          | e.g. EL 7[^2]                             |
-| Windows          | x64, x86 (WoW64) | >= Windows 8.1/2012 R2          | Tier 1                                          | [^4],[^5]                                 |
-| Windows          | x86 (native)     | >= Windows 8.1/2012 R2          | Tier 1 (running) / Experimental (compiling)[^6] |                                           |
-| Windows          | x64, x86         | Windows Server 2012 (not R2)    | Experimental                                    |                                           |
+| Windows          | x64, x86 (WoW64) | >= Windows 10/Server 2016       | Tier 1                                          | [^4],[^5]                                 |
+| Windows          | x86 (native)     | >= Windows 10/Server 2016       | Tier 1 (running) / Experimental (compiling)[^6] |                                           |
+| Windows          | x64, x86         | Windows 8.1/Server 2012         | Experimental                                    |                                           |
 | Windows          | arm64            | >= Windows 10                   | Tier 2 (compiling) / Experimental (running)     |                                           |
 | macOS            | x64              | >= 10.13                        | Tier 1                                          | For notes about compilation see [^7]      |
 | macOS            | arm64            | >= 11                           | Tier 1                                          |                                           |


### PR DESCRIPTION
Both versions will be end of life in 2023, before the end of Node.js 18.

Refs: https://docs.microsoft.com/en-us/lifecycle/products/windows-81
Refs: https://docs.microsoft.com/en-us/lifecycle/products/windows-server-2012-r2
