### PR TITLE
doc: close tag in n-api.md

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1191,6 +1191,7 @@ added:
 NAPI_EXTERN napi_status node_api_throw_syntax_error(napi_env env,
                                                     const char* code,
                                                     const char* msg);
+```
 
 * `[in] env`: The environment that the API is invoked under.
 * `[in] code`: Optional error code to be set on the error.


### PR DESCRIPTION
[node_api_throw_syntax_error](https://nodejs.org/api/n-api.html#node_api_throw_syntax_error)