### PR TITLE
crypto: fix fingerprint string size calculation

### DIFF
--- a/src/crypto/crypto_common.cc
+++ b/src/crypto/crypto_common.cc
@@ -421,7 +421,7 @@ MaybeLocal<Object> GetLastIssuedCert(
 void AddFingerprintDigest(
     const unsigned char* md,
     unsigned int md_size,
-    char fingerprint[3 * EVP_MAX_MD_SIZE + 1]) {
+    char fingerprint[3 * EVP_MAX_MD_SIZE]) {
   unsigned int i;
   const char hex[] = "0123456789ABCDEF";
 
@@ -571,7 +571,7 @@ MaybeLocal<Value> GetFingerprintDigest(
     X509* cert) {
   unsigned char md[EVP_MAX_MD_SIZE];
   unsigned int md_size;
-  char fingerprint[EVP_MAX_MD_SIZE * 3 + 1];
+  char fingerprint[EVP_MAX_MD_SIZE * 3];
 
   if (X509_digest(cert, method, md, &md_size)) {
     AddFingerprintDigest(md, md_size, fingerprint);


### PR DESCRIPTION
The function generating fingerprint strings never accesses more than `EVP_MAX_MD_SIZE * 3` characters, including the terminating `'\0'`. (This is true even without #42145.) Adding an extra byte to the buffer size only adds confusion since it will never be accessed.

`(3*i)+2` is at most `3 * (md_size - 1) + 2`, i.e., `3 * md_size - 1` for `i < md_size`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
