### PR TITLE
buffer: atob throw error when the input value is invalid

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1268,17 +1268,15 @@ function atob(input) {
       kForgivingBase64AllowedChars,
       StringPrototypeCharCodeAt(input, n));
 
-    if (index > 4) { // The first five char are ASCII whitespace.
+    if (index > 4) {
+      // The first 5 elements of `kForgivingBase64AllowedChars` are
+      // ASCII whitespace char codes.
       nonAsciiWhitespaceCharCount++;
     } else if (index === -1) {
       throw lazyDOMException('Invalid character', 'InvalidCharacterError');
     }
   }
 
-  // If data's code point length divides by 4 leaving a remainder of 1, then
-  // return failure.
-  //
-  // See #3 - https://infra.spec.whatwg.org/#forgiving-base64
   if (nonAsciiWhitespaceCharCount % 4 === 1) {
     throw lazyDOMException(
       'The string to be decoded is not correctly encoded.',

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1232,12 +1232,14 @@ function btoa(input) {
   return buf.toString('base64');
 }
 
-// Refs: https://infra.spec.whatwg.org/#forgiving-base64-decode
-const kForgivingBase64AllowedChars = [
+const asciiWhitespaceCharacters = [
   // ASCII whitespace
   // Refs: https://infra.spec.whatwg.org/#ascii-whitespace
   0x09, 0x0A, 0x0C, 0x0D, 0x20,
+];
 
+// Refs: https://infra.spec.whatwg.org/#forgiving-base64-decode
+const kForgivingBase64AllowedChars = [
   // Uppercase letters
   ...ArrayFrom({ length: 26 }, (_, i) => StringPrototypeCharCodeAt('A') + i),
 
@@ -1260,32 +1262,29 @@ function atob(input) {
     throw new ERR_MISSING_ARGS('input');
   }
 
-  if (input === undefined || input === false || typeof input === 'number') {
-    throw lazyDOMException(
-      'The string to be decoded is not correctly encoded.',
-      'ValidationError');
-  }
+  input = `${input}`;
+  let nonAsciiWhitespaceCharCount = 0;
 
-  // Remove all ASCII whitespace from data.
-  //
-  // See #1 - https://infra.spec.whatwg.org/#forgiving-base64
-  input = `${input}`.replace(/\s/g, '');
+  for (let n = 0; n < input.length; n++) {
+    const char = StringPrototypeCharCodeAt(input, n);
+
+    if (ArrayPrototypeIncludes(kForgivingBase64AllowedChars, char)) {
+      nonAsciiWhitespaceCharCount++;
+    } else if (!ArrayPrototypeIncludes(asciiWhitespaceCharacters, char)) {
+      throw lazyDOMException('Invalid character', 'InvalidCharacterError');
+    }
+  }
 
   // If data's code point length divides by 4 leaving a remainder of 1, then
   // return failure.
   //
   // See #3 - https://infra.spec.whatwg.org/#forgiving-base64
-  if (input.length % 4 === 1) {
+  if (nonAsciiWhitespaceCharCount % 4 === 1) {
     throw lazyDOMException(
       'The string to be decoded is not correctly encoded.',
       'ValidationError');
   }
 
-  for (let n = 0; n < input.length; n++) {
-    if (!ArrayPrototypeIncludes(kForgivingBase64AllowedChars,
-                                StringPrototypeCharCodeAt(input, n)))
-      throw lazyDOMException('Invalid character', 'InvalidCharacterError');
-  }
   return Buffer.from(input, 'base64').toString('latin1');
 }
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1277,6 +1277,7 @@ function atob(input) {
     }
   }
 
+  // See #3 - https://infra.spec.whatwg.org/#forgiving-base64
   if (nonAsciiWhitespaceCharCount % 4 === 1) {
     throw lazyDOMException(
       'The string to be decoded is not correctly encoded.',

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -26,7 +26,7 @@ const {
   ArrayFrom,
   ArrayIsArray,
   ArrayPrototypeForEach,
-  ArrayPrototypeIncludes,
+  ArrayPrototypeIndexOf,
   MathFloor,
   MathMin,
   MathTrunc,
@@ -1232,14 +1232,12 @@ function btoa(input) {
   return buf.toString('base64');
 }
 
-const asciiWhitespaceCharacters = [
+// Refs: https://infra.spec.whatwg.org/#forgiving-base64-decode
+const kForgivingBase64AllowedChars = [
   // ASCII whitespace
   // Refs: https://infra.spec.whatwg.org/#ascii-whitespace
   0x09, 0x0A, 0x0C, 0x0D, 0x20,
-];
 
-// Refs: https://infra.spec.whatwg.org/#forgiving-base64-decode
-const kForgivingBase64AllowedChars = [
   // Uppercase letters
   ...ArrayFrom({ length: 26 }, (_, i) => StringPrototypeCharCodeAt('A') + i),
 
@@ -1266,11 +1264,13 @@ function atob(input) {
   let nonAsciiWhitespaceCharCount = 0;
 
   for (let n = 0; n < input.length; n++) {
-    const char = StringPrototypeCharCodeAt(input, n);
+    const index = ArrayPrototypeIndexOf(
+      kForgivingBase64AllowedChars,
+      StringPrototypeCharCodeAt(input, n));
 
-    if (ArrayPrototypeIncludes(kForgivingBase64AllowedChars, char)) {
+    if (index > 4) { // The first five char are ASCII whitespace.
       nonAsciiWhitespaceCharCount++;
-    } else if (!ArrayPrototypeIncludes(asciiWhitespaceCharacters, char)) {
+    } else if (index === -1) {
       throw lazyDOMException('Invalid character', 'InvalidCharacterError');
     }
   }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1259,7 +1259,28 @@ function atob(input) {
   if (arguments.length === 0) {
     throw new ERR_MISSING_ARGS('input');
   }
-  input = `${input}`;
+
+  if (input === undefined || input === false || typeof input === 'number') {
+    throw lazyDOMException(
+      'The string to be decoded is not correctly encoded.',
+      'ValidationError');
+  }
+
+  // Remove all ASCII whitespace from data.
+  //
+  // See #1 - https://infra.spec.whatwg.org/#forgiving-base64
+  input = `${input}`.replace(/\s/g, '');
+
+  // If data's code point length divides by 4 leaving a remainder of 1, then
+  // return failure.
+  //
+  // See #3 - https://infra.spec.whatwg.org/#forgiving-base64
+  if (input.length % 4 === 1) {
+    throw lazyDOMException(
+      'The string to be decoded is not correctly encoded.',
+      'ValidationError');
+  }
+
   for (let n = 0; n < input.length; n++) {
     if (!ArrayPrototypeIncludes(kForgivingBase64AllowedChars,
                                 StringPrototypeCharCodeAt(input, n)))

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1282,7 +1282,7 @@ function atob(input) {
   if (nonAsciiWhitespaceCharCount % 4 === 1) {
     throw lazyDOMException(
       'The string to be decoded is not correctly encoded.',
-      'ValidationError');
+      'InvalidCharacterError');
   }
 
   return Buffer.from(input, 'base64').toString('latin1');

--- a/test/parallel/test-btoa-atob.js
+++ b/test/parallel/test-btoa-atob.js
@@ -25,7 +25,6 @@ strictEqual(atob([]), '');
 strictEqual(atob({ toString: () => '' }), '');
 strictEqual(atob({ [Symbol.toPrimitive]: () => '' }), '');
 
-throws(() => atob(), /ERR_MISSING_ARGS/);
 throws(() => atob(Symbol()), /TypeError/);
 [undefined, false, () => {}, 0, 1, 0n, 1n, -Infinity, [1], {}].forEach((value) =>
   throws(() => atob(value), { constructor: DOMException }));

--- a/test/parallel/test-btoa-atob.js
+++ b/test/parallel/test-btoa-atob.js
@@ -14,7 +14,7 @@ throws(() => buffer.atob(), /TypeError/);
 throws(() => buffer.btoa(), /TypeError/);
 
 strictEqual(atob(' '), '');
-strictEqual(atob('  YW\tJ\njZA=\r= '), 'abcd');
+strictEqual(atob('  Y\fW\tJ\njZ A=\r= '), 'abcd');
 
 strictEqual(atob(null), '\x9Eée');
 strictEqual(atob(NaN), '5£');
@@ -26,5 +26,14 @@ strictEqual(atob({ toString: () => '' }), '');
 strictEqual(atob({ [Symbol.toPrimitive]: () => '' }), '');
 
 throws(() => atob(Symbol()), /TypeError/);
-[undefined, false, () => {}, 0, 1, 0n, 1n, -Infinity, [1], {}].forEach((value) =>
-  throws(() => atob(value), { constructor: DOMException }));
+[
+  undefined, false, () => {}, {}, [1],
+  0, 1, 0n, 1n, -Infinity,
+  'a', 'a\n\n\n', '\ra\r\r', '  a ', '\t\t\ta', 'a\f\f\f', '\ta\r \n\f',
+].forEach((value) =>
+  // See #2 - https://html.spec.whatwg.org/multipage/webappapis.html#dom-atob
+  throws(() => atob(value), {
+    constructor: DOMException,
+    name: 'InvalidCharacterError',
+    code: 5,
+  }));

--- a/test/parallel/test-btoa-atob.js
+++ b/test/parallel/test-btoa-atob.js
@@ -15,3 +15,12 @@ throws(() => buffer.btoa(), /TypeError/);
 
 strictEqual(atob(' '), '');
 strictEqual(atob('  YW\tJ\njZA=\r= '), 'abcd');
+
+throws(() => buffer.atob(undefined), /ValidationError/);
+throws(() => buffer.atob(false), /ValidationError/);
+throws(() => buffer.atob(1), /ValidationError/);
+throws(() => buffer.atob(0), /ValidationError/);
+throws(() => buffer.atob('a'), /ValidationError/);
+throws(() => buffer.atob('a '), /ValidationError/);
+throws(() => buffer.atob(' a'), /ValidationError/);
+throws(() => buffer.atob('aaaaa'), /ValidationError/);

--- a/test/parallel/test-btoa-atob.js
+++ b/test/parallel/test-btoa-atob.js
@@ -16,11 +16,16 @@ throws(() => buffer.btoa(), /TypeError/);
 strictEqual(atob(' '), '');
 strictEqual(atob('  YW\tJ\njZA=\r= '), 'abcd');
 
-throws(() => buffer.atob(undefined), /ValidationError/);
-throws(() => buffer.atob(false), /ValidationError/);
-throws(() => buffer.atob(1), /ValidationError/);
-throws(() => buffer.atob(0), /ValidationError/);
-throws(() => buffer.atob('a'), /ValidationError/);
-throws(() => buffer.atob('a '), /ValidationError/);
-throws(() => buffer.atob(' a'), /ValidationError/);
-throws(() => buffer.atob('aaaaa'), /ValidationError/);
+strictEqual(atob(null), '\x9Eée');
+strictEqual(atob(NaN), '5£');
+strictEqual(atob(Infinity), '"wâ\x9E+r');
+strictEqual(atob(true), '¶»\x9E');
+strictEqual(atob(1234), '×mø');
+strictEqual(atob([]), '');
+strictEqual(atob({ toString: () => '' }), '');
+strictEqual(atob({ [Symbol.toPrimitive]: () => '' }), '');
+
+throws(() => atob(), /ERR_MISSING_ARGS/);
+throws(() => atob(Symbol()), /TypeError/);
+[undefined, false, () => {}, 0, 1, 0n, 1n, -Infinity, [1], {}].forEach((value) =>
+  throws(() => atob(value), { constructor: DOMException }));


### PR DESCRIPTION
## Description

The specification of `atob` has various different conditions that we need
to abide by.

See: https://infra.spec.whatwg.org/#forgiving-base64-decode

Fixes: https://github.com/nodejs/node/issues/42646

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

## Considerations

Each of the new cases that are handled added _could_ be considered breaking changes. Consider the following tests run directly from the Chrome console (Version 100.0.4896.75 (Official Build) (arm64)):

```
atob(undefined)
VM85:1 Uncaught DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
    at <anonymous>:1:1

atob(false)
VM123:1 Uncaught DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
    at <anonymous>:1:1

atob(1)
VM152:1 Uncaught DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.

atob(false)
VM187:1 Uncaught DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.

atob(0)
VM217:1 Uncaught DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
    at <anonymous>:1:1

atob('a')
VM234:1 Uncaught DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
    at <anonymous>:1:1

atob('a ')
VM243:1 Uncaught DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
    at <anonymous>:1:1

atob(' a')
VM257:1 Uncaught DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
    at <anonymous>:1:1
    
atob('aaaaa')
VM283:1 Uncaught DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
    at <anonymous>:1:1
```
