### PR TITLE
module: unflag WASM modules

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -44,9 +44,8 @@ Otherwise, the file is loaded using the CommonJS module loader. See
 ### ECMAScript modules loader entry point caveat
 
 When loading [ECMAScript module loader][] loads the program entry point, the `node`
-command will only accept as input only files with `.js`, `.mjs`, or `.cjs`
-extensions; and with `.wasm` extensions when
-[`--experimental-wasm-modules`][] is enabled.
+command will only accept as input only files with `.js`, `.mjs`, `.cjs`, or
+`.wasm` extensions.
 
 ## Options
 
@@ -380,14 +379,6 @@ changes:
 -->
 
 Enable experimental WebAssembly System Interface (WASI) support.
-
-### `--experimental-wasm-modules`
-
-<!-- YAML
-added: v12.3.0
--->
-
-Enable experimental WebAssembly module support.
 
 ### `--force-context-aware`
 
@@ -1995,7 +1986,6 @@ $ node --max-old-space-size=1536 index.js
 [`"type"`]: packages.md#type
 [`--cpu-prof-dir`]: #--cpu-prof-dir
 [`--diagnostic-dir`]: #--diagnostic-dirdirectory
-[`--experimental-wasm-modules`]: #--experimental-wasm-modules
 [`--heap-prof-dir`]: #--heap-prof-dir
 [`--openssl-config`]: #--openssl-configfile
 [`--redirect-warnings`]: #--redirect-warningsfile

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -537,9 +537,8 @@ imported from the same path.
 
 > Stability: 1 - Experimental
 
-Importing WebAssembly modules is supported under the
-`--experimental-wasm-modules` flag, allowing any `.wasm` files to be
-imported as normal modules while also supporting their module imports.
+WebAssembly modules can be imported as normal modules while also supporting
+their module imports.
 
 This integration is in line with the
 [ES Module Integration Proposal for WebAssembly][].
@@ -549,12 +548,6 @@ For example, an `index.mjs` containing:
 ```js
 import * as M from './module.wasm';
 console.log(M);
-```
-
-executed under:
-
-```bash
-node --experimental-wasm-modules index.mjs
 ```
 
 would provide the exports interface for the instantiation of `module.wasm`.

--- a/doc/node.1
+++ b/doc/node.1
@@ -171,9 +171,6 @@ Enable experimental ES module support in VM module.
 .It Fl -experimental-wasi-unstable-preview1
 Enable experimental WebAssembly System Interface support.
 .
-.It Fl -experimental-wasm-modules
-Enable experimental WebAssembly module support.
-.
 .It Fl -force-context-aware
 Disable loading native addons that are not context-aware.
 .

--- a/lib/internal/modules/esm/formats.js
+++ b/lib/internal/modules/esm/formats.js
@@ -3,10 +3,6 @@
 const {
   RegExpPrototypeTest,
 } = primordials;
-const { getOptionValue } = require('internal/options');
-
-
-const experimentalWasmModules = getOptionValue('--experimental-wasm-modules');
 
 const extensionFormatMap = {
   '__proto__': null,
@@ -14,6 +10,7 @@ const extensionFormatMap = {
   '.js': 'module',
   '.json': 'json',
   '.mjs': 'module',
+  '.wasm': 'wasm',
 };
 
 const legacyExtensionFormatMap = {
@@ -23,11 +20,8 @@ const legacyExtensionFormatMap = {
   '.json': 'commonjs',
   '.mjs': 'module',
   '.node': 'commonjs',
+  '.wasm': 'wasm',
 };
-
-if (experimentalWasmModules) {
-  extensionFormatMap['.wasm'] = legacyExtensionFormatMap['.wasm'] = 'wasm';
-}
 
 function mimeToFormat(mime) {
   if (
@@ -37,7 +31,7 @@ function mimeToFormat(mime) {
     )
   ) return 'module';
   if (mime === 'application/json') return 'json';
-  if (experimentalWasmModules && mime === 'application/wasm') return 'wasm';
+  if (mime === 'application/wasm') return 'wasm';
   return null;
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -336,10 +336,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental https: support for the ES Module loader",
             &EnvironmentOptions::experimental_https_modules,
             kAllowedInEnvironment);
-  AddOption("--experimental-wasm-modules",
-            "experimental ES Module support for webassembly modules",
-            &EnvironmentOptions::experimental_wasm_modules,
-            kAllowedInEnvironment);
+  AddOption("--experimental-wasm-modules", "", NoOp{}, kAllowedInEnvironment);
   AddOption("--experimental-import-meta-resolve",
             "experimental ES Module import.meta.resolve() support",
             &EnvironmentOptions::experimental_import_meta_resolve,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -111,7 +111,6 @@ class EnvironmentOptions : public Options {
   bool experimental_global_web_crypto = false;
   bool experimental_https_modules = false;
   std::string experimental_specifier_resolution;
-  bool experimental_wasm_modules = false;
   bool experimental_import_meta_resolve = false;
   std::string module_type;
   std::string experimental_policy;

--- a/test/es-module/test-esm-wasm.mjs
+++ b/test/es-module/test-esm-wasm.mjs
@@ -1,4 +1,3 @@
-// Flags: --experimental-wasm-modules
 import '../common/index.mjs';
 import { path } from '../common/fixtures.mjs';
 import { add, addImported } from '../fixtures/es-modules/simple.wasm';
@@ -18,7 +17,6 @@ strictEqual(addImported(1), 43);
 
 // Test warning message
 const child = spawn(process.execPath, [
-  '--experimental-wasm-modules',
   path('/es-modules/wasm-modules.mjs'),
 ]);
 


### PR DESCRIPTION
WebAssembly has been unflagged in V8 for years, and is presented on equal footing with Javascript in [how V8 describes itself][v8.dev] for years now ("Google’s open source high-performance JavaScript and WebAssembly engine").

I can't find any specified reasons to keep it flagged and called experimental in Node (though maybe this PR will draw those out?).

Following https://github.com/nodejs/node/pull/41736 as a model, this PR leaves the flag present as a no-op and removes it from documentation, but keeps the "Stability: 1 - Experimental" in esm.md and the runtime warning message. I want to remove those too (or else draw out some specified reasons not to :) ) but there appears to be a convention of decoupling unflagging from stabilizing: https://github.com/nodejs/node/pull/41736#discussion_r794963854, so, like JSON modules, maybe drop the warning in 18.0.0?

[v8.dev]: https://v8.dev/

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
