### PR TITLE
lib: ensure `TextDecoder` only removes `utf8` BOM on `utf8` encoding

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -512,6 +512,7 @@ function makeTextDecoderJS() {
         this[kHandle].write(input);
 
       if (result.length > 0 &&
+          this[kEncoding] === 'utf-8' &&
           !this[kBOMSeen] &&
           !(this[kFlags] & CONVERTER_FLAGS_IGNORE_BOM)) {
         // If the very first result in the stream is a BOM, and we are not

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -41,7 +41,7 @@ assert(TextDecoder);
     // which should not be removed
     const buf = Buffer.from([0xef, 0xbb, 0xbf, 0x74, 0x00, 0x65,
                              0x00, 0x73, 0x00, 0x74, 0x00, 0xac,
-                             0x20]);
+                             0x20], 'utf16le');
     const dec = new TextDecoder(i);
     assert.strictEqual(dec.encoding, 'utf-16le');
     const res = dec.decode(buf);

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -40,8 +40,8 @@ assert(TextDecoder);
     // This is a utf16le buffer with a utf8 BOM,
     // which should not be removed
     const buf = Buffer.from([0xef, 0xbb, 0xbf, 0x74, 0x00, 0x65,
-                            0x00, 0x73, 0x00, 0x74, 0x00, 0xac,
-                            0x20])
+                             0x00, 0x73, 0x00, 0x74, 0x00, 0xac,
+                             0x20]);
     const dec = new TextDecoder(i);
     assert.strictEqual(dec.encoding, 'utf-16-le');
     const res = dec.decode(buf);

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -43,7 +43,7 @@ assert(TextDecoder);
                              0x00, 0x73, 0x00, 0x74, 0x00, 0xac,
                              0x20]);
     const dec = new TextDecoder(i);
-    assert.strictEqual(dec.encoding, 'utf-16-le');
+    assert.strictEqual(dec.encoding, 'utf-16le');
     const res = dec.decode(buf);
     assert.strictEqual(res, '\ufefftest€');
   });

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -45,7 +45,7 @@ assert(TextDecoder);
     const dec = new TextDecoder(i);
     assert.strictEqual(dec.encoding, 'utf-16le');
     const res = dec.decode(buf);
-    assert.strictEqual(res, '\ufefftest€');
+    assert.strictEqual(res, '믯璿攀猀琀가');
   });
 }
 

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -34,6 +34,21 @@ assert(TextDecoder);
   });
 }
 
+// Test TextDecoder, UTF-16LE, fatal: false, ignoreBOM: false
+{
+  ['utf-16', 'utf-16le'].forEach((i) => {
+    // This is a utf16le buffer with a utf8 BOM,
+    // which should not be removed
+    const buf = Buffer.from([0xef, 0xbb, 0xbf, 0x74, 0x00, 0x65,
+                            0x00, 0x73, 0x00, 0x74, 0x00, 0xac,
+                            0x20])
+    const dec = new TextDecoder(i);
+    assert.strictEqual(dec.encoding, 'utf-16-le');
+    const res = dec.decode(buf);
+    assert.strictEqual(res, '\ufefftest€');
+  });
+}
+
 // Test TextDecoder, UTF-8, fatal: false, ignoreBOM: true
 {
   ['unicode-1-1-utf-8', 'utf8', 'utf-8'].forEach((i) => {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

While working on https://github.com/gulpjs/remove-bom-stream/pull/8, I noticed that our test case to ensure a UTF-8 BOM at the beginning of a UTF-16 file wouldn't be removed; however, it was.

I dug into the PR at https://github.com/nodejs/node/pull/30132 and noticed that it lost the utf-8 and utf-16-le checks in the refactor.

This should limit the BOM removal to just the UTF-8 encoding. There should also be a follow-up PR that adds the utf-16-le BOM removal back to the code.
