### PR TITLE
doc: add documentation of `node inspect` options

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -106,6 +106,10 @@ To begin watching an expression, type `watch('my_expression')`. The command
 
 Start the Node.js debugger client on port `port`. Default `port` is `9229`.
 
+### `-p pid`
+
+Start the Node.js debugger client against a given `pid`.
+
 ## Command reference
 
 ### Stepping

--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -100,6 +100,12 @@ To begin watching an expression, type `watch('my_expression')`. The command
 `watchers` will print the active watchers. To remove a watcher, type
 `unwatch('my_expression')`.
 
+## Options
+
+### `--port=port`
+
+Start the Node.js debugger client on port `port`. Default `port` is `9229`.
+
 ## Command reference
 
 ### Stepping


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

According to [Command-line API doc](https://nodejs.org/api/cli.html#synopsis), the detail documentation of options of `node inspect` should be placed in [Debugger documentation](https://nodejs.org/api/debugger.html), but currently they are missing.


And `node inspect --port=port` option is mentioned in [Debugging Guide](https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options) but it isn't included in [Debugger documentation](https://nodejs.org/api/debugger.html). This is also confusing.