### PR TITLE
src: handling v8 thread pool of zero

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1368,9 +1368,8 @@ added: v5.10.0
 
 Set V8's thread pool size which will be used to allocate background jobs.
 
-If set to `0` then Node.js will choose an appropriate size of the thread pool based
-on the number of online processors.
-
+If set to `0` then Node.js will choose an appropriate size of the thread pool
+based on the number of online processors.
 
 ### `--zero-fill-buffers`
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1368,11 +1368,9 @@ added: v5.10.0
 
 Set V8's thread pool size which will be used to allocate background jobs.
 
-If set to `0` then V8 will choose an appropriate size of the thread pool based
+If set to `0` then Node.js will choose an appropriate size of the thread pool based
 on the number of online processors.
 
-If the value provided is larger than V8's maximum, then the largest value
-will be chosen.
 
 ### `--zero-fill-buffers`
 

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -45,6 +45,19 @@ static void PlatformWorkerThread(void* data) {
   }
 }
 
+static int GetActualThreadPoolSize(int thread_pool_size) {
+  if (thread_pool_size < 1) {
+    uv_cpu_info_t* cpu_info;
+    int count;
+
+    if (uv_cpu_info(&cpu_info, &count) == 0) {
+      uv_free_cpu_info(cpu_info, count);
+      thread_pool_size = count - 1;
+    }
+  }
+  return std::max(thread_pool_size, 1);
+}
+
 }  // namespace
 
 class WorkerThreadsTaskRunner::DelayedTaskScheduler {
@@ -340,6 +353,8 @@ NodePlatform::NodePlatform(int thread_pool_size,
   // current v8::Platform instance.
   SetTracingController(tracing_controller_);
   DCHECK_EQ(GetTracingController(), tracing_controller_);
+
+  thread_pool_size = GetActualThreadPoolSize(thread_pool_size);
   worker_thread_task_runner_ =
       std::make_shared<WorkerThreadsTaskRunner>(thread_pool_size);
 }

--- a/test/parallel/test-worker-v8-pool-size-0.js
+++ b/test/parallel/test-worker-v8-pool-size-0.js
@@ -1,0 +1,15 @@
+// Flags: --v8-pool-size=0
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Worker, isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+  const w = new Worker(__filename);
+  w.on('online', common.mustCall());
+  w.on('exit', common.mustCall((code) => assert.strictEqual(code, 0)));
+  process.on('exit', (code) => {
+    assert.strictEqual(code, 0);
+  });
+}


### PR DESCRIPTION
Resolved: #42523

Problem:

If no platform worker exists, Node.js doesn't shut down when background
tasks scheduled exist. It keeps waiting in `NodePlatform::DrainTasks`.

Observation:

It seems that Node.js used V8's `DefaultPlatform` implementation a long 
time ago, which chooses a suitable default value in case `--v8-pool-size=0` 
is given as a command-line option. However, Node.js currently uses its 
own v8::Platform implementation, `NodePlatform`. It seems not to have 
the logic to handle the case.

I referred to #4344 to track the issue.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
