### PR TITLE
test,fs: add fs.rm() tests for .git directories

### DIFF
--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -130,6 +130,17 @@ function removeAsync(dir) {
   }));
 }
 
+// Removing a .git directory should not throw an EPERM.
+// Refs: https://github.com/isaacs/rimraf/issues/21.
+{
+  const gitDirectory = nextDirPath();
+  fs.mkdirSync(gitDirectory);
+  execSync(`git -C ${gitDirectory} init`);
+  fs.rm(gitDirectory, { recursive: true }, common.mustSucceed(() => {
+    assert.strictEqual(fs.existsSync(gitDirectory), false);
+  }));
+}
+
 // Test the synchronous version.
 {
   const dir = nextDirPath();
@@ -177,6 +188,16 @@ function removeAsync(dir) {
 
   // Attempted removal should fail now because the directory is gone.
   assert.throws(() => fs.rmSync(dir), { syscall: 'stat' });
+}
+
+// Removing a .git directory should not throw an EPERM.
+// Refs: https://github.com/isaacs/rimraf/issues/21.
+{
+  const gitDirectory = nextDirPath();
+  fs.mkdirSync(gitDirectory);
+  execSync(`git -C ${gitDirectory} init`);
+  fs.rmSync(gitDirectory, { recursive: true });
+  assert.strictEqual(fs.existsSync(gitDirectory), false);
 }
 
 // Test the Promises based version.
@@ -228,6 +249,16 @@ function removeAsync(dir) {
   } finally {
     fs.rmSync(fileURL, { force: true });
   }
+})().then(common.mustCall());
+
+// Removing a .git directory should not throw an EPERM.
+// Refs: https://github.com/isaacs/rimraf/issues/21.
+(async () => {
+  const gitDirectory = nextDirPath();
+  fs.mkdirSync(gitDirectory);
+  execSync(`git -C ${gitDirectory} init`);
+  await fs.promises.rm(gitDirectory, { recursive: true });
+  assert.strictEqual(fs.existsSync(gitDirectory), false);
 })().then(common.mustCall());
 
 // Test input validation.

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -16,6 +16,10 @@ let count = 0;
 const nextDirPath = (name = 'rm') =>
   path.join(tmpdir.path, `${name}-${count++}`);
 
+const isGitPresent = (() => {
+  try { execSync('git --version'); return true; } catch { return false; }
+})();
+
 function makeNonEmptyDirectory(depth, files, folders, dirname, createSymLinks) {
   fs.mkdirSync(dirname, { recursive: true });
   fs.writeFileSync(path.join(dirname, 'text.txt'), 'hello', 'utf8');
@@ -132,7 +136,7 @@ function removeAsync(dir) {
 
 // Removing a .git directory should not throw an EPERM.
 // Refs: https://github.com/isaacs/rimraf/issues/21.
-{
+if (isGitPresent) {
   const gitDirectory = nextDirPath();
   fs.mkdirSync(gitDirectory);
   execSync(`git -C ${gitDirectory} init`);
@@ -192,7 +196,7 @@ function removeAsync(dir) {
 
 // Removing a .git directory should not throw an EPERM.
 // Refs: https://github.com/isaacs/rimraf/issues/21.
-{
+if (isGitPresent) {
   const gitDirectory = nextDirPath();
   fs.mkdirSync(gitDirectory);
   execSync(`git -C ${gitDirectory} init`);
@@ -253,13 +257,15 @@ function removeAsync(dir) {
 
 // Removing a .git directory should not throw an EPERM.
 // Refs: https://github.com/isaacs/rimraf/issues/21.
-(async () => {
-  const gitDirectory = nextDirPath();
-  fs.mkdirSync(gitDirectory);
-  execSync(`git -C ${gitDirectory} init`);
-  await fs.promises.rm(gitDirectory, { recursive: true });
-  assert.strictEqual(fs.existsSync(gitDirectory), false);
-})().then(common.mustCall());
+if (isGitPresent) {
+  (async () => {
+    const gitDirectory = nextDirPath();
+    fs.mkdirSync(gitDirectory);
+    execSync(`git -C ${gitDirectory} init`);
+    await fs.promises.rm(gitDirectory, { recursive: true });
+    assert.strictEqual(fs.existsSync(gitDirectory), false);
+  })().then(common.mustCall());
+}
 
 // Test input validation.
 {

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -21,11 +21,8 @@ const isGitPresent = (() => {
 })();
 
 function gitInit(gitDirectory) {
-  const cwd = process.cwd();
   fs.mkdirSync(gitDirectory);
-  process.chdir(gitDirectory);
-  execSync('git init');
-  process.chdir(cwd);
+  execSync('git init', { cwd: gitDirectory });
 }
 
 function makeNonEmptyDirectory(depth, files, folders, dirname, createSymLinks) {

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -20,6 +20,14 @@ const isGitPresent = (() => {
   try { execSync('git --version'); return true; } catch { return false; }
 })();
 
+function gitInit(gitDirectory) {
+  const cwd = process.cwd();
+  fs.mkdirSync(gitDirectory);
+  process.chdir(gitDirectory);
+  execSync('git init');
+  process.chdir(cwd);
+}
+
 function makeNonEmptyDirectory(depth, files, folders, dirname, createSymLinks) {
   fs.mkdirSync(dirname, { recursive: true });
   fs.writeFileSync(path.join(dirname, 'text.txt'), 'hello', 'utf8');
@@ -138,8 +146,7 @@ function removeAsync(dir) {
 // Refs: https://github.com/isaacs/rimraf/issues/21.
 if (isGitPresent) {
   const gitDirectory = nextDirPath();
-  fs.mkdirSync(gitDirectory);
-  execSync(`git -C ${gitDirectory} init`);
+  gitInit(gitDirectory);
   fs.rm(gitDirectory, { recursive: true }, common.mustSucceed(() => {
     assert.strictEqual(fs.existsSync(gitDirectory), false);
   }));
@@ -198,8 +205,7 @@ if (isGitPresent) {
 // Refs: https://github.com/isaacs/rimraf/issues/21.
 if (isGitPresent) {
   const gitDirectory = nextDirPath();
-  fs.mkdirSync(gitDirectory);
-  execSync(`git -C ${gitDirectory} init`);
+  gitInit(gitDirectory);
   fs.rmSync(gitDirectory, { recursive: true });
   assert.strictEqual(fs.existsSync(gitDirectory), false);
 }
@@ -260,8 +266,7 @@ if (isGitPresent) {
 if (isGitPresent) {
   (async () => {
     const gitDirectory = nextDirPath();
-    fs.mkdirSync(gitDirectory);
-    execSync(`git -C ${gitDirectory} init`);
+    gitInit(gitDirectory);
     await fs.promises.rm(gitDirectory, { recursive: true });
     assert.strictEqual(fs.existsSync(gitDirectory), false);
   })().then(common.mustCall());


### PR DESCRIPTION
Git for Windows creates read-only files inside the .git directory.
fs.rm() was built in a way, to work around any EPERM error that can
happen while deleting the .git directory by turning the directory
into a writable one. This change adds a regression test for that.

Refs: https://github.com/isaacs/rimraf/issues/21
Refs: https://github.com/nodejs/node/pull/38810#issuecomment-1073152001
Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
