### PR TITLE
doc: improved parallel specification

### DIFF
--- a/doc/contributing/building-node-with-ninja.md
+++ b/doc/contributing/building-node-with-ninja.md
@@ -28,7 +28,8 @@ system has. You can use the `-j` parameter to override this behavior,
 which is equivalent to the `-j` parameter in the regular `make`:
 
 ```bash
-make -j [number]
+make -j4 # With this flag, Ninja will limit itself to 4 parallel jobs,
+         # regardless of the number of cores on the current machine.
 ```
 
 ## Producing a debug build

--- a/doc/contributing/building-node-with-ninja.md
+++ b/doc/contributing/building-node-with-ninja.md
@@ -22,7 +22,7 @@ ninja: Entering directory `out/Release`
 
 The bottom line will change while building, showing the progress as
 `[finished/total]` build steps. This is useful output that `make` does not
-produce and is one of the benefits of using Ninja. When using Ninja builds
+produce and is one of the benefits of using Ninja. When using Ninja, builds
 are always run in parallel, based by default on the number of CPUs your
 system has, you can also use the `-j` parameter if you don't want to use
 all the CPU. This will be the equivalent to the `-j` parameter in the

--- a/doc/contributing/building-node-with-ninja.md
+++ b/doc/contributing/building-node-with-ninja.md
@@ -22,14 +22,14 @@ ninja: Entering directory `out/Release`
 
 The bottom line will change while building, showing the progress as
 `[finished/total]` build steps. This is useful output that `make` does not
-produce and is one of the benefits of using Ninja. Also, Ninja will likely
-compile much faster than even `make -j4` (or
-`-j<number of processor threads on your machine>`). You can still pass the
-number of processes to run for [Ninja][] using the environment variable `JOBS`.
-This will be the equivalent to the `-j` parameter in the regular `make`:
+produce and is one of the benefits of using Ninja. When using Ninja builds
+are always run in parallel, based by default on the number of CPUs your
+system has, you can also use the `-j` parameter if you don't want to use
+all the CPU. This will be the equivalent to the `-j` parameter in the
+regular `make`:
 
 ```bash
-JOBS=12 make
+make -j [number]
 ```
 
 ## Producing a debug build

--- a/doc/contributing/building-node-with-ninja.md
+++ b/doc/contributing/building-node-with-ninja.md
@@ -24,9 +24,8 @@ The bottom line will change while building, showing the progress as
 `[finished/total]` build steps. This is useful output that `make` does not
 produce and is one of the benefits of using Ninja. When using Ninja, builds
 are always run in parallel, based by default on the number of CPUs your
-system has, you can also use the `-j` parameter if you don't want to use
-all the CPU. This will be the equivalent to the `-j` parameter in the
-regular `make`:
+system has. You can use the `-j` parameter to override this behavior,
+which is equivalent to the `-j` parameter in the regular `make`:
 
 ```bash
 make -j [number]


### PR DESCRIPTION
In current version description of parallel correlation are inconsistent with the [Ninja][] official website, I therefore propose this improvement.

[Ninja]: https://ninja-build.org/manual.html#_comparison_to_make