### PR TITLE
debugger: add string validation for watch(expr) of `node inspect`

### DIFF
--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -1024,6 +1024,7 @@ function createRepl(inspector) {
       },
 
       watch(expr) {
+        validateString(expr, 'expression');
         ArrayPrototypePush(watchedExpressions, expr);
       },
 

--- a/test/sequential/test-debugger-watch-validation.js
+++ b/test/sequential/test-debugger-watch-validation.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const startCLI = require('../common/debugger');
+
+const assert = require('assert');
+
+const cli = startCLI([fixtures.path('debugger/break.js')]);
+
+(async () => {
+  await cli.waitForInitialBreak();
+  await cli.command('watch()');
+  await cli.waitFor(/ERR_INVALID_ARG_TYPE/);
+  assert.match(cli.output, /TypeError \[ERR_INVALID_ARG_TYPE\]: The "expression" argument must be of type string\. Received undefined/);
+})()
+.finally(() => cli.quit())
+.then(common.mustCall());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

`watch(expr)` command of `node inspect` can accept non-string values, which result in inconsistent bugs.
This PR added the string validation to prevent this issue.

### Before
```console
$ node inspect -e "console.log()"
debug> watch()
debug> watch(1)
debug> watchers
  0: undefined = '<Invalid parameters>'
  1: 1 = '<Invalid parameters>'
```

### After
```console
$ node inspect -e "console.log()"
debug> watch()
node:internal/validators:119
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

Uncaught:
TypeError [ERR_INVALID_ARG_TYPE]: The "expression" argument must be of type string. Received undefined
```