### PR TITLE
doc: elevate node-clinic diagnostic tier

### DIFF
--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -113,6 +113,7 @@ The tools are currently assigned to Tiers as follows:
 | Profiling | V8 CodeEventHandler API              | Partial (V8 Tests)            | Yes                     | 2           |
 | Profiling | V8 --interpreted-frames-native-stack | Yes                           | Yes                     | 2           |
 | Profiling | Linux perf                           | Yes                           | Partial                 | 2           |
+| Profiling | node-clinic                          | No                            | No                      | 3           |
 
 ## Tier 4
 
@@ -142,6 +143,5 @@ The tools are currently assigned to Tiers as follows:
 | Profiling | DTrace                    | No                            | Partial                 | 3           |
 | Profiling | Windows Xperf             | No                            | ?                       | ?           |
 | Profiling | 0x                        | No                            | No                      | 4           |
-| Profiling | node-clinic               | No                            | No                      | too early   |
 | F/P/T     | appmetrics                | No                            | No                      | ?           |
 | M/T       | eBPF tracing tool         | No                            | No                      | ?           |


### PR DESCRIPTION
Fixes: https://github.com/nodejs/diagnostics/issues/537.

As discussed in the last Diagnostics WG(https://github.com/nodejs/diagnostics/issues/552). I'm not sure how the `node-clinic` tests could be integrated into the nightly CI.