### PR TITLE
doc: use ASCII apostrophes consistently

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Report security bugs in Node.js via [HackerOne](https://hackerone.com/nodejs).
 
-Your report will be acknowledged within 5 days, and you’ll receive a more
+Your report will be acknowledged within 5 days, and you'll receive a more
 detailed response to your report within 10 days indicating the next steps in
 handling your submission.
 
@@ -49,7 +49,7 @@ Here is the security disclosure policy for Node.js
 
 * This process can take some time, especially when coordination is required
   with maintainers of other projects. Every effort will be made to handle the
-  bug in as timely a manner as possible; however, it’s important that we follow
+  bug in as timely a manner as possible; however, it's important that we follow
   the release process above to ensure that the disclosure is handled in a
   consistent manner.
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -318,7 +318,7 @@ console.log(uint16array);
 ```
 
 It is possible to create a new `Buffer` that shares the same allocated
-memory as a [`TypedArray`][] instance by using the `TypedArray` object’s
+memory as a [`TypedArray`][] instance by using the `TypedArray` object's
 `.buffer` property in the same way. [`Buffer.from()`][`Buffer.from(arrayBuf)`]
 behaves like `new Uint8Array()` in this context.
 

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -408,7 +408,7 @@ added: v10.0.0
 
 Try to construct a table with the columns of the properties of `tabularData`
 (or use `properties`) and rows of `tabularData` and log it. Falls back to just
-logging the argument if it can’t be parsed as tabular.
+logging the argument if it can't be parsed as tabular.
 
 ```js
 // These can't be parsed as tabular data
@@ -459,7 +459,7 @@ changes:
     description: The elapsed time is displayed with a suitable time unit.
   - version: v6.0.0
     pr-url: https://github.com/nodejs/node/pull/5901
-    description: This method no longer supports multiple calls that don’t map
+    description: This method no longer supports multiple calls that don't map
                  to individual `console.time()` calls; see below for details.
 -->
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2569,7 +2569,7 @@ changes:
 Type: Runtime
 
 Passing a callback to [`worker.terminate()`][] is deprecated. Use the returned
-`Promise` instead, or a listener to the worker’s `'exit'` event.
+`Promise` instead, or a listener to the worker's `'exit'` event.
 
 ### DEP0133: `http` `connection`
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -143,7 +143,7 @@ algorithm][]. All other specifier resolutions are always only resolved with
 the standard relative [URL][] resolution semantics.
 
 Like in CommonJS, module files within packages can be accessed by appending a
-path to the package name unless the package’s [`package.json`][] contains an
+path to the package name unless the package's [`package.json`][] contains an
 [`"exports"`][] field, in which case files within packages can only be accessed
 via the paths defined in [`"exports"`][].
 
@@ -719,7 +719,7 @@ Hooks are part of a chain, even if that chain consists of only one custom
 (user-provided) hook and the default hook, which is always present. Hook
 functions nest: each one must always return a plain object, and chaining happens
 as a result of each function calling `next<hookName>()`, which is a reference
-to the subsequent loader’s hook.
+to the subsequent loader's hook.
 
 A hook that returns a value lacking a required property triggers an exception.
 A hook that returns without calling `next<hookName>()` _and_ without returning
@@ -989,7 +989,7 @@ export function globalPreload({ port }) {
 ### Examples
 
 The various loader hooks can be used together to accomplish wide-ranging
-customizations of Node.js’ code loading and evaluation behaviors.
+customizations of the Node.js code loading and evaluation behaviors.
 
 #### HTTPS loader
 
@@ -1066,7 +1066,7 @@ prints the current version of CoffeeScript per the module at the URL in
 
 #### Transpiler loader
 
-Sources that are in formats Node.js doesn’t understand can be converted into
+Sources that are in formats Node.js doesn't understand can be converted into
 JavaScript using the [`load` hook][load hook]. Before that hook gets called,
 however, a [`resolve` hook][resolve hook] needs to tell Node.js not to
 throw an error on unknown file types.

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -813,7 +813,7 @@ stack trace for such warnings.
 
 The emitted warning can be inspected with [`process.on('warning')`][] and will
 have the additional `emitter`, `type`, and `count` properties, referring to
-the event emitter instance, the event’s name and the number of attached
+the event emitter instance, the event's name and the number of attached
 listeners, respectively.
 Its `name` property is set to `'MaxListenersExceededWarning'`.
 
@@ -1633,7 +1633,7 @@ added: v14.5.0
 -->
 
 * `event` {Event}
-* Returns: {boolean} `true` if either event’s `cancelable` attribute value is
+* Returns: {boolean} `true` if either event's `cancelable` attribute value is
   false or its `preventDefault()` method was not invoked, otherwise `false`.
 
 Dispatches the `event` to the list of handlers for `event.type`.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2515,7 +2515,7 @@ The "not recommended" examples above check for existence and then use the
 file; the "recommended" examples are better because they use the file directly
 and handle the error, if any.
 
-In general, check for the existence of a file only if the file won’t be
+In general, check for the existence of a file only if the file won't be
 used directly, for example when its existence is a signal from another
 process.
 
@@ -3989,7 +3989,7 @@ If the `target` does not exist, `'file'` will be used. Windows junction points
 require the destination path to be absolute. When using `'junction'`, the
 `target` argument will automatically be normalized to absolute path.
 
-Relative targets are relative to the link’s parent directory.
+Relative targets are relative to the link's parent directory.
 
 ```mjs
 import { symlink } from 'node:fs';

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -224,7 +224,7 @@ in your project's `package.json`.
 
 ## Package entry points
 
-In a package’s `package.json` file, two fields can define entry points for a
+In a package's `package.json` file, two fields can define entry points for a
 package: [`"main"`][] and [`"exports"`][]. The [`"main"`][] field is supported
 in all versions of Node.js, but its capabilities are limited: it only defines
 the main entry point of the package.
@@ -255,7 +255,7 @@ likely be a breaking change.**
 
 To make the introduction of [`"exports"`][] non-breaking, ensure that every
 previously supported entry point is exported. It is best to explicitly specify
-entry points so that the package’s public API is well-defined. For example,
+entry points so that the package's public API is well-defined. For example,
 a project that previous exported `main`, `lib`,
 `feature`, and the `package.json` could use the following `package.exports`:
 
@@ -303,7 +303,7 @@ path `import feature from 'my-mod/feature/index.js`.
 ### Main entry point export
 
 To set the main entry point for a package, it is advisable to define both
-[`"exports"`][] and [`"main"`][] in the package’s [`package.json`][] file:
+[`"exports"`][] and [`"main"`][] in the package's [`package.json`][] file:
 
 ```json
 {
@@ -700,8 +700,8 @@ changes:
     description: Unflag self-referencing a package using its name.
 -->
 
-Within a package, the values defined in the package’s
-`package.json` [`"exports"`][] field can be referenced via the package’s name.
+Within a package, the values defined in the package's
+`package.json` [`"exports"`][] field can be referenced via the package's name.
 For example, assuming the `package.json` is:
 
 ```json
@@ -905,7 +905,7 @@ This approach is appropriate for any of the following use cases:
   install both this package and those other packages. For example a `utilities`
   package is used directly in an application, and a `utilities-plus` package
   adds a few more functions to `utilities`. Because the wrapper exports
-  underlying CommonJS files, it doesn’t matter if `utilities-plus` is written in
+  underlying CommonJS files, it doesn't matter if `utilities-plus` is written in
   CommonJS or ES module syntax; it will work either way.
 * The package stores internal state, and the package author would prefer not to
   refactor the package to isolate its state management. See the next section.
@@ -915,7 +915,7 @@ be to add an export, e.g. `"./module"`, to point to an all-ES module-syntax
 version of the package. This could be used via `import 'pkg/module'` by users
 who are certain that the CommonJS version will not be loaded anywhere in the
 application, such as by dependencies; or if the CommonJS version can be loaded
-but doesn’t affect the ES module version (for example, because the package is
+but doesn't affect the ES module version (for example, because the package is
 stateless):
 
 ```json
@@ -949,22 +949,22 @@ points directly:
 
 This can be done if both the CommonJS and ES module versions of the package are
 equivalent, for example because one is the transpiled output of the other; and
-the package’s management of state is carefully isolated (or the package is
+the package's management of state is carefully isolated (or the package is
 stateless).
 
 The reason that state is an issue is because both the CommonJS and ES module
 versions of the package might get used within an application; for example, the
-user’s application code could `import` the ES module version while a dependency
+user's application code could `import` the ES module version while a dependency
 `require`s the CommonJS version. If that were to occur, two copies of the
 package would be loaded in memory and therefore two separate states would be
 present. This would likely cause hard-to-troubleshoot bugs.
 
-Aside from writing a stateless package (if JavaScript’s `Math` were a package,
+Aside from writing a stateless package (if JavaScript's `Math` were a package,
 for example, it would be stateless as all of its methods are static), there are
-some ways to isolate state so that it’s shared between the potentially loaded
+some ways to isolate state so that it's shared between the potentially loaded
 CommonJS and ES module instances of the package:
 
-1. If possible, contain all state within an instantiated object. JavaScript’s
+1. If possible, contain all state within an instantiated object. JavaScript's
    `Date`, for example, needs to be instantiated to contain state; if it were a
    package, it would be used like this:
 
@@ -974,7 +974,7 @@ CommonJS and ES module instances of the package:
    // someDate contains state; Date does not
    ```
 
-   The `new` keyword isn’t required; a package’s function can return a new
+   The `new` keyword isn't required; a package's function can return a new
    object, or modify a passed-in object, to keep the state external to the
    package.
 
@@ -1001,7 +1001,7 @@ CommonJS and ES module instances of the package:
    each reference of `pkg` will contain the same state; and modifying that
    state from either module system will apply to both.
 
-Any plugins that attach to the package’s singleton would need to separately
+Any plugins that attach to the package's singleton would need to separately
 attach to both the CommonJS and ES module singletons.
 
 This approach is appropriate for any of the following use cases:
@@ -1076,7 +1076,7 @@ changes:
 }
 ```
 
-The `"name"` field defines your package’s name. Publishing to the
+The `"name"` field defines your package's name. Publishing to the
 _npm_ registry requires a name that satisfies
 [certain requirements](https://docs.npmjs.com/files/package.json#name).
 
@@ -1159,7 +1159,7 @@ Files ending with `.js` are loaded as ES modules when the nearest parent
 `"module"`.
 
 The nearest parent `package.json` is defined as the first `package.json` found
-when searching in the current folder, that folder’s parent, and so on up
+when searching in the current folder, that folder's parent, and so on up
 until a node\_modules folder or the volume root is reached.
 
 ```json

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1527,7 +1527,7 @@ added: v0.1.27
 changes:
   - version: v11.14.0
     pr-url: https://github.com/nodejs/node/pull/26544
-    description: Worker threads will now use a copy of the parent thread’s
+    description: Worker threads will now use a copy of the parent thread's
                  `process.env` by default, configurable through the `env`
                  option of the `Worker` constructor.
   - version: v10.0.0
@@ -1650,7 +1650,7 @@ console.log(env.test);
 
 Unless explicitly specified when creating a [`Worker`][] instance,
 each [`Worker`][] thread has its own copy of `process.env`, based on its
-parent thread’s `process.env`, or whatever was specified as the `env` option
+parent thread's `process.env`, or whatever was specified as the `env` option
 to the [`Worker`][] constructor. Changes to `process.env` will not be visible
 across [`Worker`][] threads, and only the main thread can make changes that
 are visible to the operating system or to native add-ons.

--- a/doc/api/synopsis.md
+++ b/doc/api/synopsis.md
@@ -19,7 +19,7 @@ Commands in this document start with `$` or `>` to replicate how they would
 appear in a user's terminal. Do not include the `$` and `>` characters. They are
 there to show the start of each command.
 
-Lines that don’t start with `$` or `>` character show the output of the previous
+Lines that don't start with `$` or `>` character show the output of the previous
 command.
 
 First, make sure to have downloaded and installed Node.js. See

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -660,7 +660,7 @@ added: v16.7.0
   `URL.createObjectURL()`.
 
 Removes the stored {Blob} identified by the given ID. Attempting to revoke a
-ID that isn’t registered will silently fail.
+ID that isn't registered will silently fail.
 
 ### Class: `URLSearchParams`
 

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -456,7 +456,7 @@ For use inside of a custom [`serializer._writeHostObject()`][].
 
 * `buffer` {Buffer|TypedArray|DataView}
 
-Write raw bytes into the serializer’s internal buffer. The deserializer
+Write raw bytes into the serializer's internal buffer. The deserializer
 will require a way to compute the length of the buffer.
 For use inside of a custom [`serializer._writeHostObject()`][].
 
@@ -571,7 +571,7 @@ For use inside of a custom [`deserializer._readHostObject()`][].
 * `length` {integer}
 * Returns: {Buffer}
 
-Read raw bytes from the deserializer’s internal buffer. The `length` parameter
+Read raw bytes from the deserializer's internal buffer. The `length` parameter
 must correspond to the length of the buffer that was passed to
 [`serializer.writeRawBytes()`][].
 For use inside of a custom [`deserializer._readHostObject()`][].

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -237,7 +237,7 @@ changes:
 Receive a single message from a given `MessagePort`. If no message is available,
 `undefined` is returned, otherwise an object with a single `message` property
 that contains the message payload, corresponding to the oldest message in the
-`MessagePort`’s queue.
+`MessagePort`'s queue.
 
 ```js
 const { MessageChannel, receiveMessageOnPort } = require('node:worker_threads');
@@ -336,7 +336,7 @@ added: v10.5.0
 -->
 
 An arbitrary JavaScript value that contains a clone of the data passed
-to this thread’s `Worker` constructor.
+to this thread's `Worker` constructor.
 
 The data is cloned as if using [`postMessage()`][`port.postMessage()`],
 according to the [HTML structured clone algorithm][].
@@ -939,7 +939,7 @@ changes:
     description: The `resourceLimits` option was introduced.
 -->
 
-* `filename` {string|URL} The path to the Worker’s main script or module. Must
+* `filename` {string|URL} The path to the Worker's main script or module. Must
   be either an absolute path or a relative path (i.e. relative to the
   current working directory) starting with `./` or `../`, or a WHATWG `URL`
   object using `file:` or `data:` protocol.
@@ -955,7 +955,7 @@ changes:
   * `env` {Object} If set, specifies the initial value of `process.env` inside
     the Worker thread. As a special value, [`worker.SHARE_ENV`][] may be used
     to specify that the parent thread and the child thread should share their
-    environment variables; in that case, changes to one thread’s `process.env`
+    environment variables; in that case, changes to one thread's `process.env`
     object affect the other thread as well. **Default:** `process.env`.
   * `eval` {boolean} If `true` and the first argument is a `string`, interpret
     the first argument to the constructor as a script that is executed once the

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -304,8 +304,8 @@ speed, at the cost of memory usage.
 There are equivalents to the zlib options for Brotli-based streams, although
 these options have different ranges than the zlib ones:
 
-* zlib’s `level` option matches Brotli’s `BROTLI_PARAM_QUALITY` option.
-* zlib’s `windowBits` option matches Brotli’s `BROTLI_PARAM_LGWIN` option.
+* zlib's `level` option matches Brotli's `BROTLI_PARAM_QUALITY` option.
+* zlib's `windowBits` option matches Brotli's `BROTLI_PARAM_LGWIN` option.
 
 See [below][Brotli parameters] for more details on Brotli-specific options.
 

--- a/doc/contributing/cpp-style-guide.md
+++ b/doc/contributing/cpp-style-guide.md
@@ -51,7 +51,7 @@ tools.
 
 ## Formatting
 
-Unfortunately, the C++ linter (based on [Google’s `cpplint`][]), which can be
+Unfortunately, the C++ linter (based on [Google's `cpplint`][]), which can be
 run explicitly via `make lint-cpp`, does not currently catch a lot of rules that
 are specific to the Node.js C++ code base. This document explains the most
 common of these rules:
@@ -117,7 +117,7 @@ void FunctionWithAVeryLongName(int parameter_with_a_very_long_name,
                                ...);
 ```
 
-If that doesn’t work, break after the `(` and use 4 spaces of indentation:
+If that doesn't work, break after the `(` and use 4 spaces of indentation:
 
 ```cpp
 void FunctionWithAReallyReallyReallyLongNameSeriouslyStopIt(
@@ -397,7 +397,7 @@ even `try` and `catch` **will** break.
 [ES.48]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-casts
 [ES.49]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-casts-named
 [Google C++ Style Guide]: https://google.github.io/styleguide/cppguide.html
-[Google’s `cpplint`]: https://github.com/google/styleguide
+[Google's `cpplint`]: https://github.com/google/styleguide
 [R.20]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-owner
 [R.21]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-unique
 [Run Time Type Information]: https://en.wikipedia.org/wiki/Run-time_type_information

--- a/doc/contributing/maintaining-icu.md
+++ b/doc/contributing/maintaining-icu.md
@@ -193,9 +193,9 @@ Floating patches are applied at `configure` time. The "patch" files
 are used instead of the original source files. The patch files are
 complete `.cpp` files replacing the original contents.
 
-Patches are tied to a specific ICU version. They won’t apply to a
+Patches are tied to a specific ICU version. They won't apply to a
 future ICU version.  We assume that you filed a bug against [ICU][] and
-upstreamed the fix, so the patch won’t be needed in a later ICU
+upstreamed the fix, so the patch won't be needed in a later ICU
 version.
 
 ### Example

--- a/onboarding.md
+++ b/onboarding.md
@@ -144,12 +144,12 @@ The project has a venue for real-time discussion:
 
 * Approving a change
   * Collaborators indicate that they have reviewed and approve of the changes in
-    a pull request using GitHub’s approval interface
+    a pull request using GitHub's approval interface
   * Some people like to comment `LGTM` (“Looks Good To Me”)
-  * You have the authority to approve any other collaborator’s work.
+  * You have the authority to approve any other collaborator's work.
   * You cannot approve your own pull requests.
   * When explicitly using `Changes requested`, show empathy – comments will
-    usually be addressed even if you don’t use it.
+    usually be addressed even if you don't use it.
     * If you do, it is nice if you are available later to check whether your
       comments have been addressed
     * If you see that the requested changes have been made, you can clear
@@ -158,7 +158,7 @@ The project has a venue for real-time discussion:
       comments to block the pull request from landing.
 
 * What belongs in Node.js:
-  * Opinions vary – it’s good to have a broad collaborator base for that reason!
+  * Opinions vary – it's good to have a broad collaborator base for that reason!
   * If Node.js itself needs it (due to historical reasons), then it belongs in
     Node.js.
     * That is to say, `url` is there because of `http`, `freelist` is there

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # Node.js C++ codebase
 
-Hi! 👋 You’ve found the C++ code backing Node.js. This README aims to help you
+Hi! 👋 You've found the C++ code backing Node.js. This README aims to help you
 get started working on it and document some idioms you may encounter while
 doing so.
 
@@ -22,7 +22,7 @@ accessed online in the following locations:
 
 * On GitHub: [`v8.h` in Node.js master][]
 * On GitHub: [`v8.h` in V8 master][]
-* On the Chromium project’s Code Search application: [`v8.h` in Code Search][]
+* On the Chromium project's Code Search application: [`v8.h` in Code Search][]
 
 V8 also provides an [introduction for V8 embedders][],
 which can be useful for understanding some of the concepts it uses in its
@@ -42,7 +42,7 @@ There is a [reference documentation for the libuv API][].
 
 The Node.js C++ files follow this structure:
 
-The `.h` header files contain declarations, and sometimes definitions that don’t
+The `.h` header files contain declarations, and sometimes definitions that don't
 require including other headers (e.g. getters, setters, etc.). They should only
 include other `.h` header files and nothing else.
 
@@ -272,7 +272,7 @@ Often, the `Context` is passed around for [exception handling][].
 Typical ways of accessing the current `Context` in the Node.js code are:
 
 * Given an [`Isolate`][], using `isolate->GetCurrentContext()`.
-* Given an [`Environment`][], using `env->context()` to get the `Environment`’s
+* Given an [`Environment`][], using `env->context()` to get the `Environment`'s
   main context.
 
 <a id="event-loop"></a>
@@ -288,7 +288,7 @@ The current event loop can be accessed using `env->event_loop()` given an
 [`Environment`][] instance. The restriction of using a single event loop
 is not inherent to the design of Node.js, and a sufficiently committed person
 could restructure Node.js to provide e.g. the ability to run parts of Node.js
-inside an event loop separate from the active thread’s event loop.
+inside an event loop separate from the active thread's event loop.
 
 <a id="environment"></a>
 
@@ -351,7 +351,7 @@ The platform can be accessed through `isolate_data->platform()` given an
 
 * The current Node.js instance was not started by an embedder; or
 * The current Node.js instance was started by an embedder whose `v8::Platform`
-  implementation also implement’s the `node::MultiIsolatePlatform` interface
+  implementation also implement's the `node::MultiIsolatePlatform` interface
   and who passed this to Node.js.
 
 <a id="binding-functions"></a>
@@ -419,7 +419,7 @@ void Initialize(Local<Object> target,
 }
 
 // Run the `Initialize` function when loading this module through
-// `internalBinding('cares_wrap')` in Node.js’s built-in JavaScript code:
+// `internalBinding('cares_wrap')` in Node.js's built-in JavaScript code:
 NODE_MODULE_CONTEXT_AWARE_INTERNAL(cares_wrap, Initialize)
 ```
 
@@ -484,7 +484,7 @@ That object is always a [`BaseObject`][].
 
 Its class needs to have a static `type_name` field based on a
 constant string, in order to disambiguate it from other classes of this type,
-and which could e.g. match the binding’s name (in the example above, that would
+and which could e.g. match the binding's name (in the example above, that would
 be `cares_wrap`).
 
 ```cpp
@@ -556,7 +556,7 @@ the process otherwise. `maybe.FromJust()` (aka `maybe.ToChecked()`) can be used
 to access the value and crash the process if it is not set.
 
 This should only be performed if it is actually sure that the operation has
-not failed. A lot of Node.js’s source code does **not** follow this rule, and
+not failed. A lot of the Node.js source code does **not** follow this rule, and
 can be brought to crash through this.
 
 In particular, it is often not safe to assume that an operation does not throw
@@ -621,18 +621,18 @@ v8::Maybe<double> SumNumbers(v8::Local<v8::Context> context,
     v8::Local<v8::Value> entry;
     if (array_of_integers->Get(context, i).ToLocal(&entry)) {
       // Oops, we might have hit a getter that throws an exception!
-      // It’s better to not continue return an empty (“nothing”) Maybe.
+      // It's better to not continue return an empty (“nothing”) Maybe.
       return v8::Nothing<double>();
     }
 
     if (!entry->IsNumber()) {
-      // Let’s just skip any non-numbers. It would also be reasonable to throw
+      // Let's just skip any non-numbers. It would also be reasonable to throw
       // an exception here, e.g. using the error system in src/node_errors.h,
       // and then to return an empty Maybe again.
       continue;
     }
 
-    // This cast is valid, because we’ve made sure it’s really a number.
+    // This cast is valid, because we've made sure it's really a number.
     v8::Local<v8::Number> entry_as_number = entry.As<v8::Number>();
 
     sum += entry_as_number->Value();
@@ -643,7 +643,7 @@ v8::Maybe<double> SumNumbers(v8::Local<v8::Context> context,
 
 // Function that is exposed to JS:
 void SumNumbers(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  // This will crash if the first argument is not an array. Let’s assume we
+  // This will crash if the first argument is not an array. Let's assume we
   // have performed type checking in a JavaScript wrapper function.
   CHECK(args[0]->IsArray());
 
@@ -859,7 +859,7 @@ this information is provided to async tracking tools.
 The `AsyncWrap` class has a set of methods called `MakeCallback()`, with the
 intention of the naming being that it is used to “make calls back into
 JavaScript” from the event loop, rather than making callbacks in some way.
-(As the naming has made its way into Node.js’s public API, it’s not worth
+(As the naming has made its way into the Node.js public API, it's not worth
 the breakage of fixing it).
 
 `MakeCallback()` generally calls a method on the JavaScript object associated
@@ -936,7 +936,7 @@ classes provide the same facilities as [`MakeCallback()`][], namely:
 
 Usually, using `AsyncWrap::MakeCallback()` or using the constructor taking
 an `AsyncWrap*` argument (i.e. used as
-`InternalCallbackScope callback_scope(this);`) suffices inside of Node.js’s
+`InternalCallbackScope callback_scope(this);`) suffices inside of the Node.js
 C++ codebase.
 
 ## C++ utilities


### PR DESCRIPTION
We can use non-ASCII apostrophes, but we should be consistent. Because the vast majority of apostrophes in our docs is ASCII, this changes the few non-ASCII apostrophes (`’`) to ASCII apostrophes (`'`). This resolves such minor inconsistencies:

![example inconsistency using both ASCII and non-ASCII apostrophes](https://user-images.githubusercontent.com/3109072/168479074-d4ce57b8-0bb8-49bf-ad65-0f8a1988b93a.png)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
