### PR TITLE
test: reduce impact of flaky HTTP server tests

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -21,6 +21,9 @@ test-fs-rmdir-recursive: PASS, FLAKY
 test-domain-error-types: PASS,FLAKY
 
 [$system==macos]
+# https://github.com/nodejs/node/issues/42741
+test-http-server-headers-timeout-keepalive: PASS,FLAKY
+test-http-server-request-timeout-keepalive: PASS,FLAKY
 
 [$arch==arm || $arch==arm64]
 # https://github.com/nodejs/node/pull/31178

--- a/test/parallel/test-http-server-headers-timeout-keepalive.js
+++ b/test/parallel/test-http-server-headers-timeout-keepalive.js
@@ -24,7 +24,7 @@ function performRequestWithDelay(client, firstDelay, secondDelay, closeAfter) {
   }, firstDelay + secondDelay).unref();
 }
 
-const headersTimeout = common.platformTimeout(2000);
+const headersTimeout = common.platformTimeout(5000);
 const server = createServer({
   headersTimeout,
   requestTimeout: 0,

--- a/test/parallel/test-http-server-request-timeout-keepalive.js
+++ b/test/parallel/test-http-server-request-timeout-keepalive.js
@@ -24,7 +24,7 @@ function performRequestWithDelay(client, firstDelay, secondDelay, closeAfter) {
   }, firstDelay + secondDelay).unref();
 }
 
-const requestTimeout = common.platformTimeout(2000);
+const requestTimeout = common.platformTimeout(5000);
 const server = createServer({
   headersTimeout: 0,
   requestTimeout,


### PR DESCRIPTION
Mark the tests as flaky on macOS and increase the timeout for other platforms (namely, FreeBSD).

Context: https://github.com/nodejs/node/issues/42741#issuecomment-1113196037

> Median success rate (refer to patch and separate tables above):
> 
> |                   | osx11  | freebsd12-x64 |
> |-------------------|--------|---------------|
> | master (2000ms)   | 91.0 % | 83.8 %        |
> | patched (5000ms)  | 71.3 % | 100 %         |

---

Refs: https://github.com/nodejs/node/issues/42741

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
