### PR TITLE
doc: delete heapdump from diagnostic tooling support tiers

### DIFF
--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -125,7 +125,6 @@ The tools are currently assigned to Tiers as follows:
 | Tool Type | Tool/API Name             | Regular Testing in Node.js CI | Integrated with Node.js | Target Tier |
 | --------- | ------------------------- | ----------------------------- | ----------------------- | ----------- |
 | FFDC      | node-report               | No                            | No                      | 1           |
-| Memory    | node-heapdump             | No                            | No                      | 2           |
 | Memory    | V8 heap profiler          | No                            | Yes                     | 1           |
 | Memory    | V8 sampling heap profiler | No                            | Yes                     | 1           |
 | AsyncFlow | Async Hooks (API)         | ?                             | Yes                     | 1           |


### PR DESCRIPTION
Hey node family 👋

## Context

The diagnostic working group currently works on an [initiative](https://github.com/nodejs/diagnostics/issues/532) to re-evaluate the diagnostic tooling list and its maturity.

## Updated

In the previous instance, we examined the case of the `heapdump` module: [issue link](https://github.com/nodejs/diagnostics/issues/548).

We found that we have a native way to do it (thanks to v8).

For this reason, we thought that it could be better to remove it from the list.

## Discuss

Feel free to share your thoughts on that and your experience with this tool.

With love ❤️  

cc @nodejs/diagnostics 