### PR TITLE
stream: do cleanup when iterator is destroyed

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1122,7 +1122,7 @@ async function* createAsyncIterator(stream, options) {
   stream.on('readable', next);
 
   let error;
-  eos(stream, { writable: false }, (err) => {
+  const cleanup = eos(stream, { writable: false }, (err) => {
     error = err ? aggregateTwoErrors(error, err) : null;
     callback();
     callback = nop;
@@ -1150,6 +1150,9 @@ async function* createAsyncIterator(stream, options) {
       (error === undefined || stream._readableState.autoDestroy)
     ) {
       destroyImpl.destroyer(stream, null);
+    } else {
+      stream.off('readable', next);
+      cleanup();
     }
   }
 }


### PR DESCRIPTION
When you create a [`readable.iterator`](https://nodejs.org/api/stream.html#readableiteratoroptions) from a stream with `options.destroyOnReturn` on `false`, the iterator doesn't do any cleanup when the iterator exits, causing it to add multiple listeners to the stream

### Code that reproduces the bug
```js
const pass = new stream.PassThrough().end();
for(let amount = 15; amount; --amount){
  for await (const chunk of pass.iterator({ destroyOnReturn: false })){}
}
```
### Console output
```
(node:20524) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 readable listeners added to [PassThrough]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
(node:20524) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 end listeners added to [PassThrough]. Use emitter.setMaxListeners() to increase limit
(node:20524) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 finish listeners added to [PassThrough]. Use emitter.setMaxListeners() to increase limit
(node:20524) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [PassThrough]. Use emitter.setMaxListeners() to increase limit
(node:20524) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [PassThrough]. Use emitter.setMaxListeners() to increase limit
```
### Tested node version
`v17.6.0` on `Windows 10` and [`v18.0.0-pre @ b481beecd8`](https://github.com/nodejs/node/tree/b481beecd803397940b2c4d0ed17d266ba5c1405)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
