### PR TITLE
fs: runtime deprecate string coercion in `fs.write`, `fs.writeFileSync`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3114,12 +3114,15 @@ resources and not the actual references.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Runtime deprecation.
   - version: v17.8.0
     pr-url: https://github.com/nodejs/node/pull/42149
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Implicit coercion of objects with own `toString` property, passed as second
 parameter in [`fs.write()`][], [`fs.writeFile()`][], [`fs.appendFile()`][],

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3115,7 +3115,7 @@ resources and not the actual references.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/42607
     description: Runtime deprecation.
   - version: v17.8.0
     pr-url: https://github.com/nodejs/node/pull/42149

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -163,6 +163,11 @@ const isWindows = process.platform === 'win32';
 const isOSX = process.platform === 'darwin';
 
 
+const showStringCoercionDeprecation = internalUtil.deprecate(
+  () => {},
+  'Implicit coercion of objects with own toString property is deprecated.',
+  'DEP0162'
+);
 function showTruncateDeprecation() {
   if (truncateWarn) {
     process.emitWarning(
@@ -826,6 +831,9 @@ function write(fd, buffer, offset, length, position, callback) {
   }
 
   validateStringAfterArrayBufferView(buffer, 'buffer');
+  if (typeof buffer !== 'string') {
+    showStringCoercionDeprecation();
+  }
 
   if (typeof position !== 'function') {
     if (typeof offset === 'function') {
@@ -2121,6 +2129,9 @@ function writeFile(path, data, options, callback) {
 
   if (!isArrayBufferView(data)) {
     validateStringAfterArrayBufferView(data, 'data');
+    if (typeof data !== 'string') {
+      showStringCoercionDeprecation();
+    }
     data = Buffer.from(String(data), options.encoding || 'utf8');
   }
 
@@ -2161,6 +2172,9 @@ function writeFileSync(path, data, options) {
 
   if (!isArrayBufferView(data)) {
     validateStringAfterArrayBufferView(data, 'data');
+    if (typeof data !== 'string') {
+      showStringCoercionDeprecation();
+    }
     data = Buffer.from(String(data), options.encoding || 'utf8');
   }
 

--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -104,6 +104,10 @@ tmpdir.refresh();
 
 // Test writeFileSync with an object with an own toString function
 {
+  // Runtime deprecated by DEP0162
+  common.expectWarning('DeprecationWarning',
+                       'Implicit coercion of objects with own toString property is deprecated.',
+                       'DEP0162');
   const file = path.join(tmpdir.path, 'testWriteFileSyncStringify.txt');
   const data = {
     toString() {

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -126,6 +126,12 @@ fs.open(fn3, 'w', 0o644, common.mustSucceed((fd) => {
   fs.write(fd, expected, done);
 }));
 
+
+// Test write with an object with an own toString function
+// Runtime deprecated by DEP0162
+common.expectWarning('DeprecationWarning',
+                     'Implicit coercion of objects with own toString property is deprecated.',
+                     'DEP0162');
 fs.open(fn4, 'w', 0o644, common.mustSucceed((fd) => {
   const done = common.mustSucceed((written) => {
     assert.strictEqual(written, Buffer.byteLength(expected));


### PR DESCRIPTION
This is continuation of doc-only https://github.com/nodejs/node/pull/42149

Affects `fs.write`, `fs.writeFileSync`, `fs.writeFile`, `fs.appendFile`, and `fs.appendFileSync`

cc @aduh95 
