### PR TITLE
test: validate webstream encoder/decoder inspector

### DIFF
--- a/test/parallel/test-webstream-encoding-inspect.js
+++ b/test/parallel/test-webstream-encoding-inspect.js
@@ -1,0 +1,35 @@
+'use strict';
+
+require('../common');
+
+const { TextEncoderStream, TextDecoderStream } = require('stream/web');
+const util = require('util');
+const assert = require('assert');
+
+const textEncoderStream = new TextEncoderStream();
+assert.strictEqual(
+  util.inspect(textEncoderStream),
+  `TextEncoderStream {
+  encoding: 'utf-8',
+  readable: ReadableStream { locked: false, state: 'readable', supportsBYOB: false },
+  writable: WritableStream { locked: false, state: 'writable' }
+}`
+);
+assert.throws(() => textEncoderStream[util.inspect.custom].call(), {
+  code: 'ERR_INVALID_THIS',
+});
+
+const textDecoderStream = new TextDecoderStream();
+assert.strictEqual(
+  util.inspect(textDecoderStream),
+  `TextDecoderStream {
+  encoding: 'utf-8',
+  fatal: false,
+  ignoreBOM: false,
+  readable: ReadableStream { locked: false, state: 'readable', supportsBYOB: false },
+  writable: WritableStream { locked: false, state: 'writable' }
+}`
+);
+assert.throws(() => textDecoderStream[util.inspect.custom].call(), {
+  code: 'ERR_INVALID_THIS',
+});


### PR DESCRIPTION
This validates that inspcetor outputs of TextEncoderStream & TextDecoderStream in `internal/webstreams`.

ref:
- https://coverage.nodejs.org/coverage-24adba675179ebba/lib/internal/webstreams/encoding.js.html#L98
- https://coverage.nodejs.org/coverage-24adba675179ebba/lib/internal/webstreams/encoding.js.html#L98