### PR TITLE
worker: add `hasRef()` to the handle object

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -665,6 +665,12 @@ void Worker::Ref(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+void Worker::HasRef(const FunctionCallbackInfo<Value>& args) {
+  Worker* w;
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
+  args.GetReturnValue().Set(w->has_ref_);
+}
+
 void Worker::Unref(const FunctionCallbackInfo<Value>& args) {
   Worker* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
@@ -827,6 +833,7 @@ void InitWorker(Local<Object> target,
 
     env->SetProtoMethod(w, "startThread", Worker::StartThread);
     env->SetProtoMethod(w, "stopThread", Worker::StopThread);
+    env->SetProtoMethod(w, "hasRef", Worker::HasRef);
     env->SetProtoMethod(w, "ref", Worker::Ref);
     env->SetProtoMethod(w, "unref", Worker::Unref);
     env->SetProtoMethod(w, "getResourceLimits", Worker::GetResourceLimits);
@@ -890,6 +897,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(Worker::New);
   registry->Register(Worker::StartThread);
   registry->Register(Worker::StopThread);
+  registry->Register(Worker::HasRef);
   registry->Register(Worker::Ref);
   registry->Register(Worker::Unref);
   registry->Register(Worker::GetResourceLimits);

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -61,6 +61,7 @@ class Worker : public AsyncWrap {
   static void SetEnvVars(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void StartThread(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void StopThread(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void HasRef(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Ref(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Unref(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetResourceLimits(

--- a/test/parallel/test-worker-hasref.js
+++ b/test/parallel/test-worker-hasref.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common');
+
+const { Worker } = require('worker_threads');
+const { createHook } = require('async_hooks');
+const { strictEqual } = require('assert');
+
+let handle;
+
+createHook({
+  init(asyncId, type, triggerAsyncId, resource) {
+    if (type === 'WORKER') {
+      handle = resource;
+      this.disable();
+    }
+  }
+}).enable();
+
+const w = new Worker('', { eval: true });
+
+strictEqual(handle.hasRef(), true);
+w.unref();
+strictEqual(handle.hasRef(), false);
+w.ref();
+strictEqual(handle.hasRef(), true);
+
+w.on('exit', common.mustCall((exitCode) => {
+  strictEqual(exitCode, 0);
+  strictEqual(handle.hasRef(), true);
+  setTimeout(common.mustCall(() => {
+    strictEqual(handle.hasRef(), undefined);
+  }), 0);
+}));


### PR DESCRIPTION
This should help projects like
https://github.com/mafintosh/why-is-node-running and
https://github.com/facebook/jest to detect if Worker instances are
keeping the event loop active correctly.

Fixes: https://github.com/nodejs/node/issues/42091
Refs: https://github.com/mafintosh/why-is-node-running/issues/59
Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
