### PR TITLE
doc: fix `added:` info for `outgoingMessage.writable*`

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2721,7 +2721,9 @@ See [`writable.uncork()`][]
 ### `outgoingMessage.writableCorked`
 
 <!-- YAML
-added: v14.0.0
+added:
+  - v13.2.0
+  - v12.16.0
 -->
 
 * {number}
@@ -2732,7 +2734,7 @@ This `outgoingMessage.writableCorked` will return the time how many
 ### `outgoingMessage.writableEnded`
 
 <!-- YAML
-added: v13.0.0
+added: v12.9.0
 -->
 
 * {boolean}
@@ -2744,7 +2746,7 @@ purpose, use `message.writableFinished` instead.
 ### `outgoingMessage.writableFinished`
 
 <!-- YAML
-added: v13.0.0
+added: v12.7.0
 -->
 
 * {boolean}
@@ -2754,7 +2756,7 @@ Readonly. `true` if all data has been flushed to the underlying system.
 ### `outgoingMessage.writableHighWaterMark`
 
 <!-- YAML
-added: v13.0.0
+added: v12.9.0
 -->
 
 * {number}
@@ -2769,7 +2771,7 @@ buffered by the socket.
 ### `outgoingMessage.writableLength`
 
 <!-- YAML
-added: v13.0.0
+added: v12.9.0
 -->
 
 * {number}
@@ -2780,7 +2782,7 @@ bytes (or objects) in the buffer ready to send.
 ### `outgoingMessage.writableObjectMode`
 
 <!-- YAML
-added: v13.0.0
+added: v12.9.0
 -->
 
 * {boolean}


### PR DESCRIPTION
- `outgoingMessage.writableCorked` was added to Node.js v13.2.0 via
  62e15a793a56 and backported to Node.js v12.16.0 via db8144be3187.
- `outgoingMessage.writableEnded` was added to Node.js v12.9.0 via
  f9b61d2bc7d7.
- `outgoingMessage.writableFinished` was added to Node.js v12.7.0 via
  06d0abea0d7e.
- `outgoingMessage.writableHighWaterMark`,
  `outgoingMessage.writableLength`, and
  `outgoingMessage.writableObjectMode` were added to Node.js v12.9.0 via
  16e001112c31.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
