### PR TITLE
buffer: remove mustMatch from Buffer.bytelength()

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -738,16 +738,15 @@ function byteLength(string, encoding) {
   }
 
   const len = string.length;
-  const mustMatch = (arguments.length > 2 && arguments[2] === true);
-  if (!mustMatch && len === 0)
+  if (len === 0)
     return 0;
 
   if (!encoding)
-    return (mustMatch ? -1 : byteLengthUtf8(string));
+    return byteLengthUtf8(string);
 
   const ops = getEncodingOps(encoding);
   if (ops === undefined)
-    return (mustMatch ? -1 : byteLengthUtf8(string));
+    return byteLengthUtf8(string);
   return ops.byteLength(string);
 }
 

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -23,7 +23,7 @@ const vm = require('vm');
   );
 });
 
-assert.strictEqual(Buffer.byteLength('', undefined, true), -1);
+assert.strictEqual(Buffer.byteLength(''), 0);
 
 assert(ArrayBuffer.isView(new Buffer(10)));
 assert(ArrayBuffer.isView(new SlowBuffer(10)));


### PR DESCRIPTION
Buffer.bytelength() has an undocumented third parameterm `mustMatch`.
Remove it.

Closes: https://github.com/nodejs/node/issues/38536

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
