### PR TITLE
build: bump macOS deployment target to 10.15

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -113,7 +113,7 @@ platforms. This is true regardless of entries in the table below.
 | Windows          | x86 (native)     | >= Windows 10/Server 2016       | Tier 1 (running) / Experimental (compiling)[^6] |                                           |
 | Windows          | x64, x86         | Windows 8.1/Server 2012         | Experimental                                    |                                           |
 | Windows          | arm64            | >= Windows 10                   | Tier 2 (compiling) / Experimental (running)     |                                           |
-| macOS            | x64              | >= 10.13                        | Tier 1                                          | For notes about compilation see [^7]      |
+| macOS            | x64              | >= 10.15                        | Tier 1                                          | For notes about compilation see [^7]      |
 | macOS            | arm64            | >= 11                           | Tier 1                                          |                                           |
 | SmartOS          | x64              | >= 18                           | Tier 2                                          |                                           |
 | AIX              | ppc64be >=power7 | >= 7.2 TL04                     | Tier 2                                          |                                           |
@@ -151,8 +151,7 @@ platforms. This is true regardless of entries in the table below.
     Furthermore, compiling on x86 Windows is Experimental and
     may not be possible.
 
-[^7]: Our macOS x64 Binaries are compiled with 10.13 as a target.
-    However there is no guarantee compiling on 10.13 will work as Xcode11 is
+[^7]: Our macOS x64 Binaries are compiled with 10.15 as a target. Xcode11 is
     required to compile.
 
 ### Supported toolchains
@@ -172,8 +171,8 @@ Binaries at <https://nodejs.org/download/release/> are produced on:
 | Binary package          | Platform and Toolchain                                                                                        |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------- |
 | aix-ppc64               | AIX 7.2 TL04 on PPC64BE with GCC 8                                                                            |
-| darwin-x64              | macOS 10.15, Xcode Command Line Tools 11 with -mmacosx-version-min=10.13                                      |
-| darwin-arm64 (and .pkg) | macOS 11 (arm64), Xcode Command Line Tools 12 with -mmacosx-version-min=10.13                                 |
+| darwin-x64              | macOS 10.15, Xcode Command Line Tools 11 with -mmacosx-version-min=10.15                                      |
+| darwin-arm64 (and .pkg) | macOS 11 (arm64), Xcode Command Line Tools 12 with -mmacosx-version-min=10.15                                 |
 | linux-arm64             | CentOS 7 with devtoolset-8 / GCC 8[^8]                                                                        |
 | linux-armv7l            | Cross-compiled on Ubuntu 18.04 x64 with [custom GCC toolchain](https://github.com/rvagg/rpi-newer-crosstools) |
 | linux-ppc64le           | CentOS 7 with devtoolset-8 / GCC 8[^8]                                                                        |

--- a/common.gypi
+++ b/common.gypi
@@ -497,7 +497,7 @@
           'GCC_ENABLE_CPP_RTTI': 'NO',              # -fno-rtti
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
           'PREBINDING': 'NO',                       # No -Wl,-prebind
-          'MACOSX_DEPLOYMENT_TARGET': '10.13',      # -mmacosx-version-min=10.13
+          'MACOSX_DEPLOYMENT_TARGET': '10.15',      # -mmacosx-version-min=10.15
           'USE_HEADERMAP': 'NO',
           'OTHER_CFLAGS': [
             '-fno-strict-aliasing',


### PR DESCRIPTION
Update the macOS deployment target for Node.js 18 onwards.

Refs: https://github.com/nodejs/build/issues/2815
Refs: https://github.com/libuv/libuv/pull/3406

The original idea for Node.js 18 (https://github.com/nodejs/build/issues/2815#issuecomment-982140721) was to bump the deployment target to macOS 10.14, but libuv has bumped its baseline to macOS 10.15 and also started dropping some workarounds for older versions of macOS so it seems sensible to align.

We stopped testing on macOS 10.14 for Node.js 17 (https://github.com/nodejs/build/issues/2769, https://github.com/nodejs/build/pull/2778, https://github.com/nodejs/build/pull/2785).

cc @nodejs/build @nodejs/platform-macos @nodejs/version-management 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
