### PR TITLE
fix async iterable pipeline AbortSignal examples

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2556,7 +2556,7 @@ const fs = require('fs');
 
 async function run() {
   await pipeline(
-    async function * ({ signal }) {
+    async function* ({ signal }) {
       await someLongRunningfn({ signal });
       yield 'asd';
     },

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2532,7 +2532,7 @@ const fs = require('fs');
 async function run() {
   await pipeline(
     fs.createReadStream('lowercase.txt'),
-    async function* (source, signal) {
+    async function* (source, { signal }) {
       source.setEncoding('utf8');  // Work with strings rather than `Buffer`s.
       for await (const chunk of source) {
         yield await processChunk(chunk, { signal });
@@ -2556,7 +2556,7 @@ const fs = require('fs');
 
 async function run() {
   await pipeline(
-    async function * (signal) {
+    async function * ({ signal }) {
       await someLongRunningfn({ signal });
       yield 'asd';
     },


### PR DESCRIPTION
Fix async iterable pipeline AbortSignal examples to show the correct
arguments with async generators receiving the signal in an object
wrapper.