### PR TITLE
test: add test for profile command of `node inspect`

### DIFF
--- a/test/sequential/test-debugger-profile-command.js
+++ b/test/sequential/test-debugger-profile-command.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const startCLI = require('../common/debugger');
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const cli = startCLI([fixtures.path('debugger/empty.js')]);
+
+const rootDir = path.resolve(__dirname, '..', '..');
+
+(async () => {
+  await cli.waitForInitialBreak();
+  await cli.waitForPrompt();
+  await cli.command('profile');
+  await cli.command('profileEnd');
+  assert.match(cli.output, /\[Profile \d+μs\]/);
+  await cli.command('profiles');
+  assert.match(cli.output, /\[ \[Profile \d+μs\] \]/);
+  await cli.command('profiles[0].save()');
+  assert.match(cli.output, /Saved profile to .*node\.cpuprofile/);
+
+  const cpuprofile = path.resolve(rootDir, 'node.cpuprofile');
+  const data = JSON.parse(fs.readFileSync(cpuprofile, 'utf8'));
+  assert.strictEqual(Array.isArray(data.nodes), true);
+
+  fs.rmSync(cpuprofile);
+})()
+.then(common.mustCall())
+.finally(() => cli.quit());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This test that covers profiler functionalities of `node inspect` improves code coverage of `lib/internal/debugger/inspect_repl.js` ([ref](https://coverage.nodejs.org/coverage-7ff2170f3660f606/lib/internal/debugger/inspect_repl.js.html#L953)) from 86.9% to 94.11%.

| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/22386678/167861226-9d3ab9b5-6ff8-4823-9fc1-31a561465fe2.png) | ![image](https://user-images.githubusercontent.com/22386678/167861300-0526a8e1-1fd5-4c5a-9631-2f31c3afdd14.png) |
