### PR TITLE
chore(doc): add `trace_gc` to diagnostic tooling support document

### DIFF
--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -9,7 +9,7 @@ The Node.js project has assessed the tools and the APIs which support those
 tools. Each of the tools and APIs has been put into one of
 the following tiers.
 
-* Tier 1 - Must always be working(CI tests passing) for all
+* Tier 1 - Must always be working (CI tests passing) for all
   Current and LTS Node.js releases. A release will not be shipped if the test
   suite for the tool/API is not green. To be considered for inclusion
   in this tier it must have a good test suite and that test suite and a job
@@ -29,7 +29,7 @@ the following tiers.
     its dependencies; and
   * The tool must be open source.
 
-* Tier 2 - Must be working(CI tests passing) for all
+* Tier 2 - Must be working (CI tests passing) for all
   LTS releases. An LTS release will not be shipped if the test
   suite for the tool/API is not green. To be considered for inclusion
   in this tier it must have a good test suite and that test suite and a job

--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -136,6 +136,7 @@ The tools are currently assigned to Tiers as follows:
 | Debugger  | Chrome Dev tools          | ?                             | No                      | 3           |
 | Debugger  | Chakracore - time-travel  | No                            | Data source only        | too early   |
 | Tracing   | trace\_events (API)       | No                            | Yes                     | 1           |
+| Tracing   | trace\_gc                 | No                            | Yes                     | 1           |
 | Tracing   | DTrace                    | No                            | Partial                 | 3           |
 | Tracing   | LTTng                     | No                            | Removed?                | N/A         |
 | Tracing   | ETW                       | No                            | Partial                 | 3           |


### PR DESCRIPTION
Hey node family 👋

## Context

A tiny PR that follows the initiative started by @gireeshpunathil [here](https://github.com/nodejs/diagnostics/issues/532), in the diagnostic WG repo. The goal of this initiative is to re-assess diagnostic tooling and examine how could we improve the current status.

## Added

While I read the current diagnostic-tooling-support document, I didn't see the same old `trace_gc` tool, so I added it to the list 🎉 

Let me know what do you think.

## ... for further

If it seems ok for the community, we could have a discussion about the documentation: how we could make adoption easier for newcomers, and the regular testing in Node.js CI.

📄 Regarding the documentation, I found these two links:
- https://github.com/nodejs/diagnostics/blob/main/documentation/memory/step3/using_gc_traces.md
- https://nodejs.org/api/v8.html#v8setflagsfromstringflags