### PR TITLE
lib: make `validateObject` less affected by prototype tampering

### DIFF
--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -9,6 +9,7 @@ const {
   NumberMAX_SAFE_INTEGER,
   NumberMIN_SAFE_INTEGER,
   NumberParseInt,
+  ObjectPrototypeHasOwnProperty,
   RegExpPrototypeExec,
   String,
   StringPrototypeToUpperCase,
@@ -135,6 +136,12 @@ function validateBoolean(value, name) {
     throw new ERR_INVALID_ARG_TYPE(name, 'boolean', value);
 }
 
+function getOwnPropertyValueOrDefault(options, key, defaultValue) {
+  return options == null || !ObjectPrototypeHasOwnProperty(options, key) ?
+    defaultValue :
+    options[key];
+}
+
 /**
  * @param {unknown} value
  * @param {string} name
@@ -146,10 +153,9 @@ function validateBoolean(value, name) {
  */
 const validateObject = hideStackFrames(
   (value, name, options) => {
-    const useDefaultOptions = options == null;
-    const allowArray = useDefaultOptions ? false : options.allowArray;
-    const allowFunction = useDefaultOptions ? false : options.allowFunction;
-    const nullable = useDefaultOptions ? false : options.nullable;
+    const allowArray = getOwnPropertyValueOrDefault(options, 'allowArray', false);
+    const allowFunction = getOwnPropertyValueOrDefault(options, 'allowFunction', false);
+    const nullable = getOwnPropertyValueOrDefault(options, 'nullable', false);
     if ((!nullable && value === null) ||
         (!allowArray && ArrayIsArray(value)) ||
         (typeof value !== 'object' && (

--- a/test/parallel/test-validators.js
+++ b/test/parallel/test-validators.js
@@ -105,6 +105,10 @@ const invalidArgValueError = {
 
 {
   // validateObject tests.
+  Object.prototype.nullable = true;
+  Object.prototype.allowArray = true;
+  Object.prototype.allowFunction = true;
+
   validateObject({}, 'foo');
   validateObject({ a: 42, b: 'foo' }, 'foo');
 
@@ -119,6 +123,15 @@ const invalidArgValueError = {
   validateObject(null, 'foo', { nullable: true });
   validateObject([], 'foo', { allowArray: true });
   validateObject(() => {}, 'foo', { allowFunction: true });
+
+  // validateObject should not be affected by Object.prototype tampering.
+  assert.throws(() => validateObject(null, 'foo', { allowArray: true }), invalidArgTypeError);
+  assert.throws(() => validateObject([], 'foo', { nullable: true }), invalidArgTypeError);
+  assert.throws(() => validateObject(() => {}, 'foo', { nullable: true }), invalidArgTypeError);
+
+  delete Object.prototype.nullable;
+  delete Object.prototype.allowArray;
+  delete Object.prototype.allowFunction;
 }
 
 {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
