### PR TITLE
http2: close stream and session on frameError

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -607,6 +607,8 @@ function onFrameError(id, type, code) {
   const emitter = session[kState].streams.get(id) || session;
   emitter[kUpdateTimer]();
   emitter.emit('frameError', type, code, id);
+  session[kState].streams.get(id).close(code);
+  session.close();
 }
 
 function onAltSvc(stream, origin, alt) {

--- a/test/parallel/test-http2-exceeds-server-trailer-size.js
+++ b/test/parallel/test-http2-exceeds-server-trailer-size.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { createServer, constants, connect } = require('http2');
+
+const server = createServer();
+
+server.on('stream', (stream, headers) => {
+  stream.respond(undefined, { waitForTrailers: true });
+
+  stream.on('data', common.mustNotCall());
+
+  stream.on('wantTrailers', common.mustCall(() => {
+    // Trigger a frame error by sending a trailer that is too large
+    stream.sendTrailers({ 'test-trailer': 'X'.repeat(64 * 1024) });
+  }));
+
+  stream.on('frameError', common.mustCall((frameType, errorCode) => {
+    assert.strictEqual(errorCode, constants.NGHTTP2_FRAME_SIZE_ERROR);
+  }));
+
+  stream.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+  }));
+
+  stream.on('close', common.mustCall());
+
+  stream.end();
+});
+
+server.listen(0, () => {
+  const clientSession = connect(`http://localhost:${server.address().port}`);
+
+  clientSession.on('frameError', common.mustNotCall());
+  clientSession.on('close', common.mustCall(() => {
+    server.close();
+  }));
+
+  const clientStream = clientSession.request();
+
+  clientStream.on('close', common.mustCall());
+  // These events mustn't be called once the frame size error is from the server
+  clientStream.on('frameError', common.mustNotCall());
+  clientStream.on('error', common.mustNotCall());
+
+  clientStream.end();
+});

--- a/test/parallel/test-http2-options-max-headers-block-length.js
+++ b/test/parallel/test-http2-options-max-headers-block-length.js
@@ -32,12 +32,12 @@ server.listen(0, common.mustCall(() => {
   }));
 
   req.on('frameError', common.mustCall((type, code) => {
-    assert.strictEqual(code, h2.constants.NGHTTP2_ERR_FRAME_SIZE_ERROR);
+    assert.strictEqual(code, h2.constants.NGHTTP2_FRAME_SIZE_ERROR);
   }));
 
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     name: 'Error',
-    message: 'Stream closed with error code NGHTTP2_REFUSED_STREAM'
+    message: 'Stream closed with error code NGHTTP2_FRAME_SIZE_ERROR'
   }));
 }));


### PR DESCRIPTION
Address: https://github.com/nodejs/node/issues/35133.

From the [Http2Stream#frameError event documentation](https://nodejs.org/api/http2.html#http2_event_frameerror_1):

> The 'frameError' event is emitted when an error occurs while attempting to send a frame. When invoked, the handler function will receive an integer argument identifying the frame type, and an integer argument identifying the error code. The Http2Stream instance will be destroyed **immediately** after the 'frameError' event is emitted.

The _master_ implementation wasn't closing the stream/session when a `frameError` occurs. Also, it was calling the `frameError` event with an `nghttp2` internal error code.

This PR translates the internal error code according to [RFC 7540](https://datatracker.ietf.org/doc/html/rfc7540#section-7) and closes the connection when a `frameError` occurs.