### PR TITLE
test: update V8 trace events test expectations

### DIFF
--- a/test/parallel/test-trace-events-all.js
+++ b/test/parallel/test-trace-events-all.js
@@ -27,7 +27,7 @@ proc.once('exit', common.mustCall(() => {
         return false;
       if (trace.cat !== 'v8')
         return false;
-      if (trace.name !== 'V8.GCScavenger')
+      if (!trace.name.startsWith('V8.'))
         return false;
       return true;
     }));

--- a/test/parallel/test-trace-events-v8.js
+++ b/test/parallel/test-trace-events-v8.js
@@ -29,7 +29,7 @@ proc.once('exit', common.mustCall(() => {
         return false;
       if (trace.cat !== 'v8')
         return false;
-      if (trace.name !== 'V8.GCScavenger')
+      if (!trace.name.startsWith('V8.'))
         return false;
       return true;
     }));


### PR DESCRIPTION
The event "V8.GCScavenger" is soon to be deprecated. Most of V8 trace events are either behind flags and disabled by default, or are emitted infrequently. Instead of replacing "V8.GCScavenger" with some other random event, this patch updates the tests to check that there is some event in the category "v8" whose name starts with "V8.".
