### PR TITLE
test: improve lib/internal/readline/promises.js coverage

### DIFF
--- a/test/parallel/test-readline-promises-csi.mjs
+++ b/test/parallel/test-readline-promises-csi.mjs
@@ -181,7 +181,7 @@ class TestWritable extends Writable {
     ]) {
     const test = async (dir, data) => {
       writable.data = '';
-      await readline.clearLine(dir);
+      readline.clearLine(dir);
       return new Promise((resolve) => {
         process.nextTick(() => {
           assert.deepStrictEqual(writable.data, data);
@@ -210,7 +210,7 @@ class TestWritable extends Writable {
     ]) {
     const test = async (x, y, data) => {
       writable.data = '';
-      await readline.moveCursor(x, y);
+      readline.moveCursor(x, y);
       return new Promise((resolve) => {
         process.nextTick(() => {
           assert.strictEqual(writable.data, data);
@@ -232,7 +232,7 @@ class TestWritable extends Writable {
     ]) {
     const test = async (x, y, data) => {
       writable.data = '';
-      await readline.cursorTo(x, y);
+      readline.cursorTo(x, y);
       return new Promise((resolve) => {
         process.nextTick(() => {
           assert.strictEqual(writable.data, data);

--- a/test/parallel/test-readline-promises-csi.mjs
+++ b/test/parallel/test-readline-promises-csi.mjs
@@ -4,6 +4,7 @@
 import '../common/index.mjs';
 import assert from 'assert';
 import { Readline } from 'readline/promises';
+import { setImmediate } from 'timers/promises';
 import { Writable } from 'stream';
 
 import utils from 'internal/readline/utils';
@@ -179,17 +180,9 @@ class TestWritable extends Writable {
       [1, CSI.kClearToLineEnd],
       [0, CSI.kClearLine],
     ]) {
-    const test = async (dir, data) => {
-      writable.data = '';
-      readline.clearLine(dir);
-      return new Promise((resolve) => {
-        process.nextTick(() => {
-          assert.deepStrictEqual(writable.data, data);
-          resolve();
-        });
-      });
-    };
-    await test(dir, data);
+    writable.data = '';
+    readline.clearLine(dir);
+    assert.deepStrictEqual((await setImmediate(writable)).data, data);
   }
 }
 
@@ -208,17 +201,9 @@ class TestWritable extends Writable {
       [-1, -1, '\x1b[1D\x1b[1A'],
       [1, -1, '\x1b[1C\x1b[1A'],
     ]) {
-    const test = async (x, y, data) => {
-      writable.data = '';
-      readline.moveCursor(x, y);
-      return new Promise((resolve) => {
-        process.nextTick(() => {
-          assert.strictEqual(writable.data, data);
-          resolve();
-        });
-      });
-    };
-    await test(x, y, data);
+    writable.data = '';
+    readline.moveCursor(x, y);
+    assert.deepStrictEqual((await setImmediate(writable)).data, data);
   }
 }
 
@@ -230,16 +215,8 @@ class TestWritable extends Writable {
       [1, undefined, '\x1b[2G'],
       [1, 2, '\x1b[3;2H'],
     ]) {
-    const test = async (x, y, data) => {
-      writable.data = '';
-      readline.cursorTo(x, y);
-      return new Promise((resolve) => {
-        process.nextTick(() => {
-          assert.strictEqual(writable.data, data);
-          resolve();
-        });
-      });
-    };
-    await test(x, y, data);
+    writable.data = '';
+    readline.cursorTo(x, y);
+    assert.deepStrictEqual((await setImmediate(writable)).data, data);
   }
 }

--- a/test/parallel/test-readline-promises-csi.mjs
+++ b/test/parallel/test-readline-promises-csi.mjs
@@ -168,7 +168,7 @@ class TestWritable extends Writable {
   const readline = new Readline(writable, { autoCommit: true });
 
   await readline.clearScreenDown();
-  await setImmediate(); // wait for next tick as auto commit is asynchronous.
+  await setImmediate(); // Wait for next tick as auto commit is asynchronous.
   assert.deepStrictEqual(writable.data, CSI.kClearScreenDown);
 }
 
@@ -183,7 +183,7 @@ class TestWritable extends Writable {
     ]) {
     writable.data = '';
     readline.clearLine(dir);
-    await setImmediate(); // wait for next tick as auto commit is asynchronous.
+    await setImmediate(); // Wait for next tick as auto commit is asynchronous.
     assert.deepStrictEqual(writable.data, data);
   }
 }
@@ -205,7 +205,7 @@ class TestWritable extends Writable {
     ]) {
     writable.data = '';
     readline.moveCursor(x, y);
-    await setImmediate(); // wait for next tick as auto commit is asynchronous.
+    await setImmediate(); // Wait for next tick as auto commit is asynchronous.
     assert.deepStrictEqual(writable.data, data);
   }
 }
@@ -220,7 +220,7 @@ class TestWritable extends Writable {
     ]) {
     writable.data = '';
     readline.cursorTo(x, y);
-    await setImmediate(); // wait for next tick as auto commit is asynchronous.
+    await setImmediate(); // Wait for next tick as auto commit is asynchronous.
     assert.deepStrictEqual(writable.data, data);
   }
 }

--- a/test/parallel/test-readline-promises-csi.mjs
+++ b/test/parallel/test-readline-promises-csi.mjs
@@ -168,7 +168,8 @@ class TestWritable extends Writable {
   const readline = new Readline(writable, { autoCommit: true });
 
   await readline.clearScreenDown();
-  process.nextTick(() => assert.deepStrictEqual(writable.data, CSI.kClearScreenDown));
+  await setImmediate(); // wait for next tick as auto commit is asynchronous.
+  assert.deepStrictEqual(writable.data, CSI.kClearScreenDown);
 }
 
 {
@@ -182,7 +183,8 @@ class TestWritable extends Writable {
     ]) {
     writable.data = '';
     readline.clearLine(dir);
-    assert.deepStrictEqual((await setImmediate(writable)).data, data);
+    await setImmediate(); // wait for next tick as auto commit is asynchronous.
+    assert.deepStrictEqual(writable.data, data);
   }
 }
 
@@ -203,7 +205,8 @@ class TestWritable extends Writable {
     ]) {
     writable.data = '';
     readline.moveCursor(x, y);
-    assert.deepStrictEqual((await setImmediate(writable)).data, data);
+    await setImmediate(); // wait for next tick as auto commit is asynchronous.
+    assert.deepStrictEqual(writable.data, data);
   }
 }
 
@@ -217,6 +220,7 @@ class TestWritable extends Writable {
     ]) {
     writable.data = '';
     readline.cursorTo(x, y);
-    assert.deepStrictEqual((await setImmediate(writable)).data, data);
+    await setImmediate(); // wait for next tick as auto commit is asynchronous.
+    assert.deepStrictEqual(writable.data, data);
   }
 }

--- a/test/parallel/test-readline-promises-csi.mjs
+++ b/test/parallel/test-readline-promises-csi.mjs
@@ -173,7 +173,7 @@ class TestWritable extends Writable {
 {
   const writable = new TestWritable();
   const readline = new Readline(writable, { autoCommit: true });
-  for (const set of
+  for (const [dir, data] of
     [
       [-1, CSI.kClearToLineBeginning],
       [1, CSI.kClearToLineEnd],
@@ -189,14 +189,14 @@ class TestWritable extends Writable {
         });
       });
     };
-    await test(set[0], set[1]);
+    await test(dir, data);
   }
 }
 
 {
   const writable = new TestWritable();
   const readline = new Readline(writable, { autoCommit: true });
-  for (const set of
+  for (const [x, y, data] of
     [
       [0, 0, ''],
       [1, 0, '\x1b[1C'],
@@ -218,14 +218,14 @@ class TestWritable extends Writable {
         });
       });
     };
-    await test(set[0], set[1], set[2]);
+    await test(x, y, data);
   }
 }
 
 {
   const writable = new TestWritable();
   const readline = new Readline(writable, { autoCommit: true });
-  for (const set of
+  for (const [x, y, data] of
     [
       [1, undefined, '\x1b[2G'],
       [1, 2, '\x1b[3;2H'],
@@ -240,6 +240,6 @@ class TestWritable extends Writable {
         });
       });
     };
-    await test(set[0], set[1], set[2]);
+    await test(x, y, data);
   }
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This improves a test coverage in `lib/internal/readline/promises.js`

ref: https://coverage.nodejs.org/coverage-419f02ba1f00cac3/lib/internal/readline/promises.js.html

This validates that `autoCommit` option work correctly.

