### PR TITLE
lib: use `spawn` options for timeout in `execFile`

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -305,9 +305,6 @@ function execFile(file, args = [], options, callback) {
     ...options
   };
 
-  // Validate the timeout, if present.
-  validateTimeout(options.timeout);
-
   // Validate maxBuffer, if present.
   validateMaxBuffer(options.maxBuffer);
 
@@ -317,8 +314,10 @@ function execFile(file, args = [], options, callback) {
     cwd: options.cwd,
     env: options.env,
     gid: options.gid,
+    killSignal: options.killSignal,
     shell: options.shell,
     signal: options.signal,
+    timeout: options.timeout,
     uid: options.uid,
     windowsHide: !!options.windowsHide,
     windowsVerbatimArguments: !!options.windowsVerbatimArguments
@@ -336,7 +335,6 @@ function execFile(file, args = [], options, callback) {
   let stderrLen = 0;
   let killed = false;
   let exited = false;
-  let timeoutId;
 
   let ex = null;
 
@@ -345,11 +343,6 @@ function execFile(file, args = [], options, callback) {
   function exithandler(code, signal) {
     if (exited) return;
     exited = true;
-
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-      timeoutId = null;
-    }
 
     if (!callback) return;
 
@@ -421,13 +414,6 @@ function execFile(file, args = [], options, callback) {
       ex = e;
       exithandler();
     }
-  }
-
-  if (options.timeout > 0) {
-    timeoutId = setTimeout(function delayedKill() {
-      kill();
-      timeoutId = null;
-    }, options.timeout);
   }
 
   if (child.stdout) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Timeout support was added to `spawn` in v15.13.0 ([PR](https://github.com/nodejs/node/pull/37256)), but `execFile` has continued to use its own mechanism to implement the timeout functionality, which is now basically replicating the logic added to `spawn`.

This PR removes the repeated logic from `execFile` and delegates timeout handling to `spawn` instead. It does so by forwarding the options `timeout` and `killSignal`.

The only visible change I can think of is a different order of parameter validation in `execFile`, which means a possibly different error message in the case that both `timeout` and at least another option are passed invalid values. Looking at the other functions in child_process and their tests, and after reading the documentation, it seems to me though that no particular order of parameter validation is being enforced, so I guess this change would have no significant impact.

No functionality was added or removed. All tests are still passing.