### PR TITLE
node-api: enable napi_ref for all value types

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2046,6 +2046,48 @@ the `napi_value` in question is of the JavaScript type expected by the API.
 
 ### Enum types
 
+#### `napi_features`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+```c
+typedef enum {
+  napi_feature_none = 0,
+  napi_feature_reference_all_types = 1 << 0,
+
+  napi_default_experimental_features = napi_feature_reference_all_types,
+
+  napi_default_features = napi_default_experimental_features, // version specific
+} napi_features;
+```
+
+The `napi_features` allow changing internal behavior of existing Node-API
+functions.
+
+We pass a `napi_features` pointer to the `napi_module` struct in the
+`NAPI_MODULE_X` macro. This macro is used for the module registration.
+If the module is initialized without using this macro, then there will be
+no features selected and the module will use the `napi_feature_none`.
+
+Each Node-API version defines its own default set of features.
+For the current version it can be accessed using `napi_default_features`.
+A module can override the set of its enabled features by adding
+`NAPI_CUSTOM_FEATURES` definition to the `.gyp` file and then defining the
+value of the global `napi_module_features` variable.
+To check enabled features use the `napi_is_feature_enabled` function.
+
+For example, to disables `napi_feature_reference_all_types` feature we can
+exclude its bit from the `napi_default_features` set:
+
+```c
+napi_features napi_module_features =
+    napi_default_features & ~napi_feature_reference_all_types;
+```
+
 #### `napi_key_collection_mode`
 
 <!-- YAML
@@ -5699,6 +5741,32 @@ support it:
 * Use the dynamically loaded pointer to invoke the function.
 * If the function is not available, provide an alternate implementation
   that does not use the function.
+
+#### `napi_is_feature_enabled`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+```c
+NAPI_EXTERN napi_status napi_is_feature_enabled(napi_env env,
+                                                napi_features feature,
+                                                bool* result);
+```
+
+* `[in] env`: The environment that the API is invoked under.
+* `[in] feature`: The feature that we want to test.
+* `[out] result`: Whether the feature or a set of features are enabled.
+
+Returns `napi_ok` if the API succeeded.
+
+The function checks enabled features for the module.
+If `feature` parameter has multiple `napi_features` bit flags, then the
+function returns `true` only when all the requested fatures are enabled.
+
+See [`napi_features`][] for more details about Node-API features.
 
 ## Memory management
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2046,7 +2046,7 @@ the `napi_value` in question is of the JavaScript type expected by the API.
 
 ### Enum types
 
-#### `napi_features`
+#### `node_api_features`
 
 <!-- YAML
 added: REPLACEME
@@ -2056,36 +2056,37 @@ added: REPLACEME
 
 ```c
 typedef enum {
-  napi_feature_none = 0,
-  napi_feature_reference_all_types = 1 << 0,
+  node_api_feature_none = 0,
+  node_api_feature_reference_all_types = 1 << 0,
 
-  napi_default_experimental_features = napi_feature_reference_all_types,
+  node_api_default_experimental_features = node_api_feature_reference_all_types,
 
-  napi_default_features = napi_default_experimental_features, // version specific
-} napi_features;
+   // version specific
+  node_api_default_features = node_api_default_experimental_features,
+} node_api_features;
 ```
 
-The `napi_features` allow changing internal behavior of existing Node-API
+The `node_api_features` allow changing internal behavior of existing Node-API
 functions.
 
-We pass a `napi_features` pointer to the `napi_module` struct in the
+We pass a `node_api_features` pointer to the `napi_module` struct in the
 `NAPI_MODULE_X` macro. This macro is used for the module registration.
 If the module is initialized without using this macro, then there will be
-no features selected and the module will use the `napi_feature_none`.
+no features selected and the module will use the `node_api_feature_none`.
 
 Each Node-API version defines its own default set of features.
-For the current version it can be accessed using `napi_default_features`.
+For the current version it can be accessed using `node_api_default_features`.
 A module can override the set of its enabled features by adding
-`NAPI_CUSTOM_FEATURES` definition to the `.gyp` file and then defining the
-value of the global `napi_module_features` variable.
-To check enabled features use the `napi_is_feature_enabled` function.
+`NODE_API_CUSTOM_FEATURES` definition to the `.gyp` file and then defining the
+value of the global `node_api_module_features` variable.
+To check enabled features use the `node_api_is_feature_enabled` function.
 
-For example, to disables `napi_feature_reference_all_types` feature we can
-exclude its bit from the `napi_default_features` set:
+For example, to disables `node_api_feature_reference_all_types` feature we can
+exclude its bit from the `node_api_default_features` set:
 
 ```c
-napi_features napi_module_features =
-    napi_default_features & ~napi_feature_reference_all_types;
+node_api_features node_api_module_features =
+    node_api_default_features & ~node_api_feature_reference_all_types;
 ```
 
 #### `napi_key_collection_mode`
@@ -5742,7 +5743,7 @@ support it:
 * If the function is not available, provide an alternate implementation
   that does not use the function.
 
-#### `napi_is_feature_enabled`
+#### `node_api_is_feature_enabled`
 
 <!-- YAML
 added: REPLACEME
@@ -5751,9 +5752,9 @@ added: REPLACEME
 > Stability: 1 - Experimental
 
 ```c
-NAPI_EXTERN napi_status napi_is_feature_enabled(napi_env env,
-                                                napi_features feature,
-                                                bool* result);
+NAPI_EXTERN napi_status node_api_is_feature_enabled(napi_env env,
+                                                    node_api_features feature,
+                                                    bool* result);
 ```
 
 * `[in] env`: The environment that the API is invoked under.
@@ -5763,10 +5764,10 @@ NAPI_EXTERN napi_status napi_is_feature_enabled(napi_env env,
 Returns `napi_ok` if the API succeeded.
 
 The function checks enabled features for the module.
-If `feature` parameter has multiple `napi_features` bit flags, then the
+If `feature` parameter has multiple `node_api_features` bit flags, then the
 function returns `true` only when all the requested fatures are enabled.
 
-See `napi_features` for more details about Node-API features.
+See `node_api_features` for more details about Node-API features.
 
 ## Memory management
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5766,7 +5766,7 @@ The function checks enabled features for the module.
 If `feature` parameter has multiple `napi_features` bit flags, then the
 function returns `true` only when all the requested fatures are enabled.
 
-See [`napi_features`][] for more details about Node-API features.
+See `napi_features` for more details about Node-API features.
 
 ## Memory management
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2081,7 +2081,7 @@ A module can override the set of its enabled features by adding
 value of the global `node_api_module_features` variable.
 To check enabled features use the `node_api_is_feature_enabled` function.
 
-For example, to disables `node_api_feature_reference_all_types` feature we can
+For example, to disable `node_api_feature_reference_all_types` feature we can
 exclude its bit from the `node_api_default_features` set:
 
 ```c
@@ -5758,7 +5758,7 @@ NAPI_EXTERN napi_status node_api_is_feature_enabled(napi_env env,
 ```
 
 * `[in] env`: The environment that the API is invoked under.
-* `[in] feature`: The feature that we want to test.
+* `[in] feature`: The features that we want to test.
 * `[out] result`: Whether the feature or a set of features are enabled.
 
 Returns `napi_ok` if the API succeeded.

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -566,6 +566,11 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_object_seal(napi_env env,
                                                     napi_value object);
 #endif  // NAPI_VERSION >= 8
 
+#ifdef NAPI_EXPERIMENTAL
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_is_feature_enabled(napi_env env, napi_features feature, bool* result);
+#endif  // NAPI_EXPERIMENTAL
+
 EXTERN_C_END
 
 #endif  // SRC_JS_NATIVE_API_H_

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -567,8 +567,8 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_object_seal(napi_env env,
 #endif  // NAPI_VERSION >= 8
 
 #ifdef NAPI_EXPERIMENTAL
-NAPI_EXTERN napi_status NAPI_CDECL
-napi_is_feature_enabled(napi_env env, napi_features feature, bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL node_api_is_feature_enabled(
+    napi_env env, node_api_features feature, bool* result);
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END

--- a/src/js_native_api_types.h
+++ b/src/js_native_api_types.h
@@ -108,6 +108,37 @@ typedef enum {
 //   * the definition of `napi_status` in doc/api/n-api.md to reflect the newly
 //     added value(s).
 
+#ifdef NAPI_EXPERIMENTAL
+// Features allow changing internal behavior of existing Node-API functions.
+//
+// We pass a napi_features pointer to the napi_module struct
+// in the NAPI_MODULE_X macro. This macro is used for the module registration.
+// If the module is initialized without using this macro, then there will be
+// no features selected and the module will use the napi_feature_none.
+//
+// Each Node-API version defines its own default set of features.
+// For the current version it can be accessed using napi_default_features.
+// A module can override the set of its enabled features by adding
+// NAPI_CUSTOM_FEATURES definition to the .gyp file and then defining the
+// value of the global napi_module_features variable.
+// To check enabled features use the `napi_is_feature_enabled` function.
+//
+// For example, to disables napi_feature_reference_all_types:
+// napi_features napi_module_features =
+//   napi_default_features & ~napi_feature_reference_all_types;
+typedef enum {
+  // To be used when no features needs to be set.
+  napi_feature_none = 0,
+  // Use napi_ref for all value types.
+  // Not only objects, functions, and symbols as before.
+  napi_feature_reference_all_types = 1 << 0,
+  // Each version of NAPI is going to have its own default set of features.
+  napi_default_experimental_features = napi_feature_reference_all_types,
+  // This variable must be conditionally set depending on the NAPI version.
+  napi_default_features = napi_default_experimental_features,
+} napi_features;
+#endif
+
 typedef napi_value(NAPI_CDECL* napi_callback)(napi_env env,
                                               napi_callback_info info);
 typedef void(NAPI_CDECL* napi_finalize)(napi_env env,

--- a/src/js_native_api_types.h
+++ b/src/js_native_api_types.h
@@ -111,32 +111,32 @@ typedef enum {
 #ifdef NAPI_EXPERIMENTAL
 // Features allow changing internal behavior of existing Node-API functions.
 //
-// We pass a napi_features pointer to the napi_module struct
+// We pass a node_api_features pointer to the napi_module struct
 // in the NAPI_MODULE_X macro. This macro is used for the module registration.
 // If the module is initialized without using this macro, then there will be
-// no features selected and the module will use the napi_feature_none.
+// no features selected and the module will use the node_api_feature_none.
 //
 // Each Node-API version defines its own default set of features.
-// For the current version it can be accessed using napi_default_features.
+// For the current version it can be accessed using node_api_default_features.
 // A module can override the set of its enabled features by adding
-// NAPI_CUSTOM_FEATURES definition to the .gyp file and then defining the
-// value of the global napi_module_features variable.
-// To check enabled features use the `napi_is_feature_enabled` function.
+// NODE_API_CUSTOM_FEATURES definition to the .gyp file and then defining the
+// value of the global node_api_module_features variable.
+// To check enabled features use the `node_api_is_feature_enabled` function.
 //
-// For example, to disables napi_feature_reference_all_types:
-// napi_features napi_module_features =
-//   napi_default_features & ~napi_feature_reference_all_types;
+// For example, to disables node_api_feature_reference_all_types:
+// node_api_features node_api_module_features =
+//   node_api_default_features & ~node_api_feature_reference_all_types;
 typedef enum {
   // To be used when no features needs to be set.
-  napi_feature_none = 0,
+  node_api_feature_none = 0,
   // Use napi_ref for all value types.
-  // Not only objects, functions, and symbols as before.
-  napi_feature_reference_all_types = 1 << 0,
-  // Each version of NAPI is going to have its own default set of features.
-  napi_default_experimental_features = napi_feature_reference_all_types,
-  // This variable must be conditionally set depending on the NAPI version.
-  napi_default_features = napi_default_experimental_features,
-} napi_features;
+  // Not only objects, external objects, functions, and symbols as before.
+  node_api_feature_reference_all_types = 1 << 0,
+  // Each version of Node-API is going to have its own default set of features.
+  node_api_default_experimental_features = node_api_feature_reference_all_types,
+  // This variable must be conditionally set depending on the Node-API version.
+  node_api_default_features = node_api_default_experimental_features,
+} node_api_features;
 #endif
 
 typedef napi_value(NAPI_CDECL* napi_callback)(napi_env env,

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -21,7 +21,7 @@
 
 node_napi_env__::node_napi_env__(v8::Local<v8::Context> context,
                                  const std::string& module_filename,
-                                 napi_features* features)
+                                 node_api_features* features)
     : napi_env__(context, features), filename(module_filename) {
   CHECK_NOT_NULL(node_env());
 }
@@ -128,7 +128,7 @@ class BufferFinalizer : private Finalizer {
 
 inline napi_env NewEnv(v8::Local<v8::Context> context,
                        const std::string& module_filename,
-                       napi_features* features) {
+                       node_api_features* features) {
   node_napi_env result;
 
   result = new node_napi_env__(context, module_filename, features);
@@ -593,7 +593,7 @@ void napi_module_register_by_symbol_with_features(
     v8::Local<v8::Value> module,
     v8::Local<v8::Context> context,
     napi_addon_register_func init,
-    napi_features* features);
+    node_api_features* features);
 
 // Intercepts the Node-V8 module registration callback. Converts parameters
 // to NAPI equivalents and then calls the registration callback specified
@@ -623,7 +623,7 @@ void napi_module_register_by_symbol_with_features(
     v8::Local<v8::Value> module,
     v8::Local<v8::Context> context,
     napi_addon_register_func init,
-    napi_features* features) {
+    node_api_features* features) {
   node::Environment* node_env = node::Environment::GetCurrent(context);
   std::string module_filename = "";
   if (init == nullptr) {

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -20,8 +20,9 @@
 #include <memory>
 
 node_napi_env__::node_napi_env__(v8::Local<v8::Context> context,
-                                 const std::string& module_filename)
-    : napi_env__(context), filename(module_filename) {
+                                 const std::string& module_filename,
+                                 napi_features* features)
+    : napi_env__(context, features), filename(module_filename) {
   CHECK_NOT_NULL(node_env());
 }
 
@@ -126,10 +127,11 @@ class BufferFinalizer : private Finalizer {
 };
 
 inline napi_env NewEnv(v8::Local<v8::Context> context,
-                       const std::string& module_filename) {
+                       const std::string& module_filename,
+                       napi_features* features) {
   node_napi_env result;
 
-  result = new node_napi_env__(context, module_filename);
+  result = new node_napi_env__(context, module_filename, features);
   // TODO(addaleax): There was previously code that tried to delete the
   // napi_env when its v8::Context was garbage collected;
   // However, as long as N-API addons using this napi_env are in place,
@@ -586,6 +588,13 @@ class AsyncContext {
 
 }  // end of namespace v8impl
 
+void napi_module_register_by_symbol_with_features(
+    v8::Local<v8::Object> exports,
+    v8::Local<v8::Value> module,
+    v8::Local<v8::Context> context,
+    napi_addon_register_func init,
+    napi_features* features);
+
 // Intercepts the Node-V8 module registration callback. Converts parameters
 // to NAPI equivalents and then calls the registration callback specified
 // by the NAPI module.
@@ -593,17 +602,28 @@ static void napi_module_register_cb(v8::Local<v8::Object> exports,
                                     v8::Local<v8::Value> module,
                                     v8::Local<v8::Context> context,
                                     void* priv) {
-  napi_module_register_by_symbol(
+  napi_module_register_by_symbol_with_features(
       exports,
       module,
       context,
-      static_cast<const napi_module*>(priv)->nm_register_func);
+      static_cast<const napi_module*>(priv)->nm_register_func,
+      static_cast<const napi_module*>(priv)->nm_features);
 }
 
 void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
                                     v8::Local<v8::Value> module,
                                     v8::Local<v8::Context> context,
                                     napi_addon_register_func init) {
+  napi_module_register_by_symbol_with_features(
+      exports, module, context, init, nullptr);
+}
+
+void napi_module_register_by_symbol_with_features(
+    v8::Local<v8::Object> exports,
+    v8::Local<v8::Value> module,
+    v8::Local<v8::Context> context,
+    napi_addon_register_func init,
+    napi_features* features) {
   node::Environment* node_env = node::Environment::GetCurrent(context);
   std::string module_filename = "";
   if (init == nullptr) {
@@ -631,7 +651,7 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
   }
 
   // Create a new napi_env for this specific module.
-  napi_env env = v8impl::NewEnv(context, module_filename);
+  napi_env env = v8impl::NewEnv(context, module_filename, features);
 
   napi_value _exports;
   env->CallIntoModule([&](napi_env env) {

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -39,7 +39,7 @@ typedef struct napi_module {
   const char* nm_modname;
   void* nm_priv;
 #ifdef NAPI_EXPERIMENTAL
-  napi_features* nm_features;
+  node_api_features* nm_features;
   void* reserved[3];
 #else
   void* reserved[4];
@@ -79,30 +79,30 @@ typedef struct napi_module {
 #endif
 
 #ifdef NAPI_EXPERIMENTAL
-#ifdef NAPI_CUSTOM_FEATURES
+#ifdef NODE_API_CUSTOM_FEATURES
 
-// Define value of napi_module_features variable in your module when
-// NAPI_CUSTOM_FEATURES is set in gyp file.
-extern napi_features napi_module_features;
-#define NAPI_DEFINE_DEFAULT_FEATURES
+// Define value of node_api_module_features variable in your module when
+// NODE_API_CUSTOM_FEATURES is set in gyp file.
+extern node_api_features node_api_module_features;
+#define NODE_API_DEFINE_DEFAULT_FEATURES
 
-#else  // NAPI_CUSTOM_FEATURES
+#else  // NODE_API_CUSTOM_FEATURES
 
-#define NAPI_DEFINE_DEFAULT_FEATURES                                           \
-  static napi_features napi_module_features = napi_default_features;
+#define NODE_API_DEFINE_DEFAULT_FEATURES                                       \
+  static node_api_features node_api_module_features = node_api_default_features;
 
-#endif  // NAPI_CUSTOM_FEATURES
+#endif  // NODE_API_CUSTOM_FEATURES
 
-#define NAPI_FEATURES_PTR /* NOLINT */ &napi_module_features,
+#define NODE_API_FEATURES_PTR /* NOLINT */ &node_api_module_features,
 
 #else  // NAPI_EXPERIMENTAL
-#define NAPI_DEFINE_DEFAULT_FEATURES
-#define NAPI_FEATURES_PTR
+#define NODE_API_DEFINE_DEFAULT_FEATURES
+#define NODE_API_FEATURES_PTR
 #endif  // NAPI_EXPERIMENTAL
 
 #define NAPI_MODULE_X(modname, regfunc, priv, flags)                           \
   EXTERN_C_START                                                               \
-  NAPI_DEFINE_DEFAULT_FEATURES                                                 \
+  NODE_API_DEFINE_DEFAULT_FEATURES                                             \
   static napi_module _module = {                                               \
       NAPI_MODULE_VERSION,                                                     \
       flags,                                                                   \
@@ -110,7 +110,7 @@ extern napi_features napi_module_features;
       regfunc,                                                                 \
       #modname,                                                                \
       priv,                                                                    \
-      NAPI_FEATURES_PTR{0},                                                    \
+      NODE_API_FEATURES_PTR{0},                                                \
   };                                                                           \
   NAPI_C_CTOR(_register_##modname) { napi_module_register(&_module); }         \
   EXTERN_C_END

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -112,9 +112,7 @@ extern napi_features napi_module_features;
       priv,                                                                    \
       NAPI_FEATURES_PTR{0},                                                    \
   };                                                                           \
-  NAPI_C_CTOR(_register_##modname) {                                           \
-    napi_module_register(&_module);                                            \
-  }                                                                            \
+  NAPI_C_CTOR(_register_##modname) { napi_module_register(&_module); }         \
   EXTERN_C_END
 
 #define NAPI_MODULE_INITIALIZER_X(base, version)                               \

--- a/src/node_api_internals.h
+++ b/src/node_api_internals.h
@@ -11,7 +11,7 @@
 struct node_napi_env__ : public napi_env__ {
   node_napi_env__(v8::Local<v8::Context> context,
                   const std::string& module_filename,
-                  napi_features* features);
+                  node_api_features* features);
 
   bool can_call_into_js() const override;
   v8::Maybe<bool> mark_arraybuffer_as_untransferable(

--- a/src/node_api_internals.h
+++ b/src/node_api_internals.h
@@ -10,7 +10,8 @@
 
 struct node_napi_env__ : public napi_env__ {
   node_napi_env__(v8::Local<v8::Context> context,
-                  const std::string& module_filename);
+                  const std::string& module_filename,
+                  napi_features* features);
 
   bool can_call_into_js() const override;
   v8::Maybe<bool> mark_arraybuffer_as_untransferable(

--- a/test/js-native-api/common.h
+++ b/test/js-native-api/common.h
@@ -1,3 +1,4 @@
+#define NAPI_EXPERIMENTAL
 #include <js_native_api.h>
 
 // Empty value so that macros here are able to return NULL or void

--- a/test/js-native-api/entry_point.c
+++ b/test/js-native-api/entry_point.c
@@ -1,3 +1,4 @@
+#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 
 EXTERN_C_START

--- a/test/js-native-api/test_reference/binding.gyp
+++ b/test/js-native-api/test_reference/binding.gyp
@@ -5,7 +5,8 @@
       "sources": [
         "../entry_point.c",
         "test_reference.c"
-      ]
+      ],
+      'defines': [ 'NAPI_CUSTOM_FEATURES' ]
     }
   ]
 }

--- a/test/js-native-api/test_reference/binding.gyp
+++ b/test/js-native-api/test_reference/binding.gyp
@@ -6,7 +6,7 @@
         "../entry_point.c",
         "test_reference.c"
       ],
-      'defines': [ 'NAPI_CUSTOM_FEATURES' ]
+      'defines': [ 'NODE_API_CUSTOM_FEATURES' ]
     }
   ]
 }

--- a/test/js-native-api/test_reference/test_reference.c
+++ b/test/js-native-api/test_reference/test_reference.c
@@ -283,4 +283,7 @@ napi_value Init(napi_env env, napi_value exports) {
 
   return exports;
 }
+
+// Make sure that this test uses the old napi_ref behavior.
+napi_features napi_module_features = napi_default_features & ~napi_feature_reference_all_types;
 EXTERN_C_END

--- a/test/js-native-api/test_reference/test_reference.c
+++ b/test/js-native-api/test_reference/test_reference.c
@@ -285,5 +285,7 @@ napi_value Init(napi_env env, napi_value exports) {
 }
 
 // Make sure that this test uses the old napi_ref behavior.
-napi_features napi_module_features = napi_default_features & ~napi_feature_reference_all_types;
+node_api_features node_api_module_features =
+  node_api_default_features & ~node_api_feature_reference_all_types;
+
 EXTERN_C_END

--- a/test/js-native-api/test_reference_all_types/binding.gyp
+++ b/test/js-native-api/test_reference_all_types/binding.gyp
@@ -1,0 +1,11 @@
+{
+  "targets": [
+    {
+      "target_name": "test_reference_all_types",
+      "sources": [
+        "../entry_point.c",
+        "test_reference_all_types.c"
+      ]
+    }
+  ]
+}

--- a/test/js-native-api/test_reference_all_types/test.js
+++ b/test/js-native-api/test_reference_all_types/test.js
@@ -1,0 +1,86 @@
+'use strict';
+// Flags: --expose-gc
+
+const { gcUntil, buildType } = require('../../common');
+const assert = require('assert');
+
+// Testing API calls for references to all value types.
+const addon = require(`./build/${buildType}/test_reference_all_types`);
+
+async function runTests() {
+  let entryCount = 0;
+
+  (() => {
+    // Create values of all napi_valuetype types.
+    const undefinedValue = undefined;
+    const nullValue = null;
+    const booleanValue = false;
+    const numberValue = 42;
+    const stringValue = 'test_string';
+    const symbolValue = Symbol.for('test_symbol');
+    const objectValue = { x: 1, y: 2 };
+    const functionValue = (x, y) => x + y;
+    const externalValue = addon.createExternal();
+    const bigintValue = 9007199254740991n;
+
+    const allValues = [
+      undefinedValue,
+      nullValue,
+      booleanValue,
+      numberValue,
+      stringValue,
+      symbolValue,
+      objectValue,
+      functionValue,
+      externalValue,
+      bigintValue,
+    ];
+    entryCount = allValues.length;
+    const objectValueIndex = allValues.indexOf(objectValue);
+    const functionValueIndex = allValues.indexOf(functionValue);
+
+    // Go over all values of different types, create strong ref values for
+    // them, read the stored values, and check how the ref count works.
+    for (const value of allValues) {
+      const index = addon.createRef(value);
+      const refValue = addon.getRefValue(index);
+      assert.strictEqual(value, refValue);
+      assert.strictEqual(addon.ref(index), 2);
+      assert.strictEqual(addon.unref(index), 1);
+      assert.strictEqual(addon.unref(index), 0);
+    }
+
+    // The references become weak pointers when the ref count is 0.
+    // To be compatible with the JavaScript spec we expect these
+    // types to be objects and functions.
+    // Here we know that the GC is not run yet because the values are
+    // still in the allValues array.
+    assert.strictEqual(addon.getRefValue(objectValueIndex), objectValue);
+    assert.strictEqual(addon.getRefValue(functionValueIndex), functionValue);
+
+    const objWithFinalizer = {};
+    addon.addFinalizer(objWithFinalizer);
+  })();
+
+  assert.strictEqual(addon.getFinalizeCount(), 0);
+  await gcUntil('Wait until a finalizer is called',
+                () => (addon.getFinalizeCount() === 1));
+
+  // Create and call finalizer again to make sure that all finalizers are run.
+  (() => {
+    const objWithFinalizer = {};
+    addon.addFinalizer(objWithFinalizer);
+  })();
+
+  await gcUntil('Wait until a finalizer is called again',
+                () => (addon.getFinalizeCount() === 1));
+
+  // After GC and finalizers run, all references with refCount==0 must return
+  // undefined value.
+  for (let i = 0; i < entryCount; ++i) {
+    const refValue = addon.getRefValue(i);
+    assert.strictEqual(refValue, undefined);
+    addon.deleteRef(i);
+  }
+}
+runTests();

--- a/test/js-native-api/test_reference_all_types/test.js
+++ b/test/js-native-api/test_reference_all_types/test.js
@@ -1,14 +1,14 @@
 'use strict';
 // Flags: --expose-gc
-
+//
+// Testing API calls for references to all value types.
+//
 const { gcUntil, buildType } = require('../../common');
 const assert = require('assert');
-
-// Testing API calls for references to all value types.
 const addon = require(`./build/${buildType}/test_reference_all_types`);
 
 async function runTests() {
-  let entryCount = 0;
+  let allEntries = [];
 
   (() => {
     // Create values of all napi_valuetype types.
@@ -23,41 +23,40 @@ async function runTests() {
     const externalValue = addon.createExternal();
     const bigintValue = 9007199254740991n;
 
-    const allValues = [
-      undefinedValue,
-      nullValue,
-      booleanValue,
-      numberValue,
-      stringValue,
-      symbolValue,
-      objectValue,
-      functionValue,
-      externalValue,
-      bigintValue,
+    allEntries = [
+      { value: undefinedValue, canBeWeak: false },
+      { value: nullValue, canBeWeak: false },
+      { value: booleanValue, canBeWeak: false },
+      { value: numberValue, canBeWeak: false },
+      { value: stringValue, canBeWeak: false },
+      { value: symbolValue, canBeWeak: false },
+      { value: objectValue, canBeWeak: true },
+      { value: functionValue, canBeWeak: true },
+      { value: externalValue, canBeWeak: true },
+      { value: bigintValue, canBeWeak: false },
     ];
-    entryCount = allValues.length;
-    const objectValueIndex = allValues.indexOf(objectValue);
-    const functionValueIndex = allValues.indexOf(functionValue);
 
     // Go over all values of different types, create strong ref values for
     // them, read the stored values, and check how the ref count works.
-    for (const value of allValues) {
-      const index = addon.createRef(value);
+    for (const entry of allEntries) {
+      const index = addon.createRef(entry.value);
       const refValue = addon.getRefValue(index);
-      assert.strictEqual(value, refValue);
+      assert.strictEqual(entry.value, refValue);
       assert.strictEqual(addon.ref(index), 2);
       assert.strictEqual(addon.unref(index), 1);
       assert.strictEqual(addon.unref(index), 0);
     }
 
     // The references become weak pointers when the ref count is 0.
-    // To be compatible with the JavaScript spec we expect these
-    // types to be objects and functions.
     // Here we know that the GC is not run yet because the values are
-    // still in the allValues array.
-    assert.strictEqual(addon.getRefValue(objectValueIndex), objectValue);
-    assert.strictEqual(addon.getRefValue(functionValueIndex), functionValue);
+    // still in the allEntries array.
+    allEntries.forEach((entry, index) => {
+      assert.strictEqual(addon.getRefValue(index), entry.value);
+      // Set to undefined to allow GC collect the value.
+      entry.value = undefined;
+    });
 
+    // To check that GC pass is done.
     const objWithFinalizer = {};
     addon.addFinalizer(objWithFinalizer);
   })();
@@ -66,21 +65,25 @@ async function runTests() {
   await gcUntil('Wait until a finalizer is called',
                 () => (addon.getFinalizeCount() === 1));
 
-  // Create and call finalizer again to make sure that all finalizers are run.
+  // Create and call finalizer again to make sure that we had another GC pass.
   (() => {
     const objWithFinalizer = {};
     addon.addFinalizer(objWithFinalizer);
   })();
-
   await gcUntil('Wait until a finalizer is called again',
-                () => (addon.getFinalizeCount() === 1));
+                () => (addon.getFinalizeCount() === 2));
 
-  // After GC and finalizers run, all references with refCount==0 must return
-  // undefined value.
-  for (let i = 0; i < entryCount; ++i) {
-    const refValue = addon.getRefValue(i);
-    assert.strictEqual(refValue, undefined);
-    addon.deleteRef(i);
-  }
+  // After GC and finalizers run, all values that support weak reference
+  // semantic must return undefined value.
+  // It also includes the value at index 0 because it is the undefined value.
+  // Other value types are not collected by GC.
+  allEntries.forEach((entry, index) => {
+    if (entry.canBeWeak || index === 0) {
+      assert.strictEqual(addon.getRefValue(index), undefined);
+    } else {
+      assert.notStrictEqual(addon.getRefValue(index), undefined);
+    }
+    addon.deleteRef(index);
+  });
 }
 runTests();

--- a/test/js-native-api/test_reference_all_types/test_reference_all_types.c
+++ b/test/js-native-api/test_reference_all_types/test_reference_all_types.c
@@ -1,0 +1,183 @@
+#include "../common.h"
+#include "stdlib.h"
+
+#define NODE_API_ASSERT_STATUS(env, assertion, message)                        \
+  NODE_API_ASSERT_BASE(env, assertion, message, napi_generic_failure)
+
+#define NODE_API_CHECK_STATUS(env, the_call)                                   \
+  do {                                                                         \
+    napi_status status = (the_call);                                           \
+    if (status != napi_ok) {                                                   \
+      return status;                                                           \
+    }                                                                          \
+  } while (0)
+
+static uint32_t finalizeCount = 0;
+
+static void FreeData(napi_env env, void* data, void* hint) {
+  NODE_API_ASSERT_RETURN_VOID(env, data != NULL, "Expects non-NULL data.");
+  free(data);
+}
+
+static void Finalize(napi_env env, void* data, void* hint) {
+  ++finalizeCount;
+}
+
+static napi_status GetArgValue(napi_env env,
+                               napi_callback_info info,
+                               napi_value* argValue) {
+  size_t argc = 1;
+  NODE_API_CHECK_STATUS(
+      env, napi_get_cb_info(env, info, &argc, argValue, NULL, NULL));
+
+  NODE_API_ASSERT_STATUS(env, argc == 1, "Expects one arg.");
+  return napi_ok;
+}
+
+static napi_status GetArgValueAsIndex(napi_env env,
+                                      napi_callback_info info,
+                                      uint32_t* index) {
+  napi_value argValue;
+  NODE_API_CHECK_STATUS(env, GetArgValue(env, info, &argValue));
+
+  napi_valuetype valueType;
+  NODE_API_CHECK_STATUS(env, napi_typeof(env, argValue, &valueType));
+  NODE_API_ASSERT_STATUS(
+      env, valueType == napi_number, "Argument must be a number.");
+
+  return napi_get_value_uint32(env, argValue, index);
+}
+
+static napi_status GetRef(napi_env env,
+                          napi_callback_info info,
+                          napi_ref* ref) {
+  uint32_t index;
+  NODE_API_CHECK_STATUS(env, GetArgValueAsIndex(env, info, &index));
+
+  napi_ref* refValues;
+  NODE_API_CHECK_STATUS(env, napi_get_instance_data(env, (void**)&refValues));
+  NODE_API_ASSERT_STATUS(env, refValues != NULL, "Cannot get instance data.");
+
+  *ref = refValues[index];
+  return napi_ok;
+}
+
+static napi_value ToUInt32Value(napi_env env, uint32_t value) {
+  napi_value result;
+  NODE_API_CALL(env, napi_create_uint32(env, value, &result));
+  return result;
+}
+
+static napi_status CheckFeature(napi_env env) {
+  bool canReferenceAllTypes;
+  NODE_API_CHECK_STATUS(
+      env,
+      napi_is_feature_enabled(
+          env, napi_feature_reference_all_types, &canReferenceAllTypes));
+  NODE_API_ASSERT_STATUS(
+      env, canReferenceAllTypes, "Must be able to reference all value types.");
+  return napi_ok;
+}
+
+static napi_status InitRefArray(napi_env env) {
+  // valueRefs array has one entry per napi_valuetype
+  napi_ref* valueRefs = malloc(sizeof(napi_ref) * ((int)napi_bigint + 1));
+  return napi_set_instance_data(env, valueRefs, &FreeData, NULL);
+}
+
+static napi_value CreateExternal(napi_env env, napi_callback_info info) {
+  napi_value result;
+  int* data = (int*)malloc(sizeof(int));
+  *data = 42;
+  NODE_API_CALL(env, napi_create_external(env, data, &FreeData, NULL, &result));
+  return result;
+}
+
+static napi_value CreateRef(napi_env env, napi_callback_info info) {
+  napi_value argValue;
+  NODE_API_CALL(env, GetArgValue(env, info, &argValue));
+
+  napi_valuetype valueType;
+  NODE_API_CALL(env, napi_typeof(env, argValue, &valueType));
+  uint32_t index = (uint32_t)valueType;
+
+  napi_ref* valueRefs;
+  NODE_API_CALL(env, napi_get_instance_data(env, (void**)&valueRefs));
+  NODE_API_CALL(env,
+                napi_create_reference(env, argValue, 1, valueRefs + index));
+
+  return ToUInt32Value(env, index);
+}
+
+static napi_value GetRefValue(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  napi_value value;
+  NODE_API_CALL(env, napi_get_reference_value(env, refValue, &value));
+  return value;
+}
+
+static napi_value Ref(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  uint32_t refCount;
+  NODE_API_CALL(env, napi_reference_ref(env, refValue, &refCount));
+  return ToUInt32Value(env, refCount);
+}
+
+static napi_value Unref(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  uint32_t refCount;
+  NODE_API_CALL(env, napi_reference_unref(env, refValue, &refCount));
+  return ToUInt32Value(env, refCount);
+}
+
+static napi_value DeleteRef(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  NODE_API_CALL(env, napi_delete_reference(env, refValue));
+  return NULL;
+}
+
+static napi_value AddFinalizer(napi_env env, napi_callback_info info) {
+  napi_value obj;
+  NODE_API_CALL(env, GetArgValue(env, info, &obj));
+
+  napi_valuetype valueType;
+  NODE_API_CALL(env, napi_typeof(env, obj, &valueType));
+  NODE_API_ASSERT(env, valueType == napi_object, "Argument must be an object.");
+
+  NODE_API_CALL(env, napi_add_finalizer(env, obj, NULL, &Finalize, NULL, NULL));
+  return NULL;
+}
+
+static napi_value GetFinalizeCount(napi_env env, napi_callback_info info) {
+  return ToUInt32Value(env, finalizeCount);
+}
+
+EXTERN_C_START
+napi_value Init(napi_env env, napi_value exports) {
+  finalizeCount = 0;
+  NODE_API_CALL(env, CheckFeature(env));
+  NODE_API_CALL(env, InitRefArray(env));
+
+  napi_property_descriptor properties[] = {
+      DECLARE_NODE_API_PROPERTY("createExternal", CreateExternal),
+      DECLARE_NODE_API_PROPERTY("createRef", CreateRef),
+      DECLARE_NODE_API_PROPERTY("getRefValue", GetRefValue),
+      DECLARE_NODE_API_PROPERTY("ref", Ref),
+      DECLARE_NODE_API_PROPERTY("unref", Unref),
+      DECLARE_NODE_API_PROPERTY("deleteRef", DeleteRef),
+      DECLARE_NODE_API_PROPERTY("addFinalizer", AddFinalizer),
+      DECLARE_NODE_API_PROPERTY("getFinalizeCount", GetFinalizeCount),
+  };
+
+  NODE_API_CALL(
+      env,
+      napi_define_properties(
+          env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
+}
+EXTERN_C_END

--- a/test/js-native-api/test_reference_all_types/test_reference_all_types.c
+++ b/test/js-native-api/test_reference_all_types/test_reference_all_types.c
@@ -72,8 +72,8 @@ static napi_status CheckFeature(napi_env env) {
   bool canReferenceAllTypes;
   NODE_API_CHECK_STATUS(
       env,
-      napi_is_feature_enabled(
-          env, napi_feature_reference_all_types, &canReferenceAllTypes));
+      node_api_is_feature_enabled(
+          env, node_api_feature_reference_all_types, &canReferenceAllTypes));
   NODE_API_ASSERT_STATUS(
       env, canReferenceAllTypes, "Must be able to reference all value types.");
   return napi_ok;
@@ -157,6 +157,7 @@ static napi_value GetFinalizeCount(napi_env env, napi_callback_info info) {
 }
 
 EXTERN_C_START
+
 napi_value Init(napi_env env, napi_value exports) {
   finalizeCount = 0;
   NODE_API_CALL(env, CheckFeature(env));

--- a/test/node-api/test_init_reference_all_types/binding.gyp
+++ b/test/node-api/test_init_reference_all_types/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_init_reference_all_types",
+      "sources": [ "test_init_reference_all_types.c" ]
+    }
+  ]
+}

--- a/test/node-api/test_init_reference_all_types/test.js
+++ b/test/node-api/test_init_reference_all_types/test.js
@@ -1,0 +1,87 @@
+'use strict';
+// Flags: --expose-gc
+
+const { gcUntil, buildType } = require('../../common');
+const assert = require('assert');
+
+// Testing API calls for references to all value types.
+// This test uses NAPI_MODULE_INIT macro to initialize module.
+const addon = require(`./build/${buildType}/test_init_reference_all_types`);
+
+async function runTests() {
+  let entryCount = 0;
+
+  (() => {
+    // Create values of all napi_valuetype types.
+    const undefinedValue = undefined;
+    const nullValue = null;
+    const booleanValue = false;
+    const numberValue = 42;
+    const stringValue = 'test_string';
+    const symbolValue = Symbol.for('test_symbol');
+    const objectValue = { x: 1, y: 2 };
+    const functionValue = (x, y) => x + y;
+    const externalValue = addon.createExternal();
+    const bigintValue = 9007199254740991n;
+
+    const allValues = [
+      undefinedValue,
+      nullValue,
+      booleanValue,
+      numberValue,
+      stringValue,
+      symbolValue,
+      objectValue,
+      functionValue,
+      externalValue,
+      bigintValue,
+    ];
+    entryCount = allValues.length;
+    const objectValueIndex = allValues.indexOf(objectValue);
+    const functionValueIndex = allValues.indexOf(functionValue);
+
+    // Go over all values of different types, create strong ref values for
+    // them, read the stored values, and check how the ref count works.
+    for (const value of allValues) {
+      const index = addon.createRef(value);
+      const refValue = addon.getRefValue(index);
+      assert.strictEqual(value, refValue);
+      assert.strictEqual(addon.ref(index), 2);
+      assert.strictEqual(addon.unref(index), 1);
+      assert.strictEqual(addon.unref(index), 0);
+    }
+
+    // The references become weak pointers when the ref count is 0.
+    // To be compatible with the JavaScript spec we expect these
+    // types to be objects and functions.
+    // Here we know that the GC is not run yet because the values are
+    // still in the allValues array.
+    assert.strictEqual(addon.getRefValue(objectValueIndex), objectValue);
+    assert.strictEqual(addon.getRefValue(functionValueIndex), functionValue);
+
+    const objWithFinalizer = {};
+    addon.addFinalizer(objWithFinalizer);
+  })();
+
+  assert.strictEqual(addon.getFinalizeCount(), 0);
+  await gcUntil('Wait until a finalizer is called',
+                () => (addon.getFinalizeCount() === 1));
+
+  // Create and call finalizer again to make sure that all finalizers are run.
+  (() => {
+    const objWithFinalizer = {};
+    addon.addFinalizer(objWithFinalizer);
+  })();
+
+  await gcUntil('Wait until a finalizer is called again',
+                () => (addon.getFinalizeCount() === 1));
+
+  // After GC and finalizers run, all references with refCount==0 must return
+  // undefined value.
+  for (let i = 0; i < entryCount; ++i) {
+    const refValue = addon.getRefValue(i);
+    assert.strictEqual(refValue, undefined);
+    addon.deleteRef(i);
+  }
+}
+runTests();

--- a/test/node-api/test_init_reference_all_types/test_init_reference_all_types.c
+++ b/test/node-api/test_init_reference_all_types/test_init_reference_all_types.c
@@ -74,8 +74,8 @@ static napi_status CheckFeature(napi_env env) {
   bool canReferenceAllTypes;
   NODE_API_CHECK_STATUS(
       env,
-      napi_is_feature_enabled(
-          env, napi_feature_reference_all_types, &canReferenceAllTypes));
+      node_api_is_feature_enabled(
+          env, node_api_feature_reference_all_types, &canReferenceAllTypes));
   NODE_API_ASSERT_STATUS(
       env, canReferenceAllTypes, "Must be able to reference all value types.");
   return napi_ok;

--- a/test/node-api/test_init_reference_all_types/test_init_reference_all_types.c
+++ b/test/node-api/test_init_reference_all_types/test_init_reference_all_types.c
@@ -1,0 +1,187 @@
+#define NAPI_EXPERIMENTAL
+#include <node_api.h>
+#include "../../js-native-api/common.h"
+#include "stdlib.h"
+
+#define NODE_API_ASSERT_STATUS(env, assertion, message)                        \
+  NODE_API_ASSERT_BASE(env, assertion, message, napi_generic_failure)
+
+#define NODE_API_CHECK_STATUS(env, the_call)                                   \
+  do {                                                                         \
+    napi_status status = (the_call);                                           \
+    if (status != napi_ok) {                                                   \
+      return status;                                                           \
+    }                                                                          \
+  } while (0)
+
+static uint32_t finalizeCount = 0;
+
+static void FreeData(napi_env env, void* data, void* hint) {
+  NODE_API_ASSERT_RETURN_VOID(env, data != NULL, "Expects non-NULL data.");
+  free(data);
+}
+
+static void Finalize(napi_env env, void* data, void* hint) {
+  ++finalizeCount;
+}
+
+static napi_status GetArgValue(napi_env env,
+                               napi_callback_info info,
+                               napi_value* argValue) {
+  size_t argc = 1;
+  NODE_API_CHECK_STATUS(
+      env, napi_get_cb_info(env, info, &argc, argValue, NULL, NULL));
+
+  NODE_API_ASSERT_STATUS(env, argc == 1, "Expects one arg.");
+  return napi_ok;
+}
+
+static napi_status GetArgValueAsIndex(napi_env env,
+                                      napi_callback_info info,
+                                      uint32_t* index) {
+  napi_value argValue;
+  NODE_API_CHECK_STATUS(env, GetArgValue(env, info, &argValue));
+
+  napi_valuetype valueType;
+  NODE_API_CHECK_STATUS(env, napi_typeof(env, argValue, &valueType));
+  NODE_API_ASSERT_STATUS(
+      env, valueType == napi_number, "Argument must be a number.");
+
+  return napi_get_value_uint32(env, argValue, index);
+}
+
+static napi_status GetRef(napi_env env,
+                          napi_callback_info info,
+                          napi_ref* ref) {
+  uint32_t index;
+  NODE_API_CHECK_STATUS(env, GetArgValueAsIndex(env, info, &index));
+
+  napi_ref* refValues;
+  NODE_API_CHECK_STATUS(env, napi_get_instance_data(env, (void**)&refValues));
+  NODE_API_ASSERT_STATUS(env, refValues != NULL, "Cannot get instance data.");
+
+  *ref = refValues[index];
+  return napi_ok;
+}
+
+static napi_value ToUInt32Value(napi_env env, uint32_t value) {
+  napi_value result;
+  NODE_API_CALL(env, napi_create_uint32(env, value, &result));
+  return result;
+}
+
+static napi_status CheckFeature(napi_env env) {
+  bool canReferenceAllTypes;
+  NODE_API_CHECK_STATUS(
+      env,
+      napi_is_feature_enabled(
+          env, napi_feature_reference_all_types, &canReferenceAllTypes));
+  NODE_API_ASSERT_STATUS(
+      env, canReferenceAllTypes, "Must be able to reference all value types.");
+  return napi_ok;
+}
+
+static napi_status InitRefArray(napi_env env) {
+  // valueRefs array has one entry per napi_valuetype
+  napi_ref* valueRefs = malloc(sizeof(napi_ref) * ((int)napi_bigint + 1));
+  return napi_set_instance_data(env, valueRefs, &FreeData, NULL);
+}
+
+static napi_value CreateExternal(napi_env env, napi_callback_info info) {
+  napi_value result;
+  int* data = (int*)malloc(sizeof(int));
+  *data = 42;
+  NODE_API_CALL(env, napi_create_external(env, data, &FreeData, NULL, &result));
+  return result;
+}
+
+static napi_value CreateRef(napi_env env, napi_callback_info info) {
+  napi_value argValue;
+  NODE_API_CALL(env, GetArgValue(env, info, &argValue));
+
+  napi_valuetype valueType;
+  NODE_API_CALL(env, napi_typeof(env, argValue, &valueType));
+  uint32_t index = (uint32_t)valueType;
+
+  napi_ref* valueRefs;
+  NODE_API_CALL(env, napi_get_instance_data(env, (void**)&valueRefs));
+  NODE_API_CALL(env,
+                napi_create_reference(env, argValue, 1, valueRefs + index));
+
+  return ToUInt32Value(env, index);
+}
+
+static napi_value GetRefValue(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  napi_value value;
+  NODE_API_CALL(env, napi_get_reference_value(env, refValue, &value));
+  return value;
+}
+
+static napi_value Ref(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  uint32_t refCount;
+  NODE_API_CALL(env, napi_reference_ref(env, refValue, &refCount));
+  return ToUInt32Value(env, refCount);
+}
+
+static napi_value Unref(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  uint32_t refCount;
+  NODE_API_CALL(env, napi_reference_unref(env, refValue, &refCount));
+  return ToUInt32Value(env, refCount);
+}
+
+static napi_value DeleteRef(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  NODE_API_CALL(env, napi_delete_reference(env, refValue));
+  return NULL;
+}
+
+static napi_value AddFinalizer(napi_env env, napi_callback_info info) {
+  napi_value obj;
+  NODE_API_CALL(env, GetArgValue(env, info, &obj));
+
+  napi_valuetype valueType;
+  NODE_API_CALL(env, napi_typeof(env, obj, &valueType));
+  NODE_API_ASSERT(env, valueType == napi_object, "Argument must be an object.");
+
+  NODE_API_CALL(env, napi_add_finalizer(env, obj, NULL, &Finalize, NULL, NULL));
+  return NULL;
+}
+
+static napi_value GetFinalizeCount(napi_env env, napi_callback_info info) {
+  return ToUInt32Value(env, finalizeCount);
+}
+
+EXTERN_C_START
+
+NAPI_MODULE_INIT() {
+  finalizeCount = 0;
+  NODE_API_CALL(env, CheckFeature(env));
+  NODE_API_CALL(env, InitRefArray(env));
+
+  napi_property_descriptor properties[] = {
+      DECLARE_NODE_API_PROPERTY("createExternal", CreateExternal),
+      DECLARE_NODE_API_PROPERTY("createRef", CreateRef),
+      DECLARE_NODE_API_PROPERTY("getRefValue", GetRefValue),
+      DECLARE_NODE_API_PROPERTY("ref", Ref),
+      DECLARE_NODE_API_PROPERTY("unref", Unref),
+      DECLARE_NODE_API_PROPERTY("deleteRef", DeleteRef),
+      DECLARE_NODE_API_PROPERTY("addFinalizer", AddFinalizer),
+      DECLARE_NODE_API_PROPERTY("getFinalizeCount", GetFinalizeCount),
+  };
+
+  NODE_API_CALL(
+      env,
+      napi_define_properties(
+          env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
+}
+
+EXTERN_C_END

--- a/test/node-api/test_init_reference_obj_only/binding.gyp
+++ b/test/node-api/test_init_reference_obj_only/binding.gyp
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    {
+      "target_name": "test_init_reference_obj_only",
+      "sources": [ "test_init_reference_obj_only.c" ],
+      'defines': [ 'NAPI_CUSTOM_FEATURES' ]
+    }
+  ]
+}

--- a/test/node-api/test_init_reference_obj_only/binding.gyp
+++ b/test/node-api/test_init_reference_obj_only/binding.gyp
@@ -3,7 +3,7 @@
     {
       "target_name": "test_init_reference_obj_only",
       "sources": [ "test_init_reference_obj_only.c" ],
-      'defines': [ 'NAPI_CUSTOM_FEATURES' ]
+      'defines': [ 'NODE_API_CUSTOM_FEATURES' ]
     }
   ]
 }

--- a/test/node-api/test_init_reference_obj_only/test.js
+++ b/test/node-api/test_init_reference_obj_only/test.js
@@ -1,0 +1,102 @@
+'use strict';
+// Flags: --expose-gc
+
+const { gcUntil, buildType } = require('../../common');
+const assert = require('assert');
+
+// Testing API calls for references to only object, function, and symbol types.
+// This is the reference behavior before when the
+// napi_feature_reference_all_types feature is not enabled.
+// This test uses NAPI_MODULE_INIT macro to initialize module.
+const addon = require(`./build/${buildType}/test_init_reference_obj_only`);
+
+async function runTests() {
+  let entryCount = 0;
+  let refIndexes = [];
+  let symbolValueIndex = -1;
+
+  (() => {
+    // Create values of all napi_valuetype types.
+    const undefinedValue = undefined;
+    const nullValue = null;
+    const booleanValue = false;
+    const numberValue = 42;
+    const stringValue = 'test_string';
+    const symbolValue = Symbol.for('test_symbol');
+    const objectValue = { x: 1, y: 2 };
+    const functionValue = (x, y) => x + y;
+    const externalValue = addon.createExternal();
+    const bigintValue = 9007199254740991n;
+
+    // true if the value can be a ref.
+    const allEntries = [
+      [ undefinedValue, false ],
+      [ nullValue, false ],
+      [ booleanValue, false ],
+      [ numberValue, false ],
+      [ stringValue, false ],
+      [ symbolValue, true ],
+      [ objectValue, true ],
+      [ functionValue, true ],
+      [ externalValue, true ],
+      [ bigintValue, false ],
+    ];
+    entryCount = allEntries.length;
+    symbolValueIndex = allEntries.findIndex(entry => entry[0] === symbolValue);
+
+    // Go over all values of different types, create strong ref values for
+    // them, read the stored values, and check how the ref count works.
+    for (const entry of allEntries) {
+      const value = entry[0];
+      if (entry[1]) {
+        const index = addon.createRef(value);
+        const refValue = addon.getRefValue(index);
+        assert.strictEqual(value, refValue);
+        assert.strictEqual(addon.ref(index), 2);
+        assert.strictEqual(addon.unref(index), 1);
+        assert.strictEqual(addon.unref(index), 0);
+      } else {
+        assert.throws(() => addon.createRef(value));
+      }
+    }
+
+    // The references become weak pointers when the ref count is 0.
+    // The old reference were supported for objects, functions, and symbols.
+    // Here we know that the GC is not run yet because the values are
+    // still in the allValues array.
+    for (let i = 0; i < entryCount; ++i) {
+      if (allEntries[i][1]) {
+        assert.strictEqual(addon.getRefValue(i), allEntries[i][0]);
+        refIndexes.push(i);
+      }
+    }
+
+    const objWithFinalizer = {};
+    addon.addFinalizer(objWithFinalizer);
+  })();
+
+  assert.strictEqual(addon.getFinalizeCount(), 0);
+  await gcUntil('Wait until a finalizer is called',
+                () => (addon.getFinalizeCount() === 1));
+
+  // Create and call finalizer again to make sure that all finalizers are run.
+  (() => {
+    const objWithFinalizer = {};
+    addon.addFinalizer(objWithFinalizer);
+  })();
+
+  await gcUntil('Wait until a finalizer is called again',
+                () => (addon.getFinalizeCount() === 1));
+
+  // After GC and finalizers run, all references with refCount==0 must return
+  // undefined value.
+  for (const index of refIndexes) {
+    const refValue = addon.getRefValue(index);
+    // Symbols do not support the weak semantic
+    if (symbolValueIndex !== 5) {
+      assert.strictEqual(refValue, undefined);
+    }
+    addon.deleteRef(index);
+  }
+}
+runTests();

--- a/test/node-api/test_init_reference_obj_only/test_init_reference_obj_only.c
+++ b/test/node-api/test_init_reference_obj_only/test_init_reference_obj_only.c
@@ -1,0 +1,190 @@
+#define NAPI_EXPERIMENTAL
+#include <node_api.h>
+#include "../../js-native-api/common.h"
+#include "stdlib.h"
+
+#define NODE_API_ASSERT_STATUS(env, assertion, message)                        \
+  NODE_API_ASSERT_BASE(env, assertion, message, napi_generic_failure)
+
+#define NODE_API_CHECK_STATUS(env, the_call)                                   \
+  do {                                                                         \
+    napi_status status = (the_call);                                           \
+    if (status != napi_ok) {                                                   \
+      return status;                                                           \
+    }                                                                          \
+  } while (0)
+
+static uint32_t finalizeCount = 0;
+
+static void FreeData(napi_env env, void* data, void* hint) {
+  NODE_API_ASSERT_RETURN_VOID(env, data != NULL, "Expects non-NULL data.");
+  free(data);
+}
+
+static void Finalize(napi_env env, void* data, void* hint) {
+  ++finalizeCount;
+}
+
+static napi_status GetArgValue(napi_env env,
+                               napi_callback_info info,
+                               napi_value* argValue) {
+  size_t argc = 1;
+  NODE_API_CHECK_STATUS(
+      env, napi_get_cb_info(env, info, &argc, argValue, NULL, NULL));
+
+  NODE_API_ASSERT_STATUS(env, argc == 1, "Expects one arg.");
+  return napi_ok;
+}
+
+static napi_status GetArgValueAsIndex(napi_env env,
+                                      napi_callback_info info,
+                                      uint32_t* index) {
+  napi_value argValue;
+  NODE_API_CHECK_STATUS(env, GetArgValue(env, info, &argValue));
+
+  napi_valuetype valueType;
+  NODE_API_CHECK_STATUS(env, napi_typeof(env, argValue, &valueType));
+  NODE_API_ASSERT_STATUS(
+      env, valueType == napi_number, "Argument must be a number.");
+
+  return napi_get_value_uint32(env, argValue, index);
+}
+
+static napi_status GetRef(napi_env env,
+                          napi_callback_info info,
+                          napi_ref* ref) {
+  uint32_t index;
+  NODE_API_CHECK_STATUS(env, GetArgValueAsIndex(env, info, &index));
+
+  napi_ref* refValues;
+  NODE_API_CHECK_STATUS(env, napi_get_instance_data(env, (void**)&refValues));
+  NODE_API_ASSERT_STATUS(env, refValues != NULL, "Cannot get instance data.");
+
+  *ref = refValues[index];
+  return napi_ok;
+}
+
+static napi_value ToUInt32Value(napi_env env, uint32_t value) {
+  napi_value result;
+  NODE_API_CALL(env, napi_create_uint32(env, value, &result));
+  return result;
+}
+
+static napi_status CheckFeature(napi_env env) {
+  bool canReferenceAllTypes;
+  NODE_API_CHECK_STATUS(
+      env,
+      napi_is_feature_enabled(
+          env, napi_feature_reference_all_types, &canReferenceAllTypes));
+  NODE_API_ASSERT_STATUS(
+      env, !canReferenceAllTypes, "Must not be able to reference all value types.");
+  return napi_ok;
+}
+
+static napi_status InitRefArray(napi_env env) {
+  // valueRefs array has one entry per napi_valuetype
+  napi_ref* valueRefs = malloc(sizeof(napi_ref) * ((int)napi_bigint + 1));
+  return napi_set_instance_data(env, valueRefs, &FreeData, NULL);
+}
+
+static napi_value CreateExternal(napi_env env, napi_callback_info info) {
+  napi_value result;
+  int* data = (int*)malloc(sizeof(int));
+  *data = 42;
+  NODE_API_CALL(env, napi_create_external(env, data, &FreeData, NULL, &result));
+  return result;
+}
+
+static napi_value CreateRef(napi_env env, napi_callback_info info) {
+  napi_value argValue;
+  NODE_API_CALL(env, GetArgValue(env, info, &argValue));
+
+  napi_valuetype valueType;
+  NODE_API_CALL(env, napi_typeof(env, argValue, &valueType));
+  uint32_t index = (uint32_t)valueType;
+
+  napi_ref* valueRefs;
+  NODE_API_CALL(env, napi_get_instance_data(env, (void**)&valueRefs));
+  NODE_API_CALL(env,
+                napi_create_reference(env, argValue, 1, valueRefs + index));
+
+  return ToUInt32Value(env, index);
+}
+
+static napi_value GetRefValue(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  napi_value value;
+  NODE_API_CALL(env, napi_get_reference_value(env, refValue, &value));
+  return value;
+}
+
+static napi_value Ref(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  uint32_t refCount;
+  NODE_API_CALL(env, napi_reference_ref(env, refValue, &refCount));
+  return ToUInt32Value(env, refCount);
+}
+
+static napi_value Unref(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  uint32_t refCount;
+  NODE_API_CALL(env, napi_reference_unref(env, refValue, &refCount));
+  return ToUInt32Value(env, refCount);
+}
+
+static napi_value DeleteRef(napi_env env, napi_callback_info info) {
+  napi_ref refValue;
+  NODE_API_CALL(env, GetRef(env, info, &refValue));
+  NODE_API_CALL(env, napi_delete_reference(env, refValue));
+  return NULL;
+}
+
+static napi_value AddFinalizer(napi_env env, napi_callback_info info) {
+  napi_value obj;
+  NODE_API_CALL(env, GetArgValue(env, info, &obj));
+
+  napi_valuetype valueType;
+  NODE_API_CALL(env, napi_typeof(env, obj, &valueType));
+  NODE_API_ASSERT(env, valueType == napi_object, "Argument must be an object.");
+
+  NODE_API_CALL(env, napi_add_finalizer(env, obj, NULL, &Finalize, NULL, NULL));
+  return NULL;
+}
+
+static napi_value GetFinalizeCount(napi_env env, napi_callback_info info) {
+  return ToUInt32Value(env, finalizeCount);
+}
+
+EXTERN_C_START
+
+NAPI_MODULE_INIT() {
+  finalizeCount = 0;
+  NODE_API_CALL(env, CheckFeature(env));
+  NODE_API_CALL(env, InitRefArray(env));
+
+  napi_property_descriptor properties[] = {
+      DECLARE_NODE_API_PROPERTY("createExternal", CreateExternal),
+      DECLARE_NODE_API_PROPERTY("createRef", CreateRef),
+      DECLARE_NODE_API_PROPERTY("getRefValue", GetRefValue),
+      DECLARE_NODE_API_PROPERTY("ref", Ref),
+      DECLARE_NODE_API_PROPERTY("unref", Unref),
+      DECLARE_NODE_API_PROPERTY("deleteRef", DeleteRef),
+      DECLARE_NODE_API_PROPERTY("addFinalizer", AddFinalizer),
+      DECLARE_NODE_API_PROPERTY("getFinalizeCount", GetFinalizeCount),
+  };
+
+  NODE_API_CALL(
+      env,
+      napi_define_properties(
+          env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
+}
+
+// Make sure that this test uses the old napi_ref behavior.
+napi_features napi_module_features = napi_default_features & ~napi_feature_reference_all_types;
+
+EXTERN_C_END

--- a/test/node-api/test_init_reference_obj_only/test_init_reference_obj_only.c
+++ b/test/node-api/test_init_reference_obj_only/test_init_reference_obj_only.c
@@ -74,10 +74,11 @@ static napi_status CheckFeature(napi_env env) {
   bool canReferenceAllTypes;
   NODE_API_CHECK_STATUS(
       env,
-      napi_is_feature_enabled(
-          env, napi_feature_reference_all_types, &canReferenceAllTypes));
-  NODE_API_ASSERT_STATUS(
-      env, !canReferenceAllTypes, "Must not be able to reference all value types.");
+      node_api_is_feature_enabled(
+          env, node_api_feature_reference_all_types, &canReferenceAllTypes));
+  NODE_API_ASSERT_STATUS(env,
+                         !canReferenceAllTypes,
+                         "Must not be able to reference all value types.");
   return napi_ok;
 }
 
@@ -185,6 +186,7 @@ NAPI_MODULE_INIT() {
 }
 
 // Make sure that this test uses the old napi_ref behavior.
-napi_features napi_module_features = napi_default_features & ~napi_feature_reference_all_types;
+node_api_features node_api_module_features =
+    node_api_default_features & ~node_api_feature_reference_all_types;
 
 EXTERN_C_END


### PR DESCRIPTION
### The issue

In the Node-API the `napi_value` exists only on the call stack. When the value needs to be persisted after the call stack is unwinded, we can use the `napi_ref`. Currently the `napi_ref` keeps `napi_value` only for `napi_object`, `napi_function`, `napi_external`, and `napi_symbol` types because `napi_ref` must support weak pointer semantic. Thus, there was a decision to not keep persistent values for other types such as `napi_string` or `napi_number`. Though, the `napi_symbol` cannot have the weak semantic, but we still can have a `napi_ref` for it.

### Solution

In this PR we enable use of `napi_ref` for strong references to all `napi_value` types. Though, only references for `napi_object`, `napi_external`, and `napi_function` types could have the true weak reference semantic. These three types could be collected by GC when the ref count is 0, while other types cannot be collected because they are always string references. To keep the backward compatibility, this PR enables the new behavior under a special `node_api_features` bit flag `node_api_feature_reference_all_types`. The `node_api_features` are being introduced in this PR.

The new `node_api_features` allow changing internal behavior of existing Node-API functions.

We pass a `node_api_features` pointer to the `napi_module` struct in the `NAPI_MODULE_X` macro. This macro is used for the module registration. If the module is initialized without using this macro, then there will be no features selected and the module will use the `node_api_feature_none`.

Each Node-API version is going to define its own default set of features. For the current version it can be accessed using `node_api_default_features`. A module can override the set of its enabled features by adding `NODE_API_CUSTOM_FEATURES` definition to the `.gyp` file and then setting the value of the global `node_api_module_features` variable. To check enabled features, use the `node_api_is_feature_enabled` function.

For example, to disable `node_api_feature_reference_all_types` we can exclude its bit from the `node_api_default_features`:
```c
node_api_features node_api_module_features =
    node_api_default_features & ~node_api_feature_reference_all_types;
```

### Documentation

The `n-api.md` documentation is updated with the info about `node_api_features` enum and the `node_api_is_feature_enabled` function.

### Testing

Added three new tests:

- `js-native-api/test_reference_all_types`.
  The test stores `napi_value` of different types and then retrieves them for the strong and weak `napi_ref` references.
- `node-api/test_init_reference_all_types`. The same as the previous test, but it uses `NAPI_MODULE_INIT` macro to initialize module instead of `NAPI_MODULE`. This is to verify that both `NAPI_MODULE` and `NAPI_MODULE_INIT` macro support feature specification.
- `node-api/test_init_reference_obj_only`. To test old references behavior and module initialization with `NAPI_MODULE_INIT` macro.

The `test_reference` and `test_init_reference_obj_only` disable the `node_api_feature_reference_all_types` feature and make sure that the old `napi_ref` behavior continues to work.

The `NAPI_EXPERIMENTAL` is added to `common.h` and `entry_point.c` in `test/js-native-api` folder to make sure that the `js-native-api` tests always use the latest Node-API version features.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
