### PR TITLE
doc: remove refs to old OpenSSL list-* commands

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2970,8 +2970,7 @@ option is not required but can be used to set the length of the authentication
 tag that will be returned by `getAuthTag()` and defaults to 16 bytes.
 
 The `algorithm` is dependent on OpenSSL, examples are `'aes192'`, etc. On
-recent OpenSSL releases, `openssl list -cipher-algorithms`
-(`openssl list-cipher-algorithms` for older versions of OpenSSL) will
+recent OpenSSL releases, `openssl list -cipher-algorithms` will
 display the available cipher algorithms.
 
 The `password` is used to derive the cipher key and initialization vector (IV).
@@ -3041,8 +3040,7 @@ option is not required but can be used to set the length of the authentication
 tag that will be returned by `getAuthTag()` and defaults to 16 bytes.
 
 The `algorithm` is dependent on OpenSSL, examples are `'aes192'`, etc. On
-recent OpenSSL releases, `openssl list -cipher-algorithms`
-(`openssl list-cipher-algorithms` for older versions of OpenSSL) will
+recent OpenSSL releases, `openssl list -cipher-algorithms` will
 display the available cipher algorithms.
 
 The `key` is the raw key used by the `algorithm` and `iv` is an
@@ -3142,8 +3140,7 @@ option is not required but can be used to restrict accepted authentication tags
 to those with the specified length.
 
 The `algorithm` is dependent on OpenSSL, examples are `'aes192'`, etc. On
-recent OpenSSL releases, `openssl list -cipher-algorithms`
-(`openssl list-cipher-algorithms` for older versions of OpenSSL) will
+recent OpenSSL releases, `openssl list -cipher-algorithms` will
 display the available cipher algorithms.
 
 The `key` is the raw key used by the `algorithm` and `iv` is an
@@ -3259,8 +3256,7 @@ can be used to specify the desired output length in bytes.
 
 The `algorithm` is dependent on the available algorithms supported by the
 version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc.
-On recent releases of OpenSSL, `openssl list -digest-algorithms`
-(`openssl list-message-digest-algorithms` for older versions of OpenSSL) will
+On recent releases of OpenSSL, `openssl list -digest-algorithms` will
 display the available digest algorithms.
 
 Example: generating the sha256 sum of a file
@@ -3343,8 +3339,7 @@ Optional `options` argument controls stream behavior.
 
 The `algorithm` is dependent on the available algorithms supported by the
 version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc.
-On recent releases of OpenSSL, `openssl list -digest-algorithms`
-(`openssl list-message-digest-algorithms` for older versions of OpenSSL) will
+On recent releases of OpenSSL, `openssl list -digest-algorithms` will
 display the available digest algorithms.
 
 The `key` is the HMAC key used to generate the cryptographic HMAC hash. If it is


### PR DESCRIPTION
The last release line that did not support the new `openssl list` command was OpenSSL 1.1.0, which reached its end-of-life status years ago.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
