### PR TITLE
src: fix syntax error not showing in stderr with node --inspect-brk

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -821,7 +821,6 @@ void Agent::ReportUncaughtException(Local<Value> error,
   if (!IsListening())
     return;
   client_->ReportUncaughtException(error, message);
-  WaitForDisconnect();
 }
 
 void Agent::PauseOnNextJavascriptStatement(const std::string& reason) {

--- a/test/parallel/test-inspector-inspect-brk-error-report.js
+++ b/test/parallel/test-inspector-inspect-brk-error-report.js
@@ -1,0 +1,30 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+common.skipIfInspectorDisabled();
+
+const { NodeInstance } = require('../common/inspector-helper.js');
+
+async function runTest() {
+  const child = new NodeInstance(['--inspect-brk'], 'console.log(1');
+  const session = await child.connectInspectorSession();
+  await session.send({ method: 'Runtime.enable' });
+  await session.send({ method: 'Debugger.enable' });
+  await session.send({ method: 'Runtime.runIfWaitingForDebugger' });
+  let match = false;
+  while (true) {
+    const stderr = await child.nextStderrString();
+    if (/SyntaxError: missing \) after argument list/.test(stderr)) {
+      match = true;
+    }
+    if (/Waiting for the debugger to disconnect/.test(stderr)) {
+      break;
+    }
+  }
+  assert.ok(match);
+  await session.disconnect();
+  return child.expectShutdown();
+}
+
+runTest().then(common.mustCall());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixed #41792

When an uncaught exception occurs with inspector enabled, `node::errors::TriggerUncaughtException` will let an inspector agent send the error report.
https://github.com/nodejs/node/blob/6e5485135737094582cdda68664ab2354154a60c/src/node_errors.cc#L336

After reporting errors, the inspector agent [waits](https://github.com/nodejs/node/blob/master/src/inspector_agent.cc#L824) for the client to disconnect. But this means the agent stops the following process and shows nothing in stderr.

Ideally, `AtExit` hook should be responsible for disconnection of inspector and the error reporters should send error information only. An inspector agent has no reason to wait for disconnection since the disconnection process is already registered to `AtExit` hook.
https://github.com/nodejs/node/blob/6e5485135737094582cdda68664ab2354154a60c/src/inspector_agent.cc#L711-L716