### PR TITLE
doc: expand history for conditional exports changes in v12

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -17,9 +17,10 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/34117
     description: Add package `"imports"` field.
   - version:
+    - v13.7.0
     - v12.17.0
     pr-url: https://github.com/nodejs/node/pull/29866
-    description: Remove the `--experimental-modules` option.
+    description: Unflag conditional exports.
   - version:
     - v13.7.0
     - v12.16.0
@@ -1200,9 +1201,10 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/34718
     description: Add support for `"exports"` patterns.
   - version:
+    - v13.7.0
     - v12.17.0
     pr-url: https://github.com/nodejs/node/pull/29866
-    description: Remove the `--experimental-modules` option.
+    description: Unflag conditional exports.
   - version:
     - v13.7.0
     - v12.16.0

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -17,10 +17,14 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/34117
     description: Add package `"imports"` field.
   - version:
+    - v12.17.0
+    pr-url: https://github.com/nodejs/node/pull/29866
+    description: Remove the `--experimental-modules` option.
+  - version:
     - v13.7.0
     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/31001
-    description: Unflag conditional exports.
+    description: Remove the `--experimental-conditional-exports` option. In 12.16.0, conditional exports are still behind `--experimental-modules`.
   - version:
     - v13.6.0
     - v12.16.0
@@ -1196,6 +1200,10 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/34718
     description: Add support for `"exports"` patterns.
   - version:
+    - v12.17.0
+    pr-url: https://github.com/nodejs/node/pull/29866
+    description: Remove the `--experimental-modules` option.
+  - version:
     - v13.7.0
     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/31008
@@ -1204,7 +1212,7 @@ changes:
     - v13.7.0
     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/31001
-    description: Remove the `--experimental-conditional-exports` option.
+    description: Remove the `--experimental-conditional-exports` option. In 12.16.0, conditional exports are still behind `--experimental-modules`.
   - version:
     - v13.2.0
     - v12.16.0


### PR DESCRIPTION
As discussed on #42336 this change adds some extra detail to the history of unflagging conditional exports across v12.16 and v2.17. In v13 conditional exports became fully unflagged in v13.7 when `--experimental-conditional-exports` was removed.

Unfortunately the version order linting rule doesn't allow putting the removal of `--experimental-modules` for just 12.17.0 above the removal of `--experimental-conditional-exports` in both 12.16.0 and 13.7.0, but hopefully the change there is still clear.

Fixes: [#36162](https://github.com/nodejs/node/issues/36162)