### PR TITLE
test: pass data into napi_create_external

### DIFF
--- a/test/js-native-api/test_exception/test_exception.c
+++ b/test/js-native-api/test_exception/test_exception.c
@@ -2,6 +2,7 @@
 #include "../common.h"
 
 static bool exceptionWasPending = false;
+static int num = 0x23432;
 
 static napi_value returnException(napi_env env, napi_callback_info info) {
   size_t argc = 1;
@@ -83,7 +84,7 @@ static napi_value createExternal(napi_env env, napi_callback_info info) {
   napi_value external;
 
   NODE_API_CALL(env,
-      napi_create_external(env, NULL, finalizer, NULL, &external));
+      napi_create_external(env, &num, finalizer, NULL, &external));
 
   return external;
 }


### PR DESCRIPTION
Since v8 10.1 v8::External::New DCHECKs that the data passed
into it cannot be a nullptr because that's not serializable
as external reference. This updates the test to pass a
dummy data pointer to the call - which does not matter for the
test since we only care about whether the finalizer is
called.

Refs: https://github.com/nodejs/node/pull/42115
Refs: https://chromium-review.googlesource.com/c/v8/v8/+/3513234

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
