### PR TITLE
buffer: fix `atob` input validation

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -23,8 +23,10 @@
 
 const {
   Array,
+  ArrayFrom,
   ArrayIsArray,
   ArrayPrototypeForEach,
+  ArrayPrototypeIncludes,
   MathFloor,
   MathMin,
   MathTrunc,
@@ -1230,8 +1232,25 @@ function btoa(input) {
   return buf.toString('base64');
 }
 
-const kBase64Digits =
-  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+// Refs: https://infra.spec.whatwg.org/#forgiving-base64-decode
+const kForgivingBase64AllowedChars = [
+  // ASCII whitespace
+  // Refs: https://infra.spec.whatwg.org/#ascii-whitespace
+  0x09, 0x0A, 0x0C, 0x0D, 0x20,
+
+  // Uppercase letters
+  ...ArrayFrom({ length: 26 }, (_, i) => StringPrototypeCharCodeAt('A') + i),
+
+  // Lowercase letters
+  ...ArrayFrom({ length: 26 }, (_, i) => StringPrototypeCharCodeAt('a') + i),
+
+  // Decimal digits
+  ...ArrayFrom({ length: 10 }, (_, i) => StringPrototypeCharCodeAt('0') + i),
+
+  0x2b, // +
+  0x2f, // /
+  0x3d, // =
+];
 
 function atob(input) {
   // The implementation here has not been performance optimized in any way and
@@ -1242,7 +1261,8 @@ function atob(input) {
   }
   input = `${input}`;
   for (let n = 0; n < input.length; n++) {
-    if (!kBase64Digits.includes(input[n]))
+    if (!ArrayPrototypeIncludes(kForgivingBase64AllowedChars,
+                                StringPrototypeCharCodeAt(input, n)))
       throw lazyDOMException('Invalid character', 'InvalidCharacterError');
   }
   return Buffer.from(input, 'base64').toString('latin1');

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1247,9 +1247,9 @@ const kForgivingBase64AllowedChars = [
   // Decimal digits
   ...ArrayFrom({ length: 10 }, (_, i) => StringPrototypeCharCodeAt('0') + i),
 
-  0x2b, // +
-  0x2f, // /
-  0x3d, // =
+  0x2B, // +
+  0x2F, // /
+  0x3D, // =
 ];
 
 function atob(input) {

--- a/test/parallel/test-btoa-atob.js
+++ b/test/parallel/test-btoa-atob.js
@@ -14,3 +14,4 @@ throws(() => buffer.atob(), /TypeError/);
 throws(() => buffer.btoa(), /TypeError/);
 
 strictEqual(atob(' '), '');
+strictEqual(atob('  YW\tJ\njZA=\r= '), 'abcd');

--- a/test/parallel/test-btoa-atob.js
+++ b/test/parallel/test-btoa-atob.js
@@ -12,3 +12,5 @@ strictEqual(globalThis.btoa, buffer.btoa);
 // Throws type error on no argument passed
 throws(() => buffer.atob(), /TypeError/);
 throws(() => buffer.btoa(), /TypeError/);
+
+strictEqual(atob(' '), '');


### PR DESCRIPTION
I've added a test case, as it looks like WTP do not test for input with whitespace: https://github.com/web-platform-tests/wpt/blob/HEAD/html/webappapis/atob/base64.any.js

//cc @jasnell 


Fixes: https://github.com/nodejs/node/issues/42530

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
