### PR TITLE
lib: improve the coverage of the validator

### DIFF
--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -82,13 +82,10 @@ const validateInteger = hideStackFrames(
 const validateInt32 = hideStackFrames(
   (value, name, min = -2147483648, max = 2147483647) => {
     // The defaults for min and max correspond to the limits of 32-bit integers.
-    if (typeof value == 'symbol' || typeof value == 'bigint') {
+    if (typeof value !== 'number') {
       throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
     }
     if (!isInt32(value)) {
-      if (typeof value !== 'number') {
-        throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
-      }
       if (!NumberIsInteger(value)) {
         throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
       }
@@ -101,13 +98,10 @@ const validateInt32 = hideStackFrames(
 );
 
 const validateUint32 = hideStackFrames((value, name, positive) => {
-  if (typeof value == 'symbol' || typeof value == 'bigint') {
+  if (typeof value !== 'number') {
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
   }
   if (!isUint32(value)) {
-    if (typeof value !== 'number') {
-      throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
-    }
     if (!NumberIsInteger(value)) {
       throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
     }

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -82,6 +82,9 @@ const validateInteger = hideStackFrames(
 const validateInt32 = hideStackFrames(
   (value, name, min = -2147483648, max = 2147483647) => {
     // The defaults for min and max correspond to the limits of 32-bit integers.
+    if (typeof value == 'symbol' || typeof value == 'bigint') {
+      throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+    }
     if (!isInt32(value)) {
       if (typeof value !== 'number') {
         throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
@@ -98,6 +101,9 @@ const validateInt32 = hideStackFrames(
 );
 
 const validateUint32 = hideStackFrames((value, name, positive) => {
+  if (typeof value == 'symbol' || typeof value == 'bigint') {
+    throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+  }
   if (!isUint32(value)) {
     if (typeof value !== 'number') {
       throw new ERR_INVALID_ARG_TYPE(name, 'number', value);

--- a/test/parallel/test-validators.js
+++ b/test/parallel/test-validators.js
@@ -46,7 +46,7 @@ const invalidArgValueError = {
 
   // validateInt32() and validateUint32()
   [
-    Symbol(), 1n, {}, [], false, true, undefined, null,
+    Symbol(), 1n, {}, [], false, true, undefined, null, () => {}, '', '1',
   ].forEach((val) => assert.throws(() => validateInt32(val, 'name'), {
     code: 'ERR_INVALID_ARG_TYPE'
   }));
@@ -56,7 +56,10 @@ const invalidArgValueError = {
     code: 'ERR_OUT_OF_RANGE'
   }));
   [
-    Symbol(), 1n, {}, [], false, true, undefined, null,
+    0, 1, -1,
+  ].forEach((val) => validateInt32(val, 'name'));
+  [
+    Symbol(), 1n, {}, [], false, true, undefined, null, () => {}, '', '1',
   ].forEach((val) => assert.throws(() => validateUint32(val, 'name'), {
     code: 'ERR_INVALID_ARG_TYPE'
   }));
@@ -65,6 +68,9 @@ const invalidArgValueError = {
   ].forEach((val) => assert.throws(() => validateUint32(val, 'name'), {
     code: 'ERR_OUT_OF_RANGE'
   }));
+  [
+    0, 1,
+  ].forEach((val) => validateUint32(val, 'name'));
 }
 
 {

--- a/test/parallel/test-validators.js
+++ b/test/parallel/test-validators.js
@@ -10,6 +10,8 @@ const {
   validateNumber,
   validateObject,
   validateString,
+  validateInt32,
+  validateUint32,
 } = require('internal/validators');
 const { MAX_SAFE_INTEGER, MIN_SAFE_INTEGER } = Number;
 const outOfRangeError = {
@@ -41,6 +43,28 @@ const invalidArgValueError = {
   // validateInteger() works with unsafe integers.
   validateInteger(MAX_SAFE_INTEGER + 1, 'foo', 0, MAX_SAFE_INTEGER + 1);
   validateInteger(MIN_SAFE_INTEGER - 1, 'foo', MIN_SAFE_INTEGER - 1);
+
+  // validateInt32() and validateUint32()
+  [
+    Symbol(), 1n, {}, [], false, true, undefined, null,
+  ].forEach((val) => assert.throws(() => validateInt32(val, 'name'), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  }));
+  [
+    2147483647 + 1, -2147483648 - 1, NaN,
+  ].forEach((val) => assert.throws(() => validateInt32(val, 'name'), {
+    code: 'ERR_OUT_OF_RANGE'
+  }));
+  [
+    Symbol(), 1n, {}, [], false, true, undefined, null,
+  ].forEach((val) => assert.throws(() => validateUint32(val, 'name'), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  }));
+  [
+    4294967296, -1, NaN,
+  ].forEach((val) => assert.throws(() => validateUint32(val, 'name'), {
+    code: 'ERR_OUT_OF_RANGE'
+  }));
 }
 
 {


### PR DESCRIPTION
In current version, if you take `symbol` or `bigint` as arguments to the validator, a native error will be thrown.