### PR TITLE
crypto: do not add undefined hash in webcrypto normalizeAlgorithm

### DIFF
--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -206,34 +206,38 @@ function validateMaxBufferLength(data, name) {
   }
 }
 
-function normalizeAlgorithm(algorithm, label = 'algorithm') {
+function normalizeAlgorithm(algorithm) {
   if (algorithm != null) {
     if (typeof algorithm === 'string')
       algorithm = { name: algorithm };
 
     if (typeof algorithm === 'object') {
       const { name } = algorithm;
-      let hash;
       if (typeof name !== 'string' ||
           !ArrayPrototypeIncludes(
             kAlgorithmsKeys,
             StringPrototypeToLowerCase(name))) {
         throw lazyDOMException('Unrecognized name.', 'NotSupportedError');
       }
-      if (algorithm.hash !== undefined) {
-        hash = normalizeAlgorithm(algorithm.hash, 'algorithm.hash');
+      let { hash } = algorithm;
+      if (hash !== undefined) {
+        hash = normalizeAlgorithm(hash);
         if (!ArrayPrototypeIncludes(kHashTypes, hash.name))
           throw lazyDOMException('Unrecognized name.', 'NotSupportedError');
       }
-      return {
+      const normalized = {
         ...algorithm,
         name: kAlgorithms[StringPrototypeToLowerCase(name)],
-        hash,
       };
+      if (hash) {
+        normalized.hash = hash;
+      }
+      return normalized;
     }
   }
   throw lazyDOMException('Unrecognized name.', 'NotSupportedError');
 }
+
 
 function hasAnyNotIn(set, checks) {
   for (const s of set)

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -238,7 +238,6 @@ function normalizeAlgorithm(algorithm) {
   throw lazyDOMException('Unrecognized name.', 'NotSupportedError');
 }
 
-
 function hasAnyNotIn(set, checks) {
   for (const s of set)
     if (!ArrayPrototypeIncludes(checks, s))

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -557,10 +557,10 @@ async function unwrapKey(
   extractable,
   keyUsages) {
   wrappedKey = getArrayBufferOrView(wrappedKey, 'wrappedKey');
-
+  unwrapAlgo = normalizeAlgorithm(unwrapAlgo);
   let keyData = await cipherOrWrap(
     kWebCryptoCipherDecrypt,
-    normalizeAlgorithm(unwrapAlgo),
+    unwrapAlgo,
     unwrappingKey,
     wrappedKey,
     'unwrapKey');

--- a/test/parallel/test-webcrypto-util.js
+++ b/test/parallel/test-webcrypto-util.js
@@ -12,13 +12,13 @@ const {
 } = require('internal/crypto/util');
 
 {
-  // Check that normalizeAlgorithm does not add an undefined hash property
+  // Check that normalizeAlgorithm does not add an undefined hash property.
   assert.strictEqual('hash' in normalizeAlgorithm({ name: 'ECDH' }), false);
   assert.strictEqual('hash' in normalizeAlgorithm('ECDH'), false);
 }
 
 {
-  // Check that normalizeAlgorithm does not mutate object inputs
+  // Check that normalizeAlgorithm does not mutate object inputs.
   const algorithm = { name: 'ECDH', hash: 'SHA-256' };
   assert.strictEqual(normalizeAlgorithm(algorithm) !== algorithm, true);
   assert.deepStrictEqual(algorithm, { name: 'ECDH', hash: 'SHA-256' });

--- a/test/parallel/test-webcrypto-utils.js
+++ b/test/parallel/test-webcrypto-utils.js
@@ -1,0 +1,25 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+
+const {
+  normalizeAlgorithm,
+} = require('internal/crypto/util');
+
+{
+  // Check that normalizeAlgorithm does not add an undefined hash property
+  assert.strictEqual('hash' in normalizeAlgorithm({ name: 'ECDH' }), false);
+  assert.strictEqual('hash' in normalizeAlgorithm('ECDH'), false);
+}
+
+{
+  // Check that normalizeAlgorithm does not mutate object inputs
+  const algorithm = { name: 'ECDH', hash: 'SHA-256' };
+  assert.strictEqual(normalizeAlgorithm(algorithm) !== algorithm, true);
+  assert.deepStrictEqual(algorithm, { name: 'ECDH', hash: 'SHA-256' });
+}


### PR DESCRIPTION
Every now and then, when working with node's WebCryptoAPI, I noticed that the key's algorithm had an `undefined` hash property that wasn't present at the time of importing/deriving/generating. This, while not affecting the functionality of webcrypto, is not expected. This PR fixes that.