### PR TITLE
esm: fix relative imports for https

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -1125,7 +1125,7 @@ async function defaultResolve(specifier, context = {}, defaultResolveUnused) {
         )
       )
     ) {
-      return { url: specifier };
+      return { url: parsed.href };
     }
   } catch {
     // Ignore exception

--- a/test/es-module/test-http-imports.mjs
+++ b/test/es-module/test-http-imports.mjs
@@ -61,6 +61,10 @@ for (const { protocol, createServer } of [
     const host = new URL(base);
     host.protocol = protocol;
     host.hostname = hostname;
+    // /not-found is a 404
+    // ?redirect causes a redirect, no body. JSON.parse({status:number,location:string})
+    // ?mime sets the content-type, string
+    // ?body sets the body, string
     const server = createServer(function(_req, res) {
       const url = new URL(_req.url, host);
       const redirect = url.searchParams.get('redirect');
@@ -133,6 +137,15 @@ for (const { protocol, createServer } of [
     assert.strict.equal(depsNS.data, 1);
     assert.strict.equal(depsNS.http, ns);
 
+    const relativeDeps = new URL(url.href);
+    relativeDeps.searchParams.set('body', `
+      import * as http from "./";
+      export {http};
+    `);
+    const relativeDepsNS = await import(relativeDeps.href);
+    assert.strict.deepStrictEqual(Object.keys(relativeDepsNS), ['http']);
+    assert.strict.equal(relativeDepsNS.http, ns);
+  
     const fileDep = new URL(url.href);
     const { href } = pathToFileURL(path('/es-modules/message.mjs'));
     fileDep.searchParams.set('body', `


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This fixes imports using relative specifiers from within HTTPS source texts. Technically it also fixes `data:` but that scheme never allows relative specifiers anyway. Can also verify against a JS CDN using: `node --experimental-network-imports -e 'import("https://jspm.dev/npm:lit-html@1.4.1/lib/template-factory.js")'`.

This only 1/2 fixes JS CDN issues we have seen, a different one will be opened for redirects changing the resolution base URL for dependencies.