### PR TITLE
node-api: run Node-API finalizers in GC second pass

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5288,6 +5288,48 @@ invocation. If it is deleted before then, then the finalize callback may never
 be invoked. Therefore, when obtaining a reference a finalize callback is also
 required in order to enable correct disposal of the reference.
 
+### `node_api_set_finalizer_error_handler`
+
+<!-- YAML
+added: REPLACEME
+napiVersion: REPLACEME
+-->
+
+```c
+node_api_set_finalizer_error_handler(napi_env env,
+                                     napi_value error_handler);
+```
+
+* `[in] env`: The environment that the API is invoked under.
+* `[in] error_handler`: A JavaScript function that can handle JavaScript
+  exceptions thrown from a native finalizer.
+
+Returns `napi_ok` if the API succeeded.
+
+Sets or removes finalizer error handler which will be called when a native
+finalizer throws a JavaScript exception.
+
+By default any JavaScript exception from a native finalizer causes an unhandled
+exception that can be handled by a process-wide
+`process.on('uncaughtException', ...)` event handler.
+Otherwise, the unhandled exception causes the process termination.
+The `node_api_set_finalizer_error_handler` allows to set the error handler per
+`napi_env` instance which is created per native module instance, and to handle
+module-specific finalizer errors.
+
+The `error_handler` is a function with the following requirements:
+
+* the function receives a single paramter - the JavaScript error object;
+* the function can return `false` to indicate that the error was not handled and
+  to cause the unhandled exception;
+* if function returns any other value, then the exception is considered to
+  be handled;
+* if function throws a JavaScript exception, then it causes the the unhandled
+  exception.
+
+If the passed `error_handler` parameter is not a function, then the finalizer
+error handler is removed.
+
 ## Simple asynchronous operations
 
 Addon modules often need to leverage async helpers from libuv as part of their

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -562,6 +562,12 @@ NAPI_EXTERN napi_status napi_object_freeze(napi_env env, napi_value object);
 NAPI_EXTERN napi_status napi_object_seal(napi_env env, napi_value object);
 #endif  // NAPI_VERSION >= 8
 
+#ifdef NAPI_EXPERIMENTAL
+// Set a handler for JS errors in finalizers.
+NAPI_EXTERN napi_status
+node_api_set_finalizer_error_handler(napi_env env, napi_value error_handler);
+#endif  // NAPI_EXPERIMENTAL
+
 EXTERN_C_END
 
 #endif  // SRC_JS_NATIVE_API_H_

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -102,9 +102,13 @@ struct napi_env__ {
     }
   }
 
+  static void HandleFinalizerException(napi_env env,
+                                       v8::Local<v8::Value> exception);
+
   virtual void CallFinalizer(napi_finalize cb, void* data, void* hint) {
     v8::HandleScope handle_scope(isolate);
-    CallIntoModule([&](napi_env env) { cb(env, data, hint); });
+    CallIntoModule([&](napi_env env) { cb(env, data, hint); },
+                   HandleFinalizerException);
   }
 
   v8impl::Persistent<v8::Value> last_exception;
@@ -119,6 +123,7 @@ struct napi_env__ {
   int open_callback_scopes = 0;
   int refs = 1;
   void* instance_data = nullptr;
+  v8impl::Persistent<v8::Value> finalizer_error_handler;
 };
 
 // This class is used to keep a napi_env live in a way that

--- a/test/js-native-api/test_finalizer_exception/binding.gyp
+++ b/test/js-native-api/test_finalizer_exception/binding.gyp
@@ -1,0 +1,12 @@
+{
+  "targets": [
+    {
+      "target_name": "test_finalizer_exception",
+      "sources": [
+        "../entry_point.c",
+        "testobject.cc",
+        "test_finalizer_exception.cc"
+      ]
+    }
+  ]
+}

--- a/test/js-native-api/test_finalizer_exception/test_finalizer_exception.cc
+++ b/test/js-native-api/test_finalizer_exception/test_finalizer_exception.cc
@@ -1,0 +1,51 @@
+#define NAPI_EXPERIMENTAL
+#include <js_native_api.h>
+#include "../common.h"
+#include "testobject.h"
+
+napi_value CreateObject(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1] = {};
+  NODE_API_CALL(env,
+                napi_get_cb_info(env, info, &argc, args, nullptr, nullptr));
+
+  napi_value instance;
+  NODE_API_CALL(env, TestObject::NewInstance(env, args[0], &instance));
+
+  return instance;
+}
+
+napi_value SetFinalizerErrorHandler(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1] = {};
+  NODE_API_CALL(env,
+                napi_get_cb_info(env, info, &argc, args, nullptr, nullptr));
+
+  NODE_API_CALL(env, node_api_set_finalizer_error_handler(env, args[0]));
+
+  napi_value undefined;
+  NODE_API_CALL(env, napi_get_undefined(env, &undefined));
+  return undefined;
+}
+
+EXTERN_C_START
+napi_value Init(napi_env env, napi_value exports) {
+  NODE_API_CALL(env, TestObject::Init(env));
+
+  napi_property_descriptor descriptors[] = {
+      DECLARE_NODE_API_GETTER("finalizeCount", TestObject::GetFinalizeCount),
+      DECLARE_NODE_API_PROPERTY("createObject", CreateObject),
+      DECLARE_NODE_API_PROPERTY("setFinalizerErrorHandler",
+                                SetFinalizerErrorHandler),
+  };
+
+  NODE_API_CALL(
+      env,
+      napi_define_properties(env,
+                             exports,
+                             sizeof(descriptors) / sizeof(*descriptors),
+                             descriptors));
+
+  return exports;
+}
+EXTERN_C_END

--- a/test/js-native-api/test_finalizer_exception/test_handled_exception.js
+++ b/test/js-native-api/test_finalizer_exception/test_handled_exception.js
@@ -1,0 +1,81 @@
+'use strict';
+// Flags: --expose-gc
+
+// The test verifies that if finalizer throws an exception,
+// then it can be handled by custom finalizer error handler.
+// If it is not handled in the handler, causing a
+// Node.js uncaughtException.
+
+const common = require('../../common');
+const assert = require('assert');
+const test = require(`./build/${common.buildType}/test_finalizer_exception`);
+
+assert.strictEqual(test.finalizeCount, 0);
+
+function gcUntilSync(value) {
+  for (let i = 0; i < 10; ++i) {
+    global.gc();
+    if (test.finalizeCount === value) {
+      break;
+    }
+  }
+}
+
+function runGCTests() {
+  let unhandledExceptions = 0;
+  process.on('uncaughtException', (err) => {
+    ++unhandledExceptions;
+    assert.strictEqual(err.message, 'Error during Finalize');
+  });
+
+  let handledExceptions = 0;
+  test.setFinalizerErrorHandler((err) => {
+    ++handledExceptions;
+    assert.strictEqual(err.message, 'Error during Finalize');
+    if (handledExceptions === 2) {
+      // One time we report the error to be unhandled
+      return false;
+    }
+  });
+
+  (() => {
+    test.createObject(true /* throw on destruct */);
+  })();
+  gcUntilSync(1);
+  assert.strictEqual(test.finalizeCount, 1);
+  assert.strictEqual(handledExceptions, 1);
+  assert.strictEqual(unhandledExceptions, 0);
+
+  (() => {
+    test.createObject(true /* throw on destruct */);
+    test.createObject(true /* throw on destruct */);
+  })();
+  gcUntilSync(3);
+  assert.strictEqual(test.finalizeCount, 3);
+  assert.strictEqual(handledExceptions, 3);
+  assert.strictEqual(unhandledExceptions, 1);
+
+  test.setFinalizerErrorHandler(null);
+  (() => {
+    test.createObject(true /* throw on destruct */);
+  })();
+  gcUntilSync(4);
+  assert.strictEqual(test.finalizeCount, 4);
+  assert.strictEqual(handledExceptions, 3);
+  assert.strictEqual(unhandledExceptions, 2);
+
+  // Raise unhandled exception if finalizer error handler throws.
+  test.setFinalizerErrorHandler((err) => {
+    ++handledExceptions;
+    assert.strictEqual(err.message, 'Error during Finalize');
+    throw err;
+  });
+  (() => {
+    test.createObject(true /* throw on destruct */);
+  })();
+  gcUntilSync(5);
+  assert.strictEqual(test.finalizeCount, 5);
+  assert.strictEqual(handledExceptions, 4);
+  assert.strictEqual(unhandledExceptions, 3);
+}
+runGCTests();

--- a/test/js-native-api/test_finalizer_exception/test_no_exception.js
+++ b/test/js-native-api/test_finalizer_exception/test_no_exception.js
@@ -1,0 +1,36 @@
+'use strict';
+// Flags: --expose-gc
+
+// The test verifies that finalizers are called as part of the main script
+// execution when there are no exceptions.
+
+const common = require('../../common');
+const assert = require('assert');
+const test = require(`./build/${common.buildType}/test_finalizer_exception`);
+
+assert.strictEqual(test.finalizeCount, 0);
+
+function gcUntilSync(value) {
+  for (let i = 0; i < 10; ++i) {
+    global.gc();
+    if (test.finalizeCount === value) {
+      break;
+    }
+  }
+}
+
+function runGCTests() {
+  (() => {
+    test.createObject();
+  })();
+  gcUntilSync(1);
+  assert.strictEqual(test.finalizeCount, 1);
+
+  (() => {
+    test.createObject();
+    test.createObject();
+  })();
+  gcUntilSync(3);
+  assert.strictEqual(test.finalizeCount, 3);
+}
+runGCTests();

--- a/test/js-native-api/test_finalizer_exception/test_unhandled_exception.js
+++ b/test/js-native-api/test_finalizer_exception/test_unhandled_exception.js
@@ -1,0 +1,44 @@
+'use strict';
+// Flags: --expose-gc
+
+// The test verifies that if finalizer throws an exception,
+// then it is causing a Node.js uncaughtException.
+
+const common = require('../../common');
+const assert = require('assert');
+const test = require(`./build/${common.buildType}/test_finalizer_exception`);
+
+assert.strictEqual(test.finalizeCount, 0);
+
+function gcUntilSync(value) {
+  for (let i = 0; i < 10; ++i) {
+    global.gc();
+    if (test.finalizeCount === value) {
+      break;
+    }
+  }
+}
+
+function runGCTests() {
+  let unhandledExceptions = 0;
+  process.on('uncaughtException', (err) => {
+    ++unhandledExceptions;
+    assert.strictEqual(err.message, 'Error during Finalize');
+  });
+
+  (() => {
+    test.createObject(true /* throw on destruct */);
+  })();
+  gcUntilSync(1);
+  assert.strictEqual(test.finalizeCount, 1);
+  assert.strictEqual(unhandledExceptions, 1);
+
+  (() => {
+    test.createObject(true /* throw on destruct */);
+    test.createObject(true /* throw on destruct */);
+  })();
+  gcUntilSync(3);
+  assert.strictEqual(test.finalizeCount, 3);
+  assert.strictEqual(unhandledExceptions, 3);
+}
+runGCTests();

--- a/test/js-native-api/test_finalizer_exception/testobject.cc
+++ b/test/js-native-api/test_finalizer_exception/testobject.cc
@@ -1,0 +1,94 @@
+#include "testobject.h"
+#include "../common.h"
+
+static int finalize_count = 0;
+
+TestObject::TestObject(bool throw_js_in_destructor)
+    : env_(nullptr),
+      wrapper_(nullptr),
+      throw_js_in_destructor_(throw_js_in_destructor) {}
+
+TestObject::~TestObject() {
+  napi_delete_reference(env_, wrapper_);
+}
+
+void TestObject::Destructor(napi_env env,
+                            void* nativeObject,
+                            void* /*finalize_hint*/) {
+  ++finalize_count;
+  TestObject* obj = static_cast<TestObject*>(nativeObject);
+  bool throw_js_in_destructor = obj->throw_js_in_destructor_;
+  delete obj;
+  if (throw_js_in_destructor) {
+    NODE_API_CALL_RETURN_VOID(
+        env, napi_throw_error(env, nullptr, "Error during Finalize"));
+  }
+}
+
+napi_value TestObject::GetFinalizeCount(napi_env env, napi_callback_info info) {
+  napi_value result;
+  NODE_API_CALL(env, napi_create_int32(env, finalize_count, &result));
+  return result;
+}
+
+napi_ref TestObject::constructor;
+
+napi_status TestObject::Init(napi_env env) {
+  napi_status status;
+  napi_value cons;
+  status =
+      napi_define_class(env, "TestObject", -1, New, nullptr, 0, nullptr, &cons);
+  if (status != napi_ok) return status;
+
+  status = napi_create_reference(env, cons, 1, &constructor);
+  if (status != napi_ok) return status;
+
+  return napi_ok;
+}
+
+napi_value TestObject::New(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  napi_value _this;
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, &_this, nullptr));
+
+  napi_valuetype valuetype;
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
+
+  bool throw_js_in_destructor{false};
+  if (valuetype == napi_boolean) {
+    NODE_API_CALL(env,
+                  napi_get_value_bool(env, args[0], &throw_js_in_destructor));
+  }
+
+  TestObject* obj = new TestObject(throw_js_in_destructor);
+
+  obj->env_ = env;
+  NODE_API_CALL(env,
+                napi_wrap(env,
+                          _this,
+                          obj,
+                          TestObject::Destructor,
+                          nullptr /* finalize_hint */,
+                          &obj->wrapper_));
+
+  return _this;
+}
+
+napi_status TestObject::NewInstance(napi_env env,
+                                    napi_value arg,
+                                    napi_value* instance) {
+  napi_status status;
+
+  const int argc = 1;
+  napi_value argv[argc] = {arg};
+
+  napi_value cons;
+  status = napi_get_reference_value(env, constructor, &cons);
+  if (status != napi_ok) return status;
+
+  status = napi_new_instance(env, cons, argc, argv, instance);
+  if (status != napi_ok) return status;
+
+  return napi_ok;
+}

--- a/test/js-native-api/test_finalizer_exception/testobject.h
+++ b/test/js-native-api/test_finalizer_exception/testobject.h
@@ -1,0 +1,28 @@
+#ifndef TEST_JS_NATIVE_API_TEST_FINALIZER_EXCEPTION_TESTOBJECT_H_
+#define TEST_JS_NATIVE_API_TEST_FINALIZER_EXCEPTION_TESTOBJECT_H_
+
+#include <js_native_api.h>
+
+class TestObject {
+ public:
+  static napi_status Init(napi_env env);
+  static void Destructor(napi_env env, void* nativeObject, void* finalize_hint);
+  static napi_value GetFinalizeCount(napi_env env, napi_callback_info info);
+  static napi_status NewInstance(napi_env env,
+                                 napi_value arg,
+                                 napi_value* instance);
+
+ private:
+  explicit TestObject(bool throw_js_in_destructor);
+  ~TestObject();
+
+  static napi_value New(napi_env env, napi_callback_info info);
+
+ private:
+  static napi_ref constructor;
+  napi_env env_;
+  napi_ref wrapper_;
+  bool throw_js_in_destructor_{false};
+};
+
+#endif  // TEST_JS_NATIVE_API_TEST_FINALIZER_EXCEPTION_TESTOBJECT_H_


### PR DESCRIPTION
## The issue
Currently `Reference` finalizers are run inside of `SetImmediate`.
In case if user code creates a lot of native objects in the main script, it could cause a significant memory pressure, even if the objects are properly released. This is because they are "collected" only inside of `SetImmediate` that follows the script run. 
See issue: https://github.com/nodejs/node-addon-api/issues/1140

In the https://github.com/nodejs/node/commit/a74a6e3ba131752225a527d915593d7e413b1594 commit the processing of finalizers was moved from the GC second pass to the `SetImmediate` because finalizers may throw JavaScript exceptions which can affect behavior of other functions.
If the JavaScript exception is thrown inside of `SetImmediate`, then it causes an unhandled exception which can be handled process-wide with help of `process.on('uncaughtException', ...)` event handler.

## The solution
In this PR we are switching back to processing finalizers in the GC second pass which may happen any time after GC calls.
To address the issue of handling JS exceptions from finalizers we do the following in this PR:
- By default, all JS exceptions from finalizers cause the Node.js unhandled exceptions. We apply the same error handling mechanism as used by immediate tasks created by `SetImmediate`. Thus, we address the previous issue with the finalizer JS errors interrupting other functions, and align the error handling behavior with `SetImmediate`.
- In addition to it, we are adding new `node_api_set_finalizer_error_handler` public API to setup an error handler per `napi_env` instance which is created per each native module. Each native module can handle its finalizer JS errors on its own.

## Tests
New test_finalizer_exception test is added to js-native-api to verify the new behavior.
All other js-native-api, node-api, and cctests are passing.

## Documentation
The n-api.md documentation is updated with the new `node_api_set_finalizer_error_handler` public API.
See the n-api.md for the details about the `node_api_set_finalizer_error_handler` function.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
