### PR TITLE
fs: harden `options` typecheck in reading methods

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -701,26 +701,28 @@ ObjectDefineProperty(read, kCustomPromisifyArgsSymbol,
  *   offset?: number;
  *   length?: number;
  *   position?: number | bigint | null;
- *   }} [offset]
+ *   }} [offsetOrOptions]
  * @returns {number}
  */
-function readSync(fd, buffer, offset, length, position) {
+function readSync(fd, buffer, offsetOrOptions, length, position) {
   fd = getValidatedFd(fd);
 
   validateBuffer(buffer);
 
-  if (arguments.length <= 3) {
-    // Assume fs.readSync(fd, buffer, options)
-    const options = offset || kEmptyObject;
+  let offset = offsetOrOptions;
+  if (arguments.length <= 3 || typeof offsetOrOptions === 'object') {
+    if (offsetOrOptions !== undefined) {
+      validateObject(offsetOrOptions, 'options', { nullable: true });
+    }
 
     ({
       offset = 0,
       length = buffer.byteLength - offset,
       position = null,
-    } = options);
+    } = offsetOrOptions ?? kEmptyObject);
   }
 
-  if (offset == null) {
+  if (offset === undefined) {
     offset = 0;
   } else {
     validateInteger(offset, 'offset', 0);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -639,6 +639,9 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
       buffer = Buffer.alloc(16384);
     }
 
+    if (params !== undefined) {
+      validateObject(params, 'options', { nullable: true });
+    }
     ({
       offset = 0,
       length = buffer.byteLength - offset,

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -77,6 +77,7 @@ const {
   validateBuffer,
   validateEncoding,
   validateInteger,
+  validateObject,
   validateString,
 } = require('internal/validators');
 const pathModule = require('path');
@@ -517,6 +518,9 @@ async function read(handle, bufferOrParams, offset, length, position) {
   let buffer = bufferOrParams;
   if (!isArrayBufferView(buffer)) {
     // This is fh.read(params)
+    if (bufferOrParams !== undefined) {
+      validateObject(bufferOrParams, 'options', { nullable: true });
+    }
     ({
       buffer = Buffer.alloc(16384),
       offset = 0,

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -153,11 +153,21 @@ async function executeOnHandle(dest, func) {
       });
     }
 
-    // Use fallback buffer allocation when input not buffer
+    // Use fallback buffer allocation when first argument is null
     {
       await executeOnHandle(dest, async (handle) => {
-        const ret = await handle.read(0, 0, 0, 0);
+        const ret = await handle.read(null, 0, 0, 0);
         assert.strictEqual(ret.buffer.length, 16384);
+      });
+    }
+
+    // TypeError if buffer is not ArrayBufferView or nullable object
+    {
+      await executeOnHandle(dest, async (handle) => {
+        await assert.rejects(
+          async () => handle.read(0, 0, 0, 0),
+          { code: 'ERR_INVALID_ARG_TYPE' }
+        );
       });
     }
 


### PR DESCRIPTION
~~Can we have this on `semver-patch` level?~~

This PR adds validation in [fs.read()](https://nodejs.org/api/fs.html#fsreadfd-options-callback) and [filehandle.read()](https://nodejs.org/api/fs.html#filehandlereadoptions) to make sure that first argument is a buffer or a params object (that is, not arbitrary-type value). In case of `null` or `undefined`, default values are used.

It also adds the same validation in [fs.readSync()](https://nodejs.org/api/fs.html#fsreadsyncfd-buffer-options), which has a different signature: `buffer` is not a part of `options` object, but a mandatory first argument.

Currently, said methods are destructuring any non-ArrayBufferView value as `{ buffer, offset, position, length }` object.

For example, this happens without any warning if we accidentaly pass string or array (both have `.length` property):
```mjs
import {open} from 'fs/promises';
const fh = await open(process.argv[2], 'r');
const res = await fh.read('gwak'); // or [1, 2, 3, 4]
console.log('result:', res);
console.log('string:', String(res.buffer));
console.log('string length:', String(res.buffer).length);
```
```bash
$ cat /tmp/tst
ABCDEFGHI
$ node test.mjs /tmp/tst
result: {
  bytesRead: 4,
  buffer: <Buffer 41 42 43 44 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ... 16334 more bytes>
}
string: ABCD
string length: 16384
```
With the patch:
```bash
$ node test.mjs /tmp/tst
node:internal/errors:475
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "options" argument must be of type object. Received type string ('gwak')
    at read (node:internal/fs/promises:516:7)
    at fsCall (node:internal/fs/promises:367:18)
    at FileHandle.read (node:internal/fs/promises:168:12)
    at file://test.mjs:3:22 {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v18.0.0-pre
```