### PR TITLE
Add toInt method to Buffer

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -3820,6 +3820,40 @@ for (const value of buf) {
 //   114
 ```
 
+### `buf.toInt([radix])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `radix` {number} An integer between `2` and `36` that represents the radix
+  (the base in mathematical numeral systems) of the `string`.
+
+Converts a valid `buf` containing items in the range of 0x48 (1) to 0x57 (9)
+inclusive to a `number`.
+
+```mjs
+import { Buffer } from 'node:buffer';
+
+const buf = Buffer.from([48, 49, 50]);
+
+const int = buf.toInt(10);
+
+console.log(int);
+// Prints: 123
+```
+
+```cjs
+const { Buffer } = require('node:buffer');
+
+const buf = Buffer.from([48, 49, 50]);
+
+const int = buf.toInt(10);
+
+console.log(int);
+// Prints: 123
+```
+
 ### `buf.write(string[, offset[, length]][, encoding])`
 
 <!-- YAML

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1049,6 +1049,24 @@ function _fill(buf, value, offset, end, encoding) {
   return buf;
 }
 
+Buffer.prototype.toInt = function toInt(radix = 10) {
+  let data = 0;
+
+  for (let i = this.length - 1; i >= 0; i--) {
+    const value = this[i];
+
+    if (value < 48) {
+      throw new ERR_OUT_OF_RANGE('this[i]', '>=', 48);
+    } else if (value > 57) {
+      throw new ERR_OUT_OF_RANGE('this[i]', '<=', 57);
+    }
+
+    data += radix ** (this.length - 1 - i) * (value - 48);
+  }
+
+  return data;
+};
+
 Buffer.prototype.write = function write(string, offset, length, encoding) {
   // Buffer#write(string);
   if (offset === undefined) {

--- a/test/parallel/test-buffer-toint-rangeerror.js
+++ b/test/parallel/test-buffer-toint-rangeerror.js
@@ -1,0 +1,13 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const message = {
+  code: 'ERR_OUT_OF_RANGE',
+  name: 'RangeError',
+};
+
+assert.throws(() => Buffer.from('abc').toInt(10), message);
+assert.throws(() => Buffer.from('a050').toInt(10), message);
+assert.throws(() => Buffer.from('050a').toInt(10), message);

--- a/test/parallel/test-buffer-toint.js
+++ b/test/parallel/test-buffer-toint.js
@@ -1,0 +1,25 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+{
+  const buf = Buffer.from('123');
+  const num = buf.toInt(10);
+
+  assert.strictEqual(num, 123);
+}
+
+{
+  const buf = Buffer.from('010');
+  const num = buf.toInt();
+
+  assert.strictEqual(num, 10);
+}
+
+{
+  const buf = Buffer.from('123');
+  const num = buf.toInt(16);
+
+  assert.strictEqual(num, 0x123);
+}


### PR DESCRIPTION
This pull request adds `Buffer.prototype.toInt([radix])` to `node:buffer`. Solves https://github.com/nodejs/node/issues/42871