### PR TITLE
errors,vm: update error and use cause

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2853,12 +2853,6 @@ Cached data cannot be created for modules which have already been evaluated.
 The module being returned from the linker function is from a different context
 than the parent module. Linked modules must share the same context.
 
-<a id="ERR_VM_MODULE_LINKING_ERRORED"></a>
-
-### `ERR_VM_MODULE_LINKING_ERRORED`
-
-The linker function returned a module for which linking has failed.
-
 <a id="ERR_VM_MODULE_LINK_FAILURE"></a>
 
 ### `ERR_VM_MODULE_LINK_FAILURE`
@@ -3343,6 +3337,17 @@ Used when a given value is out of the accepted range.
 ### `ERR_VM_MODULE_NOT_LINKED`
 
 The module must be successfully linked before instantiation.
+
+<a id="ERR_VM_MODULE_LINKING_ERRORED"></a>
+
+### `ERR_VM_MODULE_LINKING_ERRORED`
+
+<!-- YAML
+added: v10.0.0
+removed: REPLACEME
+-->
+
+The linker function returned a module for which linking has failed.
 
 <a id="ERR_WORKER_UNSUPPORTED_EXTENSION"></a>
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1653,8 +1653,10 @@ E('ERR_VM_MODULE_CANNOT_CREATE_CACHED_DATA',
   'Cached data cannot be created for a module which has been evaluated', Error);
 E('ERR_VM_MODULE_DIFFERENT_CONTEXT',
   'Linked modules must use the same context', Error);
-E('ERR_VM_MODULE_LINKING_ERRORED',
-  'Linking has already failed for the provided module', Error);
+E('ERR_VM_MODULE_LINK_FAILURE', function(message, cause) {
+  this.cause = cause;
+  return message;
+}, Error);
 E('ERR_VM_MODULE_NOT_MODULE',
   'Provided module is not an instance of Module', Error);
 E('ERR_VM_MODULE_STATUS', 'Module status %s', Error);

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -34,7 +34,7 @@ const {
   ERR_VM_MODULE_ALREADY_LINKED,
   ERR_VM_MODULE_DIFFERENT_CONTEXT,
   ERR_VM_MODULE_CANNOT_CREATE_CACHED_DATA,
-  ERR_VM_MODULE_LINKING_ERRORED,
+  ERR_VM_MODULE_LINK_FAILURE,
   ERR_VM_MODULE_NOT_MODULE,
   ERR_VM_MODULE_STATUS,
 } = require('internal/errors').codes;
@@ -317,9 +317,7 @@ class SourceTextModule extends Module {
           throw new ERR_VM_MODULE_DIFFERENT_CONTEXT();
         }
         if (module.status === 'errored') {
-          // TODO(devsnek): replace with ERR_VM_MODULE_LINK_FAILURE
-          // and error cause proposal.
-          throw new ERR_VM_MODULE_LINKING_ERRORED();
+          throw new ERR_VM_MODULE_LINK_FAILURE(`request for '${identifier}' resolved to an errored module`, module.error);
         }
         if (module.status === 'unlinked') {
           await module[kLink](linker);


### PR DESCRIPTION
Resolve an ancient todo that I forgot about. This provides an error that matches other link errors and also uses the `cause` property to provide more context.