### PR TITLE
module: CJS handle deleted directory relative require

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -130,9 +130,10 @@ const { validateString } = require('internal/validators');
 const pendingDeprecation = getOptionValue('--pending-deprecation');
 
 const {
-  CHAR_FORWARD_SLASH,
   CHAR_BACKWARD_SLASH,
-  CHAR_COLON
+  CHAR_COLON,
+  CHAR_DOT,
+  CHAR_FORWARD_SLASH,
 } = require('internal/constants');
 
 const {
@@ -538,9 +539,6 @@ function resolveExports(nmPath, request) {
   }
 }
 
-const trailingSlashRegex = /(?:^|\/)\.?\.$/;
-const nixRelativeCheck = /^\.\.?(?:[/]|$)/;
-const windowsRelativeCheck = /^\.\.?(?:[/\\]|$)/;
 /**
  * @param {string} request a relative or absolute file path
  * @param {Array<string>} paths file system directories to search as file paths
@@ -561,14 +559,29 @@ Module._findPath = function(request, paths, isMain) {
     return entry;
 
   let exts;
-  let trailingSlash = request.length > 0 &&
-    StringPrototypeCharCodeAt(request, request.length - 1) ===
-    CHAR_FORWARD_SLASH;
-  if (!trailingSlash) {
-    trailingSlash = RegExpPrototypeExec(trailingSlashRegex, request) !== null;
-  }
+  const trailingSlash = request.length > 0 &&
+    (StringPrototypeCharCodeAt(request, request.length - 1) === CHAR_FORWARD_SLASH || (
+      StringPrototypeCharCodeAt(request, request.length - 1) === CHAR_DOT &&
+      (
+        request.length === 1 ||
+        StringPrototypeCharCodeAt(request, request.length - 2) === CHAR_FORWARD_SLASH ||
+        (StringPrototypeCharCodeAt(request, request.length - 2) === CHAR_DOT && (
+          request.length === 2 ||
+          StringPrototypeCharCodeAt(request, request.length - 3) === CHAR_FORWARD_SLASH
+        ))
+      )
+    ));
 
-  const isRelative = RegExpPrototypeExec(isWindows ? windowsRelativeCheck : nixRelativeCheck, request) !== null;
+  const isRelative = StringPrototypeCharCodeAt(request, 0) === CHAR_DOT &&
+    (
+      request.length === 1 ||
+      StringPrototypeCharCodeAt(request, 1) === CHAR_FORWARD_SLASH ||
+      (isWindows && StringPrototypeCharCodeAt(request, 1) === CHAR_BACKWARD_SLASH) ||
+      (StringPrototypeCharCodeAt(request, 1) === CHAR_DOT && ((
+        request.length === 2 ||
+        StringPrototypeCharCodeAt(request, 2) === CHAR_FORWARD_SLASH) ||
+        (isWindows && StringPrototypeCharCodeAt(request, 2) === CHAR_BACKWARD_SLASH)))
+    );
   let insidePath = true;
   if (isRelative) {
     const normalizedRequest = path.normalize(request);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -539,6 +539,14 @@ function resolveExports(nmPath, request) {
 }
 
 const trailingSlashRegex = /(?:^|\/)\.?\.$/;
+const nixRelativeCheck = /^\.\.?(?:[/]|$)/;
+const windowsRelativeCheck = /^\.\.?(?:[/\\]|$)/;
+/**
+ * @param {string} request a relative or absolute file path
+ * @param {Array<string>} paths file system directories to search as file paths
+ * @param {boolean} isMain if the request is the main app entry point
+ * @returns {string | false}
+ */
 Module._findPath = function(request, paths, isMain) {
   const absoluteRequest = path.isAbsolute(request);
   if (absoluteRequest) {
@@ -560,11 +568,20 @@ Module._findPath = function(request, paths, isMain) {
     trailingSlash = RegExpPrototypeExec(trailingSlashRegex, request) !== null;
   }
 
+  const isRelative = RegExpPrototypeExec(isWindows ? windowsRelativeCheck : nixRelativeCheck, request) !== null;
+  let insidePath = true;
+  if (isRelative) {
+    const normalizedRequest = path.normalize(request);
+    if (StringPrototypeStartsWith(normalizedRequest, '..')) {
+      insidePath = false;
+    }
+  }
+
   // For each path
   for (let i = 0; i < paths.length; i++) {
-    // Don't search further if path doesn't exist
+    // Don't search further if path doesn't exist and request is inside the path
     const curPath = paths[i];
-    if (curPath && _stat(curPath) < 1) continue;
+    if (insidePath && curPath && _stat(curPath) < 1) continue;
 
     if (!absoluteRequest) {
       const exportsResolved = resolveExports(curPath, request);

--- a/test/parallel/test-require-enoent-dir.js
+++ b/test/parallel/test-require-enoent-dir.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+tmpdir.refresh();
+
+const fooPath = path.join(tmpdir.path, 'foo.cjs');
+fs.writeFileSync(fooPath, '');
+
+const dirPath = path.join(tmpdir.path, 'delete_me');
+fs.mkdirSync(dirPath, {
+  recursive: true
+});
+
+const barPath = path.join(dirPath, 'bar.cjs');
+fs.writeFileSync(barPath, `
+    module.exports = () => require('../foo.cjs').call()
+`);
+
+const foo = require(fooPath);
+const unique = Symbol('unique');
+foo.call = common.mustCall(() => unique);
+const bar = require(barPath);
+
+fs.rmSync(dirPath, { recursive: true });
+assert.strict.equal(bar(), unique);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This makes sure the following code works:

```cjs
const fs = require('fs');
const path = require('path');
const dir = path.join(__dirname, 'delete_me');
fs.mkdirSync(dir, {
    recursive: true
});
const barPath = path.join(dir, 'bar.cjs');
fs.writeFileSync(barPath, `
    module.exports = () => require('../foo.cjs')
`);
const bar = require(barPath);
fs.rmSync(dir, {recursive: true});
require('assert').strict.equal(bar(), exports);
```

I found this while fixing up some policy stuff and realizing baseURL wouldn't work if synchronized to disk exactly right for things like, https://github.com/bmeck/local-fs-https-imports , due to an over eager optimization in the code.