### PR TITLE
url: preserve null char in WHATWG URL errors

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -559,7 +559,7 @@ function onParseComplete(flags, protocol, username, password,
   initSearchParams(this[searchParams], query);
 }
 
-function onParseError(flags, input) {
+function onParseError(input, flags) {
   throw new ERR_INVALID_URL(input);
 }
 
@@ -641,7 +641,8 @@ class URL {
     }
     this[context] = new URLContext();
     parse(input, -1, base_context, undefined,
-          FunctionPrototypeBind(onParseComplete, this), onParseError);
+          FunctionPrototypeBind(onParseComplete, this),
+          FunctionPrototypeBind(onParseError, this, input));
   }
 
   get [special]() {
@@ -760,7 +761,8 @@ class URL {
     // toUSVString is not needed.
     input = `${input}`;
     parse(input, -1, undefined, undefined,
-          FunctionPrototypeBind(onParseComplete, this), onParseError);
+          FunctionPrototypeBind(onParseComplete, this),
+          FunctionPrototypeBind(onParseError, this, input));
   }
 
   // readonly

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -142,19 +142,9 @@ URLHost::~URLHost() {
   XX(ARG_FRAGMENT)                                                            \
   XX(ARG_COUNT)  // This one has to be last.
 
-#define ERR_ARGS(XX)                                                          \
-  XX(ERR_ARG_FLAGS)                                                           \
-  XX(ERR_ARG_INPUT)                                                           \
-
 enum url_cb_args {
 #define XX(name) name,
   ARGS(XX)
-#undef XX
-};
-
-enum url_error_cb_args {
-#define XX(name) name,
-  ERR_ARGS(XX)
 #undef XX
 };
 
@@ -1679,12 +1669,8 @@ void Parse(Environment* env,
     SetArgs(env, argv, url);
     cb->Call(context, recv, arraysize(argv), argv).FromMaybe(Local<Value>());
   } else if (error_cb->IsFunction()) {
-    Local<Value> argv[2] = { undef, undef };
-    argv[ERR_ARG_FLAGS] = Integer::NewFromUnsigned(isolate, url.flags);
-    argv[ERR_ARG_INPUT] =
-      String::NewFromUtf8(env->isolate(), input).ToLocalChecked();
-    error_cb.As<Function>()->Call(context, recv, arraysize(argv), argv)
-        .FromMaybe(Local<Value>());
+    Local<Value> flags = Integer::NewFromUnsigned(isolate, url.flags);
+    USE(error_cb.As<Function>()->Call(context, recv, 1, &flags));
   }
 }
 

--- a/test/parallel/test-url-null-char.js
+++ b/test/parallel/test-url-null-char.js
@@ -1,0 +1,8 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+assert.throws(
+  () => { new URL('a\0b'); },
+  { input: 'a\0b' }
+);


### PR DESCRIPTION
A null character in the middle of an invalid URL was resulting in an
error message that truncated the input string. This preserves the entire
input string in the error message.

Refs: https://github.com/nodejs/node/issues/39592

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
