### PR TITLE
debugger: Fix inconsistent inspector output of `exec new Map()`

### DIFF
--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -183,6 +183,95 @@ function convertResultToError(result) {
   return err;
 }
 
+class PropertyPreview {
+  constructor(attributes) {
+    ObjectAssign(this, attributes);
+  }
+
+  [customInspectSymbol](depth, opts) {
+    switch (this.type) {
+      case 'string':
+      case 'undefined':
+        return utilInspect(this.value, opts);
+      case 'number':
+      case 'boolean':
+        return opts.stylize(this.value, this.type);
+      case 'object':
+      case 'symbol':
+        if (this.subtype === 'date') {
+          return utilInspect(new Date(this.value), opts);
+        }
+        if (this.subtype === 'array') {
+          return opts.stylize(this.value, 'special');
+        }
+        return opts.stylize(this.value, this.subtype || 'special');
+      default:
+        return this.value;
+    }
+  }
+}
+
+class ObjectPreview {
+  constructor(attributes) {
+    ObjectAssign(this, attributes);
+  }
+
+  [customInspectSymbol](depth, opts) {
+    switch (this.type) {
+      case 'object': {
+        switch (this.subtype) {
+          case 'date':
+            return utilInspect(new Date(this.description), opts);
+          case 'null':
+            return utilInspect(null, opts);
+          case 'regexp':
+            return opts.stylize(this.description, 'regexp');
+          case 'set': {
+            if (!this.entries) {
+              return `${this.description} ${this.overflow ? '{ ... }' : '{}'}`;
+            }
+            const values = ArrayPrototypeMap(this.entries, (entry) =>
+              utilInspect(new ObjectPreview(entry.value), opts));
+            return `${this.description} { ${ArrayPrototypeJoin(values, ', ')} }`;
+          }
+          case 'map': {
+            if (!this.entries) {
+              return `${this.description} ${this.overflow ? '{ ... }' : '{}'}`;
+            }
+            const mappings = ArrayPrototypeMap(this.entries, (entry) => {
+              const key = utilInspect(new ObjectPreview(entry.key), opts);
+              const value = utilInspect(new ObjectPreview(entry.value), opts);
+              return `${key} => ${value}`;
+            });
+            return `${this.description} { ${ArrayPrototypeJoin(mappings, ', ')} }`;
+          }
+          case 'array':
+          case undefined: {
+            if (this.properties.length === 0) {
+              return this.subtype === 'array' ? '[]' : '{}';
+            }
+            const props = ArrayPrototypeMap(this.properties, (prop, idx) => {
+              const value = utilInspect(new PropertyPreview(prop));
+              if (prop.name === `${idx}`) return value;
+              return `${prop.name}: ${value}`;
+            });
+            if (this.overflow) {
+              ArrayPrototypePush(props, '...');
+            }
+            const singleLine = ArrayPrototypeJoin(props, ', ');
+            const propString = singleLine.length > 60 ? ArrayPrototypeJoin(props, ',\n  ') : singleLine;
+            return this.subtype === 'array' ? `[ ${propString} ]` : `{ ${propString} }`;
+          }
+          default:
+            return this.description;
+        }
+      }
+      default:
+        return this.description;
+    }
+  }
+}
+
 class RemoteObject {
   constructor(attributes) {
     ObjectAssign(this, attributes);
@@ -193,82 +282,39 @@ class RemoteObject {
   }
 
   [customInspectSymbol](depth, opts) {
-    function formatProperty(prop) {
-      switch (prop.type) {
-        case 'string':
-        case 'undefined':
-          return utilInspect(prop.value, opts);
-
-        case 'number':
-        case 'boolean':
-          return opts.stylize(prop.value, prop.type);
-
-        case 'object':
-        case 'symbol':
-          if (prop.subtype === 'date') {
-            return utilInspect(new Date(prop.value), opts);
-          }
-          if (prop.subtype === 'array') {
-            return opts.stylize(prop.value, 'special');
-          }
-          return opts.stylize(prop.value, prop.subtype || 'special');
-
-        default:
-          return prop.value;
-      }
-    }
     switch (this.type) {
       case 'boolean':
       case 'number':
       case 'string':
       case 'undefined':
         return utilInspect(this.value, opts);
-
       case 'symbol':
         return opts.stylize(this.description, 'special');
-
       case 'function': {
         const fnName = extractFunctionName(this.description);
         const formatted = `[${this.className}${fnName}]`;
         return opts.stylize(formatted, 'special');
       }
-
       case 'object':
         switch (this.subtype) {
           case 'date':
             return utilInspect(new Date(this.description), opts);
-
           case 'null':
             return utilInspect(null, opts);
-
           case 'regexp':
             return opts.stylize(this.description, 'regexp');
-
+          case 'map':
+          case 'set': {
+            const preview = utilInspect(new ObjectPreview(this.preview), opts);
+            return `${this.description} ${preview}`;
+          }
           default:
             break;
         }
         if (this.preview) {
-          const props = ArrayPrototypeMap(
-            this.preview.properties,
-            (prop, idx) => {
-              const value = formatProperty(prop);
-              if (prop.name === `${idx}`) return value;
-              return `${prop.name}: ${value}`;
-            });
-          if (this.preview.overflow) {
-            ArrayPrototypePush(props, '...');
-          }
-          const singleLine = ArrayPrototypeJoin(props, ', ');
-          const propString =
-            singleLine.length > 60 ?
-              ArrayPrototypeJoin(props, ',\n  ') :
-              singleLine;
-
-          return this.subtype === 'array' ?
-            `[ ${propString} ]` : `{ ${propString} }`;
+          return utilInspect(new ObjectPreview(this.preview), opts);
         }
         return this.description;
-
       default:
         return this.description;
     }

--- a/test/sequential/test-debugger-object-type-remote-object.js
+++ b/test/sequential/test-debugger-object-type-remote-object.js
@@ -1,0 +1,42 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const startCLI = require('../common/debugger');
+
+const assert = require('assert');
+
+const cli = startCLI([fixtures.path('debugger/empty.js')]);
+
+(async () => {
+  await cli.waitForInitialBreak();
+  await cli.waitForPrompt();
+  await cli.command('exec new Date(0)');
+  assert.match(cli.output, /1970-01-01T00:00:00\.000Z/);
+  await cli.command('exec null');
+  assert.match(cli.output, /null/);
+  await cli.command('exec /regex/g');
+  assert.match(cli.output, /\/regex\/g/);
+  await cli.command('exec new Map()');
+  assert.match(cli.output, /Map\(0\) {}/);
+  await cli.command('exec new Map([["a",1],["b",2]])');
+  assert.match(cli.output, /Map\(2\) { a => 1, b => 2 }/);
+  await cli.command('exec new Set()');
+  assert.match(cli.output, /Set\(0\) {}/);
+  await cli.command('exec new Set([1,2])');
+  assert.match(cli.output, /Set\(2\) { 1, 2 }/);
+  await cli.command('exec new Set([{a:1},new Set([1])])');
+  assert.match(cli.output, /Set\(2\) { { a: 1 }, Set\(1\) { \.\.\. } }/);
+  await cli.command('exec a={}; a');
+  assert.match(cli.output, /{}/);
+  await cli.command('exec a={a:1,b:{c:1}}; a');
+  assert.match(cli.output, /{ a: 1, b: Object }/);
+  await cli.command('exec a=[]; a');
+  assert.match(cli.output, /\[\]/);
+  await cli.command('exec a=[1,2]; a');
+  assert.match(cli.output, /\[ 1, 2 \]/);
+})()
+.finally(() => cli.quit())
+.then(common.mustCall());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixed #42405

The output string of `exec` command is from `RemoteObject[customInspectSymbol]`, but currently it doesn't support some object types such as `Map` and `Set`, which leads to invalid string representations (#42405).

This PR implemented string representations when `RemoteObject.subtype` is `set` and `map`. `RemoteObject` has their abbreviation as `ObjectPreview` in `RemoteObject.preview`, which means we can construct their string representation from `ObjectPreview`.

For example, `new Set([ {a: 1}, new Set([1]) ])` is a RemoteObject that has two ObjectPreviews (`{a: 1}` and `new Set([1])`). 
String representation of ObjectPreview `{a: 1}` will be `{a: 1}` and `new Set([1])` will be `Set(1) { ... }`. (Note that ObjectPreview treats an object nested in two or more layers as overflow, so overflowed object is converted to `{ ... }`)

1d0da48886f132b362bae680e07cf3b33627a883 added test cases for object type RemoteObject
7820dd4b2542cabb5ea6581be93f5c0d35b7e50a added [`ObjectPreview`](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ObjectPreview) and [`PropertyPreview`](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-PropertyPreview). And current string representation logics are ported to them.
5a4f767130e50002c98e214382a4dc74ab29f74a fixed string representations of `Map` and `Set`.