### PR TITLE
doc: delete Chakracore time-travel from diagnostic tooling support tiers

### DIFF
--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -134,7 +134,6 @@ The tools are currently assigned to Tiers as follows:
 | Debugger  | Command line Debug Client | ?                             | Yes                     | 1           |
 | Debugger  | llnode                    | ?                             | No                      | 2           |
 | Debugger  | Chrome Dev tools          | ?                             | No                      | 3           |
-| Debugger  | Chakracore - time-travel  | No                            | Data source only        | too early   |
 | Tracing   | trace\_events (API)       | No                            | Yes                     | 1           |
 | Tracing   | trace\_gc                 | No                            | Yes                     | 1           |
 | Tracing   | DTrace                    | No                            | Partial                 | 3           |


### PR DESCRIPTION
Hey node family 👋

## Context

The diagnostic working group currently works on an [initiative](https://github.com/nodejs/diagnostics/issues/532) to re-evaluate the diagnostic tooling list and its maturity.

## Updated

In the previous instance, we examined the case of Chakra time-travel: [issue link](https://github.com/nodejs/diagnostics/issues/545), [module link](https://github.com/mrkmarron/node-chakracore-time-travel-debugger)

We found that:
* There is no evidence of usage in the field
* Seems out of maintenance

For these reasons, we thought that it could be better to remove it from the list.

## Discuss

Feel free to share your thoughts on that and your experience with this tool.

With love ❤️  cc @nodejs/diagnostics 