### PR TITLE
doc: use parenthesis instead of em dash

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -54,8 +54,8 @@ try {
 
 When using the lexical ESM `import` keyword, the error can only be
 caught if a handler for `process.on('uncaughtException')` is registered
-_before_ any attempt to load the module is made -- using, for instance,
-a preload module.
+_before_ any attempt to load the module is made (using, for instance,
+a preload module).
 
 When using ESM, if there is a chance that the code may be run on a build
 of Node.js where crypto support is not enabled, consider using the


### PR DESCRIPTION
> Using an em dash has all sorts of typographical pitfalls. For example, in this case you've put spaces around the em dash, but [Microsoft](https://docs.microsoft.com/en-us/style-guide/punctuation/dashes-hyphens/emes) and many other style guides say that an em dash should not have spaces around it. As another example, this is two dashes put together rather than an em dash character (—). This is how it was done on mechanical typewriters that didn't have an em dash character, but now we have em dash characters! 🎉  
> 
> In contrast, the conventions with parentheses are broadly understood and agreed upon.

_Originally posted by @Trott in https://github.com/nodejs/node/pull/42198#discussion_r818839342_