### PR TITLE
os: avoid unnecessary usage of var

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -171,7 +171,7 @@ platform[SymbolToPrimitive] = () => process.platform;
  * @returns {string}
  */
 function tmpdir() {
-  var path;
+  let path;
   if (isWindows) {
     path = process.env.TEMP ||
            process.env.TMP ||
@@ -223,7 +223,7 @@ function getCIDR(address, netmask, family) {
   }
 
   const parts = StringPrototypeSplit(netmask, split);
-  for (var i = 0; i < parts.length; i++) {
+  for (let i = 0; i < parts.length; i++) {
     if (parts[i] !== '') {
       const binary = NumberParseInt(parts[i], range);
       const tmp = countBinaryOnes(binary);
@@ -261,7 +261,7 @@ function networkInterfaces() {
 
   if (data === undefined)
     return result;
-  for (var i = 0; i < data.length; i += 7) {
+  for (let i = 0; i < data.length; i += 7) {
     const name = data[i];
     const entry = {
       address: data[i + 1],


### PR DESCRIPTION
The `var` keyword is known to be problematic and is not needed here,
so better to use the `let` keyword for variable declarations.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
