### PR TITLE
wasi: remove unecessary null check

### DIFF
--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -236,11 +236,9 @@ void WASI::New(const FunctionCallbackInfo<Value>& args) {
     delete[] options.argv;
   }
 
-  if (options.envp != nullptr) {
-    for (uint32_t i = 0; options.envp[i]; i++)
-      free(const_cast<char*>(options.envp[i]));
-    delete[] options.envp;
-  }
+  for (uint32_t i = 0; options.envp[i]; i++)
+    free(const_cast<char*>(options.envp[i]));
+  delete[] options.envp;
 
   if (options.preopens != nullptr) {
     for (uint32_t i = 0; i < options.preopenc; i++) {


### PR DESCRIPTION
As reported by coverity the null check is
done after earlier code has already derefenced
options.envp. Either we should null check earlier
uses or this check is not necessary. Since options.envp
is created with new which should throw an
exception intead of returning null, it should
be safe to assume the null check is not required.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
