### PR TITLE
lib, doc: fix AsyncResource.bind not using 'this' from the caller by default

### DIFF
--- a/doc/api/async_context.md
+++ b/doc/api/async_context.md
@@ -446,6 +446,9 @@ added:
   - v14.8.0
   - v12.19.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/42177
+    description: Changed the default when `thisArg` is not provided to use `this` from the caller.
   - version: v16.0.0
     pr-url: https://github.com/nodejs/node/pull/36782
     description: Added optional thisArg.
@@ -468,6 +471,9 @@ added:
   - v14.8.0
   - v12.19.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/42177
+    description: Changed the default when `thisArg` is not provided to use `this` from the caller.
   - version: v16.0.0
     pr-url: https://github.com/nodejs/node/pull/36782
     description: Added optional thisArg.

--- a/doc/api/async_context.md
+++ b/doc/api/async_context.md
@@ -448,7 +448,8 @@ added:
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/42177
-    description: Changed the default when `thisArg` is not provided to use `this` from the caller.
+    description: Changed the default when `thisArg` is undefined to use `this`
+                 from the caller.
   - version: v16.0.0
     pr-url: https://github.com/nodejs/node/pull/36782
     description: Added optional thisArg.
@@ -473,7 +474,8 @@ added:
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/42177
-    description: Changed the default when `thisArg` is not provided to use `this` from the caller.
+    description: Changed the default when `thisArg` is undefined to use `this`
+                 from the caller.
   - version: v16.0.0
     pr-url: https://github.com/nodejs/node/pull/36782
     description: Added optional thisArg.

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -5,6 +5,7 @@ const {
   ArrayPrototypeIndexOf,
   ArrayPrototypePush,
   ArrayPrototypeSplice,
+  ArrayPrototypeUnshift,
   FunctionPrototypeBind,
   NumberIsSafeInteger,
   ObjectDefineProperties,
@@ -225,14 +226,16 @@ class AsyncResource {
 
   bind(fn, thisArg) {
     validateFunction(fn, 'fn');
-    const runInAsyncScope = FunctionPrototypeBind(
-      this.runInAsyncScope,
-      this,
-      fn);
-    function bound(...args) {
-      return runInAsyncScope(
-        thisArg !== undefined ? thisArg : this,
-        ...args);
+    const runInAsyncScope = this.runInAsyncScope;
+    const resource = this;
+    let bound;
+    if (thisArg === undefined) {
+      bound = function(...args) {
+        ArrayPrototypeUnshift(args, fn, this);
+        return ReflectApply(runInAsyncScope, resource, args);
+      };
+    } else {
+      bound = FunctionPrototypeBind(runInAsyncScope, resource, fn, thisArg);
     }
     ObjectDefineProperties(bound, {
       'length': {

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -223,15 +223,18 @@ class AsyncResource {
     return this[trigger_async_id_symbol];
   }
 
-  bind(fn, thisArg = this) {
+  bind(fn, thisArg) {
     validateFunction(fn, 'fn');
-    const ret =
-      FunctionPrototypeBind(
-        this.runInAsyncScope,
-        this,
-        fn,
-        thisArg);
-    ObjectDefineProperties(ret, {
+    const runInAsyncScope = FunctionPrototypeBind(
+      this.runInAsyncScope,
+      this,
+      fn);
+    function bound(...args) {
+      return runInAsyncScope(
+        thisArg !== undefined ? thisArg : this,
+        ...args);
+    }
+    ObjectDefineProperties(bound, {
       'length': {
         configurable: true,
         enumerable: false,
@@ -245,7 +248,7 @@ class AsyncResource {
         writable: true,
       }
     });
-    return ret;
+    return bound;
   }
 
   static bind(fn, type, thisArg) {

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -226,16 +226,15 @@ class AsyncResource {
 
   bind(fn, thisArg) {
     validateFunction(fn, 'fn');
-    const runInAsyncScope = this.runInAsyncScope;
-    const resource = this;
     let bound;
     if (thisArg === undefined) {
+      const resource = this;
       bound = function(...args) {
         ArrayPrototypeUnshift(args, fn, this);
-        return ReflectApply(runInAsyncScope, resource, args);
+        return ReflectApply(resource.runInAsyncScope, resource, args);
       };
     } else {
-      bound = FunctionPrototypeBind(runInAsyncScope, resource, fn, thisArg);
+      bound = FunctionPrototypeBind(this.runInAsyncScope, this, fn, thisArg);
     }
     ObjectDefineProperties(bound, {
       'length': {

--- a/test/parallel/test-asyncresource-bind.js
+++ b/test/parallel/test-asyncresource-bind.js
@@ -41,7 +41,7 @@ const fn3 = asyncResource.bind(common.mustCall(function() {
 fn3();
 
 const fn4 = asyncResource.bind(common.mustCall(function() {
-  assert.strictEqual(this, asyncResource);
+  assert.strictEqual(this, undefined);
 }));
 fn4();
 
@@ -49,3 +49,8 @@ const fn5 = asyncResource.bind(common.mustCall(function() {
   assert.strictEqual(this, false);
 }), false);
 fn5();
+
+const fn6 = asyncResource.bind(common.mustCall(function() {
+  assert.strictEqual(this, 'test');
+}));
+fn6.call('test');


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR updates the default behaviour of `AsyncResource.bind()` to keep the value of `this` untouched by default when the `thisArg` option is not provided instead of setting it to the resource, meaning that the bound function will have the same value for `this` as if it wasn't bound at all.

Fixes #42158