### PR TITLE
test: improve internal/url.js coverage

### DIFF
--- a/test/parallel/test-whatwg-url-custom-searchparams-inspect.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-inspect.js
@@ -9,12 +9,20 @@ const util = require('util');
 const sp = new URLSearchParams('?a=a&b=b&b=c');
 assert.strictEqual(util.inspect(sp),
                    "URLSearchParams { 'a' => 'a', 'b' => 'b', 'b' => 'c' }");
+assert.strictEqual(util.inspect(sp, { depth: -1 }), '[Object]');
+assert.strictEqual(
+  util.inspect(sp, { breakLength: 1 }),
+  "URLSearchParams {\n  'a' => 'a',\n  'b' => 'b',\n  'b' => 'c' }"
+);
 assert.strictEqual(util.inspect(sp.keys()),
                    "URLSearchParams Iterator { 'a', 'b', 'b' }");
 assert.strictEqual(util.inspect(sp.values()),
                    "URLSearchParams Iterator { 'a', 'b', 'c' }");
 assert.strictEqual(util.inspect(sp.keys(), { breakLength: 1 }),
                    "URLSearchParams Iterator {\n  'a',\n  'b',\n  'b' }");
+assert.throws(() => sp[util.inspect.custom].call(), {
+  code: 'ERR_INVALID_THIS',
+});
 
 const iterator = sp.entries();
 assert.strictEqual(util.inspect(iterator),
@@ -27,3 +35,5 @@ iterator.next();
 iterator.next();
 assert.strictEqual(util.inspect(iterator),
                    'URLSearchParams Iterator {  }');
+const emptySp = new URLSearchParams();
+assert.strictEqual(util.inspect(emptySp), 'URLSearchParams {}');


### PR DESCRIPTION
This improves a test coverage in `lib/internal/url.js`.

ref: https://coverage.nodejs.org/coverage-3c752648d4ef5510/lib/internal/url.js.html#L256

This PR adds test that validates some inspect outputs of URLSearchParams class.