### PR TITLE
build: fix format-cpp

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -70,8 +70,12 @@ jobs:
       - name: Format C/C++ files
         run: |
           make format-cpp-build
+          # The `make format-cpp` error code is intentionally ignored here
+          # because it is irrelevant. We already check if the formatter produced
+          # a diff in the next line.
+          # Refs: https://github.com/nodejs/node/pull/42764
           CLANG_FORMAT_START="$(git merge-base HEAD refs/remotes/origin/$GITHUB_BASE_REF)" \
-            make format-cpp
+            make format-cpp || true
           git --no-pager diff --exit-code && EXIT_CODE="$?" || EXIT_CODE="$?"
           if [ "$EXIT_CODE" != "0" ]
           then


### PR DESCRIPTION
According to the logs in
https://github.com/nodejs/node/pull/42681#issuecomment-1100856089,
`make format-cpp` exits with an NZEC. This change intentionally ignores
the error code because it is irrelevant. We already check if the
formatter produced a diff in the next line.


Ignoring the `make format-cpp` error code works as expected: https://github.com/nodejs/node/runs/6054137816?check_suite_focus=true

<details>

```
Formatting C++ diff from c3a581c360ca1a2a11e49e2e99ca9ea83bbbaaf9..
changed files:
    src/api/environment.cc
    src/env.h
    src/node_wasm_web_api.cc
    src/node_wasm_web_api.h
make: *** [Makefile:1437: format-cpp] Error 1
diff --git a/src/api/environment.cc b/src/api/environment.cc
index 02a4d8d2fc..f3a8f49812 100644
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -255,7 +255,8 @@ void SetIsolateMiscHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
   isolate->SetAllowWasmCodeGenerationCallback(allow_wasm_codegen_cb);
 
   Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
-  if (per_process::cli_options->get_per_isolate_options()->get_per_env_options()
+  if (per_process::cli_options->get_per_isolate_options()
+          ->get_per_env_options()
           ->experimental_fetch) {
     isolate->SetWasmStreamingCallback(wasm_web_api::StartStreamingCompilation);
   }
diff --git a/src/env.h b/src/env.h
index 7885a96771..7e35833e45 100644
--- a/src/env.h
+++ b/src/env.h
@@ -552,7 +552,7 @@ constexpr size_t kFsStatsBufferLength =
   V(udp_constructor_function, v8::Function)                                    \
   V(url_constructor_function, v8::Function)                                    \
   V(wasm_streaming_compilation_impl, v8::Function)                             \
-  V(wasm_streaming_object_constructor, v8::Function)                           \
+  V(wasm_streaming_object_constructor, v8::Function)
 
 class Environment;
 struct AllocatedBuffer;
diff --git a/src/node_wasm_web_api.cc b/src/node_wasm_web_api.cc
index 8d7a58a9cd..3a333900c9 100644
--- a/src/node_wasm_web_api.cc
+++ b/src/node_wasm_web_api.cc
@@ -95,8 +95,8 @@ void WasmStreamingObject::Push(
   }
 
   // Forward the data to V8. Internally, V8 will make a copy.
-  obj->streaming_->OnBytesReceived(
-      static_cast<const uint8_t*>(bytes) + offset, size);
+  obj->streaming_->OnBytesReceived(static_cast<const uint8_t*>(bytes) + offset,
+                                   size);
   obj->wasm_size_ += size;
 }
 
@@ -150,7 +150,7 @@ void StartStreamingCompilation(
   // instantiateStreaming).
   v8::Local<v8::Function> impl = env->wasm_streaming_compilation_impl();
   CHECK(!impl.IsEmpty());
-  v8::Local<v8::Value> args[] = { obj, info[0] };
+  v8::Local<v8::Value> args[] = {obj, info[0]};
 
   // Hand control to the JavaScript implementation. It should never throw an
   // error, but if it does, we leave it to the calling V8 code to handle that
diff --git a/src/node_wasm_web_api.h b/src/node_wasm_web_api.h
index 659344e2b8..9f5fe86816 100644
--- a/src/node_wasm_web_api.h
+++ b/src/node_wasm_web_api.h
@@ -44,8 +44,7 @@ class WasmStreamingObject final : public BaseObject {
 // This is a v8::WasmStreamingCallback implementation that must be passed to
 // v8::Isolate::SetWasmStreamingCallback when setting up the isolate in order to
 // enable the WebAssembly.(compile|instantiate)Streaming APIs.
-void StartStreamingCompilation(
-    const v8::FunctionCallbackInfo<v8::Value>& args);
+void StartStreamingCompilation(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 }  // namespace wasm_web_api
 }  // namespace node

ERROR: Please run:

  CLANG_FORMAT_START="$(git merge-base HEAD <target-branch-name>)" make format-cpp

to format the commits in your branch.
Error: Process completed with exit code 1.
```

</details>

Refs: https://github.com/nodejs/node/pull/42681#issuecomment-1100856089
Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
