### PR TITLE
fs: add read(buffer[, options]) versions

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -417,6 +417,33 @@ Reads data from the file and stores that in the given buffer.
 If the file is not modified concurrently, the end-of-file is reached when the
 number of bytes read is zero.
 
+#### `filehandle.read(buffer[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `buffer` {Buffer|TypedArray|DataView} A buffer that will be filled with the
+  file data read.
+* `options` {Object}
+  * `offset` {integer} The location in the buffer at which to start filling.
+    **Default:** `0`
+  * `length` {integer} The number of bytes to read. **Default:**
+    `buffer.byteLength - offset`
+  * `position` {integer} The location where to begin reading data from the
+    file. If `null`, data will be read from the current file position, and
+    the position will be updated. If `position` is an integer, the current
+    file position will remain unchanged. **Default:**: `null`
+* Returns: {Promise} Fulfills upon success with an object with two properties:
+  * `bytesRead` {integer} The number of bytes read
+  * `buffer` {Buffer|TypedArray|DataView} A reference to the passed in `buffer`
+    argument.
+
+Reads data from the file and stores that in the given buffer.
+
+If the file is not modified concurrently, the end-of-file is reached when the
+number of bytes read is zero.
+
 #### `filehandle.readableWebStream()`
 
 <!-- YAML
@@ -3231,6 +3258,28 @@ changes:
 * `fd` {integer}
 * `options` {Object}
   * `buffer` {Buffer|TypedArray|DataView} **Default:** `Buffer.alloc(16384)`
+  * `offset` {integer} **Default:** `0`
+  * `length` {integer} **Default:** `buffer.byteLength - offset`
+  * `position` {integer|bigint} **Default:** `null`
+* `callback` {Function}
+  * `err` {Error}
+  * `bytesRead` {integer}
+  * `buffer` {Buffer}
+
+Similar to the [`fs.read()`][] function, this version takes an optional
+`options` object. If no `options` object is specified, it will default with the
+above values.
+
+### `fs.read(fd, buffer[, options], callback)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fd` {integer}
+* `buffer` {Buffer|TypedArray|DataView} The buffer that the data will be
+  written to.
+* `options` {Object}
   * `offset` {integer} **Default:** `0`
   * `length` {integer} **Default:** `buffer.byteLength - offset`
   * `position` {integer|bigint} **Default:** `null`

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -641,7 +641,7 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
   validateBuffer(buffer);
   callback = maybeCallback(callback);
 
-  if (offset === undefined) {
+  if (offset == null) {
     offset = 0;
   } else {
     validateInteger(offset, 'offset', 0);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -136,6 +136,7 @@ const {
   validateEncoding,
   validateFunction,
   validateInteger,
+  validateObject,
   validateString,
 } = require('internal/validators');
 
@@ -609,35 +610,32 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
   fd = getValidatedFd(fd);
 
   let offset = offsetOrOptions;
-  if (
-    arguments.length === 4 &&
-    (offsetOrOptions === undefined || typeof offsetOrOptions === 'object')
-  ) {
-    // This is fs.read(fd, buffer, options, callback)
-    callback = length;
-    ({
-      offset = 0,
-      length = buffer.byteLength - offset,
-      position = null
-    } = offsetOrOptions ?? ObjectCreate(null));
-  } else if (arguments.length <= 3) {
-    // Assume fs.read(fd[, params], callback)
-    let params = ObjectCreate(null);
-    if (arguments.length < 3) {
+  let params = null;
+  if (arguments.length <= 4) {
+    if (arguments.length === 4) {
+      // This is fs.read(fd, buffer, options, callback)
+      validateObject(offsetOrOptions, 'options', { nullable: true });
+      callback = length;
+      params = offsetOrOptions;
+    } else if (arguments.length === 3) {
+      // This is fs.read(fd, bufferOrParams, callback)
+      if (!isArrayBufferView(buffer)) {
+        // This is fs.read(fd, params, callback)
+        params = buffer;
+        ({ buffer = Buffer.alloc(16384) } = params ?? ObjectCreate(null));
+      }
+      callback = offsetOrOptions;
+    } else {
       // This is fs.read(fd, callback)
       callback = buffer;
-    } else {
-      // This is fs.read(fd, params, callback)
-      params = buffer;
-      callback = offset;
+      buffer = Buffer.alloc(16384);
     }
 
     ({
-      buffer = Buffer.alloc(16384),
       offset = 0,
       length = buffer.byteLength - offset,
       position = null
-    } = params);
+    } = params ?? ObjectCreate(null));
   }
 
   validateBuffer(buffer);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -690,24 +690,26 @@ ObjectDefineProperty(read, internalUtil.customPromisifyArgs,
  *   offset?: number;
  *   length?: number;
  *   position?: number | bigint;
- *   }} [offsetOrOptions]
+ *   }} [offset]
  * @returns {number}
  */
-function readSync(fd, buffer, offsetOrOptions, length, position) {
+function readSync(fd, buffer, offset, length, position) {
   fd = getValidatedFd(fd);
 
   validateBuffer(buffer);
 
-  let offset = offsetOrOptions;
-  if (typeof offset === 'object') {
+  if (arguments.length <= 3) {
+    // Assume fs.readSync(fd, buffer, options)
+    const options = offset || ObjectCreate(null);
+
     ({
       offset = 0,
       length = buffer.byteLength - offset,
       position = null
-    } = offsetOrOptions ?? ObjectCreate(null));
+    } = options);
   }
 
-  if (offset === false || offset === undefined) {
+  if (offset == null) {
     offset = 0;
   } else {
     validateInteger(offset, 'offset', 0);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -641,7 +641,7 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
   validateBuffer(buffer);
   callback = maybeCallback(callback);
 
-  if (offset === false || offset === undefined) {
+  if (offset === undefined) {
     offset = 0;
   } else {
     validateInteger(offset, 'offset', 0);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -595,7 +595,7 @@ function openSync(path, flags, mode) {
  * Reads file from the specified `fd` (file descriptor).
  * @param {number} fd
  * @param {Buffer | TypedArray | DataView} buffer
- * @param {number} offset
+ * @param {number} offsetOrOptions
  * @param {number} length
  * @param {number | bigint} position
  * @param {(
@@ -609,7 +609,10 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
   fd = getValidatedFd(fd);
 
   let offset = offsetOrOptions;
-  if (arguments.length === 4 && typeof offsetOrOptions === 'object') {
+  if (
+    arguments.length === 4 &&
+    (offsetOrOptions === undefined || typeof offsetOrOptions === 'object')
+  ) {
     // This is fs.read(fd, buffer, options, callback)
     callback = length;
     ({
@@ -618,16 +621,13 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
       position = null
     } = offsetOrOptions ?? ObjectCreate(null));
   } else if (arguments.length <= 3) {
-    // Assume fs.read(fd, params, callback)
+    // Assume fs.read(fd[, params], callback)
     let params = ObjectCreate(null);
     if (arguments.length < 3) {
       // This is fs.read(fd, callback)
-      // buffer will be the callback
       callback = buffer;
     } else {
-      // This is fs.read(fd, {}, callback)
-      // buffer will be the params object
-      // offset is the callback
+      // This is fs.read(fd, params, callback)
       params = buffer;
       callback = offset;
     }
@@ -643,7 +643,7 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
   validateBuffer(buffer);
   callback = maybeCallback(callback);
 
-  if (offset == null) {
+  if (offset === false || offset === undefined) {
     offset = 0;
   } else {
     validateInteger(offset, 'offset', 0);
@@ -692,7 +692,7 @@ ObjectDefineProperty(read, internalUtil.customPromisifyArgs,
  *   offset?: number;
  *   length?: number;
  *   position?: number | bigint;
- *   }} [offset]
+ *   }} [offsetOrOptions]
  * @returns {number}
  */
 function readSync(fd, buffer, offsetOrOptions, length, position) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -605,21 +605,30 @@ function openSync(path, flags, mode) {
  *   ) => any} callback
  * @returns {void}
  */
-function read(fd, buffer, offset, length, position, callback) {
+function read(fd, buffer, offsetOrOptions, length, position, callback) {
   fd = getValidatedFd(fd);
 
-  if (arguments.length <= 3) {
-    // Assume fs.read(fd, options, callback)
-    let options = ObjectCreate(null);
+  let offset = offsetOrOptions;
+  if (arguments.length === 4 && typeof offsetOrOptions === 'object') {
+    // This is fs.read(fd, buffer, options, callback)
+    callback = length;
+    ({
+      offset = 0,
+      length = buffer.byteLength - offset,
+      position = null
+    } = offsetOrOptions ?? ObjectCreate(null));
+  } else if (arguments.length <= 3) {
+    // Assume fs.read(fd, params, callback)
+    let params = ObjectCreate(null);
     if (arguments.length < 3) {
       // This is fs.read(fd, callback)
       // buffer will be the callback
       callback = buffer;
     } else {
       // This is fs.read(fd, {}, callback)
-      // buffer will be the options object
+      // buffer will be the params object
       // offset is the callback
-      options = buffer;
+      params = buffer;
       callback = offset;
     }
 
@@ -628,7 +637,7 @@ function read(fd, buffer, offset, length, position, callback) {
       offset = 0,
       length = buffer.byteLength - offset,
       position = null
-    } = options);
+    } = params);
   }
 
   validateBuffer(buffer);
@@ -686,23 +695,21 @@ ObjectDefineProperty(read, internalUtil.customPromisifyArgs,
  *   }} [offset]
  * @returns {number}
  */
-function readSync(fd, buffer, offset, length, position) {
+function readSync(fd, buffer, offsetOrOptions, length, position) {
   fd = getValidatedFd(fd);
 
   validateBuffer(buffer);
 
-  if (arguments.length <= 3) {
-    // Assume fs.readSync(fd, buffer, options)
-    const options = offset || ObjectCreate(null);
-
+  let offset = offsetOrOptions;
+  if (typeof offset === 'object') {
     ({
       offset = 0,
       length = buffer.byteLength - offset,
       position = null
-    } = options);
+    } = offsetOrOptions ?? ObjectCreate(null));
   }
 
-  if (offset == null) {
+  if (offset === false || offset === undefined) {
     offset = 0;
   } else {
     validateInteger(offset, 'offset', 0);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -508,21 +508,31 @@ async function open(path, flags, mode) {
                                  flagsNumber, mode, kUsePromises));
 }
 
-async function read(handle, bufferOrOptions, offset, length, position) {
-  let buffer = bufferOrOptions;
+async function read(handle, bufferOrParams, offset, length, position) {
+  let buffer = bufferOrParams;
   if (!isArrayBufferView(buffer)) {
-    bufferOrOptions ??= ObjectCreate(null);
+    // This is fh.read(params)
+    bufferOrParams ??= ObjectCreate(null);
     ({
       buffer = Buffer.alloc(16384),
       offset = 0,
       length = buffer.byteLength - offset,
       position = null
-    } = bufferOrOptions);
+    } = bufferOrParams);
 
     validateBuffer(buffer);
   }
 
-  if (offset == null) {
+  if (typeof offset === 'object') {
+    // This is fh.read(buffer, options)
+    ({
+      offset = 0,
+      length = buffer.byteLength - offset,
+      position = null
+    } = offset ?? ObjectCreate(null));
+  }
+
+  if (offset === false || offset === undefined) {
     offset = 0;
   } else {
     validateInteger(offset, 'offset', 0);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -512,13 +512,12 @@ async function read(handle, bufferOrParams, offset, length, position) {
   let buffer = bufferOrParams;
   if (!isArrayBufferView(buffer)) {
     // This is fh.read(params)
-    bufferOrParams ??= ObjectCreate(null);
     ({
       buffer = Buffer.alloc(16384),
       offset = 0,
       length = buffer.byteLength - offset,
       position = null
-    } = bufferOrParams);
+    } = bufferOrParams ?? ObjectCreate(null));
 
     validateBuffer(buffer);
   }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -522,7 +522,7 @@ async function read(handle, bufferOrParams, offset, length, position) {
     validateBuffer(buffer);
   }
 
-  if (typeof offset === 'object') {
+  if (offset !== null && typeof offset === 'object') {
     // This is fh.read(buffer, options)
     ({
       offset = 0,
@@ -531,7 +531,7 @@ async function read(handle, bufferOrParams, offset, length, position) {
     } = offset ?? ObjectCreate(null));
   }
 
-  if (offset === undefined) {
+  if (offset == null) {
     offset = 0;
   } else {
     validateInteger(offset, 'offset', 0);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -531,7 +531,7 @@ async function read(handle, bufferOrParams, offset, length, position) {
     } = offset ?? ObjectCreate(null));
   }
 
-  if (offset === false || offset === undefined) {
+  if (offset === undefined) {
     offset = 0;
   } else {
     validateInteger(offset, 'offset', 0);

--- a/test/parallel/test-fs-read-offset-null.js
+++ b/test/parallel/test-fs-read-offset-null.js
@@ -18,17 +18,11 @@ const buf = Buffer.alloc(1);
 fs.open(filepath, 'r', (_, fd) => {
   assert.throws(
     () => fs.read(fd, { offset: null, buffer: buf }, () => {}),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError',
-    }
+    { code: 'ERR_INVALID_ARG_TYPE' }
   );
   assert.throws(
     () => fs.read(fd, buf, { offset: null }, () => {}),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError',
-    }
+    { code: 'ERR_INVALID_ARG_TYPE' }
   );
   fs.close(fd, common.mustSucceed(() => {}));
 });
@@ -40,10 +34,7 @@ let filehandle = null;
   filehandle = await fsPromises.open(filepath, 'r');
   assert.rejects(
     async () => filehandle.read(buf, { offset: null }),
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError',
-    }
+    { code: 'ERR_INVALID_ARG_TYPE' }
   );
 })()
 .then(common.mustCall())

--- a/test/parallel/test-fs-read-offset-null.js
+++ b/test/parallel/test-fs-read-offset-null.js
@@ -47,10 +47,7 @@ let filehandle = null;
   );
 })()
 .then(common.mustCall())
-.finally(async () => {
-  if (filehandle)
-    await filehandle.close();
-});
+.finally(() => filehandle?.close());
 
 (async () => {
   filehandle = await fsPromises.open(filepath, 'r');
@@ -61,7 +58,4 @@ let filehandle = null;
   assert.strictEqual(readObject.buffer[0], 120);
 })()
 .then(common.mustCall())
-.finally(async () => {
-  if (filehandle)
-    await filehandle.close();
-});
+.finally(() => filehandle?.close());

--- a/test/parallel/test-fs-read-offset-null.js
+++ b/test/parallel/test-fs-read-offset-null.js
@@ -39,7 +39,7 @@ let filehandle = null;
 (async () => {
   filehandle = await fsPromises.open(filepath, 'r');
   assert.rejects(
-    async () => await filehandle.read(buf, { offset: null }),
+    async () => filehandle.read(buf, { offset: null }),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',

--- a/test/parallel/test-fs-read-offset-null.js
+++ b/test/parallel/test-fs-read-offset-null.js
@@ -14,17 +14,25 @@ const filepath = fixtures.path('x.txt');
 const buf = Buffer.alloc(1);
 // Reading only one character, hence buffer of one byte is enough.
 
+// Test is done by making sure the first letter in buffer is
+// same as first letter in file.
+// 120 is the ascii code of letter x.
+
 // Test for callback API.
 fs.open(filepath, 'r', common.mustSucceed((fd) => {
-  assert.throws(
-    () => fs.read(fd, { offset: null, buffer: buf }, () => {}),
-    { code: 'ERR_INVALID_ARG_TYPE' }
-  );
-  assert.throws(
-    () => fs.read(fd, buf, { offset: null }, () => {}),
-    { code: 'ERR_INVALID_ARG_TYPE' }
-  );
-  fs.close(fd, common.mustSucceed(() => {}));
+  fs.read(fd, { offset: null, buffer: buf },
+          common.mustSucceed((bytesRead, buffer) => {
+            assert.strictEqual(buffer[0], 120);
+            fs.close(fd, common.mustSucceed(() => {}));
+          }));
+}));
+
+fs.open(filepath, 'r', common.mustSucceed((fd) => {
+  fs.read(fd, buf, { offset: null },
+          common.mustSucceed((bytesRead, buffer) => {
+            assert.strictEqual(buffer[0], 120);
+            fs.close(fd, common.mustSucceed(() => {}));
+          }));
 }));
 
 let filehandle = null;
@@ -32,19 +40,14 @@ let filehandle = null;
 // Test for promise api
 (async () => {
   filehandle = await fsPromises.open(filepath, 'r');
-  assert.rejects(
-    async () => filehandle.read(buf, { offset: null }),
-    { code: 'ERR_INVALID_ARG_TYPE' }
-  );
+  const readObject = await filehandle.read(buf, { offset: null }, buf.length);
+  assert.strictEqual(readObject.buffer[0], 120);
 })()
 .then(common.mustCall())
 .finally(() => filehandle?.close());
 
 (async () => {
   filehandle = await fsPromises.open(filepath, 'r');
-
-  // In this test, null is interpreted as default options, not null offset.
-  // 120 is the ascii code of letter x.
   const readObject = await filehandle.read(buf, null);
   assert.strictEqual(readObject.buffer[0], 120);
 })()

--- a/test/parallel/test-fs-read-offset-null.js
+++ b/test/parallel/test-fs-read-offset-null.js
@@ -15,7 +15,7 @@ const buf = Buffer.alloc(1);
 // Reading only one character, hence buffer of one byte is enough.
 
 // Test for callback API.
-fs.open(filepath, 'r', (_, fd) => {
+fs.open(filepath, 'r', common.mustSucceed((fd) => {
   assert.throws(
     () => fs.read(fd, { offset: null, buffer: buf }, () => {}),
     { code: 'ERR_INVALID_ARG_TYPE' }
@@ -25,7 +25,7 @@ fs.open(filepath, 'r', (_, fd) => {
     { code: 'ERR_INVALID_ARG_TYPE' }
   );
   fs.close(fd, common.mustSucceed(() => {}));
-});
+}));
 
 let filehandle = null;
 

--- a/test/parallel/test-fs-read-offset-null.js
+++ b/test/parallel/test-fs-read-offset-null.js
@@ -40,7 +40,7 @@ let filehandle = null;
 // Test for promise api
 (async () => {
   filehandle = await fsPromises.open(filepath, 'r');
-  const readObject = await filehandle.read(buf, { offset: null }, buf.length);
+  const readObject = await filehandle.read(buf, { offset: null });
   assert.strictEqual(readObject.buffer[0], 120);
 })()
 .then(common.mustCall())
@@ -48,7 +48,7 @@ let filehandle = null;
 
 (async () => {
   filehandle = await fsPromises.open(filepath, 'r');
-  const readObject = await filehandle.read(buf, null);
+  const readObject = await filehandle.read(buf, null, buf.length, 0);
   assert.strictEqual(readObject.buffer[0], 120);
 })()
 .then(common.mustCall())

--- a/test/parallel/test-fs-read-offset-null.js
+++ b/test/parallel/test-fs-read-offset-null.js
@@ -14,11 +14,11 @@ const filepath = fixtures.path('x.txt');
 const buf = Buffer.alloc(1);
 // Reading only one character, hence buffer of one byte is enough.
 
-// Test is done by making sure the first letter in buffer is
+// Tests are done by making sure the first letter in buffer is
 // same as first letter in file.
 // 120 is the ascii code of letter x.
 
-// Test for callback API.
+// Tests for callback API.
 fs.open(filepath, 'r', common.mustSucceed((fd) => {
   fs.read(fd, { offset: null, buffer: buf },
           common.mustSucceed((bytesRead, buffer) => {
@@ -37,19 +37,28 @@ fs.open(filepath, 'r', common.mustSucceed((fd) => {
 
 let filehandle = null;
 
-// Test for promise api
+// Tests for promises api
 (async () => {
   filehandle = await fsPromises.open(filepath, 'r');
   const readObject = await filehandle.read(buf, { offset: null });
   assert.strictEqual(readObject.buffer[0], 120);
 })()
-.then(common.mustCall())
-.finally(() => filehandle?.close());
+.finally(() => filehandle?.close())
+.then(common.mustCall());
+
+// Undocumented: omitted position works the same as position === null
+(async () => {
+  filehandle = await fsPromises.open(filepath, 'r');
+  const readObject = await filehandle.read(buf, null, buf.length);
+  assert.strictEqual(readObject.buffer[0], 120);
+})()
+.finally(() => filehandle?.close())
+.then(common.mustCall());
 
 (async () => {
   filehandle = await fsPromises.open(filepath, 'r');
   const readObject = await filehandle.read(buf, null, buf.length, 0);
   assert.strictEqual(readObject.buffer[0], 120);
 })()
-.then(common.mustCall())
-.finally(() => filehandle?.close());
+.finally(() => filehandle?.close())
+.then(common.mustCall());

--- a/test/parallel/test-fs-read-optional-params.js
+++ b/test/parallel/test-fs-read-optional-params.js
@@ -34,5 +34,5 @@ testValid('Passing in an empty object', {});
 testValid('Passing in an object', {
   offset: 0,
   length: bufferAsOption.byteLength,
-  position: 0
+  position: 0,
 });

--- a/test/parallel/test-fs-read-optional-params.js
+++ b/test/parallel/test-fs-read-optional-params.js
@@ -5,49 +5,36 @@ const fixtures = require('../common/fixtures');
 const fs = require('fs');
 const assert = require('assert');
 const filepath = fixtures.path('x.txt');
-const fd = fs.openSync(filepath, 'r');
 
 const expected = Buffer.from('xyz\n');
 const defaultBufferAsync = Buffer.alloc(16384);
 const bufferAsOption = Buffer.allocUnsafe(expected.byteLength);
 
-// Test not passing in any options object
-fs.read(fd, common.mustCall((err, bytesRead, buffer) => {
-  assert.strictEqual(bytesRead, expected.byteLength);
-  assert.deepStrictEqual(defaultBufferAsync.byteLength, buffer.byteLength);
-}));
-fs.read(fd, bufferAsOption, { position: 0 }, common.mustCall((err, bytesRead, buffer) => {
-  assert.strictEqual(bytesRead, expected.byteLength);
-  assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength);
-}));
+function testValid(message, ...options) {
+  const paramsMsg = `${message} (as params)`;
+  const paramsFilehandle = fs.openSync(filepath, 'r');
+  fs.read(paramsFilehandle, ...options, common.mustCall((err, bytesRead, buffer) => {
+    if (err) throw err;
+    assert.strictEqual(bytesRead, expected.byteLength, paramsMsg);
+    assert.deepStrictEqual(defaultBufferAsync.byteLength, buffer.byteLength, paramsMsg);
+    fs.closeSync(paramsFilehandle);
+  }));
 
-// Test passing in an empty options object
-fs.read(fd, { position: 0 }, common.mustCall((err, bytesRead, buffer) => {
-  assert.strictEqual(bytesRead, expected.byteLength);
-  assert.deepStrictEqual(defaultBufferAsync.byteLength, buffer.byteLength);
-}));
-fs.read(fd, bufferAsOption, { position: 0 }, common.mustCall((err, bytesRead, buffer) => {
-  assert.strictEqual(bytesRead, expected.byteLength);
-  assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength);
-}));
+  const optionsMsg = `${message} (as options)`;
+  const optionsFilehandle = fs.openSync(filepath, 'r');
+  fs.read(optionsFilehandle, bufferAsOption, ...options, common.mustCall((err, bytesRead, buffer) => {
+    if (err) throw err;
+    assert.strictEqual(bytesRead, expected.byteLength, optionsMsg);
+    assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength, optionsMsg);
+    fs.closeSync(optionsFilehandle);
+  }));
+}
 
-// Test passing in options
-fs.read(fd, {
-  buffer: bufferAsOption,
+testValid('Not passing in any object');
+testValid('Passing in a null', null);
+testValid('Passing in an empty object', {});
+testValid('Passing in an object', {
   offset: 0,
   length: bufferAsOption.byteLength,
   position: 0
-},
-        common.mustCall((err, bytesRead, buffer) => {
-          assert.strictEqual(bytesRead, expected.byteLength);
-          assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength);
-        }));
-fs.read(fd, bufferAsOption, {
-  offset: 0,
-  length: bufferAsOption.byteLength,
-  position: 0
-},
-        common.mustCall((err, bytesRead, buffer) => {
-          assert.strictEqual(bytesRead, expected.byteLength);
-          assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength);
-        }));
+});

--- a/test/parallel/test-fs-read-optional-params.js
+++ b/test/parallel/test-fs-read-optional-params.js
@@ -13,7 +13,7 @@ const bufferAsOption = Buffer.allocUnsafe(expected.byteLength);
 function testValid(message, ...options) {
   const paramsMsg = `${message} (as params)`;
   const paramsFilehandle = fs.openSync(filepath, 'r');
-  fs.read(paramsFilehandle, ...options, common.mustCall((err, bytesRead, buffer) => {
+  fs.read(paramsFilehandle, ...options, common.mustSucceed((bytesRead, buffer) => {
     assert.strictEqual(bytesRead, expected.byteLength, paramsMsg);
     assert.deepStrictEqual(defaultBufferAsync.byteLength, buffer.byteLength, paramsMsg);
     fs.closeSync(paramsFilehandle);
@@ -21,7 +21,7 @@ function testValid(message, ...options) {
 
   const optionsMsg = `${message} (as options)`;
   const optionsFilehandle = fs.openSync(filepath, 'r');
-  fs.read(optionsFilehandle, bufferAsOption, ...options, common.mustCall((err, bytesRead, buffer) => {
+  fs.read(optionsFilehandle, bufferAsOption, ...options, common.mustSucceed((bytesRead, buffer) => {
     assert.strictEqual(bytesRead, expected.byteLength, optionsMsg);
     assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength, optionsMsg);
     fs.closeSync(optionsFilehandle);

--- a/test/parallel/test-fs-read-optional-params.js
+++ b/test/parallel/test-fs-read-optional-params.js
@@ -14,7 +14,6 @@ function testValid(message, ...options) {
   const paramsMsg = `${message} (as params)`;
   const paramsFilehandle = fs.openSync(filepath, 'r');
   fs.read(paramsFilehandle, ...options, common.mustCall((err, bytesRead, buffer) => {
-    if (err) throw err;
     assert.strictEqual(bytesRead, expected.byteLength, paramsMsg);
     assert.deepStrictEqual(defaultBufferAsync.byteLength, buffer.byteLength, paramsMsg);
     fs.closeSync(paramsFilehandle);
@@ -23,7 +22,6 @@ function testValid(message, ...options) {
   const optionsMsg = `${message} (as options)`;
   const optionsFilehandle = fs.openSync(filepath, 'r');
   fs.read(optionsFilehandle, bufferAsOption, ...options, common.mustCall((err, bytesRead, buffer) => {
-    if (err) throw err;
     assert.strictEqual(bytesRead, expected.byteLength, optionsMsg);
     assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength, optionsMsg);
     fs.closeSync(optionsFilehandle);

--- a/test/parallel/test-fs-read-optional-params.js
+++ b/test/parallel/test-fs-read-optional-params.js
@@ -9,28 +9,45 @@ const fd = fs.openSync(filepath, 'r');
 
 const expected = Buffer.from('xyz\n');
 const defaultBufferAsync = Buffer.alloc(16384);
-const bufferAsOption = Buffer.allocUnsafe(expected.length);
+const bufferAsOption = Buffer.allocUnsafe(expected.byteLength);
 
 // Test not passing in any options object
 fs.read(fd, common.mustCall((err, bytesRead, buffer) => {
-  assert.strictEqual(bytesRead, expected.length);
-  assert.deepStrictEqual(defaultBufferAsync.length, buffer.length);
+  assert.strictEqual(bytesRead, expected.byteLength);
+  assert.deepStrictEqual(defaultBufferAsync.byteLength, buffer.byteLength);
+}));
+fs.read(fd, bufferAsOption, { position: 0 }, common.mustCall((err, bytesRead, buffer) => {
+  assert.strictEqual(bytesRead, expected.byteLength);
+  assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength);
 }));
 
 // Test passing in an empty options object
 fs.read(fd, { position: 0 }, common.mustCall((err, bytesRead, buffer) => {
-  assert.strictEqual(bytesRead, expected.length);
-  assert.deepStrictEqual(defaultBufferAsync.length, buffer.length);
+  assert.strictEqual(bytesRead, expected.byteLength);
+  assert.deepStrictEqual(defaultBufferAsync.byteLength, buffer.byteLength);
+}));
+fs.read(fd, bufferAsOption, { position: 0 }, common.mustCall((err, bytesRead, buffer) => {
+  assert.strictEqual(bytesRead, expected.byteLength);
+  assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength);
 }));
 
 // Test passing in options
 fs.read(fd, {
   buffer: bufferAsOption,
   offset: 0,
-  length: bufferAsOption.length,
+  length: bufferAsOption.byteLength,
   position: 0
 },
         common.mustCall((err, bytesRead, buffer) => {
-          assert.strictEqual(bytesRead, expected.length);
-          assert.deepStrictEqual(bufferAsOption.length, buffer.length);
+          assert.strictEqual(bytesRead, expected.byteLength);
+          assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength);
+        }));
+fs.read(fd, bufferAsOption, {
+  offset: 0,
+  length: bufferAsOption.byteLength,
+  position: 0
+},
+        common.mustCall((err, bytesRead, buffer) => {
+          assert.strictEqual(bytesRead, expected.byteLength);
+          assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength);
         }));

--- a/test/parallel/test-fs-read-promises-optional-params.js
+++ b/test/parallel/test-fs-read-promises-optional-params.js
@@ -10,10 +10,18 @@ const fd = fs.openSync(filepath, 'r');
 
 const expected = Buffer.from('xyz\n');
 const defaultBufferAsync = Buffer.alloc(16384);
+const bufferAsOption = Buffer.allocUnsafe(expected.byteLength);
 
 read(fd, {})
   .then(function({ bytesRead, buffer }) {
-    assert.strictEqual(bytesRead, expected.length);
-    assert.deepStrictEqual(defaultBufferAsync.length, buffer.length);
+    assert.strictEqual(bytesRead, expected.byteLength);
+    assert.deepStrictEqual(defaultBufferAsync.byteLength, buffer.byteLength);
+  })
+  .then(common.mustCall());
+
+read(fd, bufferAsOption, { position: 0 })
+  .then(function({ bytesRead, buffer }) {
+    assert.strictEqual(bytesRead, expected.byteLength);
+    assert.deepStrictEqual(bufferAsOption.byteLength, buffer.byteLength);
   })
   .then(common.mustCall());

--- a/test/parallel/test-fs-readSync-optional-params.js
+++ b/test/parallel/test-fs-readSync-optional-params.js
@@ -31,7 +31,7 @@ for (const options of [
   { length: expected.length, position: 0 },
   { offset: 0, length: expected.length, position: 0 },
 
-  { offset: null },
+  { offset: false },
   { position: null },
   { position: -1 },
   { position: 0n },
@@ -39,18 +39,8 @@ for (const options of [
   // Test default params
   {},
   null,
-  undefined,
-
-  // Test if bad params are interpreted as default (not mandatory)
-  false,
-  true,
-  Infinity,
-  42n,
-  Symbol(),
 
   // Test even more malicious corner cases
-  '4'.repeat(expected.length),
-  new String('4444'),
   [4, 4, 4, 4],
 ]) {
   runTest(Buffer.allocUnsafe(expected.length), options);

--- a/test/parallel/test-fs-readSync-optional-params.js
+++ b/test/parallel/test-fs-readSync-optional-params.js
@@ -31,7 +31,7 @@ for (const options of [
   { length: expected.length, position: 0 },
   { offset: 0, length: expected.length, position: 0 },
 
-  { offset: false },
+  { offset: null },
   { position: null },
   { position: -1 },
   { position: 0n },
@@ -39,8 +39,18 @@ for (const options of [
   // Test default params
   {},
   null,
+  undefined,
+
+  // Test if bad params are interpreted as default (not mandatory)
+  false,
+  true,
+  Infinity,
+  42n,
+  Symbol(),
 
   // Test even more malicious corner cases
+  '4'.repeat(expected.length),
+  new String('4444'),
   [4, 4, 4, 4],
 ]) {
   runTest(Buffer.allocUnsafe(expected.length), options);


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/42601 (writing counterparts)

This PR does:
- Adding `fs.read(fd, buffer[, options], callback)`
- Adding `filehandle.read(buffer[, options])`
- ~~Aligning `fs.readSync` code (changes in UB corner cases) [^UB]~~ (offloaded due to potential breakage)

These changes would allow to:
- Align writing methods with uniform `buffer[, options]` signature [^proposed]
- Align signatures of reading methods
- Which also means not only read-write interoperability within each of three APIs, but also between any of them
- Achieve a bit more consistent UB behaviour, when documentation implies similarity (["For detailed information, see the documentation of the asynchronous version of this API"](https://nodejs.org/api/fs.html#fsreadsyncfd-buffer-options))
- Have it fully completed without waiting for DEP0162 EOL
- Harden `fs.readSync` typechecking [^readSyncObject]
- (optional) Introduce `params`[^params] signatures later, if needed [^whyParams]
- (optional) Deprecate and remove `params` signatures later, if strongly needed [^badParams]
- (opinionated) Maybe make usage of `fs.read` and `fh.read` less error-prone [^badParams]

<details>
<summary>Why current behaviour is questionable</summary>

Default buffer in `fs.read` and `filehandle.read` is `Buffer.alloc(16384)`. It's a pretty reasonable value for positioned argument (i.e. if it's used only when all further arguments are unset as well), but it's a footgun when length is defined.
```js
#!/usr/bin/env node
import {open} from 'fs/promises';
async function readSubstring(filepath, len = 0, pos = 0) {
	const fh = await open(filepath, 'r');
	const res = await fh.read({ length: Number(len), position: Number(pos) });
	const str = String(res.buffer);
	return str;
}
const substr = await readSubstring(...process.argv.slice(2));
console.log(substr);
```
```bash
$ echo 123456789 > /tmp/tst
$ readsubstr.mjs /tmp/tst 3 5
678
$ readsubstr.mjs /tmp/tst 3 5 | wc -c
16385
```
Without reading the docs properly, I'd totes assume that it allocates `length + offset||0` number of bytes by default.
Because of that, `buffer` has to be allocated explicitly. Which makes `[buffer[, options]]` signature more reasonable and less misleading.
</details>



[^UB]: Changes in UB are about interpreting `false`/`null`/`undefined` values as invalid or default. I think, the best way here is to interpret `typeof offsetOrOptions === 'object'` as indicator of attempt to use "named params" version. null means default values. false and undefined means `offset === 0`. Everything else goes to offset's integer validation.
Exception: Callback API methods will still check the number of arguments as well, to keep `callback` strictly positioned.

[^proposed]: Refs: https://github.com/nodejs/node/pull/42601#discussion_r846095440

[^readSyncObject]: Current implementation of `fs.readSync` interprets any value as options object. For example, passing a primitive string will use its length property without any warning.

[^params]: I use the following terminology here: `options == { offset, length, position }`, `params == { buffer, ...options } == { buffer, offset, length, position }`

[^whyParams]: Theoretical reason to include `buffer` is its strong connection to `offset` and `length`. If we specify nonzero offset, we usually imply a non-arbitrary buffer. However, I don't have strong arguments nor good examples; and it can be worked around anyway.

[^badParams]: See "Why current behaviour is questionable" foldablie
