### PR TITLE
async_hooks: add AsyncResource.bindCurrent()

### DIFF
--- a/doc/api/async_context.md
+++ b/doc/api/async_context.md
@@ -462,10 +462,28 @@ changes:
   `AsyncResource`.
 * `thisArg` {any}
 
-Binds the given function to the current execution context.
+Binds the given function to the current execution context using a new
+`AsyncResource`.
 
 The returned function will have an `asyncResource` property referencing
 the `AsyncResource` to which the function is bound.
+
+### Static method: `AsyncResource.bindCurrent(fn[, thisArg])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function} The function to bind to the current execution context.
+* `thisArg` {any}
+
+Binds the given function to the current execution context, without creating
+an underlying `AsyncResource`, and instead using the current
+`executionAsyncResource()`.
+
+The returned function will have an `asyncResource` property referencing
+the resource to which the function is bound. Note that this might not be
+an instance of `AsyncResource`.
 
 ### `asyncResource.bind(fn[, thisArg])`
 

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -194,18 +194,14 @@ class AsyncResource {
   }
 
   runInAsyncScope(fn, thisArg, ...args) {
-    const asyncId = this[async_id_symbol];
-    emitBefore(asyncId, this[trigger_async_id_symbol], this);
-
-    try {
-      const ret =
-        ReflectApply(fn, thisArg, args);
-
-      return ret;
-    } finally {
-      if (hasAsyncIdStack())
-        emitAfter(asyncId);
-    }
+    return runInAsyncScope(
+      fn,
+      this[async_id_symbol],
+      this[trigger_async_id_symbol],
+      this,
+      thisArg,
+      ...args
+    )
   }
 
   emitDestroy() {
@@ -226,36 +222,68 @@ class AsyncResource {
 
   bind(fn, thisArg) {
     validateFunction(fn, 'fn');
-    let bound;
-    if (thisArg === undefined) {
-      const resource = this;
-      bound = function(...args) {
-        ArrayPrototypeUnshift(args, fn, this);
-        return ReflectApply(resource.runInAsyncScope, resource, args);
-      };
-    } else {
-      bound = FunctionPrototypeBind(this.runInAsyncScope, this, fn, thisArg);
-    }
-    ObjectDefineProperties(bound, {
-      'length': {
-        configurable: true,
-        enumerable: false,
-        value: fn.length,
-        writable: false,
-      },
-      'asyncResource': {
-        configurable: true,
-        enumerable: true,
-        value: this,
-        writable: true,
-      }
-    });
-    return bound;
+    const resource = this;
+    const asyncId = this[async_id_symbol];
+    const triggerId = this[trigger_async_id_symbol];
+    return bind(fn, thisArg, asyncId, triggerId, resource);
+  }
+
+  static bindCurrent(fn, thisArg) {
+    validateFunction(fn, 'fn');
+    const resource = executionAsyncResource();
+    const asyncId = executionAsyncId();
+    const triggerId = triggerAsyncId();
+    return bind(fn, thisArg, asyncId, triggerId, resource);
   }
 
   static bind(fn, type, thisArg) {
     type = type || fn.name;
     return (new AsyncResource(type || 'bound-anonymous-fn')).bind(fn, thisArg);
+  }
+}
+
+function bind(fn, thisArg, asyncId, triggerAsyncId, asyncResource) {
+  let bound;
+  if (thisArg === undefined) {
+    bound = function(...args) {
+      ArrayPrototypeUnshift(args, fn, this);
+      return runInAsyncScope(
+        fn, asyncId, triggerAsyncId, asyncResource, this, ...args
+      );
+    };
+  } else {
+    bound = FunctionPrototypeBind(
+      runInAsyncScope, null, fn, asyncId, triggerAsyncId, asyncResource, thisArg
+    );
+  }
+  ObjectDefineProperties(bound, {
+    'length': {
+      configurable: true,
+      enumerable: false,
+      value: fn.length,
+      writable: false,
+    },
+    'asyncResource': {
+      configurable: true,
+      enumerable: true,
+      value: asyncResource,
+      writable: true,
+    }
+  });
+  return bound
+}
+
+function runInAsyncScope(fn, asyncId, triggerAsyncId, asyncResource, thisArg, ...args) {
+  emitBefore(asyncId, triggerAsyncId, asyncResource);
+
+  try {
+    const ret =
+      ReflectApply(fn, thisArg, args);
+
+    return ret;
+  } finally {
+    if (hasAsyncIdStack())
+      emitAfter(asyncId);
   }
 }
 

--- a/test/parallel/test-asyncresource-bind-current.js
+++ b/test/parallel/test-asyncresource-bind-current.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { AsyncResource, executionAsyncId } = require('async_hooks');
+
+const thisArg = {};
+
+const asyncId = executionAsyncId();
+const fn1 = AsyncResource.bindCurrent(common.mustCall(() => {
+  assert.strictEqual(executionAsyncId(), asyncId);
+}, 2));
+const fn2 = AsyncResource.bindCurrent(common.mustCall(function () {
+  assert.strictEqual(executionAsyncId(), asyncId);
+  assert.strictEqual(this, thisArg);
+}, 2), thisArg);
+
+fn1();
+fn2();
+AsyncResource.bind(() => {
+  assert.notStrictEqual(executionAsyncId(), asyncId);
+  fn1();
+  fn2();
+})();


### PR DESCRIPTION
This new static method does roughly the same thing as `AsyncResource.bind()`, except that it does not create a new `AsyncResource`. Instead, it relies on the existing current one.

This is an optimization useful in basically any situation where `bind()` would be called without passing (or relying on) the `type` argument.

I opted to make a completely different method, rather than overload `bind()` even more than it already is, but I can change that if desired.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
