### PR TITLE
fix: url parser should throw error on invalid ipv4

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -411,8 +411,11 @@ void URLHost::ParseIPv4Host(const char* input, size_t length, bool* is_ipv4) {
     const char ch = pointer < end ? pointer[0] : kEOL;
     int64_t remaining = end - pointer - 1;
     if (ch == '.' || ch == kEOL) {
-      if (++parts > static_cast<int>(arraysize(numbers)))
+      // If parts’s size is greater than 4, validation error, return failure.
+      if (++parts > static_cast<int>(arraysize(numbers))) {
+        *is_ipv4 = true;
         return;
+      }
       if (pointer == mark)
         return;
       int64_t n = ParseNumber(mark, pointer);

--- a/test/fixtures/wpt/url/resources/urltestdata.json
+++ b/test/fixtures/wpt/url/resources/urltestdata.json
@@ -5317,17 +5317,12 @@
   {
     "input": "http://256.256.256.256.256",
     "base": "http://other.com/",
-    "href": "http://256.256.256.256.256/",
-    "origin": "http://256.256.256.256.256",
-    "protocol": "http:",
-    "username": "",
-    "password": "",
-    "host": "256.256.256.256.256",
-    "hostname": "256.256.256.256.256",
-    "port": "",
-    "pathname": "/",
-    "search": "",
-    "hash": ""
+    "failure": true
+  },
+  {
+    "input": "http://256.256.256.256.256.",
+    "base": "http://other.com/",
+    "failure": true
   },
   {
     "input": "https://0x.0x.0",


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/42914