### PR TITLE
v8: export more fields in getHeapStatistics

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -180,6 +180,9 @@ Returns an object with the following properties:
 * `does_zap_garbage` {number}
 * `number_of_native_contexts` {number}
 * `number_of_detached_contexts` {number}
+* `total_global_handles_size` {number}
+* `used_global_handles_size` {number}
+* `external_memory` {number}
 
 `does_zap_garbage` is a 0/1 boolean, which signifies whether the
 `--zap_code_space` option is enabled or not. This makes V8 overwrite heap
@@ -195,6 +198,15 @@ a memory leak.
 of contexts that were detached and not yet garbage collected. This number
 being non-zero indicates a potential memory leak.
 
+`total_global_handles_size` The value of total\_global\_handles\_size is the
+total memory size of V8 global handles.
+
+`used_global_handles_size` The value of used\_global\_handles\_size is the
+used memory size of V8 global handles.
+
+`external_memory` The value of external\_memory is the memory size of array
+buffers and external strings.
+
 <!-- eslint-skip -->
 
 ```js
@@ -209,7 +221,10 @@ being non-zero indicates a potential memory leak.
   peak_malloced_memory: 1127496,
   does_zap_garbage: 0,
   number_of_native_contexts: 1,
-  number_of_detached_contexts: 0
+  number_of_detached_contexts: 0,
+  total_global_handles_size: 8192,
+  used_global_handles_size: 3296,
+  external_memory: 318824
 }
 ```
 

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -107,6 +107,9 @@ const {
   kPeakMallocedMemoryIndex,
   kNumberOfNativeContextsIndex,
   kNumberOfDetachedContextsIndex,
+  kTotalGlobalHandlesSizeIndex,
+  kUsedGlobalHandlesSizeIndex,
+  kExternalMemoryIndex,
 
   // Properties for heap spaces statistics buffer extraction.
   kHeapSpaces,
@@ -165,7 +168,10 @@ function getHeapStatistics() {
     peak_malloced_memory: buffer[kPeakMallocedMemoryIndex],
     does_zap_garbage: buffer[kDoesZapGarbageIndex],
     number_of_native_contexts: buffer[kNumberOfNativeContextsIndex],
-    number_of_detached_contexts: buffer[kNumberOfDetachedContextsIndex]
+    number_of_detached_contexts: buffer[kNumberOfDetachedContextsIndex],
+    total_global_handles_size: buffer[kTotalGlobalHandlesSizeIndex],
+    used_global_handles_size: buffer[kUsedGlobalHandlesSizeIndex],
+    external_memory: buffer[kExternalMemoryIndex]
   };
 }
 

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -47,19 +47,21 @@ using v8::Uint32;
 using v8::V8;
 using v8::Value;
 
-
-#define HEAP_STATISTICS_PROPERTIES(V)                                         \
-  V(0, total_heap_size, kTotalHeapSizeIndex)                                  \
-  V(1, total_heap_size_executable, kTotalHeapSizeExecutableIndex)             \
-  V(2, total_physical_size, kTotalPhysicalSizeIndex)                          \
-  V(3, total_available_size, kTotalAvailableSize)                             \
-  V(4, used_heap_size, kUsedHeapSizeIndex)                                    \
-  V(5, heap_size_limit, kHeapSizeLimitIndex)                                  \
-  V(6, malloced_memory, kMallocedMemoryIndex)                                 \
-  V(7, peak_malloced_memory, kPeakMallocedMemoryIndex)                        \
-  V(8, does_zap_garbage, kDoesZapGarbageIndex)                                \
-  V(9, number_of_native_contexts, kNumberOfNativeContextsIndex)               \
-  V(10, number_of_detached_contexts, kNumberOfDetachedContextsIndex)
+#define HEAP_STATISTICS_PROPERTIES(V)                                          \
+  V(0, total_heap_size, kTotalHeapSizeIndex)                                   \
+  V(1, total_heap_size_executable, kTotalHeapSizeExecutableIndex)              \
+  V(2, total_physical_size, kTotalPhysicalSizeIndex)                           \
+  V(3, total_available_size, kTotalAvailableSize)                              \
+  V(4, used_heap_size, kUsedHeapSizeIndex)                                     \
+  V(5, heap_size_limit, kHeapSizeLimitIndex)                                   \
+  V(6, malloced_memory, kMallocedMemoryIndex)                                  \
+  V(7, peak_malloced_memory, kPeakMallocedMemoryIndex)                         \
+  V(8, does_zap_garbage, kDoesZapGarbageIndex)                                 \
+  V(9, number_of_native_contexts, kNumberOfNativeContextsIndex)                \
+  V(10, number_of_detached_contexts, kNumberOfDetachedContextsIndex)           \
+  V(11, total_global_handles_size, kTotalGlobalHandlesSizeIndex)               \
+  V(12, used_global_handles_size, kUsedGlobalHandlesSizeIndex)                 \
+  V(13, external_memory, kExternalMemoryIndex)
 
 #define V(a, b, c) +1
 static constexpr size_t kHeapStatisticsPropertiesCount =

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -6,15 +6,18 @@ const v8 = require('v8');
 const s = v8.getHeapStatistics();
 const keys = [
   'does_zap_garbage',
+  'external_memory',
   'heap_size_limit',
   'malloced_memory',
   'number_of_detached_contexts',
   'number_of_native_contexts',
   'peak_malloced_memory',
   'total_available_size',
+  'total_global_handles_size',
   'total_heap_size',
   'total_heap_size_executable',
   'total_physical_size',
+  'used_global_handles_size',
   'used_heap_size'];
 assert.deepStrictEqual(Object.keys(s).sort(), keys);
 keys.forEach(function(key) {


### PR DESCRIPTION
export total_global_handles_size, used_global_handles_size, external_memory in getHeapStatistics.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)