### PR TITLE
buffer: improve Blob constructor error message when passing a string

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -137,7 +137,7 @@ class Blob {
     if (sources === null ||
         typeof sources[SymbolIterator] !== 'function' ||
         typeof sources === 'string') {
-      throw new ERR_INVALID_ARG_TYPE('sources', 'Iterable', sources);
+      throw new ERR_INVALID_ARG_TYPE('sources', 'a sequence', sources);
     }
     validateObject(options, 'options');
     let {


### PR DESCRIPTION
resolve: https://github.com/nodejs/node/issues/38856

```javascript
new Blob('nodejs')
```

before:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "sources" argument must be an instance of Iterable. Received type string ('nodejs')
```

after:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "sources" argument must be a sequence. Received type string ('nodejs')
```

---
ref https://github.com/nodejs/node/issues/38856#issuecomment-851039089:
> error messages thrown by some browsers:
> Chromium: `TypeError: Failed to construct 'Blob': The provided value cannot be converted to a sequence.`
> Firefox: `TypeError: Blob constructor: Argument 1 can't be converted to a sequence.`
> Safari: `TypeError: Value is not a sequence`


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
