### PR TITLE
build: windows/arm64 native compilation support

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1115,6 +1115,7 @@ def host_arch_win():
     'x86'    : 'ia32',
     'arm'    : 'arm',
     'mips'   : 'mips',
+    'ARM64'  : 'arm64'
   }
 
   return matchup.get(arch, 'ia32')

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -198,7 +198,6 @@ if defined target_arch      set configure_flags=%configure_flags% --dest-cpu=%ta
 if defined openssl_no_asm   set configure_flags=%configure_flags% --openssl-no-asm
 if defined DEBUG_HELPER     set configure_flags=%configure_flags% --verbose
 if "%target_arch%"=="x86" if "%PROCESSOR_ARCHITECTURE%"=="AMD64" set configure_flags=%configure_flags% --no-cross-compiling
-if "%target_arch%"=="arm64" set configure_flags=%configure_flags% --cross-compiling
 
 if not exist "%~dp0deps\icu" goto no-depsicu
 if "%target%"=="Clean" echo deleting %~dp0deps\icu


### PR DESCRIPTION
Added support for detecting ARM64 host architecture for windows and avoid explicit cross-compilation flag for win/arm64 target as configure.py can auto-detect configuration from host and target architecture.

Refs: https://github.com/nodejs/build/issues/2540