### PR TITLE
tls: fix reference to certificate object subjectAltName in checkServerIdentity function

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -271,7 +271,7 @@ function splitEscapedAltNames(altNames) {
 
 exports.checkServerIdentity = function checkServerIdentity(hostname, cert) {
   const subject = cert.subject;
-  const altNames = cert.subjectaltname;
+  const altNames = cert.subjectAltName;
   const dnsNames = [];
   const ips = [];
 


### PR DESCRIPTION
tls: fix reference to certificate object subjectAltName in checkServerIdentity function
    
    The checkServerIdentify() function always fails with ERR_TLS_CERT_ALTNAME_INVALID
    error due to a bad reference to the certificate object's subjectAltName
    property. Changed the property reference from all lowercase to camelcase.
