### PR TITLE
doc: clarify guide on testing internal errors

### DIFF
--- a/doc/contributing/writing-tests.md
+++ b/doc/contributing/writing-tests.md
@@ -312,6 +312,18 @@ assert.throws(
 );
 ```
 
+In case of internal errors, prefer checking only `code` property:
+
+```js
+assert.throws(
+  () => {
+    throw new ERR_FS_FILE_TOO_LARGE(`${sizeKiB} Kb`);
+  },
+  { code: 'ERR_FS_FILE_TOO_LARGE' }
+  // Do not include message: /^File size ([0-9]+ Kb) is greater than 2 GiB$/
+);
+```
+
 ### Console output
 
 Output written by tests to stdout or stderr, such as with `console.log()` or

--- a/doc/contributing/writing-tests.md
+++ b/doc/contributing/writing-tests.md
@@ -312,7 +312,7 @@ assert.throws(
 );
 ```
 
-In case of internal errors, prefer checking only `code` property:
+In the case of internal errors, prefer checking only the `code` property:
 
 ```js
 assert.throws(


### PR DESCRIPTION
[Guide on writing tests](https://github.com/nodejs/node/blob/master/doc/contributing/writing-tests.md#assertions) seems to be contradicting with the purpose of [internal/errors](https://github.com/nodejs/node/blob/master/lib/internal/errors.js):
https://github.com/nodejs/node/blob/fe85cf70a2c16123bb109c213cc17cdcf541e38f/lib/internal/errors.js#L7-L11

The code example might give several ideas on why `.message` is subject to change at any time.
