### PR TITLE
bootstrap: support configure-time user-land snapshot

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -788,6 +788,13 @@ parser.add_argument('--node-builtin-modules-path',
     default=False,
     help='node will load builtin modules from disk instead of from binary')
 
+parser.add_argument('--node-snapshot-main',
+    action='store',
+    dest='node_snapshot_main',
+    default=None,
+    help='Run a file when building the embedded snapshot. Currently ' +
+         'experimental.')
+
 # Create compile_commands.json in out/Debug and out/Release.
 parser.add_argument('-C',
     action='store_true',
@@ -1215,6 +1222,18 @@ def configure_node(o):
     warn('building --without-snapshot is no longer possible')
 
   o['variables']['want_separate_host_toolset'] = int(cross_compiling)
+
+  if options.node_snapshot_main is not None:
+    if options.shared:
+      # This should be possible to fix, but we will need to refactor the
+      # libnode target to avoid building it twice.
+      error('--node-snapshot-main is incompatible with --shared')
+    if options.without_node_snapshot:
+      error('--node-snapshot-main is incompatible with ' +
+            '--without-node-snapshot')
+    if cross_compiling:
+      error('--node-snapshot-main is incompatible with cross compilation')
+    o['variables']['node_snapshot_main'] = options.node_snapshot_main
 
   if options.without_node_snapshot or options.node_builtin_modules_path:
     o['variables']['node_use_node_snapshot'] = 'false'

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -27,7 +27,8 @@ const { Buffer } = require('buffer');
 const { ERR_MANIFEST_ASSERT_INTEGRITY } = require('internal/errors').codes;
 const assert = require('internal/assert');
 
-function prepareMainThreadExecution(expandArgv1 = false) {
+function prepareMainThreadExecution(expandArgv1 = false,
+                                    initialzeModules = true) {
   refreshRuntimeOptions();
 
   // TODO(joyeecheung): this is also necessary for workers when they deserialize
@@ -81,9 +82,13 @@ function prepareMainThreadExecution(expandArgv1 = false) {
   initializeSourceMapsHandlers();
   initializeDeprecations();
   initializeWASI();
+
+  if (!initialzeModules) {
+    return;
+  }
+
   initializeCJSLoader();
   initializeESMLoader();
-
   const CJSLoader = require('internal/modules/cjs/loader');
   assert(!CJSLoader.hasLoadedAnyUserCJSModule);
   loadPreloadModules();
@@ -102,7 +107,8 @@ function patchProcessObject(expandArgv1) {
 
   ObjectDefineProperty(process, 'argv0', {
     enumerable: true,
-    configurable: false,
+    // Only set it to true during snapshot building.
+    configurable: getOptionValue('--build-snapshot'),
     value: process.argv[0]
   });
   process.argv[0] = process.execPath;

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -124,6 +124,12 @@ function patchProcessObject(expandArgv1) {
     }
   }
 
+  // We need to initialize the global console here again with process.stdout
+  // and friends for snapshot deserialization.
+  const globalConsole = require('internal/console/global');
+  const { initializeGlobalConsole } = require('internal/console/constructor');
+  initializeGlobalConsole(globalConsole);
+
   // TODO(joyeecheung): most of these should be deprecated and removed,
   // except some that we need to be able to mutate during run time.
   addReadOnlyProcessAlias('_eval', '--eval');

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -14,6 +14,7 @@ const {
 const {
   getOptionValue,
   getEmbedderOptions,
+  refreshOptions,
 } = require('internal/options');
 const { reconnectZeroFillToggle } = require('internal/buffer');
 const {
@@ -27,6 +28,8 @@ const { ERR_MANIFEST_ASSERT_INTEGRITY } = require('internal/errors').codes;
 const assert = require('internal/assert');
 
 function prepareMainThreadExecution(expandArgv1 = false) {
+  refreshRuntimeOptions();
+
   // TODO(joyeecheung): this is also necessary for workers when they deserialize
   // this toggle from the snapshot.
   reconnectZeroFillToggle();
@@ -85,6 +88,10 @@ function prepareMainThreadExecution(expandArgv1 = false) {
   assert(!CJSLoader.hasLoadedAnyUserCJSModule);
   loadPreloadModules();
   initializeFrozenIntrinsics();
+}
+
+function refreshRuntimeOptions() {
+  refreshOptions();
 }
 
 function patchProcessObject(expandArgv1) {
@@ -556,6 +563,7 @@ function loadPreloadModules() {
 }
 
 module.exports = {
+  refreshRuntimeOptions,
   patchProcessObject,
   setupCoverageHooks,
   setupWarningHandler,

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -111,6 +111,9 @@ function patchProcessObject(expandArgv1) {
     configurable: getOptionValue('--build-snapshot'),
     value: process.argv[0]
   });
+
+  process.exitCode = undefined;
+  process._exiting = false;
   process.argv[0] = process.execPath;
 
   if (expandArgv1 && process.argv[1] &&

--- a/lib/internal/bootstrap/switches/is_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_main_thread.js
@@ -122,15 +122,34 @@ let stdin;
 let stdout;
 let stderr;
 
+let stdoutDestroy;
+let stderrDestroy;
+
+function refreshStdoutOnSigWinch() {
+  stdout._refreshSize();
+}
+
+function refreshStderrOnSigWinch() {
+  stderr._refreshSize();
+}
+
 function getStdout() {
   if (stdout) return stdout;
   stdout = createWritableStdioStream(1);
   stdout.destroySoon = stdout.destroy;
   // Override _destroy so that the fd is never actually closed.
+  stdoutDestroy = stdout._destroy;
   stdout._destroy = dummyDestroy;
   if (stdout.isTTY) {
-    process.on('SIGWINCH', () => stdout._refreshSize());
+    process.on('SIGWINCH', refreshStdoutOnSigWinch);
   }
+
+  internalBinding('mksnapshot').cleanups.push(function cleanupStdout() {
+    stdout._destroy = stdoutDestroy;
+    stdout.destroy();
+    process.removeListener('SIGWINCH', refreshStdoutOnSigWinch);
+    stdout = undefined;
+  });
   return stdout;
 }
 
@@ -138,11 +157,18 @@ function getStderr() {
   if (stderr) return stderr;
   stderr = createWritableStdioStream(2);
   stderr.destroySoon = stderr.destroy;
+  stderrDestroy = stderr._destroy;
   // Override _destroy so that the fd is never actually closed.
   stderr._destroy = dummyDestroy;
   if (stderr.isTTY) {
-    process.on('SIGWINCH', () => stderr._refreshSize());
+    process.on('SIGWINCH', refreshStderrOnSigWinch);
   }
+  internalBinding('mksnapshot').cleanups.push(function cleanupStderr() {
+    stderr._destroy = stderrDestroy;
+    stderr.destroy();
+    process.removeListener('SIGWINCH', refreshStderrOnSigWinch);
+    stderr = undefined;
+  });
   return stderr;
 }
 
@@ -229,6 +255,10 @@ function getStdin() {
     }
   }
 
+  internalBinding('mksnapshot').cleanups.push(function cleanupStdin() {
+    stdin.destroy();
+    stdin = undefined;
+  });
   return stdin;
 }
 

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -669,9 +669,15 @@ Console.prototype.dirxml = Console.prototype.log;
 Console.prototype.error = Console.prototype.warn;
 Console.prototype.groupCollapsed = Console.prototype.group;
 
+function initializeGlobalConsole(globalConsole) {
+  globalConsole[kBindStreamsLazy](process);
+  globalConsole[kBindProperties](true, 'auto');
+}
+
 module.exports = {
   Console,
   kBindStreamsLazy,
   kBindProperties,
+  initializeGlobalConsole,
   formatTime // exported for tests
 };

--- a/lib/internal/console/global.js
+++ b/lib/internal/console/global.js
@@ -21,9 +21,7 @@ const {
 } = primordials;
 
 const {
-  Console,
-  kBindStreamsLazy,
-  kBindProperties
+  Console
 } = require('internal/console/constructor');
 
 const globalConsole = ObjectCreate({});
@@ -43,9 +41,6 @@ for (const prop of ReflectOwnKeys(Console.prototype)) {
   }
   ReflectDefineProperty(globalConsole, prop, desc);
 }
-
-globalConsole[kBindStreamsLazy](process);
-globalConsole[kBindProperties](true, 'auto');
 
 // This is a legacy feature - the Console constructor is exposed on
 // the global console instance.

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const {
+  Error,
+  SafeSet,
+  SafeArrayIterator
+} = primordials;
+
+const binding = internalBinding('mksnapshot');
+const { NativeModule } = require('internal/bootstrap/loaders');
+const {
+  compileSnapshotMain,
+} = binding;
+
+const {
+  getOptionValue
+} = require('internal/options');
+
+const {
+  readFileSync
+} = require('fs');
+
+const supportedModules = new SafeSet(new SafeArrayIterator([
+  // '_http_agent',
+  // '_http_client',
+  // '_http_common',
+  // '_http_incoming',
+  // '_http_outgoing',
+  // '_http_server',
+  '_stream_duplex',
+  '_stream_passthrough',
+  '_stream_readable',
+  '_stream_transform',
+  '_stream_wrap',
+  '_stream_writable',
+  // '_tls_common',
+  // '_tls_wrap',
+  'assert',
+  'assert/strict',
+  // 'async_hooks',
+  'buffer',
+  // 'child_process',
+  // 'cluster',
+  'console',
+  'constants',
+  'crypto',
+  // 'dgram',
+  // 'diagnostics_channel',
+  // 'dns',
+  // 'dns/promises',
+  // 'domain',
+  'events',
+  'fs',
+  'fs/promises',
+  // 'http',
+  // 'http2',
+  // 'https',
+  // 'inspector',
+  // 'module',
+  // 'net',
+  'os',
+  'path',
+  'path/posix',
+  'path/win32',
+  // 'perf_hooks',
+  'process',
+  'punycode',
+  'querystring',
+  // 'readline',
+  // 'repl',
+  'stream',
+  'stream/promises',
+  'string_decoder',
+  'sys',
+  'timers',
+  'timers/promises',
+  // 'tls',
+  // 'trace_events',
+  // 'tty',
+  'url',
+  'util',
+  'util/types',
+  'v8',
+  // 'vm',
+  // 'worker_threads',
+  // 'zlib',
+]));
+
+const warnedModules = new SafeSet();
+function supportedInUserSnapshot(id) {
+  return supportedModules.has(id);
+}
+
+function requireForUserSnapshot(id) {
+  if (!NativeModule.canBeRequiredByUsers(id)) {
+    // eslint-disable-next-line no-restricted-syntax
+    const err = new Error(
+      `Cannot find module '${id}'. `
+    );
+    err.code = 'MODULE_NOT_FOUND';
+    throw err;
+  }
+  if (!supportedInUserSnapshot(id)) {
+    if (!warnedModules.has(id)) {
+      process.emitWarning(
+        `built-in module ${id} is not yet supported in user snapshots`);
+      warnedModules.add(id);
+    }
+  }
+
+  return require(id);
+}
+
+function main() {
+  const {
+    prepareMainThreadExecution
+  } = require('internal/bootstrap/pre_execution');
+
+  prepareMainThreadExecution(true, false);
+  process.on('beforeExit', function runCleanups() {
+    for (const cleanup of binding.cleanups) {
+      cleanup();
+    }
+    process.off('beforeExit', runCleanups);
+  });
+
+  const file = process.argv[1];
+  const path = require('path');
+  const filename = path.resolve(file);
+  const dirname = path.dirname(filename);
+  const source = readFileSync(file, 'utf-8');
+  const snapshotMainFunction = compileSnapshotMain(filename, source);
+
+  if (getOptionValue('--inspect-brk')) {
+    internalBinding('inspector').callAndPauseOnStart(
+      snapshotMainFunction, undefined,
+      requireForUserSnapshot, filename, dirname);
+  } else {
+    snapshotMainFunction(requireForUserSnapshot, filename, dirname);
+  }
+}
+
+main();

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -117,11 +117,10 @@ function main() {
   } = require('internal/bootstrap/pre_execution');
 
   prepareMainThreadExecution(true, false);
-  process.on('beforeExit', function runCleanups() {
+  process.once('beforeExit', function runCleanups() {
     for (const cleanup of binding.cleanups) {
       cleanup();
     }
-    process.off('beforeExit', runCleanups);
   });
 
   const file = process.argv[1];

--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -36,6 +36,11 @@ function getEmbedderOptions() {
   return embedderOptions;
 }
 
+function refreshOptions() {
+  optionsMap = undefined;
+  aliasesMap = undefined;
+}
+
 function getOptionValue(optionName) {
   const options = getCLIOptionsFromBinding();
   if (optionName.startsWith('--no-')) {
@@ -68,5 +73,6 @@ module.exports = {
   },
   getOptionValue,
   getAllowUnauthorized,
-  getEmbedderOptions
+  getEmbedderOptions,
+  refreshOptions
 };

--- a/node.gyp
+++ b/node.gyp
@@ -7,6 +7,7 @@
     'node_use_dtrace%': 'false',
     'node_use_etw%': 'false',
     'node_no_browser_globals%': 'false',
+    'node_snapshot_main%': '',
     'node_use_node_snapshot%': 'false',
     'node_use_v8_platform%': 'true',
     'node_use_bundled_v8%': 'true',
@@ -315,23 +316,47 @@
           'dependencies': [
             'node_mksnapshot',
           ],
-          'actions': [
-            {
-              'action_name': 'node_mksnapshot',
-              'process_outputs_as_sources': 1,
-              'inputs': [
-                '<(node_mksnapshot_exec)',
+          'conditions': [
+            ['node_snapshot_main!=""', {
+              'actions': [
+                {
+                  'action_name': 'node_mksnapshot',
+                  'process_outputs_as_sources': 1,
+                  'inputs': [
+                    '<(node_mksnapshot_exec)',
+                    '<(node_snapshot_main)',
+                  ],
+                  'outputs': [
+                    '<(SHARED_INTERMEDIATE_DIR)/node_snapshot.cc',
+                  ],
+                  'action': [
+                    '<(node_mksnapshot_exec)',
+                    '--build-snapshot',
+                    '<(node_snapshot_main)',
+                    '<@(_outputs)',
+                  ],
+                },
               ],
-              'outputs': [
-                '<(SHARED_INTERMEDIATE_DIR)/node_snapshot.cc',
+            }, {
+              'actions': [
+                {
+                  'action_name': 'node_mksnapshot',
+                  'process_outputs_as_sources': 1,
+                  'inputs': [
+                    '<(node_mksnapshot_exec)',
+                  ],
+                  'outputs': [
+                    '<(SHARED_INTERMEDIATE_DIR)/node_snapshot.cc',
+                  ],
+                  'action': [
+                    '<@(_inputs)',
+                    '<@(_outputs)',
+                  ],
+                },
               ],
-              'action': [
-                '<@(_inputs)',
-                '<@(_outputs)',
-              ],
-            },
+            }],
           ],
-        }, {
+          }, {
           'sources': [
             'src/node_snapshot_stub.cc'
           ],

--- a/src/node.cc
+++ b/src/node.cc
@@ -495,6 +495,10 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
     return StartExecution(env, "internal/main/inspect");
   }
 
+  if (per_process::cli_options->build_snapshot) {
+    return StartExecution(env, "internal/main/mksnapshot");
+  }
+
   if (per_process::cli_options->print_help) {
     return StartExecution(env, "internal/main/print_help");
   }
@@ -1151,6 +1155,12 @@ int Start(int argc, char** argv) {
   InitializationResult result = InitializeOncePerProcess(argc, argv);
   if (result.early_return) {
     return result.exit_code;
+  }
+
+  if (per_process::cli_options->build_snapshot) {
+    fprintf(stderr,
+            "--build-snapshot is not yet supported in the node binary\n");
+    return 1;
   }
 
   {

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -59,6 +59,7 @@
   V(js_udp_wrap)                                                               \
   V(messaging)                                                                 \
   V(module_wrap)                                                               \
+  V(mksnapshot)                                                                \
   V(native_module)                                                             \
   V(options)                                                                   \
   V(os)                                                                        \

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -66,6 +66,7 @@ class ExternalReferenceRegistry {
   V(handle_wrap)                                                               \
   V(heap_utils)                                                                \
   V(messaging)                                                                 \
+  V(mksnapshot)                                                                \
   V(native_module)                                                             \
   V(options)                                                                   \
   V(os)                                                                        \

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -725,6 +725,11 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             "disable Object.prototype.__proto__",
             &PerProcessOptions::disable_proto,
             kAllowedInEnvironment);
+  AddOption("--build-snapshot",
+            "Generate a snapshot blob when the process exits."
+            "Currently only supported in the node_mksnapshot binary.",
+            &PerProcessOptions::build_snapshot,
+            kDisallowedInEnvironment);
 
   // 12.x renamed this inadvertently, so alias it for consistency within the
   // release line, while using the original name for consistency with older

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -229,6 +229,7 @@ class PerProcessOptions : public Options {
   bool zero_fill_all_buffers = false;
   bool debug_arraybuffer_allocations = false;
   std::string disable_proto;
+  bool build_snapshot;
 
   std::vector<std::string> security_reverts;
   bool print_bash_completion = false;

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -171,9 +171,9 @@ void SnapshotBuilder::Generate(SnapshotData* out,
           PrintCaughtException(isolate, context, bootstrapCatch);
         }
         result.ToLocalChecked();
-        // FIXME(joyee): right now running the loop in the snapshot builder
-        // seems to intrudoces inconsistencies in JS land that need to be
-        // synchronized again after snapshot restoration.
+        // FIXME(joyeecheung): right now running the loop in the snapshot
+        // builder seems to introduces inconsistencies in JS land that need to
+        // be synchronized again after snapshot restoration.
         int exit_code = SpinEventLoop(env).FromMaybe(1);
         CHECK_EQ(exit_code, 0);
         if (bootstrapCatch.HasCaught()) {

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -125,9 +125,14 @@ bool IsSnapshotableType(FastStringKey key);
 
 class SnapshotBuilder {
  public:
-  static std::string Generate(const std::vector<std::string> args,
+  static std::string Generate(const std::string& entry_file,
+                              const std::vector<std::string> args,
                               const std::vector<std::string> exec_args);
+
+  // Generate the snapshot into out.
+  // entry_file should be the content of the UTF-8 encoded entry files.
   static void Generate(SnapshotData* out,
+                       const std::string& entry_file,
                        const std::vector<std::string> args,
                        const std::vector<std::string> exec_args);
 };

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -125,14 +125,11 @@ bool IsSnapshotableType(FastStringKey key);
 
 class SnapshotBuilder {
  public:
-  static std::string Generate(const std::string& entry_file,
-                              const std::vector<std::string> args,
+  static std::string Generate(const std::vector<std::string> args,
                               const std::vector<std::string> exec_args);
 
   // Generate the snapshot into out.
-  // entry_file should be the content of the UTF-8 encoded entry files.
   static void Generate(SnapshotData* out,
-                       const std::string& entry_file,
                        const std::vector<std::string> args,
                        const std::vector<std::string> exec_args);
 };

--- a/tools/snapshot/node_mksnapshot.cc
+++ b/tools/snapshot/node_mksnapshot.cc
@@ -11,17 +11,64 @@
 #include "util-inl.h"
 #include "v8.h"
 
+int BuildSnapshot(int argc, char* argv[]);
+
 #ifdef _WIN32
 #include <windows.h>
 
-int wmain(int argc, wchar_t* argv[]) {
+int wmain(int argc, wchar_t* wargv[]) {
+  // Windows needs conversion from wchar_t to char.
+
+  // Convert argv to UTF8.
+  char** argv = new char*[argc + 1];
+  for (int i = 0; i < argc; i++) {
+    // Compute the size of the required buffer
+    DWORD size = WideCharToMultiByte(CP_UTF8,
+                                     0,
+                                     wargv[i],
+                                     -1,
+                                     nullptr,
+                                     0,
+                                     nullptr,
+                                     nullptr);
+    if (size == 0) {
+      // This should never happen.
+      fprintf(stderr, "Could not convert arguments to utf8.");
+      exit(1);
+    }
+    // Do the actual conversion
+    argv[i] = new char[size];
+    DWORD result = WideCharToMultiByte(CP_UTF8,
+                                       0,
+                                       wargv[i],
+                                       -1,
+                                       argv[i],
+                                       size,
+                                       nullptr,
+                                       nullptr);
+    if (result == 0) {
+      // This should never happen.
+      fprintf(stderr, "Could not convert arguments to utf8.");
+      exit(1);
+    }
+  }
+  argv[argc] = nullptr;
 #else   // UNIX
 int main(int argc, char* argv[]) {
   argv = uv_setup_args(argc, argv);
+
+  // Disable stdio buffering, it interacts poorly with printf()
+  // calls elsewhere in the program (e.g., any logging from V8.)
+  setvbuf(stdout, nullptr, _IONBF, 0);
+  setvbuf(stderr, nullptr, _IONBF, 0);
 #endif  // _WIN32
 
   v8::V8::SetFlagsFromString("--random_seed=42");
+  v8::V8::SetFlagsFromString("--harmony-import-assertions");
+  return BuildSnapshot(argc, argv);
+}
 
+int BuildSnapshot(int argc, char* argv[]) {
   if (argc < 2) {
     std::cerr << "Usage: " << argv[0] << " <path/to/output.cc>\n";
     std::cerr << "       " << argv[0] << " --build-snapshot "
@@ -29,17 +76,8 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-// Windows needs conversion from wchar_t to char. See node_main.cc
-#ifdef _WIN32
-  int node_argc = 1;
-  char argv0[] = "node";
-  char* node_argv[] = {argv0, nullptr};
-  node::InitializationResult result =
-      node::InitializeOncePerProcess(node_argc, node_argv);
-#else
   node::InitializationResult result =
       node::InitializeOncePerProcess(argc, argv);
-#endif
 
   CHECK(!result.early_return);
   CHECK_EQ(result.exit_code, 0);

--- a/tools/snapshot/node_mksnapshot.cc
+++ b/tools/snapshot/node_mksnapshot.cc
@@ -23,14 +23,8 @@ int wmain(int argc, wchar_t* wargv[]) {
   char** argv = new char*[argc + 1];
   for (int i = 0; i < argc; i++) {
     // Compute the size of the required buffer
-    DWORD size = WideCharToMultiByte(CP_UTF8,
-                                     0,
-                                     wargv[i],
-                                     -1,
-                                     nullptr,
-                                     0,
-                                     nullptr,
-                                     nullptr);
+    DWORD size = WideCharToMultiByte(
+        CP_UTF8, 0, wargv[i], -1, nullptr, 0, nullptr, nullptr);
     if (size == 0) {
       // This should never happen.
       fprintf(stderr, "Could not convert arguments to utf8.");
@@ -38,14 +32,8 @@ int wmain(int argc, wchar_t* wargv[]) {
     }
     // Do the actual conversion
     argv[i] = new char[size];
-    DWORD result = WideCharToMultiByte(CP_UTF8,
-                                       0,
-                                       wargv[i],
-                                       -1,
-                                       argv[i],
-                                       size,
-                                       nullptr,
-                                       nullptr);
+    DWORD result = WideCharToMultiByte(
+        CP_UTF8, 0, wargv[i], -1, argv[i], size, nullptr, nullptr);
     if (result == 0) {
       // This should never happen.
       fprintf(stderr, "Could not convert arguments to utf8.");
@@ -82,10 +70,8 @@ int BuildSnapshot(int argc, char* argv[]) {
   CHECK(!result.early_return);
   CHECK_EQ(result.exit_code, 0);
 
-  std::string snapshot_main;
   std::string out_path;
   if (node::per_process::cli_options->build_snapshot) {
-    snapshot_main = result.args[1];
     out_path = result.args[2];
   } else {
     out_path = result.args[1];
@@ -98,17 +84,14 @@ int BuildSnapshot(int argc, char* argv[]) {
   }
 
   {
-    std::string snapshot = node::SnapshotBuilder::Generate(
-        snapshot_main, result.args, result.exec_args);
+    std::string snapshot =
+        node::SnapshotBuilder::Generate(result.args, result.exec_args);
     out << snapshot;
 
     if (!out) {
       std::cerr << "Failed to write " << out_path << "\n";
-      out.close();
       return 1;
     }
-
-    out.close();
   }
 
   node::TearDownOncePerProcess();


### PR DESCRIPTION
This is a less-ambitious version of https://github.com/nodejs/node/pull/38905 which only supports user-land snapshot at configure time. I've made the last two commits separate in case they cause any regressions and it would be easier to revert them to test things out.

### bootstrap: refresh options in pre-execution

Refresh the options map during pre-execution to pave the way for
user land snapshots which may need to access run-time options at
snapshot-building time. The default embedded bootstrap snapshot
is still prevented from accessing them at snapshot building time
since it serves a wider audience and is ignorant of application
states, while the user-land snapshots are meant to be
application-specific and so it makes sense for them to access
runtime states as long as the snapshotted-code
works with re-initialized runtime states.

### build: add --node-snapshot-main configure option

This adds a --build-snapshot runtime option which is currently only
supported by the node_mksnapshot binary, and a --node-snapshot-main
configure option that makes use it to run a custom script when
building the embedded snapshot. The idea is to have this experimental
feature in core as a configure-time feature for now, and investigate
the renaming V8 bugs before we make it available to more users via
making it a runtime option.

### bootstrap: make I/O streams work with user-land snapshot

Use the mksnapshot cleanup hooks to release the references
to the native streams so that they can be destroyed right
before the snapshot is taken, and move the initialization
of the global console to pre-execution so that they can be
re-initialized during snapshot dehydration. This makes
it possible for user-land snapshots to use the I/O during
snapshot building.

### bootstrap: run inspector and event loop in snapshot builder

This makes --inspect and stdin/out functional in the embedded snapshot,
currently it's not guaranteed that these work perfectly, the
plan is to investigate any out-of-sync states that might appear
in user land snapshots with this while the it is a configure-time
feature.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
