### PR TITLE
lib: move WebAssembly Web API into separate file

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -5,7 +5,6 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
-  PromiseResolve,
   SafeMap,
   SafeWeakMap,
   StringPrototypeStartsWith,
@@ -26,9 +25,7 @@ const {
 
 const { Buffer } = require('buffer');
 const {
-  ERR_INVALID_ARG_TYPE,
   ERR_MANIFEST_ASSERT_INTEGRITY,
-  ERR_WEBASSEMBLY_RESPONSE,
 } = require('internal/errors').codes;
 const assert = require('internal/assert');
 
@@ -222,49 +219,8 @@ function setupFetch() {
   });
 
   // The WebAssembly Web API: https://webassembly.github.io/spec/web-api
-  internalBinding('wasm_web_api').setImplementation((streamState, source) => {
-    (async () => {
-      const response = await PromiseResolve(source);
-      if (!(response instanceof lazyUndici().Response)) {
-        throw new ERR_INVALID_ARG_TYPE(
-          'source', ['Response', 'Promise resolving to Response'], response);
-      }
-
-      const contentType = response.headers.get('Content-Type');
-      if (contentType !== 'application/wasm') {
-        throw new ERR_WEBASSEMBLY_RESPONSE(
-          `has unsupported MIME type '${contentType}'`);
-      }
-
-      if (!response.ok) {
-        throw new ERR_WEBASSEMBLY_RESPONSE(
-          `has status code ${response.status}`);
-      }
-
-      if (response.bodyUsed !== false) {
-        throw new ERR_WEBASSEMBLY_RESPONSE('body has already been used');
-      }
-
-      if (response.url) {
-        streamState.setURL(response.url);
-      }
-
-      // Pass all data from the response body to the WebAssembly compiler.
-      const { body } = response;
-      if (body != null) {
-        for await (const chunk of body) {
-          streamState.push(chunk);
-        }
-      }
-    })().then(() => {
-      // No error occurred. Tell the implementation that the stream has ended.
-      streamState.finish();
-    }, (err) => {
-      // An error occurred, either because the given object was not a valid
-      // and usable Response or because a network error occurred.
-      streamState.abort(err);
-    });
-  });
+  const { wasmStreamingCallback } = require('internal/wasm_web_api');
+  internalBinding('wasm_web_api').setImplementation(wasmStreamingCallback);
 }
 
 // TODO(aduh95): move this to internal/bootstrap/browser when the CLI flag is

--- a/lib/internal/wasm_web_api.js
+++ b/lib/internal/wasm_web_api.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const {
+  PromiseResolve,
+} = primordials;
+const {
+  ERR_INVALID_ARG_TYPE,
+  ERR_WEBASSEMBLY_RESPONSE,
+} = require('internal/errors').codes;
+
+let undici;
+function lazyUndici() {
+  return undici ??= require('internal/deps/undici/undici');
+}
+
+// This is essentially an implementation of a v8::WasmStreamingCallback, except
+// that it is implemented in JavaScript because the fetch() implementation is
+// difficult to use from C++. See lib/internal/bootstrap/pre_execution.js and
+// src/node_wasm_web_api.cc that interact with this function.
+function wasmStreamingCallback(streamState, source) {
+  (async () => {
+    const response = await PromiseResolve(source);
+    if (!(response instanceof lazyUndici().Response)) {
+      throw new ERR_INVALID_ARG_TYPE(
+        'source', ['Response', 'Promise resolving to Response'], response);
+    }
+
+    const contentType = response.headers.get('Content-Type');
+    if (contentType !== 'application/wasm') {
+      throw new ERR_WEBASSEMBLY_RESPONSE(
+        `has unsupported MIME type '${contentType}'`);
+    }
+
+    if (!response.ok) {
+      throw new ERR_WEBASSEMBLY_RESPONSE(
+        `has status code ${response.status}`);
+    }
+
+    if (response.bodyUsed !== false) {
+      throw new ERR_WEBASSEMBLY_RESPONSE('body has already been used');
+    }
+
+    if (response.url) {
+      streamState.setURL(response.url);
+    }
+
+    // Pass all data from the response body to the WebAssembly compiler.
+    const { body } = response;
+    if (body != null) {
+      for await (const chunk of body) {
+        streamState.push(chunk);
+      }
+    }
+  })().then(() => {
+    // No error occurred. Tell the implementation that the stream has ended.
+    streamState.finish();
+  }, (err) => {
+    // An error occurred, either because the given object was not a valid
+    // and usable Response or because a network error occurred.
+    streamState.abort(err);
+  });
+}
+
+module.exports = {
+  wasmStreamingCallback
+};

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -140,6 +140,7 @@ const expectedModules = new Set([
   'NativeModule internal/util/types',
   'NativeModule internal/validators',
   'NativeModule internal/vm/module',
+  'NativeModule internal/wasm_web_api',
   'NativeModule internal/webstreams/adapters',
   'NativeModule internal/webstreams/compression',
   'NativeModule internal/webstreams/encoding',


### PR DESCRIPTION
This moves just the JavaScript part of the WebAssembly Web API implementation into a separate file to avoid bloating `pre_execution.js`.

Refs: https://github.com/nodejs/node/pull/42960#discussion_r864871357

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
