### PR TITLE
test: skip test that cannot pass under --node-builtin-modules-path

### DIFF
--- a/test/parallel/test-worker-init-failure.js
+++ b/test/parallel/test-worker-init-failure.js
@@ -10,6 +10,10 @@ if (common.isWindows) {
   common.skip('ulimit does not work on Windows.');
 }
 
+if (process.config.variables.node_builtin_modules_path) {
+  common.skip('this test cannot pass when Node.js is built with --node-builtin-modules-path');
+}
+
 // A reasonably low fd count. An empty node process
 // creates around 30 fds for its internal purposes,
 // so making it too low will crash the process early,


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/40879.

The test `test-worker-init-failure.js` cannot pass when Node is built using `--node-builtin-modules-path`, because the test intentionally lowers the limit of the number of files that can be concurrently opened and using builtin modules blows past this limit. See error in https://github.com/nodejs/node/issues/40879#issuecomment-1104697730.

The test is already skipped in Windows environments. This PR makes it also get skipped when Node is built using `--node-builtin-modules-path`. This makes development easier, as now I can develop using `--node-builtin-modules-path` and run the tests and expect all of them to pass (unless my new code broke something). cc @HarshithaKP @addaleax @Trott 