### PR TITLE
test: improve _http_incoming.js coverage

### DIFF
--- a/test/parallel/test-set-incoming-message-header.js
+++ b/test/parallel/test-set-incoming-message-header.js
@@ -1,0 +1,27 @@
+'use strict';
+
+require('../common');
+const { IncomingMessage } = require('http');
+const assert = require('assert');
+
+// Headers setter function set a header correctly
+{
+  const im = new IncomingMessage();
+  im.headers = { key: 'value' };
+  assert.deepStrictEqual(im.headers, { key: 'value' });
+}
+
+// Trailers setter function set a header correctly
+{
+  const im = new IncomingMessage();
+  im.trailers = { key: 'value' };
+  assert.deepStrictEqual(im.trailers, { key: 'value' });
+}
+
+// _addHeaderLines function set a header correctly
+{
+  const im = new IncomingMessage();
+  im.headers = { key1: 'value1' };
+  im._addHeaderLines(['key2', 'value2'], 2);
+  assert.deepStrictEqual(im.headers, { key1: 'value1', key2: 'value2' });
+}


### PR DESCRIPTION
This improves a test coverage in `lib/_http_incoming.js`.

ref: https://coverage.nodejs.org/coverage-010cb714161102de/lib/_http_incoming.js.html

This validates that the following methods work correctly.
- `IncomingMessage.headers` setter method
- `IncomingMessage.trailers` setter method
- `IncomingMessage._addHeaderLines` method