### PR TITLE
assert: fix CallTracker calls wraps the function causes the original …

### DIFF
--- a/lib/internal/assert/calltracker.js
+++ b/lib/internal/assert/calltracker.js
@@ -4,7 +4,7 @@ const {
   ArrayPrototypePush,
   Error,
   FunctionPrototype,
-  ObjectDefineProperty,
+  Proxy,
   ReflectApply,
   SafeSet,
 } = primordials;
@@ -47,26 +47,22 @@ class CallTracker {
     const callChecks = this.#callChecks;
     callChecks.add(context);
 
-    function callsFn() {
-      context.actual++;
-      if (context.actual === context.exact) {
-        // Once function has reached its call count remove it from
-        // callChecks set to prevent memory leaks.
-        callChecks.delete(context);
+    return new Proxy(fn, {
+      apply() {
+        context.actual++;
+        if (context.actual === context.exact) {
+          // Once function has reached its call count remove it from
+          // callChecks set to prevent memory leaks.
+          callChecks.delete(context);
+        }
+        // If function has been called more than expected times, add back into
+        // callchecks.
+        if (context.actual === context.exact + 1) {
+          callChecks.add(context);
+        }
+        return ReflectApply(...arguments);
       }
-      // If function has been called more than expected times, add back into
-      // callchecks.
-      if (context.actual === context.exact + 1) {
-        callChecks.add(context);
-      }
-      return ReflectApply(fn, this, arguments);
-    }
-
-    ObjectDefineProperty(callsFn, 'length', {
-      value: fn.length
     });
-
-    return callsFn;
   }
 
   report() {

--- a/lib/internal/assert/calltracker.js
+++ b/lib/internal/assert/calltracker.js
@@ -49,7 +49,7 @@ class CallTracker {
 
     return new Proxy(fn, {
       __proto__: null,
-      apply() {
+      apply(fn, thisArg, argList) {
         context.actual++;
         if (context.actual === context.exact) {
           // Once function has reached its call count remove it from
@@ -61,7 +61,7 @@ class CallTracker {
         if (context.actual === context.exact + 1) {
           callChecks.add(context);
         }
-        return ReflectApply(...arguments);
+        return ReflectApply(fn, thisArg, argList);
       },
     });
   }

--- a/lib/internal/assert/calltracker.js
+++ b/lib/internal/assert/calltracker.js
@@ -4,6 +4,7 @@ const {
   ArrayPrototypePush,
   Error,
   FunctionPrototype,
+  ObjectDefineProperty,
   ReflectApply,
   SafeSet,
 } = primordials;
@@ -46,7 +47,7 @@ class CallTracker {
     const callChecks = this.#callChecks;
     callChecks.add(context);
 
-    return function() {
+    function callsFn() {
       context.actual++;
       if (context.actual === context.exact) {
         // Once function has reached its call count remove it from
@@ -59,7 +60,13 @@ class CallTracker {
         callChecks.add(context);
       }
       return ReflectApply(fn, this, arguments);
-    };
+    }
+
+    ObjectDefineProperty(callsFn, 'length', {
+      value: fn.length
+    });
+
+    return callsFn;
   }
 
   report() {

--- a/lib/internal/assert/calltracker.js
+++ b/lib/internal/assert/calltracker.js
@@ -48,6 +48,7 @@ class CallTracker {
     callChecks.add(context);
 
     return new Proxy(fn, {
+      __proto__: null,
       apply() {
         context.actual++;
         if (context.actual === context.exact) {
@@ -61,7 +62,7 @@ class CallTracker {
           callChecks.add(context);
         }
         return ReflectApply(...arguments);
-      }
+      },
     });
   }
 

--- a/test/parallel/test-assert-calltracker-calls.js
+++ b/test/parallel/test-assert-calltracker-calls.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 // This test ensures that assert.CallTracker.calls() works as intended.
@@ -83,12 +83,28 @@ assert.throws(
   function func() {}
   const tracker = new assert.CallTracker();
   const callsfunc = tracker.calls(func);
-  assert.strictEqual(func.length, callsfunc.length);
+  assert.strictEqual(callsfunc.length, 0);
 }
 
 {
   function func(a, b, c = 2) {}
   const tracker = new assert.CallTracker();
   const callsfunc = tracker.calls(func);
-  assert.strictEqual(func.length, callsfunc.length);
+  assert.strictEqual(callsfunc.length, 2);
+}
+
+{
+  function func(a, b, c = 2) {}
+  delete func.length;
+  const tracker = new assert.CallTracker();
+  const callsfunc = tracker.calls(func);
+  assert.strictEqual(Object.hasOwn(callsfunc, 'length'), false);
+}
+
+{
+  function func(a, b, c = 2) {}
+  Object.defineProperty(func, 'length', { get: common.mustNotCall() });
+  const tracker = new assert.CallTracker();
+  const callsfunc = tracker.calls(func);
+  assert.strictEqual(Object.hasOwn(callsfunc, 'length'), true);
 }

--- a/test/parallel/test-assert-calltracker-calls.js
+++ b/test/parallel/test-assert-calltracker-calls.js
@@ -102,15 +102,27 @@ assert.throws(
 }
 
 {
+  const ArrayIteratorPrototype = Reflect.getPrototypeOf(
+    Array.prototype.values()
+  );
+  const { next } = ArrayIteratorPrototype;
+  ArrayIteratorPrototype.next = common.mustNotCall(
+    '%ArrayIteratorPrototype%.next'
+  );
   Object.prototype.get = common.mustNotCall('%Object.prototype%.get');
+
   const customPropertyValue = Symbol();
-  function func(a, b, c = 2) {}
+  function func(a, b, c = 2) {
+    return a + b + c;
+  }
   func.customProperty = customPropertyValue;
   Object.defineProperty(func, 'length', { get: common.mustNotCall() });
   const tracker = new assert.CallTracker();
   const callsfunc = tracker.calls(func);
   assert.strictEqual(Object.hasOwn(callsfunc, 'length'), true);
   assert.strictEqual(callsfunc.customProperty, customPropertyValue);
+  assert.strictEqual(callsfunc(1, 2, 3), 6);
 
+  ArrayIteratorPrototype.next = next;
   delete Object.prototype.get;
 }

--- a/test/parallel/test-assert-calltracker-calls.js
+++ b/test/parallel/test-assert-calltracker-calls.js
@@ -102,9 +102,15 @@ assert.throws(
 }
 
 {
+  Object.prototype.get = common.mustNotCall('%Object.prototype%.get');
+  const customPropertyValue = Symbol();
   function func(a, b, c = 2) {}
+  func.customProperty = customPropertyValue;
   Object.defineProperty(func, 'length', { get: common.mustNotCall() });
   const tracker = new assert.CallTracker();
   const callsfunc = tracker.calls(func);
   assert.strictEqual(Object.hasOwn(callsfunc, 'length'), true);
+  assert.strictEqual(callsfunc.customProperty, customPropertyValue);
+
+  delete Object.prototype.get;
 }

--- a/test/parallel/test-assert-calltracker-calls.js
+++ b/test/parallel/test-assert-calltracker-calls.js
@@ -78,3 +78,17 @@ assert.throws(
   callsNoop();
   tracker.verify();
 }
+
+{
+  function func() {}
+  const tracker = new assert.CallTracker();
+  const callsfunc = tracker.calls(func);
+  assert.strictEqual(func.length, callsfunc.length);
+}
+
+{
+  function func(a, b, c = 2) {}
+  const tracker = new assert.CallTracker();
+  const callsfunc = tracker.calls(func);
+  assert.strictEqual(func.length, callsfunc.length);
+}


### PR DESCRIPTION
CallTracker calls wraps the function causes the original length to be lost. But many scenarios depend on the length of the function.
```js
function func(a, b, c = 2) {}
const tracker = new assert.CallTracker();
const callsfunc = tracker.calls(func);
```
`func.length` is `2`, but `callsfunc.length` is `0`.

Fixes: https://github.com/nodejs/node/issues/40484