### PR TITLE
child_process: add hasRef to ChildProcess

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1434,6 +1434,32 @@ console.log(`Spawned child pid: ${grep.pid}`);
 grep.stdin.end();
 ```
 
+### `subprocess.hasRef()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {boolean}
+
+Indicates whether a `subprocess` is "ref'ed" by the parent process's event
+loop. If `true`, the parent waits for the child to exit before exiting itself.
+
+```js
+const { spawn } = require('child_process');
+
+const subprocess = spawn(process.argv[0], ['child_program.js'], {
+  detached: true,
+  stdio: 'ignore',
+});
+
+subprocess.on('exit', (code) => {
+  subprocess.hasRef(); // false
+});
+
+subprocess.hasRef(); // true
+```
+
 ### `subprocess.ref()`
 
 <!-- YAML

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -519,6 +519,11 @@ ChildProcess.prototype.unref = function() {
   if (this._handle) this._handle.unref();
 };
 
+
+ChildProcess.prototype.hasRef = function() {
+  return this._handle ? this._handle.hasRef() : false;
+};
+
 class Control extends EventEmitter {
   #channel = null;
   #refs = 0;

--- a/test/parallel/test-child-process-hasref.js
+++ b/test/parallel/test-child-process-hasref.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { spawn, ChildProcess } = require('child_process');
+
+const command = common.isWindows ? 'dir' : 'ls';
+const child = spawn(command);
+
+assert.strictEqual(child.hasRef(), true);
+
+child.unref();
+assert.strictEqual(child.hasRef(), false);
+
+child.ref();
+assert.strictEqual(child.hasRef(), true);
+
+function mustHasRef() {
+  return common.mustCall(() => assert.strictEqual(child.hasRef(), true));
+}
+
+function mustHasNoRef() {
+  return common.mustCall(() => assert.strictEqual(child.hasRef(), false));
+}
+
+child.stdout.on('data', mustHasRef());
+child.stdout.on('end', mustHasRef());
+child.stdout.on('close', mustHasNoRef());
+child.on('exit', mustHasNoRef());
+child.on('close', mustHasNoRef());


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/42091

The issue above reported a specific use case about `hasRef()`.
After reading the issue, I started thinking users may naturally expect
`hasRef` method if `ref()` and `unref()` exist on an object they use. 
As of now, however, `hasRef()` exists on `Timer` only.

This commit suggests adding `hasRef` method to `ChildProcess` first.
There are more similar cases. (fs.FSWatcher, fs.StatWatcher, net.Socket,
and so on)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
