### PR TITLE
tools: lint osx shell scripts

### DIFF
--- a/tools/macos-firewall.sh
+++ b/tools/macos-firewall.sh
@@ -3,16 +3,16 @@
 # popups asking to accept incoming network connections when
 # running tests.
 SFW="/usr/libexec/ApplicationFirewall/socketfilterfw"
-TOOLSDIR="`dirname \"$0\"`"
-TOOLSDIR="`( cd \"$TOOLSDIR\" && pwd) `"
-ROOTDIR="`( cd \"$TOOLSDIR/..\" && pwd) `"
+TOOLSDIR="$(dirname "$0")"
+TOOLSDIR="$(cd "$TOOLSDIR" && pwd)"
+ROOTDIR="$(cd "$TOOLSDIR/.." && pwd)"
 OUTDIR="$TOOLSDIR/../out"
 # Using cd and pwd here so that the path used for socketfilterfw does not
 # contain a '..', which seems to cause the rules to be incorrectly added
 # and they are not removed when this script is re-run. Instead the new
 # rules are simply appended. By using pwd we can get the full path
 # without '..' and things work as expected.
-OUTDIR="`( cd \"$OUTDIR\" && pwd) `"
+OUTDIR="$(cd "$OUTDIR" && pwd)"
 NODE_RELEASE="$OUTDIR/Release/node"
 NODE_DEBUG="$OUTDIR/Debug/node"
 NODE_LINK="$ROOTDIR/node"

--- a/tools/osx-notarize.sh
+++ b/tools/osx-notarize.sh
@@ -28,8 +28,7 @@ if [ ! -f "${gon_exe}" ]; then
   (cd "${HOME}/.gon/" && rm -f gon && unzip "${gon_exe}.zip" && mv gon "${gon_exe}")
 fi
 
-cat tools/osx-gon-config.json.tmpl \
-  | sed -e "s/{{appleid}}/${NOTARIZATION_ID}/" -e "s/{{pkgid}}/${pkgid}/" \
+sed -e "s/{{appleid}}/${NOTARIZATION_ID}/" -e "s/{{pkgid}}/${pkgid}/" tools/osx-gon-config.json.tmpl \
   > gon-config.json
 
 "${gon_exe}" -log-level=info gon-config.json


### PR DESCRIPTION
- [SC2002](https://github.com/koalaman/shellcheck/wiki/SC2002) Useless cat. Consider `cmd < file | ..` or `cmd file | ..` instead.
- [SC2006](https://github.com/koalaman/shellcheck/wiki/SC2006) Use `$(...)` notation instead of legacy backticked `` `...` ``.
- Nested subshells (`$( (...) )`, `` ` (...) ` ``) are redundant.