### PR TITLE
doc: aes webcrypto unwrap is not a node-specific extensions

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -845,10 +845,10 @@ promise is resolved with a {CryptoKey} object.
 The wrapping algorithms currently supported include:
 
 * `'RSA-OAEP'`
-* `'AES-CTR'`[^1]
-* `'AES-CBC'`[^1]
-* `'AES-GCM'`[^1]
-* `'AES-KW'`[^1]
+* `'AES-CTR'`
+* `'AES-CBC'`
+* `'AES-GCM'`
+* `'AES-KW'`
 
 The unwrapped key algorithms supported include:
 


### PR DESCRIPTION
`'AES-CTR'`, `'AES-CBC'`, `'AES-GCM'`, and `'AES-KW'` are regular SubtleCrypto.unwrapKey algorithm, not node-specific extensions