### PR TITLE
doc: use consistent method symbol

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2410,8 +2410,8 @@ changes:
     queued to be sent, and unacknowledged `PING` and `SETTINGS` frames are all
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
-    This is similar to [`http.Server.maxHeadersCount`][] or
-    [`http.ClientRequest.maxHeadersCount`][]. The minimum value is `4`.
+    This is similar to [`server.maxHeadersCount`][] or
+    [`request.maxHeadersCount`][] in the `http` module. The minimum value is `4`.
     **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.
@@ -2567,8 +2567,8 @@ changes:
     queued to be sent, and unacknowledged `PING` and `SETTINGS` frames are all
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
-    This is similar to [`http.Server.maxHeadersCount`][] or
-    [`http.ClientRequest.maxHeadersCount`][]. The minimum value is `4`.
+    This is similar to [`server.maxHeadersCount`][] or
+    [`request.maxHeadersCount`][] in the `http` module. The minimum value is `4`.
     **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.
@@ -2695,8 +2695,8 @@ changes:
     queued to be sent, and unacknowledged `PING` and `SETTINGS` frames are all
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
-    This is similar to [`http.Server.maxHeadersCount`][] or
-    [`http.ClientRequest.maxHeadersCount`][]. The minimum value is `1`.
+    This is similar to [`server.maxHeadersCount`][] or
+    [`request.maxHeadersCount`][] in the `http` module. The minimum value is `1`.
     **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.
@@ -4135,8 +4135,6 @@ you need to implement any fall-back behavior yourself.
 [`Http2Stream`]: #class-http2stream
 [`ServerHttp2Stream`]: #class-serverhttp2stream
 [`TypeError`]: errors.md#class-typeerror
-[`http.ClientRequest.maxHeadersCount`]: http.md#requestmaxheaderscount
-[`http.Server.maxHeadersCount`]: http.md#servermaxheaderscount
 [`http2.SecureServer`]: #class-http2secureserver
 [`http2.Server`]: #class-http2server
 [`http2.createSecureServer()`]: #http2createsecureserveroptions-onrequesthandler
@@ -4152,6 +4150,7 @@ you need to implement any fall-back behavior yourself.
 [`net.connect()`]: net.md#netconnect
 [`net.createServer()`]: net.md#netcreateserveroptions-connectionlistener
 [`request.authority`]: #requestauthority
+[`request.maxHeadersCount`]: http.md#requestmaxheaderscount
 [`request.socket.getPeerCertificate()`]: tls.md#tlssocketgetpeercertificatedetailed
 [`request.socket`]: #requestsocket
 [`response.end()`]: #responseenddata-encoding-callback
@@ -4162,6 +4161,7 @@ you need to implement any fall-back behavior yourself.
 [`response.write(data, encoding)`]: http.md#responsewritechunk-encoding-callback
 [`response.writeContinue()`]: #responsewritecontinue
 [`response.writeHead()`]: #responsewriteheadstatuscode-statusmessage-headers
+[`server.maxHeadersCount`]: http.md#servermaxheaderscount
 [`tls.Server.close()`]: tls.md#serverclosecallback
 [`tls.TLSSocket`]: tls.md#class-tlstlssocket
 [`tls.connect()`]: tls.md#tlsconnectoptions-callback

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2411,7 +2411,7 @@ changes:
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
     This is similar to [`server.maxHeadersCount`][] or
-    [`request.maxHeadersCount`][] in the `http` module. The minimum value is `4`.
+    [`request.maxHeadersCount`][] in the `node:http` module. The minimum value is `4`.
     **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.
@@ -2568,7 +2568,7 @@ changes:
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
     This is similar to [`server.maxHeadersCount`][] or
-    [`request.maxHeadersCount`][] in the `http` module. The minimum value is `4`.
+    [`request.maxHeadersCount`][] in the `node:http` module. The minimum value is `4`.
     **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.
@@ -2696,7 +2696,7 @@ changes:
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
     This is similar to [`server.maxHeadersCount`][] or
-    [`request.maxHeadersCount`][] in the `http` module. The minimum value is `1`.
+    [`request.maxHeadersCount`][] in the `node:http` module. The minimum value is `1`.
     **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2410,8 +2410,8 @@ changes:
     queued to be sent, and unacknowledged `PING` and `SETTINGS` frames are all
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
-    This is similar to [`http.Server#maxHeadersCount`][] or
-    [`http.ClientRequest#maxHeadersCount`][]. The minimum value is `4`.
+    This is similar to [`http.Server.maxHeadersCount`][] or
+    [`http.ClientRequest.maxHeadersCount`][]. The minimum value is `4`.
     **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.
@@ -2567,8 +2567,8 @@ changes:
     queued to be sent, and unacknowledged `PING` and `SETTINGS` frames are all
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
-    This is similar to [`http.Server#maxHeadersCount`][] or
-    [`http.ClientRequest#maxHeadersCount`][]. The minimum value is `4`.
+    This is similar to [`http.Server.maxHeadersCount`][] or
+    [`http.ClientRequest.maxHeadersCount`][]. The minimum value is `4`.
     **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.
@@ -2695,8 +2695,8 @@ changes:
     queued to be sent, and unacknowledged `PING` and `SETTINGS` frames are all
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
-    This is similar to [`http.Server#maxHeadersCount`][] or
-    [`http.ClientRequest#maxHeadersCount`][]. The minimum value is `1`.
+    This is similar to [`http.Server.maxHeadersCount`][] or
+    [`http.ClientRequest.maxHeadersCount`][]. The minimum value is `1`.
     **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.
@@ -4135,8 +4135,8 @@ you need to implement any fall-back behavior yourself.
 [`Http2Stream`]: #class-http2stream
 [`ServerHttp2Stream`]: #class-serverhttp2stream
 [`TypeError`]: errors.md#class-typeerror
-[`http.ClientRequest#maxHeadersCount`]: http.md#requestmaxheaderscount
-[`http.Server#maxHeadersCount`]: http.md#servermaxheaderscount
+[`http.ClientRequest.maxHeadersCount`]: http.md#requestmaxheaderscount
+[`http.Server.maxHeadersCount`]: http.md#servermaxheaderscount
 [`http2.SecureServer`]: #class-http2secureserver
 [`http2.Server`]: #class-http2server
 [`http2.createSecureServer()`]: #http2createsecureserveroptions-onrequesthandler

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2411,8 +2411,8 @@ changes:
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
     This is similar to [`server.maxHeadersCount`][] or
-    [`request.maxHeadersCount`][] in the `node:http` module. The minimum value is `4`.
-    **Default:** `128`.
+    [`request.maxHeadersCount`][] in the `node:http` module. The minimum value
+    is `4`. **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.
   * `maxSendHeaderBlockLength` {number} Sets the maximum allowed size for a
@@ -2568,8 +2568,8 @@ changes:
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
     This is similar to [`server.maxHeadersCount`][] or
-    [`request.maxHeadersCount`][] in the `node:http` module. The minimum value is `4`.
-    **Default:** `128`.
+    [`request.maxHeadersCount`][] in the `node:http` module. The minimum value
+    is `4`. **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.
   * `maxSendHeaderBlockLength` {number} Sets the maximum allowed size for a
@@ -2696,8 +2696,8 @@ changes:
     counted towards the current limit. **Default:** `10`.
   * `maxHeaderListPairs` {number} Sets the maximum number of header entries.
     This is similar to [`server.maxHeadersCount`][] or
-    [`request.maxHeadersCount`][] in the `node:http` module. The minimum value is `1`.
-    **Default:** `128`.
+    [`request.maxHeadersCount`][] in the `node:http` module. The minimum value
+    is `1`. **Default:** `128`.
   * `maxOutstandingPings` {number} Sets the maximum number of outstanding,
     unacknowledged pings. **Default:** `10`.
   * `maxReservedRemoteStreams` {number} Sets the maximum number of reserved push

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -133,7 +133,7 @@ added: v0.1.90
 * `callback` {Function}
 * Returns: {https.Server}
 
-See [`http.Server.close()`][].
+See [`server.close()`][] in the `http` module.
 
 ### `server.closeAllConnections()`
 
@@ -141,7 +141,7 @@ See [`http.Server.close()`][].
 added: REPLACEME
 -->
 
-See [`http.Server.closeAllConnections()`][].
+See [`server.closeAllConnections()`][] in the `http` module.
 
 ### `server.closeIdleConnections()`
 
@@ -149,7 +149,7 @@ See [`http.Server.closeAllConnections()`][].
 added: REPLACEME
 -->
 
-See [`http.Server.closeIdleConnections()`][].
+See [`server.closeIdleConnections()`][] in the `http` module.
 
 ### `server.headersTimeout`
 
@@ -159,7 +159,7 @@ added: v11.3.0
 
 * {number} **Default:** `60000`
 
-See [`http.Server.headersTimeout`][].
+See [`server.headersTimeout`][] in the `http` module.
 
 ### `server.listen()`
 
@@ -170,7 +170,7 @@ This method is identical to [`server.listen()`][] from [`net.Server`][].
 
 * {number} **Default:** `2000`
 
-See [`http.Server.maxHeadersCount`][].
+See [`server.maxHeadersCount`][] in the `http` module.
 
 ### `server.requestTimeout`
 
@@ -180,7 +180,7 @@ added: v14.11.0
 
 * {number} **Default:** `0`
 
-See [`http.Server.requestTimeout`][].
+See [`server.requestTimeout`][] in the `http` module.
 
 ### `server.setTimeout([msecs][, callback])`
 
@@ -192,7 +192,7 @@ added: v0.11.2
 * `callback` {Function}
 * Returns: {https.Server}
 
-See [`http.Server.setTimeout()`][].
+See [`server.setTimeout()`][] in the `http` module.
 
 ### `server.timeout`
 
@@ -206,7 +206,7 @@ changes:
 
 * {number} **Default:** 0 (no timeout)
 
-See [`http.Server.timeout`][].
+See [`server.timeout`][] in the `http` module.
 
 ### `server.keepAliveTimeout`
 
@@ -216,7 +216,7 @@ added: v8.0.0
 
 * {number} **Default:** `5000` (5 seconds)
 
-See [`http.Server.keepAliveTimeout`][].
+See [`server.keepAliveTimeout`][] in the `http` module.
 
 ## `https.createServer([options][, requestListener])`
 
@@ -539,15 +539,6 @@ headers: max-age=0; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; p
 [`http.Agent(options)`]: http.md#new-agentoptions
 [`http.Agent`]: http.md#class-httpagent
 [`http.ClientRequest`]: http.md#class-httpclientrequest
-[`http.Server.close()`]: http.md#serverclosecallback
-[`http.Server.closeAllConnections()`]: http.md#servercloseallconnections
-[`http.Server.closeIdleConnections()`]: http.md#servercloseidleconnections
-[`http.Server.headersTimeout`]: http.md#serverheaderstimeout
-[`http.Server.keepAliveTimeout`]: http.md#serverkeepalivetimeout
-[`http.Server.maxHeadersCount`]: http.md#servermaxheaderscount
-[`http.Server.requestTimeout`]: http.md#serverrequesttimeout
-[`http.Server.setTimeout()`]: http.md#serversettimeoutmsecs-callback
-[`http.Server.timeout`]: http.md#servertimeout
 [`http.Server`]: http.md#class-httpserver
 [`http.createServer()`]: http.md#httpcreateserveroptions-requestlistener
 [`http.get()`]: http.md#httpgetoptions-callback
@@ -557,7 +548,16 @@ headers: max-age=0; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; p
 [`import()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports
 [`net.Server`]: net.md#class-netserver
 [`new URL()`]: url.md#new-urlinput-base
+[`server.close()`]: http.md#serverclosecallback
+[`server.closeAllConnections()`]: http.md#servercloseallconnections
+[`server.closeIdleConnections()`]: http.md#servercloseidleconnections
+[`server.headersTimeout`]: http.md#serverheaderstimeout
+[`server.keepAliveTimeout`]: http.md#serverkeepalivetimeout
 [`server.listen()`]: net.md#serverlisten
+[`server.maxHeadersCount`]: http.md#servermaxheaderscount
+[`server.requestTimeout`]: http.md#serverrequesttimeout
+[`server.setTimeout()`]: http.md#serversettimeoutmsecs-callback
+[`server.timeout`]: http.md#servertimeout
 [`tls.connect()`]: tls.md#tlsconnectoptions-callback
 [`tls.createSecureContext()`]: tls.md#tlscreatesecurecontextoptions
 [`tls.createServer()`]: tls.md#tlscreateserveroptions-secureconnectionlistener

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -133,7 +133,7 @@ added: v0.1.90
 * `callback` {Function}
 * Returns: {https.Server}
 
-See [`server.close()`][] in the `http` module.
+See [`server.close()`][] in the `node:http` module.
 
 ### `server.closeAllConnections()`
 
@@ -141,7 +141,7 @@ See [`server.close()`][] in the `http` module.
 added: REPLACEME
 -->
 
-See [`server.closeAllConnections()`][] in the `http` module.
+See [`server.closeAllConnections()`][] in the `node:http` module.
 
 ### `server.closeIdleConnections()`
 
@@ -149,7 +149,7 @@ See [`server.closeAllConnections()`][] in the `http` module.
 added: REPLACEME
 -->
 
-See [`server.closeIdleConnections()`][] in the `http` module.
+See [`server.closeIdleConnections()`][] in the `node:http` module.
 
 ### `server.headersTimeout`
 
@@ -159,7 +159,7 @@ added: v11.3.0
 
 * {number} **Default:** `60000`
 
-See [`server.headersTimeout`][] in the `http` module.
+See [`server.headersTimeout`][] in the `node:http` module.
 
 ### `server.listen()`
 
@@ -170,7 +170,7 @@ This method is identical to [`server.listen()`][] from [`net.Server`][].
 
 * {number} **Default:** `2000`
 
-See [`server.maxHeadersCount`][] in the `http` module.
+See [`server.maxHeadersCount`][] in the `node:http` module.
 
 ### `server.requestTimeout`
 
@@ -180,7 +180,7 @@ added: v14.11.0
 
 * {number} **Default:** `0`
 
-See [`server.requestTimeout`][] in the `http` module.
+See [`server.requestTimeout`][] in the `node:http` module.
 
 ### `server.setTimeout([msecs][, callback])`
 
@@ -192,7 +192,7 @@ added: v0.11.2
 * `callback` {Function}
 * Returns: {https.Server}
 
-See [`server.setTimeout()`][] in the `http` module.
+See [`server.setTimeout()`][] in the `node:http` module.
 
 ### `server.timeout`
 
@@ -206,7 +206,7 @@ changes:
 
 * {number} **Default:** 0 (no timeout)
 
-See [`server.timeout`][] in the `http` module.
+See [`server.timeout`][] in the `node:http` module.
 
 ### `server.keepAliveTimeout`
 
@@ -216,7 +216,7 @@ added: v8.0.0
 
 * {number} **Default:** `5000` (5 seconds)
 
-See [`server.keepAliveTimeout`][] in the `http` module.
+See [`server.keepAliveTimeout`][] in the `node:http` module.
 
 ## `https.createServer([options][, requestListener])`
 

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -159,7 +159,7 @@ added: v11.3.0
 
 * {number} **Default:** `60000`
 
-See [`http.Server#headersTimeout`][].
+See [`http.Server.headersTimeout`][].
 
 ### `server.listen()`
 
@@ -170,7 +170,7 @@ This method is identical to [`server.listen()`][] from [`net.Server`][].
 
 * {number} **Default:** `2000`
 
-See [`http.Server#maxHeadersCount`][].
+See [`http.Server.maxHeadersCount`][].
 
 ### `server.requestTimeout`
 
@@ -180,7 +180,7 @@ added: v14.11.0
 
 * {number} **Default:** `0`
 
-See [`http.Server#requestTimeout`][].
+See [`http.Server.requestTimeout`][].
 
 ### `server.setTimeout([msecs][, callback])`
 
@@ -192,7 +192,7 @@ added: v0.11.2
 * `callback` {Function}
 * Returns: {https.Server}
 
-See [`http.Server#setTimeout()`][].
+See [`http.Server.setTimeout()`][].
 
 ### `server.timeout`
 
@@ -206,7 +206,7 @@ changes:
 
 * {number} **Default:** 0 (no timeout)
 
-See [`http.Server#timeout`][].
+See [`http.Server.timeout`][].
 
 ### `server.keepAliveTimeout`
 
@@ -216,7 +216,7 @@ added: v8.0.0
 
 * {number} **Default:** `5000` (5 seconds)
 
-See [`http.Server#keepAliveTimeout`][].
+See [`http.Server.keepAliveTimeout`][].
 
 ## `https.createServer([options][, requestListener])`
 
@@ -539,15 +539,15 @@ headers: max-age=0; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; p
 [`http.Agent(options)`]: http.md#new-agentoptions
 [`http.Agent`]: http.md#class-httpagent
 [`http.ClientRequest`]: http.md#class-httpclientrequest
-[`http.Server#headersTimeout`]: http.md#serverheaderstimeout
-[`http.Server#keepAliveTimeout`]: http.md#serverkeepalivetimeout
-[`http.Server#maxHeadersCount`]: http.md#servermaxheaderscount
-[`http.Server#requestTimeout`]: http.md#serverrequesttimeout
-[`http.Server#setTimeout()`]: http.md#serversettimeoutmsecs-callback
-[`http.Server#timeout`]: http.md#servertimeout
 [`http.Server.close()`]: http.md#serverclosecallback
 [`http.Server.closeAllConnections()`]: http.md#servercloseallconnections
 [`http.Server.closeIdleConnections()`]: http.md#servercloseidleconnections
+[`http.Server.headersTimeout`]: http.md#serverheaderstimeout
+[`http.Server.keepAliveTimeout`]: http.md#serverkeepalivetimeout
+[`http.Server.maxHeadersCount`]: http.md#servermaxheaderscount
+[`http.Server.requestTimeout`]: http.md#serverrequesttimeout
+[`http.Server.setTimeout()`]: http.md#serversettimeoutmsecs-callback
+[`http.Server.timeout`]: http.md#servertimeout
 [`http.Server`]: http.md#class-httpserver
 [`http.createServer()`]: http.md#httpcreateserveroptions-requestlistener
 [`http.get()`]: http.md#httpgetoptions-callback


### PR DESCRIPTION
This PR fixed little inconsistency in symbol used to denote class method in HTTP, HTTPS and HTTP2 documentation.