### PR TITLE
test: improve lib/crypto.js coverage

### DIFF
--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -339,6 +339,11 @@ assert.throws(
   assert.ok(desc);
   assert.strictEqual(desc.configurable, true);
   assert.strictEqual(desc.enumerable, false);
+
+  crypto[f] = { key: 'value' };
+  assert.deepStrictEqual(Object.getOwnPropertyDescriptor(crypto, f).value, {
+    key: 'value',
+  });
 });
 
 

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -340,10 +340,13 @@ assert.throws(
   assert.strictEqual(desc.configurable, true);
   assert.strictEqual(desc.enumerable, false);
 
-  crypto[f] = { key: 'value' };
-  assert.deepStrictEqual(Object.getOwnPropertyDescriptor(crypto, f).value, {
-    key: 'value',
-  });
+  const newVal = Symbol();
+  crypto[f] = newVal;
+
+  {
+    const desc = Object.getOwnPropertyDescriptor(crypto, f);
+    assert.strictEqual(desc.value, newVal);
+  }
 });
 
 

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -346,6 +346,7 @@ assert.throws(
   {
     const desc = Object.getOwnPropertyDescriptor(crypto, f);
     assert.strictEqual(desc.value, newVal);
+    assert.strictEqual(desc.enumerable, true);
   }
 });
 


### PR DESCRIPTION
This improves a test coverage in `lib/crypto.js`.

ref: https://coverage.nodejs.org/coverage-6d3920d579a3dc3a/lib/crypto.js.html#L310

This PR adds a test that validate the setter method of `getRandomBytesAlias` return object works correctly.