### PR TITLE
doc: fix Embedder's Guide link to V8 official docs

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1367,7 +1367,7 @@ console.log(result);
 ```
 
 [Electron]: https://electronjs.org/
-[Embedder's Guide]: https://github.com/v8/v8/wiki/Embedder's%20Guide
+[Embedder's Guide]: https://v8.dev/docs/embed
 [Linking to libraries included with Node.js]: #linking-to-libraries-included-with-nodejs
 [Native Abstractions for Node.js]: https://github.com/nodejs/nan
 [V8]: https://v8.dev/


### PR DESCRIPTION
Embedder's Guide link is moved from V8 GitHub Wiki to [V8 official docs](https://v8.dev/docs/embed), when you open this [page](https://github.com/v8/v8/wiki/Embedder's%20Guide) you still need to open the actual docs so it's need multiple steps to open the actual docs