### PR TITLE
crypto: fix webcrypto derive key lengths

### DIFF
--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -153,6 +153,41 @@ async function deriveBits(algorithm, baseKey, length) {
   throw lazyDOMException('Unrecognized name.');
 }
 
+function getKeyLength({ name, length, hash }) {
+  switch (name) {
+    case 'AES-CTR':
+    case 'AES-CBC':
+    case 'AES-GCM':
+    case 'AES-KW':
+      if (length !== 128 && length !== 192 && length !== 256)
+        throw lazyDOMException('Invalid key length', 'OperationError');
+
+      return length;
+    case 'HMAC':
+      if (length === undefined) {
+        switch (hash?.name) {
+          case 'SHA-1':
+            return 160;
+          case 'SHA-256':
+            return 256;
+          case 'SHA-384':
+            return 384;
+          case 'SHA-512':
+            return 512;
+        }
+      }
+
+      if (typeof length === 'number' && length !== 0) {
+        return length;
+      }
+
+      throw lazyDOMException('Invalid key length', 'OperationError');
+    case 'HKDF':
+    case 'PBKDF2':
+      return null;
+  }
+}
+
 async function deriveKey(
   algorithm,
   baseKey,
@@ -176,7 +211,7 @@ async function deriveKey(
   validateBoolean(extractable, 'extractable');
   validateArray(keyUsages, 'keyUsages');
 
-  const { length } = derivedKeyAlgorithm;
+  const length = getKeyLength(derivedKeyAlgorithm);
   let bits;
   switch (algorithm.name) {
     case 'ECDH':


### PR DESCRIPTION
This implements the `get key length` operation of possible `deriveKey` derived key's algorithms.

Specifically, for

**AES Keys**
<img width="731" alt="image" src="https://user-images.githubusercontent.com/241506/161079583-e038cd79-2551-4074-bc60-71f0f0d36a91.png">


**PBKDF2 and HKDF Keys**
> Return null.

**HMAC Keys**

<img width="757" alt="image" src="https://user-images.githubusercontent.com/241506/161079504-a97df55d-75f8-4881-abe9-2833f8b614db.png">
