### PR TITLE
url: fix url.parse() for @hostname

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -294,22 +294,29 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     rest = rest.slice(proto.length);
   }
 
-  // Figure out if it's got a host
-  // user@server is *always* interpreted as a hostname, and url
+  // Figure out if it's got a host.
+  // user@server is *always* interpreted as a hostname, and URL
   // resolution will treat //foo/bar as host=foo,path=bar because that's
-  // how the browser resolves relative URLs.
+  // how the browser resolves relative URLs. http:@example.com is treated
+  // the same as http://example.com.
   let slashes;
+  let at;
   if (slashesDenoteHost || proto || hostPattern.test(rest)) {
     slashes = rest.charCodeAt(0) === CHAR_FORWARD_SLASH &&
-              rest.charCodeAt(1) === CHAR_FORWARD_SLASH;
-    if (slashes && !(proto && hostlessProtocol.has(lowerProto))) {
-      rest = rest.slice(2);
-      this.slashes = true;
+                  rest.charCodeAt(1) === CHAR_FORWARD_SLASH;
+    at = rest.charCodeAt(0) === CHAR_AT;
+    if (!(proto && hostlessProtocol.has(lowerProto))) {
+      if (slashes) {
+        rest = rest.slice(2);
+        this.slashes = true;
+      } else if (at) {
+        rest = rest.slice(1);
+      }
     }
   }
 
   if (!hostlessProtocol.has(lowerProto) &&
-      (slashes || (proto && !slashedProtocol.has(proto)))) {
+      (slashes || at || (proto && !slashedProtocol.has(proto)))) {
 
     // there's a hostname.
     // the first instance of /, ?, ;, or # ends the host.

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -975,7 +975,22 @@ const parseTests = {
     query: null,
     pathname: '/everybody',
     path: '/everybody',
-    href: '//fhqwhgads@example.com/everybody#to-the-limit'
+    href: '//fhqwhgads@example.com/everybody#to-the-limit',
+  },
+
+  'http:@localhost': {
+    protocol: 'http:',
+    slashes: null,
+    auth: null,
+    host: 'localhost',
+    port: null,
+    hostname: 'localhost',
+    hash: null,
+    search: null,
+    query: null,
+    pathname: '/',
+    path: '/',
+    href: 'http://localhost/',
   },
 };
 


### PR DESCRIPTION
Make url.parse() behave more like browsers and WHATWHG URL when dealing
with URLs that have the format `http:@example.com`. This is the same as
`http://example.com`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
