### PR TITLE
test: fix `common.mustNotCall` error message

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -29,7 +29,7 @@ const fs = require('fs');
 // Do not require 'os' until needed so that test-os-checked-function can
 // monkey patch it. If 'os' is required here, that test will fail.
 const path = require('path');
-const util = require('util');
+const { inspect } = require('util');
 const { isMainThread } = require('worker_threads');
 
 const tmpdir = require('./tmpdir');
@@ -97,7 +97,7 @@ if (process.argv.length === 2 &&
           (process.features.inspector || !flag.startsWith('--inspect'))) {
         console.log(
           'NOTE: The test started as a child_process using these flags:',
-          util.inspect(flags),
+          inspect(flags),
           'Use NODE_SKIP_FLAG_CHECK to run the test with the original flags.'
         );
         const args = [...flags, ...process.execArgv, ...process.argv.slice(1)];
@@ -149,7 +149,7 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
   process.on('exit', () => {
     // Iterate through handles to make sure nothing crashes
     for (const k in initHandles)
-      util.inspect(initHandles[k]);
+      inspect(initHandles[k]);
   });
 
   const _queueDestroyAsyncId = async_wrap.queueDestroyAsyncId;
@@ -159,7 +159,7 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
       process._rawDebug();
       throw new Error(`same id added to destroy list twice (${id})`);
     }
-    destroyListList[id] = util.inspect(new Error());
+    destroyListList[id] = inspect(new Error());
     _queueDestroyAsyncId(id);
   };
 
@@ -173,7 +173,7 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
       }
       initHandles[id] = {
         resource,
-        stack: util.inspect(new Error()).substr(6)
+        stack: inspect(new Error()).substr(6)
       };
     },
     before() { },
@@ -184,7 +184,7 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
         process._rawDebug();
         throw new Error(`destroy called for same id (${id})`);
       }
-      destroydIdsList[id] = util.inspect(new Error());
+      destroydIdsList[id] = inspect(new Error());
     },
   }).enable();
 }
@@ -424,7 +424,7 @@ function _mustCallInner(fn, criteria = 1, field) {
   const context = {
     [field]: criteria,
     actual: 0,
-    stack: util.inspect(new Error()),
+    stack: inspect(new Error()),
     name: fn.name || '<anonymous>'
   };
 
@@ -512,7 +512,7 @@ function mustNotCall(msg) {
   const callSite = getCallSite(mustNotCall);
   return function mustNotCall(...args) {
     const argsInfo = args.length > 0 ?
-      `\ncalled with arguments: ${args.map(util.inspect).join(', ')}` : '';
+      `\ncalled with arguments: ${args.map((arg) => inspect(arg)).join(', ')}` : '';
     assert.fail(
       `${msg || 'function should not have been called'} at ${callSite}` +
       argsInfo);
@@ -614,7 +614,7 @@ function expectWarning(nameOrMap, expected, code) {
       if (!catchWarning[warning.name]) {
         throw new TypeError(
           `"${warning.name}" was triggered without being expected.\n` +
-          util.inspect(warning)
+          inspect(warning)
         );
       }
       catchWarning[warning.name](warning);
@@ -635,7 +635,7 @@ function expectsError(validator, exact) {
     if (args.length !== 1) {
       // Do not use `assert.strictEqual()` to prevent `inspect` from
       // always being called.
-      assert.fail(`Expected one argument, got ${util.inspect(args)}`);
+      assert.fail(`Expected one argument, got ${inspect(args)}`);
     }
     const error = args.pop();
     const descriptor = Object.getOwnPropertyDescriptor(error, 'message');
@@ -740,9 +740,9 @@ function invalidArgTypeHelper(input) {
     if (input.constructor && input.constructor.name) {
       return ` Received an instance of ${input.constructor.name}`;
     }
-    return ` Received ${util.inspect(input, { depth: -1 })}`;
+    return ` Received ${inspect(input, { depth: -1 })}`;
   }
-  let inspected = util.inspect(input, { colors: false });
+  let inspected = inspect(input, { colors: false });
   if (inspected.length > 25)
     inspected = `${inspected.slice(0, 25)}...`;
   return ` Received type ${typeof input} (${inspected})`;

--- a/test/parallel/test-common-must-not-call.js
+++ b/test/parallel/test-common-must-not-call.js
@@ -39,3 +39,18 @@ try {
 } catch (e) {
   validate2(e);
 }
+
+assert.throws(
+  () => new Proxy({ prop: Symbol() }, { get: common.mustNotCall() }).prop,
+  { code: 'ERR_ASSERTION' }
+);
+
+{
+  const { inspect } = util;
+  delete util.inspect;
+  assert.throws(
+    () => common.mustNotCall()(null),
+    { code: 'ERR_ASSERTION' }
+  );
+  util.inspect = inspect;
+}


### PR DESCRIPTION
When using `util.inspect` as a callback, the array index (second
argument) is picked up as the `showHidden` param, and the argument
array (third argument) as the `depth` param. This fails with a seemingly
unrelated error message when the argument array contains a
`Symbol`-related property.

Before this change, the following error was output:

```
node:internal/util/inspect:1014
  if (recurseTimes > ctx.depth && ctx.depth !== null) {
                   ^

TypeError: Cannot convert a Symbol value to a string
    at Array.join (<anonymous>)
    at Array.toString (<anonymous>)
    at formatRaw (node:internal/util/inspect:1014:20)
    at formatValue (node:internal/util/inspect:817:10)
    at inspect (node:internal/util/inspect:347:10)
    at Array.map (<anonymous>)
    at Object.mustNotCall [as get] (…)
    at Array.join (<anonymous>)
    at Array.toString (<anonymous>)
    at formatRaw (node:internal/util/inspect:1014:20)

Node.js v19.0.0-pre
```

With this change:

```
node:assert:170
  throw err;
  ^

AssertionError [ERR_ASSERTION]: function should not have been called at …
called with arguments: [Function: func] { customProperty: Symbol() }, 'customProperty', [Function: func] { customProperty: Symbol() }
    at Object.mustNotCall [as get] (…/test/common/index.js:516:12)
    at Object.<anonymous> (…)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Module._load (node:internal/modules/cjs/loader:827:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47 {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: [Getter],
  expected: [Getter],
  operator: 'fail'
}

Node.js v19.0.0-pre
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
