### PR TITLE
deps: exclude linker scripts for windows builds

### DIFF
--- a/deps/openssl/config/archs/BSD-x86/asm/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86/asm/configdata.pm
@@ -204,9 +204,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8039,6 +8039,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8056,10 +8059,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-opt.o"
             ],
             "products" => {
                 "bin" => [
@@ -9760,10 +9760,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27339,8 +27339,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27367,7 +27367,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27384,8 +27384,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/BSD-x86/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86"
-#define DATE "built on: Mon May  9 17:35:57 2022 UTC"
+#define DATE "built on: Mon May 16 03:44:42 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/BSD-x86/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86/asm_avx2/configdata.pm
@@ -204,9 +204,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27339,8 +27339,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27367,7 +27367,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27384,8 +27384,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/BSD-x86/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86"
-#define DATE "built on: Mon May  9 17:36:06 2022 UTC"
+#define DATE "built on: Mon May 16 03:44:57 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/BSD-x86/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86/no-asm/configdata.pm
@@ -203,9 +203,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -7982,6 +7982,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -7999,10 +8002,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-opt.o"
             ],
             "products" => {
                 "bin" => [
@@ -9677,10 +9677,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27155,8 +27155,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27183,7 +27183,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27200,8 +27200,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/BSD-x86/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86"
-#define DATE "built on: Mon May  9 17:36:16 2022 UTC"
+#define DATE "built on: Mon May 16 03:45:11 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/BSD-x86_64/asm/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86_64/asm/configdata.pm
@@ -204,9 +204,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27508,8 +27508,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27536,7 +27536,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27553,8 +27553,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/BSD-x86_64/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86_64/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86_64"
-#define DATE "built on: Mon May  9 17:36:24 2022 UTC"
+#define DATE "built on: Mon May 16 03:45:25 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/BSD-x86_64/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86_64/asm_avx2/configdata.pm
@@ -204,9 +204,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8042,9 +8042,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8062,7 +8059,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -27508,8 +27508,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27536,7 +27536,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27553,8 +27553,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/BSD-x86_64/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86_64/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86_64"
-#define DATE "built on: Mon May  9 17:36:36 2022 UTC"
+#define DATE "built on: Mon May 16 03:45:43 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/BSD-x86_64/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86_64/no-asm/configdata.pm
@@ -203,9 +203,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27156,8 +27156,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27184,7 +27184,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27201,8 +27201,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/BSD-x86_64/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86_64/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86_64"
-#define DATE "built on: Mon May  9 17:36:48 2022 UTC"
+#define DATE "built on: Mon May 16 03:46:02 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN32/asm/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN32/asm/configdata.pm
@@ -217,9 +217,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -287,7 +287,7 @@ our %target = (
     "LDFLAGS" => "/nologo /debug",
     "MT" => "mt",
     "MTFLAGS" => "-nologo",
-    "RANLIB" => "CODE(0x561b475f03f0)",
+    "RANLIB" => "CODE(0x55faf816d238)",
     "RC" => "rc",
     "_conf_fname_int" => [
         "Configurations/00-base-templates.conf",
@@ -8093,6 +8093,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8112,10 +8115,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-tlssrp_depr.o",
                 "apps/lib/libapps-lib-win32_init.o",
                 "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/libtestutil-lib-win32_init.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-win32_init.o"
             ],
             "products" => {
                 "bin" => [
@@ -9815,10 +9815,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27418,8 +27418,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27446,7 +27446,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27463,8 +27463,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/VC-WIN32/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN32/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Mon May  9 17:43:21 2022 UTC"
+#define DATE "built on: Mon May 16 03:56:53 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN32/asm/openssl-fips.gypi
+++ b/deps/openssl/config/archs/VC-WIN32/asm/openssl-fips.gypi
@@ -305,8 +305,6 @@
       './config/archs/VC-WIN32/asm/crypto/des/crypt586.asm',
       './config/archs/VC-WIN32/asm/crypto/des/des-586.asm',
       './config/archs/VC-WIN32/asm/crypto/md5/md5-586.asm',
-      './config/archs/VC-WIN32/asm/providers/legacy.ld',
-      './config/archs/VC-WIN32/asm/providers/fips.ld',
 
     ],
     'openssl_defines_VC-WIN32': [

--- a/deps/openssl/config/archs/VC-WIN32/asm/openssl.gypi
+++ b/deps/openssl/config/archs/VC-WIN32/asm/openssl.gypi
@@ -981,8 +981,6 @@
       './config/archs/VC-WIN32/asm/crypto/des/crypt586.asm',
       './config/archs/VC-WIN32/asm/crypto/des/des-586.asm',
       './config/archs/VC-WIN32/asm/crypto/md5/md5-586.asm',
-      './config/archs/VC-WIN32/asm/providers/legacy.ld',
-      './config/archs/VC-WIN32/asm/providers/fips.ld',
     ],
     'openssl_defines_VC-WIN32': [
       'NDEBUG',

--- a/deps/openssl/config/archs/VC-WIN32/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN32/asm_avx2/configdata.pm
@@ -217,9 +217,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -287,7 +287,7 @@ our %target = (
     "LDFLAGS" => "/nologo /debug",
     "MT" => "mt",
     "MTFLAGS" => "-nologo",
-    "RANLIB" => "CODE(0x5614f015f400)",
+    "RANLIB" => "CODE(0x562885b4eb48)",
     "RC" => "rc",
     "_conf_fname_int" => [
         "Configurations/00-base-templates.conf",
@@ -27418,8 +27418,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27446,7 +27446,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27463,8 +27463,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/VC-WIN32/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN32/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Mon May  9 17:43:29 2022 UTC"
+#define DATE "built on: Mon May 16 03:57:06 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN32/asm_avx2/openssl-fips.gypi
+++ b/deps/openssl/config/archs/VC-WIN32/asm_avx2/openssl-fips.gypi
@@ -305,8 +305,6 @@
       './config/archs/VC-WIN32/asm_avx2/crypto/des/crypt586.asm',
       './config/archs/VC-WIN32/asm_avx2/crypto/des/des-586.asm',
       './config/archs/VC-WIN32/asm_avx2/crypto/md5/md5-586.asm',
-      './config/archs/VC-WIN32/asm_avx2/providers/legacy.ld',
-      './config/archs/VC-WIN32/asm_avx2/providers/fips.ld',
 
     ],
     'openssl_defines_VC-WIN32': [

--- a/deps/openssl/config/archs/VC-WIN32/asm_avx2/openssl.gypi
+++ b/deps/openssl/config/archs/VC-WIN32/asm_avx2/openssl.gypi
@@ -981,8 +981,6 @@
       './config/archs/VC-WIN32/asm_avx2/crypto/des/crypt586.asm',
       './config/archs/VC-WIN32/asm_avx2/crypto/des/des-586.asm',
       './config/archs/VC-WIN32/asm_avx2/crypto/md5/md5-586.asm',
-      './config/archs/VC-WIN32/asm_avx2/providers/legacy.ld',
-      './config/archs/VC-WIN32/asm_avx2/providers/fips.ld',
     ],
     'openssl_defines_VC-WIN32': [
       'NDEBUG',

--- a/deps/openssl/config/archs/VC-WIN32/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN32/no-asm/configdata.pm
@@ -216,9 +216,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -287,7 +287,7 @@ our %target = (
     "LDFLAGS" => "/nologo /debug",
     "MT" => "mt",
     "MTFLAGS" => "-nologo",
-    "RANLIB" => "CODE(0x5574754114a0)",
+    "RANLIB" => "CODE(0x562deb967e18)",
     "RC" => "rc",
     "_conf_fname_int" => [
         "Configurations/00-base-templates.conf",
@@ -8036,6 +8036,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8055,10 +8058,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-tlssrp_depr.o",
                 "apps/lib/libapps-lib-win32_init.o",
                 "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/libtestutil-lib-win32_init.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-win32_init.o"
             ],
             "products" => {
                 "bin" => [
@@ -27234,8 +27234,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27262,7 +27262,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27279,8 +27279,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/VC-WIN32/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN32/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Mon May  9 17:43:37 2022 UTC"
+#define DATE "built on: Mon May 16 03:57:20 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN32/no-asm/openssl-fips.gypi
+++ b/deps/openssl/config/archs/VC-WIN32/no-asm/openssl-fips.gypi
@@ -279,8 +279,6 @@
       './config/archs/VC-WIN32/no-asm/providers/common/der/der_ecx_gen.c',
       './config/archs/VC-WIN32/no-asm/providers/common/der/der_rsa_gen.c',
       './config/archs/VC-WIN32/no-asm/providers/common/der/der_wrap_gen.c',
-      './config/archs/VC-WIN32/no-asm/providers/legacy.ld',
-      './config/archs/VC-WIN32/no-asm/providers/fips.ld',
 
     ],
     'openssl_defines_VC-WIN32': [

--- a/deps/openssl/config/archs/VC-WIN32/no-asm/openssl.gypi
+++ b/deps/openssl/config/archs/VC-WIN32/no-asm/openssl.gypi
@@ -965,8 +965,6 @@
       './config/archs/VC-WIN32/no-asm/providers/common/der/der_ecx_gen.c',
       './config/archs/VC-WIN32/no-asm/providers/common/der/der_rsa_gen.c',
       './config/archs/VC-WIN32/no-asm/providers/common/der/der_wrap_gen.c',
-      './config/archs/VC-WIN32/no-asm/providers/legacy.ld',
-      './config/archs/VC-WIN32/no-asm/providers/fips.ld',
     ],
     'openssl_defines_VC-WIN32': [
       'NDEBUG',

--- a/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/configdata.pm
@@ -214,9 +214,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -283,7 +283,7 @@ our %target = (
     "LDFLAGS" => "/nologo /debug",
     "MT" => "mt",
     "MTFLAGS" => "-nologo",
-    "RANLIB" => "CODE(0x5595a95d84a0)",
+    "RANLIB" => "CODE(0x5568891ede98)",
     "RC" => "rc",
     "_conf_fname_int" => [
         "Configurations/00-base-templates.conf",
@@ -27226,8 +27226,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27254,7 +27254,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27271,8 +27271,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: VC-WIN64-ARM"
-#define DATE "built on: Mon May  9 17:43:44 2022 UTC"
+#define DATE "built on: Mon May 16 03:57:33 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/openssl-fips.gypi
+++ b/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/openssl-fips.gypi
@@ -279,8 +279,6 @@
       './config/archs/VC-WIN64-ARM/no-asm/providers/common/der/der_ecx_gen.c',
       './config/archs/VC-WIN64-ARM/no-asm/providers/common/der/der_rsa_gen.c',
       './config/archs/VC-WIN64-ARM/no-asm/providers/common/der/der_wrap_gen.c',
-      './config/archs/VC-WIN64-ARM/no-asm/providers/legacy.ld',
-      './config/archs/VC-WIN64-ARM/no-asm/providers/fips.ld',
 
     ],
     'openssl_defines_VC-WIN64-ARM': [

--- a/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/openssl.gypi
+++ b/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/openssl.gypi
@@ -965,8 +965,6 @@
       './config/archs/VC-WIN64-ARM/no-asm/providers/common/der/der_ecx_gen.c',
       './config/archs/VC-WIN64-ARM/no-asm/providers/common/der/der_rsa_gen.c',
       './config/archs/VC-WIN64-ARM/no-asm/providers/common/der/der_wrap_gen.c',
-      './config/archs/VC-WIN64-ARM/no-asm/providers/legacy.ld',
-      './config/archs/VC-WIN64-ARM/no-asm/providers/fips.ld',
     ],
     'openssl_defines_VC-WIN64-ARM': [
       'NDEBUG',

--- a/deps/openssl/config/archs/VC-WIN64A/asm/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN64A/asm/configdata.pm
@@ -220,9 +220,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -290,7 +290,7 @@ our %target = (
     "LDFLAGS" => "/nologo /debug",
     "MT" => "mt",
     "MTFLAGS" => "-nologo",
-    "RANLIB" => "CODE(0x5634200ce4c0)",
+    "RANLIB" => "CODE(0x564a8cf6c4c8)",
     "RC" => "rc",
     "_conf_fname_int" => [
         "Configurations/00-base-templates.conf",
@@ -8099,6 +8099,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8118,10 +8121,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-tlssrp_depr.o",
                 "apps/lib/libapps-lib-win32_init.o",
                 "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/libtestutil-lib-win32_init.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-win32_init.o"
             ],
             "products" => {
                 "bin" => [
@@ -9852,10 +9852,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27579,8 +27579,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27607,7 +27607,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27624,8 +27624,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/VC-WIN64A/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN64A/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Mon May  9 17:42:51 2022 UTC"
+#define DATE "built on: Mon May 16 03:56:05 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN64A/asm/openssl-fips.gypi
+++ b/deps/openssl/config/archs/VC-WIN64A/asm/openssl-fips.gypi
@@ -317,8 +317,6 @@
       './config/archs/VC-WIN64A/asm/crypto/bn/x86_64-mont.asm',
       './config/archs/VC-WIN64A/asm/crypto/bn/x86_64-mont5.asm',
       './config/archs/VC-WIN64A/asm/crypto/md5/md5-x86_64.asm',
-      './config/archs/VC-WIN64A/asm/providers/legacy.ld',
-      './config/archs/VC-WIN64A/asm/providers/fips.ld',
 
     ],
     'openssl_defines_VC-WIN64A': [

--- a/deps/openssl/config/archs/VC-WIN64A/asm/openssl.gypi
+++ b/deps/openssl/config/archs/VC-WIN64A/asm/openssl.gypi
@@ -999,8 +999,6 @@
       './config/archs/VC-WIN64A/asm/crypto/bn/x86_64-mont.asm',
       './config/archs/VC-WIN64A/asm/crypto/bn/x86_64-mont5.asm',
       './config/archs/VC-WIN64A/asm/crypto/md5/md5-x86_64.asm',
-      './config/archs/VC-WIN64A/asm/providers/legacy.ld',
-      './config/archs/VC-WIN64A/asm/providers/fips.ld',
     ],
     'openssl_defines_VC-WIN64A': [
       'NDEBUG',

--- a/deps/openssl/config/archs/VC-WIN64A/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN64A/asm_avx2/configdata.pm
@@ -220,9 +220,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -290,7 +290,7 @@ our %target = (
     "LDFLAGS" => "/nologo /debug",
     "MT" => "mt",
     "MTFLAGS" => "-nologo",
-    "RANLIB" => "CODE(0x559446543400)",
+    "RANLIB" => "CODE(0x55c4f0a0f3f8)",
     "RC" => "rc",
     "_conf_fname_int" => [
         "Configurations/00-base-templates.conf",
@@ -8099,6 +8099,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8118,10 +8121,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-tlssrp_depr.o",
                 "apps/lib/libapps-lib-win32_init.o",
                 "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/libtestutil-lib-win32_init.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-win32_init.o"
             ],
             "products" => {
                 "bin" => [
@@ -27579,8 +27579,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27607,7 +27607,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27624,8 +27624,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/VC-WIN64A/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN64A/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Mon May  9 17:43:02 2022 UTC"
+#define DATE "built on: Mon May 16 03:56:23 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN64A/asm_avx2/openssl-fips.gypi
+++ b/deps/openssl/config/archs/VC-WIN64A/asm_avx2/openssl-fips.gypi
@@ -317,8 +317,6 @@
       './config/archs/VC-WIN64A/asm_avx2/crypto/bn/x86_64-mont.asm',
       './config/archs/VC-WIN64A/asm_avx2/crypto/bn/x86_64-mont5.asm',
       './config/archs/VC-WIN64A/asm_avx2/crypto/md5/md5-x86_64.asm',
-      './config/archs/VC-WIN64A/asm_avx2/providers/legacy.ld',
-      './config/archs/VC-WIN64A/asm_avx2/providers/fips.ld',
 
     ],
     'openssl_defines_VC-WIN64A': [

--- a/deps/openssl/config/archs/VC-WIN64A/asm_avx2/openssl.gypi
+++ b/deps/openssl/config/archs/VC-WIN64A/asm_avx2/openssl.gypi
@@ -999,8 +999,6 @@
       './config/archs/VC-WIN64A/asm_avx2/crypto/bn/x86_64-mont.asm',
       './config/archs/VC-WIN64A/asm_avx2/crypto/bn/x86_64-mont5.asm',
       './config/archs/VC-WIN64A/asm_avx2/crypto/md5/md5-x86_64.asm',
-      './config/archs/VC-WIN64A/asm_avx2/providers/legacy.ld',
-      './config/archs/VC-WIN64A/asm_avx2/providers/fips.ld',
     ],
     'openssl_defines_VC-WIN64A': [
       'NDEBUG',

--- a/deps/openssl/config/archs/VC-WIN64A/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN64A/no-asm/configdata.pm
@@ -219,9 +219,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -290,7 +290,7 @@ our %target = (
     "LDFLAGS" => "/nologo /debug",
     "MT" => "mt",
     "MTFLAGS" => "-nologo",
-    "RANLIB" => "CODE(0x562934e5a4a0)",
+    "RANLIB" => "CODE(0x55d8601c4318)",
     "RC" => "rc",
     "_conf_fname_int" => [
         "Configurations/00-base-templates.conf",
@@ -8040,9 +8040,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8062,7 +8059,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-tlssrp_depr.o",
                 "apps/lib/libapps-lib-win32_init.o",
                 "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/libtestutil-lib-win32_init.o"
+                "apps/lib/libtestutil-lib-win32_init.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -9736,10 +9736,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27238,8 +27238,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27266,7 +27266,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27283,8 +27283,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/VC-WIN64A/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN64A/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Mon May  9 17:43:13 2022 UTC"
+#define DATE "built on: Mon May 16 03:56:40 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN64A/no-asm/openssl-fips.gypi
+++ b/deps/openssl/config/archs/VC-WIN64A/no-asm/openssl-fips.gypi
@@ -279,8 +279,6 @@
       './config/archs/VC-WIN64A/no-asm/providers/common/der/der_ecx_gen.c',
       './config/archs/VC-WIN64A/no-asm/providers/common/der/der_rsa_gen.c',
       './config/archs/VC-WIN64A/no-asm/providers/common/der/der_wrap_gen.c',
-      './config/archs/VC-WIN64A/no-asm/providers/legacy.ld',
-      './config/archs/VC-WIN64A/no-asm/providers/fips.ld',
 
     ],
     'openssl_defines_VC-WIN64A': [

--- a/deps/openssl/config/archs/VC-WIN64A/no-asm/openssl.gypi
+++ b/deps/openssl/config/archs/VC-WIN64A/no-asm/openssl.gypi
@@ -965,8 +965,6 @@
       './config/archs/VC-WIN64A/no-asm/providers/common/der/der_ecx_gen.c',
       './config/archs/VC-WIN64A/no-asm/providers/common/der/der_rsa_gen.c',
       './config/archs/VC-WIN64A/no-asm/providers/common/der/der_wrap_gen.c',
-      './config/archs/VC-WIN64A/no-asm/providers/legacy.ld',
-      './config/archs/VC-WIN64A/no-asm/providers/fips.ld',
     ],
     'openssl_defines_VC-WIN64A': [
       'NDEBUG',

--- a/deps/openssl/config/archs/aix64-gcc-as/asm/configdata.pm
+++ b/deps/openssl/config/archs/aix64-gcc-as/asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -896,16 +896,7 @@ our %unified_info = (
             "test/buildtest_c_aes" => {
                 "noinst" => "1"
             },
-            "test/buildtest_c_asn1" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_asn1t" => {
-                "noinst" => "1"
-            },
             "test/buildtest_c_async" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_bio" => {
                 "noinst" => "1"
             },
             "test/buildtest_c_blowfish" => {
@@ -926,22 +917,10 @@ our %unified_info = (
             "test/buildtest_c_cmac" => {
                 "noinst" => "1"
             },
-            "test/buildtest_c_cmp" => {
-                "noinst" => "1"
-            },
             "test/buildtest_c_cmp_util" => {
                 "noinst" => "1"
             },
-            "test/buildtest_c_cms" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_conf" => {
-                "noinst" => "1"
-            },
             "test/buildtest_c_conf_api" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_configuration" => {
                 "noinst" => "1"
             },
             "test/buildtest_c_conftypes" => {
@@ -959,16 +938,7 @@ our %unified_info = (
             "test/buildtest_c_core_object" => {
                 "noinst" => "1"
             },
-            "test/buildtest_c_crmf" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_crypto" => {
-                "noinst" => "1"
-            },
             "test/buildtest_c_cryptoerr_legacy" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_ct" => {
                 "noinst" => "1"
             },
             "test/buildtest_c_decoder" => {
@@ -1007,16 +977,10 @@ our %unified_info = (
             "test/buildtest_c_engine" => {
                 "noinst" => "1"
             },
-            "test/buildtest_c_ess" => {
-                "noinst" => "1"
-            },
             "test/buildtest_c_evp" => {
                 "noinst" => "1"
             },
             "test/buildtest_c_fips_names" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_fipskey" => {
                 "noinst" => "1"
             },
             "test/buildtest_c_hmac" => {
@@ -1029,9 +993,6 @@ our %unified_info = (
                 "noinst" => "1"
             },
             "test/buildtest_c_kdf" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_lhash" => {
                 "noinst" => "1"
             },
             "test/buildtest_c_macros" => {
@@ -1055,12 +1016,6 @@ our %unified_info = (
             "test/buildtest_c_objects" => {
                 "noinst" => "1"
             },
-            "test/buildtest_c_ocsp" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_opensslv" => {
-                "noinst" => "1"
-            },
             "test/buildtest_c_ossl_typ" => {
                 "noinst" => "1"
             },
@@ -1074,12 +1029,6 @@ our %unified_info = (
                 "noinst" => "1"
             },
             "test/buildtest_c_pem2" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_pkcs12" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_pkcs7" => {
                 "noinst" => "1"
             },
             "test/buildtest_c_prov_ssl" => {
@@ -1106,9 +1055,6 @@ our %unified_info = (
             "test/buildtest_c_rsa" => {
                 "noinst" => "1"
             },
-            "test/buildtest_c_safestack" => {
-                "noinst" => "1"
-            },
             "test/buildtest_c_seed" => {
                 "noinst" => "1"
             },
@@ -1118,13 +1064,7 @@ our %unified_info = (
             "test/buildtest_c_sha" => {
                 "noinst" => "1"
             },
-            "test/buildtest_c_srp" => {
-                "noinst" => "1"
-            },
             "test/buildtest_c_srtp" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_ssl" => {
                 "noinst" => "1"
             },
             "test/buildtest_c_ssl2" => {
@@ -1154,19 +1094,7 @@ our %unified_info = (
             "test/buildtest_c_types" => {
                 "noinst" => "1"
             },
-            "test/buildtest_c_ui" => {
-                "noinst" => "1"
-            },
             "test/buildtest_c_whrlpool" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_x509" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_x509_vfy" => {
-                "noinst" => "1"
-            },
-            "test/buildtest_c_x509v3" => {
                 "noinst" => "1"
             },
             "test/casttest" => {
@@ -7203,19 +7131,7 @@ our %unified_info = (
             "libcrypto",
             "libssl"
         ],
-        "test/buildtest_c_asn1" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_asn1t" => [
-            "libcrypto",
-            "libssl"
-        ],
         "test/buildtest_c_async" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_bio" => [
             "libcrypto",
             "libssl"
         ],
@@ -7243,27 +7159,11 @@ our %unified_info = (
             "libcrypto",
             "libssl"
         ],
-        "test/buildtest_c_cmp" => [
-            "libcrypto",
-            "libssl"
-        ],
         "test/buildtest_c_cmp_util" => [
             "libcrypto",
             "libssl"
         ],
-        "test/buildtest_c_cms" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_conf" => [
-            "libcrypto",
-            "libssl"
-        ],
         "test/buildtest_c_conf_api" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_configuration" => [
             "libcrypto",
             "libssl"
         ],
@@ -7287,19 +7187,7 @@ our %unified_info = (
             "libcrypto",
             "libssl"
         ],
-        "test/buildtest_c_crmf" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_crypto" => [
-            "libcrypto",
-            "libssl"
-        ],
         "test/buildtest_c_cryptoerr_legacy" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_ct" => [
             "libcrypto",
             "libssl"
         ],
@@ -7351,19 +7239,11 @@ our %unified_info = (
             "libcrypto",
             "libssl"
         ],
-        "test/buildtest_c_ess" => [
-            "libcrypto",
-            "libssl"
-        ],
         "test/buildtest_c_evp" => [
             "libcrypto",
             "libssl"
         ],
         "test/buildtest_c_fips_names" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_fipskey" => [
             "libcrypto",
             "libssl"
         ],
@@ -7380,10 +7260,6 @@ our %unified_info = (
             "libssl"
         ],
         "test/buildtest_c_kdf" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_lhash" => [
             "libcrypto",
             "libssl"
         ],
@@ -7415,14 +7291,6 @@ our %unified_info = (
             "libcrypto",
             "libssl"
         ],
-        "test/buildtest_c_ocsp" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_opensslv" => [
-            "libcrypto",
-            "libssl"
-        ],
         "test/buildtest_c_ossl_typ" => [
             "libcrypto",
             "libssl"
@@ -7440,14 +7308,6 @@ our %unified_info = (
             "libssl"
         ],
         "test/buildtest_c_pem2" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_pkcs12" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_pkcs7" => [
             "libcrypto",
             "libssl"
         ],
@@ -7483,10 +7343,6 @@ our %unified_info = (
             "libcrypto",
             "libssl"
         ],
-        "test/buildtest_c_safestack" => [
-            "libcrypto",
-            "libssl"
-        ],
         "test/buildtest_c_seed" => [
             "libcrypto",
             "libssl"
@@ -7499,15 +7355,7 @@ our %unified_info = (
             "libcrypto",
             "libssl"
         ],
-        "test/buildtest_c_srp" => [
-            "libcrypto",
-            "libssl"
-        ],
         "test/buildtest_c_srtp" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_ssl" => [
             "libcrypto",
             "libssl"
         ],
@@ -7547,23 +7395,7 @@ our %unified_info = (
             "libcrypto",
             "libssl"
         ],
-        "test/buildtest_c_ui" => [
-            "libcrypto",
-            "libssl"
-        ],
         "test/buildtest_c_whrlpool" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_x509" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_x509_vfy" => [
-            "libcrypto",
-            "libssl"
-        ],
-        "test/buildtest_c_x509v3" => [
             "libcrypto",
             "libssl"
         ],
@@ -16020,21 +15852,9 @@ our %unified_info = (
             "test/generate_buildtest.pl",
             "aes"
         ],
-        "test/buildtest_asn1.c" => [
-            "test/generate_buildtest.pl",
-            "asn1"
-        ],
-        "test/buildtest_asn1t.c" => [
-            "test/generate_buildtest.pl",
-            "asn1t"
-        ],
         "test/buildtest_async.c" => [
             "test/generate_buildtest.pl",
             "async"
-        ],
-        "test/buildtest_bio.c" => [
-            "test/generate_buildtest.pl",
-            "bio"
         ],
         "test/buildtest_blowfish.c" => [
             "test/generate_buildtest.pl",
@@ -16060,29 +15880,13 @@ our %unified_info = (
             "test/generate_buildtest.pl",
             "cmac"
         ],
-        "test/buildtest_cmp.c" => [
-            "test/generate_buildtest.pl",
-            "cmp"
-        ],
         "test/buildtest_cmp_util.c" => [
             "test/generate_buildtest.pl",
             "cmp_util"
         ],
-        "test/buildtest_cms.c" => [
-            "test/generate_buildtest.pl",
-            "cms"
-        ],
-        "test/buildtest_conf.c" => [
-            "test/generate_buildtest.pl",
-            "conf"
-        ],
         "test/buildtest_conf_api.c" => [
             "test/generate_buildtest.pl",
             "conf_api"
-        ],
-        "test/buildtest_configuration.c" => [
-            "test/generate_buildtest.pl",
-            "configuration"
         ],
         "test/buildtest_conftypes.c" => [
             "test/generate_buildtest.pl",
@@ -16104,21 +15908,9 @@ our %unified_info = (
             "test/generate_buildtest.pl",
             "core_object"
         ],
-        "test/buildtest_crmf.c" => [
-            "test/generate_buildtest.pl",
-            "crmf"
-        ],
-        "test/buildtest_crypto.c" => [
-            "test/generate_buildtest.pl",
-            "crypto"
-        ],
         "test/buildtest_cryptoerr_legacy.c" => [
             "test/generate_buildtest.pl",
             "cryptoerr_legacy"
-        ],
-        "test/buildtest_ct.c" => [
-            "test/generate_buildtest.pl",
-            "ct"
         ],
         "test/buildtest_decoder.c" => [
             "test/generate_buildtest.pl",
@@ -16168,10 +15960,6 @@ our %unified_info = (
             "test/generate_buildtest.pl",
             "engine"
         ],
-        "test/buildtest_ess.c" => [
-            "test/generate_buildtest.pl",
-            "ess"
-        ],
         "test/buildtest_evp.c" => [
             "test/generate_buildtest.pl",
             "evp"
@@ -16179,10 +15967,6 @@ our %unified_info = (
         "test/buildtest_fips_names.c" => [
             "test/generate_buildtest.pl",
             "fips_names"
-        ],
-        "test/buildtest_fipskey.c" => [
-            "test/generate_buildtest.pl",
-            "fipskey"
         ],
         "test/buildtest_hmac.c" => [
             "test/generate_buildtest.pl",
@@ -16199,10 +15983,6 @@ our %unified_info = (
         "test/buildtest_kdf.c" => [
             "test/generate_buildtest.pl",
             "kdf"
-        ],
-        "test/buildtest_lhash.c" => [
-            "test/generate_buildtest.pl",
-            "lhash"
         ],
         "test/buildtest_macros.c" => [
             "test/generate_buildtest.pl",
@@ -16232,14 +16012,6 @@ our %unified_info = (
             "test/generate_buildtest.pl",
             "objects"
         ],
-        "test/buildtest_ocsp.c" => [
-            "test/generate_buildtest.pl",
-            "ocsp"
-        ],
-        "test/buildtest_opensslv.c" => [
-            "test/generate_buildtest.pl",
-            "opensslv"
-        ],
         "test/buildtest_ossl_typ.c" => [
             "test/generate_buildtest.pl",
             "ossl_typ"
@@ -16259,14 +16031,6 @@ our %unified_info = (
         "test/buildtest_pem2.c" => [
             "test/generate_buildtest.pl",
             "pem2"
-        ],
-        "test/buildtest_pkcs12.c" => [
-            "test/generate_buildtest.pl",
-            "pkcs12"
-        ],
-        "test/buildtest_pkcs7.c" => [
-            "test/generate_buildtest.pl",
-            "pkcs7"
         ],
         "test/buildtest_prov_ssl.c" => [
             "test/generate_buildtest.pl",
@@ -16300,10 +16064,6 @@ our %unified_info = (
             "test/generate_buildtest.pl",
             "rsa"
         ],
-        "test/buildtest_safestack.c" => [
-            "test/generate_buildtest.pl",
-            "safestack"
-        ],
         "test/buildtest_seed.c" => [
             "test/generate_buildtest.pl",
             "seed"
@@ -16316,17 +16076,9 @@ our %unified_info = (
             "test/generate_buildtest.pl",
             "sha"
         ],
-        "test/buildtest_srp.c" => [
-            "test/generate_buildtest.pl",
-            "srp"
-        ],
         "test/buildtest_srtp.c" => [
             "test/generate_buildtest.pl",
             "srtp"
-        ],
-        "test/buildtest_ssl.c" => [
-            "test/generate_buildtest.pl",
-            "ssl"
         ],
         "test/buildtest_ssl2.c" => [
             "test/generate_buildtest.pl",
@@ -16364,25 +16116,9 @@ our %unified_info = (
             "test/generate_buildtest.pl",
             "types"
         ],
-        "test/buildtest_ui.c" => [
-            "test/generate_buildtest.pl",
-            "ui"
-        ],
         "test/buildtest_whrlpool.c" => [
             "test/generate_buildtest.pl",
             "whrlpool"
-        ],
-        "test/buildtest_x509.c" => [
-            "test/generate_buildtest.pl",
-            "x509"
-        ],
-        "test/buildtest_x509_vfy.c" => [
-            "test/generate_buildtest.pl",
-            "x509_vfy"
-        ],
-        "test/buildtest_x509v3.c" => [
-            "test/generate_buildtest.pl",
-            "x509v3"
         ],
         "test/p_test.ld" => [
             "util/providers.num"
@@ -18366,16 +18102,7 @@ our %unified_info = (
         "test/buildtest_c_aes" => [
             "include"
         ],
-        "test/buildtest_c_asn1" => [
-            "include"
-        ],
-        "test/buildtest_c_asn1t" => [
-            "include"
-        ],
         "test/buildtest_c_async" => [
-            "include"
-        ],
-        "test/buildtest_c_bio" => [
             "include"
         ],
         "test/buildtest_c_blowfish" => [
@@ -18396,22 +18123,10 @@ our %unified_info = (
         "test/buildtest_c_cmac" => [
             "include"
         ],
-        "test/buildtest_c_cmp" => [
-            "include"
-        ],
         "test/buildtest_c_cmp_util" => [
             "include"
         ],
-        "test/buildtest_c_cms" => [
-            "include"
-        ],
-        "test/buildtest_c_conf" => [
-            "include"
-        ],
         "test/buildtest_c_conf_api" => [
-            "include"
-        ],
-        "test/buildtest_c_configuration" => [
             "include"
         ],
         "test/buildtest_c_conftypes" => [
@@ -18429,16 +18144,7 @@ our %unified_info = (
         "test/buildtest_c_core_object" => [
             "include"
         ],
-        "test/buildtest_c_crmf" => [
-            "include"
-        ],
-        "test/buildtest_c_crypto" => [
-            "include"
-        ],
         "test/buildtest_c_cryptoerr_legacy" => [
-            "include"
-        ],
-        "test/buildtest_c_ct" => [
             "include"
         ],
         "test/buildtest_c_decoder" => [
@@ -18477,16 +18183,10 @@ our %unified_info = (
         "test/buildtest_c_engine" => [
             "include"
         ],
-        "test/buildtest_c_ess" => [
-            "include"
-        ],
         "test/buildtest_c_evp" => [
             "include"
         ],
         "test/buildtest_c_fips_names" => [
-            "include"
-        ],
-        "test/buildtest_c_fipskey" => [
             "include"
         ],
         "test/buildtest_c_hmac" => [
@@ -18499,9 +18199,6 @@ our %unified_info = (
             "include"
         ],
         "test/buildtest_c_kdf" => [
-            "include"
-        ],
-        "test/buildtest_c_lhash" => [
             "include"
         ],
         "test/buildtest_c_macros" => [
@@ -18525,12 +18222,6 @@ our %unified_info = (
         "test/buildtest_c_objects" => [
             "include"
         ],
-        "test/buildtest_c_ocsp" => [
-            "include"
-        ],
-        "test/buildtest_c_opensslv" => [
-            "include"
-        ],
         "test/buildtest_c_ossl_typ" => [
             "include"
         ],
@@ -18544,12 +18235,6 @@ our %unified_info = (
             "include"
         ],
         "test/buildtest_c_pem2" => [
-            "include"
-        ],
-        "test/buildtest_c_pkcs12" => [
-            "include"
-        ],
-        "test/buildtest_c_pkcs7" => [
             "include"
         ],
         "test/buildtest_c_prov_ssl" => [
@@ -18576,9 +18261,6 @@ our %unified_info = (
         "test/buildtest_c_rsa" => [
             "include"
         ],
-        "test/buildtest_c_safestack" => [
-            "include"
-        ],
         "test/buildtest_c_seed" => [
             "include"
         ],
@@ -18588,13 +18270,7 @@ our %unified_info = (
         "test/buildtest_c_sha" => [
             "include"
         ],
-        "test/buildtest_c_srp" => [
-            "include"
-        ],
         "test/buildtest_c_srtp" => [
-            "include"
-        ],
-        "test/buildtest_c_ssl" => [
             "include"
         ],
         "test/buildtest_c_ssl2" => [
@@ -18624,19 +18300,7 @@ our %unified_info = (
         "test/buildtest_c_types" => [
             "include"
         ],
-        "test/buildtest_c_ui" => [
-            "include"
-        ],
         "test/buildtest_c_whrlpool" => [
-            "include"
-        ],
-        "test/buildtest_c_x509" => [
-            "include"
-        ],
-        "test/buildtest_c_x509_vfy" => [
-            "include"
-        ],
-        "test/buildtest_c_x509v3" => [
             "include"
         ],
         "test/casttest" => [
@@ -20243,31 +19907,21 @@ our %unified_info = (
         "test/bn_internal_test",
         "test/bntest",
         "test/buildtest_c_aes",
-        "test/buildtest_c_asn1",
-        "test/buildtest_c_asn1t",
         "test/buildtest_c_async",
-        "test/buildtest_c_bio",
         "test/buildtest_c_blowfish",
         "test/buildtest_c_bn",
         "test/buildtest_c_buffer",
         "test/buildtest_c_camellia",
         "test/buildtest_c_cast",
         "test/buildtest_c_cmac",
-        "test/buildtest_c_cmp",
         "test/buildtest_c_cmp_util",
-        "test/buildtest_c_cms",
-        "test/buildtest_c_conf",
         "test/buildtest_c_conf_api",
-        "test/buildtest_c_configuration",
         "test/buildtest_c_conftypes",
         "test/buildtest_c_core",
         "test/buildtest_c_core_dispatch",
         "test/buildtest_c_core_names",
         "test/buildtest_c_core_object",
-        "test/buildtest_c_crmf",
-        "test/buildtest_c_crypto",
         "test/buildtest_c_cryptoerr_legacy",
-        "test/buildtest_c_ct",
         "test/buildtest_c_decoder",
         "test/buildtest_c_des",
         "test/buildtest_c_dh",
@@ -20280,15 +19934,12 @@ our %unified_info = (
         "test/buildtest_c_ecdsa",
         "test/buildtest_c_encoder",
         "test/buildtest_c_engine",
-        "test/buildtest_c_ess",
         "test/buildtest_c_evp",
         "test/buildtest_c_fips_names",
-        "test/buildtest_c_fipskey",
         "test/buildtest_c_hmac",
         "test/buildtest_c_http",
         "test/buildtest_c_idea",
         "test/buildtest_c_kdf",
-        "test/buildtest_c_lhash",
         "test/buildtest_c_macros",
         "test/buildtest_c_md4",
         "test/buildtest_c_md5",
@@ -20296,15 +19947,11 @@ our %unified_info = (
         "test/buildtest_c_modes",
         "test/buildtest_c_obj_mac",
         "test/buildtest_c_objects",
-        "test/buildtest_c_ocsp",
-        "test/buildtest_c_opensslv",
         "test/buildtest_c_ossl_typ",
         "test/buildtest_c_param_build",
         "test/buildtest_c_params",
         "test/buildtest_c_pem",
         "test/buildtest_c_pem2",
-        "test/buildtest_c_pkcs12",
-        "test/buildtest_c_pkcs7",
         "test/buildtest_c_prov_ssl",
         "test/buildtest_c_provider",
         "test/buildtest_c_quic",
@@ -20313,13 +19960,10 @@ our %unified_info = (
         "test/buildtest_c_rc4",
         "test/buildtest_c_ripemd",
         "test/buildtest_c_rsa",
-        "test/buildtest_c_safestack",
         "test/buildtest_c_seed",
         "test/buildtest_c_self_test",
         "test/buildtest_c_sha",
-        "test/buildtest_c_srp",
         "test/buildtest_c_srtp",
-        "test/buildtest_c_ssl",
         "test/buildtest_c_ssl2",
         "test/buildtest_c_sslerr_legacy",
         "test/buildtest_c_stack",
@@ -20329,11 +19973,7 @@ our %unified_info = (
         "test/buildtest_c_ts",
         "test/buildtest_c_txt_db",
         "test/buildtest_c_types",
-        "test/buildtest_c_ui",
         "test/buildtest_c_whrlpool",
-        "test/buildtest_c_x509",
-        "test/buildtest_c_x509_vfy",
-        "test/buildtest_c_x509v3",
         "test/casttest",
         "test/chacha_internal_test",
         "test/cipher_overhead_test",
@@ -26132,29 +25772,11 @@ our %unified_info = (
         "test/buildtest_c_aes-bin-buildtest_aes.o" => [
             "test/buildtest_aes.c"
         ],
-        "test/buildtest_c_asn1" => [
-            "test/buildtest_c_asn1-bin-buildtest_asn1.o"
-        ],
-        "test/buildtest_c_asn1-bin-buildtest_asn1.o" => [
-            "test/buildtest_asn1.c"
-        ],
-        "test/buildtest_c_asn1t" => [
-            "test/buildtest_c_asn1t-bin-buildtest_asn1t.o"
-        ],
-        "test/buildtest_c_asn1t-bin-buildtest_asn1t.o" => [
-            "test/buildtest_asn1t.c"
-        ],
         "test/buildtest_c_async" => [
             "test/buildtest_c_async-bin-buildtest_async.o"
         ],
         "test/buildtest_c_async-bin-buildtest_async.o" => [
             "test/buildtest_async.c"
-        ],
-        "test/buildtest_c_bio" => [
-            "test/buildtest_c_bio-bin-buildtest_bio.o"
-        ],
-        "test/buildtest_c_bio-bin-buildtest_bio.o" => [
-            "test/buildtest_bio.c"
         ],
         "test/buildtest_c_blowfish" => [
             "test/buildtest_c_blowfish-bin-buildtest_blowfish.o"
@@ -26192,41 +25814,17 @@ our %unified_info = (
         "test/buildtest_c_cmac-bin-buildtest_cmac.o" => [
             "test/buildtest_cmac.c"
         ],
-        "test/buildtest_c_cmp" => [
-            "test/buildtest_c_cmp-bin-buildtest_cmp.o"
-        ],
-        "test/buildtest_c_cmp-bin-buildtest_cmp.o" => [
-            "test/buildtest_cmp.c"
-        ],
         "test/buildtest_c_cmp_util" => [
             "test/buildtest_c_cmp_util-bin-buildtest_cmp_util.o"
         ],
         "test/buildtest_c_cmp_util-bin-buildtest_cmp_util.o" => [
             "test/buildtest_cmp_util.c"
         ],
-        "test/buildtest_c_cms" => [
-            "test/buildtest_c_cms-bin-buildtest_cms.o"
-        ],
-        "test/buildtest_c_cms-bin-buildtest_cms.o" => [
-            "test/buildtest_cms.c"
-        ],
-        "test/buildtest_c_conf" => [
-            "test/buildtest_c_conf-bin-buildtest_conf.o"
-        ],
-        "test/buildtest_c_conf-bin-buildtest_conf.o" => [
-            "test/buildtest_conf.c"
-        ],
         "test/buildtest_c_conf_api" => [
             "test/buildtest_c_conf_api-bin-buildtest_conf_api.o"
         ],
         "test/buildtest_c_conf_api-bin-buildtest_conf_api.o" => [
             "test/buildtest_conf_api.c"
-        ],
-        "test/buildtest_c_configuration" => [
-            "test/buildtest_c_configuration-bin-buildtest_configuration.o"
-        ],
-        "test/buildtest_c_configuration-bin-buildtest_configuration.o" => [
-            "test/buildtest_configuration.c"
         ],
         "test/buildtest_c_conftypes" => [
             "test/buildtest_c_conftypes-bin-buildtest_conftypes.o"
@@ -26258,29 +25856,11 @@ our %unified_info = (
         "test/buildtest_c_core_object-bin-buildtest_core_object.o" => [
             "test/buildtest_core_object.c"
         ],
-        "test/buildtest_c_crmf" => [
-            "test/buildtest_c_crmf-bin-buildtest_crmf.o"
-        ],
-        "test/buildtest_c_crmf-bin-buildtest_crmf.o" => [
-            "test/buildtest_crmf.c"
-        ],
-        "test/buildtest_c_crypto" => [
-            "test/buildtest_c_crypto-bin-buildtest_crypto.o"
-        ],
-        "test/buildtest_c_crypto-bin-buildtest_crypto.o" => [
-            "test/buildtest_crypto.c"
-        ],
         "test/buildtest_c_cryptoerr_legacy" => [
             "test/buildtest_c_cryptoerr_legacy-bin-buildtest_cryptoerr_legacy.o"
         ],
         "test/buildtest_c_cryptoerr_legacy-bin-buildtest_cryptoerr_legacy.o" => [
             "test/buildtest_cryptoerr_legacy.c"
-        ],
-        "test/buildtest_c_ct" => [
-            "test/buildtest_c_ct-bin-buildtest_ct.o"
-        ],
-        "test/buildtest_c_ct-bin-buildtest_ct.o" => [
-            "test/buildtest_ct.c"
         ],
         "test/buildtest_c_decoder" => [
             "test/buildtest_c_decoder-bin-buildtest_decoder.o"
@@ -26354,12 +25934,6 @@ our %unified_info = (
         "test/buildtest_c_engine-bin-buildtest_engine.o" => [
             "test/buildtest_engine.c"
         ],
-        "test/buildtest_c_ess" => [
-            "test/buildtest_c_ess-bin-buildtest_ess.o"
-        ],
-        "test/buildtest_c_ess-bin-buildtest_ess.o" => [
-            "test/buildtest_ess.c"
-        ],
         "test/buildtest_c_evp" => [
             "test/buildtest_c_evp-bin-buildtest_evp.o"
         ],
@@ -26371,12 +25945,6 @@ our %unified_info = (
         ],
         "test/buildtest_c_fips_names-bin-buildtest_fips_names.o" => [
             "test/buildtest_fips_names.c"
-        ],
-        "test/buildtest_c_fipskey" => [
-            "test/buildtest_c_fipskey-bin-buildtest_fipskey.o"
-        ],
-        "test/buildtest_c_fipskey-bin-buildtest_fipskey.o" => [
-            "test/buildtest_fipskey.c"
         ],
         "test/buildtest_c_hmac" => [
             "test/buildtest_c_hmac-bin-buildtest_hmac.o"
@@ -26401,12 +25969,6 @@ our %unified_info = (
         ],
         "test/buildtest_c_kdf-bin-buildtest_kdf.o" => [
             "test/buildtest_kdf.c"
-        ],
-        "test/buildtest_c_lhash" => [
-            "test/buildtest_c_lhash-bin-buildtest_lhash.o"
-        ],
-        "test/buildtest_c_lhash-bin-buildtest_lhash.o" => [
-            "test/buildtest_lhash.c"
         ],
         "test/buildtest_c_macros" => [
             "test/buildtest_c_macros-bin-buildtest_macros.o"
@@ -26450,18 +26012,6 @@ our %unified_info = (
         "test/buildtest_c_objects-bin-buildtest_objects.o" => [
             "test/buildtest_objects.c"
         ],
-        "test/buildtest_c_ocsp" => [
-            "test/buildtest_c_ocsp-bin-buildtest_ocsp.o"
-        ],
-        "test/buildtest_c_ocsp-bin-buildtest_ocsp.o" => [
-            "test/buildtest_ocsp.c"
-        ],
-        "test/buildtest_c_opensslv" => [
-            "test/buildtest_c_opensslv-bin-buildtest_opensslv.o"
-        ],
-        "test/buildtest_c_opensslv-bin-buildtest_opensslv.o" => [
-            "test/buildtest_opensslv.c"
-        ],
         "test/buildtest_c_ossl_typ" => [
             "test/buildtest_c_ossl_typ-bin-buildtest_ossl_typ.o"
         ],
@@ -26491,18 +26041,6 @@ our %unified_info = (
         ],
         "test/buildtest_c_pem2-bin-buildtest_pem2.o" => [
             "test/buildtest_pem2.c"
-        ],
-        "test/buildtest_c_pkcs12" => [
-            "test/buildtest_c_pkcs12-bin-buildtest_pkcs12.o"
-        ],
-        "test/buildtest_c_pkcs12-bin-buildtest_pkcs12.o" => [
-            "test/buildtest_pkcs12.c"
-        ],
-        "test/buildtest_c_pkcs7" => [
-            "test/buildtest_c_pkcs7-bin-buildtest_pkcs7.o"
-        ],
-        "test/buildtest_c_pkcs7-bin-buildtest_pkcs7.o" => [
-            "test/buildtest_pkcs7.c"
         ],
         "test/buildtest_c_prov_ssl" => [
             "test/buildtest_c_prov_ssl-bin-buildtest_prov_ssl.o"
@@ -26552,12 +26090,6 @@ our %unified_info = (
         "test/buildtest_c_rsa-bin-buildtest_rsa.o" => [
             "test/buildtest_rsa.c"
         ],
-        "test/buildtest_c_safestack" => [
-            "test/buildtest_c_safestack-bin-buildtest_safestack.o"
-        ],
-        "test/buildtest_c_safestack-bin-buildtest_safestack.o" => [
-            "test/buildtest_safestack.c"
-        ],
         "test/buildtest_c_seed" => [
             "test/buildtest_c_seed-bin-buildtest_seed.o"
         ],
@@ -26576,23 +26108,11 @@ our %unified_info = (
         "test/buildtest_c_sha-bin-buildtest_sha.o" => [
             "test/buildtest_sha.c"
         ],
-        "test/buildtest_c_srp" => [
-            "test/buildtest_c_srp-bin-buildtest_srp.o"
-        ],
-        "test/buildtest_c_srp-bin-buildtest_srp.o" => [
-            "test/buildtest_srp.c"
-        ],
         "test/buildtest_c_srtp" => [
             "test/buildtest_c_srtp-bin-buildtest_srtp.o"
         ],
         "test/buildtest_c_srtp-bin-buildtest_srtp.o" => [
             "test/buildtest_srtp.c"
-        ],
-        "test/buildtest_c_ssl" => [
-            "test/buildtest_c_ssl-bin-buildtest_ssl.o"
-        ],
-        "test/buildtest_c_ssl-bin-buildtest_ssl.o" => [
-            "test/buildtest_ssl.c"
         ],
         "test/buildtest_c_ssl2" => [
             "test/buildtest_c_ssl2-bin-buildtest_ssl2.o"
@@ -26648,35 +26168,11 @@ our %unified_info = (
         "test/buildtest_c_types-bin-buildtest_types.o" => [
             "test/buildtest_types.c"
         ],
-        "test/buildtest_c_ui" => [
-            "test/buildtest_c_ui-bin-buildtest_ui.o"
-        ],
-        "test/buildtest_c_ui-bin-buildtest_ui.o" => [
-            "test/buildtest_ui.c"
-        ],
         "test/buildtest_c_whrlpool" => [
             "test/buildtest_c_whrlpool-bin-buildtest_whrlpool.o"
         ],
         "test/buildtest_c_whrlpool-bin-buildtest_whrlpool.o" => [
             "test/buildtest_whrlpool.c"
-        ],
-        "test/buildtest_c_x509" => [
-            "test/buildtest_c_x509-bin-buildtest_x509.o"
-        ],
-        "test/buildtest_c_x509-bin-buildtest_x509.o" => [
-            "test/buildtest_x509.c"
-        ],
-        "test/buildtest_c_x509_vfy" => [
-            "test/buildtest_c_x509_vfy-bin-buildtest_x509_vfy.o"
-        ],
-        "test/buildtest_c_x509_vfy-bin-buildtest_x509_vfy.o" => [
-            "test/buildtest_x509_vfy.c"
-        ],
-        "test/buildtest_c_x509v3" => [
-            "test/buildtest_c_x509v3-bin-buildtest_x509v3.o"
-        ],
-        "test/buildtest_c_x509v3-bin-buildtest_x509v3.o" => [
-            "test/buildtest_x509v3.c"
         ],
         "test/casttest" => [
             "test/casttest-bin-casttest.o"
@@ -27907,8 +27403,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27935,7 +27431,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27952,8 +27448,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/aix64-gcc-as/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/aix64-gcc-as/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: aix64-gcc-as"
-#define DATE "built on: Mon May  9 17:35:30 2022 UTC"
+#define DATE "built on: Mon May 16 03:43:59 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/aix64-gcc-as/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/aix64-gcc-as/asm_avx2/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -9757,10 +9757,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27403,8 +27403,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27431,7 +27431,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27448,8 +27448,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/aix64-gcc-as/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/aix64-gcc-as/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: aix64-gcc-as"
-#define DATE "built on: Mon May  9 17:35:39 2022 UTC"
+#define DATE "built on: Mon May 16 03:44:14 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/aix64-gcc-as/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/aix64-gcc-as/no-asm/configdata.pm
@@ -206,9 +206,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -9680,10 +9680,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27157,8 +27157,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27185,7 +27185,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27202,8 +27202,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/aix64-gcc-as/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/aix64-gcc-as/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: aix64-gcc-as"
-#define DATE "built on: Mon May  9 17:35:48 2022 UTC"
+#define DATE "built on: Mon May 16 03:44:29 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin-i386-cc/asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin-i386-cc/asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27302,8 +27302,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27330,7 +27330,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27347,8 +27347,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/darwin-i386-cc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin-i386-cc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin-i386-cc"
-#define DATE "built on: Mon May  9 17:37:27 2022 UTC"
+#define DATE "built on: Mon May 16 03:47:06 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin-i386-cc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/darwin-i386-cc/asm_avx2/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27302,8 +27302,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27330,7 +27330,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27347,8 +27347,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/darwin-i386-cc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin-i386-cc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin-i386-cc"
-#define DATE "built on: Mon May  9 17:37:36 2022 UTC"
+#define DATE "built on: Mon May 16 03:47:21 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin-i386-cc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin-i386-cc/no-asm/configdata.pm
@@ -206,9 +206,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -7976,6 +7976,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -7993,10 +7996,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-opt.o"
             ],
             "products" => {
                 "bin" => [
@@ -27118,8 +27118,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27146,7 +27146,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27163,8 +27163,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/darwin-i386-cc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin-i386-cc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin-i386-cc"
-#define DATE "built on: Mon May  9 17:37:45 2022 UTC"
+#define DATE "built on: Mon May 16 03:47:36 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-arm64-cc/asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27327,8 +27327,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27355,7 +27355,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27372,8 +27372,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/darwin64-arm64-cc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-arm64-cc"
-#define DATE "built on: Mon May  9 17:37:53 2022 UTC"
+#define DATE "built on: Mon May 16 03:47:49 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-arm64-cc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/asm_avx2/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8005,9 +8005,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8025,7 +8022,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -9722,10 +9722,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27327,8 +27327,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27355,7 +27355,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27372,8 +27372,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/darwin64-arm64-cc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-arm64-cc"
-#define DATE "built on: Mon May  9 17:38:02 2022 UTC"
+#define DATE "built on: Mon May 16 03:48:03 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-arm64-cc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/no-asm/configdata.pm
@@ -206,9 +206,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27118,8 +27118,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27146,7 +27146,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27163,8 +27163,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/darwin64-arm64-cc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-arm64-cc"
-#define DATE "built on: Mon May  9 17:38:11 2022 UTC"
+#define DATE "built on: Mon May 16 03:48:17 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8035,9 +8035,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8055,7 +8052,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -27470,8 +27470,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27498,7 +27498,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27515,8 +27515,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-x86_64-cc"
-#define DATE "built on: Mon May  9 17:36:56 2022 UTC"
+#define DATE "built on: Mon May 16 03:46:16 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/asm_avx2/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8035,6 +8035,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8052,10 +8055,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-opt.o"
             ],
             "products" => {
                 "bin" => [
@@ -27470,8 +27470,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27498,7 +27498,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27515,8 +27515,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-x86_64-cc"
-#define DATE "built on: Mon May  9 17:37:08 2022 UTC"
+#define DATE "built on: Mon May 16 03:46:35 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/no-asm/configdata.pm
@@ -206,9 +206,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -9669,10 +9669,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27118,8 +27118,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27146,7 +27146,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27163,8 +27163,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-x86_64-cc"
-#define DATE "built on: Mon May  9 17:37:19 2022 UTC"
+#define DATE "built on: Mon May 16 03:46:53 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-aarch64/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-aarch64/asm/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8020,9 +8020,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8040,7 +8037,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -9738,10 +9738,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27371,8 +27371,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27399,7 +27399,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27416,8 +27416,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-aarch64/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-aarch64/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-aarch64"
-#define DATE "built on: Mon May  9 17:38:18 2022 UTC"
+#define DATE "built on: Mon May 16 03:48:30 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-aarch64/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-aarch64/asm_avx2/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27371,8 +27371,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27399,7 +27399,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27416,8 +27416,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-aarch64/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-aarch64/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-aarch64"
-#define DATE "built on: Mon May  9 17:38:27 2022 UTC"
+#define DATE "built on: Mon May 16 03:48:45 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-aarch64/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-aarch64/no-asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -7991,6 +7991,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8008,10 +8011,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-opt.o"
             ],
             "products" => {
                 "bin" => [
@@ -27162,8 +27162,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27190,7 +27190,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27207,8 +27207,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-aarch64/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-aarch64/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-aarch64"
-#define DATE "built on: Mon May  9 17:38:36 2022 UTC"
+#define DATE "built on: Mon May 16 03:49:00 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-armv4/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-armv4/asm/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -9750,10 +9750,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27422,8 +27422,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27450,7 +27450,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27467,8 +27467,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-armv4/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-armv4/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-armv4"
-#define DATE "built on: Mon May  9 17:38:44 2022 UTC"
+#define DATE "built on: Mon May 16 03:49:13 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-armv4/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-armv4/asm_avx2/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8029,9 +8029,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8049,7 +8046,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -27422,8 +27422,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27450,7 +27450,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27467,8 +27467,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-armv4/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-armv4/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-armv4"
-#define DATE "built on: Mon May  9 17:38:53 2022 UTC"
+#define DATE "built on: Mon May 16 03:49:28 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-armv4/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-armv4/no-asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -7991,6 +7991,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8008,10 +8011,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-opt.o"
             ],
             "products" => {
                 "bin" => [
@@ -9685,10 +9685,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27162,8 +27162,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27190,7 +27190,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27207,8 +27207,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-armv4/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-armv4/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-armv4"
-#define DATE "built on: Mon May  9 17:39:02 2022 UTC"
+#define DATE "built on: Mon May 16 03:49:42 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-elf/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-elf/asm/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8047,6 +8047,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8064,10 +8067,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-opt.o"
             ],
             "products" => {
                 "bin" => [
@@ -9767,10 +9767,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27345,8 +27345,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27373,7 +27373,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27390,8 +27390,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-elf/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-elf/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-elf"
-#define DATE "built on: Mon May  9 17:39:10 2022 UTC"
+#define DATE "built on: Mon May 16 03:49:55 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-elf/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-elf/asm_avx2/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8047,9 +8047,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8067,7 +8064,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -27345,8 +27345,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27373,7 +27373,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27390,8 +27390,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-elf/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-elf/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-elf"
-#define DATE "built on: Mon May  9 17:39:20 2022 UTC"
+#define DATE "built on: Mon May 16 03:50:10 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-elf/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-elf/no-asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27161,8 +27161,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27189,7 +27189,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27206,8 +27206,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-elf/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-elf/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-elf"
-#define DATE "built on: Mon May  9 17:39:29 2022 UTC"
+#define DATE "built on: Mon May 16 03:50:25 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc64le/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc64le/asm/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27408,8 +27408,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27436,7 +27436,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27453,8 +27453,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-ppc64le/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc64le/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc64le"
-#define DATE "built on: Mon May  9 17:40:09 2022 UTC"
+#define DATE "built on: Mon May 16 03:51:30 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc64le/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc64le/asm_avx2/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8025,6 +8025,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8042,10 +8045,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-opt.o"
             ],
             "products" => {
                 "bin" => [
@@ -27408,8 +27408,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27436,7 +27436,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27453,8 +27453,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-ppc64le/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc64le/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc64le"
-#define DATE "built on: Mon May  9 17:40:18 2022 UTC"
+#define DATE "built on: Mon May 16 03:51:44 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc64le/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc64le/no-asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -7991,9 +7991,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8011,7 +8008,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -9685,10 +9685,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27162,8 +27162,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27190,7 +27190,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27207,8 +27207,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-ppc64le/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc64le/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc64le"
-#define DATE "built on: Mon May  9 17:40:27 2022 UTC"
+#define DATE "built on: Mon May 16 03:51:59 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-x86_64/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-x86_64/asm/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8051,9 +8051,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8071,7 +8068,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -9813,10 +9813,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27515,8 +27515,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27543,7 +27543,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27560,8 +27560,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-x86_64/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-x86_64/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-x86_64"
-#define DATE "built on: Mon May  9 17:39:37 2022 UTC"
+#define DATE "built on: Mon May 16 03:50:39 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-x86_64/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-x86_64/asm_avx2/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8051,9 +8051,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8071,7 +8068,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -9813,10 +9813,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27515,8 +27515,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27543,7 +27543,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27560,8 +27560,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-x86_64/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-x86_64/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-x86_64"
-#define DATE "built on: Mon May  9 17:39:49 2022 UTC"
+#define DATE "built on: Mon May 16 03:50:59 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-x86_64/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-x86_64/no-asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27163,8 +27163,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27191,7 +27191,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27208,8 +27208,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux-x86_64/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-x86_64/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-x86_64"
-#define DATE "built on: Mon May  9 17:40:01 2022 UTC"
+#define DATE "built on: Mon May 16 03:51:17 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux32-s390x/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux32-s390x/asm/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27344,8 +27344,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27372,7 +27372,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27389,8 +27389,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux32-s390x/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux32-s390x/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux32-s390x"
-#define DATE "built on: Mon May  9 17:40:35 2022 UTC"
+#define DATE "built on: Mon May 16 03:52:12 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux32-s390x/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux32-s390x/asm_avx2/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8032,6 +8032,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8049,10 +8052,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-opt.o"
             ],
             "products" => {
                 "bin" => [
@@ -27344,8 +27344,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27372,7 +27372,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27389,8 +27389,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux32-s390x/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux32-s390x/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux32-s390x"
-#define DATE "built on: Mon May  9 17:40:44 2022 UTC"
+#define DATE "built on: Mon May 16 03:52:27 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux32-s390x/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux32-s390x/no-asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -9685,10 +9685,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27162,8 +27162,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27190,7 +27190,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27207,8 +27207,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux32-s390x/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux32-s390x/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux32-s390x"
-#define DATE "built on: Mon May  9 17:40:53 2022 UTC"
+#define DATE "built on: Mon May 16 03:52:42 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-mips64/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux64-mips64/asm/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8013,9 +8013,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8033,7 +8030,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -9717,10 +9717,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27276,8 +27276,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27304,7 +27304,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27321,8 +27321,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux64-mips64/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-mips64/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-mips64"
-#define DATE "built on: Mon May  9 17:41:27 2022 UTC"
+#define DATE "built on: Mon May 16 03:53:41 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-mips64/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux64-mips64/asm_avx2/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27276,8 +27276,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27304,7 +27304,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27321,8 +27321,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux64-mips64/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-mips64/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-mips64"
-#define DATE "built on: Mon May  9 17:41:35 2022 UTC"
+#define DATE "built on: Mon May 16 03:53:57 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-mips64/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux64-mips64/no-asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -9686,10 +9686,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27163,8 +27163,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27191,7 +27191,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27208,8 +27208,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux64-mips64/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-mips64/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-mips64"
-#define DATE "built on: Mon May  9 17:41:43 2022 UTC"
+#define DATE "built on: Mon May 16 03:54:12 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-riscv64/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux64-riscv64/no-asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27161,8 +27161,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27189,7 +27189,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27206,8 +27206,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux64-riscv64/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-riscv64/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-riscv64"
-#define DATE "built on: Mon May  9 17:43:51 2022 UTC"
+#define DATE "built on: Mon May 16 03:57:47 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-s390x/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux64-s390x/asm/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -9756,10 +9756,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27356,8 +27356,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27384,7 +27384,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27401,8 +27401,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux64-s390x/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-s390x/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-s390x"
-#define DATE "built on: Mon May  9 17:41:01 2022 UTC"
+#define DATE "built on: Mon May 16 03:52:57 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-s390x/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux64-s390x/asm_avx2/configdata.pm
@@ -208,9 +208,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27356,8 +27356,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27384,7 +27384,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27401,8 +27401,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux64-s390x/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-s390x/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-s390x"
-#define DATE "built on: Mon May  9 17:41:10 2022 UTC"
+#define DATE "built on: Mon May 16 03:53:12 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-s390x/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux64-s390x/no-asm/configdata.pm
@@ -207,9 +207,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -7992,9 +7992,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8012,7 +8009,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -9686,10 +9686,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27163,8 +27163,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27191,7 +27191,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27208,8 +27208,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/linux64-s390x/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-s390x/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-s390x"
-#define DATE "built on: Mon May  9 17:41:19 2022 UTC"
+#define DATE "built on: Mon May 16 03:53:27 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris-x86-gcc/asm/configdata.pm
+++ b/deps/openssl/config/archs/solaris-x86-gcc/asm/configdata.pm
@@ -205,9 +205,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8040,6 +8040,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8057,10 +8060,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-opt.o"
             ],
             "products" => {
                 "bin" => [
@@ -9760,10 +9760,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27338,8 +27338,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27366,7 +27366,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27383,8 +27383,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/solaris-x86-gcc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris-x86-gcc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris-x86-gcc"
-#define DATE "built on: Mon May  9 17:41:51 2022 UTC"
+#define DATE "built on: Mon May 16 03:54:25 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris-x86-gcc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/solaris-x86-gcc/asm_avx2/configdata.pm
@@ -205,9 +205,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -8040,6 +8040,9 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8057,10 +8060,7 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o",
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o"
+                "apps/lib/libtestutil-lib-opt.o"
             ],
             "products" => {
                 "bin" => [
@@ -9760,10 +9760,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27338,8 +27338,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27366,7 +27366,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27383,8 +27383,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/solaris-x86-gcc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris-x86-gcc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris-x86-gcc"
-#define DATE "built on: Mon May  9 17:42:01 2022 UTC"
+#define DATE "built on: Mon May 16 03:54:41 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris-x86-gcc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/solaris-x86-gcc/no-asm/configdata.pm
@@ -204,9 +204,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -27154,8 +27154,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27182,7 +27182,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27199,8 +27199,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/solaris-x86-gcc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris-x86-gcc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris-x86-gcc"
-#define DATE "built on: Mon May  9 17:42:10 2022 UTC"
+#define DATE "built on: Mon May 16 03:54:56 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/asm/configdata.pm
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/asm/configdata.pm
@@ -205,9 +205,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -9805,10 +9805,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
+                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o",
-                "providers/fips/fips-dso-fips_entry.o"
+                "providers/fips/libfips-lib-self_test_kats.o"
             ],
             "products" => {
                 "dso" => [
@@ -27507,8 +27507,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27535,7 +27535,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27552,8 +27552,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris64-x86_64-gcc"
-#define DATE "built on: Mon May  9 17:42:18 2022 UTC"
+#define DATE "built on: Mon May 16 03:55:10 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/asm_avx2/configdata.pm
@@ -205,9 +205,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -9805,10 +9805,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27507,8 +27507,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27535,7 +27535,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27552,8 +27552,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris64-x86_64-gcc"
-#define DATE "built on: Mon May  9 17:42:30 2022 UTC"
+#define DATE "built on: Mon May 16 03:55:29 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/no-asm/configdata.pm
@@ -204,9 +204,9 @@ our %config = (
     "openssldir" => "",
     "options" => "enable-ssl-trace enable-fips no-afalgeng no-asan no-asm no-buildtest-c++ no-comp no-crypto-mdebug no-crypto-mdebug-backtrace no-devcryptoeng no-dynamic-engine no-ec_nistp_64_gcc_128 no-egd no-external-tests no-fuzz-afl no-fuzz-libfuzzer no-ktls no-loadereng no-md2 no-msan no-rc5 no-sctp no-shared no-ssl3 no-ssl3-method no-trace no-ubsan no-unit-test no-uplink no-weak-ssl-ciphers no-zlib no-zlib-dynamic",
     "patch" => "3",
-    "perl_archname" => "x86_64-linux-gnu-thread-multi",
+    "perl_archname" => "x86_64-linux-thread-multi",
     "perl_cmd" => "/usr/bin/perl",
-    "perl_version" => "5.30.0",
+    "perl_version" => "5.34.1",
     "perlargv" => [
         "no-comp",
         "no-shared",
@@ -7984,9 +7984,6 @@ our %unified_info = (
         },
         "apps/lib" => {
             "deps" => [
-                "apps/lib/openssl-bin-cmp_mock_srv.o",
-                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
-                "apps/lib/uitest-bin-apps_ui.o",
                 "apps/lib/libapps-lib-app_libctx.o",
                 "apps/lib/libapps-lib-app_params.o",
                 "apps/lib/libapps-lib-app_provider.o",
@@ -8004,7 +8001,10 @@ our %unified_info = (
                 "apps/lib/libapps-lib-s_cb.o",
                 "apps/lib/libapps-lib-s_socket.o",
                 "apps/lib/libapps-lib-tlssrp_depr.o",
-                "apps/lib/libtestutil-lib-opt.o"
+                "apps/lib/libtestutil-lib-opt.o",
+                "apps/lib/openssl-bin-cmp_mock_srv.o",
+                "apps/lib/cmp_client_test-bin-cmp_mock_srv.o",
+                "apps/lib/uitest-bin-apps_ui.o"
             ],
             "products" => {
                 "bin" => [
@@ -9678,10 +9678,10 @@ our %unified_info = (
         },
         "providers/fips" => {
             "deps" => [
-                "providers/fips/fips-dso-fips_entry.o",
                 "providers/fips/libfips-lib-fipsprov.o",
                 "providers/fips/libfips-lib-self_test.o",
-                "providers/fips/libfips-lib-self_test_kats.o"
+                "providers/fips/libfips-lib-self_test_kats.o",
+                "providers/fips/fips-dso-fips_entry.o"
             ],
             "products" => {
                 "dso" => [
@@ -27155,8 +27155,8 @@ unless (caller) {
     use File::Copy;
     use Pod::Usage;
 
-    use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-    use OpenSSL::fallback '/home/rafaelgss/repos/os/node/deps/openssl/openssl/external/perl/MODULES.txt';
+    use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+    use OpenSSL::fallback '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/external/perl/MODULES.txt';
 
     my $here = dirname($0);
 
@@ -27183,7 +27183,7 @@ unless (caller) {
             );
 
         use lib '.';
-        use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+        use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
         use gentemplate;
 
         print 'Creating ',$buildfile_template,"\n";
@@ -27200,8 +27200,8 @@ unless (caller) {
 
         my $prepend = <<'_____';
 use File::Spec::Functions;
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/util/perl';
-use lib '/home/rafaelgss/repos/os/node/deps/openssl/openssl/Configurations';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/util/perl';
+use lib '/home/danielbevenius/work/nodejs/node/deps/openssl/openssl/Configurations';
 use lib '.';
 use platform;
 _____

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris64-x86_64-gcc"
-#define DATE "built on: Mon May  9 17:42:42 2022 UTC"
+#define DATE "built on: Mon May 16 03:55:50 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/generate_gypi.pl
+++ b/deps/openssl/config/generate_gypi.pl
@@ -102,7 +102,7 @@ copy("$src_dir/providers/common/include/prov/der_digests.h",
 
 my $linker_script_dir = "<(PRODUCT_DIR)/../../deps/openssl/config/archs/$arch/$asm/providers";
 my $fips_linker_script = "";
-if ($fips_ld ne "") {
+if ($fips_ld ne "" and not $is_win) {
   $fips_linker_script = "$linker_script_dir/fips.ld";
   copy("$src_dir/providers/fips.ld",
        "$base_dir/providers/fips.ld") or die "Copy failed: $!";
@@ -195,7 +195,7 @@ foreach my $obj (@{$unified_info{sources}->{'providers/liblegacy.a'}}) {
 }
 
 foreach my $obj (@{$unified_info{sources}->{'providers/legacy'}}) {
-  if ($obj eq 'providers/legacy.ld') {
+  if ($obj eq 'providers/legacy.ld' and not $is_win) {
     push(@generated_srcs, $obj);
   } else {
     my $src = ${$unified_info{sources}->{$obj}}[0];
@@ -238,7 +238,7 @@ foreach my $obj (@{$unified_info{sources}->{'providers/libcommon.a'}}) {
 }
 
 foreach my $obj (@{$unified_info{sources}->{'providers/fips'}}) {
-  if ($obj eq 'providers/fips.ld') {
+  if ($obj eq 'providers/fips.ld' and not $is_win) {
     push(@generated_srcs, $obj);
   } else {
     my $src = ${$unified_info{sources}->{$obj}}[0];


### PR DESCRIPTION
This commit ignore fips.ld and legacy.ld linker scripts for Windows
environments using msbuild.

Fixes: https://github.com/nodejs/node/issues/40854
