### PR TITLE
doc: replace 'HEAD' with main or master in links

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -10,7 +10,7 @@ body:
         Please fill in as much of the following form as you're able.
 
         For more information on how the project manages feature
-        requests, see [Feature request management](https://github.com/nodejs/node/blob/HEAD/doc/contributing/feature-request-management.md).
+        requests, see [Feature request management](https://github.com/nodejs/node/blob/master/doc/contributing/feature-request-management.md).
   - type: textarea
     attributes:
       label: What is the problem this feature will solve?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 <!--
 Before submitting a pull request, please read
-https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.
+https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.
 
 Commit message formatting guidelines:
-https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines
+https://github.com/nodejs/node/blob/master/doc/contributing/pull-requests.md#commit-message-guidelines
 
 For code changes:
 1. Include tests for any bug fixes or new features.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -663,7 +663,7 @@ $ make
 
 ## `Intl` (ECMA-402) support
 
-[Intl](https://github.com/nodejs/node/blob/HEAD/doc/api/intl.md) support is
+[Intl](https://github.com/nodejs/node/blob/master/doc/api/intl.md) support is
 enabled by default.
 
 ### Build with full ICU support (all locales supported by ICU)
@@ -1043,4 +1043,4 @@ When Node.js is built (with an intention to distribute) with an ABI
 incompatible with the official Node.js builds (e.g. using a ABI incompatible
 version of a dependency), please reserve and use a custom `NODE_MODULE_VERSION`
 by opening a pull request against the registry available at
-<https://github.com/nodejs/node/blob/HEAD/doc/abi_version_registry.json>.
+<https://github.com/nodejs/node/blob/master/doc/abi_version_registry.json>.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Code of Conduct
 
-* [Node.js Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md)
-* [Node.js Moderation Policy](https://github.com/nodejs/admin/blob/HEAD/Moderation-Policy.md)
+* [Node.js Code of Conduct](https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md)
+* [Node.js Moderation Policy](https://github.com/nodejs/admin/blob/main/Moderation-Policy.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 ## [Code of Conduct](./doc/contributing/code-of-conduct.md)
 
 The Node.js project has a
-[Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md)
+[Code of Conduct](https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md)
 to which all contributors must adhere.
 
 See [details on our policy on Code of Conduct](./doc/contributing/code-of-conduct.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -176,7 +176,7 @@ The TSC follows a [Consensus Seeking][] decision-making model per the
 [TSC Charter][].
 
 [Consensus Seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
-[TSC Charter]: https://github.com/nodejs/TSC/blob/HEAD/TSC-Charter.md
+[TSC Charter]: https://github.com/nodejs/TSC/blob/main/TSC-Charter.md
 [collaborators discussion page]: https://github.com/orgs/nodejs/teams/collaborators/discussions
 [nodejs/help]: https://github.com/nodejs/help
 [nodejs/node]: https://github.com/nodejs/node

--- a/README.md
+++ b/README.md
@@ -765,13 +765,13 @@ releases on a rotation basis as outlined in the
 Node.js is available under the
 [MIT license](https://opensource.org/licenses/MIT). Node.js also includes
 external libraries that are available under a variety of licenses.  See
-[LICENSE](https://github.com/nodejs/node/blob/HEAD/LICENSE) for the full
+[LICENSE](https://github.com/nodejs/node/blob/master/LICENSE) for the full
 license text.
 
-[Code of Conduct]: https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md
+[Code of Conduct]: https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md
 [Contributing to the project]: CONTRIBUTING.md
 [Node.js website]: https://nodejs.org/
 [OpenJS Foundation]: https://openjsf.org/
 [Strategic initiatives]: doc/contributing/strategic-initiatives.md
 [Technical values and prioritization]: doc/contributing/technical-values.md
-[Working Groups]: https://github.com/nodejs/TSC/blob/HEAD/WORKING_GROUPS.md
+[Working Groups]: https://github.com/nodejs/TSC/blob/main/WORKING_GROUPS.md

--- a/doc/README.md
+++ b/doc/README.md
@@ -113,5 +113,5 @@ For topics not covered here, refer to the [Microsoft Writing Style Guide][].
 [`remark-preset-lint-node`]: https://github.com/nodejs/remark-preset-lint-node
 [doctools README]: ../tools/doc/README.md
 [info string]: https://github.github.com/gfm/#info-string
-[language]: https://github.com/highlightjs/highlight.js/blob/HEAD/SUPPORTED_LANGUAGES.md
+[language]: https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md
 [plugin]: https://editorconfig.org/#download

--- a/onboarding.md
+++ b/onboarding.md
@@ -109,7 +109,7 @@ The project has a venue for real-time discussion:
     organization (not just collaborators on Node.js core) have access. Its
     contents should not be shared externally.
   * You can find the full moderation policy
-    [here](https://github.com/nodejs/admin/blob/HEAD/Moderation-Policy.md).
+    [here](https://github.com/nodejs/admin/blob/main/Moderation-Policy.md).
 
 ## Reviewing pull requests
 
@@ -252,13 +252,13 @@ needs to be pointed out separately during the onboarding.
 * If you are interested in helping to fix coverity reports consider requesting
   access to the projects coverity project as outlined in [static-analysis][].
 
-[Code of Conduct]: https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md
+[Code of Conduct]: https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md
 [Labels]: doc/contributing/collaborator-guide.md#labels
 [Landing pull requests]: doc/contributing/collaborator-guide.md#landing-pull-requests
 [Publicizing or hiding organization membership]: https://help.github.com/articles/publicizing-or-hiding-organization-membership/
 [`author-ready`]: doc/contributing/collaborator-guide.md#author-ready-pull-requests
 [`core-validate-commit`]: https://github.com/nodejs/core-validate-commit
-[`git-node`]: https://github.com/nodejs/node-core-utils/blob/HEAD/docs/git-node.md
+[`git-node`]: https://github.com/nodejs/node-core-utils/blob/main/docs/git-node.md
 [`node-core-utils`]: https://github.com/nodejs/node-core-utils
 [set up the credentials]: https://github.com/nodejs/node-core-utils#setting-up-github-credentials
 [static-analysis]: doc/contributing/static-analysis.md


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Replace the word "HEAD" with the word main or master in some of the links on the docs
 because with "HEAD" it's return 404 page