### PR TITLE
test: improve readline/emitKeypressEvents.js coverage

### DIFF
--- a/test/parallel/test-readline-emit-keypress-events.js
+++ b/test/parallel/test-readline-emit-keypress-events.js
@@ -61,6 +61,12 @@ const expectedKeys = [
   stream.removeListener('keypress', keypressListener);
   stream.write('foo');
 
+  assert.deepStrictEqual(sequence, []);
+  assert.deepStrictEqual(keys, []);
+
+  stream.on('keypress', keypressListener);
+  stream.write('foo');
+
   assert.deepStrictEqual(sequence, expectedSequence);
   assert.deepStrictEqual(keys, expectedKeys);
 }

--- a/test/parallel/test-readline-emit-keypress-events.js
+++ b/test/parallel/test-readline-emit-keypress-events.js
@@ -7,22 +7,60 @@ require('../common');
 const assert = require('assert');
 const readline = require('readline');
 const PassThrough = require('stream').PassThrough;
-const stream = new PassThrough();
-const sequence = [];
-const keys = [];
 
-readline.emitKeypressEvents(stream);
-
-stream.on('keypress', (s, k) => {
-  sequence.push(s);
-  keys.push(k);
-});
-
-stream.write('foo');
-
-assert.deepStrictEqual(sequence, ['f', 'o', 'o']);
-assert.deepStrictEqual(keys, [
+const expectedSequence = ['f', 'o', 'o'];
+const expectedKeys = [
   { sequence: 'f', name: 'f', ctrl: false, meta: false, shift: false },
   { sequence: 'o', name: 'o', ctrl: false, meta: false, shift: false },
   { sequence: 'o', name: 'o', ctrl: false, meta: false, shift: false },
-]);
+];
+
+{
+  const stream = new PassThrough();
+  const sequence = [];
+  const keys = [];
+
+  readline.emitKeypressEvents(stream);
+  stream.on('keypress', (s, k) => {
+    sequence.push(s);
+    keys.push(k);
+  });
+  stream.write('foo');
+
+  assert.deepStrictEqual(sequence, expectedSequence);
+  assert.deepStrictEqual(keys, expectedKeys);
+}
+
+{
+  const stream = new PassThrough();
+  const sequence = [];
+  const keys = [];
+
+  stream.on('keypress', (s, k) => {
+    sequence.push(s);
+    keys.push(k);
+  });
+  readline.emitKeypressEvents(stream);
+  stream.write('foo');
+
+  assert.deepStrictEqual(sequence, expectedSequence);
+  assert.deepStrictEqual(keys, expectedKeys);
+}
+
+{
+  const stream = new PassThrough();
+  const sequence = [];
+  const keys = [];
+  const keypressListener = (s, k) => {
+    sequence.push(s);
+    keys.push(k);
+  };
+
+  stream.on('keypress', keypressListener);
+  readline.emitKeypressEvents(stream);
+  stream.removeListener('keypress', keypressListener);
+  stream.write('foo');
+
+  assert.deepStrictEqual(sequence, expectedSequence);
+  assert.deepStrictEqual(keys, expectedKeys);
+}


### PR DESCRIPTION
The previous test case did not cover the case where the stream add `keypress` listener before `emitKeypressEvents` and listens first and then removes the `keypress` listener.

Refer: https://coverage.nodejs.org/coverage-68fb0bf553e2af3e/lib/internal/readline/emitKeypressEvents.js.html