### PR TITLE
bootstrap: fix wasm_web_api external reference registration

### DIFF
--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -90,6 +90,7 @@ class ExternalReferenceRegistry {
   V(uv)                                                                        \
   V(v8)                                                                        \
   V(zlib)                                                                      \
+  V(wasm_web_api)                                                              \
   V(worker)
 
 #if NODE_HAVE_I18N_SUPPORT

--- a/src/node_wasm_web_api.cc
+++ b/src/node_wasm_web_api.cc
@@ -41,6 +41,7 @@ Local<Function> WasmStreamingObject::Initialize(Environment* env) {
 
 void WasmStreamingObject::RegisterExternalReferences(
     ExternalReferenceRegistry* registry) {
+  registry->Register(New);
   registry->Register(Push);
   registry->Register(Finish);
   registry->Register(Abort);
@@ -198,6 +199,8 @@ void Initialize(Local<Object> target,
 
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(SetImplementation);
+  registry->Register(StartStreamingCompilation);
+  WasmStreamingObject::RegisterExternalReferences(registry);
 }
 
 }  // namespace wasm_web_api


### PR DESCRIPTION
The external references were not actually registered.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
