### PR TITLE
crypto: fix error code handling in `ParsePrivateKey()`

### DIFF
--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -143,7 +143,7 @@ int SSL_CTX_use_certificate_chain(SSL_CTX* ctx,
                                   X509Pointer* cert,
                                   X509Pointer* issuer) {
   // Just to ensure that `ERR_peek_last_error` below will return only errors
-  // that we are interested in
+  // that we are interested in.
   ERR_clear_error();
 
   X509Pointer x(

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -214,6 +214,10 @@ ParseKeyResult ParsePrivateKey(EVPKeyPointer* pkey,
                                const PrivateKeyEncodingConfig& config,
                                const char* key,
                                size_t key_len) {
+  // Just to ensure that `ERR_peek_last_error` below will return only errors
+  // that we are interested in.
+  ERR_clear_error();
+
   const ByteSource* passphrase = config.passphrase_.get();
 
   if (config.format_ == kKeyFormatPEM) {
@@ -255,7 +259,7 @@ ParseKeyResult ParsePrivateKey(EVPKeyPointer* pkey,
   }
 
   // OpenSSL can fail to parse the key but still return a non-null pointer.
-  unsigned long err = ERR_peek_error();  // NOLINT(runtime/int)
+  unsigned long err = ERR_peek_last_error();  // NOLINT(runtime/int)
   if (err != 0)
     pkey->reset();
 

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -518,11 +518,7 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
 
 {
   // Reading an encrypted key without a passphrase should fail.
-  assert.throws(() => createPrivateKey(privateDsa), common.hasOpenSSL3 ? {
-    name: 'Error',
-    message: 'error:07880109:common libcrypto routines::interrupted or ' +
-             'cancelled',
-  } : {
+  assert.throws(() => createPrivateKey(privateDsa), {
     name: 'TypeError',
     code: 'ERR_MISSING_PASSPHRASE',
     message: 'Passphrase required for encrypted key'

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -211,16 +211,11 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 
     // Since the private key is encrypted, signing shouldn't work anymore.
     const publicKey = { key: publicKeyDER, ...publicKeyEncoding };
-    const expectedError = common.hasOpenSSL3 ? {
-      name: 'Error',
-      message: 'error:07880109:common libcrypto routines::interrupted or ' +
-               'cancelled'
-    } : {
+    assert.throws(() => testSignVerify(publicKey, privateKey), {
       name: 'TypeError',
       code: 'ERR_MISSING_PASSPHRASE',
       message: 'Passphrase required for encrypted key'
-    };
-    assert.throws(() => testSignVerify(publicKey, privateKey), expectedError);
+    });
 
     const key = { key: privateKey, passphrase: 'secret' };
     testEncryptDecrypt(publicKey, key);
@@ -565,10 +560,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 
     // Since the private key is encrypted, signing shouldn't work anymore.
     assert.throws(() => testSignVerify(publicKey, privateKey),
-                  common.hasOpenSSL3 ? {
-                    message: 'error:07880109:common libcrypto ' +
-                             'routines::interrupted or cancelled'
-                  } : {
+                  {
                     name: 'TypeError',
                     code: 'ERR_MISSING_PASSPHRASE',
                     message: 'Passphrase required for encrypted key'
@@ -599,10 +591,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 
     // Since the private key is encrypted, signing shouldn't work anymore.
     assert.throws(() => testSignVerify(publicKey, privateKey),
-                  common.hasOpenSSL3 ? {
-                    message: 'error:07880109:common libcrypto ' +
-                             'routines::interrupted or cancelled'
-                  } : {
+                  {
                     name: 'TypeError',
                     code: 'ERR_MISSING_PASSPHRASE',
                     message: 'Passphrase required for encrypted key'
@@ -636,10 +625,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 
     // Since the private key is encrypted, signing shouldn't work anymore.
     assert.throws(() => testSignVerify(publicKey, privateKey),
-                  common.hasOpenSSL3 ? {
-                    message: 'error:07880109:common libcrypto ' +
-                             'routines::interrupted or cancelled'
-                  } : {
+                  {
                     name: 'TypeError',
                     code: 'ERR_MISSING_PASSPHRASE',
                     message: 'Passphrase required for encrypted key'
@@ -674,10 +660,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 
     // Since the private key is encrypted, signing shouldn't work anymore.
     assert.throws(() => testSignVerify(publicKey, privateKey),
-                  common.hasOpenSSL3 ? {
-                    message: 'error:07880109:common libcrypto ' +
-                             'routines::interrupted or cancelled'
-                  } : {
+                  {
                     name: 'TypeError',
                     code: 'ERR_MISSING_PASSPHRASE',
                     message: 'Passphrase required for encrypted key'
@@ -1571,11 +1554,7 @@ for (const type of ['pkcs1', 'pkcs8']) {
     // the key, and not specifying a passphrase should fail when decoding it.
     assert.throws(() => {
       return testSignVerify(publicKey, privateKey);
-    }, common.hasOpenSSL3 ? {
-      name: 'Error',
-      code: 'ERR_OSSL_CRYPTO_INTERRUPTED_OR_CANCELLED',
-      message: 'error:07880109:common libcrypto routines::interrupted or cancelled'
-    } : {
+    }, {
       name: 'TypeError',
       code: 'ERR_MISSING_PASSPHRASE',
       message: 'Passphrase required for encrypted key'

--- a/test/parallel/test-crypto-private-decrypt-gh32240.js
+++ b/test/parallel/test-crypto-private-decrypt-gh32240.js
@@ -34,8 +34,5 @@ function decrypt(key) {
 }
 
 decrypt(pkey);
-assert.throws(() => decrypt(pkeyEncrypted), common.hasOpenSSL3 ?
-  { message: 'error:07880109:common libcrypto routines::interrupted or ' +
-             'cancelled' } :
-  { code: 'ERR_MISSING_PASSPHRASE' });
+assert.throws(() => decrypt(pkeyEncrypted), { code: 'ERR_MISSING_PASSPHRASE' });
 decrypt(pkey);  // Should not throw.


### PR DESCRIPTION
This changes the code to select the latest error code instead of the
earliest one from the OpenSSL error stack. It helps in getting rid of
the inconsistency between the empty passphrase related error codes of
OpenSSL 1.1.1 and 3.

Refs: https://github.com/nodejs/node/pull/42319#discussion_r829884295
Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
