### PR TITLE
src: fix regression that a source marker is lost with --enable-source-maps

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -62,7 +62,8 @@ static std::string GetErrorSource(Isolate* isolate,
   // added in the JavaScript context:
   Environment* env = Environment::GetCurrent(isolate);
   const bool has_source_map_url =
-      !message->GetScriptOrigin().SourceMapUrl().IsEmpty();
+      !message->GetScriptOrigin().SourceMapUrl().IsEmpty() &&
+      !message->GetScriptOrigin().SourceMapUrl()->IsUndefined();
   if (has_source_map_url && env != nullptr && env->source_maps_enabled()) {
     return sourceline;
   }

--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -25,8 +25,10 @@ const assert = require('assert');
 const exec = require('child_process').exec;
 const fixtures = require('../common/fixtures');
 
-function errExec(script, callback) {
-  const cmd = `"${process.argv[0]}" "${fixtures.path(script)}"`;
+function errExec(script, option, callback) {
+  callback = typeof option === 'function' ? option : callback;
+  option = typeof option === 'string' ? option : '';
+  const cmd = `"${process.argv[0]}" ${option} "${fixtures.path(script)}"`;
   return exec(cmd, (err, stdout, stderr) => {
     // There was some error
     assert.ok(err);
@@ -77,5 +79,10 @@ errExec('throws_error6.js', common.mustCall((err, stdout, stderr) => {
 
 // Object that throws in toString() doesn't print garbage
 errExec('throws_error7.js', common.mustCall((err, stdout, stderr) => {
+  assert.match(stderr, /throw {\r?\n\^\r?\n{ toString: \[Function: toString] }\r?\n\r?\nNode\.js \S+\r?\n$/);
+}));
+
+// Regression tests for https://github.com/nodejs/node/issues/39149
+errExec('throws_error7.js', '--enable-source-maps', common.mustCall((err, stdout, stderr) => {
   assert.match(stderr, /throw {\r?\n\^\r?\n{ toString: \[Function: toString] }\r?\n\r?\nNode\.js \S+\r?\n$/);
 }));


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes #39149

Since [#33491](https://github.com/nodejs/node/pull/33491/files#diff-090d65062da5652b79f8a641489e4bd33b37faf28b8e91cc2ac31ab43084a3d2), source markers in exception messages are handled in JS land. However the logic to detect whether the code has a source map url or not is incorrect, which results in #39149.

#### actual
```console
$ node --enable-source-maps -e "{"
SyntaxError: Unexpected end of input
    at new Script (node:vm:100:7)
    at createScript (node:vm:257:10)
    at Object.runInThisContext (node:vm:305:10)
    at node:internal/process/execution:76:19
    at [eval]-wrapper:6:22
    at evalScript (node:internal/process/execution:75:60)
    at node:internal/main/eval_string:27:3

Node.js v18.1.0
````

#### expected
```console
$ out/Release/node --enable-source-maps -e "{"
[eval]:1
{
 

SyntaxError: Unexpected end of input
    at new Script (node:vm:100:7)
    at createScript (node:vm:257:10)
    at Object.runInThisContext (node:vm:305:10)
    at node:internal/process/execution:76:19
    at [eval]-wrapper:6:22
    at evalScript (node:internal/process/execution:75:60)
    at node:internal/main/eval_string:27:3

Node.js v19.0.0-pre
```
