### PR TITLE
util: fix TypeError when console.log a static property name in class

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -579,7 +579,8 @@ function getConstructorName(obj, ctx, recurseTimes, protoProps) {
         addPrototypeProperties(
           ctx, tmp, firstProto || tmp, recurseTimes, protoProps);
       }
-      return descriptor.value.name;
+      const name = descriptor.value.name;
+      return typeof name === 'symbol' ? SymbolPrototypeToString(name) : name;
     }
 
     obj = ObjectGetPrototypeOf(obj);

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -579,8 +579,7 @@ function getConstructorName(obj, ctx, recurseTimes, protoProps) {
         addPrototypeProperties(
           ctx, tmp, firstProto || tmp, recurseTimes, protoProps);
       }
-      const name = descriptor.value.name;
-      return typeof name === 'symbol' ? SymbolPrototypeToString(name) : name;
+      return String(descriptor.value.name);
     }
 
     obj = ObjectGetPrototypeOf(obj);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1396,6 +1396,9 @@ if (typeof Symbol !== 'undefined') {
   class SetSubclass extends Set {}
   class MapSubclass extends Map {}
   class PromiseSubclass extends Promise {}
+  class SymbolNameClass {
+    static name = Symbol('name');
+  }
 
   const x = new ObjectSubclass();
   x.foo = 42;
@@ -1409,6 +1412,8 @@ if (typeof Symbol !== 'undefined') {
                      "MapSubclass(1) [Map] { 'foo' => 42 }");
   assert.strictEqual(util.inspect(new PromiseSubclass(() => {})),
                      'PromiseSubclass [Promise] { <pending> }');
+  assert.strictEqual(util.inspect(new SymbolNameClass()),
+                     'Symbol(name) {}');
   assert.strictEqual(
     util.inspect({ a: { b: new ArraySubclass([1, [2], 3]) } }, { depth: 1 }),
     '{ a: { b: [ArraySubclass] } }'


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixed #42773

Constructor name from `getConstructorName` will be converted to string by template literal (`${constructor}`) in a subsequent process.

In this case, `getConstructorName` need to convert symbol to string by `Symbol.prototype.toString` beforehand since `${Symbol()}` throws TypeError ([spec](https://262.ecma-international.org/12.0/#sec-tostring)).