### PR TITLE
http2: compat support for array headers

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3985,7 +3985,7 @@ changes:
 
 * `statusCode` {number}
 * `statusMessage` {string}
-* `headers` {Object}
+* `headers` {Object|Array}
 * Returns: {http2.Http2ServerResponse}
 
 Sends a response header to the request. The status code is a 3-digit HTTP

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -682,9 +682,19 @@ class Http2ServerResponse extends Stream {
 
     let i;
     if (ArrayIsArray(headers)) {
-      for (i = 0; i < headers.length; i++) {
-        const header = headers[i];
-        this[kSetHeader](header[0], header[1]);
+      if (headers.length && ArrayIsArray(headers[0])) {
+        for (i = 0; i < headers.length; i++) {
+          const header = headers[i];
+          this[kSetHeader](header[0], header[1]);
+        }
+      } else {
+        if (headers.length % 2 !== 0) {
+          throw new ERR_INVALID_ARG_VALUE('headers', headers);
+        }
+
+        for (i = 0; i < headers.length; i += 2) {
+          this[kSetHeader](headers[i], headers[i + 1]);
+        }
       }
     } else if (typeof headers === 'object') {
       const keys = ObjectKeys(headers);

--- a/test/parallel/test-http2-compat-serverresponse-writehead-array.js
+++ b/test/parallel/test-http2-compat-serverresponse-writehead-array.js
@@ -4,40 +4,92 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
-const h2 = require('http2');
+const http2 = require('http2');
 
-// Http2ServerResponse.writeHead should support nested arrays
+// Http2ServerResponse.writeHead should support arrays and nested arrays
 
-const server = h2.createServer();
-server.listen(0, common.mustCall(() => {
-  const port = server.address().port;
-  server.once('request', common.mustCall((request, response) => {
-    const returnVal = response.writeHead(200, [
-      ['foo', 'bar'],
-      ['ABC', 123],
-    ]);
-    assert.strictEqual(returnVal, response);
-    response.end(common.mustCall(() => { server.close(); }));
-  }));
+{
+  const server = http2.createServer();
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
 
-  const url = `http://localhost:${port}`;
-  const client = h2.connect(url, common.mustCall(() => {
-    const headers = {
-      ':path': '/',
-      ':method': 'GET',
-      ':scheme': 'http',
-      ':authority': `localhost:${port}`
-    };
-    const request = client.request(headers);
-    request.on('response', common.mustCall((headers) => {
-      assert.strictEqual(headers.foo, 'bar');
-      assert.strictEqual(headers.abc, '123');
-      assert.strictEqual(headers[':status'], 200);
-    }, 1));
-    request.on('end', common.mustCall(() => {
-      client.close();
+    server.once('request', common.mustCall((request, response) => {
+      const returnVal = response.writeHead(200, [
+        ['foo', 'bar'],
+        ['ABC', 123],
+      ]);
+      assert.strictEqual(returnVal, response);
+      response.end(common.mustCall(() => { server.close(); }));
     }));
-    request.end();
-    request.resume();
+
+    const client = http2.connect(`http://localhost:${port}`, common.mustCall(() => {
+      const request = client.request();
+
+      request.on('response', common.mustCall((headers) => {
+        assert.strictEqual(headers.foo, 'bar');
+        assert.strictEqual(headers.abc, '123');
+        assert.strictEqual(headers[':status'], 200);
+      }, 1));
+      request.on('end', common.mustCall(() => {
+        client.close();
+      }));
+      request.end();
+      request.resume();
+    }));
   }));
-}));
+}
+
+{
+  const server = http2.createServer();
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+
+    server.once('request', common.mustCall((request, response) => {
+      const returnVal = response.writeHead(200, ['foo', 'bar', 'ABC', 123]);
+      assert.strictEqual(returnVal, response);
+      response.end(common.mustCall(() => { server.close(); }));
+    }));
+
+    const client = http2.connect(`http://localhost:${port}`, common.mustCall(() => {
+      const request = client.request();
+
+      request.on('response', common.mustCall((headers) => {
+        assert.strictEqual(headers.foo, 'bar');
+        assert.strictEqual(headers.abc, '123');
+        assert.strictEqual(headers[':status'], 200);
+      }, 1));
+      request.on('end', common.mustCall(() => {
+        client.close();
+      }));
+      request.end();
+      request.resume();
+    }));
+  }));
+}
+
+{
+  const server = http2.createServer();
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+
+    server.once('request', common.mustCall((request, response) => {
+      try {
+        response.writeHead(200, ['foo', 'bar', 'ABC', 123, 'extra']);
+      } catch (err) {
+        assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
+      }
+
+      response.end(common.mustCall(() => { server.close(); }));
+    }));
+
+    const client = http2.connect(`http://localhost:${port}`, common.mustCall(() => {
+      const request = client.request();
+
+      request.on('end', common.mustCall(() => {
+        client.close();
+      }));
+      request.end();
+      request.resume();
+    }));
+  }));
+}


### PR DESCRIPTION
fix #42898 
http2 `response.writeHead` supports array headers, compatible with http1.