### PR TITLE
crypto: improve prime size argument validation

### DIFF
--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -43,6 +43,7 @@ const {
   validateNumber,
   validateBoolean,
   validateFunction,
+  validateInt32,
   validateObject,
   validateUint32,
 } = require('internal/validators');
@@ -460,7 +461,7 @@ function createRandomPrimeJob(type, size, options) {
 }
 
 function generatePrime(size, options, callback) {
-  validateUint32(size, 'size', true);
+  validateInt32(size, 'size', 1);
   if (typeof options === 'function') {
     callback = options;
     options = {};
@@ -482,7 +483,7 @@ function generatePrime(size, options, callback) {
 }
 
 function generatePrimeSync(size, options = {}) {
-  validateUint32(size, 'size', true);
+  validateInt32(size, 'size', 1);
 
   const job = createRandomPrimeJob(kCryptoJobSync, size, options);
   const { 0: err, 1: prime } = job.run();

--- a/src/crypto/crypto_random.cc
+++ b/src/crypto/crypto_random.cc
@@ -122,11 +122,9 @@ Maybe<bool> RandomPrimeTraits::AdditionalConfig(
     }
   }
 
+  // The JS interface already ensures that the (positive) size fits into an int.
   int bits = static_cast<int>(size);
-  if (bits < 0) {
-    THROW_ERR_OUT_OF_RANGE(env, "invalid size");
-    return Nothing<bool>();
-  }
+  CHECK_GT(bits, 0);
 
   if (params->add) {
     if (BN_num_bits(params->add.get()) > bits) {

--- a/test/parallel/test-crypto-prime.js
+++ b/test/parallel/test-crypto-prime.js
@@ -41,12 +41,14 @@ const pCheckPrime = promisify(checkPrime);
   });
 });
 
-[-1, 0, 2 ** 31, 2 ** 31 + 1, 2 ** 32 - 1, 2 ** 32].forEach((i) => {
-  assert.throws(() => generatePrime(i, common.mustNotCall()), {
-    code: 'ERR_OUT_OF_RANGE'
+[-1, 0, 2 ** 31, 2 ** 31 + 1, 2 ** 32 - 1, 2 ** 32].forEach((size) => {
+  assert.throws(() => generatePrime(size, common.mustNotCall()), {
+    code: 'ERR_OUT_OF_RANGE',
+    message: />= 1 && <= 2147483647/
   });
-  assert.throws(() => generatePrimeSync(i), {
-    code: 'ERR_OUT_OF_RANGE'
+  assert.throws(() => generatePrimeSync(size), {
+    code: 'ERR_OUT_OF_RANGE',
+    message: />= 1 && <= 2147483647/
   });
 });
 


### PR DESCRIPTION
The current validation in JavaScript is insufficient and also produces an incorrect error message, restricting the `size` parameter to 32-bit values, whereas the C++ backend restricts the `size` parameter to the positive range of an `int`.

This change tightens the validation in JavaScript and adapts the error message accordingly, making the validation in C++ superfluous.

Refs: https://github.com/nodejs/node/pull/42207

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
