### PR TITLE
doc: add missing `rename` event in fs.FSWatcher

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -6130,6 +6130,18 @@ added: v0.5.8
 Emitted when an error occurs while watching the file. The errored
 {fs.FSWatcher} object is no longer usable in the event handler.
 
+#### Event: `'rename'`
+
+<!-- YAML
+added: v0.5.8
+-->
+
+* `eventType` {string} The type of rename event that has occurred
+* `filename` {string|Buffer} The filename that renamed (if relevant/available)
+
+Emitted when a filename appears or disappears in a watched directory on most
+platforms. See more details in [`fs.watch()`][].
+
 #### `watcher.close()`
 
 <!-- YAML


### PR DESCRIPTION
`rename` event is mentioned in the `fs.watch` section, but it isn't
included in the `fs.FSWatcher` section.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
