### PR TITLE
test: improve internal/worker/io.js coverage

### DIFF
--- a/test/parallel/test-worker-broadcastchannel.js
+++ b/test/parallel/test-worker-broadcastchannel.js
@@ -7,6 +7,7 @@ const {
   receiveMessageOnPort
 } = require('worker_threads');
 const assert = require('assert');
+const { inspect } = require('util');
 
 assert.throws(() => new BroadcastChannel(Symbol('test')), {
   message: /Cannot convert a Symbol value to a string/
@@ -167,4 +168,18 @@ assert.throws(() => new BroadcastChannel(), {
       code: 'ERR_INVALID_THIS',
     });
   });
+}
+
+{
+  const bc = new BroadcastChannel('channel5');
+  assert.strictEqual(
+    inspect(bc.ref()),
+    "BroadcastChannel { name: 'channel5', active: true }"
+  );
+
+  bc.close();
+  assert.strictEqual(
+    inspect(bc.ref()),
+    "BroadcastChannel { name: 'channel5', active: false }"
+  );
 }


### PR DESCRIPTION
This improves a test coverage in `internal/worker/io.js`

ref: https://coverage.nodejs.org/coverage-6d3920d579a3dc3a/lib/internal/worker/io.js.html#L485

This PR adds a test that validates the `BroadcastChannel.ref()` method works correctly.