### PR TITLE
fs: remove unnecessary ?? operator

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -528,7 +528,7 @@ async function read(handle, bufferOrParams, offset, length, position) {
       offset = 0,
       length = buffer.byteLength - offset,
       position = null
-    } = offset ?? ObjectCreate(null));
+    } = offset);
   }
 
   if (offset == null) {


### PR DESCRIPTION
This was introduced in 57678e55817366c39a3a241f89949c8fbe8418bc

With the `if` conditional around this statement, `options` will always
be evaluated as truthy. That means that the nullish coalescing operator
will always evaluate to the left side, make it unnecessary.