### PR TITLE
crypto: clean up parameter validation in HKDF

### DIFF
--- a/lib/internal/crypto/hkdf.js
+++ b/lib/internal/crypto/hkdf.js
@@ -53,13 +53,10 @@ const {
 } = require('internal/errors');
 
 const validateParameters = hideStackFrames((hash, key, salt, info, length) => {
-  key = prepareKey(key);
-  salt = toBuf(salt);
-  info = toBuf(info);
-
   validateString(hash, 'digest');
-  validateByteSource(salt, 'salt');
-  validateByteSource(info, 'info');
+  key = prepareKey(key);
+  salt = validateByteSource(salt, 'salt');
+  info = validateByteSource(info, 'info');
 
   validateInteger(length, 'length', 0, kMaxLength);
 

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -271,7 +271,7 @@ const validateByteSource = hideStackFrames((val, name) => {
   val = toBuf(val);
 
   if (isAnyArrayBuffer(val) || isArrayBufferView(val))
-    return;
+    return val;
 
   throw new ERR_INVALID_ARG_TYPE(
     name,

--- a/test/parallel/test-crypto-hkdf.js
+++ b/test/parallel/test-crypto-hkdf.js
@@ -15,6 +15,11 @@ const {
 } = require('crypto');
 
 {
+  assert.throws(() => hkdf(), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: /The "digest" argument must be of type string/
+  });
+
   [1, {}, [], false, Infinity].forEach((i) => {
     assert.throws(() => hkdf(i, 'a'), {
       code: 'ERR_INVALID_ARG_TYPE',


### PR DESCRIPTION
- `validateByteSource` internally always calls `toBuf`, so reuse that value instead of calling `toBuf` both in `validateParameters` and in `validateByteSource`.
- Validate `digest` before `key`. This improves the error message when no arguments are specified: it now refers to the type of the first argument, not to the type of the second argument.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
