### PR TITLE
doc: http2.createServer `options` as optional

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2343,7 +2343,7 @@ Throws `ERR_HTTP2_INVALID_SETTING_VALUE` for invalid `settings` values.
 
 Throws `ERR_INVALID_ARG_TYPE` for invalid `settings` argument.
 
-### `http2.createServer(options[, onRequestHandler])`
+### `http2.createServer([options][, onRequestHandler])`
 
 <!-- YAML
 added: v8.4.0


### PR DESCRIPTION
The method might be designed to explicitly take `options`. However,
the implementation and many examples already allow the first parameter
of a function type.

https://github.com/nodejs/node/blob/eeb27c2e0aecbf418635a8c4b7c4529385798c63/lib/internal/http2/core.js#L3316-L3321

```js
// an example in doc/api/http2.md
const http2 = require('node:http2');
const server = http2.createServer();
server.on('stream', (stream, headers) => { ... });
```

I'm not sure whether applying the same to [http2.createSecureServer](https://github.com/nodejs/node/blob/master/doc/api/http2.md#http2createsecureserveroptions-onrequesthandler) is 
meaningful. But, seeing [https.createServer](https://github.com/nodejs/node/blob/master/doc/api/https.md#httpscreateserveroptions-requestlistener), the `options` parameter is
handled as optional.


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
