### PR TITLE
node-api: fix lambda typo in node_api.cc comment

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -36,7 +36,7 @@ v8::Maybe<bool> node_napi_env__::mark_arraybuffer_as_untransferable(
 void node_napi_env__::CallFinalizer(napi_finalize cb, void* data, void* hint) {
   // we need to keep the env live until the finalizer has been run
   // EnvRefHolder provides an exception safe wrapper to Ref and then
-  // Unref once the lamba is freed
+  // Unref once the lambda is freed
   EnvRefHolder liveEnv(static_cast<napi_env>(this));
   node_env()->SetImmediate(
       [=, liveEnv = std::move(liveEnv)](node::Environment* node_env) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fix small code comment in `node_api.cc`:

`lamba` -> `lambda`