### PR TITLE
doc: clarify napi_finalize behavior

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5123,6 +5123,12 @@ invocation. If it is deleted before then, then the finalize callback may never
 be invoked. Therefore, when obtaining a reference a finalize callback is also
 required in order to enable correct disposal of the reference.
 
+_Caution_: Finalizer callbacks may be deferred, leaving a window where the
+object has been garbage collected (and the weak reference is invalid) but
+the finalizer hasn't been called yet. When using `napi_get_reference_value`
+on weak references returned by `napi_wrap()`, you should still handle an
+empty result.
+
 Calling `napi_wrap()` a second time on an object will return an error. To
 associate another native instance with the object, use `napi_remove_wrap()`
 first.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5123,11 +5123,10 @@ invocation. If it is deleted before then, then the finalize callback may never
 be invoked. Therefore, when obtaining a reference a finalize callback is also
 required in order to enable correct disposal of the reference.
 
-_Caution_: Finalizer callbacks may be deferred, leaving a window where the
-object has been garbage collected (and the weak reference is invalid) but
-the finalizer hasn't been called yet. When using `napi_get_reference_value`
-on weak references returned by `napi_wrap()`, you should still handle an
-empty result.
+Finalizer callbacks may be deferred, leaving a window where the object has
+been garbage collected (and the weak reference is invalid) but the finalizer
+hasn't been called yet. When using `napi_get_reference_value()` on weak
+references returned by `napi_wrap()`, you should still handle an empty result.
 
 Calling `napi_wrap()` a second time on an object will return an error. To
 associate another native instance with the object, use `napi_remove_wrap()`


### PR DESCRIPTION
We currently defer finalizer callbacks until the loop is idle.

Warn users that the weak reference returned by `napi_wrap()` isn't guaranteed to be valid just because the finalizer hasn't yet been called.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
