### PR TITLE
Greatly speed up 'advanced' ipc receiving with big messages

### DIFF
--- a/lib/internal/child_process/serialization.js
+++ b/lib/internal/child_process/serialization.js
@@ -5,7 +5,6 @@ const {
   JSONStringify,
   StringPrototypeSplit,
   ArrayPrototypePush,
-  ReflectApply,
   Symbol,
   TypedArrayPrototypeSubarray,
 } = primordials;
@@ -15,7 +14,6 @@ const v8 = require('v8');
 const { isArrayBufferView } = require('internal/util/types');
 const assert = require('internal/assert');
 const { streamBaseState, kLastWriteWasAsync } = internalBinding('stream_wrap');
-const { readUInt32BE } = require('internal/buffer');
 
 const kMessageBuffer = Symbol('kMessageBuffer');
 const kMessageBufferSize = Symbol('kMessageBufferSize');
@@ -71,7 +69,12 @@ const advanced = {
     while (messageBufferHead.length >= 4) {
       // We call `readUInt32BE` manually here, because this is faster than first converting
       // it to a buffer and using `readUInt32BE` on that.
-      const fullMessageSize = ReflectApply(readUInt32BE, messageBufferHead, [0]) + 4;
+      const fullMessageSize = (
+        messageBufferHead[0] << 24 |
+        messageBufferHead[1] << 16 |
+        messageBufferHead[2] << 8 |
+        messageBufferHead[3]
+      ) + 4;
 
       if (channel[kMessageBufferSize] < fullMessageSize) break;
 

--- a/lib/internal/child_process/serialization.js
+++ b/lib/internal/child_process/serialization.js
@@ -15,6 +15,7 @@ const assert = require('internal/assert');
 const { streamBaseState, kLastWriteWasAsync } = internalBinding('stream_wrap');
 
 const kMessageBuffer = Symbol('kMessageBuffer');
+const kMessageBufferSize = Symbol('kMessageBufferSize');
 const kJSONBuffer = Symbol('kJSONBuffer');
 const kStringDecoder = Symbol('kStringDecoder');
 
@@ -51,29 +52,51 @@ class ChildProcessDeserializer extends v8.DefaultDeserializer {
 //   (aka 'advanced')
 const advanced = {
   initMessageChannel(channel) {
-    channel[kMessageBuffer] = Buffer.alloc(0);
+    channel[kMessageBuffer] = [];
+    channel[kMessageBufferSize] = 0;
     channel.buffering = false;
   },
 
   *parseChannelMessages(channel, readData) {
     if (readData.length === 0) return;
 
-    let messageBuffer = Buffer.concat([channel[kMessageBuffer], readData]);
-    while (messageBuffer.length > 4) {
-      const size = messageBuffer.readUInt32BE();
-      if (messageBuffer.length < 4 + size) {
-        break;
-      }
+    channel[kMessageBuffer].push(readData);
+    channel[kMessageBufferSize] += readData.length;
+
+    // Index 0 should always be present because we just pushed data into it.
+    let messageBufferHead = channel[kMessageBuffer][0];
+    while (messageBufferHead.length >= 4) {
+      // We read the uint manually here, because this is faster than first converting
+      // it to a buffer and using `readUInt32BE` on that.
+      const size =
+        messageBufferHead[0] << 24 |
+        messageBufferHead[1] << 16 |
+        messageBufferHead[2] << 8 |
+        messageBufferHead[3];
+
+      if (channel[kMessageBufferSize] < 4 + size) break;
+
+      const concatenatedBuffer = channel[kMessageBuffer].length === 1 ?
+        channel[kMessageBuffer][0] :
+        Buffer.concat(
+          channel[kMessageBuffer],
+          channel[kMessageBufferSize]
+        );
 
       const deserializer = new ChildProcessDeserializer(
-        TypedArrayPrototypeSubarray(messageBuffer, 4, 4 + size));
-      messageBuffer = TypedArrayPrototypeSubarray(messageBuffer, 4 + size);
+        TypedArrayPrototypeSubarray(concatenatedBuffer, 4, 4 + size)
+      );
+
+      messageBufferHead = TypedArrayPrototypeSubarray(concatenatedBuffer, 4 + size);
+      channel[kMessageBufferSize] = messageBufferHead.length;
+      channel[kMessageBuffer] =
+        channel[kMessageBufferSize] !== 0 ? [messageBufferHead] : [];
 
       deserializer.readHeader();
       yield deserializer.readValue();
     }
-    channel[kMessageBuffer] = messageBuffer;
-    channel.buffering = messageBuffer.length > 0;
+
+    channel.buffering = channel[kMessageBufferSize] > 0;
   },
 
   writeChannelMessage(channel, req, message, handle) {

--- a/lib/internal/child_process/serialization.js
+++ b/lib/internal/child_process/serialization.js
@@ -4,6 +4,8 @@ const {
   JSONParse,
   JSONStringify,
   StringPrototypeSplit,
+  ArrayPrototypePush,
+  ReflectApply,
   Symbol,
   TypedArrayPrototypeSubarray,
 } = primordials;
@@ -13,6 +15,7 @@ const v8 = require('v8');
 const { isArrayBufferView } = require('internal/util/types');
 const assert = require('internal/assert');
 const { streamBaseState, kLastWriteWasAsync } = internalBinding('stream_wrap');
+const { readUInt32BE } = require('internal/buffer');
 
 const kMessageBuffer = Symbol('kMessageBuffer');
 const kMessageBufferSize = Symbol('kMessageBufferSize');
@@ -60,7 +63,7 @@ const advanced = {
   *parseChannelMessages(channel, readData) {
     if (readData.length === 0) return;
 
-    channel[kMessageBuffer].push(readData);
+    ArrayPrototypePush(channel[kMessageBuffer], readData);
     channel[kMessageBufferSize] += readData.length;
 
     // Index 0 should always be present because we just pushed data into it.
@@ -68,7 +71,7 @@ const advanced = {
     while (messageBufferHead.length >= 4) {
       // We call `readUInt32BE` manually here, because this is faster than first converting
       // it to a buffer and using `readUInt32BE` on that.
-      const fullMessageSize = Buffer.prototype.readUInt32BE.call(messageBufferHead, 0) + 4;
+      const fullMessageSize = ReflectApply(readUInt32BE, messageBufferHead, [0]) + 4;
 
       if (channel[kMessageBufferSize] < fullMessageSize) break;
 

--- a/lib/internal/child_process/serialization.js
+++ b/lib/internal/child_process/serialization.js
@@ -66,15 +66,11 @@ const advanced = {
     // Index 0 should always be present because we just pushed data into it.
     let messageBufferHead = channel[kMessageBuffer][0];
     while (messageBufferHead.length >= 4) {
-      // We read the uint manually here, because this is faster than first converting
+      // We call `readUInt32BE` manually here, because this is faster than first converting
       // it to a buffer and using `readUInt32BE` on that.
-      const size =
-        messageBufferHead[0] << 24 |
-        messageBufferHead[1] << 16 |
-        messageBufferHead[2] << 8 |
-        messageBufferHead[3];
+      const fullMessageSize = Buffer.prototype.readUInt32BE.call(messageBufferHead, 0) + 4;
 
-      if (channel[kMessageBufferSize] < 4 + size) break;
+      if (channel[kMessageBufferSize] < fullMessageSize) break;
 
       const concatenatedBuffer = channel[kMessageBuffer].length === 1 ?
         channel[kMessageBuffer][0] :
@@ -84,10 +80,10 @@ const advanced = {
         );
 
       const deserializer = new ChildProcessDeserializer(
-        TypedArrayPrototypeSubarray(concatenatedBuffer, 4, 4 + size)
+        TypedArrayPrototypeSubarray(concatenatedBuffer, 4, fullMessageSize)
       );
 
-      messageBufferHead = TypedArrayPrototypeSubarray(concatenatedBuffer, 4 + size);
+      messageBufferHead = TypedArrayPrototypeSubarray(concatenatedBuffer, fullMessageSize);
       channel[kMessageBufferSize] = messageBufferHead.length;
       channel[kMessageBuffer] =
         channel[kMessageBufferSize] !== 0 ? [messageBufferHead] : [];

--- a/lib/internal/child_process/serialization.js
+++ b/lib/internal/child_process/serialization.js
@@ -100,20 +100,27 @@ const advanced = {
 
   writeChannelMessage(channel, req, message, handle) {
     const ser = new ChildProcessSerializer();
+    // Add 4 bytes, to later populate with message length
+    ser.writeRawBytes(Buffer.allocUnsafe(4));
     ser.writeHeader();
     ser.writeValue(message);
-    const serializedMessage = ser.releaseBuffer();
-    const sizeBuffer = Buffer.allocUnsafe(4);
-    sizeBuffer.writeUInt32BE(serializedMessage.length);
 
-    const buffer = Buffer.concat([
-      sizeBuffer,
-      serializedMessage,
-    ]);
-    const result = channel.writeBuffer(req, buffer, handle);
+    const serializedMessage = ser.releaseBuffer();
+    const serializedMessageLength = serializedMessage.length - 4;
+
+    serializedMessage.set([
+      serializedMessageLength >> 24 & 0xFF,
+      serializedMessageLength >> 16 & 0xFF,
+      serializedMessageLength >> 8 & 0xFF,
+      serializedMessageLength & 0xFF,
+    ], 0);
+
+    const result = channel.writeBuffer(req, serializedMessage, handle);
+
     // Mirror what stream_base_commons.js does for Buffer retention.
     if (streamBaseState[kLastWriteWasAsync])
-      req.buffer = buffer;
+      req.buffer = serializedMessage;
+
     return result;
   },
 };


### PR DESCRIPTION
### Problem

I was running into an issue where I needed to transfer large buffers between a child_process and the main process with 'advanced' serializing, and this was suprisingly very slow.

### Solution

After some debugging and profiling I found that the `Buffer` functions, and mainly the `Buffer.concat` function were to blame. So I have changed the code to use these functions as little as possible. 

Now it will not concat each and every incoming part, it will instead store these in an array and only concat them when the full message has been collected.

### Tests

I wrote a small test where I transferred different buffer sizes from a child process to the parent, and timed how long it took before the message was received in the parent.

(The scripts I used to test this: [test-ipc.zip](https://github.com/nodejs/node/files/8597833/test-ipc.zip))

Before fix:
```
1kb   :  1 ms
8kb   :  0 ms
64kb  :  0 ms
512kb :  1 ms
1mb   :  6 ms
2mb   :  17 ms
4mb   :  43 ms
8mb   :  176 ms
16mb  :  717 ms
32mb  :  2726 ms
64mb  :  11781 ms
128mb :  57075 ms
1gb   :  3299888 ms (55 minutes)
```

After fix:
```
1kb   :  1 ms
8kb   :  0 ms
64kb  :  0 ms
512kb :  1 ms
1mb   :  2 ms
2mb   :  3 ms
4mb   :  6 ms
8mb   :  15 ms
16mb  :  31 ms
32mb  :  73 ms
64mb  :  142 ms
128mb :  217 ms
1gb   :  1426 ms
```