### PR TITLE
child_process: add env contents types in JSDoc

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -98,7 +98,7 @@ const MAX_BUFFER = 1024 * 1024;
  * @param {{
  *   cwd?: string;
  *   detached?: boolean;
- *   env?: object;
+ *   env?: Record<string, string>;
  *   execPath?: string;
  *   execArgv?: string[];
  *   gid?: number;
@@ -199,7 +199,7 @@ function normalizeExecArgs(command, options, callback) {
  * @param {string} command
  * @param {{
  *   cmd?: string;
- *   env?: object;
+ *   env?: Record<string, string>;
  *   encoding?: string;
  *   shell?: string;
  *   signal?: AbortSignal;
@@ -253,7 +253,7 @@ ObjectDefineProperty(exec, promisify.custom, {
  * @param {string[]} [args]
  * @param {{
  *   cwd?: string;
- *   env?: object;
+ *   env?: Record<string, string>;
  *   encoding?: string;
  *   timeout?: number;
  *   maxBuffer?: number;
@@ -662,7 +662,7 @@ function abortChildProcess(child, killSignal) {
  * @param {string[]} [args]
  * @param {{
  *   cwd?: string;
- *   env?: object;
+ *   env?: Record<string, string>;
  *   argv0?: string;
  *   stdio?: Array | string;
  *   detached?: boolean;
@@ -735,7 +735,7 @@ function spawn(file, args, options) {
  *   input?: string | Buffer | TypedArray | DataView;
  *   argv0?: string;
  *   stdio?: string | Array;
- *   env?: object;
+ *   env?: Record<string, string>;
  *   uid?: number;
  *   gid?: number;
  *   timeout?: number;
@@ -827,7 +827,7 @@ function checkExecSyncError(ret, args, cmd) {
  *   cwd?: string;
  *   input?: string | Buffer | TypedArray | DataView;
  *   stdio?: string | Array;
- *   env?: object;
+ *   env?: Record<string, string>;
  *   uid?: number;
  *   gid?: number;
  *   timeout?: number;
@@ -864,7 +864,7 @@ function execFileSync(command, args, options) {
  *   cwd?: string;
  *   input?: string | Buffer | TypedArray | DataView;
  *   stdio?: string | Array;
- *   env?: object;
+ *   env?: Record<string, string>;
  *   shell?: string;
  *   uid?: number;
  *   gid?: number;


### PR DESCRIPTION
Use JSDoc to indicate that the `env` object keys and values must be
strings.

Refs: https://github.com/nodejs/node/pull/42489#discussion_r835867932

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
