### PR TITLE
doc: remove reference to obsolete security program

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,11 @@ The Node.js project engages in an official bug bounty program for security
 researchers and responsible public disclosures.  The program is managed through
 the HackerOne platform. See <https://hackerone.com/nodejs> for further details.
 
+## Reporting a bug in a third party module
+
+Security bugs in third party modules should be reported to their respective
+maintainers.
+
 ## Disclosure policy
 
 Here is the security disclosure policy for Node.js

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,18 +19,6 @@ The Node.js project engages in an official bug bounty program for security
 researchers and responsible public disclosures.  The program is managed through
 the HackerOne platform. See <https://hackerone.com/nodejs> for further details.
 
-## Reporting a bug in a third party module
-
-Security bugs in third party modules should be reported to their respective
-maintainers and should also be coordinated through the Node.js Ecosystem
-Security Team via [HackerOne](https://hackerone.com/nodejs-ecosystem).
-
-Details regarding this process can be found in the
-[Security Working Group repository](https://github.com/nodejs/security-wg/blob/HEAD/processes/third_party_vuln_process.md).
-
-Thank you for improving the security of Node.js and its ecosystem. Your efforts
-and responsible disclosure are greatly appreciated and will be acknowledged.
-
 ## Disclosure policy
 
 Here is the security disclosure policy for Node.js


### PR DESCRIPTION
The ecosystem security program via HackerOne is no longer a thing.
Remove mention of it from SECURITY.md.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
