### PR TITLE
benchmark: Add NodeError and Error benchmark

### DIFF
--- a/benchmark/error/error.js
+++ b/benchmark/error/error.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [1e7],
+});
+
+function main({ n }) {
+  bench.start();
+  for (let i = 0; i < n; ++i)
+    new Error('test');
+  bench.end(n);
+}

--- a/benchmark/error/node-error.js
+++ b/benchmark/error/node-error.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+
+const bench = common.createBenchmark(main, {
+  n: [1e7],
+}, {
+  flags: ['--expose-internals']
+});
+
+function main({ n }) {
+  const {
+    codes: {
+      ERR_INVALID_STATE,
+    }
+  } = require('internal/errors');
+  bench.start();
+  for (let i = 0; i < n; ++i)
+    new ERR_INVALID_STATE.TypeError('test');
+  bench.end(n);
+}


### PR DESCRIPTION
While investigating `fetch` performance (https://github.com/nodejs/undici/issues/1203#issuecomment-1100969210) I've found that `NodeError` is a bottleneck in `WebStreams`.

I created this Pull Request to share the insights and help as I can to improve the `NodeError` performance. We can use this PR thread to discuss approaches to solve it.

For reference, this is the benchmark result I'm getting:

```sh
  *-cpu
       description: CPU
       product: AMD Ryzen 5 3500X 6-Core Processor
       vendor: Advanced Micro Devices [AMD]
       physical id: 2f
       bus info: cpu@0
       version: AMD Ryzen 5 3500X 6-Core Processor
       serial: Unknown
       slot: AM4
       size: 4030MHz
       capacity: 4100MHz
       width: 64 bits
       clock: 100MHz
```

```console
rafaelgss@rafaelgss-desktop:~/repos/os/node$ ./node benchmark/error/error.js
error/error.js disableEntropyCache=0 n=10000000: 506,239.3888750024
error/error.js disableEntropyCache=1 n=10000000: 490,143.20360859093
rafaelgss@rafaelgss-desktop:~/repos/os/node$ ./node benchmark/error/node-error.js
error/node-error.js disableEntropyCache=0 n=10000000: 159,137.83392330573
error/node-error.js disableEntropyCache=1 n=10000000: 159,349.56687673234
```

cc: @jasnell @mcollina

