### PR TITLE
test: fix `parallel/test-dgram-udp6-link-local-address`

### DIFF
--- a/test/parallel/test-dgram-udp6-link-local-address.js
+++ b/test/parallel/test-dgram-udp6-link-local-address.js
@@ -12,7 +12,7 @@ const { isWindows } = common;
 function linklocal() {
   for (const [ifname, entries] of Object.entries(os.networkInterfaces())) {
     for (const { address, family, scopeid } of entries) {
-      if (family === 'IPv6' && address.startsWith('fe80:')) {
+      if (family === 6 && address.startsWith('fe80:')) {
         return { address, ifname, scopeid };
       }
     }


### PR DESCRIPTION
Since #41431 landed, this test is always skipped because `family` is now an integer, not a string anymore.

Thanks @bl-ue for the report.

Refs: https://github.com/nodejs/node/pull/41431

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
