### PR TITLE
tools: enable ESLint no-var rule in lib

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -260,6 +260,7 @@ module.exports = {
     'no-useless-concat': 'error',
     'no-useless-constructor': 'error',
     'no-useless-return': 'error',
+    'no-var': 'error',
     'no-void': 'error',
     'no-whitespace-before-property': 'error',
     'object-curly-newline': 'error',

--- a/benchmark/.eslintrc.yaml
+++ b/benchmark/.eslintrc.yaml
@@ -5,5 +5,4 @@ env:
   es6: true
 
 rules:
-  no-var: error
   prefer-arrow-callback: error

--- a/doc/.eslintrc.yaml
+++ b/doc/.eslintrc.yaml
@@ -9,7 +9,6 @@ rules:
   symbol-description: off
 
   # Add new ECMAScript features gradually
-  no-var: error
   prefer-const: error
   prefer-rest-params: error
   prefer-template: error

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -196,6 +196,7 @@ function emitInitNative(asyncId, type, triggerAsyncId, resource) {
   try {
     // Using var here instead of let because "for (var ...)" is faster than let.
     // Refs: https://github.com/nodejs/node/pull/30380#issuecomment-552948364
+    // eslint-disable-next-line no-var
     for (var i = 0; i < active_hooks.array.length; i++) {
       if (typeof active_hooks.array[i][init_symbol] === 'function') {
         active_hooks.array[i][init_symbol](
@@ -228,6 +229,7 @@ function emitHook(symbol, asyncId) {
   try {
     // Using var here instead of let because "for (var ...)" is faster than let.
     // Refs: https://github.com/nodejs/node/pull/30380#issuecomment-552948364
+    // eslint-disable-next-line no-var
     for (var i = 0; i < active_hooks.array.length; i++) {
       if (typeof active_hooks.array[i][symbol] === 'function') {
         active_hooks.array[i][symbol](asyncId);

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -71,7 +71,7 @@ function lazyRequire(name) {
   return ret;
 }
 
-var defaultEncoding = 'buffer';
+let defaultEncoding = 'buffer';
 
 function setDefaultEncoding(val) {
   defaultEncoding = val;

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -67,7 +67,7 @@ function onlookupall(err, addresses) {
 
   const family = this.family;
 
-  for (var i = 0; i < addresses.length; i++) {
+  for (let i = 0; i < addresses.length; i++) {
     const address = addresses[i];
 
     addresses[i] = {
@@ -121,10 +121,10 @@ function createLookupPromise(family, hostname, all, hints, verbatim) {
 }
 
 function lookup(hostname, options) {
-  var hints = 0;
-  var family = -1;
-  var all = false;
-  var verbatim = getDefaultVerbatim();
+  let hints = 0;
+  let family = -1;
+  let all = false;
+  let verbatim = getDefaultVerbatim();
 
   // Parse arguments
   if (hostname) {
@@ -297,7 +297,7 @@ Resolver.prototype.resolveNaptr = resolveMap.NAPTR = resolver('queryNaptr');
 Resolver.prototype.resolveSoa = resolveMap.SOA = resolver('querySoa');
 Resolver.prototype.reverse = resolver('getHostByAddr');
 Resolver.prototype.resolve = function resolve(hostname, rrtype) {
-  var resolver;
+  let resolver;
 
   if (rrtype !== undefined) {
     validateString(rrtype, 'rrtype');

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -588,7 +588,7 @@ const assertWithinRange = hideStackFrames(
 
 function toHeaderObject(headers, sensitiveHeaders) {
   const obj = ObjectCreate(null);
-  for (var n = 0; n < headers.length; n += 2) {
+  for (let n = 0; n < headers.length; n += 2) {
     const name = headers[n];
     let value = headers[n + 1];
     if (name === HTTP2_HEADER_STATUS)

--- a/lib/internal/js_stream_socket.js
+++ b/lib/internal/js_stream_socket.js
@@ -171,6 +171,7 @@ class JSStreamSocket extends Socket {
 
     this.stream.cork();
     // Use `var` over `let` for performance optimization.
+    // eslint-disable-next-line no-var
     for (var i = 0; i < bufs.length; ++i)
       this.stream.write(bufs[i], done);
     this.stream.uncork();

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -6,7 +6,6 @@ env:
 
 rules:
   multiline-comment-style: [error, separate-lines]
-  no-var: error
   prefer-const: error
   symbol-description: off
 

--- a/tools/.eslintrc.yaml
+++ b/tools/.eslintrc.yaml
@@ -12,4 +12,3 @@ rules:
     - error
     - args: after-used
   prefer-arrow-callback: error
-  no-var: error


### PR DESCRIPTION
First commit is from https://github.com/nodejs/node/pull/42563. Other two commits change the rest of the files in lib and enables the ESLint rule.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
