### PR TITLE
doc: Fix typos in function declarations

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -145,7 +145,7 @@ exec('"my script.cmd" a b', (err, stdout, stderr) => {
 });
 ```
 
-### `child_process.exec(command[, options][, callback])`
+### `child_process.exec(command, options, callback)`
 
 <!-- YAML
 added: v0.1.90
@@ -277,7 +277,7 @@ const child = exec('grep ssh', { signal }, (error) => {
 controller.abort();
 ```
 
-### `child_process.execFile(file[, args][, options][, callback])`
+### `child_process.execFile(file, [args], options, callback])`
 
 <!-- YAML
 added: v0.1.91
@@ -389,7 +389,7 @@ const child = execFile('node', ['--version'], { signal }, (error) => {
 controller.abort();
 ```
 
-### `child_process.fork(modulePath[, args][, options])`
+### `child_process.fork(modulePath, [args], options])`
 
 <!-- YAML
 added: v0.5.0
@@ -517,7 +517,7 @@ if (process.argv[2] === 'child') {
 }
 ```
 
-### `child_process.spawn(command[, args][, options])`
+### `child_process.spawn(command, [args], options])`
 
 <!-- YAML
 added: v0.1.90
@@ -892,7 +892,7 @@ Blocking calls like these are mostly useful for simplifying general-purpose
 scripting tasks and for simplifying the loading/processing of application
 configuration at startup.
 
-### `child_process.execFileSync(file[, args][, options])`
+### `child_process.execFileSync(file, [args], options])`
 
 <!-- YAML
 added: v0.11.12
@@ -968,7 +968,7 @@ If the process times out or has a non-zero exit code, this method will throw an
 function. Any input containing shell metacharacters may be used to trigger
 arbitrary command execution.**
 
-### `child_process.execSync(command[, options])`
+### `child_process.execSync(command, options)`
 
 <!-- YAML
 added: v0.11.12
@@ -1035,7 +1035,7 @@ The [`Error`][] object will contain the entire result from
 **Never pass unsanitized user input to this function. Any input containing shell
 metacharacters may be used to trigger arbitrary command execution.**
 
-### `child_process.spawnSync(command[, args][, options])`
+### `child_process.spawnSync(command, [args], options])`
 
 <!-- YAML
 added: v0.11.12
@@ -1456,7 +1456,7 @@ subprocess.unref();
 subprocess.ref();
 ```
 
-### `subprocess.send(message[, sendHandle[, options]][, callback])`
+### `subprocess.send(message, sendHandle, o[ptions], callback])`
 
 <!-- YAML
 added: v0.5.9


### PR DESCRIPTION
Fixed the typos that has been in the declaration of some modules like `child_process`. It had several typos including have `[,` in many functions parameters.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
