### PR TITLE
doc: remove outdated footnote (Python 2 --> 3 for V8 tests)

### DIFF
--- a/doc/contributing/maintaining-V8.md
+++ b/doc/contributing/maintaining-V8.md
@@ -407,7 +407,7 @@ This would require some tooling to:
 [^1]: Node.js 0.12 and older are intentionally omitted from this document
     as their support has ended.
 
-[^2]: On macOS, The V8 tests require a full Xcode install, not just the "command
+[^2]: On macOS, the V8 tests require a full Xcode install, not just the "command
     line tools" for Xcode.
 
 [ChromiumReleaseCalendar]: https://www.chromium.org/developers/calendar

--- a/doc/contributing/maintaining-V8.md
+++ b/doc/contributing/maintaining-V8.md
@@ -222,7 +222,7 @@ to be cherry-picked in the Node.js repository and V8-CI must test the change.
   * Run the Node.js [V8 CI][] in addition to the [Node.js CI][].
     The CI uses the `test-v8` target in the `Makefile`, which uses
     `tools/make-v8.sh` to reconstruct a git tree in the `deps/v8` directory to
-    run V8 tests.
+    run V8 tests.[^2]
 
 The [`git-node`][] tool can be used to simplify this task. Run
 `git node v8 backport <sha>` to cherry-pick a commit.
@@ -406,6 +406,9 @@ This would require some tooling to:
 
 [^1]: Node.js 0.12 and older are intentionally omitted from this document
     as their support has ended.
+
+[^2]: On macOS, The V8 tests require a full Xcode install, not just the "command
+    line tools" for Xcode.
 
 [ChromiumReleaseCalendar]: https://www.chromium.org/developers/calendar
 [Node.js CI]: https://ci.nodejs.org/job/node-test-pull-request/

--- a/doc/contributing/maintaining-V8.md
+++ b/doc/contributing/maintaining-V8.md
@@ -222,7 +222,7 @@ to be cherry-picked in the Node.js repository and V8-CI must test the change.
   * Run the Node.js [V8 CI][] in addition to the [Node.js CI][].
     The CI uses the `test-v8` target in the `Makefile`, which uses
     `tools/make-v8.sh` to reconstruct a git tree in the `deps/v8` directory to
-    run V8 tests.[^2]
+    run V8 tests.
 
 The [`git-node`][] tool can be used to simplify this task. Run
 `git node v8 backport <sha>` to cherry-pick a commit.
@@ -406,11 +406,6 @@ This would require some tooling to:
 
 [^1]: Node.js 0.12 and older are intentionally omitted from this document
     as their support has ended.
-
-[^2]: The V8 tests still require Python 2. To run these tests locally, you can
-    run `PYTHON2 ./configure.py` before running `make test-v8`, in the root
-    of this repository. On macOS, this also requires a full Xcode install,
-    not just the "command line tools" for Xcode.
 
 [ChromiumReleaseCalendar]: https://www.chromium.org/developers/calendar
 [Node.js CI]: https://ci.nodejs.org/job/node-test-pull-request/


### PR DESCRIPTION
Various Python 3 compatibility fixes were made in upstream V8,
and they have even dropped Python 2 compatibility in various scripts.

depot_tools, which bootstraps the V8 build, is also moving to Python 3.

As of Node v18.0.0-ish, this footnote is no-longer accurate.

(Running `make test-v8` no-longer requires Python 2,
and it won't work anymore if you don't have a copy of Python 3.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
