### PR TITLE
async_hooks: avoid decrementing iterator after erase

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -250,10 +250,9 @@ inline void AsyncHooks::AddContext(v8::Local<v8::Context> ctx) {
 inline void AsyncHooks::RemoveContext(v8::Local<v8::Context> ctx) {
   v8::Isolate* isolate = env()->isolate();
   v8::HandleScope handle_scope(isolate);
-  contexts_.erase(std::remove_if(contexts_.begin(), contexts_.end(),
-                                [&](auto&& el) {
-                                   return el.IsEmpty();
-                                }),
+  contexts_.erase(std::remove_if(contexts_.begin(),
+                                 contexts_.end(),
+                                 [&](auto&& el) { return el.IsEmpty(); }),
                   contexts_.end());
   for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
     v8::Local<v8::Context> saved_context =

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -107,8 +107,7 @@ inline void AsyncHooks::SetJSPromiseHooks(v8::Local<v8::Function> init,
   js_promise_hooks_[3].Reset(env()->isolate(), resolve);
   for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
     if (it->IsEmpty()) {
-      it = contexts_.erase(it);
-      it--;
+      contexts_.erase(it--);
       continue;
     }
     PersistentToLocal::Weak(env()->isolate(), *it)
@@ -251,12 +250,12 @@ inline void AsyncHooks::AddContext(v8::Local<v8::Context> ctx) {
 inline void AsyncHooks::RemoveContext(v8::Local<v8::Context> ctx) {
   v8::Isolate* isolate = env()->isolate();
   v8::HandleScope handle_scope(isolate);
+  contexts_.erase(std::remove_if(contexts_.begin(), contexts_.end(),
+                                [&](auto&& el) {
+                                   return el.IsEmpty();
+                                }),
+                  contexts_.end());
   for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
-    if (it->IsEmpty()) {
-      it = contexts_.erase(it);
-      it--;
-      continue;
-    }
     v8::Local<v8::Context> saved_context =
       PersistentToLocal::Weak(isolate, *it);
     if (saved_context == ctx) {


### PR DESCRIPTION
decrementing an iterator returned by `std::vector::erase` may have
undefined behaviour and should not be used. Decrementing `end()`
on an empty container is undefined and `.erase()` could leave
the container empty.

Instead, by calling `vec.erase(it--)` we decrement the valid iterator
before the erase operation but after being passed to the erase method.

In case of `AsyncHooks::RemoveContext` perform the cleanup of empty
contexts upfront using `std::remove_if` because the iteration gets
interrupted as soon as the context to be removed has been found.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
