### PR TITLE
esm: fix base URL for network imports

### DIFF
--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -193,6 +193,11 @@ function addBuiltinLibsToObject(object, dummyModuleName) {
   });
 }
 
+/**
+ * 
+ * @param {string | URL} referrer
+ * @returns {string}
+ */
 function normalizeReferrerURL(referrer) {
   if (typeof referrer === 'string' && path.isAbsolute(referrer)) {
     return pathToFileURL(referrer).href;

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -194,7 +194,7 @@ function addBuiltinLibsToObject(object, dummyModuleName) {
 }
 
 /**
- * 
+ *
  * @param {string | URL} referrer
  * @returns {string}
  */

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1017,7 +1017,7 @@ function wrapSafe(filename, content, cjsModuleInstance) {
       displayErrors: true,
       importModuleDynamically: (specifier, _, importAssertions) => {
         const loader = asyncESM.esmLoader;
-        return loader.import(specifier, 
+        return loader.import(specifier,
                              loader.baseURL(normalizeReferrerURL(filename)),
                              importAssertions);
       },

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1015,10 +1015,10 @@ function wrapSafe(filename, content, cjsModuleInstance) {
       filename,
       lineOffset: 0,
       displayErrors: true,
-      importModuleDynamically: (specifier, _, importAssertions) => {
+      importModuleDynamically: async (specifier, _, importAssertions) => {
         const loader = asyncESM.esmLoader;
         return loader.import(specifier,
-                             loader.baseURL(normalizeReferrerURL(filename)),
+                             loader.getBaseURL(normalizeReferrerURL(filename)),
                              importAssertions);
       },
     });
@@ -1035,7 +1035,7 @@ function wrapSafe(filename, content, cjsModuleInstance) {
       importModuleDynamically(specifier, _, importAssertions) {
         const loader = asyncESM.esmLoader;
         return loader.import(specifier,
-                             loader.baseURL(normalizeReferrerURL(filename)),
+                             loader.getBaseURL(normalizeReferrerURL(filename)),
                              importAssertions);
       },
     });

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1015,9 +1015,10 @@ function wrapSafe(filename, content, cjsModuleInstance) {
       filename,
       lineOffset: 0,
       displayErrors: true,
-      importModuleDynamically: async (specifier, _, importAssertions) => {
+      importModuleDynamically: (specifier, _, importAssertions) => {
         const loader = asyncESM.esmLoader;
-        return loader.import(specifier, normalizeReferrerURL(filename),
+        return loader.import(specifier, 
+                             loader.baseURL(normalizeReferrerURL(filename)),
                              importAssertions);
       },
     });
@@ -1033,7 +1034,8 @@ function wrapSafe(filename, content, cjsModuleInstance) {
       filename,
       importModuleDynamically(specifier, _, importAssertions) {
         const loader = asyncESM.esmLoader;
-        return loader.import(specifier, normalizeReferrerURL(filename),
+        return loader.import(specifier,
+                             loader.baseURL(normalizeReferrerURL(filename)),
                              importAssertions);
       },
     });

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -33,7 +33,7 @@ function initializeImportMeta(meta, context) {
     meta.resolve = createImportMetaResolve(url);
   }
 
-  url = asyncESM.esmLoader.baseURL(url);
+  url = asyncESM.esmLoader.getBaseURL(url);
 
   meta.url = url;
 }

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -24,6 +24,11 @@ function createImportMetaResolve(defaultParentUrl) {
   };
 }
 
+/**
+ * 
+ * @param {object} meta 
+ * @param {{url: string}} context 
+ */
 function initializeImportMeta(meta, context) {
   let url = context.url;
 
@@ -32,14 +37,7 @@ function initializeImportMeta(meta, context) {
     meta.resolve = createImportMetaResolve(url);
   }
 
-  if (
-    StringPrototypeStartsWith(url, 'http:') ||
-    StringPrototypeStartsWith(url, 'https:')
-  ) {
-    // The request & response have already settled, so they are in fetchModule's
-    // cache, in which case, fetchModule returns immediately and synchronously
-    url = fetchModule(new URL(url), context).resolvedHREF;
-  }
+  url = asyncESM.esmLoader.baseURL(url);
 
   meta.url = url;
 }

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -3,12 +3,9 @@
 const { getOptionValue } = require('internal/options');
 const experimentalImportMetaResolve =
   getOptionValue('--experimental-import-meta-resolve');
-const { fetchModule } = require('internal/modules/esm/fetch_module');
-const { URL } = require('internal/url');
 const {
   PromisePrototypeThen,
   PromiseReject,
-  StringPrototypeStartsWith,
 } = primordials;
 const asyncESM = require('internal/process/esm_loader');
 
@@ -25,9 +22,8 @@ function createImportMetaResolve(defaultParentUrl) {
 }
 
 /**
- * 
- * @param {object} meta 
- * @param {{url: string}} context 
+ * @param {object} meta
+ * @param {{url: string}} context
  */
 function initializeImportMeta(meta, context) {
   let url = context.url;

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -247,7 +247,7 @@ class ESMLoader {
    * of https://example.com/bar
    *
    * MUST BE SYNCHRONOUS for import.meta initialization
-   * MUST BE CALLED AFTER body for url is received due to I/O
+   * MUST BE CALLED AFTER receiving the url body due to I/O
    * @param {string} url
    * @returns {string}
    */

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -23,6 +23,7 @@ const {
 const { MessageChannel } = require('internal/worker/io');
 
 const {
+  ERR_INTERNAL_ASSERTION,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_RETURN_PROPERTY_VALUE,
@@ -260,6 +261,10 @@ class ESMLoader {
       // fetchModule's cache, in which case, fetchModule returns
       // immediately and synchronously
       url = fetchModule(new URL(url), { parentURL: url }).resolvedHREF;
+      // This should only occur if the module hasn't been fetched yet
+      if (typeof url !== 'string') {
+        throw new ERR_INTERNAL_ASSERTION(`Base url for module ${url} not loaded.`);
+      }
     }
     return url;
   }

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -234,18 +234,18 @@ class ESMLoader {
   /**
    * Returns the url to use for resolution for a given cache key url
    * These are not guaranteed to be the same.
-   * 
+   *
    * In WHATWG HTTP spec for ESM the cache key is the non-I/O bound
    * synchronous resolution using only string operations
    *   ~= resolveImportMap(new URL(specifier, importerHREF))
-   * 
+   *
    * The url used for subsequent resolution is the response URL after
    * all redirects have been resolved.
-   * 
+   *
    * https://example.com/foo redirecting to https://example.com/bar
    * would have a cache key of https://example.com/foo and baseURL
    * of https://example.com/bar
-   * 
+   *
    * MUST BE SYNCHRONOUS for import.meta initialization
    * MUST BE CALLED AFTER body for url is received due to I/O
    * @param {string} url
@@ -259,7 +259,7 @@ class ESMLoader {
       // The request & response have already settled, so they are in
       // fetchModule's cache, in which case, fetchModule returns
       // immediately and synchronously
-      url = fetchModule(new URL(url), {parentURL: url}).resolvedHREF;
+      url = fetchModule(new URL(url), { parentURL: url }).resolvedHREF;
     }
     return url;
   }

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -232,7 +232,7 @@ class ESMLoader {
   }
 
   /**
-   * Returns the url to use for resolution for a given cache key url
+   * Returns the url to use for the resolution of a given cache key url
    * These are not guaranteed to be the same.
    *
    * In WHATWG HTTP spec for ESM the cache key is the non-I/O bound

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -17,6 +17,7 @@ const {
   RegExpPrototypeExec,
   SafeArrayIterator,
   SafeWeakMap,
+  StringPrototypeStartsWith,
   globalThis,
 } = primordials;
 const { MessageChannel } = require('internal/worker/io');
@@ -47,6 +48,9 @@ const { defaultLoad } = require('internal/modules/esm/load');
 const { translators } = require(
   'internal/modules/esm/translators');
 const { getOptionValue } = require('internal/options');
+const {
+  fetchModule,
+} = require('internal/modules/esm/fetch_module');
 
 /**
  * An ESMLoader instance is used as the main entry point for loading ES modules.
@@ -209,7 +213,9 @@ class ESMLoader {
       const module = new ModuleWrap(url, undefined, source, 0, 0);
       callbackMap.set(module, {
         importModuleDynamically: (specifier, { url }, importAssertions) => {
-          return this.import(specifier, url, importAssertions);
+          return this.import(specifier,
+                             this.baseURL(url),
+                             importAssertions);
         }
       });
 
@@ -223,6 +229,39 @@ class ESMLoader {
     return {
       namespace: module.getNamespace(),
     };
+  }
+
+  /**
+   * Returns the url to use for resolution for a given cache key url
+   * These are not guaranteed to be the same.
+   * 
+   * In WHATWG HTTP spec for ESM the cache key is the non-I/O bound
+   * synchronous resolution using only string operations
+   *   ~= resolveImportMap(new URL(specifier, importerHREF))
+   * 
+   * The url used for subsequent resolution is the response URL after
+   * all redirects have been resolved.
+   * 
+   * https://example.com/foo redirecting to https://example.com/bar
+   * would have a cache key of https://example.com/foo and baseURL
+   * of https://example.com/bar
+   * 
+   * MUST BE SYNCHRONOUS for import.meta initialization
+   * MUST BE CALLED AFTER body for url is received due to I/O
+   * @param {string} url
+   * @returns {string}
+   */
+  baseURL(url) {
+    if (
+      StringPrototypeStartsWith(url, 'http:') ||
+      StringPrototypeStartsWith(url, 'https:')
+    ) {
+      // The request & response have already settled, so they are in
+      // fetchModule's cache, in which case, fetchModule returns
+      // immediately and synchronously
+      url = fetchModule(new URL(url), {parentURL: url}).resolvedHREF;
+    }
+    return url;
   }
 
   /**

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -215,7 +215,7 @@ class ESMLoader {
       callbackMap.set(module, {
         importModuleDynamically: (specifier, { url }, importAssertions) => {
           return this.import(specifier,
-                             this.baseURL(url),
+                             this.getBaseURL(url),
                              importAssertions);
         }
       });
@@ -252,7 +252,7 @@ class ESMLoader {
    * @param {string} url
    * @returns {string}
    */
-  baseURL(url) {
+  getBaseURL(url) {
     if (
       StringPrototypeStartsWith(url, 'http:') ||
       StringPrototypeStartsWith(url, 'https:')

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -76,7 +76,7 @@ class ModuleJob {
       // these `link` callbacks depending on each other.
       const dependencyJobs = [];
       const promises = this.module.link(async (specifier, assertions) => {
-        const baseURL = this.loader.baseURL(url);
+        const baseURL = this.loader.getBaseURL(url);
         const jobPromise = this.loader.getModuleJob(specifier, baseURL, assertions);
         ArrayPrototypePush(dependencyJobs, jobPromise);
         const job = await jobPromise;

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -76,7 +76,8 @@ class ModuleJob {
       // these `link` callbacks depending on each other.
       const dependencyJobs = [];
       const promises = this.module.link(async (specifier, assertions) => {
-        const jobPromise = this.loader.getModuleJob(specifier, url, assertions);
+        const baseURL = this.loader.baseURL(url);
+        const jobPromise = this.loader.getModuleJob(specifier, baseURL, assertions);
         ArrayPrototypePush(dependencyJobs, jobPromise);
         const job = await jobPromise;
         return job.modulePromise;

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -104,7 +104,7 @@ function errPath(url) {
 
 async function importModuleDynamically(specifier, { url }, assertions) {
   return asyncESM.esmLoader.import(specifier,
-                                   asyncESM.esmLoader.baseURL(url),
+                                   asyncESM.esmLoader.getBaseURL(url),
                                    assertions);
 }
 

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -103,7 +103,9 @@ function errPath(url) {
 }
 
 async function importModuleDynamically(specifier, { url }, assertions) {
-  return asyncESM.esmLoader.import(specifier, url, assertions);
+  return asyncESM.esmLoader.import(specifier,
+                                   asyncESM.esmLoader.baseURL(url),
+                                   assertions);
 }
 
 // Strategy for loading a standard JavaScript module.

--- a/test/es-module/test-http-imports.mjs
+++ b/test/es-module/test-http-imports.mjs
@@ -116,6 +116,21 @@ for (const { protocol, createServer } of [
     assert.strict.notEqual(redirectedNS.default, ns.default);
     assert.strict.equal(redirectedNS.url, url.href);
 
+    // Redirects have same import.meta.url but different cache
+    // entry on Web
+    const relativeAfterRedirect = new URL(url.href + 'foo/index.js');
+    const redirected = new URL(url.href + 'bar/index.js');
+    redirected.searchParams.set('body', `export let relativeDepURL = (await import("./baz.js")).url`);
+    relativeAfterRedirect.searchParams.set('redirect', JSON.stringify({
+      status: 302,
+      location: redirected.href
+    }));
+    const relativeAfterRedirectedNS = await import(relativeAfterRedirect.href);
+    assert.strict.equal(
+      relativeAfterRedirectedNS.relativeDepURL,
+      url.href + 'bar/baz.js'
+    );
+
     const crossProtocolRedirect = new URL(url.href);
     crossProtocolRedirect.searchParams.set('redirect', JSON.stringify({
       status: 302,

--- a/test/es-module/test-http-imports.mjs
+++ b/test/es-module/test-http-imports.mjs
@@ -120,7 +120,7 @@ for (const { protocol, createServer } of [
     // entry on Web
     const relativeAfterRedirect = new URL(url.href + 'foo/index.js');
     const redirected = new URL(url.href + 'bar/index.js');
-    redirected.searchParams.set('body', `export let relativeDepURL = (await import("./baz.js")).url`);
+    redirected.searchParams.set('body', 'export let relativeDepURL = (await import("./baz.js")).url');
     relativeAfterRedirect.searchParams.set('redirect', JSON.stringify({
       status: 302,
       location: redirected.href

--- a/test/es-module/test-http-imports.mjs
+++ b/test/es-module/test-http-imports.mjs
@@ -116,7 +116,7 @@ for (const { protocol, createServer } of [
     assert.strict.notEqual(redirectedNS.default, ns.default);
     assert.strict.equal(redirectedNS.url, url.href);
 
-    // Redirects have same import.meta.url but different cache
+    // Redirects have the same import.meta.url but different cache
     // entry on Web
     const relativeAfterRedirect = new URL(url.href + 'foo/index.js');
     const redirected = new URL(url.href + 'bar/index.js');


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Per the PR text this kind of explains what is going on:

```mjs
  /**
   * ...
   * 
   * In WHATWG HTTP spec for ESM the cache key is the non-I/O bound
   * synchronous resolution using only string operations
   *   ~= resolveImportMap(new URL(specifier, importerHREF))
   * 
   * The url used for subsequent resolution is the response URL after
   * all redirects have been resolved.
   * 
   * https://example.com/foo redirecting to https://example.com/bar
   * would have a cache key of https://example.com/foo and baseURL
   * of https://example.com/bar
   * 
   * ...
   */
```

Likely this should be a bigger refactor because callbackMap is becoming spaghetti but that should/can be punted for now.

This is 1/2 of the issues we have seen with HTTPS CDNs for ESM and is a partial fix for https://github.com/nodejs/node/issues/42098 .

I would note that the URL mentioned in the corresponding issue continues to fail even with this and https://github.com/nodejs/node/pull/42119 because it redirects to an absolute URL with a 404:

```
302 https://unpkg.com/uuid?module ->
200 https://unpkg.com/uuid@8.3.2/dist/esm-node/index.js?module -> (this is where the PR fixes apply in both PRs)
200 https://unpkg.com/uuid@8.3.2/dist/esm-node/rng.js?module ->
404 https://unpkg.com/crypto@latest?module
```

Before this PR the base URL used for resolving `./rng.js` was incorrectly using the cache key of the module `https://unpkg.com/uuid?module`. Per [WHATWG](https://html.spec.whatwg.org/multipage/webappapis.html#hostresolveimportedmodule(referencingscriptormodule,-modulerequest)) this should actually be changed to `https://unpkg.com/uuid@8.3.2/dist/esm-node/index.js?module`

> Set [base URL](https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url) to referencing script's base URL.

And [WHATWG](https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script):

> It is intentional that the [module map](https://html.spec.whatwg.org/multipage/webappapis.html#module-map) is keyed by the [request URL](https://fetch.spec.whatwg.org/#concept-request-url), whereas the [base URL](https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url) for the [module script](https://html.spec.whatwg.org/multipage/webappapis.html#module-script) is set to the [response URL](https://fetch.spec.whatwg.org/#concept-response-url). The former is used to deduplicate fetches, while the latter is used for URL resolution.

After both PRs the behavior in Node matches the browser: https://jsfiddle.net/n8cwL4bm/