### PR TITLE
esm: graduate top-level-await to stable

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -566,8 +566,6 @@ would provide the exports interface for the instantiation of `module.wasm`.
 added: v14.8.0
 -->
 
-> Stability: 1 - Experimental
-
 The `await` keyword may be used in the top level body of an ECMAScript module.
 
 Assuming an `a.mjs` with

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -432,9 +432,7 @@ void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {
   // Otherwise, `result` is the last evaluated value of the module,
   // which could be a promise, which would result in it being incorrectly
   // unwrapped when the higher level code awaits the evaluation.
-  if (env->isolate_data()->options()->experimental_top_level_await) {
-    args.GetReturnValue().Set(result.ToLocalChecked());
-  }
+  args.GetReturnValue().Set(result.ToLocalChecked());
 }
 
 void ModuleWrap::GetNamespace(const FunctionCallbackInfo<Value>& args) {

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -428,10 +428,6 @@ void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  // If TLA is enabled, `result` is the evaluation's promise.
-  // Otherwise, `result` is the last evaluated value of the module,
-  // which could be a promise, which would result in it being incorrectly
-  // unwrapped when the higher level code awaits the evaluation.
   args.GetReturnValue().Set(result.ToLocalChecked());
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -704,14 +704,8 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             kAllowedInEnvironment);
   Implies("--report-signal", "--report-on-signal");
 
-  AddOption("--experimental-top-level-await",
-            "",
-            &PerIsolateOptions::experimental_top_level_await,
-            kAllowedInEnvironment);
-  AddOption("--harmony-top-level-await", "", V8Option{});
-  Implies("--experimental-top-level-await", "--harmony-top-level-await");
-  Implies("--harmony-top-level-await", "--experimental-top-level-await");
-  ImpliesNot("--no-harmony-top-level-await", "--experimental-top-level-await");
+  AddOption("--experimental-top-level-await", "",
+            NoOp{}, kAllowedInEnvironment);
 
   Insert(eop, &PerIsolateOptions::get_per_env_options);
 }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -704,8 +704,8 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             kAllowedInEnvironment);
   Implies("--report-signal", "--report-on-signal");
 
-  AddOption("--experimental-top-level-await", "",
-            NoOp{}, kAllowedInEnvironment);
+  AddOption(
+      "--experimental-top-level-await", "", NoOp{}, kAllowedInEnvironment);
 
   Insert(eop, &PerIsolateOptions::get_per_env_options);
 }

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -206,7 +206,6 @@ class PerIsolateOptions : public Options {
   bool node_snapshot = true;
   bool report_uncaught_exception = false;
   bool report_on_signal = false;
-  bool experimental_top_level_await = true;
   std::string report_signal = "SIGUSR2";
   inline EnvironmentOptions* get_per_env_options();
   void CheckOptions(std::vector<std::string>* errors) override;


### PR DESCRIPTION
Removes the experimental label in the docs and makes the `--experimental-top-level-await` flag a no-op.

V8 has removed the harmony flag in V8 9.1 and they consider the feature stable, there's no reason to keep it experimental in Node.js.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
