### PR TITLE
node-api: explicitly set __cdecl for Node-API functions

### DIFF
--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -49,227 +49,228 @@
 
 EXTERN_C_START
 
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_get_last_error_info(napi_env env, const napi_extended_error_info** result);
 
 // Getters for defined singletons
-NAPI_EXTERN napi_status napi_get_undefined(napi_env env, napi_value* result);
-NAPI_EXTERN napi_status napi_get_null(napi_env env, napi_value* result);
-NAPI_EXTERN napi_status napi_get_global(napi_env env, napi_value* result);
-NAPI_EXTERN napi_status napi_get_boolean(napi_env env,
-                                         bool value,
-                                         napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_undefined(napi_env env,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_null(napi_env env,
+                                                 napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_global(napi_env env,
+                                                   napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_boolean(napi_env env,
+                                                    bool value,
+                                                    napi_value* result);
 
 // Methods to create Primitive types/Objects
-NAPI_EXTERN napi_status napi_create_object(napi_env env, napi_value* result);
-NAPI_EXTERN napi_status napi_create_array(napi_env env, napi_value* result);
-NAPI_EXTERN napi_status napi_create_array_with_length(napi_env env,
-                                                      size_t length,
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_object(napi_env env,
                                                       napi_value* result);
-NAPI_EXTERN napi_status napi_create_double(napi_env env,
-                                           double value,
-                                           napi_value* result);
-NAPI_EXTERN napi_status napi_create_int32(napi_env env,
-                                          int32_t value,
-                                          napi_value* result);
-NAPI_EXTERN napi_status napi_create_uint32(napi_env env,
-                                           uint32_t value,
-                                           napi_value* result);
-NAPI_EXTERN napi_status napi_create_int64(napi_env env,
-                                          int64_t value,
-                                          napi_value* result);
-NAPI_EXTERN napi_status napi_create_string_latin1(napi_env env,
-                                                  const char* str,
-                                                  size_t length,
-                                                  napi_value* result);
-NAPI_EXTERN napi_status napi_create_string_utf8(napi_env env,
-                                                const char* str,
-                                                size_t length,
-                                                napi_value* result);
-NAPI_EXTERN napi_status napi_create_string_utf16(napi_env env,
-                                                 const char16_t* str,
-                                                 size_t length,
-                                                 napi_value* result);
-NAPI_EXTERN napi_status napi_create_symbol(napi_env env,
-                                           napi_value description,
-                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_array(napi_env env,
+                                                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_array_with_length(napi_env env, size_t length, napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_double(napi_env env,
+                                                      double value,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_int32(napi_env env,
+                                                     int32_t value,
+                                                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_uint32(napi_env env,
+                                                      uint32_t value,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_int64(napi_env env,
+                                                     int64_t value,
+                                                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_string_latin1(
+    napi_env env, const char* str, size_t length, napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_string_utf8(napi_env env,
+                                                           const char* str,
+                                                           size_t length,
+                                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_string_utf16(napi_env env,
+                                                            const char16_t* str,
+                                                            size_t length,
+                                                            napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_symbol(napi_env env,
+                                                      napi_value description,
+                                                      napi_value* result);
 #ifdef NAPI_EXPERIMENTAL
-NAPI_EXTERN napi_status node_api_symbol_for(napi_env env,
-                                            const char* utf8description,
-                                            size_t length,
-                                            napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+node_api_symbol_for(napi_env env,
+                    const char* utf8description,
+                    size_t length,
+                    napi_value* result);
 #endif  // NAPI_EXPERIMENTAL
-NAPI_EXTERN napi_status napi_create_function(napi_env env,
-                                             const char* utf8name,
-                                             size_t length,
-                                             napi_callback cb,
-                                             void* data,
-                                             napi_value* result);
-NAPI_EXTERN napi_status napi_create_error(napi_env env,
-                                          napi_value code,
-                                          napi_value msg,
-                                          napi_value* result);
-NAPI_EXTERN napi_status napi_create_type_error(napi_env env,
-                                               napi_value code,
-                                               napi_value msg,
-                                               napi_value* result);
-NAPI_EXTERN napi_status napi_create_range_error(napi_env env,
-                                                napi_value code,
-                                                napi_value msg,
-                                                napi_value* result);
-#ifdef NAPI_EXPERIMENTAL
-NAPI_EXTERN napi_status node_api_create_syntax_error(napi_env env,
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_function(napi_env env,
+                                                        const char* utf8name,
+                                                        size_t length,
+                                                        napi_callback cb,
+                                                        void* data,
+                                                        napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_error(napi_env env,
                                                      napi_value code,
                                                      napi_value msg,
                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_type_error(napi_env env,
+                                                          napi_value code,
+                                                          napi_value msg,
+                                                          napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_range_error(napi_env env,
+                                                           napi_value code,
+                                                           napi_value msg,
+                                                           napi_value* result);
+#ifdef NAPI_EXPERIMENTAL
+NAPI_EXTERN napi_status NAPI_CDECL node_api_create_syntax_error(
+    napi_env env, napi_value code, napi_value msg, napi_value* result);
 #endif  // NAPI_EXPERIMENTAL
 
 // Methods to get the native napi_value from Primitive type
-NAPI_EXTERN napi_status napi_typeof(napi_env env,
-                                    napi_value value,
-                                    napi_valuetype* result);
-NAPI_EXTERN napi_status napi_get_value_double(napi_env env,
-                                              napi_value value,
-                                              double* result);
-NAPI_EXTERN napi_status napi_get_value_int32(napi_env env,
-                                             napi_value value,
-                                             int32_t* result);
-NAPI_EXTERN napi_status napi_get_value_uint32(napi_env env,
-                                              napi_value value,
-                                              uint32_t* result);
-NAPI_EXTERN napi_status napi_get_value_int64(napi_env env,
-                                             napi_value value,
-                                             int64_t* result);
-NAPI_EXTERN napi_status napi_get_value_bool(napi_env env,
-                                            napi_value value,
-                                            bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_typeof(napi_env env,
+                                               napi_value value,
+                                               napi_valuetype* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_double(napi_env env,
+                                                         napi_value value,
+                                                         double* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_int32(napi_env env,
+                                                        napi_value value,
+                                                        int32_t* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_uint32(napi_env env,
+                                                         napi_value value,
+                                                         uint32_t* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_int64(napi_env env,
+                                                        napi_value value,
+                                                        int64_t* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_bool(napi_env env,
+                                                       napi_value value,
+                                                       bool* result);
 
 // Copies LATIN-1 encoded bytes from a string into a buffer.
-NAPI_EXTERN napi_status napi_get_value_string_latin1(
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_string_latin1(
     napi_env env, napi_value value, char* buf, size_t bufsize, size_t* result);
 
 // Copies UTF-8 encoded bytes from a string into a buffer.
-NAPI_EXTERN napi_status napi_get_value_string_utf8(
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_string_utf8(
     napi_env env, napi_value value, char* buf, size_t bufsize, size_t* result);
 
 // Copies UTF-16 encoded bytes from a string into a buffer.
-NAPI_EXTERN napi_status napi_get_value_string_utf16(napi_env env,
-                                                    napi_value value,
-                                                    char16_t* buf,
-                                                    size_t bufsize,
-                                                    size_t* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_string_utf16(napi_env env,
+                                                               napi_value value,
+                                                               char16_t* buf,
+                                                               size_t bufsize,
+                                                               size_t* result);
 
 // Methods to coerce values
 // These APIs may execute user scripts
-NAPI_EXTERN napi_status napi_coerce_to_bool(napi_env env,
-                                            napi_value value,
-                                            napi_value* result);
-NAPI_EXTERN napi_status napi_coerce_to_number(napi_env env,
-                                              napi_value value,
-                                              napi_value* result);
-NAPI_EXTERN napi_status napi_coerce_to_object(napi_env env,
-                                              napi_value value,
-                                              napi_value* result);
-NAPI_EXTERN napi_status napi_coerce_to_string(napi_env env,
-                                              napi_value value,
-                                              napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_coerce_to_bool(napi_env env,
+                                                       napi_value value,
+                                                       napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_coerce_to_number(napi_env env,
+                                                         napi_value value,
+                                                         napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_coerce_to_object(napi_env env,
+                                                         napi_value value,
+                                                         napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_coerce_to_string(napi_env env,
+                                                         napi_value value,
+                                                         napi_value* result);
 
 // Methods to work with Objects
-NAPI_EXTERN napi_status napi_get_prototype(napi_env env,
-                                           napi_value object,
-                                           napi_value* result);
-NAPI_EXTERN napi_status napi_get_property_names(napi_env env,
-                                                napi_value object,
-                                                napi_value* result);
-NAPI_EXTERN napi_status napi_set_property(napi_env env,
-                                          napi_value object,
-                                          napi_value key,
-                                          napi_value value);
-NAPI_EXTERN napi_status napi_has_property(napi_env env,
-                                          napi_value object,
-                                          napi_value key,
-                                          bool* result);
-NAPI_EXTERN napi_status napi_get_property(napi_env env,
-                                          napi_value object,
-                                          napi_value key,
-                                          napi_value* result);
-NAPI_EXTERN napi_status napi_delete_property(napi_env env,
-                                             napi_value object,
-                                             napi_value key,
-                                             bool* result);
-NAPI_EXTERN napi_status napi_has_own_property(napi_env env,
-                                              napi_value object,
-                                              napi_value key,
-                                              bool* result);
-NAPI_EXTERN napi_status napi_set_named_property(napi_env env,
-                                                napi_value object,
-                                                const char* utf8name,
-                                                napi_value value);
-NAPI_EXTERN napi_status napi_has_named_property(napi_env env,
-                                                napi_value object,
-                                                const char* utf8name,
-                                                bool* result);
-NAPI_EXTERN napi_status napi_get_named_property(napi_env env,
-                                                napi_value object,
-                                                const char* utf8name,
-                                                napi_value* result);
-NAPI_EXTERN napi_status napi_set_element(napi_env env,
-                                         napi_value object,
-                                         uint32_t index,
-                                         napi_value value);
-NAPI_EXTERN napi_status napi_has_element(napi_env env,
-                                         napi_value object,
-                                         uint32_t index,
-                                         bool* result);
-NAPI_EXTERN napi_status napi_get_element(napi_env env,
-                                         napi_value object,
-                                         uint32_t index,
-                                         napi_value* result);
-NAPI_EXTERN napi_status napi_delete_element(napi_env env,
-                                            napi_value object,
-                                            uint32_t index,
-                                            bool* result);
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_prototype(napi_env env,
+                                                      napi_value object,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_property_names(napi_env env,
+                                                           napi_value object,
+                                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_set_property(napi_env env,
+                                                     napi_value object,
+                                                     napi_value key,
+                                                     napi_value value);
+NAPI_EXTERN napi_status NAPI_CDECL napi_has_property(napi_env env,
+                                                     napi_value object,
+                                                     napi_value key,
+                                                     bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_property(napi_env env,
+                                                     napi_value object,
+                                                     napi_value key,
+                                                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_delete_property(napi_env env,
+                                                        napi_value object,
+                                                        napi_value key,
+                                                        bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_has_own_property(napi_env env,
+                                                         napi_value object,
+                                                         napi_value key,
+                                                         bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_set_named_property(napi_env env,
+                                                           napi_value object,
+                                                           const char* utf8name,
+                                                           napi_value value);
+NAPI_EXTERN napi_status NAPI_CDECL napi_has_named_property(napi_env env,
+                                                           napi_value object,
+                                                           const char* utf8name,
+                                                           bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_named_property(napi_env env,
+                                                           napi_value object,
+                                                           const char* utf8name,
+                                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_set_element(napi_env env,
+                                                    napi_value object,
+                                                    uint32_t index,
+                                                    napi_value value);
+NAPI_EXTERN napi_status NAPI_CDECL napi_has_element(napi_env env,
+                                                    napi_value object,
+                                                    uint32_t index,
+                                                    bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_element(napi_env env,
+                                                    napi_value object,
+                                                    uint32_t index,
+                                                    napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_delete_element(napi_env env,
+                                                       napi_value object,
+                                                       uint32_t index,
+                                                       bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_define_properties(napi_env env,
                        napi_value object,
                        size_t property_count,
                        const napi_property_descriptor* properties);
 
 // Methods to work with Arrays
-NAPI_EXTERN napi_status napi_is_array(napi_env env,
-                                      napi_value value,
-                                      bool* result);
-NAPI_EXTERN napi_status napi_get_array_length(napi_env env,
-                                              napi_value value,
-                                              uint32_t* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_array(napi_env env,
+                                                 napi_value value,
+                                                 bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_array_length(napi_env env,
+                                                         napi_value value,
+                                                         uint32_t* result);
 
 // Methods to compare values
-NAPI_EXTERN napi_status napi_strict_equals(napi_env env,
-                                           napi_value lhs,
-                                           napi_value rhs,
-                                           bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_strict_equals(napi_env env,
+                                                      napi_value lhs,
+                                                      napi_value rhs,
+                                                      bool* result);
 
 // Methods to work with Functions
-NAPI_EXTERN napi_status napi_call_function(napi_env env,
-                                           napi_value recv,
-                                           napi_value func,
-                                           size_t argc,
-                                           const napi_value* argv,
-                                           napi_value* result);
-NAPI_EXTERN napi_status napi_new_instance(napi_env env,
-                                          napi_value constructor,
-                                          size_t argc,
-                                          const napi_value* argv,
-                                          napi_value* result);
-NAPI_EXTERN napi_status napi_instanceof(napi_env env,
-                                        napi_value object,
-                                        napi_value constructor,
-                                        bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_call_function(napi_env env,
+                                                      napi_value recv,
+                                                      napi_value func,
+                                                      size_t argc,
+                                                      const napi_value* argv,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_new_instance(napi_env env,
+                                                     napi_value constructor,
+                                                     size_t argc,
+                                                     const napi_value* argv,
+                                                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_instanceof(napi_env env,
+                                                   napi_value object,
+                                                   napi_value constructor,
+                                                   bool* result);
 
 // Methods to work with napi_callbacks
 
 // Gets all callback info in a single call. (Ugly, but faster.)
-NAPI_EXTERN napi_status napi_get_cb_info(
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_cb_info(
     napi_env env,               // [in] NAPI environment handle
     napi_callback_info cbinfo,  // [in] Opaque callback-info handle
     size_t* argc,      // [in-out] Specifies the size of the provided argv array
@@ -278,10 +279,9 @@ NAPI_EXTERN napi_status napi_get_cb_info(
     napi_value* this_arg,  // [out] Receives the JS 'this' arg for the call
     void** data);          // [out] Receives the data pointer for the callback.
 
-NAPI_EXTERN napi_status napi_get_new_target(napi_env env,
-                                            napi_callback_info cbinfo,
-                                            napi_value* result);
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_new_target(
+    napi_env env, napi_callback_info cbinfo, napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_define_class(napi_env env,
                   const char* utf8name,
                   size_t length,
@@ -292,235 +292,240 @@ napi_define_class(napi_env env,
                   napi_value* result);
 
 // Methods to work with external data objects
-NAPI_EXTERN napi_status napi_wrap(napi_env env,
-                                  napi_value js_object,
-                                  void* native_object,
-                                  napi_finalize finalize_cb,
-                                  void* finalize_hint,
-                                  napi_ref* result);
-NAPI_EXTERN napi_status napi_unwrap(napi_env env,
-                                    napi_value js_object,
-                                    void** result);
-NAPI_EXTERN napi_status napi_remove_wrap(napi_env env,
-                                         napi_value js_object,
-                                         void** result);
-NAPI_EXTERN napi_status napi_create_external(napi_env env,
-                                             void* data,
+NAPI_EXTERN napi_status NAPI_CDECL napi_wrap(napi_env env,
+                                             napi_value js_object,
+                                             void* native_object,
                                              napi_finalize finalize_cb,
                                              void* finalize_hint,
-                                             napi_value* result);
-NAPI_EXTERN napi_status napi_get_value_external(napi_env env,
-                                                napi_value value,
-                                                void** result);
+                                             napi_ref* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_unwrap(napi_env env,
+                                               napi_value js_object,
+                                               void** result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_remove_wrap(napi_env env,
+                                                    napi_value js_object,
+                                                    void** result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_external(napi_env env,
+                     void* data,
+                     napi_finalize finalize_cb,
+                     void* finalize_hint,
+                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_external(napi_env env,
+                                                           napi_value value,
+                                                           void** result);
 
 // Methods to control object lifespan
 
 // Set initial_refcount to 0 for a weak reference, >0 for a strong reference.
-NAPI_EXTERN napi_status napi_create_reference(napi_env env,
-                                              napi_value value,
-                                              uint32_t initial_refcount,
-                                              napi_ref* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_reference(napi_env env,
+                      napi_value value,
+                      uint32_t initial_refcount,
+                      napi_ref* result);
 
 // Deletes a reference. The referenced value is released, and may
 // be GC'd unless there are other references to it.
-NAPI_EXTERN napi_status napi_delete_reference(napi_env env, napi_ref ref);
+NAPI_EXTERN napi_status NAPI_CDECL napi_delete_reference(napi_env env,
+                                                         napi_ref ref);
 
 // Increments the reference count, optionally returning the resulting count.
 // After this call the  reference will be a strong reference because its
 // refcount is >0, and the referenced object is effectively "pinned".
 // Calling this when the refcount is 0 and the object is unavailable
 // results in an error.
-NAPI_EXTERN napi_status napi_reference_ref(napi_env env,
-                                           napi_ref ref,
-                                           uint32_t* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_reference_ref(napi_env env,
+                                                      napi_ref ref,
+                                                      uint32_t* result);
 
 // Decrements the reference count, optionally returning the resulting count.
 // If the result is 0 the reference is now weak and the object may be GC'd
 // at any time if there are no other references. Calling this when the
 // refcount is already 0 results in an error.
-NAPI_EXTERN napi_status napi_reference_unref(napi_env env,
-                                             napi_ref ref,
-                                             uint32_t* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_reference_unref(napi_env env,
+                                                        napi_ref ref,
+                                                        uint32_t* result);
 
 // Attempts to get a referenced value. If the reference is weak,
 // the value might no longer be available, in that case the call
 // is still successful but the result is NULL.
-NAPI_EXTERN napi_status napi_get_reference_value(napi_env env,
-                                                 napi_ref ref,
-                                                 napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_reference_value(napi_env env,
+                                                            napi_ref ref,
+                                                            napi_value* result);
 
-NAPI_EXTERN napi_status napi_open_handle_scope(napi_env env,
-                                               napi_handle_scope* result);
-NAPI_EXTERN napi_status napi_close_handle_scope(napi_env env,
-                                                napi_handle_scope scope);
-NAPI_EXTERN napi_status napi_open_escapable_handle_scope(
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_open_handle_scope(napi_env env, napi_handle_scope* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_close_handle_scope(napi_env env, napi_handle_scope scope);
+NAPI_EXTERN napi_status NAPI_CDECL napi_open_escapable_handle_scope(
     napi_env env, napi_escapable_handle_scope* result);
-NAPI_EXTERN napi_status napi_close_escapable_handle_scope(
+NAPI_EXTERN napi_status NAPI_CDECL napi_close_escapable_handle_scope(
     napi_env env, napi_escapable_handle_scope scope);
 
-NAPI_EXTERN napi_status napi_escape_handle(napi_env env,
-                                           napi_escapable_handle_scope scope,
-                                           napi_value escapee,
-                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_escape_handle(napi_env env,
+                   napi_escapable_handle_scope scope,
+                   napi_value escapee,
+                   napi_value* result);
 
 // Methods to support error handling
-NAPI_EXTERN napi_status napi_throw(napi_env env, napi_value error);
-NAPI_EXTERN napi_status napi_throw_error(napi_env env,
-                                         const char* code,
-                                         const char* msg);
-NAPI_EXTERN napi_status napi_throw_type_error(napi_env env,
-                                              const char* code,
-                                              const char* msg);
-NAPI_EXTERN napi_status napi_throw_range_error(napi_env env,
-                                               const char* code,
-                                               const char* msg);
-#ifdef NAPI_EXPERIMENTAL
-NAPI_EXTERN napi_status node_api_throw_syntax_error(napi_env env,
+NAPI_EXTERN napi_status NAPI_CDECL napi_throw(napi_env env, napi_value error);
+NAPI_EXTERN napi_status NAPI_CDECL napi_throw_error(napi_env env,
                                                     const char* code,
                                                     const char* msg);
+NAPI_EXTERN napi_status NAPI_CDECL napi_throw_type_error(napi_env env,
+                                                         const char* code,
+                                                         const char* msg);
+NAPI_EXTERN napi_status NAPI_CDECL napi_throw_range_error(napi_env env,
+                                                          const char* code,
+                                                          const char* msg);
+#ifdef NAPI_EXPERIMENTAL
+NAPI_EXTERN napi_status NAPI_CDECL node_api_throw_syntax_error(napi_env env,
+                                                               const char* code,
+                                                               const char* msg);
 #endif  // NAPI_EXPERIMENTAL
-NAPI_EXTERN napi_status napi_is_error(napi_env env,
-                                      napi_value value,
-                                      bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_error(napi_env env,
+                                                 napi_value value,
+                                                 bool* result);
 
 // Methods to support catching exceptions
-NAPI_EXTERN napi_status napi_is_exception_pending(napi_env env, bool* result);
-NAPI_EXTERN napi_status napi_get_and_clear_last_exception(napi_env env,
-                                                          napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_exception_pending(napi_env env,
+                                                             bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_and_clear_last_exception(napi_env env, napi_value* result);
 
 // Methods to work with array buffers and typed arrays
-NAPI_EXTERN napi_status napi_is_arraybuffer(napi_env env,
-                                            napi_value value,
-                                            bool* result);
-NAPI_EXTERN napi_status napi_create_arraybuffer(napi_env env,
-                                                size_t byte_length,
-                                                void** data,
-                                                napi_value* result);
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_arraybuffer(napi_env env,
+                                                       napi_value value,
+                                                       bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_arraybuffer(napi_env env,
+                                                           size_t byte_length,
+                                                           void** data,
+                                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_external_arraybuffer(napi_env env,
                                  void* external_data,
                                  size_t byte_length,
                                  napi_finalize finalize_cb,
                                  void* finalize_hint,
                                  napi_value* result);
-NAPI_EXTERN napi_status napi_get_arraybuffer_info(napi_env env,
-                                                  napi_value arraybuffer,
-                                                  void** data,
-                                                  size_t* byte_length);
-NAPI_EXTERN napi_status napi_is_typedarray(napi_env env,
-                                           napi_value value,
-                                           bool* result);
-NAPI_EXTERN napi_status napi_create_typedarray(napi_env env,
-                                               napi_typedarray_type type,
-                                               size_t length,
-                                               napi_value arraybuffer,
-                                               size_t byte_offset,
-                                               napi_value* result);
-NAPI_EXTERN napi_status napi_get_typedarray_info(napi_env env,
-                                                 napi_value typedarray,
-                                                 napi_typedarray_type* type,
-                                                 size_t* length,
-                                                 void** data,
-                                                 napi_value* arraybuffer,
-                                                 size_t* byte_offset);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_arraybuffer_info(
+    napi_env env, napi_value arraybuffer, void** data, size_t* byte_length);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_typedarray(napi_env env,
+                                                      napi_value value,
+                                                      bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_typedarray(napi_env env,
+                       napi_typedarray_type type,
+                       size_t length,
+                       napi_value arraybuffer,
+                       size_t byte_offset,
+                       napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_typedarray_info(napi_env env,
+                         napi_value typedarray,
+                         napi_typedarray_type* type,
+                         size_t* length,
+                         void** data,
+                         napi_value* arraybuffer,
+                         size_t* byte_offset);
 
-NAPI_EXTERN napi_status napi_create_dataview(napi_env env,
-                                             size_t length,
-                                             napi_value arraybuffer,
-                                             size_t byte_offset,
-                                             napi_value* result);
-NAPI_EXTERN napi_status napi_is_dataview(napi_env env,
-                                         napi_value value,
-                                         bool* result);
-NAPI_EXTERN napi_status napi_get_dataview_info(napi_env env,
-                                               napi_value dataview,
-                                               size_t* bytelength,
-                                               void** data,
-                                               napi_value* arraybuffer,
-                                               size_t* byte_offset);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_dataview(napi_env env,
+                                                        size_t length,
+                                                        napi_value arraybuffer,
+                                                        size_t byte_offset,
+                                                        napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_dataview(napi_env env,
+                                                    napi_value value,
+                                                    bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_dataview_info(napi_env env,
+                       napi_value dataview,
+                       size_t* bytelength,
+                       void** data,
+                       napi_value* arraybuffer,
+                       size_t* byte_offset);
 
 // version management
-NAPI_EXTERN napi_status napi_get_version(napi_env env, uint32_t* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_version(napi_env env,
+                                                    uint32_t* result);
 
 // Promises
-NAPI_EXTERN napi_status napi_create_promise(napi_env env,
-                                            napi_deferred* deferred,
-                                            napi_value* promise);
-NAPI_EXTERN napi_status napi_resolve_deferred(napi_env env,
-                                              napi_deferred deferred,
-                                              napi_value resolution);
-NAPI_EXTERN napi_status napi_reject_deferred(napi_env env,
-                                             napi_deferred deferred,
-                                             napi_value rejection);
-NAPI_EXTERN napi_status napi_is_promise(napi_env env,
-                                        napi_value value,
-                                        bool* is_promise);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_promise(napi_env env,
+                                                       napi_deferred* deferred,
+                                                       napi_value* promise);
+NAPI_EXTERN napi_status NAPI_CDECL napi_resolve_deferred(napi_env env,
+                                                         napi_deferred deferred,
+                                                         napi_value resolution);
+NAPI_EXTERN napi_status NAPI_CDECL napi_reject_deferred(napi_env env,
+                                                        napi_deferred deferred,
+                                                        napi_value rejection);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_promise(napi_env env,
+                                                   napi_value value,
+                                                   bool* is_promise);
 
 // Running a script
-NAPI_EXTERN napi_status napi_run_script(napi_env env,
-                                        napi_value script,
-                                        napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_run_script(napi_env env,
+                                                   napi_value script,
+                                                   napi_value* result);
 
 // Memory management
-NAPI_EXTERN napi_status napi_adjust_external_memory(napi_env env,
-                                                    int64_t change_in_bytes,
-                                                    int64_t* adjusted_value);
+NAPI_EXTERN napi_status NAPI_CDECL napi_adjust_external_memory(
+    napi_env env, int64_t change_in_bytes, int64_t* adjusted_value);
 
 #if NAPI_VERSION >= 5
 
 // Dates
-NAPI_EXTERN napi_status napi_create_date(napi_env env,
-                                         double time,
-                                         napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_date(napi_env env,
+                                                    double time,
+                                                    napi_value* result);
 
-NAPI_EXTERN napi_status napi_is_date(napi_env env,
-                                     napi_value value,
-                                     bool* is_date);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_date(napi_env env,
+                                                napi_value value,
+                                                bool* is_date);
 
-NAPI_EXTERN napi_status napi_get_date_value(napi_env env,
-                                            napi_value value,
-                                            double* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_date_value(napi_env env,
+                                                       napi_value value,
+                                                       double* result);
 
 // Add finalizer for pointer
-NAPI_EXTERN napi_status napi_add_finalizer(napi_env env,
-                                           napi_value js_object,
-                                           void* native_object,
-                                           napi_finalize finalize_cb,
-                                           void* finalize_hint,
-                                           napi_ref* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_add_finalizer(napi_env env,
+                                                      napi_value js_object,
+                                                      void* native_object,
+                                                      napi_finalize finalize_cb,
+                                                      void* finalize_hint,
+                                                      napi_ref* result);
 
 #endif  // NAPI_VERSION >= 5
 
 #if NAPI_VERSION >= 6
 
 // BigInt
-NAPI_EXTERN napi_status napi_create_bigint_int64(napi_env env,
-                                                 int64_t value,
-                                                 napi_value* result);
-NAPI_EXTERN napi_status napi_create_bigint_uint64(napi_env env,
-                                                  uint64_t value,
-                                                  napi_value* result);
-NAPI_EXTERN napi_status napi_create_bigint_words(napi_env env,
-                                                 int sign_bit,
-                                                 size_t word_count,
-                                                 const uint64_t* words,
-                                                 napi_value* result);
-NAPI_EXTERN napi_status napi_get_value_bigint_int64(napi_env env,
-                                                    napi_value value,
-                                                    int64_t* result,
-                                                    bool* lossless);
-NAPI_EXTERN napi_status napi_get_value_bigint_uint64(napi_env env,
-                                                     napi_value value,
-                                                     uint64_t* result,
-                                                     bool* lossless);
-NAPI_EXTERN napi_status napi_get_value_bigint_words(napi_env env,
-                                                    napi_value value,
-                                                    int* sign_bit,
-                                                    size_t* word_count,
-                                                    uint64_t* words);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_bigint_int64(napi_env env,
+                                                            int64_t value,
+                                                            napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_bigint_uint64(napi_env env, uint64_t value, napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_bigint_words(napi_env env,
+                         int sign_bit,
+                         size_t word_count,
+                         const uint64_t* words,
+                         napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_bigint_int64(napi_env env,
+                                                               napi_value value,
+                                                               int64_t* result,
+                                                               bool* lossless);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_bigint_uint64(
+    napi_env env, napi_value value, uint64_t* result, bool* lossless);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_value_bigint_words(napi_env env,
+                            napi_value value,
+                            int* sign_bit,
+                            size_t* word_count,
+                            uint64_t* words);
 
 // Object
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_get_all_property_names(napi_env env,
                             napi_value object,
                             napi_key_collection_mode key_mode,
@@ -529,37 +534,36 @@ napi_get_all_property_names(napi_env env,
                             napi_value* result);
 
 // Instance data
-NAPI_EXTERN napi_status napi_set_instance_data(napi_env env,
-                                               void* data,
-                                               napi_finalize finalize_cb,
-                                               void* finalize_hint);
+NAPI_EXTERN napi_status NAPI_CDECL napi_set_instance_data(
+    napi_env env, void* data, napi_finalize finalize_cb, void* finalize_hint);
 
-NAPI_EXTERN napi_status napi_get_instance_data(napi_env env, void** data);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_instance_data(napi_env env,
+                                                          void** data);
 #endif  // NAPI_VERSION >= 6
 
 #if NAPI_VERSION >= 7
 // ArrayBuffer detaching
-NAPI_EXTERN napi_status napi_detach_arraybuffer(napi_env env,
-                                                napi_value arraybuffer);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_detach_arraybuffer(napi_env env, napi_value arraybuffer);
 
-NAPI_EXTERN napi_status napi_is_detached_arraybuffer(napi_env env,
-                                                     napi_value value,
-                                                     bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_is_detached_arraybuffer(napi_env env, napi_value value, bool* result);
 #endif  // NAPI_VERSION >= 7
 
 #if NAPI_VERSION >= 8
 // Type tagging
-NAPI_EXTERN napi_status napi_type_tag_object(napi_env env,
-                                             napi_value value,
-                                             const napi_type_tag* type_tag);
+NAPI_EXTERN napi_status NAPI_CDECL napi_type_tag_object(
+    napi_env env, napi_value value, const napi_type_tag* type_tag);
 
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_check_object_type_tag(napi_env env,
                            napi_value value,
                            const napi_type_tag* type_tag,
                            bool* result);
-NAPI_EXTERN napi_status napi_object_freeze(napi_env env, napi_value object);
-NAPI_EXTERN napi_status napi_object_seal(napi_env env, napi_value object);
+NAPI_EXTERN napi_status NAPI_CDECL napi_object_freeze(napi_env env,
+                                                      napi_value object);
+NAPI_EXTERN napi_status NAPI_CDECL napi_object_seal(napi_env env,
+                                                    napi_value object);
 #endif  // NAPI_VERSION >= 8
 
 EXTERN_C_END

--- a/src/js_native_api_types.h
+++ b/src/js_native_api_types.h
@@ -11,6 +11,14 @@
 typedef uint16_t char16_t;
 #endif
 
+#ifndef NAPI_CDECL
+#ifdef _WIN32
+#define NAPI_CDECL __cdecl
+#else
+#define NAPI_CDECL
+#endif
+#endif
+
 // JSVM API types are all opaque pointers for ABI stability
 // typedef undefined structs instead of void* for compile time type safety
 typedef struct napi_env__* napi_env;
@@ -100,10 +108,11 @@ typedef enum {
 //   * the definition of `napi_status` in doc/api/n-api.md to reflect the newly
 //     added value(s).
 
-typedef napi_value (*napi_callback)(napi_env env, napi_callback_info info);
-typedef void (*napi_finalize)(napi_env env,
-                              void* finalize_data,
-                              void* finalize_hint);
+typedef napi_value(NAPI_CDECL* napi_callback)(napi_env env,
+                                              napi_callback_info info);
+typedef void(NAPI_CDECL* napi_finalize)(napi_env env,
+                                        void* finalize_data,
+                                        void* finalize_hint);
 
 typedef struct {
   // One of utf8name or name should be NULL.

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -750,8 +750,8 @@ static const char* error_messages[] = {
     "Main thread would deadlock",
 };
 
-napi_status napi_get_last_error_info(napi_env env,
-                                     const napi_extended_error_info** result) {
+napi_status NAPI_CDECL napi_get_last_error_info(
+    napi_env env, const napi_extended_error_info** result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -775,12 +775,12 @@ napi_status napi_get_last_error_info(napi_env env,
   return napi_ok;
 }
 
-napi_status napi_create_function(napi_env env,
-                                 const char* utf8name,
-                                 size_t length,
-                                 napi_callback cb,
-                                 void* callback_data,
-                                 napi_value* result) {
+napi_status NAPI_CDECL napi_create_function(napi_env env,
+                                            const char* utf8name,
+                                            size_t length,
+                                            napi_callback cb,
+                                            void* callback_data,
+                                            napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
   CHECK_ARG(env, cb);
@@ -803,14 +803,15 @@ napi_status napi_create_function(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_define_class(napi_env env,
-                              const char* utf8name,
-                              size_t length,
-                              napi_callback constructor,
-                              void* callback_data,
-                              size_t property_count,
-                              const napi_property_descriptor* properties,
-                              napi_value* result) {
+napi_status NAPI_CDECL
+napi_define_class(napi_env env,
+                  const char* utf8name,
+                  size_t length,
+                  napi_callback constructor,
+                  void* callback_data,
+                  size_t property_count,
+                  const napi_property_descriptor* properties,
+                  napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
   CHECK_ARG(env, constructor);
@@ -901,9 +902,9 @@ napi_status napi_define_class(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_get_property_names(napi_env env,
-                                    napi_value object,
-                                    napi_value* result) {
+napi_status NAPI_CDECL napi_get_property_names(napi_env env,
+                                               napi_value object,
+                                               napi_value* result) {
   return napi_get_all_property_names(
       env,
       object,
@@ -913,12 +914,13 @@ napi_status napi_get_property_names(napi_env env,
       result);
 }
 
-napi_status napi_get_all_property_names(napi_env env,
-                                        napi_value object,
-                                        napi_key_collection_mode key_mode,
-                                        napi_key_filter key_filter,
-                                        napi_key_conversion key_conversion,
-                                        napi_value* result) {
+napi_status NAPI_CDECL
+napi_get_all_property_names(napi_env env,
+                            napi_value object,
+                            napi_key_collection_mode key_mode,
+                            napi_key_filter key_filter,
+                            napi_key_conversion key_conversion,
+                            napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -987,10 +989,10 @@ napi_status napi_get_all_property_names(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_set_property(napi_env env,
-                              napi_value object,
-                              napi_value key,
-                              napi_value value) {
+napi_status NAPI_CDECL napi_set_property(napi_env env,
+                                         napi_value object,
+                                         napi_value key,
+                                         napi_value value) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, key);
   CHECK_ARG(env, value);
@@ -1009,10 +1011,10 @@ napi_status napi_set_property(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_has_property(napi_env env,
-                              napi_value object,
-                              napi_value key,
-                              bool* result) {
+napi_status NAPI_CDECL napi_has_property(napi_env env,
+                                         napi_value object,
+                                         napi_value key,
+                                         bool* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
   CHECK_ARG(env, key);
@@ -1031,10 +1033,10 @@ napi_status napi_has_property(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_get_property(napi_env env,
-                              napi_value object,
-                              napi_value key,
-                              napi_value* result) {
+napi_status NAPI_CDECL napi_get_property(napi_env env,
+                                         napi_value object,
+                                         napi_value key,
+                                         napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, key);
   CHECK_ARG(env, result);
@@ -1054,10 +1056,10 @@ napi_status napi_get_property(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_delete_property(napi_env env,
-                                 napi_value object,
-                                 napi_value key,
-                                 bool* result) {
+napi_status NAPI_CDECL napi_delete_property(napi_env env,
+                                            napi_value object,
+                                            napi_value key,
+                                            bool* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, key);
 
@@ -1074,10 +1076,10 @@ napi_status napi_delete_property(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_has_own_property(napi_env env,
-                                  napi_value object,
-                                  napi_value key,
-                                  bool* result) {
+napi_status NAPI_CDECL napi_has_own_property(napi_env env,
+                                             napi_value object,
+                                             napi_value key,
+                                             bool* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, key);
   CHECK_ARG(env, result);
@@ -1095,10 +1097,10 @@ napi_status napi_has_own_property(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_set_named_property(napi_env env,
-                                    napi_value object,
-                                    const char* utf8name,
-                                    napi_value value) {
+napi_status NAPI_CDECL napi_set_named_property(napi_env env,
+                                               napi_value object,
+                                               const char* utf8name,
+                                               napi_value value) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, value);
 
@@ -1118,10 +1120,10 @@ napi_status napi_set_named_property(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_has_named_property(napi_env env,
-                                    napi_value object,
-                                    const char* utf8name,
-                                    bool* result) {
+napi_status NAPI_CDECL napi_has_named_property(napi_env env,
+                                               napi_value object,
+                                               const char* utf8name,
+                                               bool* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -1141,10 +1143,10 @@ napi_status napi_has_named_property(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_get_named_property(napi_env env,
-                                    napi_value object,
-                                    const char* utf8name,
-                                    napi_value* result) {
+napi_status NAPI_CDECL napi_get_named_property(napi_env env,
+                                               napi_value object,
+                                               const char* utf8name,
+                                               napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -1166,10 +1168,10 @@ napi_status napi_get_named_property(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_set_element(napi_env env,
-                             napi_value object,
-                             uint32_t index,
-                             napi_value value) {
+napi_status NAPI_CDECL napi_set_element(napi_env env,
+                                        napi_value object,
+                                        uint32_t index,
+                                        napi_value value) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, value);
 
@@ -1186,10 +1188,10 @@ napi_status napi_set_element(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_has_element(napi_env env,
-                             napi_value object,
-                             uint32_t index,
-                             bool* result) {
+napi_status NAPI_CDECL napi_has_element(napi_env env,
+                                        napi_value object,
+                                        uint32_t index,
+                                        bool* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -1206,10 +1208,10 @@ napi_status napi_has_element(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_get_element(napi_env env,
-                             napi_value object,
-                             uint32_t index,
-                             napi_value* result) {
+napi_status NAPI_CDECL napi_get_element(napi_env env,
+                                        napi_value object,
+                                        uint32_t index,
+                                        napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -1226,10 +1228,10 @@ napi_status napi_get_element(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_delete_element(napi_env env,
-                                napi_value object,
-                                uint32_t index,
-                                bool* result) {
+napi_status NAPI_CDECL napi_delete_element(napi_env env,
+                                           napi_value object,
+                                           uint32_t index,
+                                           bool* result) {
   NAPI_PREAMBLE(env);
 
   v8::Local<v8::Context> context = env->context();
@@ -1244,10 +1246,11 @@ napi_status napi_delete_element(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_define_properties(napi_env env,
-                                   napi_value object,
-                                   size_t property_count,
-                                   const napi_property_descriptor* properties) {
+napi_status NAPI_CDECL
+napi_define_properties(napi_env env,
+                       napi_value object,
+                       size_t property_count,
+                       const napi_property_descriptor* properties) {
   NAPI_PREAMBLE(env);
   if (property_count > 0) {
     CHECK_ARG(env, properties);
@@ -1322,7 +1325,7 @@ napi_status napi_define_properties(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_object_freeze(napi_env env, napi_value object) {
+napi_status NAPI_CDECL napi_object_freeze(napi_env env, napi_value object) {
   NAPI_PREAMBLE(env);
 
   v8::Local<v8::Context> context = env->context();
@@ -1339,7 +1342,7 @@ napi_status napi_object_freeze(napi_env env, napi_value object) {
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_object_seal(napi_env env, napi_value object) {
+napi_status NAPI_CDECL napi_object_seal(napi_env env, napi_value object) {
   NAPI_PREAMBLE(env);
 
   v8::Local<v8::Context> context = env->context();
@@ -1356,7 +1359,9 @@ napi_status napi_object_seal(napi_env env, napi_value object) {
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_is_array(napi_env env, napi_value value, bool* result) {
+napi_status NAPI_CDECL napi_is_array(napi_env env,
+                                     napi_value value,
+                                     bool* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, result);
@@ -1367,9 +1372,9 @@ napi_status napi_is_array(napi_env env, napi_value value, bool* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_array_length(napi_env env,
-                                  napi_value value,
-                                  uint32_t* result) {
+napi_status NAPI_CDECL napi_get_array_length(napi_env env,
+                                             napi_value value,
+                                             uint32_t* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, result);
@@ -1383,10 +1388,10 @@ napi_status napi_get_array_length(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_strict_equals(napi_env env,
-                               napi_value lhs,
-                               napi_value rhs,
-                               bool* result) {
+napi_status NAPI_CDECL napi_strict_equals(napi_env env,
+                                          napi_value lhs,
+                                          napi_value rhs,
+                                          bool* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, lhs);
   CHECK_ARG(env, rhs);
@@ -1399,9 +1404,9 @@ napi_status napi_strict_equals(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_get_prototype(napi_env env,
-                               napi_value object,
-                               napi_value* result) {
+napi_status NAPI_CDECL napi_get_prototype(napi_env env,
+                                          napi_value object,
+                                          napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -1415,7 +1420,7 @@ napi_status napi_get_prototype(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_create_object(napi_env env, napi_value* result) {
+napi_status NAPI_CDECL napi_create_object(napi_env env, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1424,7 +1429,7 @@ napi_status napi_create_object(napi_env env, napi_value* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_array(napi_env env, napi_value* result) {
+napi_status NAPI_CDECL napi_create_array(napi_env env, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1433,9 +1438,9 @@ napi_status napi_create_array(napi_env env, napi_value* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_array_with_length(napi_env env,
-                                          size_t length,
-                                          napi_value* result) {
+napi_status NAPI_CDECL napi_create_array_with_length(napi_env env,
+                                                     size_t length,
+                                                     napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1445,10 +1450,10 @@ napi_status napi_create_array_with_length(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_string_latin1(napi_env env,
-                                      const char* str,
-                                      size_t length,
-                                      napi_value* result) {
+napi_status NAPI_CDECL napi_create_string_latin1(napi_env env,
+                                                 const char* str,
+                                                 size_t length,
+                                                 napi_value* result) {
   CHECK_ENV(env);
   if (length > 0) CHECK_ARG(env, str);
   CHECK_ARG(env, result);
@@ -1467,10 +1472,10 @@ napi_status napi_create_string_latin1(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_string_utf8(napi_env env,
-                                    const char* str,
-                                    size_t length,
-                                    napi_value* result) {
+napi_status NAPI_CDECL napi_create_string_utf8(napi_env env,
+                                               const char* str,
+                                               size_t length,
+                                               napi_value* result) {
   CHECK_ENV(env);
   if (length > 0) CHECK_ARG(env, str);
   CHECK_ARG(env, result);
@@ -1485,10 +1490,10 @@ napi_status napi_create_string_utf8(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_string_utf16(napi_env env,
-                                     const char16_t* str,
-                                     size_t length,
-                                     napi_value* result) {
+napi_status NAPI_CDECL napi_create_string_utf16(napi_env env,
+                                                const char16_t* str,
+                                                size_t length,
+                                                napi_value* result) {
   CHECK_ENV(env);
   if (length > 0) CHECK_ARG(env, str);
   CHECK_ARG(env, result);
@@ -1507,7 +1512,9 @@ napi_status napi_create_string_utf16(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_double(napi_env env, double value, napi_value* result) {
+napi_status NAPI_CDECL napi_create_double(napi_env env,
+                                          double value,
+                                          napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1517,7 +1524,9 @@ napi_status napi_create_double(napi_env env, double value, napi_value* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_int32(napi_env env, int32_t value, napi_value* result) {
+napi_status NAPI_CDECL napi_create_int32(napi_env env,
+                                         int32_t value,
+                                         napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1527,9 +1536,9 @@ napi_status napi_create_int32(napi_env env, int32_t value, napi_value* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_uint32(napi_env env,
-                               uint32_t value,
-                               napi_value* result) {
+napi_status NAPI_CDECL napi_create_uint32(napi_env env,
+                                          uint32_t value,
+                                          napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1539,7 +1548,9 @@ napi_status napi_create_uint32(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_int64(napi_env env, int64_t value, napi_value* result) {
+napi_status NAPI_CDECL napi_create_int64(napi_env env,
+                                         int64_t value,
+                                         napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1549,9 +1560,9 @@ napi_status napi_create_int64(napi_env env, int64_t value, napi_value* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_bigint_int64(napi_env env,
-                                     int64_t value,
-                                     napi_value* result) {
+napi_status NAPI_CDECL napi_create_bigint_int64(napi_env env,
+                                                int64_t value,
+                                                napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1561,9 +1572,9 @@ napi_status napi_create_bigint_int64(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_bigint_uint64(napi_env env,
-                                      uint64_t value,
-                                      napi_value* result) {
+napi_status NAPI_CDECL napi_create_bigint_uint64(napi_env env,
+                                                 uint64_t value,
+                                                 napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1573,11 +1584,11 @@ napi_status napi_create_bigint_uint64(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_bigint_words(napi_env env,
-                                     int sign_bit,
-                                     size_t word_count,
-                                     const uint64_t* words,
-                                     napi_value* result) {
+napi_status NAPI_CDECL napi_create_bigint_words(napi_env env,
+                                                int sign_bit,
+                                                size_t word_count,
+                                                const uint64_t* words,
+                                                napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, words);
   CHECK_ARG(env, result);
@@ -1595,7 +1606,9 @@ napi_status napi_create_bigint_words(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_get_boolean(napi_env env, bool value, napi_value* result) {
+napi_status NAPI_CDECL napi_get_boolean(napi_env env,
+                                        bool value,
+                                        napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1610,9 +1623,9 @@ napi_status napi_get_boolean(napi_env env, bool value, napi_value* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_symbol(napi_env env,
-                               napi_value description,
-                               napi_value* result) {
+napi_status NAPI_CDECL napi_create_symbol(napi_env env,
+                                          napi_value description,
+                                          napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1631,10 +1644,10 @@ napi_status napi_create_symbol(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status node_api_symbol_for(napi_env env,
-                                const char* utf8description,
-                                size_t length,
-                                napi_value* result) {
+napi_status NAPI_CDECL node_api_symbol_for(napi_env env,
+                                           const char* utf8description,
+                                           size_t length,
+                                           napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1676,10 +1689,10 @@ static inline napi_status set_error_code(napi_env env,
   return napi_ok;
 }
 
-napi_status napi_create_error(napi_env env,
-                              napi_value code,
-                              napi_value msg,
-                              napi_value* result) {
+napi_status NAPI_CDECL napi_create_error(napi_env env,
+                                         napi_value code,
+                                         napi_value msg,
+                                         napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, msg);
   CHECK_ARG(env, result);
@@ -1696,10 +1709,10 @@ napi_status napi_create_error(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_type_error(napi_env env,
-                                   napi_value code,
-                                   napi_value msg,
-                                   napi_value* result) {
+napi_status NAPI_CDECL napi_create_type_error(napi_env env,
+                                              napi_value code,
+                                              napi_value msg,
+                                              napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, msg);
   CHECK_ARG(env, result);
@@ -1716,10 +1729,10 @@ napi_status napi_create_type_error(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_range_error(napi_env env,
-                                    napi_value code,
-                                    napi_value msg,
-                                    napi_value* result) {
+napi_status NAPI_CDECL napi_create_range_error(napi_env env,
+                                               napi_value code,
+                                               napi_value msg,
+                                               napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, msg);
   CHECK_ARG(env, result);
@@ -1736,10 +1749,10 @@ napi_status napi_create_range_error(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status node_api_create_syntax_error(napi_env env,
-                                         napi_value code,
-                                         napi_value msg,
-                                         napi_value* result) {
+napi_status NAPI_CDECL node_api_create_syntax_error(napi_env env,
+                                                    napi_value code,
+                                                    napi_value msg,
+                                                    napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, msg);
   CHECK_ARG(env, result);
@@ -1756,9 +1769,9 @@ napi_status node_api_create_syntax_error(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_typeof(napi_env env,
-                        napi_value value,
-                        napi_valuetype* result) {
+napi_status NAPI_CDECL napi_typeof(napi_env env,
+                                   napi_value value,
+                                   napi_valuetype* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -1799,7 +1812,7 @@ napi_status napi_typeof(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_undefined(napi_env env, napi_value* result) {
+napi_status NAPI_CDECL napi_get_undefined(napi_env env, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1808,7 +1821,7 @@ napi_status napi_get_undefined(napi_env env, napi_value* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_null(napi_env env, napi_value* result) {
+napi_status NAPI_CDECL napi_get_null(napi_env env, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1818,7 +1831,7 @@ napi_status napi_get_null(napi_env env, napi_value* result) {
 }
 
 // Gets all callback info in a single call. (Ugly, but faster.)
-napi_status napi_get_cb_info(
+napi_status NAPI_CDECL napi_get_cb_info(
     napi_env env,               // [in] NAPI environment handle
     napi_callback_info cbinfo,  // [in] Opaque callback-info handle
     size_t* argc,      // [in-out] Specifies the size of the provided argv array
@@ -1849,9 +1862,9 @@ napi_status napi_get_cb_info(
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_new_target(napi_env env,
-                                napi_callback_info cbinfo,
-                                napi_value* result) {
+napi_status NAPI_CDECL napi_get_new_target(napi_env env,
+                                           napi_callback_info cbinfo,
+                                           napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, cbinfo);
   CHECK_ARG(env, result);
@@ -1863,12 +1876,12 @@ napi_status napi_get_new_target(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_call_function(napi_env env,
-                               napi_value recv,
-                               napi_value func,
-                               size_t argc,
-                               const napi_value* argv,
-                               napi_value* result) {
+napi_status NAPI_CDECL napi_call_function(napi_env env,
+                                          napi_value recv,
+                                          napi_value func,
+                                          size_t argc,
+                                          const napi_value* argv,
+                                          napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, recv);
   if (argc > 0) {
@@ -1899,7 +1912,7 @@ napi_status napi_call_function(napi_env env,
   }
 }
 
-napi_status napi_get_global(napi_env env, napi_value* result) {
+napi_status NAPI_CDECL napi_get_global(napi_env env, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1908,7 +1921,7 @@ napi_status napi_get_global(napi_env env, napi_value* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_throw(napi_env env, napi_value error) {
+napi_status NAPI_CDECL napi_throw(napi_env env, napi_value error) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, error);
 
@@ -1920,7 +1933,9 @@ napi_status napi_throw(napi_env env, napi_value error) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_throw_error(napi_env env, const char* code, const char* msg) {
+napi_status NAPI_CDECL napi_throw_error(napi_env env,
+                                        const char* code,
+                                        const char* msg) {
   NAPI_PREAMBLE(env);
 
   v8::Isolate* isolate = env->isolate;
@@ -1936,9 +1951,9 @@ napi_status napi_throw_error(napi_env env, const char* code, const char* msg) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_throw_type_error(napi_env env,
-                                  const char* code,
-                                  const char* msg) {
+napi_status NAPI_CDECL napi_throw_type_error(napi_env env,
+                                             const char* code,
+                                             const char* msg) {
   NAPI_PREAMBLE(env);
 
   v8::Isolate* isolate = env->isolate;
@@ -1954,9 +1969,9 @@ napi_status napi_throw_type_error(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_throw_range_error(napi_env env,
-                                   const char* code,
-                                   const char* msg) {
+napi_status NAPI_CDECL napi_throw_range_error(napi_env env,
+                                              const char* code,
+                                              const char* msg) {
   NAPI_PREAMBLE(env);
 
   v8::Isolate* isolate = env->isolate;
@@ -1972,9 +1987,9 @@ napi_status napi_throw_range_error(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status node_api_throw_syntax_error(napi_env env,
-                                        const char* code,
-                                        const char* msg) {
+napi_status NAPI_CDECL node_api_throw_syntax_error(napi_env env,
+                                                   const char* code,
+                                                   const char* msg) {
   NAPI_PREAMBLE(env);
 
   v8::Isolate* isolate = env->isolate;
@@ -1990,7 +2005,9 @@ napi_status node_api_throw_syntax_error(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_is_error(napi_env env, napi_value value, bool* result) {
+napi_status NAPI_CDECL napi_is_error(napi_env env,
+                                     napi_value value,
+                                     bool* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot
   // throw JS exceptions.
   CHECK_ENV(env);
@@ -2003,9 +2020,9 @@ napi_status napi_is_error(napi_env env, napi_value value, bool* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_value_double(napi_env env,
-                                  napi_value value,
-                                  double* result) {
+napi_status NAPI_CDECL napi_get_value_double(napi_env env,
+                                             napi_value value,
+                                             double* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2020,9 +2037,9 @@ napi_status napi_get_value_double(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_value_int32(napi_env env,
-                                 napi_value value,
-                                 int32_t* result) {
+napi_status NAPI_CDECL napi_get_value_int32(napi_env env,
+                                            napi_value value,
+                                            int32_t* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2044,9 +2061,9 @@ napi_status napi_get_value_int32(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_value_uint32(napi_env env,
-                                  napi_value value,
-                                  uint32_t* result) {
+napi_status NAPI_CDECL napi_get_value_uint32(napi_env env,
+                                             napi_value value,
+                                             uint32_t* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2068,9 +2085,9 @@ napi_status napi_get_value_uint32(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_value_int64(napi_env env,
-                                 napi_value value,
-                                 int64_t* result) {
+napi_status NAPI_CDECL napi_get_value_int64(napi_env env,
+                                            napi_value value,
+                                            int64_t* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2102,10 +2119,10 @@ napi_status napi_get_value_int64(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_value_bigint_int64(napi_env env,
-                                        napi_value value,
-                                        int64_t* result,
-                                        bool* lossless) {
+napi_status NAPI_CDECL napi_get_value_bigint_int64(napi_env env,
+                                                   napi_value value,
+                                                   int64_t* result,
+                                                   bool* lossless) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, result);
@@ -2120,10 +2137,10 @@ napi_status napi_get_value_bigint_int64(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_value_bigint_uint64(napi_env env,
-                                         napi_value value,
-                                         uint64_t* result,
-                                         bool* lossless) {
+napi_status NAPI_CDECL napi_get_value_bigint_uint64(napi_env env,
+                                                    napi_value value,
+                                                    uint64_t* result,
+                                                    bool* lossless) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, result);
@@ -2138,11 +2155,11 @@ napi_status napi_get_value_bigint_uint64(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_value_bigint_words(napi_env env,
-                                        napi_value value,
-                                        int* sign_bit,
-                                        size_t* word_count,
-                                        uint64_t* words) {
+napi_status NAPI_CDECL napi_get_value_bigint_words(napi_env env,
+                                                   napi_value value,
+                                                   int* sign_bit,
+                                                   size_t* word_count,
+                                                   uint64_t* words) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, word_count);
@@ -2168,7 +2185,9 @@ napi_status napi_get_value_bigint_words(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_value_bool(napi_env env, napi_value value, bool* result) {
+napi_status NAPI_CDECL napi_get_value_bool(napi_env env,
+                                           napi_value value,
+                                           bool* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2191,7 +2210,7 @@ napi_status napi_get_value_bool(napi_env env, napi_value value, bool* result) {
 // If buf is NULL, this method returns the length of the string (in bytes)
 // via the result parameter.
 // The result argument is optional unless buf is NULL.
-napi_status napi_get_value_string_latin1(
+napi_status NAPI_CDECL napi_get_value_string_latin1(
     napi_env env, napi_value value, char* buf, size_t bufsize, size_t* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
@@ -2229,7 +2248,7 @@ napi_status napi_get_value_string_latin1(
 // If buf is NULL, this method returns the length of the string (in bytes)
 // via the result parameter.
 // The result argument is optional unless buf is NULL.
-napi_status napi_get_value_string_utf8(
+napi_status NAPI_CDECL napi_get_value_string_utf8(
     napi_env env, napi_value value, char* buf, size_t bufsize, size_t* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
@@ -2267,11 +2286,11 @@ napi_status napi_get_value_string_utf8(
 // If buf is NULL, this method returns the length of the string (in 2-byte
 // code units) via the result parameter.
 // The result argument is optional unless buf is NULL.
-napi_status napi_get_value_string_utf16(napi_env env,
-                                        napi_value value,
-                                        char16_t* buf,
-                                        size_t bufsize,
-                                        size_t* result) {
+napi_status NAPI_CDECL napi_get_value_string_utf16(napi_env env,
+                                                   napi_value value,
+                                                   char16_t* buf,
+                                                   size_t bufsize,
+                                                   size_t* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
 
@@ -2300,9 +2319,9 @@ napi_status napi_get_value_string_utf16(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_coerce_to_bool(napi_env env,
-                                napi_value value,
-                                napi_value* result) {
+napi_status NAPI_CDECL napi_coerce_to_bool(napi_env env,
+                                           napi_value value,
+                                           napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, result);
@@ -2315,7 +2334,7 @@ napi_status napi_coerce_to_bool(napi_env env,
 }
 
 #define GEN_COERCE_FUNCTION(UpperCaseName, MixedCaseName, LowerCaseName)       \
-  napi_status napi_coerce_to_##LowerCaseName(                                  \
+  napi_status NAPI_CDECL napi_coerce_to_##LowerCaseName(                       \
       napi_env env, napi_value value, napi_value* result) {                    \
     NAPI_PREAMBLE(env);                                                        \
     CHECK_ARG(env, value);                                                     \
@@ -2336,29 +2355,33 @@ GEN_COERCE_FUNCTION(STRING, String, string)
 
 #undef GEN_COERCE_FUNCTION
 
-napi_status napi_wrap(napi_env env,
-                      napi_value js_object,
-                      void* native_object,
-                      napi_finalize finalize_cb,
-                      void* finalize_hint,
-                      napi_ref* result) {
+napi_status NAPI_CDECL napi_wrap(napi_env env,
+                                 napi_value js_object,
+                                 void* native_object,
+                                 napi_finalize finalize_cb,
+                                 void* finalize_hint,
+                                 napi_ref* result) {
   return v8impl::Wrap<v8impl::retrievable>(
       env, js_object, native_object, finalize_cb, finalize_hint, result);
 }
 
-napi_status napi_unwrap(napi_env env, napi_value obj, void** result) {
+napi_status NAPI_CDECL napi_unwrap(napi_env env,
+                                   napi_value obj,
+                                   void** result) {
   return v8impl::Unwrap(env, obj, result, v8impl::KeepWrap);
 }
 
-napi_status napi_remove_wrap(napi_env env, napi_value obj, void** result) {
+napi_status NAPI_CDECL napi_remove_wrap(napi_env env,
+                                        napi_value obj,
+                                        void** result) {
   return v8impl::Unwrap(env, obj, result, v8impl::RemoveWrap);
 }
 
-napi_status napi_create_external(napi_env env,
-                                 void* data,
-                                 napi_finalize finalize_cb,
-                                 void* finalize_hint,
-                                 napi_value* result) {
+napi_status NAPI_CDECL napi_create_external(napi_env env,
+                                            void* data,
+                                            napi_finalize finalize_cb,
+                                            void* finalize_hint,
+                                            napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -2376,9 +2399,9 @@ napi_status napi_create_external(napi_env env,
   return napi_clear_last_error(env);
 }
 
-NAPI_EXTERN napi_status napi_type_tag_object(napi_env env,
-                                             napi_value object,
-                                             const napi_type_tag* type_tag) {
+napi_status NAPI_CDECL napi_type_tag_object(napi_env env,
+                                            napi_value object,
+                                            const napi_type_tag* type_tag) {
   NAPI_PREAMBLE(env);
   v8::Local<v8::Context> context = env->context();
   v8::Local<v8::Object> obj;
@@ -2403,11 +2426,10 @@ NAPI_EXTERN napi_status napi_type_tag_object(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-NAPI_EXTERN napi_status
-napi_check_object_type_tag(napi_env env,
-                           napi_value object,
-                           const napi_type_tag* type_tag,
-                           bool* result) {
+napi_status NAPI_CDECL napi_check_object_type_tag(napi_env env,
+                                                  napi_value object,
+                                                  const napi_type_tag* type_tag,
+                                                  bool* result) {
   NAPI_PREAMBLE(env);
   v8::Local<v8::Context> context = env->context();
   v8::Local<v8::Object> obj;
@@ -2437,9 +2459,9 @@ napi_check_object_type_tag(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_get_value_external(napi_env env,
-                                    napi_value value,
-                                    void** result) {
+napi_status NAPI_CDECL napi_get_value_external(napi_env env,
+                                               napi_value value,
+                                               void** result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, result);
@@ -2454,10 +2476,10 @@ napi_status napi_get_value_external(napi_env env,
 }
 
 // Set initial_refcount to 0 for a weak reference, >0 for a strong reference.
-napi_status napi_create_reference(napi_env env,
-                                  napi_value value,
-                                  uint32_t initial_refcount,
-                                  napi_ref* result) {
+napi_status NAPI_CDECL napi_create_reference(napi_env env,
+                                             napi_value value,
+                                             uint32_t initial_refcount,
+                                             napi_ref* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2479,7 +2501,7 @@ napi_status napi_create_reference(napi_env env,
 
 // Deletes a reference. The referenced value is released, and may be GC'd unless
 // there are other references to it.
-napi_status napi_delete_reference(napi_env env, napi_ref ref) {
+napi_status NAPI_CDECL napi_delete_reference(napi_env env, napi_ref ref) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2495,7 +2517,9 @@ napi_status napi_delete_reference(napi_env env, napi_ref ref) {
 // refcount is >0, and the referenced object is effectively "pinned".
 // Calling this when the refcount is 0 and the object is unavailable
 // results in an error.
-napi_status napi_reference_ref(napi_env env, napi_ref ref, uint32_t* result) {
+napi_status NAPI_CDECL napi_reference_ref(napi_env env,
+                                          napi_ref ref,
+                                          uint32_t* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2515,7 +2539,9 @@ napi_status napi_reference_ref(napi_env env, napi_ref ref, uint32_t* result) {
 // the result is 0 the reference is now weak and the object may be GC'd at any
 // time if there are no other references. Calling this when the refcount is
 // already 0 results in an error.
-napi_status napi_reference_unref(napi_env env, napi_ref ref, uint32_t* result) {
+napi_status NAPI_CDECL napi_reference_unref(napi_env env,
+                                            napi_ref ref,
+                                            uint32_t* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2539,9 +2565,9 @@ napi_status napi_reference_unref(napi_env env, napi_ref ref, uint32_t* result) {
 // Attempts to get a referenced value. If the reference is weak, the value might
 // no longer be available, in that case the call is still successful but the
 // result is NULL.
-napi_status napi_get_reference_value(napi_env env,
-                                     napi_ref ref,
-                                     napi_value* result) {
+napi_status NAPI_CDECL napi_get_reference_value(napi_env env,
+                                                napi_ref ref,
+                                                napi_value* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2554,7 +2580,8 @@ napi_status napi_get_reference_value(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_open_handle_scope(napi_env env, napi_handle_scope* result) {
+napi_status NAPI_CDECL napi_open_handle_scope(napi_env env,
+                                              napi_handle_scope* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2566,7 +2593,8 @@ napi_status napi_open_handle_scope(napi_env env, napi_handle_scope* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_close_handle_scope(napi_env env, napi_handle_scope scope) {
+napi_status NAPI_CDECL napi_close_handle_scope(napi_env env,
+                                               napi_handle_scope scope) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2580,7 +2608,7 @@ napi_status napi_close_handle_scope(napi_env env, napi_handle_scope scope) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_open_escapable_handle_scope(
+napi_status NAPI_CDECL napi_open_escapable_handle_scope(
     napi_env env, napi_escapable_handle_scope* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
@@ -2593,7 +2621,7 @@ napi_status napi_open_escapable_handle_scope(
   return napi_clear_last_error(env);
 }
 
-napi_status napi_close_escapable_handle_scope(
+napi_status NAPI_CDECL napi_close_escapable_handle_scope(
     napi_env env, napi_escapable_handle_scope scope) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
@@ -2608,10 +2636,10 @@ napi_status napi_close_escapable_handle_scope(
   return napi_clear_last_error(env);
 }
 
-napi_status napi_escape_handle(napi_env env,
-                               napi_escapable_handle_scope scope,
-                               napi_value escapee,
-                               napi_value* result) {
+napi_status NAPI_CDECL napi_escape_handle(napi_env env,
+                                          napi_escapable_handle_scope scope,
+                                          napi_value escapee,
+                                          napi_value* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2629,11 +2657,11 @@ napi_status napi_escape_handle(napi_env env,
   return napi_set_last_error(env, napi_escape_called_twice);
 }
 
-napi_status napi_new_instance(napi_env env,
-                              napi_value constructor,
-                              size_t argc,
-                              const napi_value* argv,
-                              napi_value* result) {
+napi_status NAPI_CDECL napi_new_instance(napi_env env,
+                                         napi_value constructor,
+                                         size_t argc,
+                                         const napi_value* argv,
+                                         napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, constructor);
   if (argc > 0) {
@@ -2657,10 +2685,10 @@ napi_status napi_new_instance(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_instanceof(napi_env env,
-                            napi_value object,
-                            napi_value constructor,
-                            bool* result) {
+napi_status NAPI_CDECL napi_instanceof(napi_env env,
+                                       napi_value object,
+                                       napi_value constructor,
+                                       bool* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, object);
   CHECK_ARG(env, result);
@@ -2689,7 +2717,7 @@ napi_status napi_instanceof(napi_env env,
 }
 
 // Methods to support catching exceptions
-napi_status napi_is_exception_pending(napi_env env, bool* result) {
+napi_status NAPI_CDECL napi_is_exception_pending(napi_env env, bool* result) {
   // NAPI_PREAMBLE is not used here: this function must execute when there is a
   // pending exception.
   CHECK_ENV(env);
@@ -2699,8 +2727,8 @@ napi_status napi_is_exception_pending(napi_env env, bool* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_and_clear_last_exception(napi_env env,
-                                              napi_value* result) {
+napi_status NAPI_CDECL napi_get_and_clear_last_exception(napi_env env,
+                                                         napi_value* result) {
   // NAPI_PREAMBLE is not used here: this function must execute when there is a
   // pending exception.
   CHECK_ENV(env);
@@ -2717,7 +2745,9 @@ napi_status napi_get_and_clear_last_exception(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_is_arraybuffer(napi_env env, napi_value value, bool* result) {
+napi_status NAPI_CDECL napi_is_arraybuffer(napi_env env,
+                                           napi_value value,
+                                           bool* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, result);
@@ -2728,10 +2758,10 @@ napi_status napi_is_arraybuffer(napi_env env, napi_value value, bool* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_arraybuffer(napi_env env,
-                                    size_t byte_length,
-                                    void** data,
-                                    napi_value* result) {
+napi_status NAPI_CDECL napi_create_arraybuffer(napi_env env,
+                                               size_t byte_length,
+                                               void** data,
+                                               napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -2749,12 +2779,13 @@ napi_status napi_create_arraybuffer(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_create_external_arraybuffer(napi_env env,
-                                             void* external_data,
-                                             size_t byte_length,
-                                             napi_finalize finalize_cb,
-                                             void* finalize_hint,
-                                             napi_value* result) {
+napi_status NAPI_CDECL
+napi_create_external_arraybuffer(napi_env env,
+                                 void* external_data,
+                                 size_t byte_length,
+                                 napi_finalize finalize_cb,
+                                 void* finalize_hint,
+                                 napi_value* result) {
   // The API contract here is that the cleanup function runs on the JS thread,
   // and is able to use napi_env. Implementing that properly is hard, so use the
   // `Buffer` variant for easier implementation.
@@ -2765,10 +2796,10 @@ napi_status napi_create_external_arraybuffer(napi_env env,
       env, buffer, nullptr, nullptr, nullptr, result, nullptr);
 }
 
-napi_status napi_get_arraybuffer_info(napi_env env,
-                                      napi_value arraybuffer,
-                                      void** data,
-                                      size_t* byte_length) {
+napi_status NAPI_CDECL napi_get_arraybuffer_info(napi_env env,
+                                                 napi_value arraybuffer,
+                                                 void** data,
+                                                 size_t* byte_length) {
   CHECK_ENV(env);
   CHECK_ARG(env, arraybuffer);
 
@@ -2789,7 +2820,9 @@ napi_status napi_get_arraybuffer_info(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_is_typedarray(napi_env env, napi_value value, bool* result) {
+napi_status NAPI_CDECL napi_is_typedarray(napi_env env,
+                                          napi_value value,
+                                          bool* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, result);
@@ -2800,12 +2833,12 @@ napi_status napi_is_typedarray(napi_env env, napi_value value, bool* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_typedarray(napi_env env,
-                                   napi_typedarray_type type,
-                                   size_t length,
-                                   napi_value arraybuffer,
-                                   size_t byte_offset,
-                                   napi_value* result) {
+napi_status NAPI_CDECL napi_create_typedarray(napi_env env,
+                                              napi_typedarray_type type,
+                                              size_t length,
+                                              napi_value arraybuffer,
+                                              size_t byte_offset,
+                                              napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, arraybuffer);
   CHECK_ARG(env, result);
@@ -2869,13 +2902,13 @@ napi_status napi_create_typedarray(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_get_typedarray_info(napi_env env,
-                                     napi_value typedarray,
-                                     napi_typedarray_type* type,
-                                     size_t* length,
-                                     void** data,
-                                     napi_value* arraybuffer,
-                                     size_t* byte_offset) {
+napi_status NAPI_CDECL napi_get_typedarray_info(napi_env env,
+                                                napi_value typedarray,
+                                                napi_typedarray_type* type,
+                                                size_t* length,
+                                                void** data,
+                                                napi_value* arraybuffer,
+                                                size_t* byte_offset) {
   CHECK_ENV(env);
   CHECK_ARG(env, typedarray);
 
@@ -2937,11 +2970,11 @@ napi_status napi_get_typedarray_info(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_dataview(napi_env env,
-                                 size_t byte_length,
-                                 napi_value arraybuffer,
-                                 size_t byte_offset,
-                                 napi_value* result) {
+napi_status NAPI_CDECL napi_create_dataview(napi_env env,
+                                            size_t byte_length,
+                                            napi_value arraybuffer,
+                                            size_t byte_offset,
+                                            napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, arraybuffer);
   CHECK_ARG(env, result);
@@ -2964,7 +2997,9 @@ napi_status napi_create_dataview(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_is_dataview(napi_env env, napi_value value, bool* result) {
+napi_status NAPI_CDECL napi_is_dataview(napi_env env,
+                                        napi_value value,
+                                        bool* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, result);
@@ -2975,12 +3010,12 @@ napi_status napi_is_dataview(napi_env env, napi_value value, bool* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_dataview_info(napi_env env,
-                                   napi_value dataview,
-                                   size_t* byte_length,
-                                   void** data,
-                                   napi_value* arraybuffer,
-                                   size_t* byte_offset) {
+napi_status NAPI_CDECL napi_get_dataview_info(napi_env env,
+                                              napi_value dataview,
+                                              size_t* byte_length,
+                                              void** data,
+                                              napi_value* arraybuffer,
+                                              size_t* byte_offset) {
   CHECK_ENV(env);
   CHECK_ARG(env, dataview);
 
@@ -3016,16 +3051,16 @@ napi_status napi_get_dataview_info(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_version(napi_env env, uint32_t* result) {
+napi_status NAPI_CDECL napi_get_version(napi_env env, uint32_t* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
   *result = NAPI_VERSION;
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_promise(napi_env env,
-                                napi_deferred* deferred,
-                                napi_value* promise) {
+napi_status NAPI_CDECL napi_create_promise(napi_env env,
+                                           napi_deferred* deferred,
+                                           napi_value* promise) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, deferred);
   CHECK_ARG(env, promise);
@@ -3042,19 +3077,21 @@ napi_status napi_create_promise(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_resolve_deferred(napi_env env,
-                                  napi_deferred deferred,
-                                  napi_value resolution) {
+napi_status NAPI_CDECL napi_resolve_deferred(napi_env env,
+                                             napi_deferred deferred,
+                                             napi_value resolution) {
   return v8impl::ConcludeDeferred(env, deferred, resolution, true);
 }
 
-napi_status napi_reject_deferred(napi_env env,
-                                 napi_deferred deferred,
-                                 napi_value resolution) {
+napi_status NAPI_CDECL napi_reject_deferred(napi_env env,
+                                            napi_deferred deferred,
+                                            napi_value resolution) {
   return v8impl::ConcludeDeferred(env, deferred, resolution, false);
 }
 
-napi_status napi_is_promise(napi_env env, napi_value value, bool* is_promise) {
+napi_status NAPI_CDECL napi_is_promise(napi_env env,
+                                       napi_value value,
+                                       bool* is_promise) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, is_promise);
@@ -3064,7 +3101,9 @@ napi_status napi_is_promise(napi_env env, napi_value value, bool* is_promise) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_date(napi_env env, double time, napi_value* result) {
+napi_status NAPI_CDECL napi_create_date(napi_env env,
+                                        double time,
+                                        napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -3076,7 +3115,9 @@ napi_status napi_create_date(napi_env env, double time, napi_value* result) {
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_is_date(napi_env env, napi_value value, bool* is_date) {
+napi_status NAPI_CDECL napi_is_date(napi_env env,
+                                    napi_value value,
+                                    bool* is_date) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, is_date);
@@ -3086,9 +3127,9 @@ napi_status napi_is_date(napi_env env, napi_value value, bool* is_date) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_date_value(napi_env env,
-                                napi_value value,
-                                double* result) {
+napi_status NAPI_CDECL napi_get_date_value(napi_env env,
+                                           napi_value value,
+                                           double* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, result);
@@ -3102,9 +3143,9 @@ napi_status napi_get_date_value(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_run_script(napi_env env,
-                            napi_value script,
-                            napi_value* result) {
+napi_status NAPI_CDECL napi_run_script(napi_env env,
+                                       napi_value script,
+                                       napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, script);
   CHECK_ARG(env, result);
@@ -3127,19 +3168,19 @@ napi_status napi_run_script(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_add_finalizer(napi_env env,
-                               napi_value js_object,
-                               void* native_object,
-                               napi_finalize finalize_cb,
-                               void* finalize_hint,
-                               napi_ref* result) {
+napi_status NAPI_CDECL napi_add_finalizer(napi_env env,
+                                          napi_value js_object,
+                                          void* native_object,
+                                          napi_finalize finalize_cb,
+                                          void* finalize_hint,
+                                          napi_ref* result) {
   return v8impl::Wrap<v8impl::anonymous>(
       env, js_object, native_object, finalize_cb, finalize_hint, result);
 }
 
-napi_status napi_adjust_external_memory(napi_env env,
-                                        int64_t change_in_bytes,
-                                        int64_t* adjusted_value) {
+napi_status NAPI_CDECL napi_adjust_external_memory(napi_env env,
+                                                   int64_t change_in_bytes,
+                                                   int64_t* adjusted_value) {
   CHECK_ENV(env);
   CHECK_ARG(env, adjusted_value);
 
@@ -3149,10 +3190,10 @@ napi_status napi_adjust_external_memory(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_set_instance_data(napi_env env,
-                                   void* data,
-                                   napi_finalize finalize_cb,
-                                   void* finalize_hint) {
+napi_status NAPI_CDECL napi_set_instance_data(napi_env env,
+                                              void* data,
+                                              napi_finalize finalize_cb,
+                                              void* finalize_hint) {
   CHECK_ENV(env);
 
   v8impl::RefBase* old_data = static_cast<v8impl::RefBase*>(env->instance_data);
@@ -3168,7 +3209,7 @@ napi_status napi_set_instance_data(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_instance_data(napi_env env, void** data) {
+napi_status NAPI_CDECL napi_get_instance_data(napi_env env, void** data) {
   CHECK_ENV(env);
   CHECK_ARG(env, data);
 
@@ -3179,7 +3220,8 @@ napi_status napi_get_instance_data(napi_env env, void** data) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer) {
+napi_status NAPI_CDECL napi_detach_arraybuffer(napi_env env,
+                                               napi_value arraybuffer) {
   CHECK_ENV(env);
   CHECK_ARG(env, arraybuffer);
 
@@ -3196,9 +3238,9 @@ napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_is_detached_arraybuffer(napi_env env,
-                                         napi_value arraybuffer,
-                                         bool* result) {
+napi_status NAPI_CDECL napi_is_detached_arraybuffer(napi_env env,
+                                                    napi_value arraybuffer,
+                                                    bool* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, arraybuffer);
   CHECK_ARG(env, result);

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -628,15 +628,14 @@ node_module napi_module_to_node_module(const napi_module* mod) {
 }  // namespace node
 
 // Registers a NAPI module.
-void napi_module_register(napi_module* mod) {
+void NAPI_CDECL napi_module_register(napi_module* mod) {
   node::node_module* nm =
       new node::node_module(node::napi_module_to_node_module(mod));
   node::node_module_register(nm);
 }
 
-napi_status napi_add_env_cleanup_hook(napi_env env,
-                                      void (*fun)(void* arg),
-                                      void* arg) {
+napi_status NAPI_CDECL napi_add_env_cleanup_hook(
+    napi_env env, void(NAPI_CDECL* fun)(void* arg), void* arg) {
   CHECK_ENV(env);
   CHECK_ARG(env, fun);
 
@@ -645,9 +644,8 @@ napi_status napi_add_env_cleanup_hook(napi_env env,
   return napi_ok;
 }
 
-napi_status napi_remove_env_cleanup_hook(napi_env env,
-                                         void (*fun)(void* arg),
-                                         void* arg) {
+napi_status NAPI_CDECL napi_remove_env_cleanup_hook(
+    napi_env env, void(NAPI_CDECL* fun)(void* arg), void* arg) {
   CHECK_ENV(env);
   CHECK_ARG(env, fun);
 
@@ -691,11 +689,11 @@ struct napi_async_cleanup_hook_handle__ {
   void* done_data_ = nullptr;
 };
 
-napi_status napi_add_async_cleanup_hook(
-    napi_env env,
-    napi_async_cleanup_hook hook,
-    void* arg,
-    napi_async_cleanup_hook_handle* remove_handle) {
+napi_status NAPI_CDECL
+napi_add_async_cleanup_hook(napi_env env,
+                            napi_async_cleanup_hook hook,
+                            void* arg,
+                            napi_async_cleanup_hook_handle* remove_handle) {
   CHECK_ENV(env);
   CHECK_ARG(env, hook);
 
@@ -707,8 +705,8 @@ napi_status napi_add_async_cleanup_hook(
   return napi_clear_last_error(env);
 }
 
-napi_status napi_remove_async_cleanup_hook(
-    napi_async_cleanup_hook_handle remove_handle) {
+napi_status NAPI_CDECL
+napi_remove_async_cleanup_hook(napi_async_cleanup_hook_handle remove_handle) {
   if (remove_handle == nullptr) return napi_invalid_arg;
 
   delete remove_handle;
@@ -716,7 +714,7 @@ napi_status napi_remove_async_cleanup_hook(
   return napi_ok;
 }
 
-napi_status napi_fatal_exception(napi_env env, napi_value err) {
+napi_status NAPI_CDECL napi_fatal_exception(napi_env env, napi_value err) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, err);
 
@@ -726,10 +724,10 @@ napi_status napi_fatal_exception(napi_env env, napi_value err) {
   return napi_clear_last_error(env);
 }
 
-NAPI_NO_RETURN void napi_fatal_error(const char* location,
-                                     size_t location_len,
-                                     const char* message,
-                                     size_t message_len) {
+NAPI_NO_RETURN void NAPI_CDECL napi_fatal_error(const char* location,
+                                                size_t location_len,
+                                                const char* message,
+                                                size_t message_len) {
   std::string location_string;
   std::string message_string;
 
@@ -748,10 +746,11 @@ NAPI_NO_RETURN void napi_fatal_error(const char* location,
   node::FatalError(location_string.c_str(), message_string.c_str());
 }
 
-napi_status napi_open_callback_scope(napi_env env,
-                                     napi_value /** ignored */,
-                                     napi_async_context async_context_handle,
-                                     napi_callback_scope* result) {
+napi_status NAPI_CDECL
+napi_open_callback_scope(napi_env env,
+                         napi_value /** ignored */,
+                         napi_async_context async_context_handle,
+                         napi_callback_scope* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -765,7 +764,8 @@ napi_status napi_open_callback_scope(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_close_callback_scope(napi_env env, napi_callback_scope scope) {
+napi_status NAPI_CDECL napi_close_callback_scope(napi_env env,
+                                                 napi_callback_scope scope) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -780,10 +780,10 @@ napi_status napi_close_callback_scope(napi_env env, napi_callback_scope scope) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_async_init(napi_env env,
-                            napi_value async_resource,
-                            napi_value async_resource_name,
-                            napi_async_context* result) {
+napi_status NAPI_CDECL napi_async_init(napi_env env,
+                                       napi_value async_resource,
+                                       napi_value async_resource_name,
+                                       napi_async_context* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, async_resource_name);
   CHECK_ARG(env, result);
@@ -815,7 +815,8 @@ napi_status napi_async_init(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_async_destroy(napi_env env, napi_async_context async_context) {
+napi_status NAPI_CDECL napi_async_destroy(napi_env env,
+                                          napi_async_context async_context) {
   CHECK_ENV(env);
   CHECK_ARG(env, async_context);
 
@@ -827,13 +828,13 @@ napi_status napi_async_destroy(napi_env env, napi_async_context async_context) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_make_callback(napi_env env,
-                               napi_async_context async_context,
-                               napi_value recv,
-                               napi_value func,
-                               size_t argc,
-                               const napi_value* argv,
-                               napi_value* result) {
+napi_status NAPI_CDECL napi_make_callback(napi_env env,
+                                          napi_async_context async_context,
+                                          napi_value recv,
+                                          napi_value func,
+                                          size_t argc,
+                                          const napi_value* argv,
+                                          napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, recv);
   if (argc > 0) {
@@ -881,10 +882,10 @@ napi_status napi_make_callback(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_create_buffer(napi_env env,
-                               size_t length,
-                               void** data,
-                               napi_value* result) {
+napi_status NAPI_CDECL napi_create_buffer(napi_env env,
+                                          size_t length,
+                                          void** data,
+                                          napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -903,12 +904,12 @@ napi_status napi_create_buffer(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_create_external_buffer(napi_env env,
-                                        size_t length,
-                                        void* data,
-                                        napi_finalize finalize_cb,
-                                        void* finalize_hint,
-                                        napi_value* result) {
+napi_status NAPI_CDECL napi_create_external_buffer(napi_env env,
+                                                   size_t length,
+                                                   void* data,
+                                                   napi_finalize finalize_cb,
+                                                   void* finalize_hint,
+                                                   napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -939,11 +940,11 @@ napi_status napi_create_external_buffer(napi_env env,
   // coverity[leaked_storage]
 }
 
-napi_status napi_create_buffer_copy(napi_env env,
-                                    size_t length,
-                                    const void* data,
-                                    void** result_data,
-                                    napi_value* result) {
+napi_status NAPI_CDECL napi_create_buffer_copy(napi_env env,
+                                               size_t length,
+                                               const void* data,
+                                               void** result_data,
+                                               napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -962,7 +963,9 @@ napi_status napi_create_buffer_copy(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_is_buffer(napi_env env, napi_value value, bool* result) {
+napi_status NAPI_CDECL napi_is_buffer(napi_env env,
+                                      napi_value value,
+                                      bool* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, result);
@@ -971,10 +974,10 @@ napi_status napi_is_buffer(napi_env env, napi_value value, bool* result) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_buffer_info(napi_env env,
-                                 napi_value value,
-                                 void** data,
-                                 size_t* length) {
+napi_status NAPI_CDECL napi_get_buffer_info(napi_env env,
+                                            napi_value value,
+                                            void** data,
+                                            size_t* length) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
 
@@ -990,8 +993,8 @@ napi_status napi_get_buffer_info(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_node_version(napi_env env,
-                                  const napi_node_version** result) {
+napi_status NAPI_CDECL napi_get_node_version(napi_env env,
+                                             const napi_node_version** result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
   static const napi_node_version version = {
@@ -1095,13 +1098,14 @@ class Work : public node::AsyncResource, public node::ThreadPoolWork {
     }                                                                          \
   } while (0)
 
-napi_status napi_create_async_work(napi_env env,
-                                   napi_value async_resource,
-                                   napi_value async_resource_name,
-                                   napi_async_execute_callback execute,
-                                   napi_async_complete_callback complete,
-                                   void* data,
-                                   napi_async_work* result) {
+napi_status NAPI_CDECL
+napi_create_async_work(napi_env env,
+                       napi_value async_resource,
+                       napi_value async_resource_name,
+                       napi_async_execute_callback execute,
+                       napi_async_complete_callback complete,
+                       void* data,
+                       napi_async_work* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, execute);
   CHECK_ARG(env, result);
@@ -1130,7 +1134,8 @@ napi_status napi_create_async_work(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_delete_async_work(napi_env env, napi_async_work work) {
+napi_status NAPI_CDECL napi_delete_async_work(napi_env env,
+                                              napi_async_work work) {
   CHECK_ENV(env);
   CHECK_ARG(env, work);
 
@@ -1139,14 +1144,15 @@ napi_status napi_delete_async_work(napi_env env, napi_async_work work) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_uv_event_loop(napi_env env, uv_loop_t** loop) {
+napi_status NAPI_CDECL napi_get_uv_event_loop(napi_env env, uv_loop_t** loop) {
   CHECK_ENV(env);
   CHECK_ARG(env, loop);
   *loop = reinterpret_cast<node_napi_env>(env)->node_env()->event_loop();
   return napi_clear_last_error(env);
 }
 
-napi_status napi_queue_async_work(napi_env env, napi_async_work work) {
+napi_status NAPI_CDECL napi_queue_async_work(napi_env env,
+                                             napi_async_work work) {
   CHECK_ENV(env);
   CHECK_ARG(env, work);
 
@@ -1160,7 +1166,8 @@ napi_status napi_queue_async_work(napi_env env, napi_async_work work) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_cancel_async_work(napi_env env, napi_async_work work) {
+napi_status NAPI_CDECL napi_cancel_async_work(napi_env env,
+                                              napi_async_work work) {
   CHECK_ENV(env);
   CHECK_ARG(env, work);
 
@@ -1171,18 +1178,18 @@ napi_status napi_cancel_async_work(napi_env env, napi_async_work work) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_threadsafe_function(
-    napi_env env,
-    napi_value func,
-    napi_value async_resource,
-    napi_value async_resource_name,
-    size_t max_queue_size,
-    size_t initial_thread_count,
-    void* thread_finalize_data,
-    napi_finalize thread_finalize_cb,
-    void* context,
-    napi_threadsafe_function_call_js call_js_cb,
-    napi_threadsafe_function* result) {
+napi_status NAPI_CDECL
+napi_create_threadsafe_function(napi_env env,
+                                napi_value func,
+                                napi_value async_resource,
+                                napi_value async_resource_name,
+                                size_t max_queue_size,
+                                size_t initial_thread_count,
+                                void* thread_finalize_data,
+                                napi_finalize thread_finalize_cb,
+                                void* context,
+                                napi_threadsafe_function_call_js call_js_cb,
+                                napi_threadsafe_function* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, async_resource_name);
   RETURN_STATUS_IF_FALSE(env, initial_thread_count > 0, napi_invalid_arg);
@@ -1234,8 +1241,8 @@ napi_status napi_create_threadsafe_function(
   return napi_set_last_error(env, status);
 }
 
-napi_status napi_get_threadsafe_function_context(napi_threadsafe_function func,
-                                                 void** result) {
+napi_status NAPI_CDECL napi_get_threadsafe_function_context(
+    napi_threadsafe_function func, void** result) {
   CHECK_NOT_NULL(func);
   CHECK_NOT_NULL(result);
 
@@ -1243,39 +1250,41 @@ napi_status napi_get_threadsafe_function_context(napi_threadsafe_function func,
   return napi_ok;
 }
 
-napi_status napi_call_threadsafe_function(
-    napi_threadsafe_function func,
-    void* data,
-    napi_threadsafe_function_call_mode is_blocking) {
+napi_status NAPI_CDECL
+napi_call_threadsafe_function(napi_threadsafe_function func,
+                              void* data,
+                              napi_threadsafe_function_call_mode is_blocking) {
   CHECK_NOT_NULL(func);
   return reinterpret_cast<v8impl::ThreadSafeFunction*>(func)->Push(data,
                                                                    is_blocking);
 }
 
-napi_status napi_acquire_threadsafe_function(napi_threadsafe_function func) {
+napi_status NAPI_CDECL
+napi_acquire_threadsafe_function(napi_threadsafe_function func) {
   CHECK_NOT_NULL(func);
   return reinterpret_cast<v8impl::ThreadSafeFunction*>(func)->Acquire();
 }
 
-napi_status napi_release_threadsafe_function(
+napi_status NAPI_CDECL napi_release_threadsafe_function(
     napi_threadsafe_function func, napi_threadsafe_function_release_mode mode) {
   CHECK_NOT_NULL(func);
   return reinterpret_cast<v8impl::ThreadSafeFunction*>(func)->Release(mode);
 }
 
-napi_status napi_unref_threadsafe_function(napi_env env,
-                                           napi_threadsafe_function func) {
+napi_status NAPI_CDECL
+napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function func) {
   CHECK_NOT_NULL(func);
   return reinterpret_cast<v8impl::ThreadSafeFunction*>(func)->Unref();
 }
 
-napi_status napi_ref_threadsafe_function(napi_env env,
-                                         napi_threadsafe_function func) {
+napi_status NAPI_CDECL
+napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func) {
   CHECK_NOT_NULL(func);
   return reinterpret_cast<v8impl::ThreadSafeFunction*>(func)->Ref();
 }
 
-napi_status node_api_get_module_file_name(napi_env env, const char** result) {
+napi_status NAPI_CDECL node_api_get_module_file_name(napi_env env,
+                                                     const char** result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -28,8 +28,8 @@ struct uv_loop_s;  // Forward declaration.
 #define NAPI_NO_RETURN
 #endif
 
-typedef napi_value (*napi_addon_register_func)(napi_env env,
-                                               napi_value exports);
+typedef napi_value(NAPI_CDECL* napi_addon_register_func)(napi_env env,
+                                                         napi_value exports);
 
 typedef struct napi_module {
   int nm_version;
@@ -46,13 +46,13 @@ typedef struct napi_module {
 #if defined(_MSC_VER)
 #if defined(__cplusplus)
 #define NAPI_C_CTOR(fn)                                                        \
-  static void __cdecl fn(void);                                                \
+  static void NAPI_CDECL fn(void);                                             \
   namespace {                                                                  \
   struct fn##_ {                                                               \
     fn##_() { fn(); }                                                          \
   } fn##_v_;                                                                   \
   }                                                                            \
-  static void __cdecl fn(void)
+  static void NAPI_CDECL fn(void)
 #else  // !defined(__cplusplus)
 #pragma section(".CRT$XCU", read)
 // The NAPI_C_CTOR macro defines a function fn that is called during CRT
@@ -62,10 +62,10 @@ typedef struct napi_module {
 // optimized. See for details:
 // https://docs.microsoft.com/en-us/cpp/c-runtime-library/crt-initialization?view=msvc-170
 #define NAPI_C_CTOR(fn)                                                        \
-  static void __cdecl fn(void);                                                \
-  __declspec(dllexport, allocate(".CRT$XCU")) void(__cdecl * fn##_)(void) =    \
+  static void NAPI_CDECL fn(void);                                             \
+  __declspec(dllexport, allocate(".CRT$XCU")) void(NAPI_CDECL * fn##_)(void) = \
       fn;                                                                      \
-  static void __cdecl fn(void)
+  static void NAPI_CDECL fn(void)
 #endif  // defined(__cplusplus)
 #else
 #define NAPI_C_CTOR(fn)                                                        \
@@ -121,102 +121,105 @@ typedef struct napi_module {
 
 EXTERN_C_START
 
-NAPI_EXTERN void napi_module_register(napi_module* mod);
+NAPI_EXTERN void NAPI_CDECL napi_module_register(napi_module* mod);
 
-NAPI_EXTERN NAPI_NO_RETURN void napi_fatal_error(const char* location,
-                                                 size_t location_len,
-                                                 const char* message,
-                                                 size_t message_len);
+NAPI_EXTERN NAPI_NO_RETURN void NAPI_CDECL
+napi_fatal_error(const char* location,
+                 size_t location_len,
+                 const char* message,
+                 size_t message_len);
 
 // Methods for custom handling of async operations
-NAPI_EXTERN napi_status napi_async_init(napi_env env,
-                                        napi_value async_resource,
-                                        napi_value async_resource_name,
-                                        napi_async_context* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_async_init(napi_env env,
+                napi_value async_resource,
+                napi_value async_resource_name,
+                napi_async_context* result);
 
-NAPI_EXTERN napi_status napi_async_destroy(napi_env env,
-                                           napi_async_context async_context);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_async_destroy(napi_env env, napi_async_context async_context);
 
-NAPI_EXTERN napi_status napi_make_callback(napi_env env,
-                                           napi_async_context async_context,
-                                           napi_value recv,
-                                           napi_value func,
-                                           size_t argc,
-                                           const napi_value* argv,
-                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_make_callback(napi_env env,
+                   napi_async_context async_context,
+                   napi_value recv,
+                   napi_value func,
+                   size_t argc,
+                   const napi_value* argv,
+                   napi_value* result);
 
 // Methods to provide node::Buffer functionality with napi types
-NAPI_EXTERN napi_status napi_create_buffer(napi_env env,
-                                           size_t length,
-                                           void** data,
-                                           napi_value* result);
-NAPI_EXTERN napi_status napi_create_external_buffer(napi_env env,
-                                                    size_t length,
-                                                    void* data,
-                                                    napi_finalize finalize_cb,
-                                                    void* finalize_hint,
-                                                    napi_value* result);
-NAPI_EXTERN napi_status napi_create_buffer_copy(napi_env env,
-                                                size_t length,
-                                                const void* data,
-                                                void** result_data,
-                                                napi_value* result);
-NAPI_EXTERN napi_status napi_is_buffer(napi_env env,
-                                       napi_value value,
-                                       bool* result);
-NAPI_EXTERN napi_status napi_get_buffer_info(napi_env env,
-                                             napi_value value,
-                                             void** data,
-                                             size_t* length);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_buffer(napi_env env,
+                                                      size_t length,
+                                                      void** data,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_external_buffer(napi_env env,
+                            size_t length,
+                            void* data,
+                            napi_finalize finalize_cb,
+                            void* finalize_hint,
+                            napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_buffer_copy(napi_env env,
+                                                           size_t length,
+                                                           const void* data,
+                                                           void** result_data,
+                                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_buffer(napi_env env,
+                                                  napi_value value,
+                                                  bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_buffer_info(napi_env env,
+                                                        napi_value value,
+                                                        void** data,
+                                                        size_t* length);
 
 // Methods to manage simple async operations
-NAPI_EXTERN
-napi_status napi_create_async_work(napi_env env,
-                                   napi_value async_resource,
-                                   napi_value async_resource_name,
-                                   napi_async_execute_callback execute,
-                                   napi_async_complete_callback complete,
-                                   void* data,
-                                   napi_async_work* result);
-NAPI_EXTERN napi_status napi_delete_async_work(napi_env env,
-                                               napi_async_work work);
-NAPI_EXTERN napi_status napi_queue_async_work(napi_env env,
-                                              napi_async_work work);
-NAPI_EXTERN napi_status napi_cancel_async_work(napi_env env,
-                                               napi_async_work work);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_async_work(napi_env env,
+                       napi_value async_resource,
+                       napi_value async_resource_name,
+                       napi_async_execute_callback execute,
+                       napi_async_complete_callback complete,
+                       void* data,
+                       napi_async_work* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_delete_async_work(napi_env env,
+                                                          napi_async_work work);
+NAPI_EXTERN napi_status NAPI_CDECL napi_queue_async_work(napi_env env,
+                                                         napi_async_work work);
+NAPI_EXTERN napi_status NAPI_CDECL napi_cancel_async_work(napi_env env,
+                                                          napi_async_work work);
 
 // version management
-NAPI_EXTERN
-napi_status napi_get_node_version(napi_env env,
-                                  const napi_node_version** version);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_node_version(napi_env env, const napi_node_version** version);
 
 #if NAPI_VERSION >= 2
 
 // Return the current libuv event loop for a given environment
-NAPI_EXTERN napi_status napi_get_uv_event_loop(napi_env env,
-                                               struct uv_loop_s** loop);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_uv_event_loop(napi_env env, struct uv_loop_s** loop);
 
 #endif  // NAPI_VERSION >= 2
 
 #if NAPI_VERSION >= 3
 
-NAPI_EXTERN napi_status napi_fatal_exception(napi_env env, napi_value err);
+NAPI_EXTERN napi_status NAPI_CDECL napi_fatal_exception(napi_env env,
+                                                        napi_value err);
 
-NAPI_EXTERN napi_status napi_add_env_cleanup_hook(napi_env env,
-                                                  void (*fun)(void* arg),
-                                                  void* arg);
+NAPI_EXTERN napi_status NAPI_CDECL napi_add_env_cleanup_hook(
+    napi_env env, void(NAPI_CDECL* fun)(void* arg), void* arg);
 
-NAPI_EXTERN napi_status napi_remove_env_cleanup_hook(napi_env env,
-                                                     void (*fun)(void* arg),
-                                                     void* arg);
+NAPI_EXTERN napi_status NAPI_CDECL napi_remove_env_cleanup_hook(
+    napi_env env, void(NAPI_CDECL* fun)(void* arg), void* arg);
 
-NAPI_EXTERN napi_status napi_open_callback_scope(napi_env env,
-                                                 napi_value resource_object,
-                                                 napi_async_context context,
-                                                 napi_callback_scope* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_open_callback_scope(napi_env env,
+                         napi_value resource_object,
+                         napi_async_context context,
+                         napi_callback_scope* result);
 
-NAPI_EXTERN napi_status napi_close_callback_scope(napi_env env,
-                                                  napi_callback_scope scope);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_close_callback_scope(napi_env env, napi_callback_scope scope);
 
 #endif  // NAPI_VERSION >= 3
 
@@ -224,7 +227,7 @@ NAPI_EXTERN napi_status napi_close_callback_scope(napi_env env,
 
 #ifndef __wasm32__
 // Calling into JS from other threads
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_threadsafe_function(napi_env env,
                                 napi_value func,
                                 napi_value async_resource,
@@ -237,24 +240,24 @@ napi_create_threadsafe_function(napi_env env,
                                 napi_threadsafe_function_call_js call_js_cb,
                                 napi_threadsafe_function* result);
 
-NAPI_EXTERN napi_status napi_get_threadsafe_function_context(
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_threadsafe_function_context(
     napi_threadsafe_function func, void** result);
 
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_call_threadsafe_function(napi_threadsafe_function func,
                               void* data,
                               napi_threadsafe_function_call_mode is_blocking);
 
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_acquire_threadsafe_function(napi_threadsafe_function func);
 
-NAPI_EXTERN napi_status napi_release_threadsafe_function(
+NAPI_EXTERN napi_status NAPI_CDECL napi_release_threadsafe_function(
     napi_threadsafe_function func, napi_threadsafe_function_release_mode mode);
 
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 #endif  // __wasm32__
 
@@ -262,21 +265,21 @@ napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 
 #if NAPI_VERSION >= 8
 
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_add_async_cleanup_hook(napi_env env,
                             napi_async_cleanup_hook hook,
                             void* arg,
                             napi_async_cleanup_hook_handle* remove_handle);
 
-NAPI_EXTERN napi_status
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_remove_async_cleanup_hook(napi_async_cleanup_hook_handle remove_handle);
 
 #endif  // NAPI_VERSION >= 8
 
 #ifdef NAPI_EXPERIMENTAL
 
-NAPI_EXTERN napi_status node_api_get_module_file_name(napi_env env,
-                                                      const char** result);
+NAPI_EXTERN napi_status NAPI_CDECL
+node_api_get_module_file_name(napi_env env, const char** result);
 
 #endif  // NAPI_EXPERIMENTAL
 

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -22,15 +22,13 @@ typedef enum {
 } napi_threadsafe_function_call_mode;
 #endif  // NAPI_VERSION >= 4
 
-typedef void (*napi_async_execute_callback)(napi_env env, void* data);
-typedef void (*napi_async_complete_callback)(napi_env env,
-                                             napi_status status,
-                                             void* data);
+typedef void(NAPI_CDECL* napi_async_execute_callback)(napi_env env, void* data);
+typedef void(NAPI_CDECL* napi_async_complete_callback)(napi_env env,
+                                                       napi_status status,
+                                                       void* data);
 #if NAPI_VERSION >= 4
-typedef void (*napi_threadsafe_function_call_js)(napi_env env,
-                                                 napi_value js_callback,
-                                                 void* context,
-                                                 void* data);
+typedef void(NAPI_CDECL* napi_threadsafe_function_call_js)(
+    napi_env env, napi_value js_callback, void* context, void* data);
 #endif  // NAPI_VERSION >= 4
 
 typedef struct {
@@ -42,8 +40,8 @@ typedef struct {
 
 #if NAPI_VERSION >= 8
 typedef struct napi_async_cleanup_hook_handle__* napi_async_cleanup_hook_handle;
-typedef void (*napi_async_cleanup_hook)(napi_async_cleanup_hook_handle handle,
-                                        void* data);
+typedef void(NAPI_CDECL* napi_async_cleanup_hook)(
+    napi_async_cleanup_hook_handle handle, void* data);
 #endif  // NAPI_VERSION >= 8
 
 #endif  // SRC_NODE_API_TYPES_H_


### PR DESCRIPTION
### The issue

The Node-API is a quite generic ABI-safe API that can be used as JavaScript engine ABI-safe API outside of Node.JS project.
The issue is that currently it does not specify calling conventions which is critical if Windows DLLs compiled with different default calling conventions. It is not important for x64 or non-Windows platforms because they use one predefined calling convention, but for Windows x86 applications there are multiple calling conventions, and their mismatch causes a runtime crash.

E.g. I had previously added `__cdecl` to `v8jsi.dll` copy of [`js_native_api.h`](https://github.com/microsoft/v8-jsi/blob/master/src/public/js_native_api.h), but we still saw crashes in Windows x86 because `__cdecl` was not added to function pointers in [`js_native_api_types.h`](https://github.com/microsoft/v8-jsi/blob/master/src/public/js_native_api_types.h). The issue is being addressed by https://github.com/microsoft/v8-jsi/pull/122.
This example shows how important the calling conventions are for Window x86 platform.

### The solution

In this PR we are adding `__cdecl` to all functions and function pointers that target Win32 platform.
To do that we add a new macro `NAPI_CDECL`. It is expanded to `__cdecl` for Win32 platforms and to nothing for other platforms.

### Discussion

This PR sets `__cdecl` as the calling conventions because it is the default in C/C++ compilers.
It would be ideal to use `__stdcall` calling conventions to match Windows API because it produces more compact code on calling side, but my concern is that such change may affect existing code. Though, if Node.JS is not shipped for x86, then it may be still safe to use `__stdcall` instead of `__cdecl`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
