### PR TITLE
crypto: fix auth tag length error when mode != GCM

### DIFF
--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -593,7 +593,8 @@ bool CipherBase::InitAuthenticated(
     // Tell OpenSSL about the desired length.
     if (!EVP_CIPHER_CTX_ctrl(ctx_.get(), EVP_CTRL_AEAD_SET_TAG, auth_tag_len,
                              nullptr)) {
-      THROW_ERR_CRYPTO_INVALID_AUTH_TAG(env());
+      THROW_ERR_CRYPTO_INVALID_AUTH_TAG(
+          env(), "Invalid authentication tag length: %u", auth_tag_len);
       return false;
     }
 

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -44,7 +44,7 @@ const errMessages = {
   state: / state/,
   FIPS: /not supported in FIPS mode/,
   length: /Invalid initialization vector/,
-  authTagLength: /Invalid authentication tag/
+  authTagLength: /Invalid authentication tag length/
 };
 
 const ciphers = crypto.getCiphers();
@@ -684,6 +684,20 @@ for (const test of TEST_CASES) {
       code: 'ERR_OSSL_TAG_NOT_SET'
     } : {
       message: /Unsupported state/
+    });
+  }
+}
+
+{
+  const key = Buffer.alloc(32);
+  const iv = Buffer.alloc(12);
+
+  for (const authTagLength of [0, 17]) {
+    assert.throws(() => {
+      crypto.createCipheriv('chacha20-poly1305', key, iv, { authTagLength });
+    }, {
+      code: 'ERR_CRYPTO_INVALID_AUTH_TAG',
+      message: errMessages.authTagLength
     });
   }
 }


### PR DESCRIPTION
The error message currently says that the authentication tag is invalid, while really the authentication tag _length_ is invalid. This is particularly confusing when encrypting a message since no authentication tag exists at all until the operation is finalized. This change uses the same message for non-GCM ciphers that is used for GCM ciphers already.

Example:

```js
crypto.createCipheriv('chacha20-poly1305', Buffer.alloc(32), Buffer.alloc(12), {
  authTagLength: 17
})
```

Before:

```
Uncaught TypeError: Invalid authentication tag
    at Cipheriv.createCipherBase (node:internal/crypto/cipher:116:19)
    at Cipheriv.createCipherWithIV (node:internal/crypto/cipher:135:3)
    at new Cipheriv (node:internal/crypto/cipher:243:3)
    at Object.createCipheriv (node:crypto:138:10) {
  code: 'ERR_CRYPTO_INVALID_AUTH_TAG'
}
```

With this change:

```
Uncaught TypeError: Invalid authentication tag length: 17
    at Cipheriv.createCipherBase (node:internal/crypto/cipher:116:19)
    at Cipheriv.createCipherWithIV (node:internal/crypto/cipher:135:3)
    at new Cipheriv (node:internal/crypto/cipher:243:3)
    at Object.createCipheriv (node:crypto:141:10) {
  code: 'ERR_CRYPTO_INVALID_AUTH_TAG'
}
```


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
