### PR TITLE
test: fix flaky HTTP server tests

### DIFF
--- a/test/parallel/test-http-server-headers-timeout-keepalive.js
+++ b/test/parallel/test-http-server-headers-timeout-keepalive.js
@@ -14,9 +14,6 @@ function performRequestWithDelay(client, firstDelay, secondDelay, closeAfter) {
   client.resume();
   client.write('GET / HTTP/1.1\r\n');
 
-  firstDelay = common.platformTimeout(firstDelay);
-  secondDelay = common.platformTimeout(secondDelay);
-
   setTimeout(() => {
     client.write('Connection: ');
   }, firstDelay).unref();
@@ -27,12 +24,12 @@ function performRequestWithDelay(client, firstDelay, secondDelay, closeAfter) {
   }, firstDelay + secondDelay).unref();
 }
 
-const headersTimeout = common.platformTimeout(1000);
+const headersTimeout = common.platformTimeout(2000);
 const server = createServer({
   headersTimeout,
   requestTimeout: 0,
   keepAliveTimeout: 0,
-  connectionsCheckingInterval: common.platformTimeout(250),
+  connectionsCheckingInterval: headersTimeout / 4,
 }, common.mustCallAtLeast((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end();
@@ -60,7 +57,7 @@ server.listen(0, common.mustCall(() => {
         'HTTP/1.1 200 OK'
       );
 
-      const defer = common.platformTimeout(headersTimeout * 1.5);
+      const defer = headersTimeout * 1.5;
 
       // Wait some time to make sure headersTimeout
       // does not interfere with keep alive

--- a/test/parallel/test-http-server-request-timeout-keepalive.js
+++ b/test/parallel/test-http-server-request-timeout-keepalive.js
@@ -14,9 +14,6 @@ function performRequestWithDelay(client, firstDelay, secondDelay, closeAfter) {
   client.resume();
   client.write('GET / HTTP/1.1\r\n');
 
-  firstDelay = common.platformTimeout(firstDelay);
-  secondDelay = common.platformTimeout(secondDelay);
-
   setTimeout(() => {
     client.write('Connection: ');
   }, firstDelay).unref();
@@ -27,12 +24,12 @@ function performRequestWithDelay(client, firstDelay, secondDelay, closeAfter) {
   }, firstDelay + secondDelay).unref();
 }
 
-const requestTimeout = common.platformTimeout(1000);
+const requestTimeout = common.platformTimeout(2000);
 const server = createServer({
   headersTimeout: 0,
   requestTimeout,
   keepAliveTimeout: 0,
-  connectionsCheckingInterval: common.platformTimeout(250),
+  connectionsCheckingInterval: requestTimeout / 4
 }, common.mustCallAtLeast((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end();
@@ -58,7 +55,7 @@ server.listen(0, common.mustCall(() => {
         'HTTP/1.1 200 OK'
       );
 
-      const defer = common.platformTimeout(requestTimeout * 1.5);
+      const defer = requestTimeout * 1.5;
 
       // Wait some time to make sure requestTimeout
       // does not interfere with keep alive


### PR DESCRIPTION
These two tests have been causing lots of CI failures, both in Jenkins and GitHub actions. They incorrectly use `common.platformTimeout()`, which scales a given amount of time by a factor that depends on the platform. However, these tests compute some times as `common.platformTimeout(x * common.platformTimeout(y))`, effectively squaring the platform-dependent factor.

I also increased the base timeout from 1000ms to 2000ms. As a reference, I ran one of the tests  (`test-http-server-headers-timeout-keepalive.js`) with different base timeouts, 8000 times each, using 200 concurrent processes across 16 cores.

| base timeout | successful | success rate |
|--------------|------------|--------------|
|  500ms       | 7676       | 95.95 %      |
|  600ms       | 7911       | 98.89 %      |
|  800ms       | 7944       | 99.30 %      |
| 1000ms       | 7989       | 99.86 %      |
| 2000ms       | 7999       | 99.99 %      |

Refs: https://github.com/nodejs/node/pull/41263
Fixes: https://github.com/nodejs/node/issues/42741

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
