### PR TITLE
report: add more heap infos in process report

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -131,11 +131,20 @@ is provided below for reference.
     }
   ],
   "javascriptHeap": {
-    "totalMemory": 6127616,
-    "totalCommittedMemory": 4357352,
-    "usedMemory": 3221136,
-    "availableMemory": 1521370240,
-    "memoryLimit": 1526909922,
+    "totalMemory": 5660672,
+    "executableMemory": 524288,
+    "totalCommittedMemory": 5488640,
+    "availableMemory": 4341379928,
+    "totalGlobalHandlesMemory": 8192,
+    "usedGlobalHandlesMemory": 3136,
+    "usedMemory": 4816432,
+    "memoryLimit": 4345298944,
+    "mallocedMemory": 254128,
+    "externalMemory": 315644,
+    "peakMallocedMemory": 98752,
+    "nativeContextCount": 1,
+    "detachedContextCount": 0,
+    "doesZapGarbage": 0,
     "heapSpaces": {
       "read_only_space": {
         "memorySize": 524288,

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -608,12 +608,27 @@ static void PrintGCStatistics(JSONWriter* writer, Isolate* isolate) {
 
   writer->json_objectstart("javascriptHeap");
   writer->json_keyvalue("totalMemory", v8_heap_stats.total_heap_size());
+  writer->json_keyvalue("executableMemory",
+                        v8_heap_stats.total_heap_size_executable());
   writer->json_keyvalue("totalCommittedMemory",
                         v8_heap_stats.total_physical_size());
-  writer->json_keyvalue("usedMemory", v8_heap_stats.used_heap_size());
   writer->json_keyvalue("availableMemory",
                         v8_heap_stats.total_available_size());
+  writer->json_keyvalue("totalGlobalHandlesMemory",
+                        v8_heap_stats.total_global_handles_size());
+  writer->json_keyvalue("usedGlobalHandlesMemory",
+                        v8_heap_stats.used_global_handles_size());
+  writer->json_keyvalue("usedMemory", v8_heap_stats.used_heap_size());
   writer->json_keyvalue("memoryLimit", v8_heap_stats.heap_size_limit());
+  writer->json_keyvalue("mallocedMemory", v8_heap_stats.malloced_memory());
+  writer->json_keyvalue("externalMemory", v8_heap_stats.external_memory());
+  writer->json_keyvalue("peakMallocedMemory",
+                        v8_heap_stats.peak_malloced_memory());
+  writer->json_keyvalue("nativeContextCount",
+                        v8_heap_stats.number_of_native_contexts());
+  writer->json_keyvalue("detachedContextCount",
+                        v8_heap_stats.number_of_detached_contexts());
+  writer->json_keyvalue("doesZapGarbage", v8_heap_stats.does_zap_garbage());
 
   writer->json_objectstart("heapSpaces");
   // Loop through heap spaces

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -193,14 +193,32 @@ function _validateContent(report, fields = []) {
 
     // Verify the format of the javascriptHeap section.
     const heap = report.javascriptHeap;
-    const jsHeapFields = ['totalMemory', 'totalCommittedMemory', 'usedMemory',
-                          'availableMemory', 'memoryLimit', 'heapSpaces'];
+    // See `PrintGCStatistics` in node_report.cc
+    const jsHeapFields = [
+      'totalMemory',
+      'executableMemory',
+      'totalCommittedMemory',
+      'availableMemory',
+      'totalGlobalHandlesMemory',
+      'usedGlobalHandlesMemory',
+      'usedMemory',
+      'memoryLimit',
+      'mallocedMemory',
+      'externalMemory',
+      'peakMallocedMemory',
+      'nativeContextCount',
+      'detachedContextCount',
+      'doesZapGarbage',
+      'heapSpaces',
+    ];
     checkForUnknownFields(heap, jsHeapFields);
-    assert(Number.isSafeInteger(heap.totalMemory));
-    assert(Number.isSafeInteger(heap.totalCommittedMemory));
-    assert(Number.isSafeInteger(heap.usedMemory));
-    assert(Number.isSafeInteger(heap.availableMemory));
-    assert(Number.isSafeInteger(heap.memoryLimit));
+    // Do not check `heapSpaces` here
+    for (let i = 0; i < jsHeapFields.length - 1; i++) {
+      assert(
+        Number.isSafeInteger(heap[jsHeapFields[i]]),
+        `heap.${jsHeapFields[i]} is not a safe integer`
+      );
+    }
     assert(typeof heap.heapSpaces === 'object' && heap.heapSpaces !== null);
     const heapSpaceFields = ['memorySize', 'committedMemory', 'capacity',
                              'used', 'available'];


### PR DESCRIPTION
add more heap infos in process report

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
