### PR TITLE
crypto: prettify othername in PrintGeneralName

### DIFF
--- a/src/crypto/crypto_common.cc
+++ b/src/crypto/crypto_common.cc
@@ -721,9 +721,8 @@ static inline void PrintUtf8AltName(const BIOPointer& out,
                true, safe_prefix);
 }
 
-// This function currently emulates the behavior of i2v_GENERAL_NAME in a safer
-// and less ambiguous way.
-// TODO(tniessen): gradually improve the format in the next major version(s)
+// This function emulates the behavior of i2v_GENERAL_NAME in a safer and less
+// ambiguous way. "othername:" entries use the GENERAL_NAME_print format.
 static bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen) {
   if (gen->type == GEN_DNS) {
     ASN1_IA5STRING* name = gen->d.dNSName;
@@ -795,33 +794,32 @@ static bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen) {
     OBJ_obj2txt(oline, sizeof(oline), gen->d.rid, true);
     BIO_printf(out.get(), "Registered ID:%s", oline);
   } else if (gen->type == GEN_OTHERNAME) {
-    // TODO(tniessen): the format that is used here is based on OpenSSL's
-    // implementation of i2v_GENERAL_NAME (as of OpenSSL 3.0.1), mostly for
-    // backward compatibility. It is somewhat awkward, especially when passed to
-    // translatePeerCertificate, and should be changed in the future, probably
-    // to the format used by GENERAL_NAME_print (in a major release).
+    // The format that is used here is based on OpenSSL's implementation of
+    // GENERAL_NAME_print (as of OpenSSL 3.0.1). Earlier versions of Node.js
+    // instead produced the same format as i2v_GENERAL_NAME, which was somewhat
+    // awkward, especially when passed to translatePeerCertificate.
     bool unicode = true;
     const char* prefix = nullptr;
-    // OpenSSL 1.1.1 does not support othername in i2v_GENERAL_NAME and may not
-    // define these NIDs.
+    // OpenSSL 1.1.1 does not support othername in GENERAL_NAME_print and may
+    // not define these NIDs.
 #if OPENSSL_VERSION_MAJOR >= 3
     int nid = OBJ_obj2nid(gen->d.otherName->type_id);
     switch (nid) {
       case NID_id_on_SmtpUTF8Mailbox:
-        prefix = " SmtpUTF8Mailbox:";
+        prefix = "SmtpUTF8Mailbox";
         break;
       case NID_XmppAddr:
-        prefix = " XmppAddr:";
+        prefix = "XmppAddr";
         break;
       case NID_SRVName:
-        prefix = " SRVName:";
+        prefix = "SRVName";
         unicode = false;
         break;
       case NID_ms_upn:
-        prefix = " UPN:";
+        prefix = "UPN";
         break;
       case NID_NAIRealm:
-        prefix = " NAIRealm:";
+        prefix = "NAIRealm";
         break;
     }
 #endif  // OPENSSL_VERSION_MAJOR >= 3

--- a/test/parallel/test-x509-escaping.js
+++ b/test/parallel/test-x509-escaping.js
@@ -88,22 +88,22 @@ const { hasOpenSSL3 } = common;
     // OpenSSL should not know it.
     'Registered ID:1.3.9999.12.34',
     hasOpenSSL3 ?
-      'othername: XmppAddr::abc123' :
+      'othername:XmppAddr:abc123' :
       'othername:<unsupported>',
     hasOpenSSL3 ?
-      'othername:" XmppAddr::abc123\\u002c DNS:good.example.com"' :
+      'othername:"XmppAddr:abc123\\u002c DNS:good.example.com"' :
       'othername:<unsupported>',
     hasOpenSSL3 ?
-      'othername:" XmppAddr::good.example.com\\u0000abc123"' :
+      'othername:"XmppAddr:good.example.com\\u0000abc123"' :
       'othername:<unsupported>',
     // This is unsupported because the OID is not recognized.
     'othername:<unsupported>',
-    hasOpenSSL3 ? 'othername: SRVName::abc123' : 'othername:<unsupported>',
+    hasOpenSSL3 ? 'othername:SRVName:abc123' : 'othername:<unsupported>',
     // This is unsupported because it is an SRVName with a UTF8String value,
     // which is not allowed for SRVName.
     'othername:<unsupported>',
     hasOpenSSL3 ?
-      'othername:" SRVName::abc\\u0000def"' :
+      'othername:"SRVName:abc\\u0000def"' :
       'othername:<unsupported>',
   ];
 
@@ -173,14 +173,14 @@ const { hasOpenSSL3 } = common;
       },
     },
     hasOpenSSL3 ? {
-      text: 'OCSP - othername: XmppAddr::good.example.com\n' +
+      text: 'OCSP - othername:XmppAddr:good.example.com\n' +
             'OCSP - othername:<unsupported>\n' +
-            'OCSP - othername: SRVName::abc123',
+            'OCSP - othername:SRVName:abc123',
       legacy: {
         'OCSP - othername': [
-          ' XmppAddr::good.example.com',
+          'XmppAddr:good.example.com',
           '<unsupported>',
-          ' SRVName::abc123',
+          'SRVName:abc123',
         ],
       },
     } : {
@@ -196,10 +196,10 @@ const { hasOpenSSL3 } = common;
       },
     },
     hasOpenSSL3 ? {
-      text: 'OCSP - othername:" XmppAddr::good.example.com\\u0000abc123"',
+      text: 'OCSP - othername:"XmppAddr:good.example.com\\u0000abc123"',
       legacy: {
         'OCSP - othername': [
-          ' XmppAddr::good.example.com\0abc123',
+          'XmppAddr:good.example.com\0abc123',
         ],
       },
     } : {


### PR DESCRIPTION
This change switches from the format produced by `i2v_GENERAL_NAME` to the format produced by `GENERAL_NAME_print` for `GEN_OTHERNAME` entries. This effectively produces entries of the form `othername:SRVName:example.com` instead of `othername: SRVName::example.com`. This is more consistent with other `GENERIC_NAME` entries and produces less awkward values in the legacy object representation.

(Please take a look at the modified test file to see the effect.)

---

This addresses the following TODO:

https://github.com/nodejs/node/blob/626367c4e3b57dab3e6c1e9926cc24e2d662e14a/src/crypto/crypto_common.cc#L798-L802

I also consider this the last major change required to resolve this TODO:

https://github.com/nodejs/node/blob/626367c4e3b57dab3e6c1e9926cc24e2d662e14a/src/crypto/crypto_common.cc#L726

---

Refs: https://github.com/nodejs/node/commit/466e5415a2b7b3574ab5403acb87e89a94a980d1

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
