### PR TITLE
src: TraceEventScope should mark sync duration events

### DIFF
--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -32,8 +32,7 @@ void EmitBeforeExit(Environment* env) {
 }
 
 Maybe<bool> EmitProcessBeforeExit(Environment* env) {
-  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
-                              "BeforeExit", env);
+  TRACE_EVENT0(TRACING_CATEGORY_NODE1(environment), "BeforeExit");
   if (!env->destroy_async_id_list()->empty())
     AsyncWrap::DestroyAsyncIdsCallback(env);
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -674,8 +674,7 @@ void Environment::PrintSyncTrace() const {
 
 void Environment::RunCleanup() {
   started_cleanup_ = true;
-  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
-                              "RunCleanup", this);
+  TRACE_EVENT0(TRACING_CATEGORY_NODE1(environment), "RunCleanup");
   bindings_.clear();
   CleanupHandles();
 
@@ -717,8 +716,7 @@ void Environment::RunCleanup() {
 }
 
 void Environment::RunAtExitCallbacks() {
-  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
-                              "AtExit", this);
+  TRACE_EVENT0(TRACING_CATEGORY_NODE1(environment), "AtExit");
   for (ExitCallback at_exit : at_exit_functions_) {
     at_exit.cb_(at_exit.arg_);
   }
@@ -744,8 +742,8 @@ void Environment::RunAndClearInterrupts() {
 }
 
 void Environment::RunAndClearNativeImmediates(bool only_refed) {
-  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
-                              "RunAndClearNativeImmediates", this);
+  TRACE_EVENT0(TRACING_CATEGORY_NODE1(environment),
+               "RunAndClearNativeImmediates");
   HandleScope handle_scope(isolate_);
   InternalCallbackScope cb_scope(this, Object::New(isolate_), { 0, 0 });
 
@@ -849,8 +847,7 @@ void Environment::ToggleTimerRef(bool ref) {
 
 void Environment::RunTimers(uv_timer_t* handle) {
   Environment* env = Environment::from_timer_handle(handle);
-  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
-                              "RunTimers", env);
+  TRACE_EVENT0(TRACING_CATEGORY_NODE1(environment), "RunTimers");
 
   if (!env->can_call_into_js())
     return;
@@ -911,8 +908,7 @@ void Environment::RunTimers(uv_timer_t* handle) {
 
 void Environment::CheckImmediate(uv_check_t* handle) {
   Environment* env = Environment::from_immediate_check_handle(handle);
-  TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
-                              "CheckImmediate", env);
+  TRACE_EVENT0(TRACING_CATEGORY_NODE1(environment), "CheckImmediate");
 
   HandleScope scope(env->isolate());
   Context::Scope context_scope(env->context());

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -740,11 +740,10 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
   if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
           TRACING_CATEGORY_NODE2(vm, script)) != 0) {
     Utf8Value fn(isolate, filename);
-    TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(
-        TRACING_CATEGORY_NODE2(vm, script),
-        "ContextifyScript::New",
-        contextify_script,
-        "filename", TRACE_STR_COPY(*fn));
+    TRACE_EVENT_BEGIN1(TRACING_CATEGORY_NODE2(vm, script),
+                       "ContextifyScript::New",
+                       "filename",
+                       TRACE_STR_COPY(*fn));
   }
 
   ScriptCompiler::CachedData* cached_data = nullptr;
@@ -794,10 +793,8 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
     no_abort_scope.Close();
     if (!try_catch.HasTerminated())
       try_catch.ReThrow();
-    TRACE_EVENT_NESTABLE_ASYNC_END0(
-        TRACING_CATEGORY_NODE2(vm, script),
-        "ContextifyScript::New",
-        contextify_script);
+    TRACE_EVENT_END0(TRACING_CATEGORY_NODE2(vm, script),
+                     "ContextifyScript::New");
     return;
   }
   contextify_script->script_.Reset(isolate, v8_script.ToLocalChecked());
@@ -826,10 +823,7 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
         env->cached_data_produced_string(),
         Boolean::New(isolate, cached_data_produced)).Check();
   }
-  TRACE_EVENT_NESTABLE_ASYNC_END0(
-      TRACING_CATEGORY_NODE2(vm, script),
-      "ContextifyScript::New",
-      contextify_script);
+  TRACE_EVENT_END0(TRACING_CATEGORY_NODE2(vm, script), "ContextifyScript::New");
 }
 
 bool ContextifyScript::InstanceOf(Environment* env,
@@ -865,8 +859,7 @@ void ContextifyScript::RunInThisContext(
   ContextifyScript* wrapped_script;
   ASSIGN_OR_RETURN_UNWRAP(&wrapped_script, args.Holder());
 
-  TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(
-      TRACING_CATEGORY_NODE2(vm, script), "RunInThisContext", wrapped_script);
+  TRACE_EVENT0(TRACING_CATEGORY_NODE2(vm, script), "RunInThisContext");
 
   // TODO(addaleax): Use an options object or otherwise merge this with
   // RunInContext().
@@ -892,9 +885,6 @@ void ContextifyScript::RunInThisContext(
               break_on_first_line,
               nullptr,  // microtask_queue
               args);
-
-  TRACE_EVENT_NESTABLE_ASYNC_END0(
-      TRACING_CATEGORY_NODE2(vm, script), "RunInThisContext", wrapped_script);
 }
 
 void ContextifyScript::RunInContext(const FunctionCallbackInfo<Value>& args) {
@@ -916,8 +906,7 @@ void ContextifyScript::RunInContext(const FunctionCallbackInfo<Value>& args) {
   if (context.IsEmpty())
     return;
 
-  TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(
-      TRACING_CATEGORY_NODE2(vm, script), "RunInContext", wrapped_script);
+  TRACE_EVENT0(TRACING_CATEGORY_NODE2(vm, script), "RunInContext");
 
   CHECK(args[1]->IsNumber());
   int64_t timeout = args[1]->IntegerValue(env->context()).FromJust();
@@ -940,9 +929,6 @@ void ContextifyScript::RunInContext(const FunctionCallbackInfo<Value>& args) {
               break_on_first_line,
               contextify_context->microtask_queue(),
               args);
-
-  TRACE_EVENT_NESTABLE_ASYNC_END0(
-      TRACING_CATEGORY_NODE2(vm, script), "RunInContext", wrapped_script);
 }
 
 bool ContextifyScript::EvalMachine(Environment* env,

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -382,23 +382,6 @@ namespace heap {
 v8::Maybe<void> WriteSnapshot(Environment* env, const char* filename);
 }
 
-class TraceEventScope {
- public:
-  TraceEventScope(const char* category,
-                  const char* name,
-                  void* id) : category_(category), name_(name), id_(id) {
-    TRACE_EVENT_NESTABLE_ASYNC_BEGIN0(category_, name_, id_);
-  }
-  ~TraceEventScope() {
-    TRACE_EVENT_NESTABLE_ASYNC_END0(category_, name_, id_);
-  }
-
- private:
-  const char* category_;
-  const char* name_;
-  void* id_;
-};
-
 namespace heap {
 
 void DeleteHeapSnapshot(const v8::HeapSnapshot* snapshot);


### PR DESCRIPTION
According to the chrome trace event format [document](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.nso4gcezn7n1), works that are performed on one single thread should be traced with sync duration events. In this way, these events can be grouped under one thread and the trace event viewer can estimate the CPU usage of that thread.

<details>
<summary>click to see screen shots</summary>

Before:
<img width="1896" alt="Screen Shot 2022-05-05 at 11 54 19 PM" src="https://user-images.githubusercontent.com/8500303/166963935-a6ca4bd5-56fb-4ef8-8c70-fa3e28b3f522.png">

Note that there are no events recorded in the JavaScriptMainThread nor WorkerThread 1.

After:
<img width="1900" alt="Screen Shot 2022-05-05 at 11 54 13 PM" src="https://user-images.githubusercontent.com/8500303/166963956-ecebe24d-defd-4870-88a5-9eddde34cc45.png">

Environment events like cleanup are correctly grouped under their thread.

</details>