### PR TITLE
doc: fix version history for Loaders API

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -301,7 +301,12 @@ Enable experimental `import.meta.resolve()` support.
 ### `--experimental-loader=module`
 
 <!-- YAML
-added: v9.0.0
+added: v8.8.0
+changes:
+  - version: v12.11.1
+    pr-url: https://github.com/nodejs/node/pull/29752
+    description: This flag was renamed from `--loader` to
+                 `--experimental-loader`.
 -->
 
 Specify the `module` of a custom experimental [ECMAScript module loader][].

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -674,6 +674,15 @@ of Node.js applications.
 
 ## Loaders
 
+<!-- YAML
+added: v8.8.0
+changes:
+  - version: v16.12.0
+    pr-url: https://github.com/nodejs/node/pull/37468
+    description: Removed `getFormat`, `getSource`, `transformSource`, and
+                 `globalPreload`; added `load` hook and `getGlobalPreload` hook.
+-->
+
 > Stability: 1 - Experimental
 
 > This API is currently being redesigned and will still change.


### PR DESCRIPTION
FWIW https://github.com/nodejs/node/pull/15445 introduced a `--loader` flag (which landed in 8.8.0), and https://github.com/nodejs/node/pull/29752 renamed it to `--experimental-loader` (which landed in 12.11.1).

https://github.com/nodejs/node/pull/37468 changed greatly the API, and IMO it's useful to have it documented somewhere.

//cc @nodejs/loaders 
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
