### PR TITLE
src: check if the script file exists before starting inspector

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -673,10 +673,12 @@ Agent::Agent(Environment* env)
 Agent::~Agent() {}
 
 bool Agent::Start(const std::string& path,
+                  const std::string& script_path,
                   const DebugOptions& options,
                   std::shared_ptr<ExclusiveAccess<HostPort>> host_port,
                   bool is_main) {
   path_ = path;
+  script_path_ = script_path;
   debug_options_ = options;
   CHECK_NOT_NULL(host_port);
   host_port_ = host_port;
@@ -747,6 +749,7 @@ bool Agent::StartIoThread() {
 
   io_ = InspectorIo::Start(client_->getThreadHandle(),
                            path_,
+                           script_path_,
                            host_port_,
                            debug_options_.inspect_publish_uid);
   if (io_ == nullptr) {

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -47,6 +47,7 @@ class Agent {
 
   // Create client_, may create io_ if option enabled
   bool Start(const std::string& path,
+             const std::string& script_path,
              const DebugOptions& options,
              std::shared_ptr<ExclusiveAccess<HostPort>> host_port,
              bool is_main);
@@ -126,6 +127,7 @@ class Agent {
   std::unique_ptr<InspectorIo> io_;
   std::unique_ptr<ParentInspectorHandle> parent_handle_;
   std::string path_;
+  std::string script_path_;
 
   // This is a copy of the debug options parsed from CLI in the Environment.
   // Do not use the host_port in that, instead manipulate the shared host_port_

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -26,22 +26,6 @@ using v8_inspector::StringView;
 // kKill closes connections and stops the server, kStop only stops the server
 enum class TransportAction { kKill, kSendMessage, kStop };
 
-std::string ScriptPath(uv_loop_t* loop, const std::string& script_name) {
-  std::string script_path;
-
-  if (!script_name.empty()) {
-    uv_fs_t req;
-    req.ptr = nullptr;
-    if (0 == uv_fs_realpath(loop, &req, script_name.c_str(), nullptr)) {
-      CHECK_NOT_NULL(req.ptr);
-      script_path = std::string(static_cast<char*>(req.ptr));
-    }
-    uv_fs_req_cleanup(&req);
-  }
-
-  return script_path;
-}
-
 // UUID RFC: https://www.ietf.org/rfc/rfc4122.txt
 // Used ver 4 - with numbers
 std::string GenerateID() {
@@ -239,11 +223,13 @@ class InspectorIoDelegate: public node::inspector::SocketServerDelegate {
 std::unique_ptr<InspectorIo> InspectorIo::Start(
     std::shared_ptr<MainThreadHandle> main_thread,
     const std::string& path,
+    const std::string& script_path,
     std::shared_ptr<ExclusiveAccess<HostPort>> host_port,
     const InspectPublishUid& inspect_publish_uid) {
   auto io = std::unique_ptr<InspectorIo>(
       new InspectorIo(main_thread,
                       path,
+                      script_path,
                       host_port,
                       inspect_publish_uid));
   if (io->request_queue_->Expired()) {  // Thread is not running
@@ -254,6 +240,7 @@ std::unique_ptr<InspectorIo> InspectorIo::Start(
 
 InspectorIo::InspectorIo(std::shared_ptr<MainThreadHandle> main_thread,
                          const std::string& path,
+                         const std::string& script_path,
                          std::shared_ptr<ExclusiveAccess<HostPort>> host_port,
                          const InspectPublishUid& inspect_publish_uid)
     : main_thread_(main_thread),
@@ -261,6 +248,7 @@ InspectorIo::InspectorIo(std::shared_ptr<MainThreadHandle> main_thread,
       inspect_publish_uid_(inspect_publish_uid),
       thread_(),
       script_name_(path),
+      script_path_(script_path),
       id_(GenerateID()) {
   Mutex::ScopedLock scoped_lock(thread_start_lock_);
   CHECK_EQ(uv_thread_create(&thread_, InspectorIo::ThreadMain, this), 0);
@@ -289,10 +277,9 @@ void InspectorIo::ThreadMain() {
   CHECK_EQ(err, 0);
   std::shared_ptr<RequestQueueData> queue(new RequestQueueData(&loop),
                                           RequestQueueData::CloseAndFree);
-  std::string script_path = ScriptPath(&loop, script_name_);
   std::unique_ptr<InspectorIoDelegate> delegate(
       new InspectorIoDelegate(queue, main_thread_, id_,
-                              script_path, script_name_));
+                              script_path_, script_name_));
   std::string host;
   int port;
   {

--- a/src/inspector_io.h
+++ b/src/inspector_io.h
@@ -30,6 +30,7 @@ class InspectorIo {
   static std::unique_ptr<InspectorIo> Start(
       std::shared_ptr<MainThreadHandle> main_thread,
       const std::string& path,
+      const std::string& script_path,
       std::shared_ptr<ExclusiveAccess<HostPort>> host_port,
       const InspectPublishUid& inspect_publish_uid);
 
@@ -42,6 +43,7 @@ class InspectorIo {
  private:
   InspectorIo(std::shared_ptr<MainThreadHandle> handle,
               const std::string& path,
+              const std::string& script_path,
               std::shared_ptr<ExclusiveAccess<HostPort>> host_port,
               const InspectPublishUid& inspect_publish_uid);
 
@@ -68,6 +70,7 @@ class InspectorIo {
   Mutex thread_start_lock_;
   ConditionVariable thread_start_condition_;
   std::string script_name_;
+  std::string script_path_;
   // May be accessed from any thread
   const std::string id_;
 };

--- a/src/node.cc
+++ b/src/node.cc
@@ -215,11 +215,26 @@ int Environment::InitializeInspector(
     inspector_path = argv_.size() > 1 ? argv_[1].c_str() : "";
   }
 
+  std::string script_path = "";
+  if (options_->debug_options().inspector_enabled && !inspector_path.empty()) {
+    uv_fs_t req;
+    req.ptr = nullptr;
+    int err = uv_fs_realpath(nullptr, &req, inspector_path.c_str(), nullptr);
+    if (err != 0) {
+      uv_fs_req_cleanup(&req);
+      return 12;  // Signal internal error
+    }
+    CHECK_NOT_NULL(req.ptr);
+    script_path = std::string(static_cast<char*>(req.ptr));
+    uv_fs_req_cleanup(&req);
+  }
+
   CHECK(!inspector_agent_->IsListening());
   // Inspector agent can't fail to start, but if it was configured to listen
   // right away on the websocket port and fails to bind/etc, this will return
   // false.
   inspector_agent_->Start(inspector_path,
+                          script_path,
                           options_->debug_options(),
                           inspector_host_port(),
                           is_main);

--- a/test/sequential/test-debug-prompt.js
+++ b/test/sequential/test-debug-prompt.js
@@ -4,15 +4,32 @@ const common = require('../common');
 common.skipIfInspectorDisabled();
 const spawn = require('child_process').spawn;
 
-const proc = spawn(process.execPath, ['inspect', 'foo']);
-proc.stdout.setEncoding('utf8');
+{
+  const proc = spawn(process.execPath, ['inspect', 'test/sequential/test-debug-prompt.js']);
+  proc.stdout.setEncoding('utf8');
 
-let needToSendExit = true;
-let output = '';
-proc.stdout.on('data', (data) => {
-  output += data;
-  if (output.includes('debug> ') && needToSendExit) {
-    proc.stdin.write('.exit\n');
-    needToSendExit = false;
-  }
-});
+  let needToSendExit = true;
+  let output = '';
+  proc.stdout.on('data', (data) => {
+    output += data;
+    if (output.includes('debug> ') && needToSendExit) {
+      proc.stdin.write('.exit\n');
+      needToSendExit = false;
+    }
+  });
+}
+
+{
+  const proc = spawn(process.execPath, ['inspect', 'test/sequential/no-exist.js']);
+  proc.stdout.setEncoding('utf8');
+
+  let needToSendExit = true;
+  let output = '';
+  proc.stdout.on('data', (data) => {
+    output += data;
+    if (output.includes('MODULE_NOT_FOUND') && needToSendExit) {
+      proc.kill();
+      needToSendExit = false;
+    }
+  });
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixed #42600

Currently `node --inspect-brk index.js` will start the inspector and wait a connection event though `index.js` doesn't exist. And immediately after connected, node will throw `Cannot find module` error and wait to be disconnected.

This PR added the ability to check for the existence of the script file before an inspector agent is started. If the script is missing, inspector is not enabled and node module loader will throw MODULE_NOT_FUOND error.

|                                  | v17.9.0                                         | This PR                                   |
| -------------------------------- | ----------------------------------------------- | ----------------------------------------- |
| `node --inspect no-exist.js`     | Enable inspector agent & MODULE_NOT_FOUND error | MODULE_NOT_FOUND error                    |
| `node --inspect-brk no-exist.js` | Enable inspector agent                          | MODULE_NOT_FOUND error                    |
| `node inspect no-exist.js`       | Enable inspector agent but commands fail        | MODULE_NOT_FOUND error in a child process |
| `node --inspect`                 | Enable inspector agent                          | Enable inspector agent                    |
| `node --inspect-brk`             | Enable inspector agent                          | Enable inspector agent                    |