### PR TITLE
doc: clarify that some modules don't work when compiled without ssl

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -30,6 +30,41 @@ can be accessed using:
 const http2 = require('http2');
 ```
 
+## Determining if crypto support is unavailable
+
+It is possible for Node.js to be built without including support for the
+`crypto` module. In such cases, attempting to `import` from `http2` or
+calling `require('http2')` will result in an error being thrown.
+
+When using CommonJS, the error thrown can be caught using try/catch:
+
+```cjs
+let http2;
+try {
+  http2 = require('http2');
+} catch (err) {
+  console.log('http2 support is disabled!');
+}
+```
+
+When using the lexical ESM `import` keyword, the error can only be
+caught if a handler for `process.on('uncaughtException')` is registered
+_before_ any attempt to load the module is made -- using, for instance,
+a preload module.
+
+When using ESM, if there is a chance that the code may be run on a build
+of Node.js where crypto support is not enabled, consider using the
+`import()` function instead of the lexical `import` keyword:
+
+```mjs
+let http2;
+try {
+  http2 = await import('http2');
+} catch (err) {
+  console.log('http2 support is disabled!');
+}
+```
+
 ## Core API
 
 The Core API provides a low-level interface designed specifically around

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -49,8 +49,8 @@ try {
 
 When using the lexical ESM `import` keyword, the error can only be
 caught if a handler for `process.on('uncaughtException')` is registered
-_before_ any attempt to load the module is made -- using, for instance,
-a preload module.
+_before_ any attempt to load the module is made (using, for instance,
+a preload module).
 
 When using ESM, if there is a chance that the code may be run on a build
 of Node.js where crypto support is not enabled, consider using the

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -30,8 +30,8 @@ try {
 
 When using the lexical ESM `import` keyword, the error can only be
 caught if a handler for `process.on('uncaughtException')` is registered
-_before_ any attempt to load the module is made -- using, for instance,
-a preload module.
+_before_ any attempt to load the module is made (using, for instance,
+a preload module).
 
 When using ESM, if there is a chance that the code may be run on a build
 of Node.js where crypto support is not enabled, consider using the

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -9,6 +9,43 @@
 HTTPS is the HTTP protocol over TLS/SSL. In Node.js this is implemented as a
 separate module.
 
+## Determining if crypto support is unavailable
+
+It is possible for Node.js to be built without including support for the
+`crypto` module. In such cases, attempting to `import` from `https` or
+calling `require('https')` will result in an error being thrown.
+
+When using CommonJS, the error thrown can be caught using try/catch:
+
+<!-- eslint-skip -->
+
+```cjs
+let https;
+try {
+  https = require('https');
+} catch (err) {
+  console.log('https support is disabled!');
+}
+```
+
+When using the lexical ESM `import` keyword, the error can only be
+caught if a handler for `process.on('uncaughtException')` is registered
+_before_ any attempt to load the module is made -- using, for instance,
+a preload module.
+
+When using ESM, if there is a chance that the code may be run on a build
+of Node.js where crypto support is not enabled, consider using the
+`import()` function instead of the lexical `import` keyword:
+
+```mjs
+let https;
+try {
+  https = await import('https');
+} catch (err) {
+  console.log('https support is disabled!');
+}
+```
+
 ## Class: `https.Agent`
 
 <!-- YAML

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -14,6 +14,43 @@ The module can be accessed using:
 const tls = require('tls');
 ```
 
+## Determining if crypto support is unavailable
+
+It is possible for Node.js to be built without including support for the
+`crypto` module. In such cases, attempting to `import` from `tls` or
+calling `require('tls')` will result in an error being thrown.
+
+When using CommonJS, the error thrown can be caught using try/catch:
+
+<!-- eslint-skip -->
+
+```cjs
+let tls;
+try {
+  tls = require('tls');
+} catch (err) {
+  console.log('tls support is disabled!');
+}
+```
+
+When using the lexical ESM `import` keyword, the error can only be
+caught if a handler for `process.on('uncaughtException')` is registered
+_before_ any attempt to load the module is made -- using, for instance,
+a preload module.
+
+When using ESM, if there is a chance that the code may be run on a build
+of Node.js where crypto support is not enabled, consider using the
+`import()` function instead of the lexical `import` keyword:
+
+```mjs
+let tls;
+try {
+  tls = await import('tls');
+} catch (err) {
+  console.log('tls support is disabled!');
+}
+```
+
 ## TLS/SSL concepts
 
 TLS/SSL is a set of protocols that rely on a public key infrastructure (PKI) to

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -35,8 +35,8 @@ try {
 
 When using the lexical ESM `import` keyword, the error can only be
 caught if a handler for `process.on('uncaughtException')` is registered
-_before_ any attempt to load the module is made -- using, for instance,
-a preload module.
+_before_ any attempt to load the module is made (using, for instance,
+a preload module).
 
 When using ESM, if there is a chance that the code may be run on a build
 of Node.js where crypto support is not enabled, consider using the


### PR DESCRIPTION
We have a section on the crypto docs to deal with possible lack of support, but nothing for other modules that depend on OpenSSL APIs. This PR tries to fix that.

/cc @mcollina 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
