### PR TITLE
test: use consistent timeouts

### DIFF
--- a/test/parallel/test-http-server-headers-timeout-delayed-headers.js
+++ b/test/parallel/test-http-server-headers-timeout-delayed-headers.js
@@ -10,12 +10,12 @@ const { connect } = require('net');
 // pauses before start sending the request.
 
 let sendDelayedRequestHeaders;
-const headersTimeout = common.platformTimeout(1000);
+const headersTimeout = common.platformTimeout(2000);
 const server = createServer({
   headersTimeout,
   requestTimeout: 0,
   keepAliveTimeout: 0,
-  connectionsCheckingInterval: common.platformTimeout(250),
+  connectionsCheckingInterval: headersTimeout / 4,
 }, common.mustNotCall());
 server.on('connection', common.mustCall(() => {
   assert.strictEqual(typeof sendDelayedRequestHeaders, 'function');

--- a/test/parallel/test-http-server-headers-timeout-interrupted-headers.js
+++ b/test/parallel/test-http-server-headers-timeout-interrupted-headers.js
@@ -10,12 +10,12 @@ const { connect } = require('net');
 // pauses sending in the middle of a header.
 
 let sendDelayedRequestHeaders;
-const headersTimeout = common.platformTimeout(1000);
+const headersTimeout = common.platformTimeout(2000);
 const server = createServer({
   headersTimeout,
   requestTimeout: 0,
   keepAliveTimeout: 0,
-  connectionsCheckingInterval: common.platformTimeout(250),
+  connectionsCheckingInterval: headersTimeout / 4,
 }, common.mustNotCall());
 server.on('connection', common.mustCall(() => {
   assert.strictEqual(typeof sendDelayedRequestHeaders, 'function');

--- a/test/parallel/test-http-server-headers-timeout-pipelining.js
+++ b/test/parallel/test-http-server-headers-timeout-pipelining.js
@@ -9,12 +9,12 @@ const { connect } = require('net');
 // after server.requestTimeout if the client
 // does not complete a request when using pipelining.
 
-const headersTimeout = common.platformTimeout(1000);
+const headersTimeout = common.platformTimeout(2000);
 const server = createServer({
   headersTimeout,
   requestTimeout: 0,
   keepAliveTimeout: 0,
-  connectionsCheckingInterval: common.platformTimeout(250),
+  connectionsCheckingInterval: headersTimeout / 4,
 }, common.mustCallAtLeast((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end();

--- a/test/parallel/test-http-server-request-timeout-delayed-body.js
+++ b/test/parallel/test-http-server-request-timeout-delayed-body.js
@@ -10,12 +10,12 @@ const { connect } = require('net');
 // pauses before start sending the body.
 
 let sendDelayedRequestBody;
-const requestTimeout = common.platformTimeout(1000);
+const requestTimeout = common.platformTimeout(2000);
 const server = createServer({
   headersTimeout: 0,
   requestTimeout,
   keepAliveTimeout: 0,
-  connectionsCheckingInterval: common.platformTimeout(250),
+  connectionsCheckingInterval: requestTimeout / 4,
 }, common.mustCall((req, res) => {
   let body = '';
   req.setEncoding('utf-8');

--- a/test/parallel/test-http-server-request-timeout-delayed-headers.js
+++ b/test/parallel/test-http-server-request-timeout-delayed-headers.js
@@ -10,12 +10,12 @@ const { connect } = require('net');
 // pauses before start sending the request.
 
 let sendDelayedRequestHeaders;
-const requestTimeout = common.platformTimeout(1000);
+const requestTimeout = common.platformTimeout(2000);
 const server = createServer({
   headersTimeout: 0,
   requestTimeout,
   keepAliveTimeout: 0,
-  connectionsCheckingInterval: common.platformTimeout(250),
+  connectionsCheckingInterval: requestTimeout / 4,
 }, common.mustNotCall());
 server.on('connection', common.mustCall(() => {
   assert.strictEqual(typeof sendDelayedRequestHeaders, 'function');

--- a/test/parallel/test-http-server-request-timeout-interrupted-body.js
+++ b/test/parallel/test-http-server-request-timeout-interrupted-body.js
@@ -10,12 +10,12 @@ const { connect } = require('net');
 // pauses sending in the middle of the body.
 
 let sendDelayedRequestBody;
-const requestTimeout = common.platformTimeout(1000);
+const requestTimeout = common.platformTimeout(2000);
 const server = createServer({
   headersTimeout: 0,
   requestTimeout,
   keepAliveTimeout: 0,
-  connectionsCheckingInterval: common.platformTimeout(250),
+  connectionsCheckingInterval: requestTimeout / 4,
 }, common.mustCall((req, res) => {
   let body = '';
   req.setEncoding('utf-8');

--- a/test/parallel/test-http-server-request-timeout-interrupted-headers.js
+++ b/test/parallel/test-http-server-request-timeout-interrupted-headers.js
@@ -10,12 +10,12 @@ const { connect } = require('net');
 // pauses sending in the middle of a header.
 
 let sendDelayedRequestHeaders;
-const requestTimeout = common.platformTimeout(1000);
+const requestTimeout = common.platformTimeout(2000);
 const server = createServer({
   headersTimeout: 0,
   requestTimeout,
   keepAliveTimeout: 0,
-  connectionsCheckingInterval: common.platformTimeout(250),
+  connectionsCheckingInterval: requestTimeout / 4,
 }, common.mustNotCall());
 server.on('connection', common.mustCall(() => {
   assert.strictEqual(typeof sendDelayedRequestHeaders, 'function');

--- a/test/parallel/test-http-server-request-timeout-keepalive.js
+++ b/test/parallel/test-http-server-request-timeout-keepalive.js
@@ -67,7 +67,7 @@ server.listen(0, common.mustCall(() => {
         performRequestWithDelay(
           client,
           requestTimeout / 5,
-          requestTimeout,
+          requestTimeout * 2,
           true
         );
       }, defer).unref();
@@ -88,7 +88,7 @@ server.listen(0, common.mustCall(() => {
   client.on('error', errOrEnd);
   client.on('end', errOrEnd);
 
-  // Perform a second request expected to finish before requestTimeout
+  // Perform a first request which is completed immediately
   performRequestWithDelay(
     client,
     requestTimeout / 5,

--- a/test/parallel/test-http-server-request-timeout-pipelining.js
+++ b/test/parallel/test-http-server-request-timeout-pipelining.js
@@ -9,12 +9,12 @@ const { connect } = require('net');
 // after server.requestTimeout if the client
 // does not complete a request when using pipelining.
 
-const requestTimeout = common.platformTimeout(1000);
+const requestTimeout = common.platformTimeout(2000);
 const server = createServer({
   headersTimeout: 0,
   requestTimeout,
   keepAliveTimeout: 0,
-  connectionsCheckingInterval: common.platformTimeout(250),
+  connectionsCheckingInterval: requestTimeout / 4
 }, common.mustCallAtLeast((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end();
@@ -66,5 +66,5 @@ server.listen(0, common.mustCall(() => {
   // Complete the request
   setTimeout(() => {
     client.write('close\r\n\r\n');
-  }, requestTimeout * 1.5).unref();
+  }, requestTimeout * 2).unref();
 }));

--- a/test/parallel/test-http-server-request-timeout-upgrade.js
+++ b/test/parallel/test-http-server-request-timeout-upgrade.js
@@ -8,12 +8,12 @@ const { connect } = require('net');
 // This test validates that the requestTimeoout
 // is disabled after the connection is upgraded.
 let sendDelayedRequestHeaders;
-const requestTimeout = common.platformTimeout(1000);
+const requestTimeout = common.platformTimeout(2000);
 const server = createServer({
   headersTimeout: 0,
   requestTimeout,
   keepAliveTimeout: 0,
-  connectionsCheckingInterval: common.platformTimeout(250),
+  connectionsCheckingInterval: requestTimeout / 4
 }, common.mustNotCall());
 server.on('connection', common.mustCall(() => {
   assert.strictEqual(typeof sendDelayedRequestHeaders, 'function');
@@ -58,6 +58,6 @@ server.listen(0, common.mustCall(() => {
     setTimeout(() => {
       client.write('12345678901234567890');
       client.end();
-    }, common.platformTimeout(2000)).unref();
+    }, requestTimeout * 2).unref();
   });
 }));

--- a/test/parallel/test-http-server-request-timeouts-mixed.js
+++ b/test/parallel/test-http-server-request-timeouts-mixed.js
@@ -23,9 +23,7 @@ const server = createServer({
   keepAliveTimeout: 0,
   connectionsCheckingInterval
 }, common.mustCall((req, res) => {
-  req.on('data', () => {
-    // No-op
-  });
+  req.resume();
 
   req.on('end', () => {
     res.writeHead(200, { 'Content-Type': 'text/plain' });

--- a/test/parallel/test-http-server-request-timeouts-mixed.js
+++ b/test/parallel/test-http-server-request-timeouts-mixed.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { createServer } = require('http');
+const { connect } = require('net');
+
+// This test validates that request are correct checked for both requests and headers timeout in various situations.
+
+const requestBodyPart1 = 'POST / HTTP/1.1\r\nContent-Length: 20\r\n';
+const requestBodyPart2 = 'Connection: close\r\n\r\n1234567890';
+const requestBodyPart3 = '1234567890';
+
+const responseOk = 'HTTP/1.1 200 OK\r\n';
+const responseTimeout = 'HTTP/1.1 408 Request Timeout\r\n';
+
+const headersTimeout = common.platformTimeout(2000);
+const connectionsCheckingInterval = headersTimeout / 4;
+
+const server = createServer({
+  headersTimeout,
+  requestTimeout: headersTimeout * 2,
+  keepAliveTimeout: 0,
+  connectionsCheckingInterval
+}, common.mustCall((req, res) => {
+  req.on('data', () => {
+    // No-op
+  });
+
+  req.on('end', () => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end();
+  });
+}, 4));
+
+assert.strictEqual(server.headersTimeout, headersTimeout);
+assert.strictEqual(server.requestTimeout, headersTimeout * 2);
+
+let i = 0;
+function createClient(server) {
+  const request = {
+    index: i++,
+    client: connect(server.address().port),
+    response: '',
+    completed: false
+  };
+
+  request.client.on('data', common.mustCallAtLeast((chunk) => {
+    request.response += chunk.toString('utf-8');
+  }));
+
+  request.client.on('end', common.mustCall(() => {
+    request.completed = true;
+  }));
+
+  request.client.on('error', common.mustNotCall());
+
+  request.client.resume();
+
+  return request;
+}
+
+server.listen(0, common.mustCall(() => {
+  const request1 = createClient(server);
+  let request2;
+  let request3;
+  let request4;
+  let request5;
+
+  // Send the first request and stop before the body
+  request1.client.write(requestBodyPart1);
+
+  // After a little while send two new requests
+  setTimeout(() => {
+    request2 = createClient(server);
+    request3 = createClient(server);
+
+    // Send the second request, stop in the middle of the headers
+    request2.client.write(requestBodyPart1);
+    // Send the second request, stop in the middle of the headers
+    request3.client.write(requestBodyPart1);
+  }, headersTimeout * 0.2);
+
+  // After another little while send the last two new requests
+  setTimeout(() => {
+    request4 = createClient(server);
+    request5 = createClient(server);
+
+    // Send the fourth request, stop in the middle of the headers
+    request4.client.write(requestBodyPart1);
+    // Send the fifth request, stop in the middle of the headers
+    request5.client.write(requestBodyPart1);
+  }, headersTimeout * 0.6);
+
+  setTimeout(() => {
+    // Finish the first request
+    request1.client.write(requestBodyPart2 + requestBodyPart3);
+
+    // Complete headers for all requests but second
+    request3.client.write(requestBodyPart2);
+    request4.client.write(requestBodyPart2);
+    request5.client.write(requestBodyPart2);
+  }, headersTimeout * 0.8);
+
+  setTimeout(() => {
+    // After the first timeout, the first request should have been completed and second timedout
+    assert(request1.completed);
+    assert(request2.completed);
+    assert(!request3.completed);
+    assert(!request4.completed);
+    assert(!request5.completed);
+
+    assert(request1.response.startsWith(responseOk));
+    assert(request2.response.startsWith(responseTimeout)); // It is expired due to headersTimeout
+  }, headersTimeout * 1.2 + connectionsCheckingInterval);
+
+  setTimeout(() => {
+    // Complete the body for the fourth request
+    request4.client.write(requestBodyPart3);
+  }, headersTimeout * 1.5);
+
+  setTimeout(() => {
+    // All request should be completed now, either with 200 or 408
+    assert(request3.completed);
+    assert(request4.completed);
+    assert(request5.completed);
+
+    assert(request3.response.startsWith(responseTimeout)); // It is expired due to requestTimeout
+    assert(request4.response.startsWith(responseOk));
+    assert(request5.response.startsWith(responseTimeout)); // It is expired due to requestTimeout
+    server.close();
+  }, headersTimeout * 3 + connectionsCheckingInterval);
+}));


### PR DESCRIPTION
This PR enforces consistent timeouts for HTTP tests.