### PR TITLE
doc: add note about header values encoding

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -987,6 +987,17 @@ or
 request.setHeader('Cookie', ['type=ninja', 'language=javascript']);
 ```
 
+When the value is a string an exception will be thrown if it contains
+characters outside the `latin1` encoding.
+
+If you need to pass UTF-8 characters in the value please encode the value
+using the [RFC 8187][] standard.
+
+```js
+const filename = 'Rock 🎵.txt';
+request.setHeader('Content-Disposition', `inline; filename*=utf-8''${encodeURIComponent(filename)}`);
+```
+
 ### `request.setNoDelay([noDelay])`
 
 <!-- YAML
@@ -3406,6 +3417,7 @@ try {
 }
 ```
 
+[RFC 8187]: https://www.rfc-editor.org/rfc/rfc8187.txt
 [`'checkContinue'`]: #event-checkcontinue
 [`'finish'`]: #event-finish
 [`'request'`]: #event-request

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -995,7 +995,7 @@ using the [RFC 8187][] standard.
 
 ```js
 const filename = 'Rock 🎵.txt';
-request.setHeader('Content-Disposition', `inline; filename*=utf-8''${encodeURIComponent(filename)}`);
+request.setHeader('Content-Disposition', `attachment; filename*=utf-8''${encodeURIComponent(filename)}`);
 ```
 
 ### `request.setNoDelay([noDelay])`


### PR DESCRIPTION
This PR add a note about `http.Outgoing.setHeader`.
At the moment, if the user use `.setHeader(name, value)` and value contains non latin1 characters, then method will throw an exception. But this is not documented anywhere.

Additionally it also suggests to use RFC8187 standard when UTF-8 values must be passed (rather than arbitrarily convert those values to latin1 as suggested on the net).

Fixes: #42579 