### PR TITLE
doc: fix experimental-specifier-resolution cli command typo

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -341,7 +341,7 @@ added: v16.6.0
 
 Use this flag to disable top-level await in REPL.
 
-### `--experimental-specifier-resolution=mode`
+### `--experimental-specifier-resolution=node`
 
 <!-- YAML
 added:


### PR DESCRIPTION
`--experimental-specifier-resolution=mode` 

amended to

`--experimental-specifier-resolution=node`