### PR TITLE
test: reduce flakiness of `test-fs-read-position-validation.mjs`

### DIFF
--- a/test/parallel/test-fs-read-position-validation.mjs
+++ b/test/parallel/test-fs-read-position-validation.mjs
@@ -20,7 +20,8 @@ async function testValid(position, allowedErrors = []) {
       const handler = common.mustCall((err) => {
         callCount--;
         if (err && !allowedErrors.includes(err.code)) {
-          fs.close(fd, common.mustSucceed(() => reject(err)));
+          fs.close(fd, common.mustSucceed());
+          reject(err);
         } else if (callCount === 0) {
           fs.close(fd, common.mustSucceed(resolve));
         }

--- a/test/parallel/test-fs-read-position-validation.mjs
+++ b/test/parallel/test-fs-read-position-validation.mjs
@@ -13,7 +13,7 @@ const length = buffer.byteLength;
 
 // allowedErrors is an array of acceptable internal errors
 // For example, on some platforms read syscall might return -EFBIG
-function testValid(position, allowedErrors = []) {
+async function testValid(position, allowedErrors = []) {
   return new Promise((resolve, reject) => {
     fs.open(filepath, 'r', common.mustSucceed((fd) => {
       let callCount = 3;
@@ -33,7 +33,7 @@ function testValid(position, allowedErrors = []) {
   });
 }
 
-function testInvalid(code, position) {
+async function testInvalid(code, position) {
   return new Promise((resolve, reject) => {
     fs.open(filepath, 'r', common.mustSucceed((fd) => {
       try {

--- a/test/parallel/test-fs-read-position-validation.mjs
+++ b/test/parallel/test-fs-read-position-validation.mjs
@@ -59,7 +59,7 @@ function testInvalidCb(code, position, callback) {
 const testValidArr = util.promisify(testValidCb);
 const testInvalid = util.promisify(testInvalidCb);
 
-// Wrapper to make allowerErrors optional
+// Wrapper to make allowedErrors optional
 async function testValid(position, allowedErrors) {
   return testValidArr([position, allowedErrors]);
 }

--- a/test/parallel/test-fs-read-position-validation.mjs
+++ b/test/parallel/test-fs-read-position-validation.mjs
@@ -20,8 +20,7 @@ async function testValid(position, allowedErrors = []) {
       const handler = common.mustCall((err) => {
         callCount--;
         if (err && !allowedErrors.includes(err.code)) {
-          fs.close(fd, common.mustSucceed());
-          assert.fail(err);
+          fs.close(fd, common.mustSucceed(() => reject(err)));
         } else if (callCount === 0) {
           fs.close(fd, common.mustSucceed(resolve));
         }
@@ -49,8 +48,11 @@ async function testInvalid(code, position) {
           () => fs.read(fd, buffer, { offset, length, position }, common.mustNotCall()),
           { code }
         );
+        resolve();
+      } catch (err) {
+        reject(err);
       } finally {
-        fs.close(fd, common.mustSucceed(resolve));
+        fs.close(fd, common.mustSucceed());
       }
     }));
   });

--- a/test/parallel/test-fs-readSync-position-validation.mjs
+++ b/test/parallel/test-fs-readSync-position-validation.mjs
@@ -1,0 +1,80 @@
+import '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import fs from 'fs';
+import assert from 'assert';
+
+// This test ensures that "position" argument is correctly validated
+
+const filepath = fixtures.path('x.txt');
+
+const buffer = Buffer.from('xyz\n');
+const offset = 0;
+const length = buffer.byteLength;
+
+// allowedErrors is an array of acceptable internal errors
+// For example, on some platforms read syscall might return -EFBIG
+function testValid(position, allowedErrors = []) {
+  let fdSync;
+  try {
+    fdSync = fs.openSync(filepath, 'r');
+    fs.readSync(fdSync, buffer, offset, length, position);
+    fs.readSync(fdSync, buffer, { offset, length, position });
+  } catch (err) {
+    if (!allowedErrors.includes(err.code)) {
+      assert.fail(err);
+    }
+  } finally {
+    if (fdSync) fs.closeSync(fdSync);
+  }
+}
+
+function testInvalid(code, position, internalCatch = false) {
+  let fdSync;
+  try {
+    fdSync = fs.openSync(filepath, 'r');
+    assert.throws(
+      () => fs.readSync(fdSync, buffer, offset, length, position),
+      { code }
+    );
+    assert.throws(
+      () => fs.readSync(fdSync, buffer, { offset, length, position }),
+      { code }
+    );
+  } finally {
+    if (fdSync) fs.closeSync(fdSync);
+  }
+}
+
+{
+  testValid(undefined);
+  testValid(null);
+  testValid(-1);
+  testValid(-1n);
+
+  testValid(0);
+  testValid(0n);
+  testValid(1);
+  testValid(1n);
+  testValid(9);
+  testValid(9n);
+  testValid(Number.MAX_SAFE_INTEGER, [ 'EFBIG' ]);
+
+  testValid(2n ** 63n - 1n - BigInt(length), [ 'EFBIG' ]);
+  testInvalid('ERR_OUT_OF_RANGE', 2n ** 63n);
+
+  // TODO(LiviaMedeiros): test `2n ** 63n - BigInt(length)`
+
+  testInvalid('ERR_OUT_OF_RANGE', NaN);
+  testInvalid('ERR_OUT_OF_RANGE', -Infinity);
+  testInvalid('ERR_OUT_OF_RANGE', Infinity);
+  testInvalid('ERR_OUT_OF_RANGE', -0.999);
+  testInvalid('ERR_OUT_OF_RANGE', -(2n ** 64n));
+  testInvalid('ERR_OUT_OF_RANGE', Number.MAX_SAFE_INTEGER + 1);
+  testInvalid('ERR_OUT_OF_RANGE', Number.MAX_VALUE);
+
+  for (const badTypeValue of [
+    false, true, '1', Symbol(1), {}, [], () => {}, Promise.resolve(1),
+  ]) {
+    testInvalid('ERR_INVALID_ARG_TYPE', badTypeValue);
+  }
+}


### PR DESCRIPTION
The said test failed randomly several times with `EBADF` error code: [[1]](https://ci.nodejs.org/job/node-test-commit-linux-containered/31769/nodes=ubuntu1804_sharedlibs_zlib_x64/testReport/junit/(root)/test/parallel_test_fs_read_position_validation/), [[2]](https://ci.nodejs.org/job/node-test-commit-linux/45657/nodes=alpine-last-latest-x64/testReport/junit/(root)/test/parallel_test_fs_read_position_validation/), [[3]](https://ci.nodejs.org/job/node-test-commit-linux-containered/31735/nodes=ubuntu1804_sharedlibs_openssl111_x64/testReport/junit/(root)/test/parallel_test_fs_read_position_validation/)

This PR should make the test more reliable by promisifying Callback API parts and calling them in sequence.
Additionally, it separates Callback API and Synchronous API parts into two tests, in anticipation of validation in Promises API.