### PR TITLE
test: improve lib/internal/source_map/source_map.js coverage

### DIFF
--- a/test/fixtures/source-map/disk-index.map
+++ b/test/fixtures/source-map/disk-index.map
@@ -1,0 +1,30 @@
+{
+  "version": 3,
+  "sources": [
+    "disk.js"
+  ],
+  "sections": [
+    { "offset": {"line": 0, "column": 0 }, "map": 
+     {
+      "version": 3,
+      "sources": [
+        "section.js"
+      ],
+      "names": [
+        "Foo",
+        "[object Object]",
+        "x",
+        "this",
+        "console",
+        "info",
+        "methodC",
+        "a",
+        "b",
+        "methodA"
+      ],
+      "mappings": "MAAMA,IACJC,YAAaC,EAAE,IACbC,KAAKD,EAAIA,EAAIA,EAAI,GACjB,GAAIC,KAAKD,EAAG,CACVE,QAAQC,KAAK,eACR,CACLD,QAAQC,KAAK,aAEfF,KAAKG,UAEPL,UACEG,QAAQC,KAAK,WAEfJ,UACEG,QAAQC,KAAK,aAEfJ,UACEG,QAAQC,KAAK,WAEfJ,UACEG,QAAQC,KAAK,cAIjB,MAAME,EAAI,IAAIP,IAAI,GAClB,MAAMQ,EAAI,IAAIR,IAAI,IAClBO,EAAEE",
+      "sourceRoot": "./"
+     }
+    }
+  ]
+}

--- a/test/parallel/test-source-map-api.js
+++ b/test/parallel/test-source-map-api.js
@@ -126,6 +126,27 @@ const { readFileSync } = require('fs');
   assert.strictEqual(Object.keys(result).length, 0);
 }
 
+// SourceMap can be instantiated with Index Source Map V3 object as payload.
+{
+  const payload = JSON.parse(readFileSync(
+    require.resolve('../fixtures/source-map/disk-index.map'), 'utf8'
+  ));
+  const sourceMap = new SourceMap(payload);
+  const {
+    originalLine,
+    originalColumn,
+    originalSource
+  } = sourceMap.findEntry(0, 29);
+  assert.strictEqual(originalLine, 2);
+  assert.strictEqual(originalColumn, 4);
+  assert(originalSource.endsWith('section.js'));
+  // The stored payload should be a clone:
+  assert.strictEqual(payload.mappings, sourceMap.payload.mappings);
+  assert.notStrictEqual(payload, sourceMap.payload);
+  assert.strictEqual(payload.sources[0], sourceMap.payload.sources[0]);
+  assert.notStrictEqual(payload.sources, sourceMap.payload.sources);
+}
+
 // Test various known decodings to ensure decodeVLQ works correctly.
 {
   function makeMinimalMap(column) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This improves a test coverage in `lib/internal/source_map/source_map.js` coverage

Ref: https://coverage.nodejs.org/coverage-0699150267c08fb2/lib/internal/source_map/source_map.js.html#L154
Ref: https://coverage.nodejs.org/coverage-0699150267c08fb2/lib/internal/source_map/source_map.js.html#L165

This validates that [index source map](https://sourcemaps.info/spec.html#h.535es3xeprgt) is supported.
