### PR TITLE
deps: V8: cherry-pick c6f6626deb14

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.15',
+    'v8_embedder_string': '-node.16',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/regexp/riscv64/regexp-macro-assembler-riscv64.cc
+++ b/deps/v8/src/regexp/riscv64/regexp-macro-assembler-riscv64.cc
@@ -899,8 +899,8 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
           __ Branch(&load_char_start_regexp, ne, current_input_offset(),
                     Operand(s3));
           // Offset from the end is zero if we already reached the end.
-          __ BranchShort(&exit_label_, eq, current_input_offset(),
-                         Operand(zero_reg));
+          __ Branch(&exit_label_, eq, current_input_offset(),
+                    Operand(zero_reg));
           // Advance current position after a zero-length match.
           Label advance;
           __ bind(&advance);


### PR DESCRIPTION
Original commit message:

    [riscv64] Fix segmentation fault of webpack-make from cockpit

    issue: https://github.com/riscv-collab/v8/issues/520

    Change-Id: I7fe298ad16a2f599805929db0f084a81c4eb7f7a
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3503170
    Auto-Submit: Yahan Lu <yahan@iscas.ac.cn>
    Reviewed-by: ji qiu <qiuji@iscas.ac.cn>
    Reviewed-by: Yahan Lu <yahan@iscas.ac.cn>
    Commit-Queue: Yahan Lu <yahan@iscas.ac.cn>
    Cr-Commit-Position: refs/heads/main@{#79376}

Refs: https://github.com/v8/v8/commit/c6f6626deb147fccc8bb5c32f96481efd9aaad0a

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
