### PR TITLE
doc: fix errors in Web Streams doc

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -209,7 +209,7 @@ added: v16.5.0
     `transform.writable` do not cause this `ReadableStream` to be
     canceled.
   * `preventClose` {boolean} When `true`, closing this `ReadableStream`
-    will not cause `transform.writable` to be closed.
+    does not cause `transform.writable` to be closed.
   * `signal` {AbortSignal} Allows the transfer of data to be canceled
     using an {AbortController}.
 * Returns: {ReadableStream} From `transform.readable`.

--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -287,7 +287,7 @@ added: v16.5.0
   * `preventCancel` {boolean} When `true`, errors in the `destination`
     will not cause this `ReadableStream` to be canceled.
   * `preventClose` {boolean} When `true`, closing this `ReadableStream`
-    will not cause `destination` to be closed.
+    does not cause `destination` to be closed.
   * `signal` {AbortSignal} Allows the transfer of data to be canceled
     using an {AbortController}.
 * Returns: A promise fulfilled with `undefined`

--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -283,12 +283,11 @@ added: v16.5.0
   `ReadableStream`'s data will be written.
 * `options` {Object}
   * `preventAbort` {boolean} When `true`, errors in this `ReadableStream`
-    will not cause `transform.writable` to be aborted.
-  * `preventCancel` {boolean} When `true`, errors in the destination
-    `transform.writable` is not cause this `ReadableStream` to be
-    canceled.
+    will not cause `destination` to be aborted.
+  * `preventCancel` {boolean} When `true`, errors in the `destination`
+    is not cause this `ReadableStream` to be canceled.
   * `preventClose` {boolean} When `true`, closing this `ReadableStream`
-    will no cause `transform.writable` to be closed.
+    will no cause `destination` to be closed.
   * `signal` {AbortSignal} Allows the transfer of data to be canceled
     using an {AbortController}.
 * Returns: A promise fulfilled with `undefined`
@@ -319,7 +318,7 @@ added: v16.5.0
 * `options` {Object}
   * `preventCancel` {boolean} When `true`, prevents the {ReadableStream}
     from being closed when the async iterator abruptly terminates.
-    **Defaults**: `false`
+    **Default**: `false`.
 
 Creates and returns an async iterator usable for consuming this
 `ReadableStream`'s data.
@@ -461,7 +460,7 @@ changes:
 -->
 
 The `ReadableStreamBYOBReader` is an alternative consumer for
-byte-oriented {ReadableStream}'s (those that are created with
+byte-oriented {ReadableStream}s (those that are created with
 `underlyingSource.type` set equal to `'bytes'` when the
 `ReadableStream` was created).
 

--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -206,7 +206,7 @@ added: v16.5.0
   * `preventAbort` {boolean} When `true`, errors in this `ReadableStream`
     will not cause `transform.writable` to be aborted.
   * `preventCancel` {boolean} When `true`, errors in the destination
-    `transform.writable` will not cause this `ReadableStream` to be
+    `transform.writable` do not cause this `ReadableStream` to be
     canceled.
   * `preventClose` {boolean} When `true`, closing this `ReadableStream`
     will not cause `transform.writable` to be closed.

--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -206,10 +206,10 @@ added: v16.5.0
   * `preventAbort` {boolean} When `true`, errors in this `ReadableStream`
     will not cause `transform.writable` to be aborted.
   * `preventCancel` {boolean} When `true`, errors in the destination
-    `transform.writable` is not cause this `ReadableStream` to be
+    `transform.writable` will not cause this `ReadableStream` to be
     canceled.
   * `preventClose` {boolean} When `true`, closing this `ReadableStream`
-    will no cause `transform.writable` to be closed.
+    will not cause `transform.writable` to be closed.
   * `signal` {AbortSignal} Allows the transfer of data to be canceled
     using an {AbortController}.
 * Returns: {ReadableStream} From `transform.readable`.
@@ -285,9 +285,9 @@ added: v16.5.0
   * `preventAbort` {boolean} When `true`, errors in this `ReadableStream`
     will not cause `destination` to be aborted.
   * `preventCancel` {boolean} When `true`, errors in the `destination`
-    is not cause this `ReadableStream` to be canceled.
+    will not cause this `ReadableStream` to be canceled.
   * `preventClose` {boolean} When `true`, closing this `ReadableStream`
-    will no cause `destination` to be closed.
+    will not cause `destination` to be closed.
   * `signal` {AbortSignal} Allows the transfer of data to be canceled
     using an {AbortController}.
 * Returns: A promise fulfilled with `undefined`


### PR DESCRIPTION
* fix typo.
*  replace `transform.writable` with `destination` in `readableStream.pipeTo(destination, options)` options description.