### PR TITLE
fs: make sure to write entire buffer

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -578,6 +578,7 @@ async function write(handle, buffer, offset, length, position) {
     const bytesWritten =
       (await binding.writeBuffer(handle.fd, buffer, offset,
                                  length, position, kUsePromises)) || 0;
+
     return { bytesWritten, buffer };
   }
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -578,7 +578,6 @@ async function write(handle, buffer, offset, length, position) {
     const bytesWritten =
       (await binding.writeBuffer(handle.fd, buffer, offset,
                                  length, position, kUsePromises)) || 0;
-
     return { bytesWritten, buffer };
   }
 

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -405,8 +405,11 @@ function writeAll(data, size, pos, cb, retries = 0) {
       return cb(new Error('writev failed'));
     }
 
-    if (bytesWritten < size) {
-      writeAll(buffer.slice(bytesWritten), size - bytesWritten, pos + bytesWritten, cb, retries);
+    size -= bytesWritten
+    pos += bytesWritten
+
+    if (size) {
+      writeAll(buffer.slice(bytesWritten), size, pos, cb, retries);
     } else {
       cb();
     }
@@ -432,8 +435,11 @@ function writevAll(chunks, size, pos, cb, retries = 0) {
       return cb(new Error('writev failed'));
     }
 
-    if (bytesWritten < size) {
-      writevAll([Buffer.concat(buffers).slice(bytesWritten)], size - bytesWritten, pos + bytesWritten, cb, retries);
+    size -= bytesWritten
+    pos += bytesWritten
+
+    if (size) {
+      writevAll([Buffer.concat(buffers).slice(bytesWritten)], size, pos, cb, retries);
     } else {
       cb();
     }

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -386,9 +386,42 @@ WriteStream.prototype.open = openWriteFs;
 
 WriteStream.prototype._construct = _construct;
 
+function writeAll(data, pos, cb) {
+  const len = data.length;
+  this[kFs].write(this.fd, data, 0, len, pos, (er, bytesWritten) => {
+    if (this.destroyed || er) {
+      return cb(er);
+    }
+
+    this.bytesWritten += bytesWritten;
+
+    if (bytesWritten < len) {
+      writeAll(data.slice(bytesWritten), pos + bytesWritten, cb);
+    } else {
+      cb();
+    }
+  });
+}
+
+function writevAll(chunks, pos, cb) {
+  this[kFs].writev(this.fd, chunks, this.pos, (er, bytesWritten) => {
+    if (this.destroyed || er) {
+      return cb(er);
+    }
+
+    this.bytesWritten += bytesWritten;
+
+    if (bytesWritten < len) {
+      writevAll([Buffer.concat(chunks).slice(bytesWritten)], pos + bytesWritten, cb);
+    } else {
+      cb();
+    }
+  });
+}
+
 WriteStream.prototype._write = function(data, encoding, cb) {
   this[kIsPerformingIO] = true;
-  this[kFs].write(this.fd, data, 0, data.length, this.pos, (er, bytes) => {
+  writeAll.call(this, data, this.pos, (er) => {
     this[kIsPerformingIO] = false;
     if (this.destroyed) {
       // Tell ._destroy() that it's safe to close the fd now.
@@ -396,12 +429,7 @@ WriteStream.prototype._write = function(data, encoding, cb) {
       return this.emit(kIoDone, er);
     }
 
-    if (er) {
-      return cb(er);
-    }
-
-    this.bytesWritten += bytes;
-    cb();
+    cb(er);
   });
 
   if (this.pos !== undefined)
@@ -421,7 +449,7 @@ WriteStream.prototype._writev = function(data, cb) {
   }
 
   this[kIsPerformingIO] = true;
-  this[kFs].writev(this.fd, chunks, this.pos, (er, bytes) => {
+  writevAll.call(this, chunks, this.pos, (er) => {
     this[kIsPerformingIO] = false;
     if (this.destroyed) {
       // Tell ._destroy() that it's safe to close the fd now.
@@ -429,12 +457,7 @@ WriteStream.prototype._writev = function(data, cb) {
       return this.emit(kIoDone, er);
     }
 
-    if (er) {
-      return cb(er);
-    }
-
-    this.bytesWritten += bytes;
-    cb();
+    cb(er);
   });
 
   if (this.pos !== undefined)

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -415,6 +415,10 @@ function writeAll(data, pos, cb, retries = 0) {
 }
 
 function writevAll(chunks, pos, cb, retries = 0) {
+  let len = 0;
+  for (const chunk of chunks) {
+    len += Buffer.byteLength(chunk);
+  }
   this[kFs].writev(this.fd, chunks, this.pos, (er, bytesWritten) => {
     if (er?.code === 'EAGAIN') {
       er = null;

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -406,7 +406,7 @@ function writeAll(data, size, pos, cb, retries = 0) {
     }
 
     if (bytesWritten < size) {
-      writeAll(buffer.slice(bytesWritten), pos + bytesWritten, cb, retries);
+      writeAll(buffer.slice(bytesWritten), size - bytesWritten, pos + bytesWritten, cb, retries);
     } else {
       cb();
     }
@@ -433,7 +433,7 @@ function writevAll(chunks, size, pos, cb, retries = 0) {
     }
 
     if (bytesWritten < size) {
-      writevAll([Buffer.concat(buffers).slice(bytesWritten)], pos + bytesWritten, cb, retries);
+      writevAll([Buffer.concat(buffers).slice(bytesWritten)], size - bytesWritten, pos + bytesWritten, cb, retries);
     } else {
       cb();
     }

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -414,7 +414,7 @@ function writeAll(data, pos, cb, retries = 0) {
 
 function writevAll(chunks, pos, cb, retries = 0) {
   if (retries > 5) {
-    process.nextTick(() => cb(new Error('write failed')))
+    process.nextTick(() => cb(new Error('writev failed')))
   }
 
   this[kFs].writev(this.fd, chunks, this.pos, (er, bytesWritten) => {

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -386,9 +386,18 @@ WriteStream.prototype.open = openWriteFs;
 
 WriteStream.prototype._construct = _construct;
 
-function writeAll(data, pos, cb) {
+function writeAll(data, pos, cb, retries = 0) {
+  if (retries > 5) {
+    process.nextTick(() => cb(new Error('write failed')))
+  }
+
   const len = data.length;
   this[kFs].write(this.fd, data, 0, len, pos, (er, bytesWritten) => {
+    if (er?.code === 'EAGAIN') {
+      er = null
+      bytesWritten = 0
+    }
+
     if (this.destroyed || er) {
       return cb(er);
     }
@@ -396,15 +405,24 @@ function writeAll(data, pos, cb) {
     this.bytesWritten += bytesWritten;
 
     if (bytesWritten < len) {
-      writeAll(data.slice(bytesWritten), pos + bytesWritten, cb);
+      writeAll(data.slice(bytesWritten), pos + bytesWritten, cb, retries + 1);
     } else {
       cb();
     }
   });
 }
 
-function writevAll(chunks, pos, cb) {
+function writevAll(chunks, pos, cb, retries = 0) {
+  if (retries > 5) {
+    process.nextTick(() => cb(new Error('write failed')))
+  }
+
   this[kFs].writev(this.fd, chunks, this.pos, (er, bytesWritten) => {
+    if (er?.code === 'EAGAIN') {
+      er = null
+      bytesWritten = 0
+    }
+
     if (this.destroyed || er) {
       return cb(er);
     }
@@ -412,7 +430,7 @@ function writevAll(chunks, pos, cb) {
     this.bytesWritten += bytesWritten;
 
     if (bytesWritten < len) {
-      writevAll([Buffer.concat(chunks).slice(bytesWritten)], pos + bytesWritten, cb);
+      writevAll([Buffer.concat(chunks).slice(bytesWritten)], pos + bytesWritten, cb, retries + 1);
     } else {
       cb();
     }

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -386,8 +386,8 @@ WriteStream.prototype.open = openWriteFs;
 
 WriteStream.prototype._construct = _construct;
 
-function writeAll(data, pos, cb, retries = 0) {
-  this[kFs].write(this.fd, data, 0, data.length, pos, (er, bytesWritten, buffer) => {
+function writeAll(data, size, pos, cb, retries = 0) {
+  this[kFs].write(this.fd, data, 0, size, pos, (er, bytesWritten) => {
     if (er?.code === 'EAGAIN') {
       er = null;
       bytesWritten = 0;
@@ -405,9 +405,7 @@ function writeAll(data, pos, cb, retries = 0) {
       return cb(new Error('writev failed'));
     }
 
-    const len = Byffer.byteLength(data);
-
-    if (bytesWritten < len) {
+    if (bytesWritten < size) {
       writeAll(data.slice(bytesWritten), pos + bytesWritten, cb, retries);
     } else {
       cb();
@@ -415,7 +413,7 @@ function writeAll(data, pos, cb, retries = 0) {
   });
 }
 
-function writevAll(chunks, pos, cb, retries = 0) {
+function writevAll(chunks, size, pos, cb, retries = 0) {
   this[kFs].writev(this.fd, chunks, this.pos, (er, bytesWritten, buffers) => {
     if (er?.code === 'EAGAIN') {
       er = null;
@@ -434,12 +432,7 @@ function writevAll(chunks, pos, cb, retries = 0) {
       return cb(new Error('writev failed'));
     }
 
-    let len = 0;
-    for (const buf of buffers) {
-      len += Buffer.byteLength(buf);
-    }
-
-    if (bytesWritten < len) {
+    if (bytesWritten < size) {
       writevAll([Buffer.concat(buffers).slice(bytesWritten)], pos + bytesWritten, cb, retries);
     } else {
       cb();
@@ -449,7 +442,7 @@ function writevAll(chunks, pos, cb, retries = 0) {
 
 WriteStream.prototype._write = function(data, encoding, cb) {
   this[kIsPerformingIO] = true;
-  writeAll.call(this, data, this.pos, (er) => {
+  writeAll.call(this, data.length, data, this.pos, (er) => {
     this[kIsPerformingIO] = false;
     if (this.destroyed) {
       // Tell ._destroy() that it's safe to close the fd now.
@@ -477,7 +470,7 @@ WriteStream.prototype._writev = function(data, cb) {
   }
 
   this[kIsPerformingIO] = true;
-  writevAll.call(this, chunks, this.pos, (er) => {
+  writevAll.call(this, size, chunks, this.pos, (er) => {
     this[kIsPerformingIO] = false;
     if (this.destroyed) {
       // Tell ._destroy() that it's safe to close the fd now.

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -400,15 +400,12 @@ function writeAll(data, size, pos, cb, retries = 0) {
     this.bytesWritten += bytesWritten;
 
     retries = bytesWritten ? 0 : retries + 1;
+    size -= bytesWritten;
+    pos += bytesWritten;
 
     if (retries > 5) {
-      return cb(new Error('writev failed'));
-    }
-
-    size -= bytesWritten
-    pos += bytesWritten
-
-    if (size) {
+      cb(new Error('writev failed'));
+    } else if (size) {
       writeAll(buffer.slice(bytesWritten), size, pos, cb, retries);
     } else {
       cb();
@@ -430,15 +427,12 @@ function writevAll(chunks, size, pos, cb, retries = 0) {
     this.bytesWritten += bytesWritten;
 
     retries = bytesWritten ? 0 : retries + 1;
+    size -= bytesWritten;
+    pos += bytesWritten;
 
     if (retries > 5) {
-      return cb(new Error('writev failed'));
-    }
-
-    size -= bytesWritten
-    pos += bytesWritten
-
-    if (size) {
+      cb(new Error('writev failed'));
+    } else if (size) {
       writevAll([Buffer.concat(buffers).slice(bytesWritten)], size, pos, cb, retries);
     } else {
       cb();

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -390,15 +390,15 @@ function writeAll(data, pos, cb, retries = 0) {
   const len = data.length;
   this[kFs].write(this.fd, data, 0, len, pos, (er, bytesWritten) => {
     if (er?.code === 'EAGAIN') {
-      er = null
-      bytesWritten = 0
+      er = null;
+      bytesWritten = 0;
     }
 
     if (this.destroyed || er) {
       return cb(er);
     }
 
-    retries = bytesWritten ? 0 : retries + 1
+    retries = bytesWritten ? 0 : retries + 1;
 
     if (retries > 5) {
       return cb(new Error('writev failed'));
@@ -417,8 +417,8 @@ function writeAll(data, pos, cb, retries = 0) {
 function writevAll(chunks, pos, cb, retries = 0) {
   this[kFs].writev(this.fd, chunks, this.pos, (er, bytesWritten) => {
     if (er?.code === 'EAGAIN') {
-      er = null
-      bytesWritten = 0
+      er = null;
+      bytesWritten = 0;
     }
 
     if (this.destroyed || er) {
@@ -427,7 +427,7 @@ function writevAll(chunks, pos, cb, retries = 0) {
 
     this.bytesWritten += bytesWritten;
 
-    retries = bytesWritten ? 0 : retries + 1
+    retries = bytesWritten ? 0 : retries + 1;
 
     if (retries > 5) {
       return cb(new Error('writev failed'));

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -387,7 +387,7 @@ WriteStream.prototype.open = openWriteFs;
 WriteStream.prototype._construct = _construct;
 
 function writeAll(data, size, pos, cb, retries = 0) {
-  this[kFs].write(this.fd, data, 0, size, pos, (er, bytesWritten) => {
+  this[kFs].write(this.fd, data, 0, size, pos, (er, bytesWritten, buffer) => {
     if (er?.code === 'EAGAIN') {
       er = null;
       bytesWritten = 0;
@@ -406,7 +406,7 @@ function writeAll(data, size, pos, cb, retries = 0) {
     }
 
     if (bytesWritten < size) {
-      writeAll(data.slice(bytesWritten), pos + bytesWritten, cb, retries);
+      writeAll(buffer.slice(bytesWritten), pos + bytesWritten, cb, retries);
     } else {
       cb();
     }

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -387,10 +387,6 @@ WriteStream.prototype.open = openWriteFs;
 WriteStream.prototype._construct = _construct;
 
 function writeAll(data, pos, cb, retries = 0) {
-  if (retries > 5) {
-    process.nextTick(() => cb(new Error('write failed')))
-  }
-
   const len = data.length;
   this[kFs].write(this.fd, data, 0, len, pos, (er, bytesWritten) => {
     if (er?.code === 'EAGAIN') {
@@ -402,10 +398,16 @@ function writeAll(data, pos, cb, retries = 0) {
       return cb(er);
     }
 
+    retries = bytesWritten ? 0 : retries + 1
+
+    if (retries > 5) {
+      return cb(new Error('writev failed'));
+    }
+
     this.bytesWritten += bytesWritten;
 
     if (bytesWritten < len) {
-      writeAll(data.slice(bytesWritten), pos + bytesWritten, cb, retries + 1);
+      writeAll(data.slice(bytesWritten), pos + bytesWritten, cb, retries);
     } else {
       cb();
     }
@@ -413,10 +415,6 @@ function writeAll(data, pos, cb, retries = 0) {
 }
 
 function writevAll(chunks, pos, cb, retries = 0) {
-  if (retries > 5) {
-    process.nextTick(() => cb(new Error('writev failed')))
-  }
-
   this[kFs].writev(this.fd, chunks, this.pos, (er, bytesWritten) => {
     if (er?.code === 'EAGAIN') {
       er = null
@@ -429,8 +427,14 @@ function writevAll(chunks, pos, cb, retries = 0) {
 
     this.bytesWritten += bytesWritten;
 
+    retries = bytesWritten ? 0 : retries + 1
+
+    if (retries > 5) {
+      return cb(new Error('writev failed'));
+    }
+
     if (bytesWritten < len) {
-      writevAll([Buffer.concat(chunks).slice(bytesWritten)], pos + bytesWritten, cb, retries + 1);
+      writevAll([Buffer.concat(chunks).slice(bytesWritten)], pos + bytesWritten, cb, retries);
     } else {
       cb();
     }

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -387,8 +387,7 @@ WriteStream.prototype.open = openWriteFs;
 WriteStream.prototype._construct = _construct;
 
 function writeAll(data, pos, cb, retries = 0) {
-  const len = data.length;
-  this[kFs].write(this.fd, data, 0, len, pos, (er, bytesWritten) => {
+  this[kFs].write(this.fd, data, 0, data.length, pos, (er, bytesWritten, buffer) => {
     if (er?.code === 'EAGAIN') {
       er = null;
       bytesWritten = 0;
@@ -398,13 +397,15 @@ function writeAll(data, pos, cb, retries = 0) {
       return cb(er);
     }
 
+    this.bytesWritten += bytesWritten;
+
     retries = bytesWritten ? 0 : retries + 1;
 
     if (retries > 5) {
       return cb(new Error('writev failed'));
     }
 
-    this.bytesWritten += bytesWritten;
+    const len = Byffer.byteLength(data);
 
     if (bytesWritten < len) {
       writeAll(data.slice(bytesWritten), pos + bytesWritten, cb, retries);
@@ -415,11 +416,7 @@ function writeAll(data, pos, cb, retries = 0) {
 }
 
 function writevAll(chunks, pos, cb, retries = 0) {
-  let len = 0;
-  for (const chunk of chunks) {
-    len += Buffer.byteLength(chunk);
-  }
-  this[kFs].writev(this.fd, chunks, this.pos, (er, bytesWritten) => {
+  this[kFs].writev(this.fd, chunks, this.pos, (er, bytesWritten, buffers) => {
     if (er?.code === 'EAGAIN') {
       er = null;
       bytesWritten = 0;
@@ -437,8 +434,13 @@ function writevAll(chunks, pos, cb, retries = 0) {
       return cb(new Error('writev failed'));
     }
 
+    let len = 0;
+    for (const buf of buffers) {
+      len += Buffer.byteLength(buf);
+    }
+
     if (bytesWritten < len) {
-      writevAll([Buffer.concat(chunks).slice(bytesWritten)], pos + bytesWritten, cb, retries);
+      writevAll([Buffer.concat(buffers).slice(bytesWritten)], pos + bytesWritten, cb, retries);
     } else {
       cb();
     }


### PR DESCRIPTION
fs.write(v) is not guaranteed to write everything in a single
call. Make sure we don't assume so.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
