### PR TITLE
node-api,src: fix module registration in MSVC C++

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -822,17 +822,44 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
 
 #ifdef NODE_SHARED_MODE
 # define NODE_CTOR_PREFIX
+# define NODE_CTOR_ANONYMOUS_NAMESPACE_START
+# define NODE_CTOR_ANONYMOUS_NAMESPACE_END
 #else
 # define NODE_CTOR_PREFIX static
+# define NODE_CTOR_NAMESPACE namespace
+# define NODE_CTOR_ANONYMOUS_NAMESPACE_START NODE_CTOR_NAMESPACE {
+# define NODE_CTOR_ANONYMOUS_NAMESPACE_END }
 #endif
 
 #if defined(_MSC_VER)
+#if defined(__cplusplus)
+// The NODE_C_CTOR macro defines a function fn that is called during dynamic
+// initialization of static variables.
+// The order of the dynamic initialization is not defined and code in fn
+// function must avoid using other static variables with dynamic initialization.
+#define NODE_C_CTOR(fn)                                               \
+  NODE_CTOR_PREFIX void __cdecl fn(void);                             \
+  NODE_CTOR_ANONYMOUS_NAMESPACE_START                                 \
+  struct fn##_ {                                                      \
+    static int Call##fn() { return (fn(), 0); }                       \
+    static inline const int x = Call##fn();                           \
+  };                                                                  \
+  NODE_CTOR_ANONYMOUS_NAMESPACE_END                                   \
+  NODE_CTOR_PREFIX void __cdecl fn(void)
+#else
 #pragma section(".CRT$XCU", read)
+// The NODE_C_CTOR macro defines a function fn that is called during CRT
+// initialization.
+// C does not support dynamic initialization of static variables and this code
+// simulates C++ behavior. Exporting the function pointer prevents it from being
+// optimized. See for details:
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/crt-initialization?view=msvc-170
 #define NODE_C_CTOR(fn)                                               \
   NODE_CTOR_PREFIX void __cdecl fn(void);                             \
   __declspec(dllexport, allocate(".CRT$XCU"))                         \
       void (__cdecl*fn ## _)(void) = fn;                              \
   NODE_CTOR_PREFIX void __cdecl fn(void)
+#endif
 #else
 #define NODE_C_CTOR(fn)                                               \
   NODE_CTOR_PREFIX void fn(void) __attribute__((constructor));        \

--- a/test/js-native-api/common.h
+++ b/test/js-native-api/common.h
@@ -62,6 +62,9 @@
 #define DECLARE_NODE_API_GETTER(name, func)                              \
   { (name), NULL, NULL, (func), NULL, NULL, napi_default, NULL }
 
+#define DECLARE_NODE_API_PROPERTY_VALUE(name, value)                     \
+  { (name), NULL, NULL, NULL, NULL, (value), napi_default, NULL }
+
 void add_returned_status(napi_env env,
                          const char* key,
                          napi_value object,

--- a/test/node-api/test_init_order/binding.gyp
+++ b/test/node-api/test_init_order/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_init_order",
+      "sources": [ "test_init_order.cc" ]
+    }
+  ]
+}

--- a/test/node-api/test_init_order/test.js
+++ b/test/node-api/test_init_order/test.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// This test verifies that C++ static variable dynamic initialization is called
+// correctly and does not interfere with the module initialization.
+const common = require('../../common');
+const test_init_order = require(`./build/${common.buildType}/test_init_order`);
+const assert = require('assert');
+
+assert.strictEqual(test_init_order.cppIntValue, 42);
+assert.strictEqual(test_init_order.cppStringValue, '123');

--- a/test/node-api/test_init_order/test_init_order.cc
+++ b/test/node-api/test_init_order/test_init_order.cc
@@ -1,0 +1,47 @@
+#include <node_api.h>
+#include <memory>
+#include <string>
+#include "../../js-native-api/common.h"
+
+namespace {
+
+inline std::string testString = "123";
+
+struct ValueHolder {
+  int value{42};
+};
+
+class MyClass {
+ public:
+  // Ensure that the static variable is initialized by a dynamic static
+  // initializer.
+  static std::unique_ptr<ValueHolder> valueHolder;
+};
+
+std::unique_ptr<ValueHolder> MyClass::valueHolder{new ValueHolder()};
+
+}  // namespace
+
+EXTERN_C_START
+napi_value Init(napi_env env, napi_value exports) {
+  napi_value cppIntValue, cppStringValue;
+  NODE_API_CALL(
+      env, napi_create_int32(env, MyClass::valueHolder->value, &cppIntValue));
+  NODE_API_CALL(
+      env,
+      napi_create_string_utf8(
+          env, testString.c_str(), NAPI_AUTO_LENGTH, &cppStringValue));
+
+  napi_property_descriptor descriptors[] = {
+      DECLARE_NODE_API_PROPERTY_VALUE("cppIntValue", cppIntValue),
+      DECLARE_NODE_API_PROPERTY_VALUE("cppStringValue", cppStringValue)};
+
+  NODE_API_CALL(env,
+                napi_define_properties(
+                    env, exports, std::size(descriptors), descriptors));
+
+  return exports;
+}
+EXTERN_C_END
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
This PR addresses the issue #41852 where the use of the `.CRT$XCU` section by `NAPI_C_CTOR` and `NODE_C_CTOR` macros can prevent dynamic initialization of C++ static variables by MSVC.

### Issue details

We use the `NAPI_C_CTOR` and `NODE_C_CTOR` macros to register Node-API and legacy Node modules.
They make sure that the registration function is called when an addon shared library (`.dll` or `.so`) is loaded.
Typically, developers use C++ static variable dynamic initializers (when a variable is initialized by a function call) to call such registration functions. The standard C programming language does not have such facility and the C-based code must rely on the compiler-specific extensions to achieve the same results:

- GCC and Clang define `__attribute__((constructor))` to specify a function that must be called on shared library load.
- MSVC does not have any such special extensions for C and developers use the CRT initialization mechanism that MSVC uses for C++. To call dynamic initializers for static variables it uses the special `.CRT$XCU` section.

We use both of these techniques in `NAPI_C_CTOR` and `NODE_C_CTOR` macros depending on the compiler.
But when these macros are used in C++ code as we see in #41852, it can interfere with the MSVC C++ static variable initialization.

### Solution

The solution for this issue is to use different code for C++ vs C.
Currently we do this separation only for MSVC, but we can adopt the same technique for other compilers in future.
We call the registration function as a part of the C++ static variable initialization.

``` c++
#define NAPI_C_CTOR(fn)                                                        \
  static void __cdecl fn(void);                                                \
  namespace {                                                                  \
  struct fn##_ {                                                               \
    static int Call##fn() { return (fn(), 0); }                                \
    static inline const int x = Call##fn();                                    \
  };                                                                           \
  }                                                                            \
  static void __cdecl fn(void)
```

Note that:
- we use an anonymous namespace to match the `static` keyword used for the functions;
- we do not add new symbols, but rather use the same `fn##_` for the struct name which was previously used for a pointer - it should help avoid conflicts in the existing code;
- use of the `static inline` requires at least C++ 17.

We could have a simpler implementation, but the `NODE_C_CTOR` macro may avoid using the `static` keyword for functions and it means that it can be used from headers, and not only from `.cc` files. The `static inline` fields is the simplest way to support such scenario.

Resolve #41852
