### PR TITLE
doc: add next-10 to strategic initiaves

### DIFF
--- a/doc/contributing/strategic-initiatives.md
+++ b/doc/contributing/strategic-initiatives.md
@@ -13,6 +13,7 @@ agenda to ensure they are active and have the support they need.
 | QUIC / HTTP3              | [James M Snell][jasnell]    | <https://github.com/nodejs/quic>                                                             |
 | Startup performance       | [Joyee Cheung][joyeecheung] | <https://github.com/nodejs/node/issues/35711>                                                |
 | V8 Currency               | [Michaël Zasso][targos]     |                                                                                              |
+| Next-10                   | [Michael Dawson][mhdawson]  | <https://github.com/nodejs/next-10>                                                          |
 
 <details>
 <summary>List of completed initiatives</summary>
@@ -38,5 +39,6 @@ agenda to ensure they are active and have the support they need.
 [aduh95]: https://github.com/aduh95
 [jasnell]: https://github.com/jasnell
 [joyeecheung]: https://github.com/joyeecheung
+[mhdawson]: https://github.com/mhdawson
 [mmarchini]: https://github.com/mmarchini
 [targos]: https://github.com/targos


### PR DESCRIPTION
It was suggested to me that adding the next-10
effort to the strategic initiatives would be a good
way to keep the TSC up to date an in the loop on
the effort.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
