### PR TITLE
src: fix crypto.privateEncrypt fails first time

### DIFF
--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -318,6 +318,7 @@ MaybeLocal<Value> WritePrivateKey(
     }
   }
 
+  MarkPopErrorOnReturn mark_pop_error_on_return;
   bool err;
 
   PKEncodingType encoding_type = config.type_.ToChecked();

--- a/test/parallel/test-crypto-aes-128-ecb.js
+++ b/test/parallel/test-crypto-aes-128-ecb.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: {
+    type: 'spki',
+    format: 'pem'
+  },
+  privateKeyEncoding: {
+    type: 'pkcs8',
+    format: 'pem',
+    cipher: 'aes-128-ecb',
+    passphrase: 'abcdef'
+  }
+});
+assert.notStrictEqual(privateKey.toString(), '');
+
+const msg = 'The quick brown fox jumps over the lazy dog';
+
+const encryptedString = crypto.privateEncrypt({
+  key: privateKey,
+  passphrase: 'abcdef'
+}, Buffer.from(msg)).toString('base64');
+const decryptedString = crypto.publicDecrypt(publicKey, Buffer.from(encryptedString, 'base64')).toString();
+console.log(`Encrypted: ${encryptedString}`);
+console.log(`Decrypted: ${decryptedString}`);
+
+assert.notStrictEqual(encryptedString, '');
+assert.strictEqual(decryptedString, msg);

--- a/test/parallel/test-crypto-publicDecrypt-fails-first-time.js
+++ b/test/parallel/test-crypto-publicDecrypt-fails-first-time.js
@@ -1,9 +1,13 @@
 'use strict';
 const common = require('../common');
+
+// Test for https://github.com/nodejs/node/issues/40814
+
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-// Test for https://github.com/nodejs/node/issues/40814
+if (!common.hasOpenSSL3)
+  common.skip('only openssl3'); // https://github.com/nodejs/node/pull/42793#issuecomment-1107491901
 
 const assert = require('assert');
 const crypto = require('crypto');

--- a/test/parallel/test-crypto-publicDecrypt-fails-first-time.js
+++ b/test/parallel/test-crypto-publicDecrypt-fails-first-time.js
@@ -3,6 +3,8 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+// Test for https://github.com/nodejs/node/issues/40814
+
 const assert = require('assert');
 const crypto = require('crypto');
 


### PR DESCRIPTION
Fix crypto.privateEncrypt fails for the first time after crypto.generateKeyPairSync with certain parameters

Because the error stack is not cleaned up when crypto.generateKeyPairSync exits.

Fixes: https://github.com/nodejs/node/issues/40814

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
