### PR TITLE
os: reorder get temp environment variable for windows

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -173,8 +173,8 @@ platform[SymbolToPrimitive] = () => process.platform;
 function tmpdir() {
   var path;
   if (isWindows) {
-    path = process.env.TEMP ||
-           process.env.TMP ||
+    path = process.env.TMP ||
+           process.env.TEMP ||
            (process.env.SystemRoot || process.env.windir) + '\\temp';
     if (path.length > 1 && StringPrototypeEndsWith(path, '\\') &&
         !StringPrototypeEndsWith(path, ':\\'))

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -43,19 +43,19 @@ process.env.TMPDIR = '/tmpdir';
 process.env.TMP = '/tmp';
 process.env.TEMP = '/temp';
 if (common.isWindows) {
-  assert.strictEqual(os.tmpdir(), '/temp');
-  process.env.TEMP = '';
   assert.strictEqual(os.tmpdir(), '/tmp');
   process.env.TMP = '';
+  assert.strictEqual(os.tmpdir(), '/temp');
+  process.env.TEMP = '';
   const expected = `${process.env.SystemRoot || process.env.windir}\\temp`;
   assert.strictEqual(os.tmpdir(), expected);
-  process.env.TEMP = '\\temp\\';
-  assert.strictEqual(os.tmpdir(), '\\temp');
-  process.env.TEMP = '\\tmpdir/';
+  process.env.TMP = '\\tmp\\';
+  assert.strictEqual(os.tmpdir(), '\\tmp');
+  process.env.TMP = '\\tmpdir/';
   assert.strictEqual(os.tmpdir(), '\\tmpdir/');
-  process.env.TEMP = '\\';
+  process.env.TMP = '\\';
   assert.strictEqual(os.tmpdir(), '\\');
-  process.env.TEMP = 'C:\\';
+  process.env.TMP = 'C:\\';
   assert.strictEqual(os.tmpdir(), 'C:\\');
 } else {
   assert.strictEqual(os.tmpdir(), '/tmpdir');


### PR DESCRIPTION
According to windows document, the temp direcotry  should check $TMP
first, after that, check $TEMP, or node will get different temp
directory compared with c/c++ program if user have different path
for $TMP and $TEMP in windows.

Refs: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
