### PR TITLE
test: improve lib/readline.js coverage

### DIFF
--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -71,6 +71,20 @@ function assertCursorRowsAndCols(rli, rows, cols) {
   assert(rl instanceof readline.Interface);
 }
 
+{
+  const fi = new FakeInput();
+  const completer = (line) => [[], line];
+  const rli = new readline.Interface(
+    fi,
+    fi,
+    common.mustCallAtLeast(completer),
+    true,
+  );
+  assert(rli instanceof readline.Interface);
+  fi.emit('data', 'a\t');
+  rli.close();
+}
+
 [
   undefined,
   50,

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -76,7 +76,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
   const rli = new readline.Interface(
     fi,
     fi,
-    common.mustCallAtLeast((line) => [[], line]),
+    common.mustCall((line) => [[], line]),
     true,
   );
   assert(rli instanceof readline.Interface);

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -73,11 +73,10 @@ function assertCursorRowsAndCols(rli, rows, cols) {
 
 {
   const fi = new FakeInput();
-  const completer = (line) => [[], line];
   const rli = new readline.Interface(
     fi,
     fi,
-    common.mustCallAtLeast(completer),
+    common.mustCallAtLeast((line) => [[], line]),
     true,
   );
   assert(rli instanceof readline.Interface);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This improves a test coverage in `lib/readline.js`

Ref: https://coverage.nodejs.org/coverage-a0461255c05c79cf/lib/readline.js.html#L105

This validates that work correctly when a `completer` argument of constructor .