### PR TITLE
tools: revert generator/make.py for OpenSSL3

### DIFF
--- a/tools/gyp/pylib/gyp/generator/make.py
+++ b/tools/gyp/pylib/gyp/generator/make.py
@@ -106,6 +106,7 @@ def CalculateVariables(default_variables, params):
         default_variables.setdefault("SHARED_LIB_DIR", "$(builddir)/lib.$(TOOLSET)")
         default_variables.setdefault("LIB_DIR", "$(obj).$(TOOLSET)")
 
+
 def CalculateGeneratorInputInfo(params):
     """Calculate the generator specific info that gets fed to input (called by
     gyp)."""
@@ -155,31 +156,6 @@ cmd_alink_thin = rm -f $@ && $(AR.$(TOOLSET)) crsT $@ $(filter %.o,$^)
 quiet_cmd_link = LINK($(TOOLSET)) $@
 cmd_link = $(LINK.$(TOOLSET)) -o $@ $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -Wl,--start-group $(LD_INPUTS) $(LIBS) -Wl,--end-group
 
-# Note: this does not handle spaces in paths
-define xargs
-	$(1) $(word 1,$(2))
-$(if $(word 2,$(2)),$(call xargs,$(1),$(wordlist 2,$(words $(2)),$(2))))
-endef
-
-define write-to-file
-	@: >$(1)
-$(call xargs,@printf "%s\\n" >>$(1),$(2))
-endef
-
-OBJ_FILE_LIST := ar-file-list
-
-define create_archive
-        rm -f $(1) $(1).$(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
-        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
-        $(AR.$(TOOLSET)) crs $(1) @$(1).$(OBJ_FILE_LIST)
-endef
-
-define create_thin_archive
-        rm -f $(1) $(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
-        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
-        $(AR.$(TOOLSET)) crsT $(1) @$(1).$(OBJ_FILE_LIST)
-endef
-
 # We support two kinds of shared objects (.so):
 # 1) shared_library, which is just bundling together many dependent libraries
 # into a link line.
@@ -223,31 +199,6 @@ cmd_alink = rm -f $@ && $(AR.$(TOOLSET)) crs $@ $(filter %.o,$^)
 
 quiet_cmd_alink_thin = AR($(TOOLSET)) $@
 cmd_alink_thin = rm -f $@ && $(AR.$(TOOLSET)) crsT $@ $(filter %.o,$^)
-
-# Note: this does not handle spaces in paths
-define xargs
-	$(1) $(word 1,$(2))
-$(if $(word 2,$(2)),$(call xargs,$(1),$(wordlist 2,$(words $(2)),$(2))))
-endef
-
-define write-to-file
-	@: >$(1)
-$(call xargs,@printf "%s\\n" >>$(1),$(2))
-endef
-
-OBJ_FILE_LIST := ar-file-list
-
-define create_archive
-        rm -f $(1) $(1).$(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
-        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
-        $(AR.$(TOOLSET)) crs $(1) @$(1).$(OBJ_FILE_LIST)
-endef
-
-define create_thin_archive
-        rm -f $(1) $(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
-        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
-        $(AR.$(TOOLSET)) crsT $(1) @$(1).$(OBJ_FILE_LIST)
-endef
 
 # Due to circular dependencies between libraries :(, we wrap the
 # special "figure out circular dependencies" flags around the entire
@@ -1858,28 +1809,14 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
                 self.flavor not in ("mac", "openbsd", "netbsd", "win")
                 and not self.is_standalone_static_library
             ):
-                if self.flavor in ('linux', 'android'):
-                  self.WriteMakeRule(
+                self.WriteDoCmd(
                     [self.output_binary],
                     link_deps,
-                    actions = ['$(call create_thin_archive,$@,$^)']
-                  )
-                else:
-                  self.WriteDoCmd(
-                      [self.output_binary],
-                      link_deps,
-                      "alink_thin",
-                      part_of_all,
-                      postbuilds=postbuilds,
-                  )
-            else:
-              if self.flavor in ('linux', 'android'):
-                self.WriteMakeRule(
-                    [self.output_binary],
-                    link_deps,
-                    actions = ['$(call create_archive,$@,$^)']
+                    "alink_thin",
+                    part_of_all,
+                    postbuilds=postbuilds,
                 )
-              else:
+            else:
                 self.WriteDoCmd(
                     [self.output_binary],
                     link_deps,


### PR DESCRIPTION
This commit reverts the changes made by Commit
66da32c045035cf2710a48773dc6f55f00e20c40 ("deps,test,src,doc,tools: update to OpenSSL 3.0"). This only intended for running through the CI
tests and see if anything breaks.

