### PR TITLE
[v16.x] src: add --openssl-legacy-provider option

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -732,6 +732,15 @@ Load an OpenSSL configuration file on startup. Among other uses, this can be
 used to enable FIPS-compliant crypto if Node.js is built
 against FIPS-enabled OpenSSL.
 
+### `--openssl-legacy-provider`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable OpenSSL 3.0 legacy provider when dynamically linking to OpenSSL 3.x.
+For more information please see [OSSL\_PROVIDER-legacy][OSSL_PROVIDER-legacy].
+
 ### `--pending-deprecation`
 
 <!-- YAML
@@ -1592,6 +1601,7 @@ Node.js options that are allowed are:
 * `--no-warnings`
 * `--node-memory-debug`
 * `--openssl-config`
+* `--openssl-legacy-provider`
 * `--pending-deprecation`
 * `--policy-integrity`
 * `--preserve-symlinks-main`
@@ -1952,6 +1962,7 @@ $ node --max-old-space-size=1536 index.js
 [ECMAScript module loader]: esm.md#loaders
 [Fetch API]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
 [Modules loaders]: packages.md#modules-loaders
+[OSSL_PROVIDER-legacy]: https://www.openssl.org/docs/man3.0/man7/OSSL_PROVIDER-legacy.html
 [REPL]: repl.md
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage
 [Source Map]: https://sourcemaps.info/spec.html

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -148,6 +148,16 @@ void InitCryptoOnce() {
   }
 #endif
 
+#if OPENSSL_VERSION_MAJOR >= 3
+  // --openssl-legacy-provider
+  if (per_process::cli_options->openssl_legacy_provider) {
+    OSSL_PROVIDER* legacy_provider = OSSL_PROVIDER_load(nullptr, "legacy");
+    if (legacy_provider == nullptr) {
+      fprintf(stderr, "Unable to load legacy provider.\n");
+    }
+  }
+#endif
+
   OPENSSL_init_ssl(0, settings);
   OPENSSL_INIT_free(settings);
   settings = nullptr;

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -5,6 +5,9 @@
 #include "node_binding.h"
 #include "node_external_reference.h"
 #include "node_internals.h"
+#if HAVE_OPENSSL
+#include "openssl/opensslv.h"
+#endif
 
 #include <errno.h>
 #include <sstream>

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -11,6 +11,10 @@
 #include "node_mutex.h"
 #include "util.h"
 
+#if HAVE_OPENSSL
+#include "openssl/opensslv.h"
+#endif
+
 namespace node {
 
 class HostPort {
@@ -251,6 +255,9 @@ class PerProcessOptions : public Options {
   bool use_bundled_ca = false;
   bool enable_fips_crypto = false;
   bool force_fips_crypto = false;
+#endif
+#if OPENSSL_VERSION_MAJOR >= 3
+  bool openssl_legacy_provider = false;
 #endif
 
   // Per-process because reports can be triggered outside a known V8 context.

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -43,6 +43,10 @@ for (const line of [...nodeOptionsLines, ...v8OptionsLines]) {
   }
 }
 
+if (!common.hasOpenSSL3) {
+  documented.delete('--openssl-legacy-provider');
+}
+
 // Filter out options that are conditionally present.
 const conditionalOpts = [
   {
@@ -50,6 +54,7 @@ const conditionalOpts = [
     filter: (opt) => {
       return [
         '--openssl-config',
+        common.hasOpenSSL3 ? '--openssl-legacy-provider' : '',
         '--tls-cipher-list',
         '--use-bundled-ca',
         '--use-openssl-ca',


### PR DESCRIPTION
This commit adds an option to Node.js named --openssl-legacy-provider
and if specified will load OpenSSL 3.0 Legacy provider when dynamically
linking Node.js v16.x with OpenSSL 3.0.
```console
Building:
$ ./configure --shared-openssl \
 --shared-openssl-libpath=/path/openssl_quic-3.0/lib64 \
 --shared-openssl-includes=/path/openssl_quic-3.0/include \
 --shared-openssl-libname=crypto,ssl
$ make -j8
```
Verify option is available:
```console
$ ./node --help
...
--openssl-legacy-provider  enable OpenSSL 3.0 legacy provider
```
Usage:
```console
$ export LD_LIBRARY_PATH=/path/openssl_quic-3.0/lib64
$ export OPENSSL_MODULES=/path/openssl_quic-3.0/lib64/ossl-modules/
$ export OPENSSL_CONF=/path/openssl_quic-3.0/ssl/openssl.cnf
$ ./node --openssl-legacy-provider  -p 'crypto.createHash("md4")'
Hash {
  _options: undefined,
  [Symbol(kHandle)]: Hash {},
  [Symbol(kState)]: { [Symbol(kFinalized)]: false }
}
```
Fixes: https://github.com/nodejs/node/issues/40948

Refs: https://github.com/nodejs/node/issues/40455
PR-URL: https://github.com/nodejs/node/pull/40478
Reviewed-By: Richard Lau <rlau@redhat.com>
Reviewed-By: Tobias Nießen <tniessen@tnie.de>

