### PR TITLE
test: allow numeric string for lookupService test

### DIFF
--- a/test/parallel/test-dns-lookupService-promises.js
+++ b/test/parallel/test-dns-lookupService-promises.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const dnsPromises = require('dns').promises;
 
 dnsPromises.lookupService('127.0.0.1', 22).then(common.mustCall((result) => {
-  assert(['ssh', '22'].some((x) => x === result.service));
+  assert(['ssh', '22'].includes(result.service));
   assert.strictEqual(typeof result.hostname, 'string');
   assert.notStrictEqual(result.hostname.length, 0);
 }));

--- a/test/parallel/test-dns-lookupService-promises.js
+++ b/test/parallel/test-dns-lookupService-promises.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const dnsPromises = require('dns').promises;
 
 dnsPromises.lookupService('127.0.0.1', 22).then(common.mustCall((result) => {
-  assert.strictEqual(result.service, 'ssh');
+  assert(['ssh', '22'].some((x) => x === result.service));
   assert.strictEqual(typeof result.hostname, 'string');
   assert.notStrictEqual(result.hostname.length, 0);
 }));


### PR DESCRIPTION
Fixes: #42164

If the given port number isn't associated with any service name,
the `service` resolved from `dns.lookupService` can be a numeric
string representing the port number.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
