### PR TITLE
doc: remove git:// protocol, adjust nits in onboarding.md

### DIFF
--- a/doc/contributing/backporting-to-release-lines.md
+++ b/doc/contributing/backporting-to-release-lines.md
@@ -54,7 +54,7 @@ replace that with the staging branch for the targeted release line.
    ```bash
    # Assuming your fork of Node.js is checked out in $NODE_DIR,
    # the origin remote points to your fork, and the upstream remote points
-   # to git://github.com/nodejs/node
+   # to git@github.com:nodejs/node.git
    cd $NODE_DIR
    # If v10.x-staging is checked out `pull` should be used instead of `fetch`
    git fetch upstream v10.x-staging:v10.x-staging -f

--- a/onboarding.md
+++ b/onboarding.md
@@ -39,11 +39,11 @@ onboarding session.
   * Always create a branch in your own GitHub fork for pull requests
     * Branches in the `nodejs/node` repository are only for release lines
   * Add the canonical nodejs repository as `upstream` remote:
-    * `git remote add upstream git://github.com/nodejs/node.git`
+    * `git remote add upstream git@github.com:nodejs/node.git`
   * To update from `upstream`:
     * `git checkout master`
-    * `git remote update -p` OR `git fetch --all`
-    * `git merge --ff-only upstream/master` (or `REMOTENAME/BRANCH`)
+    * `git fetch upstream HEAD`
+    * `git reset --hard FETCH_HEAD`
   * Make a new branch for each pull request you submit.
   * Membership: Consider making your membership in the Node.js GitHub
     organization public. This makes it easier to identify collaborators.
@@ -203,9 +203,9 @@ needs to be pointed out separately during the onboarding.
 ## Exercise: Make a pull request adding yourself to the README
 
 * Example:
-  <https://github.com/nodejs/node/commit/b58fe52692659c0bc25ddbe6afa7f4ae2c7f14a8>
+  <https://github.com/nodejs/node/commit/6669b3857f0f43ee0296eb7ac45086cd907b9e94>
   * For raw commit message:
-    `git show --format=%B b58fe52692659c0bc25ddbe6afa7f4ae2c7f14a8`
+    `git show --format=%B 6669b3857f0f43ee0296eb7ac45086cd907b9e94`
 * Collaborators are in alphabetical order by GitHub username.
 * Optionally, include your personal pronouns.
 * Add the `Fixes: <collaborator-nomination-issue-url>` to the commit message


### PR DESCRIPTION
A few nits found during onboarding session.

- `git://` protocol is dropped on GitHub
Refs: https://github.blog/2021-09-01-improving-git-protocol-security-github/
- Recommended way to update fork from upstream should be `reset`, not `merge`.
It's less resource-consuming and more straightforward. Maybe there are other arguments for that.
- Example commit is replaced with a modern one. The main difference is absence of `@` in commit message to avoid random pings afterwards.
Refs: https://github.com/nodejs/node/pull/42718#issuecomment-1098204164