### PR TITLE
build: set stale action back to running nightly

### DIFF
--- a/.github/workflows/close-stale-feature-requests.yml
+++ b/.github/workflows/close-stale-feature-requests.yml
@@ -1,12 +1,9 @@
 name: Close stale feature requests
 on:
   workflow_dispatch:
-    inputs:
-      daysBeforeStale:
-        description: Idle number of days before marking feature requests stale
-        required: true
-        default: 906
-        type: number
+  schedule:
+    # Run every day at 1:00 AM UTC.
+    - cron: 0 1 * * *
 
 # yamllint disable rule:empty-lines
 env:
@@ -39,7 +36,7 @@ jobs:
       - uses: actions/stale@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: ${{ github.event.inputs.daysBeforeStale }}
+          days-before-stale: 180
           days-before-close: 30
           stale-issue-label: stale
           close-issue-message: ${{ env.CLOSE_MESSAGE }}


### PR DESCRIPTION
I manually ran over  the last number of weeks so that
we did not mark all of the stale isssues all at once.
We are not caught up so we can go to running daily.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
