### PR TITLE
errors,console: refactor to use ES2020 & ES2021 syntax

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -100,7 +100,7 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
   // We have to test new.target here to see if this function is called
   // with new, because we need to define a custom instanceof to accommodate
   // the global console.
-  if (!new.target) {
+  if (new.target === undefined) {
     return ReflectConstruct(Console, arguments);
   }
 
@@ -486,7 +486,7 @@ const consoleMethods = {
     if (tabularData === null || typeof tabularData !== 'object')
       return this.log(tabularData);
 
-    if (cliTable === undefined) cliTable = require('internal/cli_table');
+    cliTable ??= require('internal/cli_table');
     const final = (k, v) => this.log(cliTable(k, v));
 
     const _inspect = (v) => {
@@ -570,8 +570,7 @@ const consoleMethods = {
       } else {
         const keys = properties || ObjectKeys(item);
         for (const key of keys) {
-          if (map[key] === undefined)
-            map[key] = [];
+          map[key] ??= [];
           if ((primitive && properties) ||
                !ObjectPrototypeHasOwnProperty(item, key))
             map[key][i] = '';

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -175,24 +175,19 @@ let assert;
 
 let internalUtil = null;
 function lazyInternalUtil() {
-  if (!internalUtil) {
-    internalUtil = require('internal/util');
-  }
+  internalUtil ??= require('internal/util');
   return internalUtil;
 }
 
 let internalUtilInspect = null;
 function lazyInternalUtilInspect() {
-  if (!internalUtilInspect) {
-    internalUtilInspect = require('internal/util/inspect');
-  }
+  internalUtilInspect ??= require('internal/util/inspect');
   return internalUtilInspect;
 }
 
 let buffer;
 function lazyBuffer() {
-  if (buffer === undefined)
-    buffer = require('buffer').Buffer;
+  buffer ??= require('buffer').Buffer;
   return buffer;
 }
 
@@ -421,7 +416,7 @@ function E(sym, val, def, ...otherClasses) {
 function getMessage(key, args, self) {
   const msg = messages.get(key);
 
-  if (assert === undefined) assert = require('internal/assert');
+  assert ??= require('internal/assert');
 
   if (typeof msg === 'function') {
     assert(
@@ -449,9 +444,7 @@ function getMessage(key, args, self) {
 let uvBinding;
 
 function lazyUv() {
-  if (!uvBinding) {
-    uvBinding = internalBinding('uv');
-  }
+  uvBinding ??= internalBinding('uv');
   return uvBinding;
 }
 
@@ -459,9 +452,7 @@ const uvUnmappedError = ['UNKNOWN', 'unknown error'];
 
 function uvErrmapGet(name) {
   uvBinding = lazyUv();
-  if (!uvBinding.errmap) {
-    uvBinding.errmap = uvBinding.getErrorMap();
-  }
+  uvBinding.errmap ??= uvBinding.getErrorMap();
   return MapPrototypeGet(uvBinding.errmap, name);
 }
 
@@ -588,7 +579,7 @@ const errnoException = hideStackFrames(
     // getSystemErrorName(err) to guard against invalid arguments from users.
     // This can be replaced with [ code ] = errmap.get(err) when this method
     // is no longer exposed to user land.
-    if (util === undefined) util = require('util');
+    util ??= require('util');
     const code = util.getSystemErrorName(err);
     const message = original ?
       `${syscall} ${code} ${original}` : `${syscall} ${code}`;
@@ -622,7 +613,7 @@ const exceptionWithHostPort = hideStackFrames(
     // getSystemErrorName(err) to guard against invalid arguments from users.
     // This can be replaced with [ code ] = errmap.get(err) when this method
     // is no longer exposed to user land.
-    if (util === undefined) util = require('util');
+    util ??= require('util');
     const code = util.getSystemErrorName(err);
     let details = '';
     if (port && port > 0) {
@@ -1238,7 +1229,7 @@ E('ERR_INVALID_ARG_TYPE',
     } else if (typeof actual === 'function' && actual.name) {
       msg += `. Received function ${actual.name}`;
     } else if (typeof actual === 'object') {
-      if (actual.constructor && actual.constructor.name) {
+      if (actual.constructor?.name) {
         msg += `. Received an instance of ${actual.constructor.name}`;
       } else {
         const inspected = lazyInternalUtilInspect()
@@ -1332,7 +1323,7 @@ E('ERR_INVALID_RETURN_PROPERTY_VALUE', (input, name, prop, value) => {
 }, TypeError);
 E('ERR_INVALID_RETURN_VALUE', (input, name, value) => {
   let type;
-  if (value && value.constructor && value.constructor.name) {
+  if (value?.constructor?.name) {
     type = `instance of ${value.constructor.name}`;
   } else {
     type = `type ${typeof value}`;


### PR DESCRIPTION
errors,console: refactor to use ES2020 & ES2021 syntax
Just simplified some codes while I'm reading the newest codes for nodejs. PTAL

ref: https://github.com/nodejs/node/pull/42088. ps: I have found this pr isn't merge yet, and I use rebase to this pr, this is long time ago and I must do something wrong :(…… So I open a new pr for this, sorry for wasting everyone's time
