### PR TITLE
build: drop shortened URL from lint-commit-message

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,4 +1,4 @@
-name: First commit message adheres to guidelines at https://goo.gl/p2fr5Q
+name: First commit message adheres to guidelines
 
 on: [pull_request]
 


### PR DESCRIPTION
The shortened link to the commit message guidelines no longer works
after they were moved from `docs/guides` to `docs/contributing`. Now
that `core-validate-commit` outputs an error message pointing to the
full URL of the commit message guidelines on failure we no longer need
to include the URL (shortened or otherwise) in the workflow title.

Refs: https://github.com/nodejs/core-validate-commit/pull/95
Refs: https://github.com/nodejs/node/issues/41697

---

As an example, 
- Before https://github.com/nodejs/core-validate-commit/pull/95:
https://github.com/nodejs/node/runs/5355414643?check_suite_focus=true
![image](https://user-images.githubusercontent.com/5445507/156201806-f59b5223-5695-4b12-a78a-38b04642209d.png)
- After https://github.com/nodejs/core-validate-commit/pull/95:
https://github.com/nodejs/node/runs/5377503722?check_suite_focus=true
![image](https://user-images.githubusercontent.com/5445507/156201977-6402e7bc-d877-41c4-9917-810b18c6df75.png)
The https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines link in the job output is clickable.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
