### PR TITLE
fs: trace fs sync api by perf_hooks

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -1366,6 +1366,20 @@ dns.lookup('localhost', () => {});
 dns.promises.resolve('localhost');
 ```
 
+### Measuring how long fs sync API takes when the operation is successful
+
+```js
+'use strict';
+const { PerformanceObserver } = require('perf_hooks');
+const fs = require('fs');
+const obs = new PerformanceObserver((items) => {
+  items.getEntries().forEach((item) => {
+    console.log(item);
+  });
+});
+obs.observe({ entryTypes: ['fs'] });
+```
+
 [Async Hooks]: async_hooks.md
 [High Resolution Time]: https://www.w3.org/TR/hr-time-2
 [Performance Timeline]: https://w3c.github.io/performance-timeline/

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -44,6 +44,7 @@ const {
   StringPrototypeCharCodeAt,
   StringPrototypeIndexOf,
   StringPrototypeSlice,
+  Symbol,
 } = primordials;
 
 const { fs: constants } = internalBinding('constants');
@@ -141,6 +142,23 @@ const {
 
 const watchers = require('internal/fs/watchers');
 const ReadFileContext = require('internal/fs/read_file_context');
+
+const {
+  startPerf,
+  stopPerf,
+} = require('internal/perf/observe');
+
+const kFsPerf = Symbol('FsPerf');
+
+function startFsPerf(context) {
+  const ctx = {};
+  startPerf(ctx, kFsPerf, { type: 'fs', ...context });
+  return ctx;
+}
+
+function stopFsPerf(context, data) {
+  stopPerf(context, kFsPerf, data);
+}
 
 let truncateWarn = true;
 let fs;
@@ -247,12 +265,14 @@ function access(path, mode, callback) {
  * @returns {void}
  */
 function accessSync(path, mode) {
+  const perfCtx = startFsPerf({ name: 'accessSync' });
   path = getValidatedPath(path);
   mode = getValidMode(mode, 'access');
 
   const ctx = { path };
   binding.access(pathModule.toNamespacedPath(path), mode, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -293,6 +313,7 @@ ObjectDefineProperty(exists, internalUtil.promisify.custom, {
  * @returns {boolean}
  */
 function existsSync(path) {
+  const perfCtx = startFsPerf({ name: 'existsSync' });
   try {
     path = getValidatedPath(path);
   } catch {
@@ -308,7 +329,7 @@ function existsSync(path) {
   if (isWindows && ctx.errno === undefined) {
     binding.stat(nPath, false, undefined, ctx);
   }
-
+  stopFsPerf(perfCtx);
   return ctx.errno === undefined;
 }
 
@@ -453,6 +474,7 @@ function tryReadSync(fd, isUserFd, buffer, pos, len) {
  * @returns {string | Buffer}
  */
 function readFileSync(path, options) {
+  const perfCtx = startFsPerf({ name: 'readFileSync' });
   options = getOptions(options, { flag: 'r' });
   const isUserFd = isFd(path); // File descriptor ownership
   const fd = isUserFd ? path : fs.openSync(path, options.flag, 0o666);
@@ -500,6 +522,7 @@ function readFileSync(path, options) {
   }
 
   if (options.encoding) buffer = buffer.toString(options.encoding);
+  stopFsPerf(perfCtx);
   return buffer;
 }
 
@@ -529,11 +552,13 @@ function close(fd, callback = defaultCloseCallback) {
  * @returns {void}
  */
 function closeSync(fd) {
+  const perfCtx = startFsPerf({ name: 'closeSync' });
   fd = getValidatedFd(fd);
 
   const ctx = {};
   binding.close(fd, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -579,6 +604,7 @@ function open(path, flags, mode, callback) {
  * @returns {number}
  */
 function openSync(path, flags, mode) {
+  const perfCtx = startFsPerf({ name: 'openSync' });
   path = getValidatedPath(path);
   const flagsNumber = stringToFlags(flags);
   mode = parseFileMode(mode, 'mode', 0o666);
@@ -588,6 +614,7 @@ function openSync(path, flags, mode) {
                               flagsNumber, mode,
                               undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
   return result;
 }
 
@@ -687,6 +714,7 @@ ObjectDefineProperty(read, internalUtil.customPromisifyArgs,
  * @returns {number}
  */
 function readSync(fd, buffer, offset, length, position) {
+  const perfCtx = startFsPerf({ name: 'readSync' });
   fd = getValidatedFd(fd);
 
   validateBuffer(buffer);
@@ -730,6 +758,7 @@ function readSync(fd, buffer, offset, length, position) {
   const result = binding.read(fd, buffer, offset, length, position,
                               undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
   return result;
 }
 
@@ -777,6 +806,7 @@ ObjectDefineProperty(readv, internalUtil.customPromisifyArgs,
  * @returns {number}
  */
 function readvSync(fd, buffers, position) {
+  const perfCtx = startFsPerf({ name: 'readvSync' });
   fd = getValidatedFd(fd);
   validateBufferArray(buffers);
 
@@ -787,6 +817,7 @@ function readvSync(fd, buffers, position) {
 
   const result = binding.readBuffers(fd, buffers, position, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
   return result;
 }
 
@@ -868,6 +899,7 @@ ObjectDefineProperty(write, internalUtil.customPromisifyArgs,
  * @returns {number}
  */
 function writeSync(fd, buffer, offset, length, position) {
+  const perfCtx = startFsPerf({ name: 'writeSync' });
   fd = getValidatedFd(fd);
   const ctx = {};
   let result;
@@ -894,6 +926,7 @@ function writeSync(fd, buffer, offset, length, position) {
                                  undefined, ctx);
   }
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
   return result;
 }
 
@@ -947,6 +980,7 @@ ObjectDefineProperty(writev, internalUtil.customPromisifyArgs, {
  * @returns {number}
  */
 function writevSync(fd, buffers, position) {
+  const perfCtx = startFsPerf({ name: 'writevSync' });
   fd = getValidatedFd(fd);
   validateBufferArray(buffers);
 
@@ -962,6 +996,7 @@ function writevSync(fd, buffers, position) {
   const result = binding.writeBuffers(fd, buffers, position, undefined, ctx);
 
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
   return result;
 }
 
@@ -993,12 +1028,14 @@ function rename(oldPath, newPath, callback) {
  * @returns {void}
  */
 function renameSync(oldPath, newPath) {
+  const perfCtx = startFsPerf({ name: 'renameSync' });
   oldPath = getValidatedPath(oldPath, 'oldPath');
   newPath = getValidatedPath(newPath, 'newPath');
   const ctx = { path: oldPath, dest: newPath };
   binding.rename(pathModule.toNamespacedPath(oldPath),
                  pathModule.toNamespacedPath(newPath), undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -1042,10 +1079,13 @@ function truncate(path, len, callback) {
  * @returns {void}
  */
 function truncateSync(path, len) {
+  const perfCtx = startFsPerf({ name: 'truncateSync' });
   if (typeof path === 'number') {
     // legacy
     showTruncateDeprecation();
-    return fs.ftruncateSync(path, len);
+    const result = fs.ftruncateSync(path, len);
+    stopFsPerf(perfCtx);
+    return result;
   }
   if (len === undefined) {
     len = 0;
@@ -1059,6 +1099,7 @@ function truncateSync(path, len) {
   } finally {
     fs.closeSync(fd);
   }
+  stopFsPerf(perfCtx);
   return ret;
 }
 
@@ -1091,12 +1132,14 @@ function ftruncate(fd, len = 0, callback) {
  * @returns {void}
  */
 function ftruncateSync(fd, len = 0) {
+  const perfCtx = startFsPerf({ name: 'ftruncateSync' });
   fd = getValidatedFd(fd);
   validateInteger(len, 'len');
   len = MathMax(0, len);
   const ctx = {};
   binding.ftruncate(fd, len, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 function lazyLoadCp() {
@@ -1170,6 +1213,7 @@ function rmdir(path, options, callback) {
  * @returns {void}
  */
 function rmdirSync(path, options) {
+  const perfCtx = startFsPerf({ name: 'rmdirSync' });
   path = getValidatedPath(path);
 
   if (options?.recursive) {
@@ -1177,7 +1221,9 @@ function rmdirSync(path, options) {
     options = validateRmOptionsSync(path, { ...options, force: false }, true);
     if (options !== false) {
       lazyLoadRimraf();
-      return rimrafSync(pathModule.toNamespacedPath(path), options);
+      const result = rimrafSync(pathModule.toNamespacedPath(path), options);
+      stopFsPerf(perfCtx);
+      return result;
     }
   } else {
     validateRmdirOptions(options);
@@ -1185,7 +1231,9 @@ function rmdirSync(path, options) {
 
   const ctx = { path };
   binding.rmdir(pathModule.toNamespacedPath(path), undefined, ctx);
-  return handleErrorFromBinding(ctx);
+  const result = handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
+  return result;
 }
 
 /**
@@ -1230,11 +1278,14 @@ function rm(path, options, callback) {
  * @returns {void}
  */
 function rmSync(path, options) {
+  const perfCtx = startFsPerf({ name: 'rmSync' });
   path = getValidatedPath(path);
   options = validateRmOptionsSync(path, options, false);
 
   lazyLoadRimraf();
-  return rimrafSync(pathModule.toNamespacedPath(path), options);
+  const result = rimrafSync(pathModule.toNamespacedPath(path), options);
+  stopFsPerf(perfCtx);
+  return result;
 }
 
 /**
@@ -1260,10 +1311,12 @@ function fdatasync(fd, callback) {
  * @returns {void}
  */
 function fdatasyncSync(fd) {
+  const perfCtx = startFsPerf({ name: 'fdatasyncSync' });
   fd = getValidatedFd(fd);
   const ctx = {};
   binding.fdatasync(fd, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -1287,10 +1340,12 @@ function fsync(fd, callback) {
  * @returns {void}
  */
 function fsyncSync(fd) {
+  const perfCtx = startFsPerf({ name: 'fsyncSync' });
   fd = getValidatedFd(fd);
   const ctx = {};
   binding.fsync(fd, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -1337,6 +1392,7 @@ function mkdir(path, options, callback) {
  * @returns {string | void}
  */
 function mkdirSync(path, options) {
+  const perfCtx = startFsPerf({ name: 'mkdirSync' });
   let mode = 0o777;
   let recursive = false;
   if (typeof options === 'number' || typeof options === 'string') {
@@ -1355,6 +1411,7 @@ function mkdirSync(path, options) {
                                parseFileMode(mode, 'mode'), recursive,
                                undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
   if (recursive) {
     return result;
   }
@@ -1404,6 +1461,7 @@ function readdir(path, options, callback) {
  * @returns {string | Buffer[] | Dirent[]}
  */
 function readdirSync(path, options) {
+  const perfCtx = startFsPerf({ name: 'readdirSync' });
   options = getOptions(options, {});
   path = getValidatedPath(path);
   const ctx = { path };
@@ -1411,7 +1469,9 @@ function readdirSync(path, options) {
                                  options.encoding, !!options.withFileTypes,
                                  undefined, ctx);
   handleErrorFromBinding(ctx);
-  return options.withFileTypes ? getDirents(path, result) : result;
+  const ret = options.withFileTypes ? getDirents(path, result) : result;
+  stopFsPerf(perfCtx);
+  return ret;
 }
 
 /**
@@ -1509,11 +1569,14 @@ function hasNoEntryError(ctx) {
  * @returns {Stats}
  */
 function fstatSync(fd, options = { bigint: false, throwIfNoEntry: true }) {
+  const perfCtx = startFsPerf({ name: 'fstatSync' });
   fd = getValidatedFd(fd);
   const ctx = { fd };
   const stats = binding.fstat(fd, options.bigint, undefined, ctx);
   handleErrorFromBinding(ctx);
-  return getStatsFromBinding(stats);
+  const result = getStatsFromBinding(stats);
+  stopFsPerf(perfCtx);
+  return result;
 }
 
 /**
@@ -1527,6 +1590,7 @@ function fstatSync(fd, options = { bigint: false, throwIfNoEntry: true }) {
  * @returns {Stats}
  */
 function lstatSync(path, options = { bigint: false, throwIfNoEntry: true }) {
+  const perfCtx = startFsPerf({ name: 'lstatSync' });
   path = getValidatedPath(path);
   const ctx = { path };
   const stats = binding.lstat(pathModule.toNamespacedPath(path),
@@ -1535,7 +1599,9 @@ function lstatSync(path, options = { bigint: false, throwIfNoEntry: true }) {
     return undefined;
   }
   handleErrorFromBinding(ctx);
-  return getStatsFromBinding(stats);
+  const result = getStatsFromBinding(stats);
+  stopFsPerf(perfCtx);
+  return result;
 }
 
 /**
@@ -1549,6 +1615,7 @@ function lstatSync(path, options = { bigint: false, throwIfNoEntry: true }) {
  * @returns {Stats}
  */
 function statSync(path, options = { bigint: false, throwIfNoEntry: true }) {
+  const perfCtx = startFsPerf({ name: 'statSync' });
   path = getValidatedPath(path);
   const ctx = { path };
   const stats = binding.stat(pathModule.toNamespacedPath(path),
@@ -1557,7 +1624,9 @@ function statSync(path, options = { bigint: false, throwIfNoEntry: true }) {
     return undefined;
   }
   handleErrorFromBinding(ctx);
-  return getStatsFromBinding(stats);
+  const result = getStatsFromBinding(stats);
+  stopFsPerf(perfCtx);
+  return result;
 }
 
 /**
@@ -1588,12 +1657,14 @@ function readlink(path, options, callback) {
  * @returns {string | Buffer}
  */
 function readlinkSync(path, options) {
+  const perfCtx = startFsPerf({ name: 'readlinkSync' });
   options = getOptions(options, {});
   path = getValidatedPath(path, 'oldPath');
   const ctx = { path };
   const result = binding.readlink(pathModule.toNamespacedPath(path),
                                   options.encoding, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
   return result;
 }
 
@@ -1658,6 +1729,7 @@ function symlink(target, path, type_, callback_) {
  * @returns {void}
  */
 function symlinkSync(target, path, type) {
+  const perfCtx = startFsPerf({ name: 'symlinkSync' });
   type = (typeof type === 'string' ? type : null);
   if (isWindows && type === null) {
     const absoluteTarget = pathModule.resolve(`${path}`, '..', `${target}`);
@@ -1674,6 +1746,7 @@ function symlinkSync(target, path, type) {
                   pathModule.toNamespacedPath(path), flags, undefined, ctx);
 
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -1706,6 +1779,7 @@ function link(existingPath, newPath, callback) {
  * @returns {void}
  */
 function linkSync(existingPath, newPath) {
+  const perfCtx = startFsPerf({ name: 'linkSync' });
   existingPath = getValidatedPath(existingPath, 'existingPath');
   newPath = getValidatedPath(newPath, 'newPath');
 
@@ -1714,6 +1788,7 @@ function linkSync(existingPath, newPath) {
                               pathModule.toNamespacedPath(newPath),
                               undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
   return result;
 }
 
@@ -1737,10 +1812,12 @@ function unlink(path, callback) {
  * @returns {void}
  */
 function unlinkSync(path) {
+  const perfCtx = startFsPerf({ name: 'unlinkSync' });
   path = getValidatedPath(path);
   const ctx = { path };
   binding.unlink(pathModule.toNamespacedPath(path), undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -1767,11 +1844,13 @@ function fchmod(fd, mode, callback) {
  * @returns {void}
  */
 function fchmodSync(fd, mode) {
+  const perfCtx = startFsPerf({ name: 'fchmodSync' });
   fd = getValidatedFd(fd);
   mode = parseFileMode(mode, 'mode');
   const ctx = {};
   binding.fchmod(fd, mode, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -1806,6 +1885,7 @@ function lchmod(path, mode, callback) {
  * @returns {void}
  */
 function lchmodSync(path, mode) {
+  const perfCtx = startFsPerf({ name: 'lchmodSync' });
   const fd = fs.openSync(path, O_WRONLY | O_SYMLINK);
 
   // Prefer to return the chmod error, if one occurs,
@@ -1816,6 +1896,7 @@ function lchmodSync(path, mode) {
   } finally {
     fs.closeSync(fd);
   }
+  stopFsPerf(perfCtx);
   return ret;
 }
 
@@ -1843,12 +1924,14 @@ function chmod(path, mode, callback) {
  * @returns {void}
  */
 function chmodSync(path, mode) {
+  const perfCtx = startFsPerf({ name: 'chmodSync' });
   path = getValidatedPath(path);
   mode = parseFileMode(mode, 'mode');
 
   const ctx = { path };
   binding.chmod(pathModule.toNamespacedPath(path), mode, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -1877,12 +1960,14 @@ function lchown(path, uid, gid, callback) {
  * @returns {void}
  */
 function lchownSync(path, uid, gid) {
+  const perfCtx = startFsPerf({ name: 'lchownSync' });
   path = getValidatedPath(path);
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
   const ctx = { path };
   binding.lchown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -1912,6 +1997,7 @@ function fchown(fd, uid, gid, callback) {
  * @returns {void}
  */
 function fchownSync(fd, uid, gid) {
+  const perfCtx = startFsPerf({ name: 'fchownSync' });
   fd = getValidatedFd(fd);
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
@@ -1919,6 +2005,7 @@ function fchownSync(fd, uid, gid) {
   const ctx = {};
   binding.fchown(fd, uid, gid, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -1950,12 +2037,14 @@ function chown(path, uid, gid, callback) {
  * @returns {void}
  */
 function chownSync(path, uid, gid) {
+  const perfCtx = startFsPerf({ name: 'chownSync' });
   path = getValidatedPath(path);
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
   const ctx = { path };
   binding.chown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -1988,12 +2077,14 @@ function utimes(path, atime, mtime, callback) {
  * @returns {void}
  */
 function utimesSync(path, atime, mtime) {
+  const perfCtx = startFsPerf({ name: 'utimesSync' });
   path = getValidatedPath(path);
   const ctx = { path };
   binding.utimes(pathModule.toNamespacedPath(path),
                  toUnixTimestamp(atime), toUnixTimestamp(mtime),
                  undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -2026,12 +2117,14 @@ function futimes(fd, atime, mtime, callback) {
  * @returns {void}
  */
 function futimesSync(fd, atime, mtime) {
+  const perfCtx = startFsPerf({ name: 'futimesSync' });
   fd = getValidatedFd(fd);
   atime = toUnixTimestamp(atime, 'atime');
   mtime = toUnixTimestamp(mtime, 'mtime');
   const ctx = {};
   binding.futimes(fd, atime, mtime, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -2064,6 +2157,7 @@ function lutimes(path, atime, mtime, callback) {
  * @returns {void}
  */
 function lutimesSync(path, atime, mtime) {
+  const perfCtx = startFsPerf({ name: 'lutimesSync' });
   path = getValidatedPath(path);
   const ctx = { path };
   binding.lutimes(pathModule.toNamespacedPath(path),
@@ -2071,6 +2165,7 @@ function lutimesSync(path, atime, mtime) {
                   toUnixTimestamp(mtime),
                   undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 function writeAll(fd, isUserFd, buffer, offset, length, signal, callback) {
@@ -2168,6 +2263,7 @@ function writeFile(path, data, options, callback) {
  * @returns {void}
  */
 function writeFileSync(path, data, options) {
+  const perfCtx = startFsPerf({ name: 'writeFileSync' });
   options = getOptions(options, { encoding: 'utf8', mode: 0o666, flag: 'w' });
 
   if (!isArrayBufferView(data)) {
@@ -2194,6 +2290,7 @@ function writeFileSync(path, data, options) {
   } finally {
     if (!isUserFd) fs.closeSync(fd);
   }
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -2234,6 +2331,7 @@ function appendFile(path, data, options, callback) {
  * @returns {void}
  */
 function appendFileSync(path, data, options) {
+  const perfCtx = startFsPerf({ name: 'appendFileSync' });
   options = getOptions(options, { encoding: 'utf8', mode: 0o666, flag: 'a' });
 
   // Don't make changes directly on options object
@@ -2244,6 +2342,7 @@ function appendFileSync(path, data, options) {
     options.flag = 'a';
 
   fs.writeFileSync(path, data, options);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -2437,6 +2536,7 @@ const emptyObj = ObjectCreate(null);
  * @returns {string | Buffer}
  */
 function realpathSync(p, options) {
+  const perfCtx = startFsPerf({ name: 'realpathSync' });
   options = getOptions(options, emptyObj);
   p = toPathIfFileURL(p);
   if (typeof p !== 'string') {
@@ -2564,7 +2664,9 @@ function realpathSync(p, options) {
   }
 
   cache?.set(original, p);
-  return encodeRealpathResult(p, options);
+  const result = encodeRealpathResult(p, options);
+  stopFsPerf(perfCtx);
+  return result;
 }
 
 /**
@@ -2574,11 +2676,13 @@ function realpathSync(p, options) {
  * @returns {string | Buffer}
  */
 realpathSync.native = (path, options) => {
+  const perfCtx = startFsPerf({ name: 'realpathSync.native' });
   options = getOptions(options, {});
   path = getValidatedPath(path);
   const ctx = { path };
   const result = binding.realpath(path, options.encoding, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
   return result;
 };
 
@@ -2769,6 +2873,7 @@ function mkdtemp(prefix, options, callback) {
  * @returns {string}
  */
 function mkdtempSync(prefix, options) {
+  const perfCtx = startFsPerf({ name: 'mkdtempSync' });
   options = getOptions(options, {});
 
   validateString(prefix, 'prefix');
@@ -2779,6 +2884,7 @@ function mkdtempSync(prefix, options) {
   const result = binding.mkdtemp(path, options.encoding,
                                  undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
   return result;
 }
 
@@ -2819,6 +2925,7 @@ function copyFile(src, dest, mode, callback) {
  * @returns {void}
  */
 function copyFileSync(src, dest, mode) {
+  const perfCtx = startFsPerf({ name: 'copyFileSync' });
   src = getValidatedPath(src, 'src');
   dest = getValidatedPath(dest, 'dest');
 
@@ -2829,6 +2936,7 @@ function copyFileSync(src, dest, mode) {
   mode = getValidMode(mode, 'copyFile');
   binding.copyFile(src, dest, mode, undefined, ctx);
   handleErrorFromBinding(ctx);
+  stopFsPerf(perfCtx);
 }
 
 /**
@@ -2862,11 +2970,13 @@ function cp(src, dest, options, callback) {
  * @returns {void}
  */
 function cpSync(src, dest, options) {
+  const perfCtx = startFsPerf({ name: 'cpSync' });
   options = validateCpOptions(options);
   src = pathModule.toNamespacedPath(getValidatedPath(src, 'src'));
   dest = pathModule.toNamespacedPath(getValidatedPath(dest, 'dest'));
   lazyLoadCp();
   cpSyncFn(src, dest, options);
+  stopFsPerf(perfCtx);
 }
 
 function lazyLoadStreams() {

--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -26,6 +26,7 @@ const {
     NODE_PERFORMANCE_ENTRY_TYPE_HTTP,
     NODE_PERFORMANCE_ENTRY_TYPE_NET,
     NODE_PERFORMANCE_ENTRY_TYPE_DNS,
+    NODE_PERFORMANCE_ENTRY_TYPE_FS,
   },
   installGarbageCollectionTracking,
   observerCounts,
@@ -78,6 +79,7 @@ let gcTrackingInstalled = false;
 
 const kSupportedEntryTypes = ObjectFreeze([
   'dns',
+  'fs',
   'function',
   'gc',
   'http',
@@ -120,6 +122,7 @@ function getObserverType(type) {
     case 'http': return NODE_PERFORMANCE_ENTRY_TYPE_HTTP;
     case 'net': return NODE_PERFORMANCE_ENTRY_TYPE_NET;
     case 'dns': return NODE_PERFORMANCE_ENTRY_TYPE_DNS;
+    case 'fs': return NODE_PERFORMANCE_ENTRY_TYPE_FS;
   }
 }
 

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -36,7 +36,8 @@ extern uint64_t performance_v8_start;
   V(HTTP, "http")                                                             \
   V(HTTP2, "http2")                                                           \
   V(NET, "net")                                                               \
-  V(DNS, "dns")
+  V(DNS, "dns")                                                               \
+  V(FS, "fs")
 
 enum PerformanceMilestone {
 #define V(name, _) NODE_PERFORMANCE_MILESTONE_##name,

--- a/test/parallel/test-fs-perf_hooks.js
+++ b/test/parallel/test-fs-perf_hooks.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const { PerformanceObserver } = require('perf_hooks');
+
+const obs = new PerformanceObserver(common.mustCallAtLeast((items) => {
+  items.getEntries().forEach((entry) => {
+    assert.strictEqual(entry.entryType, 'fs');
+    assert.strictEqual(typeof entry.startTime, 'number');
+    assert.strictEqual(typeof entry.duration, 'number');
+  });
+}));
+
+obs.observe({ type: 'fs' });
+fs.readFileSync(__filename);


### PR DESCRIPTION
fs: trace fs sync api by perf_hooks when the operation is successful.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Affected core subsystem: fs