### PR TITLE
test: fix test-process-env-tz.js by using RegExp

### DIFF
--- a/test/parallel/test-process-env-tz.js
+++ b/test/parallel/test-process-env-tz.js
@@ -31,19 +31,19 @@ if (date.toString().includes('(Central European Time)') ||
   common.skip('tzdata too old');
 }
 
-assert.strictEqual(
-  date.toString().replace('Central European Summer Time', 'CEST'),
-  'Sat Apr 14 2018 14:34:56 GMT+0200 (CEST)');
+assert.match(
+  date.toString(),
+  /^Sat Apr 14 2018 14:34:56 GMT\+0200 \(.+\)$/);
 
 process.env.TZ = 'Europe/London';
-assert.strictEqual(
-  date.toString().replace('British Summer Time', 'BST'),
-  'Sat Apr 14 2018 13:34:56 GMT+0100 (BST)');
+assert.match(
+  date.toString(),
+  /^Sat Apr 14 2018 13:34:56 GMT\+0100 \(.+\)$/);
 
 process.env.TZ = 'Etc/UTC';
-assert.strictEqual(
-  date.toString().replace('Coordinated Universal Time', 'UTC'),
-  'Sat Apr 14 2018 12:34:56 GMT+0000 (UTC)');
+assert.match(
+  date.toString(),
+  /^Sat Apr 14 2018 12:34:56 GMT\+0000 \(.+\)$/);
 
 // Just check that deleting the environment variable doesn't crash the process.
 // We can't really check the result of date.toString() because we don't know


### PR DESCRIPTION
Not all environment returns 'Central European Summer Time', 'British
Summer Time' and 'Coordinated Universal Time'. E.g. Some environment
like Chinese returns '中欧夏令时间', '英国夏令时间' and '协调世界时'.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
