### PR TITLE
tools: refactor license2rtf.js to ESM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1096,7 +1096,7 @@ endif
 		$(MACOSOUTDIR)/dist/npm/usr/local/lib/node_modules
 	unlink $(MACOSOUTDIR)/dist/node/usr/local/bin/npm
 	unlink $(MACOSOUTDIR)/dist/node/usr/local/bin/npx
-	$(NODE) tools/license2rtf.js < LICENSE > \
+	$(NODE) tools/license2rtf.mjs < LICENSE > \
 		$(MACOSOUTDIR)/installer/productbuild/Resources/license.rtf
 	cp doc/osx_installer_logo.png $(MACOSOUTDIR)/installer/productbuild/Resources
 	pkgbuild --version $(FULLVERSION) \

--- a/tools/license2rtf.mjs
+++ b/tools/license2rtf.mjs
@@ -1,8 +1,7 @@
-'use strict';
-
-const assert = require('assert');
-const Stream = require('stream');
-
+import assert from 'node:assert';
+import Stream from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { stdin, stdout } from 'node:process';
 
 /*
  * This filter consumes a stream of characters and emits one string per line.
@@ -287,19 +286,14 @@ class RtfGenerator extends Stream {
   }
 }
 
-
-const stdin = process.stdin;
-const stdout = process.stdout;
-const lineSplitter = new LineSplitter();
-const paragraphParser = new ParagraphParser();
-const unwrapper = new Unwrapper();
-const rtfGenerator = new RtfGenerator();
-
 stdin.setEncoding('utf-8');
 stdin.resume();
 
-stdin.pipe(lineSplitter);
-lineSplitter.pipe(paragraphParser);
-paragraphParser.pipe(unwrapper);
-unwrapper.pipe(rtfGenerator);
-rtfGenerator.pipe(stdout);
+await pipeline(
+  stdin,
+  new LineSplitter(),
+  new ParagraphParser(),
+  new Unwrapper(),
+  new RtfGenerator(),
+  stdout,
+);

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -420,9 +420,9 @@ if "%use_x64_node_exe%"=="true" (
     set exit_code=1
     goto exit
   )
-  %x64_node_exe% tools\license2rtf.js < LICENSE > %config%\license.rtf
+  %x64_node_exe% tools\license2rtf.mjs < LICENSE > %config%\license.rtf
 ) else (
-  %node_exe% tools\license2rtf.js < LICENSE > %config%\license.rtf
+  %node_exe% tools\license2rtf.mjs < LICENSE > %config%\license.rtf
 )
 
 if errorlevel 1 echo Failed to generate license.rtf&goto exit


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR tries to refactor license2rtf.js to ESM. Should still produce the same result:

```
$ git checkout master                                                                 
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
$ cat LICENSE | out/Release/node tools/license2rtf.js > LICENSE_ORIGINAL.rtf 
$ git checkout esm/license2rtf            
Switched to branch 'esm/license2rtf'
Your branch is up to date with 'origin/esm/license2rtf'.
$ cat LICENSE | out/Release/node tools/license2rtf.mjs > LICENSE_NEW.rtf     
$ sha256sum LICENSE_ORIGINAL.rtf LICENSE_NEW.rtf
48264d4618ee04c3347303d4de0e36d351c08ad885a9c7bf2c3b310523178325  LICENSE_ORIGINAL.rtf
48264d4618ee04c3347303d4de0e36d351c08ad885a9c7bf2c3b310523178325  LICENSE_NEW.rtf
```

Changes:

* commonjs format to esm
* use `pipeline` promise version instead of a serial of `pipe` function to improve readability

