### PR TITLE
test: use`mustSucceed` instead of `mustCall` with `assert.ifError`

### DIFF
--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -67,18 +67,16 @@ const invalidCallbackObj = {
 // Check the opendir async version
 fs.opendir(testDir, common.mustSucceed((dir) => {
   let sync = true;
-  dir.read(common.mustCall((err, dirent) => {
+  dir.read(common.mustSucceed((dirent) => {
     assert(!sync);
-    assert.ifError(err);
 
     // Order is operating / file system dependent
     assert(files.includes(dirent.name), `'files' should include ${dirent}`);
     assertDirent(dirent);
 
     let syncInner = true;
-    dir.read(common.mustCall((err, dirent) => {
+    dir.read(common.mustSucceed((dirent) => {
       assert(!syncInner);
-      assert.ifError(err);
 
       dir.close(common.mustSucceed());
     }));


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Use `mustSucceed` instead of `mustCall` + `ifError`.
