### PR TITLE
bootstrap: use SnapshotData to pass snapshot data around

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -36,6 +36,7 @@
 #include "node_binding.h"
 #include "node_external_reference.h"
 #include "node_main_instance.h"
+#include "node_native_module.h"
 #include "node_options.h"
 #include "node_perf_common.h"
 #include "node_snapshotable.h"
@@ -972,7 +973,6 @@ struct EnvSerializeInfo {
 };
 
 struct SnapshotData {
-  SnapshotData() { blob.data = nullptr; }
   v8::StartupData blob;
   std::vector<size_t> isolate_data_indices;
   EnvSerializeInfo env_info;

--- a/src/node.cc
+++ b/src/node.cc
@@ -1154,28 +1154,19 @@ int Start(int argc, char** argv) {
   }
 
   {
-    Isolate::CreateParams params;
-    const std::vector<size_t>* indices = nullptr;
-    const EnvSerializeInfo* env_info = nullptr;
     bool use_node_snapshot =
         per_process::cli_options->per_isolate->node_snapshot;
-    if (use_node_snapshot) {
-      v8::StartupData* blob = NodeMainInstance::GetEmbeddedSnapshotBlob();
-      if (blob != nullptr) {
-        params.snapshot_blob = blob;
-        indices = NodeMainInstance::GetIsolateDataIndices();
-        env_info = NodeMainInstance::GetEnvSerializeInfo();
-      }
-    }
+    const SnapshotData* snapshot_data =
+        use_node_snapshot ? NodeMainInstance::GetEmbeddedSnapshotData()
+                          : nullptr;
     uv_loop_configure(uv_default_loop(), UV_METRICS_IDLE_TIME);
 
-    NodeMainInstance main_instance(&params,
+    NodeMainInstance main_instance(snapshot_data,
                                    uv_default_loop(),
                                    per_process::v8_platform.Platform(),
                                    result.args,
-                                   result.exec_args,
-                                   indices);
-    result.exit_code = main_instance.Run(env_info);
+                                   result.exec_args);
+    result.exit_code = main_instance.Run();
   }
 
   TearDownOncePerProcess();

--- a/src/node_main_instance.h
+++ b/src/node_main_instance.h
@@ -15,6 +15,7 @@ namespace node {
 
 class ExternalReferenceRegistry;
 struct EnvSerializeInfo;
+struct SnapshotData;
 
 // TODO(joyeecheung): align this with the Worker/WorkerThreadData class.
 // We may be able to create an abstract class to reuse some of the routines.
@@ -48,29 +49,25 @@ class NodeMainInstance {
   void Dispose();
 
   // Create a main instance that owns the isolate
-  NodeMainInstance(
-      v8::Isolate::CreateParams* params,
-      uv_loop_t* event_loop,
-      MultiIsolatePlatform* platform,
-      const std::vector<std::string>& args,
-      const std::vector<std::string>& exec_args,
-      const std::vector<size_t>* per_isolate_data_indexes = nullptr);
+  NodeMainInstance(const SnapshotData* snapshot_data,
+                   uv_loop_t* event_loop,
+                   MultiIsolatePlatform* platform,
+                   const std::vector<std::string>& args,
+                   const std::vector<std::string>& exec_args);
   ~NodeMainInstance();
 
   // Start running the Node.js instances, return the exit code when finished.
-  int Run(const EnvSerializeInfo* env_info);
+  int Run();
   void Run(int* exit_code, Environment* env);
 
   IsolateData* isolate_data() { return isolate_data_.get(); }
 
   DeleteFnPtr<Environment, FreeEnvironment> CreateMainEnvironment(
-      int* exit_code, const EnvSerializeInfo* env_info);
+      int* exit_code);
 
   // If nullptr is returned, the binary is not built with embedded
   // snapshot.
-  static const std::vector<size_t>* GetIsolateDataIndices();
-  static v8::StartupData* GetEmbeddedSnapshotBlob();
-  static const EnvSerializeInfo* GetEnvSerializeInfo();
+  static const SnapshotData* GetEmbeddedSnapshotData();
   static const std::vector<intptr_t>& CollectExternalReferences();
 
   static const size_t kNodeContextIndex = 0;
@@ -93,8 +90,8 @@ class NodeMainInstance {
   v8::Isolate* isolate_;
   MultiIsolatePlatform* platform_;
   std::unique_ptr<IsolateData> isolate_data_;
-  bool owns_isolate_ = false;
-  bool deserialize_mode_ = false;
+  std::unique_ptr<v8::Isolate::CreateParams> isolate_params_;
+  const SnapshotData* snapshot_data_ = nullptr;
 };
 
 }  // namespace node

--- a/src/node_snapshot_stub.cc
+++ b/src/node_snapshot_stub.cc
@@ -6,15 +6,7 @@
 
 namespace node {
 
-v8::StartupData* NodeMainInstance::GetEmbeddedSnapshotBlob() {
-  return nullptr;
-}
-
-const std::vector<size_t>* NodeMainInstance::GetIsolateDataIndices() {
-  return nullptr;
-}
-
-const EnvSerializeInfo* NodeMainInstance::GetEnvSerializeInfo() {
+const SnapshotData* NodeMainInstance::GetEmbeddedSnapshotData() {
   return nullptr;
 }
 

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -53,31 +53,28 @@ static const char blob_data[] = {
 
 static const int blob_size = )"
      << data->blob.raw_size << R"(;
-static v8::StartupData blob = { blob_data, blob_size };
-)";
 
-  ss << R"(v8::StartupData* NodeMainInstance::GetEmbeddedSnapshotBlob() {
-  return &blob;
-}
-
-static const std::vector<size_t> isolate_data_indices {
+SnapshotData snapshot_data {
+  // -- blob begins --
+  { blob_data, blob_size },
+  // -- blob ends --
+  // -- isolate_data_indices begins --
+  {
 )";
   WriteVector(&ss,
               data->isolate_data_indices.data(),
               data->isolate_data_indices.size());
-  ss << R"(};
+  ss << R"(},
+  // -- isolate_data_indices ends --
+  // -- env_info begins --
+)" << data->env_info
+  << R"(
+  // -- env_info ends --
+};
 
-const std::vector<size_t>* NodeMainInstance::GetIsolateDataIndices() {
-  return &isolate_data_indices;
+const SnapshotData* NodeMainInstance::GetEmbeddedSnapshotData() {
+  return &snapshot_data;
 }
-
-static const EnvSerializeInfo env_info )"
-     << data->env_info << R"(;
-
-const EnvSerializeInfo* NodeMainInstance::GetEnvSerializeInfo() {
-  return &env_info;
-}
-
 }  // namespace node
 )";
 

--- a/tools/snapshot/README.md
+++ b/tools/snapshot/README.md
@@ -22,8 +22,7 @@ In the default build of the Node.js executable, to embed a V8 startup snapshot
 into the Node.js executable, `libnode` is first built with these unresolved
 symbols:
 
-- `node::NodeMainInstance::GetEmbeddedSnapshotBlob`
-- `node::NodeMainInstance::GetIsolateDataIndices`
+- `node::NodeMainInstance::GetEmbeddedSnapshotData`
 
 Then the `node_mksnapshot` executable is built with C++ files in this
 directory, as well as `src/node_snapshot_stub.cc` which defines the unresolved


### PR DESCRIPTION
Instead of passing the snapshot blob, the per-isolate data
indices and the EnvSerializeInfo separately, use the aggregate
type Snapshot to carry these around, and refactor
NodeMainInstance so that it owns the v8::Isolate::CreateParams
when it owns its isolate. This also gets rid of the owns_isolate_
and deserialize_mode_ booleans in NodeMainInstance since
NodeMainInstance can compute these by just checking if it has
pointers to the CreateParams or the SnapshotData.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
