### PR TITLE
doc: improve fragment (`:target`) anchors behavior on HTML version

### DIFF
--- a/doc/api_assets/api.js
+++ b/doc/api_assets/api.js
@@ -15,9 +15,13 @@
         }
         mq.addEventListener('change', mqChangeListener);
         if (themeToggleButton) {
-          themeToggleButton.addEventListener('click', function() {
-            mq.removeEventListener('change', mqChangeListener);
-          }, { once: true });
+          themeToggleButton.addEventListener(
+            'click',
+            function() {
+              mq.removeEventListener('change', mqChangeListener);
+            },
+            { once: true }
+          );
         }
       }
 
@@ -60,7 +64,7 @@
     for (const picker of pickers) {
       const parentNode = picker.parentNode;
 
-      picker.addEventListener('click', (e) => {
+      picker.addEventListener('click', function(e) {
         e.preventDefault();
 
         /*
@@ -76,7 +80,7 @@
           to close pickers if needed.
         */
 
-        requestAnimationFrame(() => {
+        requestAnimationFrame(function() {
           parentNode.classList.add('expanded');
           window.addEventListener('click', closeAllPickers);
           window.addEventListener('keydown', onKeyDown);
@@ -90,9 +94,9 @@
     let ignoreNextIntersection = false;
 
     new IntersectionObserver(
-      ([e]) => {
+      function(e) {
         const currentStatus = header.classList.contains('is-pinned');
-        const newStatus = e.intersectionRatio < 1;
+        const newStatus = e[0].intersectionRatio < 1;
 
         // Same status, do nothing
         if (currentStatus === newStatus) {
@@ -109,7 +113,7 @@
           The timer is reset anyway after few milliseconds.
         */
         ignoreNextIntersection = true;
-        setTimeout(() => {
+        setTimeout(function() {
           ignoreNextIntersection = false;
         }, 50);
 
@@ -119,18 +123,34 @@
     ).observe(header);
   }
 
+  function setupAltDocsLink() {
+    const linkWrapper = document.getElementById('alt-docs');
+
+    function updateHashes() {
+      for (const link of linkWrapper.querySelectorAll('a')) {
+        link.hash = location.hash;
+      }
+    }
+
+    addEventListener('hashchange', updateHashes);
+    updateHashes();
+  }
+
   function bootstrap() {
-    // Check if we have JavaScript support
+    // Check if we have JavaScript support.
     document.documentElement.classList.add('has-js');
 
-    // Restore user mode preferences
+    // Restore user mode preferences.
     setupTheme();
 
-    // Handle pickers with click/taps rather than hovers
+    // Handle pickers with click/taps rather than hovers.
     setupPickers();
 
-    // Track when the header is in sticky position
+    // Track when the header is in sticky position.
     setupStickyHeaders();
+
+    // Make link to other versions of the doc open to the same hash target (if it exists).
+    setupAltDocsLink();
   }
 
   if (document.readyState === 'loading') {

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -40,6 +40,17 @@
   --color-text-secondary: var(--green2);
 }
 
+h4 :target,
+h5 :target {
+  scroll-margin-top: 55px;
+}
+
+@supports not (content-visibility: auto) {
+  h3 :target {
+    scroll-margin-top: 55px;
+  }
+}
+
 .dark-mode {
   --background-color-highlight: var(--black2);
   --color-critical: var(--red4);


### PR DESCRIPTION
This commit aims to improve the UX when navigating the docs using links
to subsections. Previously the browser would scroll down to the section
body, skipping the section heading. Using `scroll-margin-top` CSS
property, we can fix this behavior (at least on some browsers).

Links to other versions are now updated with the current targeted hash
to improve the UX when navigating from docs of one release line to
another.

I've also removed syntax not parsable by older browsers (arrow functions
and array destructuring) since the diff is pretty small and should
improve UX on those browsers.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
