### PR TITLE
src,crypto: avoid tristate `Maybe<bool>` in `ExportJWKEcKey()`

### DIFF
--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -24,6 +24,7 @@ using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Int32;
 using v8::Just;
+using v8::JustVoid;
 using v8::Local;
 using v8::Maybe;
 using v8::Nothing;
@@ -711,7 +712,7 @@ WebCryptoKeyExportStatus ECKeyExportTraits::DoExport(
   }
 }
 
-Maybe<bool> ExportJWKEcKey(
+Maybe<void> ExportJWKEcKey(
     Environment* env,
     std::shared_ptr<KeyObjectData> key,
     Local<Object> target) {
@@ -738,7 +739,7 @@ Maybe<bool> ExportJWKEcKey(
           env->context(),
           env->jwk_kty_string(),
           env->jwk_ec_string()).IsNothing()) {
-    return Nothing<bool>();
+    return Nothing<void>();
   }
 
   if (SetEncodedValue(
@@ -753,7 +754,7 @@ Maybe<bool> ExportJWKEcKey(
           env->jwk_y_string(),
           y.get(),
           degree_bytes).IsNothing()) {
-    return Nothing<bool>();
+    return Nothing<void>();
   }
 
   Local<String> crv_name;
@@ -774,14 +775,14 @@ Maybe<bool> ExportJWKEcKey(
     default: {
       THROW_ERR_CRYPTO_JWK_UNSUPPORTED_CURVE(
           env, "Unsupported JWK EC curve: %s.", OBJ_nid2sn(nid));
-      return Nothing<bool>();
+      return Nothing<void>();
     }
   }
   if (target->Set(
       env->context(),
       env->jwk_crv_string(),
       crv_name).IsNothing()) {
-    return Nothing<bool>();
+    return Nothing<void>();
   }
 
   if (key->GetKeyType() == kKeyTypePrivate) {
@@ -791,10 +792,10 @@ Maybe<bool> ExportJWKEcKey(
       target,
       env->jwk_d_string(),
       pvt,
-      degree_bytes);
+      degree_bytes).IsJust() ? JustVoid() : Nothing<void>();
   }
 
-  return Just(true);
+  return JustVoid();
 }
 
 Maybe<bool> ExportJWKEdKey(

--- a/src/crypto/crypto_ec.h
+++ b/src/crypto/crypto_ec.h
@@ -144,7 +144,7 @@ struct ECKeyExportTraits final {
 
 using ECKeyExportJob = KeyExportJob<ECKeyExportTraits>;
 
-v8::Maybe<bool> ExportJWKEcKey(
+v8::Maybe<void> ExportJWKEcKey(
     Environment* env,
     std::shared_ptr<KeyObjectData> key,
     v8::Local<v8::Object> target);

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -497,7 +497,8 @@ Maybe<bool> ExportJWKAsymmetricKey(
       break;
     }
     case EVP_PKEY_RSA: return ExportJWKRsaKey(env, key, target);
-    case EVP_PKEY_EC: return ExportJWKEcKey(env, key, target);
+    case EVP_PKEY_EC: return ExportJWKEcKey(env, key, target).IsJust() ?
+                               Just(true) : Nothing<bool>();
     case EVP_PKEY_ED25519:
       // Fall through
     case EVP_PKEY_ED448:


### PR DESCRIPTION
The function currently uses the return value to convey whether an
exception was thrown while it was running by using either `Just(true)` or
`Nothing<bool>()`. Unfortunately, `Maybe<bool>` also has a third state -
`Just(false)`, which doesn't make any sense here. So this change avoids
the possibility of a tristate return value by making use of `Maybe<void>`
which only has two valid states - `JustVoid()` / `Nothing<void>()`, which
fits right in.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
