### PR TITLE
test: make port arbitrary in net-perf_hooks

### DIFF
--- a/test/parallel/test-net-perf_hooks.js
+++ b/test/parallel/test-net-perf_hooks.js
@@ -22,7 +22,7 @@ obs.observe({ type: 'net' });
     socket.destroy();
   }));
 
-  server.listen(8080, common.mustCall(async () => {
+  server.listen(0, common.mustCall(async () => {
     await new Promise((resolve, reject) => {
       const socket = net.connect(server.address().port);
       socket.on('end', resolve);


### PR DESCRIPTION
`8080` port is too widely used to be always free for testing.

```bash
=== release test-net-perf_hooks ===
Path: parallel/test-net-perf_hooks
node:events:505
      throw er; // Unhandled 'error' event
      ^

Error: listen EADDRINUSE: address already in use 0.0.0.0:8080
    at Server.setupListenHandle [as _listen2] (node:net:1380:16)
    at listenInCluster (node:net:1428:12)
    at Server.listen (node:net:1516:7)
    at Object.<anonymous> (/home/livia/node/test/parallel/test-net-perf_hooks.js:25:10)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Module._load (node:internal/modules/cjs/loader:827:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47
Emitted 'error' event on Server instance at:
    at emitErrorNT (node:net:1407:8)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: 'EADDRINUSE',
  errno: -98,
  syscall: 'listen',
  address: '0.0.0.0',
  port: 8080
}

Node.js v18.0.0-pre
Command: out/Release/node /home/livia/node/test/parallel/test-net-perf_hooks.js
```