### PR TITLE
src,crypto: refactor `crypto_dh.cc`

### DIFF
--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -32,7 +32,6 @@ using v8::ReadOnly;
 using v8::SideEffectType;
 using v8::Signature;
 using v8::String;
-using v8::Uint8Array;
 using v8::Value;
 
 namespace crypto {
@@ -637,8 +636,10 @@ void DiffieHellman::Stateless(const FunctionCallbackInfo<Value>& args) {
   ManagedEVPPKey our_key = our_key_object->Data()->GetAsymmetricKey();
   ManagedEVPPKey their_key = their_key_object->Data()->GetAsymmetricKey();
 
-  Local<Value> out = StatelessDiffieHellmanThreadsafe(our_key, their_key)
-      .ToBuffer(env).FromMaybe(Local<Uint8Array>());
+  Local<Value> out;
+  if (!StatelessDiffieHellmanThreadsafe(our_key, their_key)
+          .ToBuffer(env)
+              .ToLocal(&out)) return;
 
   if (Buffer::Length(out) == 0)
     return ThrowCryptoError(env, ERR_get_error(), "diffieHellman failed");

--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -37,9 +37,9 @@ using v8::Value;
 
 namespace crypto {
 namespace {
-static void ZeroPadDiffieHellmanSecret(size_t remainder_size,
-                                       char* data,
-                                       size_t length) {
+void ZeroPadDiffieHellmanSecret(size_t remainder_size,
+                                char* data,
+                                size_t length) {
   // DH_size returns number of bytes in a prime number.
   // DH_compute_key returns number of bytes in a remainder of exponent, which
   // may have less bytes than a prime number. Therefore add 0-padding to the


### PR DESCRIPTION
### src,crypto: remove uses of `AllocatedBuffer` from `crypto_dh.cc`

Refs: https://github.com/nodejs/node/pull/39941

### src: remove unnecessary `static` qualifier in `crypto_dh.cc`

`ZeroPadDiffieHellmanSecret()` is in an anonymous namespace, so it has
static linkage already.

### src,crypto: handle empty maybe correctly in `crypto_dh.cc`

`Buffer::Length()` dereferences the passed `Local`, so calling it when the
underlying pointer is a `nullptr` would lead to a crash. This fixes that
by returning early instead.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
