### PR TITLE
lib: unlink the `next` pointer for FixedQueue to avoid potential memory leaks

### DIFF
--- a/lib/internal/fixed_queue.js
+++ b/lib/internal/fixed_queue.js
@@ -111,6 +111,7 @@ module.exports = class FixedQueue {
     if (tail.isEmpty() && tail.next !== null) {
       // If there is another queue, it forms the new tail.
       this.tail = tail.next;
+      tail.next = null;
     }
     return next;
   }


### PR DESCRIPTION
In the internal FixedQueue, once a FixedCircularBuffer is used out, it does not unlink the `next` pointer, thus if a variable references the `head` or `tail` field of FixedQueue, it will cause a memory leak. I wrote a reproducing example [here](https://gist.github.com/twchn/2c86bdb7b7bf96039e37e7ad221ed8fa). Another way is to make `head` and `tail` field private, but we need to modify the test cases in `test/parallel/test-fixed-queue.js`.