### PR TITLE
assert: make `assert.fail` less affected by prototype tampering

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -441,6 +441,7 @@ class AssertionError extends Error {
 
     this.generatedMessage = !message;
     ObjectDefineProperty(this, 'name', {
+      __proto__: null,
       value: 'AssertionError [ERR_ASSERTION]',
       enumerable: false,
       writable: true,

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 // No args
@@ -38,3 +38,7 @@ assert.throws(() => {
   name: 'TypeError',
   message: 'custom message'
 });
+
+Object.prototype.get = common.mustNotCall()
+assert.throws(() => assert.fail(''), { code: 'ERR_ASSERTION' })
+delete Object.prototype.get;

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -39,6 +39,6 @@ assert.throws(() => {
   message: 'custom message'
 });
 
-Object.prototype.get = common.mustNotCall()
-assert.throws(() => assert.fail(''), { code: 'ERR_ASSERTION' })
+Object.prototype.get = common.mustNotCall();
+assert.throws(() => assert.fail(''), { code: 'ERR_ASSERTION' });
 delete Object.prototype.get;


### PR DESCRIPTION
Before this change:

```
node:internal/assert/assertion_error:443
    ObjectDefineProperty(this, 'name', {
    ^

TypeError: Invalid property descriptor. Cannot both specify accessors and a value or writable attribute, #<Object>
    at defineProperty (<anonymous>)
    at new AssertionError (node:internal/assert/assertion_error:443:5)
    at compareExceptionKey (node:assert:626:19)
    at expectedException (node:assert:693:9)
    at expectsError (node:assert:847:3)
    at Function.throws (node:assert:902:3)
    at Object.<anonymous> (…/test/parallel/test-assert-fail.js:43:8)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)

Node.js v19.0.0-pre
```

With this change:

```
node:assert:170
  throw err;
  ^

AssertionError [ERR_ASSERTION]
    at [eval]:1:8
    at Script.runInThisContext (node:vm:129:12)
    at Object.runInThisContext (node:vm:305:38)
    at node:internal/process/execution:76:19
    at [eval]-wrapper:6:22
    at evalScript (node:internal/process/execution:75:60)
    at node:internal/main/eval_string:27:3 {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: undefined,
  expected: undefined,
  operator: 'fail'
}

Node.js v19.0.0-pre
```
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
