### PR TITLE
tools: support versioned node shared libraries on z/OS

### DIFF
--- a/tools/zos/modifysidedeck.sh
+++ b/tools/zos/modifysidedeck.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+if [ "$#" -ne 3 ] || ! [ -f "$1" ]; then
+  echo ===========================
+  echo "Script to modify sidedeck references to a new DLL name"
+  echo ===========================
+  echo "Usage: $0 originalsidedeck modifiedsidedeck newdllreference" >&2
+  exit 1
+fi
+
+originalsidedeck=$1
+outputsidedeck=$2
+newdllname=$3
+
+SCRIPT_DIR=$(dirname "$0")
+ID=`date +%C%y%m%d_%H%M%S`
+TMP="/tmp/sidedeck-$(basename "$0").$ID.tmp"
+TMP2="/tmp/sidedeck-$(basename "$0").$ID.tmp.2"
+
+# Remove on exit/interrupt
+trap '/bin/rm -rf "$TMP" "$TMP2" && exit' EXIT INT TERM QUIT HUP
+
+set -x
+dd conv=unblock cbs=80 if="$originalsidedeck" of="$TMP"
+chtag -tc 1047 "$TMP"
+"$SCRIPT_DIR"/sdwrap.py -u -i "$TMP" -o "$TMP2"
+chtag -tc 819 "$TMP2"
+sed -e "s/\(^ IMPORT \(DATA\|CODE\)64,\)'[^']*'/\1'$newdllname'/g" "$TMP2" > "$TMP"
+"$SCRIPT_DIR"/sdwrap.py -i "$TMP" -o "$TMP2"
+
+# Reformat sidedeck to be USS compatible
+iconv -f ISO8859-1 -t IBM-1047 "$TMP2" > "$TMP"
+dd conv=block cbs=80 if="$TMP" of="$outputsidedeck"

--- a/tools/zos/sdwrap.py
+++ b/tools/zos/sdwrap.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+
+def wrap(args):
+  l = args.input.readline(72)
+  firstline = True
+  while l:
+    if l[-1] == '\n':
+      if firstline:
+        outstr = "{}".format(l)
+      else:
+        outstr = " {}".format(l)
+        firstline = True
+      l = args.input.readline(72)
+    else:
+      if firstline:
+        outstr = "{:<71}*\n".format(l[:-1])
+        firstline = False
+      else:
+        outstr = " {:<70}*\n".format(l[:-1])
+      l = l[-1] + args.input.readline(70)
+    args.output.write(outstr)
+
+  return 0
+
+def unwrap(args):
+  l = args.input.readline()
+  firstline = True
+  while l:
+    if len(l) > 80:
+      print("Error: input line invalid (longer than 80 characters)", file=sys.stderr)
+      return 1
+    if not firstline and l[0] != ' ':
+      print("Error: continuation line not start with blank", file=sys.stderr)
+      return 1
+
+    if len(l) > 71 and l[71] == '*':
+      if firstline:
+        args.output.write(l[:71])
+        firstline = False
+      else:
+        args.output.write(l[1:71])
+    else:
+      if firstline:
+        args.output.write(l)
+      else:
+        args.output.write(l[1:])
+        firstline = True
+    l = args.input.readline()
+  return 0
+
+def Main():
+  parser = argparse.ArgumentParser(description="Wrap sidedeck source to card formats")
+  parser.add_argument("-u", "--unwrap",
+      help="Unwrap sidedeck cards to source formats instead", action="store_true",
+      default=False)
+  parser.add_argument("-i", "--input", help="input filename, default to stdin",
+      action="store", default=None)
+  parser.add_argument("-o", "--output", help="output filename, default to stdout",
+      action="store", default=None)
+
+  args = parser.parse_args()
+
+  if args.input is None:
+    args.input = sys.stdin
+  else:
+    args.input = open(args.input, 'r')
+
+  if args.output is None:
+    args.output = sys.stdout
+  else:
+    args.output = open(args.output, 'w')
+
+  if args.unwrap:
+    return unwrap(args)
+
+  return wrap(args)
+
+if __name__ == '__main__':
+  sys.exit(Main())


### PR DESCRIPTION
The shared libraries will now be stores in lib.target as opposed to
obj.target, libnode.version.so, libnode.x (for npm backwards compat and
testing), and libnode.version.x (for builds). The install will also
include libnode.so link that points to libnode.version.so (this will be
used by native npms for backwards compat).

This PR is depend on https://github.com/nodejs/node-gyp/pull/2619 and https://github.com/nodejs/gyp-next/pull/137.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
