### PR TITLE
http: make TCP noDelay enabled by default

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2839,6 +2839,9 @@ Found'`.
 added: v0.1.13
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/42163
+    description: The `noDelay` option now defaults to `true`.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/41310
     description: The `noDelay`, `keepAlive` and `keepAliveInitialDelay`
                  options are supported now.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2838,6 +2838,10 @@ Found'`.
 <!-- YAML
 added: v0.1.13
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41310
+    description: The `noDelay`, `keepAlive` and `keepAliveInitialDelay`
+                 options are supported now.
   - version:
      - v13.8.0
      - v12.15.0
@@ -2871,7 +2875,7 @@ changes:
     **Default:** 16384 (16 KB).
   * `noDelay` {boolean} If set to `true`, it disables the use of Nagle's
     algorithm immediately after a new incoming connection is received.
-    **Default:** `false`.
+    **Default:** `true`.
   * `keepAlive` {boolean} If set to `true`, it enables keep-alive functionality
     on the socket immediately after a new incoming connection is received,
     similarly on what is done in \[`socket.setKeepAlive([enable][, initialDelay])`]\[`socket.setKeepAlive(enable, initialDelay)`].

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -822,6 +822,10 @@ behavior.
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41310
+    description: The `noDelay`, `keepAlive` and `keepAliveInitialDelay`
+                 options are supported now.
   - version: v12.10.0
     pr-url: https://github.com/nodejs/node/pull/25436
     description: Added `onread` option.

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -101,6 +101,9 @@ function Agent(options) {
 
   this.options = { __proto__: null, ...options };
 
+  if (this.options.noDelay === undefined)
+    this.options.noDelay = true;
+
   // Don't confuse net and make it think that we're connecting to a pipe
   this.options.path = null;
   this.requests = ObjectCreate(null);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -363,6 +363,9 @@ function storeHTTPOptions(options) {
   if (insecureHTTPParser !== undefined)
     validateBoolean(insecureHTTPParser, 'options.insecureHTTPParser');
   this.insecureHTTPParser = insecureHTTPParser;
+
+  if (options.noDelay === undefined)
+    options.noDelay = true;
 }
 
 function Server(options, requestListener) {

--- a/test/parallel/test-http-nodelay.js
+++ b/test/parallel/test-http-nodelay.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+
+const originalConnect = net.Socket.prototype.connect;
+
+net.Socket.prototype.connect = common.mustCall(function(args) {
+  assert.strictEqual(args[0].noDelay, true);
+  return originalConnect.call(this, args);
+});
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.writeHead(200);
+  res.end();
+  server.close();
+}));
+
+server.listen(0, common.mustCall(() => {
+  assert.strictEqual(server.noDelay, true);
+
+  const req = http.request({
+    method: 'GET',
+    port: server.address().port
+  }, common.mustCall((res) => {
+    res.on('end', () => {
+      server.close();
+      res.req.socket.end();
+    });
+
+    res.resume();
+  }));
+
+  req.end();
+}));


### PR DESCRIPTION
This PR is the continuation of the work in #41310 and it is aimed to close #34185.

The PR changes `noDelay` to be `true` by default in `http.Server` and `http.Agent` (which is also used by `http.request`). This implies that all HTTP connections (both inbound and outbound) disable Nagle's algorithm by default.