### PR TITLE
doc: fix `added:` info for `outgoingMessage.{,un}cork()`

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2505,7 +2505,9 @@ Aliases of `outgoingMessage.socket`
 ### `outgoingMessage.cork()`
 
 <!-- YAML
-added: v14.0.0
+added:
+  - v13.2.0
+  - v12.16.0
 -->
 
 See [`writable.cork()`][].
@@ -2711,7 +2713,9 @@ After calling `outgoingMessage.end()`, this property will be nulled.
 ### `outgoingMessage.uncork()`
 
 <!-- YAML
-added: v14.0.0
+added:
+  - v13.2.0
+  - v12.16.0
 -->
 
 See [`writable.uncork()`][]


### PR DESCRIPTION
`outgoingMessage.cork()` and `outgoingMessage.uncork()` were added to
Node.js v13.2.0 via 62e15a793a56 and backported to Node.js v12.16.0 via
db8144be3187.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
