### PR TITLE
doc: update test.py section in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -324,13 +324,13 @@ You can execute the entire suite of tests for a given subsystem
 by providing the name of a subsystem:
 
 ```text
-$ tools/test.py -J child-process
+$ tools/test.py child-process
 ```
 
 You can also execute the tests in a tests directory (such as `test/message`):
 
 ```text
-$ tools/test.py -J test/message
+$ tools/test.py test/message
 ```
 
 If you want to check the other options, please refer to the help by using

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -327,7 +327,8 @@ by providing the name of a subsystem:
 $ tools/test.py child-process
 ```
 
-You can also execute the tests in a tests directory (such as `test/message`):
+You can also execute the tests in a test suite directory
+(such as `test/message`):
 
 ```text
 $ tools/test.py test/message


### PR DESCRIPTION
Legacy `-J` option is enabled by default.

"tests directory" might require some extra explanation. Current line sounds like it can be a completely arbitrary directory (such as `test/custom-tests/` with a bunch of `test-something.js` files), but it won't work like that due to absence of `testcfg.py`.