### PR TITLE
v8: export cpu_profiler_metadata_size in getHeapCodeStatistics

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -41,11 +41,14 @@ added: v12.8.0
 
 * Returns: {Object}
 
-Returns an object with the following properties:
+Get statistics about code and its metadata in the heap, see V8
+[`GetHeapCodeAndMetadataStatistics`][] API. Returns an object with the
+following properties:
 
 * `code_and_metadata_size` {number}
 * `bytecode_and_metadata_size` {number}
 * `external_script_source_size` {number}
+* `cpu_profiler_metadata_size` {number}
 
 <!-- eslint-skip -->
 
@@ -53,7 +56,8 @@ Returns an object with the following properties:
 {
   code_and_metadata_size: 212208,
   bytecode_and_metadata_size: 161368,
-  external_script_source_size: 1410794
+  external_script_source_size: 1410794,
+  cpu_profiler_metadata_size: 0,
 }
 ```
 
@@ -882,6 +886,7 @@ occur synchronously in the case of `Promise.resolve()` or `Promise.reject()`.
 [`Deserializer`]: #class-v8deserializer
 [`ERR_BUFFER_TOO_LARGE`]: errors.md#err_buffer_too_large
 [`Error`]: errors.md#class-error
+[`GetHeapCodeAndMetadataStatistics`]: https://v8docs.nodesource.com/node-13.2/d5/dda/classv8_1_1_isolate.html#a6079122af17612ef54ef3348ce170866
 [`GetHeapSpaceStatistics`]: https://v8docs.nodesource.com/node-13.2/d5/dda/classv8_1_1_isolate.html#ac673576f24fdc7a33378f8f57e1d13a4
 [`NODE_V8_COVERAGE`]: cli.md#node_v8_coveragedir
 [`Serializer`]: #class-v8serializer

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -121,7 +121,8 @@ const {
   // Properties for heap code statistics buffer extraction.
   kCodeAndMetadataSizeIndex,
   kBytecodeAndMetadataSizeIndex,
-  kExternalScriptSourceSizeIndex
+  kExternalScriptSourceSizeIndex,
+  kCPUProfilerMetaDataSizeIndex,
 } = binding;
 
 const kNumberOfHeapSpaces = kHeapSpaces.length;
@@ -209,6 +210,7 @@ function getHeapSpaceStatistics() {
  *   code_and_metadata_size: number;
  *   bytecode_and_metadata_size: number;
  *   external_script_source_size: number;
+ *   cpu_profiler_metadata_size: number;
  *   }}
  */
 function getHeapCodeStatistics() {
@@ -218,7 +220,8 @@ function getHeapCodeStatistics() {
   return {
     code_and_metadata_size: buffer[kCodeAndMetadataSizeIndex],
     bytecode_and_metadata_size: buffer[kBytecodeAndMetadataSizeIndex],
-    external_script_source_size: buffer[kExternalScriptSourceSizeIndex]
+    external_script_source_size: buffer[kExternalScriptSourceSizeIndex],
+    cpu_profiler_metadata_size: buffer[kCPUProfilerMetaDataSizeIndex],
   };
 }
 

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -82,7 +82,8 @@ static constexpr size_t kHeapSpaceStatisticsPropertiesCount =
 #define HEAP_CODE_STATISTICS_PROPERTIES(V)                                     \
   V(0, code_and_metadata_size, kCodeAndMetadataSizeIndex)                      \
   V(1, bytecode_and_metadata_size, kBytecodeAndMetadataSizeIndex)              \
-  V(2, external_script_source_size, kExternalScriptSourceSizeIndex)
+  V(2, external_script_source_size, kExternalScriptSourceSizeIndex)            \
+  V(3, cpu_profiler_metadata_size, kCPUProfilerMetaDataSizeIndex)
 
 #define V(a, b, c) +1
 static const size_t kHeapCodeStatisticsPropertiesCount =

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -29,6 +29,7 @@ const heapCodeStatistics = v8.getHeapCodeStatistics();
 const heapCodeStatisticsKeys = [
   'bytecode_and_metadata_size',
   'code_and_metadata_size',
+  'cpu_profiler_metadata_size',
   'external_script_source_size'];
 assert.deepStrictEqual(Object.keys(heapCodeStatistics).sort(),
                        heapCodeStatisticsKeys);


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)