### PR TITLE
build: add configure option --v8-enable-short-builtin-calls

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -782,6 +782,13 @@ parser.add_argument('--v8-enable-hugepage',
     help='Enable V8 transparent hugepage support. This feature is only '+
          'available on Linux platform.')
 
+parser.add_argument('--v8-enable-short-builtin-calls',
+    action='store_true',
+    dest='v8_enable_short_builtin_calls',
+    default=None,
+    help='Enable V8 short builtin calls support. This feature is enabled '+
+         'on x86_64 platform by default.')
+
 parser.add_argument('--node-builtin-modules-path',
     action='store',
     dest='node_builtin_modules_path',
@@ -1464,6 +1471,8 @@ def configure_v8(o):
   if flavor != 'linux' and options.v8_enable_hugepage:
     raise Exception('--v8-enable-hugepage is supported only on linux.')
   o['variables']['v8_enable_hugepage'] = 1 if options.v8_enable_hugepage else 0
+  if options.v8_enable_short_builtin_calls or o['variables']['target_arch'] == 'x64':
+    o['variables']['v8_enable_short_builtin_calls'] = 1
 
 def configure_openssl(o):
   variables = o['variables']

--- a/tools/v8_gypfiles/features.gypi
+++ b/tools/v8_gypfiles/features.gypi
@@ -132,6 +132,9 @@
     'v8_enable_pointer_compression%': 0,
     'v8_enable_31bit_smis_on_64bit_arch%': 0,
 
+    # Sets -dV8_SHORT_BUILTIN_CALLS
+    'v8_enable_short_builtin_calls%': 0,
+
     # Sets -dOBJECT_PRINT.
     'v8_enable_object_print%': 0,
 
@@ -293,6 +296,9 @@
       }],
       ['v8_enable_pointer_compression==1 or v8_enable_31bit_smis_on_64bit_arch==1', {
         'defines': ['V8_31BIT_SMIS_ON_64BIT_ARCH',],
+      }],
+      ['v8_enable_short_builtin_calls==1', {
+        'defines': ['V8_SHORT_BUILTIN_CALLS',],
       }],
       ['v8_enable_zone_compression==1', {
         'defines': ['V8_COMPRESS_ZONES',],


### PR DESCRIPTION
Add configure option --v8-enable-short-builtin-calls
and enable it by default on x86_64 platform.