### PR TITLE
doc: readline `'line'` event emits final line

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -109,7 +109,10 @@ added: v0.1.98
 
 The `'line'` event is emitted whenever the `input` stream receives an
 end-of-line input (`\n`, `\r`, or `\r\n`). This usually occurs when the user
-presses <kbd>Enter</kbd> or <kbd>Return</kbd>.
+presses <kbd>Enter</kbd> or <kbd>Return</kbd>. 
+
+The `'line'` event is also emitted if new data has been read from a stream and
+that stream ends without a final end-of-line marker.
 
 The listener function is called with a string containing the single line of
 received input.

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -109,7 +109,7 @@ added: v0.1.98
 
 The `'line'` event is emitted whenever the `input` stream receives an
 end-of-line input (`\n`, `\r`, or `\r\n`). This usually occurs when the user
-presses <kbd>Enter</kbd> or <kbd>Return</kbd>. 
+presses <kbd>Enter</kbd> or <kbd>Return</kbd>.
 
 The `'line'` event is also emitted if new data has been read from a stream and
 that stream ends without a final end-of-line marker.


### PR DESCRIPTION
Updated docs to reflect current behaviour of readline:
final line of input will be emitted via `'line'` event
when input stream `'end'` event is emitted even when
the input is not newline terminated.

Refs: https://github.com/nodejs/node-v0.x-archive/issues/7238

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
