### PR TITLE
test: rename handlewrap.hasref tests

### DIFF
--- a/test/parallel/test-handle-wrap-hasref.js
+++ b/test/parallel/test-handle-wrap-hasref.js
@@ -133,4 +133,4 @@ const { kStateSymbol } = require('internal/dgram');
     (type) => type === 'Immediate').length, 1);
 }
 
-// See also test/pseudo-tty/test-handle-wrap-isrefed-tty.js
+// See also test/pseudo-tty/test-handle-wrap-hasref-tty.js

--- a/test/pseudo-tty/test-handle-wrap-hasref-tty.js
+++ b/test/pseudo-tty/test-handle-wrap-hasref-tty.js
@@ -1,7 +1,7 @@
 // Flags: --expose-internals --no-warnings
 'use strict';
 
-// See also test/parallel/test-handle-wrap-isrefed.js
+// See also test/parallel/test-handle-wrap-hasref.js
 
 const common = require('../common');
 const strictEqual = require('assert').strictEqual;


### PR DESCRIPTION
`HandleWrap.isRefed()` was renamed to `hasRef()`. However, the filename
of related TCs has not been reflected.

Refs: https://github.com/nodejs/node/commit/f31a5ec34a

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
