### PR TITLE
http2: set origin name correctly when servername is empty

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3119,7 +3119,7 @@ function initializeTLSOptions(options, servername) {
   options.ALPNProtocols = ['h2'];
   if (options.allowHTTP1 === true)
     ArrayPrototypePush(options.ALPNProtocols, 'http/1.1');
-  if (servername !== undefined && options.servername === undefined)
+  if (servername !== undefined && !options.servername)
     options.servername = servername;
   return options;
 }

--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -91,3 +91,9 @@ verifySecureSession(
   loadKey('agent1-cert.pem'),
   loadKey('ca1-cert.pem'),
   { servername: 'agent1' });
+
+verifySecureSession(
+  loadKey('agent8-key.pem'),
+  loadKey('agent8-cert.pem'),
+  loadKey('fake-startcom-root-cert.pem'),
+  { servername: '' });


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/39919
Refs: https://github.com/nodejs/node/pull/39934

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
