### PR TITLE
url: trim leading and trailing C0 control chars

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -117,7 +117,6 @@ const {
   CHAR_TAB,
   CHAR_CARRIAGE_RETURN,
   CHAR_LINE_FEED,
-  CHAR_FORM_FEED,
   CHAR_NO_BREAK_SPACE,
   CHAR_ZERO_WIDTH_NOBREAK_SPACE,
   CHAR_HASH,
@@ -196,11 +195,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     const code = url.charCodeAt(i);
 
     // Find first and last non-whitespace characters for trimming
-    const isWs = code === CHAR_SPACE ||
-                 code === CHAR_TAB ||
-                 code === CHAR_CARRIAGE_RETURN ||
-                 code === CHAR_LINE_FEED ||
-                 code === CHAR_FORM_FEED ||
+    const isWs = code < 33 ||
                  code === CHAR_NO_BREAK_SPACE ||
                  code === CHAR_ZERO_WIDTH_NOBREAK_SPACE;
     if (start === -1) {

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -992,6 +992,21 @@ const parseTests = {
     path: '/',
     href: 'http://localhost/',
   },
+
+  '\bhttp://example.com/\b': {
+    protocol: 'http:',
+    slashes: true,
+    auth: null,
+    host: 'example.com',
+    port: null,
+    hostname: 'example.com',
+    hash: null,
+    search: null,
+    query: null,
+    pathname: '/',
+    path: '/',
+    href: 'http://example.com/'
+  }
 };
 
 for (const u in parseTests) {


### PR DESCRIPTION
Emulate the WHATWHG URL parse behavior of trimming leading and trailing
C0 control characters. This moves url.parse() slightly closer to
WHATWHG URL behavior. The current behavior is possibly insecure for some
uses. (The url.parse() API is marked as Legacy and the documentation
specifically says it has known bugs and insecure behaviors. Still this
change makes a lot of sense.)

This issue was reported by P0cas. https://github.com/P0cas

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
