### PR TITLE
src: remove unnecessary comment in node_process_events.cc

### DIFF
--- a/src/node_process_events.cc
+++ b/src/node_process_events.cc
@@ -21,7 +21,6 @@ using v8::Value;
 MaybeLocal<Value> ProcessEmit(Environment* env,
                               const char* event,
                               Local<Value> message) {
-  // Send message to enable debug in cluster workers
   Isolate* isolate = env->isolate();
 
   Local<String> event_string;


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

I found meaningless comment in `node_process_events.cc`. I think this is unintentionally duplicated by #25397  (cc @joyeecheung)
The correct location of this comment is here:
https://github.com/nodejs/node/blob/2be596604ac13a4dd68eb9cc38e54f2df438dd97/src/inspector_agent.cc#L341-L351
