### PR TITLE
crypto: add CHECKs to remaining BIO_s_mem allocs

### DIFF
--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1424,6 +1424,7 @@ WebCryptoKeyExportStatus PKEY_SPKI_Export(
   ManagedEVPPKey m_pkey = key_data->GetAsymmetricKey();
   Mutex::ScopedLock lock(*m_pkey.mutex());
   BIOPointer bio(BIO_new(BIO_s_mem()));
+  CHECK(bio);
   if (!i2d_PUBKEY_bio(bio.get(), m_pkey.get()))
     return WebCryptoKeyExportStatus::FAILED;
 
@@ -1439,6 +1440,7 @@ WebCryptoKeyExportStatus PKEY_PKCS8_Export(
   Mutex::ScopedLock lock(*m_pkey.mutex());
 
   BIOPointer bio(BIO_new(BIO_s_mem()));
+  CHECK(bio);
   PKCS8Pointer p8inf(EVP_PKEY2PKCS8(m_pkey.get()));
   if (!i2d_PKCS8_PRIV_KEY_INFO_bio(bio.get(), p8inf.get()))
     return WebCryptoKeyExportStatus::FAILED;

--- a/src/crypto/crypto_x509.cc
+++ b/src/crypto/crypto_x509.cc
@@ -196,6 +196,7 @@ void X509Certificate::Subject(const FunctionCallbackInfo<Value>& args) {
   X509Certificate* cert;
   ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
   BIOPointer bio(BIO_new(BIO_s_mem()));
+  CHECK(bio);
   Local<Value> ret;
   if (GetSubject(env, bio, cert->get()).ToLocal(&ret))
     args.GetReturnValue().Set(ret);
@@ -206,6 +207,7 @@ void X509Certificate::Issuer(const FunctionCallbackInfo<Value>& args) {
   X509Certificate* cert;
   ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
   BIOPointer bio(BIO_new(BIO_s_mem()));
+  CHECK(bio);
   Local<Value> ret;
   if (GetIssuerString(env, bio, cert->get()).ToLocal(&ret))
     args.GetReturnValue().Set(ret);
@@ -216,6 +218,7 @@ void X509Certificate::SubjectAltName(const FunctionCallbackInfo<Value>& args) {
   X509Certificate* cert;
   ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
   BIOPointer bio(BIO_new(BIO_s_mem()));
+  CHECK(bio);
   Local<Value> ret;
   if (GetSubjectAltNameString(env, bio, cert->get()).ToLocal(&ret))
     args.GetReturnValue().Set(ret);
@@ -226,6 +229,7 @@ void X509Certificate::InfoAccess(const FunctionCallbackInfo<Value>& args) {
   X509Certificate* cert;
   ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
   BIOPointer bio(BIO_new(BIO_s_mem()));
+  CHECK(bio);
   Local<Value> ret;
   if (GetInfoAccessString(env, bio, cert->get()).ToLocal(&ret))
     args.GetReturnValue().Set(ret);
@@ -236,6 +240,7 @@ void X509Certificate::ValidFrom(const FunctionCallbackInfo<Value>& args) {
   X509Certificate* cert;
   ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
   BIOPointer bio(BIO_new(BIO_s_mem()));
+  CHECK(bio);
   Local<Value> ret;
   if (GetValidFrom(env, cert->get(), bio).ToLocal(&ret))
     args.GetReturnValue().Set(ret);
@@ -246,6 +251,7 @@ void X509Certificate::ValidTo(const FunctionCallbackInfo<Value>& args) {
   X509Certificate* cert;
   ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
   BIOPointer bio(BIO_new(BIO_s_mem()));
+  CHECK(bio);
   Local<Value> ret;
   if (GetValidTo(env, cert->get(), bio).ToLocal(&ret))
     args.GetReturnValue().Set(ret);
@@ -325,6 +331,7 @@ void X509Certificate::Pem(const FunctionCallbackInfo<Value>& args) {
   X509Certificate* cert;
   ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
   BIOPointer bio(BIO_new(BIO_s_mem()));
+  CHECK(bio);
   if (PEM_write_bio_X509(bio.get(), cert->get()))
     args.GetReturnValue().Set(ToV8Value(env, bio));
 }


### PR DESCRIPTION
These should be the only remaining unchecked `BIO_s_mem` allocations. `CHECK` that the allocation succeeds instead of crashing when it doesn't.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
