### PR TITLE
build: remove precompiled header and debug information for host builds

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -280,7 +280,11 @@
           '-std:c++17'
         ],
         'BufferSecurityCheck': 'true',
-        'DebugInformationFormat': 1,          # /Z7 embed info in .obj files
+        'target_conditions': [
+          ['_toolset=="target"', {
+            'DebugInformationFormat': 1      # /Z7 embed info in .obj files
+          }],
+        ],
         'ExceptionHandling': 0,               # /EHsc
         'MultiProcessorCompilation': 'true',
         'StringPooling': 'true',              # pool string literals

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -327,7 +327,7 @@
              '<(V8_ROOT)/src/builtins/builtins-intl-gen.cc',
            ],
          }],
-        ['OS=="win"', {
+        ['OS=="win" and _toolset=="target"', {
           'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
           'msvs_precompiled_source': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.cc',
           'sources': [
@@ -675,7 +675,7 @@
       ],
       'sources': ['<@(v8_compiler_sources)'],
       'conditions': [
-        ['OS=="win"', {
+        ['OS=="win" and _toolset=="target"', {
           'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
           'msvs_precompiled_source': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.cc',
           'sources': [
@@ -700,7 +700,7 @@
       ],
       'sources': ['<@(v8_compiler_sources)'],
       'conditions': [
-        ['OS=="win"', {
+        ['OS=="win" and _toolset=="target"', {
           'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
           'msvs_precompiled_source': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.cc',
           'sources': [
@@ -890,13 +890,15 @@
             '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_base_without_compiler.*?v8_current_cpu == \\"loong64\\".*?sources \\+= ")',
           ],
         }],        
-        ['OS=="win"', {
+        ['OS=="win" and _toolset=="target"', {
           'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
           'msvs_precompiled_source': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.cc',
           'sources': [
             '<(_msvs_precompiled_header)',
             '<(_msvs_precompiled_source)',
-          ],
+          ]
+        }],
+        ['OS=="win"', {
           # This will prevent V8's .cc files conflicting with the inspector's
           # .cpp files in the same shard.
           'msvs_settings': {


### PR DESCRIPTION
This is required to fix cross-compilation of windows/arm64 builds.

Precompiled header includes arm64 register configurations which are included for host builds and conflicts with x64 register. So they have to be removed from host builds.

Debug information is also disabled for host builds to avoid creating large libraries linker cannot handle.

Refs: #42375