### PR TITLE
test: fix dangerous .map in `test/parallel/test-http-set-trailers.js`

### DIFF
--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -96,7 +96,7 @@ const server = http.createServer((req, res) => {
 });
 server.listen(0, () => {
   Promise.all([testHttp10, testHttp11, testClientTrailers]
-    .map(util.promisify)
+    .map((f) => util.promisify(f))
     .map((f) => f(server.address().port)))
     .then(() => server.close());
 });


### PR DESCRIPTION
Passing a function directly into `.map()`/`.forEach()`/etc. might eventually lead to unexpected results because of extra arguments (`index`, `array`).