### PR TITLE
lib: optimize validators

### DIFF
--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -38,13 +38,13 @@ const {
 
 function validateTimeout(options) {
   const { timeout = -1 } = { ...options };
-  validateInt32(timeout, 'options.timeout', -1, 2 ** 31 - 1);
+  validateInt32(timeout, 'options.timeout', -1);
   return timeout;
 }
 
 function validateTries(options) {
   const { tries = 4 } = { ...options };
-  validateInt32(tries, 'options.tries', 1, 2 ** 31 - 1);
+  validateInt32(tries, 'options.tries', 1);
   return tries;
 }
 

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -103,7 +103,7 @@ const validateUint32 = hideStackFrames((value, name, positive) => {
   }
   const min = positive ? 1 : 0;
   // 2 ** 32 === 4294967296
-  const max = 4294967295;
+  const max = 4_294_967_295;
   if (value < min || value > max) {
     throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
   }

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -64,7 +64,7 @@ function parseFileMode(value, name, def) {
     value = NumberParseInt(value, 8);
   }
 
-  validateInt32(value, name, 0, 2 ** 32 - 1);
+  validateUint32(value, name);
   return value;
 }
 
@@ -85,11 +85,8 @@ const validateInt32 = hideStackFrames(
     if (typeof value !== 'number') {
       throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
     }
-    if (!isInt32(value)) {
-      if (!NumberIsInteger(value)) {
-        throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
-      }
-      throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
+    if (!NumberIsInteger(value)) {
+      throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
     }
     if (value < min || value > max) {
       throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
@@ -101,16 +98,14 @@ const validateUint32 = hideStackFrames((value, name, positive) => {
   if (typeof value !== 'number') {
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
   }
-  if (!isUint32(value)) {
-    if (!NumberIsInteger(value)) {
-      throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
-    }
-    const min = positive ? 1 : 0;
-    // 2 ** 32 === 4294967296
-    throw new ERR_OUT_OF_RANGE(name, `>= ${min} && < 4294967296`, value);
+  if (!NumberIsInteger(value)) {
+    throw new ERR_OUT_OF_RANGE(name, 'an integer', value);
   }
-  if (positive && value === 0) {
-    throw new ERR_OUT_OF_RANGE(name, '>= 1 && < 4294967296', value);
+  const min = positive ? 1 : 0;
+  // 2 ** 32 === 4294967296
+  const max = 4294967295;
+  if (value < min || value > max) {
+    throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
   }
 });
 

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -1246,10 +1246,6 @@ function addNumericalSeparator(val) {
     }, common.mustNotCall()), {
       name: 'RangeError',
       code: 'ERR_OUT_OF_RANGE',
-      message:
-        'The value of "options.modulusLength" is out of range. ' +
-        'It must be >= 0 && <= 4294967295. ' +
-        `Received ${addNumericalSeparator(modulusLength)}`
     });
   }
 

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -1172,7 +1172,7 @@ function addNumericalSeparator(val) {
       code: 'ERR_OUT_OF_RANGE',
       message:
         'The value of "options.modulusLength" is out of range. ' +
-        'It must be >= 0 && < 4294967296. ' +
+        'It must be >= 0 && <= 4294967295. ' +
         `Received ${addNumericalSeparator(modulusLength)}`
     });
   }
@@ -1216,7 +1216,7 @@ function addNumericalSeparator(val) {
       code: 'ERR_OUT_OF_RANGE',
       message:
         'The value of "options.publicExponent" is out of range. ' +
-        'It must be >= 0 && < 4294967296. ' +
+        'It must be >= 0 && <= 4294967295. ' +
         `Received ${addNumericalSeparator(publicExponent)}`
     });
   }
@@ -1260,7 +1260,7 @@ function addNumericalSeparator(val) {
       code: 'ERR_OUT_OF_RANGE',
       message:
         'The value of "options.modulusLength" is out of range. ' +
-        'It must be >= 0 && < 4294967296. ' +
+        'It must be >= 0 && <= 4294967295. ' +
         `Received ${addNumericalSeparator(modulusLength)}`
     });
   }

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -1170,10 +1170,6 @@ function addNumericalSeparator(val) {
     }, common.mustNotCall()), {
       name: 'RangeError',
       code: 'ERR_OUT_OF_RANGE',
-      message:
-        'The value of "options.modulusLength" is out of range. ' +
-        'It must be >= 0 && <= 4294967295. ' +
-        `Received ${addNumericalSeparator(modulusLength)}`
     });
   }
 
@@ -1214,10 +1210,6 @@ function addNumericalSeparator(val) {
     }, common.mustNotCall()), {
       name: 'RangeError',
       code: 'ERR_OUT_OF_RANGE',
-      message:
-        'The value of "options.publicExponent" is out of range. ' +
-        'It must be >= 0 && <= 4294967295. ' +
-        `Received ${addNumericalSeparator(publicExponent)}`
     });
   }
 }
@@ -1244,10 +1236,6 @@ function addNumericalSeparator(val) {
     }, common.mustNotCall()), {
       name: 'RangeError',
       code: 'ERR_OUT_OF_RANGE',
-      message:
-        'The value of "options.modulusLength" is out of range. ' +
-        'It must be an integer. ' +
-        `Received ${inspect(modulusLength)}`
     });
   }
 

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -1122,18 +1122,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }
 }
 
-function addNumericalSeparator(val) {
-  val = String(val);
-  let res = '';
-  let i = val.length;
-  const start = val[0] === '-' ? 1 : 0;
-  for (; i >= start + 4; i -= 3) {
-    res = `_${val.slice(i - 3, i)}${res}`;
-  }
-  return `${val.slice(0, i)}${res}`;
-}
-
-
 // Test RSA parameters.
 {
   // Test invalid modulus lengths. (non-number)

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -69,8 +69,6 @@ for (const iterations of [-1, 0]) {
     {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "iterations" is out of range. ' +
-               `It must be >= 1 && <= 4294967295. Received ${iterations}`
     }
   );
 }
@@ -108,8 +106,6 @@ for (const iterations of [-1, 0]) {
     }, {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "keylen" is out of range. It must be >= 0 && <=' +
-               ` 4294967295. Received ${input === -1 ? '-1' : '4_294_967_297'}`
     });
 });
 

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -70,7 +70,7 @@ for (const iterations of [-1, 0]) {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
       message: 'The value of "iterations" is out of range. ' +
-               `It must be >= 1 && < 4294967296. Received ${iterations}`
+               `It must be >= 1 && <= 4294967295. Received ${iterations}`
     }
   );
 }
@@ -108,8 +108,8 @@ for (const iterations of [-1, 0]) {
     }, {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "keylen" is out of range. It must be >= 0 && < ' +
-               `4294967296. Received ${input === -1 ? '-1' : '4_294_967_297'}`
+      message: 'The value of "keylen" is out of range. It must be >= 0 && <=' +
+               ` 4294967295. Received ${input === -1 ? '-1' : '4_294_967_297'}`
     });
 });
 

--- a/test/parallel/test-file-validate-mode-flag.js
+++ b/test/parallel/test-file-validate-mode-flag.js
@@ -13,27 +13,28 @@ const {
 } = require('fs');
 
 // These should throw, not crash.
+const invalid = 4294967296;
 
-assert.throws(() => open(__filename, 2176057344, common.mustNotCall()), {
+assert.throws(() => open(__filename, invalid, common.mustNotCall()), {
   code: 'ERR_OUT_OF_RANGE'
 });
 
-assert.throws(() => open(__filename, 0, 2176057344, common.mustNotCall()), {
+assert.throws(() => open(__filename, 0, invalid, common.mustNotCall()), {
   code: 'ERR_OUT_OF_RANGE'
 });
 
-assert.throws(() => openSync(__filename, 2176057344), {
+assert.throws(() => openSync(__filename, invalid), {
   code: 'ERR_OUT_OF_RANGE'
 });
 
-assert.throws(() => openSync(__filename, 0, 2176057344), {
+assert.throws(() => openSync(__filename, 0, invalid), {
   code: 'ERR_OUT_OF_RANGE'
 });
 
-assert.rejects(openPromise(__filename, 2176057344), {
+assert.rejects(openPromise(__filename, invalid), {
   code: 'ERR_OUT_OF_RANGE'
 });
 
-assert.rejects(openPromise(__filename, 0, 2176057344), {
+assert.rejects(openPromise(__filename, 0, invalid), {
   code: 'ERR_OUT_OF_RANGE'
 });

--- a/test/parallel/test-file-validate-mode-flag.js
+++ b/test/parallel/test-file-validate-mode-flag.js
@@ -13,7 +13,7 @@ const {
 } = require('fs');
 
 // These should throw, not crash.
-const invalid = 4294967296;
+const invalid = 4_294_967_296;
 
 assert.throws(() => open(__filename, invalid, common.mustNotCall()), {
   code: 'ERR_OUT_OF_RANGE'

--- a/test/parallel/test-process-setgroups.js
+++ b/test/parallel/test-process-setgroups.js
@@ -30,7 +30,7 @@ assert.throws(
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
     message: 'The value of "groups[1]" is out of range. ' +
-              'It must be >= 0 && < 4294967296. Received -1'
+              'It must be >= 0 && <= 4294967295. Received -1'
   }
 );
 

--- a/test/parallel/test-process-setgroups.js
+++ b/test/parallel/test-process-setgroups.js
@@ -29,8 +29,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "groups[1]" is out of range. ' +
-              'It must be >= 0 && <= 4294967295. Received -1'
   }
 );
 

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -133,7 +133,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     }),
     {
       message: 'The value of "tabSize" is out of range. ' +
-                'It must be >= 1 && < 4294967296. Received 0',
+                'It must be >= 1 && <= 4294967295. Received 0',
       code: 'ERR_OUT_OF_RANGE'
     }
   );

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -131,11 +131,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
       input,
       tabSize: 0
     }),
-    {
-      message: 'The value of "tabSize" is out of range. ' +
-                'It must be >= 1 && <= 4294967295. Received 0',
-      code: 'ERR_OUT_OF_RANGE'
-    }
+    { code: 'ERR_OUT_OF_RANGE' }
   );
 
   assert.throws(

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -123,7 +123,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     }),
     {
       message: 'The value of "tabSize" is out of range. ' +
-                'It must be >= 1 && < 4294967296. Received 0',
+                'It must be >= 1 && <= 4294967295. Received 0',
       code: 'ERR_OUT_OF_RANGE'
     }
   );

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -121,11 +121,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
       input,
       tabSize: 0
     }),
-    {
-      message: 'The value of "tabSize" is out of range. ' +
-                'It must be >= 1 && <= 4294967295. Received 0',
-      code: 'ERR_OUT_OF_RANGE'
-    }
+    { code: 'ERR_OUT_OF_RANGE' }
   );
 
   assert.throws(


### PR DESCRIPTION
Optimized `validateInt32` and `validateUint32`.
Fixed an incorrect call to `validateInt32` function.
Should we limit the range of `min` and `max` arguments in the `validateInt32` and `validateInteger` functions, to avoid deflected modification the check range.