### PR TITLE
doc: fix question promise API example

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -618,14 +618,14 @@ Using an `AbortController` to cancel a question.
 const ac = new AbortController();
 const signal = ac.signal;
 
-const answer = await rl.question('What is your favorite food? ', { signal });
-console.log(`Oh, so your favorite food is ${answer}`);
-
 signal.addEventListener('abort', () => {
   console.log('The food question timed out');
 }, { once: true });
 
 setTimeout(() => ac.abort(), 10000);
+
+const answer = await rl.question('What is your favorite food? ', { signal });
+console.log(`Oh, so your favorite food is ${answer}`);
 ```
 
 ### Class: `readlinePromises.Readline`

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -591,7 +591,7 @@ added: v17.0.0
   prompt.
 * `options` {Object}
   * `signal` {AbortSignal} Optionally allows the `question()` to be canceled
-    using an `AbortController`.
+    using an `AbortSignal`.
 * Returns: {Promise} A promise that is fulfilled with the user's
   input in response to the `query`.
 
@@ -612,17 +612,14 @@ const answer = await rl.question('What is your favorite food? ');
 console.log(`Oh, so your favorite food is ${answer}`);
 ```
 
-Using an `AbortController` to cancel a question.
+Using an `AbortSignal` to cancel a question.
 
 ```mjs
-const ac = new AbortController();
-const signal = ac.signal;
+const signal = AbortSignal.timeout(10_000);
 
 signal.addEventListener('abort', () => {
   console.log('The food question timed out');
 }, { once: true });
-
-setTimeout(() => ac.abort(), 10000);
 
 const answer = await rl.question('What is your favorite food? ', { signal });
 console.log(`Oh, so your favorite food is ${answer}`);


### PR DESCRIPTION
before: `.addEventListener` and `setTimeout` is blocked by `await rl.question`, so the `.question` will not be abort correctly.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
