### PR TITLE
worker: fix stream & termination race bug

### DIFF
--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -619,7 +619,8 @@ void ReportWritesToJSStreamListener::OnStreamAfterReqFinished(
     stream->ClearError();
   }
 
-  if (req_wrap_obj->Has(env->context(), env->oncomplete_string()).FromMaybe(false))
+  if (req_wrap_obj->Has(env->context(), env->oncomplete_string())
+          .FromMaybe(false))
     async_wrap->MakeCallback(env->oncomplete_string(), arraysize(argv), argv);
 }
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -619,7 +619,7 @@ void ReportWritesToJSStreamListener::OnStreamAfterReqFinished(
     stream->ClearError();
   }
 
-  if (req_wrap_obj->Has(env->context(), env->oncomplete_string()).FromJust())
+  if (req_wrap_obj->Has(env->context(), env->oncomplete_string()).FromMaybe(false))
     async_wrap->MakeCallback(env->oncomplete_string(), arraysize(argv), argv);
 }
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -601,6 +601,7 @@ void ReportWritesToJSStreamListener::OnStreamAfterReqFinished(
     StreamReq* req_wrap, int status) {
   StreamBase* stream = static_cast<StreamBase*>(stream_);
   Environment* env = stream->stream_env();
+  if (env->is_stopping()) return;
   AsyncWrap* async_wrap = req_wrap->GetAsyncWrap();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
@@ -619,8 +620,7 @@ void ReportWritesToJSStreamListener::OnStreamAfterReqFinished(
     stream->ClearError();
   }
 
-  if (req_wrap_obj->Has(env->context(), env->oncomplete_string())
-          .FromMaybe(false))
+  if (req_wrap_obj->Has(env->context(), env->oncomplete_string()).FromJust())
     async_wrap->MakeCallback(env->oncomplete_string(), arraysize(argv), argv);
 }
 

--- a/test/parallel/test-worker-http2-stream-terminate.js
+++ b/test/parallel/test-worker-http2-stream-terminate.js
@@ -1,0 +1,55 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+const makeDuplexPair = require('../common/duplexpair');
+const { Worker, isMainThread, parentPort } = require('worker_threads');
+
+// This test ensures that workers can be terminated without error while
+// stream activity is ongoing, in particular the C++ function
+// ReportWritesToJSStreamListener::OnStreamAfterReqFinished.
+
+if (isMainThread) {
+  const sab = new SharedArrayBuffer(4);
+  const terminate = new Int32Array(sab);
+
+  const w = new Worker(__filename);
+  w.postMessage(sab);
+  process.nextTick(() => {
+    Atomics.wait(terminate, 0, 0);
+    setImmediate(() => w.terminate());
+  });
+  return;
+}
+
+parentPort.on('message', (sab) => {
+  const terminate = new Int32Array(sab);
+  const server = http2.createServer();
+  let i = 0;
+  server.on('stream', (stream, headers) => {
+    if (i === 1) {
+      Atomics.store(terminate, 0, 1);
+      Atomics.notify(terminate, 0, 1);
+    }
+    i++;
+
+    stream.end('');
+  });
+
+  const { clientSide, serverSide } = makeDuplexPair();
+  server.emit('connection', serverSide);
+
+  const client = http2.connect('http://localhost:80', {
+    createConnection: () => clientSide,
+  });
+
+  function makeReq() {
+    for (let i = 0; i < 3; i++) {
+      client.request().end();
+    }
+    setImmediate(makeReq);
+  }
+  makeReq();
+
+});

--- a/test/parallel/test-worker-http2-stream-terminate.js
+++ b/test/parallel/test-worker-http2-stream-terminate.js
@@ -5,7 +5,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const http2 = require('http2');
 const makeDuplexPair = require('../common/duplexpair');
-const { Worker, isMainThread, parentPort } = require('worker_threads');
+const { Worker, parentPort } = require('worker_threads');
 
 // This test ensures that workers can be terminated without error while
 // stream activity is ongoing, in particular the C++ function
@@ -14,7 +14,10 @@ const { Worker, isMainThread, parentPort } = require('worker_threads');
 const MAX_ITERATIONS = 20;
 const MAX_THREADS = 10;
 
-if (isMainThread) {
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+
   function spinWorker(iter) {
     const w = new Worker(__filename);
     w.on('message', common.mustCall((msg) => {


### PR DESCRIPTION
`OnStreamAfterReqFinished` uses `v8::Object::Has` to check if it needs
to call `oncomplete`. `v8::Object::Has` needs to execute Javascript.
However when worker threads are involved, `OnStreamAfterReqFinished` may
be called after the worker thread termination has begun via
`worker.terminate()`. This makes `v8::Object::Has` return `Nothing`,
which triggers an assert.

This diff fixes the issue by checking `env->is_stopping()` first.

Fixes: https://github.com/nodejs/node/issues/38418