### PR TITLE
test: improve _http_outgoing coverage

### DIFF
--- a/test/parallel/test-http-outgoing-internal-headernames-getter.js
+++ b/test/parallel/test-http-outgoing-internal-headernames-getter.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 
 const { OutgoingMessage } = require('http');
+const assert = require('assert');
 
 const warn = 'OutgoingMessage.prototype._headerNames is deprecated';
 common.expectWarning('DeprecationWarning', warn, 'DEP0066');
@@ -10,4 +11,13 @@ common.expectWarning('DeprecationWarning', warn, 'DEP0066');
   // Tests for _headerNames get method
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage._headerNames; // eslint-disable-line no-unused-expressions
+}
+
+{
+  // Tests _headerNames getter result after setting a header.
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage.setHeader('key', 'value');
+  const expect = Object.create(null);
+  expect.key = 'key';
+  assert.deepStrictEqual(outgoingMessage._headerNames, expect);
 }


### PR DESCRIPTION
This improves a test coverage in `lib/_http_outgoing.js`.

ref: https://coverage.nodejs.org/coverage-29bb2bb57d2a993e/lib/_http_outgoing.js.html

This PR add a test that validate `OutgoinMessage._headerNames` getter works correctly after setting a header.