### PR TITLE
esm: fix imports from non-file module

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -1015,8 +1015,6 @@ function resolveAsCommonJS(specifier, parentURL) {
 // TODO(@JakobJingleheimer): de-dupe `specifier` & `parsed`
 function checkIfDisallowedImport(specifier, parsed, parsedParentURL) {
   if (parsedParentURL) {
-    const parentURL = fileURLToPath(parsedParentURL?.href);
-
     if (
       parsedParentURL.protocol === 'http:' ||
       parsedParentURL.protocol === 'https:'
@@ -1030,7 +1028,7 @@ function checkIfDisallowedImport(specifier, parsed, parsedParentURL) {
         ) {
           throw new ERR_NETWORK_IMPORT_DISALLOWED(
             specifier,
-            parentURL,
+            parsedParentURL,
             'remote imports cannot import from a local location.'
           );
         }
@@ -1041,14 +1039,14 @@ function checkIfDisallowedImport(specifier, parsed, parsedParentURL) {
           NativeModule.canBeRequiredWithoutScheme(specifier)) {
         throw new ERR_NETWORK_IMPORT_DISALLOWED(
           specifier,
-          parentURL,
+          parsedParentURL,
           'remote imports cannot import from a local location.'
         );
       }
 
       throw new ERR_NETWORK_IMPORT_DISALLOWED(
         specifier,
-        parentURL,
+        parsedParentURL,
         'only relative and absolute specifiers are supported.'
       );
     }

--- a/test/es-module/test-esm-data-urls.js
+++ b/test/es-module/test-esm-data-urls.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 function createURL(mime, body) {
   return `data:${mime},${body}`;
@@ -106,5 +107,9 @@ function createBase64URL(mime, body) {
     const plainESMURL = 'data:text/javascript,export%20default%202';
     const module = await import(plainESMURL);
     assert.strictEqual(module.default, 2);
+  }
+  {
+    const plainESMURL = `data:text/javascript,${encodeURIComponent(`import ${JSON.stringify(fixtures.fileURL('es-module-url', 'empty.js'))}`)}`
+    await import(plainESMURL);
   }
 })().then(common.mustCall());


### PR DESCRIPTION
Calling `fileURLToPath` on a possibly non-file URL throws. Converting to a path is not necessary anyway, as it's already common to see a URL in error messages rather than a path.

Fixes: https://github.com/nodejs/node/issues/42860

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
