### PR TITLE
fs: Fix some JSDoc and code style details

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -807,6 +807,9 @@ pipes between the parent and child. The value is one of the following:
    `child_process` object as [`subprocess.stdio[fd]`][`subprocess.stdio`]. Pipes
    created for fds 0, 1, and 2 are also available as [`subprocess.stdin`][],
    [`subprocess.stdout`][] and [`subprocess.stderr`][], respectively.
+   Currently, these are not actual Unix pipes and therefore the child process
+   can not use them by their descriptor files,
+   e.g. `/dev/fd/2` or `/dev/stdout`.
 2. `'overlapped'`: Same as `'pipe'` except that the `FILE_FLAG_OVERLAPPED` flag
    is set on the handle. This is necessary for overlapped I/O on the child
    process's stdio handles. See the

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -259,13 +259,13 @@ function exists(path, callback) {
   maybeCallback(callback);
 
   function suppressedCallback(err) {
-    callback(err ? false : true);
+    callback(!err);
   }
 
   try {
     fs.access(path, F_OK, suppressedCallback);
   } catch {
-    return callback(false);
+    callback(false);
   }
 }
 
@@ -589,9 +589,9 @@ function openSync(path, flags, mode) {
  * Reads file from the specified `fd` (file descriptor).
  * @param {number} fd
  * @param {Buffer | TypedArray | DataView} buffer
- * @param {number} offset
- * @param {number} length
- * @param {number | bigint} position
+ * @param {number} [offset]
+ * @param {number} [length]
+ * @param {number | bigint} [position]
  * @param {(
  *   err?: Error,
  *   bytesRead?: number,
@@ -637,9 +637,11 @@ function read(fd, buffer, offset, length, position, callback) {
   length |= 0;
 
   if (length === 0) {
-    return process.nextTick(function tick() {
+    process.nextTick(function tick() {
       callback(null, 0, buffer);
     });
+
+    return;
   }
 
   if (buffer.byteLength === 0) {
@@ -678,6 +680,8 @@ ObjectDefineProperty(read, internalUtil.customPromisifyArgs,
  *   length?: number;
  *   position?: number | bigint;
  *   }} [offset]
+ * @param {number} [length]
+ * @param {number | bigint} [position]
  * @returns {number}
  */
 function readSync(fd, buffer, offset, length, position) {
@@ -736,7 +740,7 @@ function readSync(fd, buffer, offset, length, position) {
  * @param {(
  *   err?: Error,
  *   bytesRead?: number,
- *   buffers?: ArrayBufferView[];
+ *   buffers?: ArrayBufferView[]
  *   ) => any} callback
  * @returns {void}
  */
@@ -755,7 +759,7 @@ function readv(fd, buffers, position, callback) {
   if (typeof position !== 'number')
     position = null;
 
-  return binding.readBuffers(fd, buffers, position, req);
+  binding.readBuffers(fd, buffers, position, req);
 }
 
 ObjectDefineProperty(readv, internalUtil.customPromisifyArgs,
@@ -793,9 +797,9 @@ function readvSync(fd, buffers, position) {
  * @param {number} [position]
  * @param {(
  *   err?: Error,
- *   bytesWritten?: number;
+ *   bytesWritten?: number,
  *   buffer?: Buffer | TypedArray | DataView
- *   ) => any} callback
+ * ) => any} callback
  * @returns {void}
  */
 function write(fd, buffer, offset, length, position, callback) {
@@ -842,7 +846,7 @@ function write(fd, buffer, offset, length, position, callback) {
 
   const req = new FSReqCallback();
   req.oncomplete = wrapper;
-  return binding.writeString(fd, str, offset, length, req);
+  binding.writeString(fd, str, offset, length, req);
 }
 
 ObjectDefineProperty(write, internalUtil.customPromisifyArgs,
@@ -921,7 +925,7 @@ function writev(fd, buffers, position, callback) {
   if (typeof position !== 'number')
     position = null;
 
-  return binding.writeBuffers(fd, buffers, position, req);
+  binding.writeBuffers(fd, buffers, position, req);
 }
 
 ObjectDefineProperty(writev, internalUtil.customPromisifyArgs, {
@@ -1028,7 +1032,7 @@ function truncate(path, len, callback) {
 
 /**
  * Synchronously truncates the file.
- * @param {string | Buffer | URL} path
+ * @param {string | Buffer | URL | number} path
  * @param {number} [len]
  * @returns {void}
  */
@@ -1043,14 +1047,12 @@ function truncateSync(path, len) {
   }
   // Allow error to be thrown, but still close fd.
   const fd = fs.openSync(path, 'r+');
-  let ret;
 
   try {
-    ret = fs.ftruncateSync(fd, len);
+    fs.ftruncateSync(fd, len);
   } finally {
     fs.closeSync(fd);
   }
-  return ret;
 }
 
 /**
@@ -1146,7 +1148,7 @@ function rmdir(path, options, callback) {
     validateRmdirOptions(options);
     const req = new FSReqCallback();
     req.oncomplete = callback;
-    return binding.rmdir(path, req);
+    binding.rmdir(path, req);
   }
 }
 
@@ -1225,7 +1227,7 @@ function rmSync(path, options) {
   options = validateRmOptionsSync(path, options, false);
 
   lazyLoadRimraf();
-  return rimrafSync(pathModule.toNamespacedPath(path), options);
+  rimrafSync(pathModule.toNamespacedPath(path), options);
 }
 
 /**
@@ -1360,7 +1362,7 @@ function mkdirSync(path, options) {
  *   }} [options]
  * @param {(
  *   err?: Error,
- *   files?: string[] | Buffer[] | Direct[];
+ *   files?: string[] | Buffer[] | Dirent[]
  *   ) => any} callback
  * @returns {void}
  */
@@ -1701,11 +1703,10 @@ function linkSync(existingPath, newPath) {
   newPath = getValidatedPath(newPath, 'newPath');
 
   const ctx = { path: existingPath, dest: newPath };
-  const result = binding.link(pathModule.toNamespacedPath(existingPath),
-                              pathModule.toNamespacedPath(newPath),
-                              undefined, ctx);
+  binding.link(pathModule.toNamespacedPath(existingPath),
+               pathModule.toNamespacedPath(newPath),
+               undefined, ctx);
   handleErrorFromBinding(ctx);
-  return result;
 }
 
 /**
@@ -1801,13 +1802,11 @@ function lchmodSync(path, mode) {
 
   // Prefer to return the chmod error, if one occurs,
   // but still try to close, and report closing errors if they occur.
-  let ret;
   try {
-    ret = fs.fchmodSync(fd, mode);
+    fs.fchmodSync(fd, mode);
   } finally {
     fs.closeSync(fd);
   }
-  return ret;
 }
 
 /**
@@ -2606,7 +2605,7 @@ function realpath(p, options, callback) {
 
   // On windows, check that the root exists. On unix there is no need.
   if (isWindows && !knownHard[base]) {
-    fs.lstat(base, (err, stats) => {
+    fs.lstat(base, (err) => {
       if (err) return callback(err);
       knownHard[base] = true;
       LOOP();
@@ -2722,7 +2721,7 @@ realpath.native = (path, options, callback) => {
   path = getValidatedPath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  return binding.realpath(path, options.encoding, req);
+  binding.realpath(path, options.encoding, req);
 };
 
 /**


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

For some reasons, I need to read some code of Node.js to understand the underlying principles and implementation details. While reading, I also found that there are some details in the code that can be improved, mainly:

1. JSDoc

Fixed some syntax, type issues, some types didn't correspond to function parameters, others had typos, and some should be optional.

2. Function return value

According to the relevant documentation of Node.js, if a function has no return value, we can not add the return keyword. In the `fs` file, some functions do this, but some other functions also have `return`, I will unify them . If the function needs to return early, use `return;`.

Next, if I have time, I'll try to fix similar issues in other files.