### PR TITLE
export v8 trace API

### DIFF
--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -11,7 +11,7 @@ const { hasTracing } = internalBinding('config');
 const kHandle = Symbol('handle');
 const kEnabled = Symbol('enabled');
 const kCategories = Symbol('categories');
-
+const { isMainThread } = require('worker_threads');
 const kMaxTracingCount = 10;
 
 const {
@@ -24,7 +24,8 @@ const { ownsProcessState } = require('internal/worker');
 if (!hasTracing || !ownsProcessState)
   throw new ERR_TRACE_EVENTS_UNAVAILABLE();
 
-const { CategorySet, getEnabledCategories } = internalBinding('trace_events');
+const { CategorySet, getEnabledCategories, trace } = internalBinding('trace_events');
+const constants = internalBinding('constants');
 const { customInspectSymbol } = require('internal/util');
 const { format } = require('internal/util/inspect');
 const {
@@ -98,5 +99,7 @@ function createTracing(options) {
 
 module.exports = {
   createTracing,
-  getEnabledCategories
+  getEnabledCategories,
+  trace: isMainThread ? trace : null,
+  events: constants.trace
 };

--- a/test/parallel/test-trace-events-api-trace.js
+++ b/test/parallel/test-trace-events-api-trace.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const common = require('../common');
+common.skipIfWorker(); // https://github.com/nodejs/node/issues/22767
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+const tmpdir = require('../common/tmpdir');
+
+if (process.argv[2] === 'isChild') {
+  const {
+    createTracing,
+    trace,
+    events: {
+      TRACE_EVENT_PHASE_NESTABLE_ASYNC_BEGIN: kBeforeEvent,
+      TRACE_EVENT_PHASE_NESTABLE_ASYNC_END: kEndEvent
+    },
+  } = require('trace_events');
+
+  const tracing = createTracing({ categories: [ 'custom' ] });
+  tracing.enable();
+  trace(kBeforeEvent, 'custom', 'hello', 0, 'world');
+  setTimeout(() => {
+    trace(kEndEvent, 'custom', 'hello', 0, 'world');
+    tracing.disable();
+  }, 1);
+} else {
+  tmpdir.refresh();
+  const parentDir = process.cwd();
+  process.chdir(tmpdir.path);
+  const proc = cp.fork(__filename, ['isChild'], {
+    execArgv: [
+      '--trace-event-categories',
+      'custom',
+    ]
+  });
+
+  proc.once('exit', common.mustCall(() => {
+    const file = path.join(tmpdir.path, 'node_trace.1.log');
+    assert(fs.existsSync(file));
+    fs.readFile(file, { encoding: 'utf-8' }, common.mustSucceed((data) => {
+      const traces = JSON.parse(data).traceEvents.filter((trace) => trace.cat !== '__metadata');
+      assert.strictEqual(traces.length, 2);
+      traces.forEach((trace) => {
+        assert.strictEqual(trace.cat, 'custom');
+        assert.strictEqual(trace.name, 'hello');
+        assert.strictEqual(trace.args.data, 'world');
+      });
+    }));
+    process.chdir(parentDir);
+  }));
+}


### PR DESCRIPTION
export v8 trace API, so user can use it to product custom trace events and collect it by inspector or trace_events.createTracing

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
