### PR TITLE
tools: fix skip PR if CI is still running

### DIFF
--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -40,8 +40,8 @@ for pr in "$@"; do
   fi
 
   # Skip PR if CI is still running
-  if gh pr checks "$pr" | grep -E "pending|fail"; then
-    echo "pr ${pr} skipped, CI still running or failed"
+  if gh pr checks "$pr" | grep -q "\spending\s"; then
+    echo "pr ${pr} skipped, CI still running"
     continue
   fi
 

--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -40,8 +40,8 @@ for pr in "$@"; do
   fi
 
   # Skip PR if CI is still running
-  if ncu-ci url "https://github.com/${OWNER}/${REPOSITORY}/pull/${pr}" 2>&1 | grep "^Result *PENDING"; then
-    echo "pr ${pr} skipped, CI still running"
+  if gh pr checks "$pr" | grep -E "pending|fail"; then
+    echo "pr ${pr} skipped, CI still running or failed"
     continue
   fi
 


### PR DESCRIPTION
The original "Skip PR if CI is still running" seems not working, I find it is because `ncu-ci url`'s output can't be greped (not totally sure because I don't have access to jenkins).

Using `gh pr checks` should be just fine I guess.

Fixes: https://github.com/nodejs/node/issues/40330

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
