### PR TITLE
test: add test for extracting function name in inspect_repl.js

### DIFF
--- a/test/parallel/test-debugger-extract-function-name.js
+++ b/test/parallel/test-debugger-extract-function-name.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const startCLI = require('../common/debugger');
+
+const assert = require('assert');
+
+const cli = startCLI([fixtures.path('debugger', 'three-lines.js')]);
+
+function onFatal(error) {
+  cli.quit();
+  throw error;
+}
+
+cli.waitForInitialBreak()
+  .then(() => cli.waitForPrompt())
+  .then(() => cli.command('exec a = function func() {}; a;'))
+  .then(() => assert.match(cli.output, /\[Function: func\]/))
+  .then(() => cli.command('exec a = function func () {}; a;'))
+  .then(() => assert.match(cli.output, /\[Function\]/))
+  .then(() => cli.command('exec a = function() {}; a;'))
+  .then(() => assert.match(cli.output, /\[Function: function\]/))
+  .then(() => cli.command('exec a = () => {}; a;'))
+  .then(() => assert.match(cli.output, /\[Function\]/))
+  .then(() => cli.command('exec a = function* func() {}; a;'))
+  .then(() => assert.match(cli.output, /\[GeneratorFunction: func\]/))
+  .then(() => cli.command('exec a = function *func() {}; a;'))
+  .then(() => assert.match(cli.output, /\[GeneratorFunction: \*func\]/))
+  .then(() => cli.command('exec a = function*func() {}; a;'))
+  .then(() => assert.match(cli.output, /\[GeneratorFunction: function\*func\]/))
+  .then(() => cli.command('exec a = function * func() {}; a;'))
+  .then(() => assert.match(cli.output, /\[GeneratorFunction\]/))
+  .then(() => cli.quit())
+  .then(null, onFatal);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This PR adds test for `extractFunctionName` function in `lib/internal/debugger/inspect_repl.js` and improves code coverage. That function previously was untested. [ref](https://coverage.nodejs.org/coverage-a66b9cabc84061f9/lib/internal/debugger/inspect_repl.js.html#L115)
I found some issues serializing a function name. I'll fix them in other PR.