### PR TITLE
net: fix socket._getpeername

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -736,9 +736,11 @@ Socket.prototype._getpeername = function() {
   if (!this._handle || !this._handle.getpeername || this.connecting) {
     return this._peername || {};
   } else if (!this._peername) {
-    this._peername = {};
+    const out = {};
+    const err = this._handle.getpeername(out);
     // FIXME(bnoordhuis) Throw when the return value is not 0?
-    this._handle.getpeername(this._peername);
+    if (err) return {};
+    this._peername = out;
   }
   return this._peername;
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -738,7 +738,6 @@ Socket.prototype._getpeername = function() {
   } else if (!this._peername) {
     const out = {};
     const err = this._handle.getpeername(out);
-    // FIXME(bnoordhuis) Throw when the return value is not 0?
     if (err) return out;
     this._peername = out;
   }

--- a/lib/net.js
+++ b/lib/net.js
@@ -739,7 +739,7 @@ Socket.prototype._getpeername = function() {
     const out = {};
     const err = this._handle.getpeername(out);
     // FIXME(bnoordhuis) Throw when the return value is not 0?
-    if (err) return {};
+    if (err) return out;
     this._peername = out;
   }
   return this._peername;

--- a/test/parallel/test-net-remote-address.js
+++ b/test/parallel/test-net-remote-address.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const net = require('net');
+const { strictEqual } = require('assert');
+
+const server = net.createServer();
+
+server.listen(common.mustCall(function() {
+  const socket = net.connect({ port: server.address().port });
+
+  strictEqual(socket.connecting, true);
+  strictEqual(socket.remoteAddress, undefined);
+
+  socket.on('connect', common.mustCall(function() {
+    strictEqual(socket.remoteAddress !== undefined, true);
+    socket.end();
+  }));
+
+  socket.on('end', common.mustCall(function() {
+    server.close();
+  }));
+}));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/43009

If calling `this._handle.getpeername` returns an error at the first
call, its result shouldn't be cached to `this._peername`.

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
