### PR TITLE
build: use ccache in make-v8.sh on ppc64le and s390x

### DIFF
--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -9,7 +9,7 @@ cd deps/v8 || exit
 find . -type d -name .git -print0 | xargs -0 rm -rf
 ../../tools/v8/fetch_deps.py .
 
-ARCH="`arch`"
+ARCH=$(arch)
 if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
   TARGET_ARCH=$ARCH
   if [ "$ARCH" = "ppc64le" ]; then
@@ -18,22 +18,34 @@ if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
   # set paths manually for now to use locally installed gn
   export BUILD_TOOLS=/home/iojs/build-tools
   export LD_LIBRARY_PATH="$BUILD_TOOLS:$LD_LIBRARY_PATH"
-  # Avoid linking to ccache symbolic links as ccache decides which
-  # binary to run based on the name of the link (we always name them gcc/g++).
-  # shellcheck disable=SC2154
-  CC_PATH=`command -v "$CC" gcc | grep -v ccache | head -n 1`
-  # shellcheck disable=SC2154
-  CXX_PATH=`command -v "$CXX" g++ | grep -v ccache | head -n 1`
   rm -f "$BUILD_TOOLS/g++"
   rm -f "$BUILD_TOOLS/gcc"
-  ln -s "$CXX_PATH" "$BUILD_TOOLS/g++"
-  ln -s "$CC_PATH" "$BUILD_TOOLS/gcc"
+  # V8's build config looks for binaries called `gcc` and `g++` if not using
+  # clang. Ensure that `gcc` and `g++` point to the compilers we want to
+  # invoke, creating symbolic links placed at the front of PATH, if needed.
+  # Avoid linking to ccache symbolic links as ccache decides which binary
+  # to run based on the name of the link (i.e. `gcc`/`g++` in our case).
+  # shellcheck disable=SC2154
+  if [ "$CC" != "" ] && [ "$CC" != "gcc" ]; then
+    CC_PATH=$(command -v "$CC" gcc | grep -v ccache | head -n 1)
+    ln -s "$CC_PATH" "$BUILD_TOOLS/gcc"
+  fi
+  # shellcheck disable=SC2154
+  if [ "$CXX" != "" ] && [ "$CXX" != "g++" ]; then
+    CXX_PATH=$(command -v "$CXX" g++ | grep -v ccache | head -n 1)
+    ln -s "$CXX_PATH" "$BUILD_TOOLS/g++"
+  fi
   export PATH="$BUILD_TOOLS:$PATH"
+  # Propagate ccache to gn.
+  case "$CXX" in
+    *ccache*) CC_WRAPPER="cc_wrapper=\"ccache\"" ;;
+    *) ;;
+  esac
 
   g++ --version
   gcc --version
   export PKG_CONFIG_PATH=$BUILD_TOOLS/pkg-config
-  gn gen -v "out.gn/$BUILD_ARCH_TYPE" --args="is_component_build=false is_debug=false use_goma=false goma_dir=\"None\" use_custom_libcxx=false v8_target_cpu=\"$TARGET_ARCH\" target_cpu=\"$TARGET_ARCH\" v8_enable_backtrace=true"
+  gn gen -v "out.gn/$BUILD_ARCH_TYPE" --args="is_component_build=false is_debug=false use_goma=false goma_dir=\"None\" use_custom_libcxx=false v8_target_cpu=\"$TARGET_ARCH\" target_cpu=\"$TARGET_ARCH\" v8_enable_backtrace=true $CC_WRAPPER"
   ninja -v -C "out.gn/$BUILD_ARCH_TYPE" d8 cctest inspector-test
 else
   DEPOT_TOOLS_DIR="$(cd _depot_tools && pwd)"


### PR DESCRIPTION
If `ccache` is available, use it during V8 builds on ppc64le and s390x.
Only create the `gcc` and `g++` shims if necessary.

---

Stumbled across https://chromium.googlesource.com/chromium/src/+/HEAD/docs/ccache_mac.md while setting up new RHEL 8 instances on the CI.

I attempted to also enable `ccache` for the `else` branch of `make-v8.sh`, e.g. for Linux x64, but while this did work on the new RHEL 8 x64 CI instance I've been setting up, this fails on test-nearform_intel-ubuntu1604-x64-1 (the machine currently used for label benchmark-ubuntu1604-intel-64 in the job) with lots of errors of this type:
```
clang++: error: argument unused during compilation:
```

I figure we can enable this for ppc64le and s390x first and potentially revisit for x64 later on. We've procrastinated over upgrading the benchmark machines (i.e. test-nearform_intel-ubuntu1604-x64-1) from Ubuntu 16.04 for a while (https://github.com/nodejs/build/issues/2656) and this could be another reason to do so.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
