### PR TITLE
esm: non file baseurls and fix cache key collision

### DIFF
--- a/lib/internal/main/eval_stdin.js
+++ b/lib/internal/main/eval_stdin.js
@@ -24,7 +24,7 @@ readStdin((code) => {
 
   const print = getOptionValue('--print');
   if (getOptionValue('--input-type') === 'module')
-    evalModule(code, print);
+    evalModule(code, print, 'node:stdin');
   else
     evalScript('[stdin]',
                code,

--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -22,7 +22,7 @@ markBootstrapComplete();
 const source = getOptionValue('--eval');
 const print = getOptionValue('--print');
 if (getOptionValue('--input-type') === 'module')
-  evalModule(source, print);
+  evalModule(source, print, 'node:execArgv');
 else
   evalScript('[eval]',
              source,

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const console = require('console');
 const { getOptionValue } = require('internal/options');
 const experimentalImportMetaResolve =
   getOptionValue('--experimental-import-meta-resolve');

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -27,7 +27,7 @@ function createImportMetaResolve(defaultParentUrl) {
  * @param {{url: string}} context
  */
 function initializeImportMeta(meta, context) {
-  const url = asyncESM.esmLoader.getBaseURL(context.url) ?? context.url;
+  const url = asyncESM.esmLoader.getBaseURL(context.url);
 
   // Alphabetical
   if (experimentalImportMetaResolve) {

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const console = require('console');
 const { getOptionValue } = require('internal/options');
 const experimentalImportMetaResolve =
   getOptionValue('--experimental-import-meta-resolve');
@@ -27,13 +28,12 @@ function createImportMetaResolve(defaultParentUrl) {
  */
 function initializeImportMeta(meta, context) {
   let url = context.url;
+  url = asyncESM.esmLoader.getBaseURL(url);
 
   // Alphabetical
   if (experimentalImportMetaResolve) {
     meta.resolve = createImportMetaResolve(url);
   }
-
-  url = asyncESM.esmLoader.getBaseURL(url);
 
   meta.url = url;
 }

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -27,8 +27,7 @@ function createImportMetaResolve(defaultParentUrl) {
  * @param {{url: string}} context
  */
 function initializeImportMeta(meta, context) {
-  let url = context.url;
-  url = asyncESM.esmLoader.getBaseURL(url);
+  const url = asyncESM.esmLoader.getBaseURL(context.url) ?? context.url;
 
   // Alphabetical
   if (experimentalImportMetaResolve) {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -16,6 +16,7 @@ const {
   PromiseAll,
   RegExpPrototypeExec,
   SafeArrayIterator,
+  SafeMap,
   SafeWeakMap,
   StringPrototypeStartsWith,
   globalThis,
@@ -30,7 +31,7 @@ const {
   ERR_INVALID_RETURN_VALUE,
   ERR_UNKNOWN_MODULE_FORMAT
 } = require('internal/errors').codes;
-const { pathToFileURL, isURLInstance, URL } = require('internal/url');
+const { isURLInstance, URL } = require('internal/url');
 const {
   isAnyArrayBuffer,
   isArrayBufferView,
@@ -52,7 +53,6 @@ const { getOptionValue } = require('internal/options');
 const {
   fetchModule,
 } = require('internal/modules/esm/fetch_module');
-const console = require('console');
 
 /**
  * An ESMLoader instance is used as the main entry point for loading ES modules.
@@ -236,7 +236,7 @@ class ESMLoader {
     };
   }
 
-  baseURLs = new Map();
+  baseURLs = new SafeMap();
   /**
    * Returns the url to use for the resolution of a given cache key url
    * These are not guaranteed to be the same.

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -52,6 +52,7 @@ const { getOptionValue } = require('internal/options');
 const {
   fetchModule,
 } = require('internal/modules/esm/fetch_module');
+const console = require('console');
 
 /**
  * An ESMLoader instance is used as the main entry point for loading ES modules.
@@ -215,6 +216,11 @@ class ESMLoader {
           return this.import(specifier,
                              this.getBaseURL(url),
                              importAssertions);
+        },
+        initializeImportMeta: (meta, wrap) => {
+          this.importMetaInitialize(meta, {
+            url: wrap.url
+          });
         }
       });
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -92,10 +92,6 @@ class ESMLoader {
    */
   cjsCache = new SafeWeakMap();
 
-  /**
-   * The index for assigning unique URLs to anonymous module evaluation
-   */
-  evalIndex = 0;
 
   /**
    * Registry of loaded modules, akin to `require.cache`
@@ -207,8 +203,10 @@ class ESMLoader {
 
   async eval(
     source,
-    url = pathToFileURL(`${process.cwd()}/[eval${++this.evalIndex}]`).href
+    url,
+    baseURL
   ) {
+    this.baseURLs.set(url, baseURL);
     const evalInstance = (url) => {
       const { ModuleWrap, callbackMap } = internalBinding('module_wrap');
       const module = new ModuleWrap(url, undefined, source, 0, 0);
@@ -232,6 +230,7 @@ class ESMLoader {
     };
   }
 
+  baseURLs = new Map();
   /**
    * Returns the url to use for the resolution of a given cache key url
    * These are not guaranteed to be the same.
@@ -253,6 +252,10 @@ class ESMLoader {
    * @returns {string}
    */
   getBaseURL(url) {
+    let baseURL = this.baseURLs.get(url);
+    if (typeof baseURL === 'string') {
+      return baseURL;
+    }
     if (
       StringPrototypeStartsWith(url, 'http:') ||
       StringPrototypeStartsWith(url, 'https:')
@@ -260,13 +263,14 @@ class ESMLoader {
       // The request & response have already settled, so they are in
       // fetchModule's cache, in which case, fetchModule returns
       // immediately and synchronously
-      url = fetchModule(new URL(url), { parentURL: url }).resolvedHREF;
+      baseURL = fetchModule(new URL(url), { parentURL: url }).resolvedHREF;
       // This should only occur if the module hasn't been fetched yet
-      if (typeof url !== 'string') {
+      if (typeof baseURL !== 'string') {
         throw new ERR_INTERNAL_ASSERTION(`Base url for module ${url} not loaded.`);
       }
+      this.baseURLs.set(url, baseURL);
     }
-    return url;
+    return baseURL;
   }
 
   /**

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -257,9 +257,8 @@ class ESMLoader {
    */
   getBaseURL(url) {
     let baseURL = this.baseURLs.get(url);
-    // this will only be a string if it exists in the Map
-    // otherwise, it doesn't have a baseURL or needs to
-    // compute the baseURL
+    // This will only be a string if it exists in the Map otherwise, it
+    // doesn't have a baseURL or needs to compute the baseURL
     if (typeof baseURL === 'string') {
       return baseURL;
     }

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -257,6 +257,9 @@ class ESMLoader {
    */
   getBaseURL(url) {
     let baseURL = this.baseURLs.get(url);
+    // this will only be a string if it exists in the Map
+    // otherwise, it doesn't have a baseURL or needs to
+    // compute the baseURL
     if (typeof baseURL === 'string') {
       return baseURL;
     }

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -217,10 +217,8 @@ class ESMLoader {
                              this.getBaseURL(url),
                              importAssertions);
         },
-        initializeImportMeta: (meta, wrap) => {
-          this.importMetaInitialize(meta, {
-            url: wrap.url
-          });
+        initializeImportMeta: (meta, { url }) => {
+          this.importMetaInitialize(meta, { url });
         }
       });
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -275,6 +275,8 @@ class ESMLoader {
         throw new ERR_INTERNAL_ASSERTION(`Base url for module ${url} not loaded.`);
       }
       this.baseURLs.set(url, baseURL);
+    } else {
+      baseURL = url;
     }
     return baseURL;
   }

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -24,7 +24,6 @@ const {
   popAsyncContext,
 } = require('internal/async_hooks');
 const { pathToFileURL } = require('internal/url');
-const console = require('console');
 
 // shouldAbortOnUncaughtToggle is a typed array for faster
 // communication with JS.
@@ -47,7 +46,7 @@ function tryGetCwd() {
 let evalIndex = 0;
 function evalModule(source, print,
                     cacheKey = pathToFileURL(`node:eval/[eval${++evalIndex}]`),
-                    baseURL = pathToFileURL(process.cwd()+'/').href,
+                    baseURL = pathToFileURL(process.cwd() + '/').href,
 ) {
   if (print) {
     throw new ERR_EVAL_ESM_CANNOT_PRINT();

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -44,7 +44,8 @@ function tryGetCwd() {
  * The index for assigning unique URLs to anonymous module evaluation
  */
 let evalIndex = 0;
-function evalModule(source, print,
+function evalModule(source,
+                    print,
                     cacheKey = pathToFileURL(`node:eval/[eval${++evalIndex}]`),
                     baseURL = pathToFileURL(process.cwd() + '/').href,
 ) {

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -23,6 +23,7 @@ const {
   emitAfter,
   popAsyncContext,
 } = require('internal/async_hooks');
+const { pathToFileURL } = require('internal/url');
 
 // shouldAbortOnUncaughtToggle is a typed array for faster
 // communication with JS.
@@ -39,13 +40,20 @@ function tryGetCwd() {
   }
 }
 
-function evalModule(source, print) {
+/**
+ * The index for assigning unique URLs to anonymous module evaluation
+ */
+let evalIndex = 0;
+function evalModule(source, print,
+                    cacheKey = pathToFileURL(`node:eval/[eval${++evalIndex}]`),
+                    baseURL = pathToFileURL(process.cwd()),
+) {
   if (print) {
     throw new ERR_EVAL_ESM_CANNOT_PRINT();
   }
   const { loadESM } = require('internal/process/esm_loader');
   const { handleMainPromise } = require('internal/modules/run_main');
-  return handleMainPromise(loadESM((loader) => loader.eval(source)));
+  return handleMainPromise(loadESM((loader) => loader.eval(source, cacheKey, baseURL)));
 }
 
 function evalScript(name, body, breakFirstLine, print) {

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -24,6 +24,7 @@ const {
   popAsyncContext,
 } = require('internal/async_hooks');
 const { pathToFileURL } = require('internal/url');
+const console = require('console');
 
 // shouldAbortOnUncaughtToggle is a typed array for faster
 // communication with JS.
@@ -46,7 +47,7 @@ function tryGetCwd() {
 let evalIndex = 0;
 function evalModule(source, print,
                     cacheKey = pathToFileURL(`node:eval/[eval${++evalIndex}]`),
-                    baseURL = pathToFileURL(process.cwd()),
+                    baseURL = pathToFileURL(process.cwd()+'/').href,
 ) {
   if (print) {
     throw new ERR_EVAL_ESM_CANNOT_PRINT();


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

fixes: #38714

I'm not actually sure if this qualifies as a breaking change since it imports from the same place just the stack trace for the modules made from stdin/execArgv are given new locations (no longer pointing to non-existant files).

This removes the cache key collision to avoid some problems with policies as well.

CC: @nodejs/modules