### PR TITLE
async_hooks: faster AsyncResource#bind()

### DIFF
--- a/benchmark/async_hooks/async-resource-bind.js
+++ b/benchmark/async_hooks/async-resource-bind.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common.js');
+const { AsyncResource } = require('async_hooks');
+
+const noop = () => {};
+const thisArg = {};
+const resource = new AsyncResource('test');
+
+const bench = common.createBenchmark(main, {
+  n: [1e100],
+  option: ['withThisArg', 'withoutThisArg']
+});
+
+function main({ n, option }) {
+  bench.start();
+  for (let i = 0; i < 1e7; i++) {
+    resource.bind(noop, null, option === 'withThisArg' ? thisArg : undefined);
+  }
+  bench.end(n);
+}

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -8,7 +8,7 @@ const {
   ArrayPrototypeUnshift,
   FunctionPrototypeBind,
   NumberIsSafeInteger,
-  ObjectDefineProperties,
+  ObjectDefineProperty,
   ObjectIs,
   ReflectApply,
   Symbol,
@@ -236,20 +236,13 @@ class AsyncResource {
     } else {
       bound = FunctionPrototypeBind(this.runInAsyncScope, this, fn, thisArg);
     }
-    ObjectDefineProperties(bound, {
-      'length': {
-        configurable: true,
-        enumerable: false,
-        value: fn.length,
-        writable: false,
-      },
-      'asyncResource': {
-        configurable: true,
-        enumerable: true,
-        value: this,
-        writable: true,
-      }
+    ObjectDefineProperty(bound, 'length', {
+      configurable: true,
+      enumerable: false,
+      value: fn.length,
+      writable: false,
     });
+    bound.asyncResource = this;
     return bound;
   }
 


### PR DESCRIPTION
~`FunctionPrototypeBind` preserves `length`, and~ the `asyncResource` property can just be set normally, avoiding the costly call to `ObjectDefineProperties`. ~In the `thisArg === undefined` case,~ reducing it to a single `ObjectDefineProperty` ~still~ has tangible performance gain.

I added a benchmark and here is the output on my machine (the `./node-master` result is without this commit, and the `./node` result is with it):





```
$ ./node benchmark/async_hooks/async-resource-bind.js
async_hooks/async-resource-bind.js option="withThisArg" n=1e+100: 5.619836901644185e+99
async_hooks/async-resource-bind.js option="withoutThisArg" n=1e+100: 5.96856136341294e+99
$ ./node-master benchmark/async_hooks/async-resource-bind.js
async_hooks/async-resource-bind.js option="withThisArg" n=1e+100: 1.5451341226758954e+99
async_hooks/async-resource-bind.js option="withoutThisArg" n=1e+100: 1.605511858099379e+99
```

<details><summary>(Expand here for old/incorrect benchmark.)</summary>

```
$ ./node benchmark/async_hooks/async-resource-bind.js
async_hooks/async-resource-bind.js option="withThisArg" n=1e+100: 4.6615746235960295e+100
async_hooks/async-resource-bind.js option="withoutThisArg" n=1e+100: 5.939287298590602e+100
$ ./node-master benchmark/async_hooks/async-resource-bind.js
async_hooks/async-resource-bind.js option="withThisArg" n=1e+100: 1.6248803889798304e+99
async_hooks/async-resource-bind.js option="withoutThisArg" n=1e+100: 1.6487041313302313e+99
```

</details>

cc @nodejs/async_hooks 
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
