### PR TITLE
readline: restrict access to promise API to `node:` prefix only

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -16,7 +16,7 @@ import * as readline from 'node:readline/promises';
 ```
 
 ```cjs
-const readline = require('readline/promises');
+const readline = require('node:readline/promises');
 ```
 
 To use the callback and sync APIs:
@@ -773,7 +773,7 @@ The `readlinePromises.createInterface()` method creates a new `readlinePromises.
 instance.
 
 ```js
-const readlinePromises = require('readline/promises');
+const readlinePromises = require('node:readline/promises');
 const rl = readlinePromises.createInterface({
   input: process.stdin,
   output: process.stdout

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -122,6 +122,7 @@ const legacyWrapperList = new SafeSet([
 
 // Modules that can only be imported via the node: scheme.
 const schemelessBlockList = new SafeSet([
+  'readline/promises',
   'test',
 ]);
 

--- a/test/parallel/test-readline-promises-csi.mjs
+++ b/test/parallel/test-readline-promises-csi.mjs
@@ -2,11 +2,11 @@
 
 
 import '../common/index.mjs';
-import assert from 'assert';
-import { Readline } from 'readline/promises';
-import { Writable } from 'stream';
+import assert from 'node:assert';
+import { Readline } from 'node:readline/promises';
+import { Writable } from 'node:stream';
 
-import utils from 'internal/readline/utils';
+import utils from 'node:internal/readline/utils';
 const { CSI } = utils;
 
 const INVALID_ARG = {

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -3,14 +3,14 @@
 const common = require('../common');
 common.skipIfDumbTerminal();
 
-const assert = require('assert');
-const readline = require('readline/promises');
+const assert = require('node:assert');
+const readline = require('node:readline/promises');
 const {
   getStringWidth,
   stripVTControlCharacters
-} = require('internal/util/inspect');
-const EventEmitter = require('events').EventEmitter;
-const { Writable, Readable } = require('stream');
+} = require('node:internal/util/inspect');
+const EventEmitter = require('node:events').EventEmitter;
+const { Writable, Readable } = require('node:stream');
 
 class FakeInput extends EventEmitter {
   resume() {}

--- a/test/parallel/test-readline-promises-tab-complete.js
+++ b/test/parallel/test-readline-promises-tab-complete.js
@@ -3,10 +3,10 @@
 // Flags: --expose-internals
 
 const common = require('../common');
-const readline = require('readline/promises');
-const assert = require('assert');
-const { EventEmitter } = require('events');
-const { getStringWidth } = require('internal/util/inspect');
+const readline = require('node:readline/promises');
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const { getStringWidth } = require('node:internal/util/inspect');
 
 common.skipIfDumbTerminal();
 


### PR DESCRIPTION
This one might be a long shot, but here it is: Node.js v17.0.0 introduced a new experimental core module `readline/promises`. On v17.x, it's available using either `readline/promises` or `node:readline/promises`. This PR removes its access using the prefixless name (`readline/promises` doesn't work anymore, only `node:readline/promises` does). The reason for this proposal is I still have the hope that we might be able to backport `node:`-only core modules to v16.x.

//cc @nodejs/tsc 
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
