### PR TITLE
test: add test for `position` validation in `fs.read()` and `fs.readSync()`

### DIFF
--- a/test/parallel/test-fs-read-position-validation.mjs
+++ b/test/parallel/test-fs-read-position-validation.mjs
@@ -1,0 +1,133 @@
+import * as common from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import fs from 'fs';
+import assert from 'assert';
+
+// This test ensures that "position" argument is correctly validated
+
+const filepath = fixtures.path('x.txt');
+
+const buffer = Buffer.from('xyz\n');
+const offset = 0;
+const length = buffer.byteLength;
+
+// allowedErrors is an array of acceptable internal errors
+// For example, on some platforms read syscall might return -EFBIG
+async function testValid(position, allowedErrors = []) {
+  let fdSync;
+  try {
+    fdSync = fs.openSync(filepath, 'r');
+    fs.readSync(fdSync, buffer, offset, length, position);
+    fs.readSync(fdSync, buffer, { offset, length, position });
+  } catch (err) {
+    if (!allowedErrors.includes(err.code)) {
+      assert.fail(err);
+    }
+  } finally {
+    if (fdSync) fs.closeSync(fdSync);
+  }
+
+  fs.open(filepath, 'r', common.mustSucceed((fd) => {
+    try {
+      if (allowedErrors.length) {
+        fs.read(fd, buffer, offset, length, position, common.mustCall((err, ...results) => {
+          if (err && !allowedErrors.includes(err.code)) {
+            assert.fail(err);
+          }
+        }));
+        fs.read(fd, { buffer, offset, length, position }, common.mustCall((err, ...results) => {
+          if (err && !allowedErrors.includes(err.code)) {
+            assert.fail(err);
+          }
+        }));
+      } else {
+        fs.read(fd, buffer, offset, length, position, common.mustSucceed());
+        fs.read(fd, { buffer, offset, length, position }, common.mustSucceed());
+      }
+    } finally {
+      fs.close(fd, common.mustSucceed());
+    }
+  }));
+}
+
+async function testInvalid(code, position, internalCatch = false) {
+  let fdSync;
+  try {
+    fdSync = fs.openSync(filepath, 'r');
+    assert.throws(
+      () => fs.readSync(fdSync, buffer, offset, length, position),
+      { code }
+    );
+    assert.throws(
+      () => fs.readSync(fdSync, buffer, { offset, length, position }),
+      { code }
+    );
+  } finally {
+    if (fdSync) fs.closeSync(fdSync);
+  }
+
+  // Set this flag for catching errors via first argument of callback function
+  if (internalCatch) {
+    fs.open(filepath, 'r', common.mustSucceed((fd) => {
+      try {
+        fs.read(fd, buffer, offset, length, position, (err, ...results) => {
+          assert.strictEqual(err.code, code);
+        });
+        fs.read(fd, { buffer, offset, length, position }, (err, ...results) => {
+          assert.strictEqual(err.code, code);
+        });
+      } finally {
+        fs.close(fd, common.mustSucceed());
+      }
+    }));
+  } else {
+    fs.open(filepath, 'r', common.mustSucceed((fd) => {
+      try {
+        assert.throws(
+          () => fs.read(fd, buffer, offset, length, position, common.mustNotCall()),
+          { code }
+        );
+        assert.throws(
+          () => fs.read(fd, { buffer, offset, length, position }, common.mustNotCall()),
+          { code }
+        );
+      } finally {
+        fs.close(fd, common.mustSucceed());
+      }
+    }));
+  }
+}
+
+{
+  await testValid(undefined);
+  await testValid(null);
+  await testValid(-1);
+  await testValid(-1n);
+
+  await testValid(0);
+  await testValid(0n);
+  await testValid(1);
+  await testValid(1n);
+  await testValid(9);
+  await testValid(9n);
+  await testValid(Number.MAX_SAFE_INTEGER, [ 'EFBIG' ]);
+
+  await testValid(2n ** 63n - 1n - BigInt(length), [ 'EFBIG' ]);
+  await testInvalid('ERR_OUT_OF_RANGE', 2n ** 63n);
+
+  // TODO(LiviaMedeiros): test `2n ** 63n - BigInt(length)`
+
+  await testInvalid('ERR_OUT_OF_RANGE', NaN);
+  await testInvalid('ERR_OUT_OF_RANGE', -Infinity);
+  await testInvalid('ERR_OUT_OF_RANGE', Infinity);
+  await testInvalid('ERR_OUT_OF_RANGE', -0.999);
+  await testInvalid('ERR_OUT_OF_RANGE', -(2n ** 64n));
+  await testInvalid('ERR_OUT_OF_RANGE', Number.MAX_SAFE_INTEGER + 1);
+  await testInvalid('ERR_OUT_OF_RANGE', Number.MAX_VALUE);
+
+  for (const badTypeValue of [
+    false, true, '1', Symbol(1), {}, [], () => {}, Promise.resolve(1),
+  ]) {
+    await testInvalid('ERR_INVALID_ARG_TYPE', badTypeValue);
+  }
+}


### PR DESCRIPTION
This PR adds a test for `position` validation in `fs.read()` and `fs.readSync()` methods.

To be expanded in: https://github.com/nodejs/node/pull/42835 (`filehandle.read()` and cases where method tries to read bytes beyond int64 limit)

<details>
<summary>Outdated stuff</summary>
This PR replaced `EINVAL` from `read(2)` syscall with `RangeError` exception, when `fs.read()` or `fs.readSync()` is called with huge bigint `position`, and adding `length` makes it bigger than `2⁶³ - 1`. 

```mjs
import { openSync, readSync } from 'fs';
const fd = openSync('/mnt/flashdrive/last_digits_of_pi');
const buffer = Buffer.alloc(9);
const result = readSync(fd, buffer, { position: 2n ** 63n - 5n, length: 9 });
```
```bash
node:fs:723
  handleErrorFromBinding(ctx);
  ^

Error: EINVAL: invalid argument, read
    at readSync (node:fs:723:3)
    at file:///tmp/test.mjs:4:16
    at ModuleJob.run (node:internal/modules/esm/module_job:197:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:61:12) {
  errno: -22,
  syscall: 'read',
  code: 'EINVAL'
}
```
</details>