### PR TITLE
fs: add directory autodetection to `fsPromises.symlink()`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1463,18 +1463,27 @@ changes:
 
 <!-- YAML
 added: v10.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/42894
+    description: If the `type` argument is `null` or omitted, Node.js will
+                 autodetect `target` type and automatically
+                 select `dir` or `file`.
+
 -->
 
 * `target` {string|Buffer|URL}
 * `path` {string|Buffer|URL}
-* `type` {string} **Default:** `'file'`
+* `type` {string|null} **Default:** `null`
 * Returns: {Promise} Fulfills with `undefined` upon success.
 
 Creates a symbolic link.
 
 The `type` argument is only used on Windows platforms and can be one of `'dir'`,
-`'file'`, or `'junction'`. Windows junction points require the destination path
-to be absolute. When using `'junction'`, the `target` argument will
+`'file'`, or `'junction'`. If the `type` argument is not a string, Node.js will
+autodetect `target` type and use `'file'` or `'dir'`. If the `target` does not
+exist, `'file'` will be used. Windows junction points require the destination
+path to be absolute. When using `'junction'`, the `target` argument will
 automatically be normalized to absolute path.
 
 ### `fsPromises.truncate(path[, len])`

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -714,8 +714,13 @@ async function readlink(path, options) {
 async function symlink(target, path, type_) {
   let type = (typeof type_ === 'string' ? type_ : null);
   if (isWindows && type === null) {
-    const absoluteTarget = pathModule.resolve(`${path}`, '..', `${target}`);
-    type = (await stat(absoluteTarget))?.isDirectory() ? 'dir' : 'file';
+    try {
+      const absoluteTarget = pathModule.resolve(`${path}`, '..', `${target}`);
+      type = (await stat(absoluteTarget)).isDirectory() ? 'dir' : 'file';
+    } catch {
+      // Default to 'file' if path is invalid or file does not exist
+      type = 'file';
+    }
   }
   target = getValidatedPath(target, 'target');
   path = getValidatedPath(path);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -116,6 +116,8 @@ const {
 const getDirectoryEntriesPromise = promisify(getDirents);
 const validateRmOptionsPromise = promisify(validateRmOptions);
 
+const isWindows = process.platform === 'win32';
+
 let cpPromises;
 function lazyLoadCpPromises() {
   return cpPromises ??= require('internal/fs/cp/cp').cpFn;
@@ -710,7 +712,11 @@ async function readlink(path, options) {
 }
 
 async function symlink(target, path, type_) {
-  const type = (typeof type_ === 'string' ? type_ : null);
+  let type = (typeof type_ === 'string' ? type_ : null);
+  if (isWindows && type === null) {
+    const absoluteTarget = pathModule.resolve(`${path}`, '..', `${target}`);
+    type = (await stat(absoluteTarget))?.isDirectory() ? 'dir' : 'file';
+  }
   target = getValidatedPath(target, 'target');
   path = getValidatedPath(path);
   return binding.symlink(preprocessSymlinkDestination(target, type, path),


### PR DESCRIPTION
Expands: https://github.com/nodejs/node/pull/23724

[fs.symlink(target, path[, type], callback)](https://nodejs.org/api/fs.html#fssymlinktarget-path-type-callback) and [fs.symlinkSync(target, path[, type])](https://nodejs.org/api/fs.html#fssymlinksynctarget-path-type) are able to autodetect directories on win32, if `typeof type !== 'string'`.
This PR ports that ability to [fsPromises.symlink(target, path[, type])](https://nodejs.org/api/fs.html#fspromisessymlinktarget-path-type).

"Directory as file" (explicit `'file'` or current `null`/`undefined`) symlink on windows works like that:
```mjs
import { mkdir, writeFile, symlink, stat, readdir, readFile } from 'fs/promises';
await mkdir('./src'); await writeFile('./src/testfile', '');
await symlink('./src', './dst_dir', 'dir');
await symlink('./src', './dst_file');

stat('./dst_dir').then(console.log); // Stats { ... }
readdir('./dst_dir').then(console.log); // [ 'testfile' ]
readFile('./dst_dir').then(console.log, console.error); // EISDIR

stat('./dst_file').then(console.log, console.error); // EPERM
readdir('./dst_file').then(console.log, console.error); // EPERM
readFile('./dst_file').then(console.log, console.error); // EPERM
```
```cmd
>dir
01.05.2022  00:26    <DIR>          .
01.05.2022  00:26    <DIR>          ..
01.05.2022  00:26    <SYMLINKD>     dst_dir [.\src]
01.05.2022  00:26    <SYMLINK>      dst_file [.\src]
01.05.2022  00:26    <DIR>          src
```
Can't `cd` into `dst_file`, can't `dir` its content, can't `type "dst_file\testfile"`.