### PR TITLE
assert: add new callTracker.callsWith function

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -330,11 +330,26 @@ added:
 -->
 
 * `fn` {Function} **Default:** A no-op function.
-* `withArgs` {Array} **Default:** An array with the arguments list.
+* `withArgs` {Array}: An array with the arguments list.
 * `exact` {number} **Default:** `1`.
 * Returns: {Function} that wraps `fn`.
 
-The wrapper function is expected to be called exactly `exact` times. If the
+The wrapper function is expected to be called exactly `exact` times and
+to be called exactly with `withArgs` arguments.
+
+The `withArgs` will compare whether the function arguments are deep-strict equal
+
+> When comparing two function instances you must pass the right instance or
+> it'll not be equal:
+
+```js
+const callsNoop = tracker.callsWith([function() {}]);
+callsNoop(function() {});
+tracker.verify();
+// Will throw an error as its expected to two different function instances not be equal
+```
+
+If the
 function has not been called exactly `exact` times when
 [`tracker.verify()`][] is called, then [`tracker.verify()`][] will throw an
 error.

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -322,11 +322,11 @@ function func() {}
 const callsfunc = tracker.calls(func);
 ```
 
-### `tracker.callsWith([fn][withArgs][, exact])`
+### `tracker.callsWith([fn],withArgs[, exact])`
 
 <!-- YAML
 added:
-  - v19.0.0
+  - REPLACEME
 -->
 
 * `fn` {Function} **Default:** A no-op function.

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -322,6 +322,73 @@ function func() {}
 const callsfunc = tracker.calls(func);
 ```
 
+### `tracker.callsWith([fn][withArgs][, exact])`
+
+<!-- YAML
+added:
+  - v19.0.0
+-->
+
+* `fn` {Function} **Default:** A no-op function.
+* `withArgs` {Array} **Default:** An array with the arguments list.
+* `exact` {number} **Default:** `1`.
+* Returns: {Function} that wraps `fn`.
+
+The wrapper function is expected to be called exactly `exact` times. If the
+function has not been called exactly `exact` times when
+[`tracker.verify()`][] is called, then [`tracker.verify()`][] will throw an
+error.
+
+```mjs
+import assert from 'node:assert';
+
+// Creates call tracker.
+const tracker = new assert.CallTracker();
+
+function func() {}
+
+// Returns a function that wraps func() that must be called exact times
+// Before tracker.verify().
+const callsfunc = tracker.callsWith(func, ['test', 1, 2]);
+callsfunc('test', 1, 2);
+
+// Or without any no-op function and calling twice
+const myfn = tracker.callsWith(['test', 1, 2], 2);
+myfn('test', 1, 2);
+myfn('test', 1, 2);
+tracker.verify();
+
+// Or
+const fn = tracker.callsWith(['test', 1, 2]);
+fn('test', 1, 2);
+tracker.verify();
+```
+
+```cjs
+const assert = require('node:assert');
+
+// Creates call tracker.
+const tracker = new assert.CallTracker();
+
+function func() {}
+
+// Returns a function that wraps func() that must be called exact times
+// Before tracker.verify().
+const callsfunc = tracker.callsWith(func, ['test', 1, 2]);
+callsfunc('test', 1, 2);
+
+// Or without any no-op function and calling twice
+const myfn = tracker.callsWith(['test', 1, 2], 2);
+myfn('test', 1, 2);
+myfn('test', 1, 2);
+tracker.verify();
+
+// Or
+const fn = tracker.callsWith(['test', 1, 2]);
+fn('test', 1, 2);
+tracker.verify();
+```
+
 ### `tracker.report()`
 
 <!-- YAML

--- a/lib/internal/assert/calltracker.js
+++ b/lib/internal/assert/calltracker.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayPrototypePush,
+  ArrayIsArray,
   Error,
   FunctionPrototype,
   Proxy,
@@ -13,11 +14,16 @@ const {
   codes: {
     ERR_UNAVAILABLE_DURING_EXIT,
   },
+  genericNodeError,
 } = require('internal/errors');
+
 const AssertionError = require('internal/assert/assertion_error');
 const {
   validateUint32,
 } = require('internal/validators');
+const {
+  isDeepStrictEqual,
+} = require('internal/util/comparisons');
 
 const noop = FunctionPrototype;
 
@@ -25,13 +31,25 @@ class CallTracker {
 
   #callChecks = new SafeSet();
 
-  calls(fn, exact = 1) {
+  #calls(fn, exact, withArgs = []) {
     if (process._exiting)
       throw new ERR_UNAVAILABLE_DURING_EXIT();
+
+    // When calls([arg1, arg2], ?1)
+    if (ArrayIsArray(fn)) {
+      exact = typeof withArgs === 'number' ? withArgs : exact;
+      withArgs = fn;
+      fn = noop;
+    }
+
+    // When calls(1)
     if (typeof fn === 'number') {
       exact = fn;
       fn = noop;
-    } else if (fn === undefined) {
+    }
+
+    // When calls()
+    if (fn === undefined) {
       fn = noop;
     }
 
@@ -40,10 +58,13 @@ class CallTracker {
     const context = {
       exact,
       actual: 0,
+      expectedArgs: withArgs,
+      currentFnArgs: [],
       // eslint-disable-next-line no-restricted-syntax
       stackTrace: new Error(),
       name: fn.name || 'calls'
     };
+
     const callChecks = this.#callChecks;
     callChecks.add(context);
 
@@ -51,14 +72,19 @@ class CallTracker {
       __proto__: null,
       apply(fn, thisArg, argList) {
         context.actual++;
-        if (context.actual === context.exact) {
+        context.currentFnArgs = argList;
+
+        // TODO:(erick): not working for functions with different instances
+        const containsExpectArgs = isDeepStrictEqual(context.currentFnArgs, context.expectedArgs);
+
+        if (context.actual === context.exact && containsExpectArgs) {
           // Once function has reached its call count remove it from
           // callChecks set to prevent memory leaks.
           callChecks.delete(context);
         }
         // If function has been called more than expected times, add back into
         // callchecks.
-        if (context.actual === context.exact + 1) {
+        if (context.actual === context.exact + 1 && containsExpectArgs) {
           callChecks.add(context);
         }
         return ReflectApply(fn, thisArg, argList);
@@ -66,14 +92,54 @@ class CallTracker {
     });
   }
 
+  callsWith(fn, withArgs, exact = 1) {
+    const expectedArgsWerePassed = ArrayIsArray(fn) ||
+      ArrayIsArray(exact) ||
+      ArrayIsArray(withArgs);
+
+    if (!expectedArgsWerePassed) {
+      const message = 'the [ withArgs ] param is required';
+
+      throw new AssertionError({
+        message,
+        details: ArrayPrototypePush([], {
+          message,
+          operator: 'callsWith',
+          stack: genericNodeError()
+        })
+      });
+    }
+
+    return this.#calls(fn, exact, withArgs);
+  }
+
+  calls(fn, exact = 1) {
+    return this.#calls(fn, exact);
+  }
+
   report() {
     const errors = [];
     for (const context of this.#callChecks) {
-      // If functions have not been called exact times
-      if (context.actual !== context.exact) {
+
+      const needsToCheckArgs = !!context.expectedArgs;
+
+      const invalidArgs = needsToCheckArgs ?
+        (context.currentFnArgs !== context.expectedArgs) :
+        false;
+
+      const msg = needsToCheckArgs ? [
+        `with args (${context.expectedArgs}) `,
+        ` with args (${context.currentFnArgs})`,
+      ] : ['', ''];
+
+      // If functions have not been called exact times and with correct arguments
+      if (
+        context.actual !== context.exact ||
+        invalidArgs
+      ) {
         const message = `Expected the ${context.name} function to be ` +
-                        `executed ${context.exact} time(s) but was ` +
-                        `executed ${context.actual} time(s).`;
+                        `executed ${context.exact} time(s) ${msg[0]}but was ` +
+                        `executed ${context.actual} time(s)${msg[1]}.`;
         ArrayPrototypePush(errors, {
           message,
           actual: context.actual,

--- a/lib/internal/assert/calltracker.js
+++ b/lib/internal/assert/calltracker.js
@@ -78,7 +78,6 @@ class CallTracker {
         if (context.expectedArgs.length)
           context.currentFnArgs = argList;
 
-        // TODO:(erick): functions with different instances are not deepStrictEqual
         const containsExpectArgs = isDeepStrictEqual(context.currentFnArgs, context.expectedArgs);
 
         if (context.actual === context.exact && containsExpectArgs) {

--- a/lib/internal/assert/calltracker.js
+++ b/lib/internal/assert/calltracker.js
@@ -52,6 +52,7 @@ class CallTracker {
     if (fn === undefined) {
       fn = noop;
     }
+    // Else calls(fn, 1, [])
 
     validateUint32(exact, 'exact', true);
 
@@ -72,9 +73,12 @@ class CallTracker {
       __proto__: null,
       apply(fn, thisArg, argList) {
         context.actual++;
-        context.currentFnArgs = argList;
 
-        // TODO:(erick): not working for functions with different instances
+        // Only spy args if requested
+        if (context.expectedArgs.length)
+          context.currentFnArgs = argList;
+
+        // TODO:(erick): functions with different instances are not deepStrictEqual
         const containsExpectArgs = isDeepStrictEqual(context.currentFnArgs, context.expectedArgs);
 
         if (context.actual === context.exact && containsExpectArgs) {

--- a/test/parallel/test-assert-calltracker-callsWith.js
+++ b/test/parallel/test-assert-calltracker-callsWith.js
@@ -1,0 +1,126 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+function bar() {}
+
+// It should call once the bar function with 1 as first argument
+{
+  const tracker = new assert.CallTracker();
+  const callsNoop = tracker.callsWith(bar, [1], 1);
+  callsNoop(1);
+  tracker.verify();
+}
+
+// It should call once the bar function with 'a' and 'b' as arguments
+{
+  const tracker = new assert.CallTracker();
+  const callsNoop = tracker.callsWith(bar, ['a', 'b'], 1);
+  callsNoop('a', 'b');
+  tracker.verify();
+}
+
+// It should call twice the bar function with 'a' and 'b' as arguments
+{
+  const tracker = new assert.CallTracker();
+  const callsNoop = tracker.callsWith(bar, ['a', 'b'], 2);
+  callsNoop('a', 'b');
+  callsNoop('a', 'b');
+  tracker.verify();
+}
+
+// When calling the watching function with incorrect params it should show an error message
+{
+  const tracker = new assert.CallTracker();
+  const callsNoop = tracker.callsWith(['a', 'b'], 1);
+  callsNoop('c', 'd');
+  const expectedMessage = 'Expected the calls function to be executed 1 time(s)' +
+  ' with args (a,b) but was executed 1 time(s) with args (c,d).';
+  const [{ message }] = tracker.report();
+  assert.deepStrictEqual(message, expectedMessage);
+}
+
+// It should show an error with calling the function wrongly once and rightly once
+{
+  const tracker = new assert.CallTracker();
+  const callsNoop = tracker.callsWith(['a', 'b'], 1);
+  callsNoop('c', 'd');
+  callsNoop('a', 'b');
+  const expectedMessage = 'Expected the calls function to be executed 1 time(s)' +
+  ' with args (a,b) but was executed 2 time(s) with args (a,b).';
+  const [{ message }] = tracker.report();
+  assert.deepStrictEqual(message, expectedMessage);
+}
+
+// It should verify once the given args
+{
+  const tracker = new assert.CallTracker();
+  const callsNoop = tracker.callsWith([bar]);
+  callsNoop(bar);
+  tracker.verify();
+}
+
+// It should call 100 times with the same args
+{
+  const tracker = new assert.CallTracker();
+  const callCount = 100;
+  const callsNoop = tracker.callsWith([ { abc: 1 }, [1], bar], callCount);
+  for (let i = 0; i < callCount; i++)
+    callsNoop({ abc: 1 }, [1], bar);
+
+  tracker.verify();
+}
+
+// Known bug: when sending a nearly created function its different (?)
+{
+  const tracker = new assert.CallTracker();
+  const callsNoop = tracker.callsWith([function() {}]);
+  callsNoop(function() {});
+
+  const [{ message }] = tracker.report();
+  const expectedMsg = 'Expected the calls function to be executed 1 time(s)' +
+  ' with args (function() {}) but was executed 1 time(s) with args (function() {}).';
+  assert.deepStrictEqual(message, expectedMsg);
+}
+
+// It should not use the same signature of tracker.call
+{
+  const tracker = new assert.CallTracker();
+  assert.throws(
+    () => tracker.callsWith(bar),
+    {
+      code: 'ERR_ASSERTION',
+    }
+  );
+}
+
+// It should not use the same signature of tracker.call
+{
+  const tracker = new assert.CallTracker();
+  assert.throws(
+    () => tracker.callsWith(1),
+    {
+      code: 'ERR_ASSERTION',
+    }
+  );
+}
+
+// It should not validate two Map instances with different values as the same
+{
+  const tracker = new assert.CallTracker();
+  const callsNoop = tracker.callsWith([ new Map([[ 'a', '1' ]]) ]);
+  callsNoop(new Map([[ 'a', '2']]));
+
+  const [{ message }] = tracker.report();
+  const expectedMsg = 'Expected the calls function to be executed 1 time(s)' +
+  ' with args ([object Map]) but was executed 1 time(s) with args ([object Map]).';
+  assert.deepStrictEqual(message, expectedMsg);
+}
+
+// It should validate two complex objects
+{
+  const tracker = new assert.CallTracker();
+  const callsNoop = tracker.callsWith([ new Map([[ 'a', '1' ]]) ]);
+  callsNoop(new Map([[ 'a', '1']]));
+  tracker.verify();
+}

--- a/test/parallel/test-assert-calltracker-callsWith.js
+++ b/test/parallel/test-assert-calltracker-callsWith.js
@@ -71,7 +71,7 @@ function bar() {}
   tracker.verify();
 }
 
-// Known bug: when sending a nearly created function its different (?)
+// Known behavior: it should validate two different function instances as not equal
 {
   const tracker = new assert.CallTracker();
   const callsNoop = tracker.callsWith([function() {}]);
@@ -105,7 +105,7 @@ function bar() {}
   );
 }
 
-// It should not validate two Map instances with different values as the same
+// It should make sure that the objects' instances have different values
 {
   const tracker = new assert.CallTracker();
   const callsNoop = tracker.callsWith([ new Map([[ 'a', '1' ]]) ]);
@@ -120,7 +120,7 @@ function bar() {}
 // It should validate two complex objects
 {
   const tracker = new assert.CallTracker();
-  const callsNoop = tracker.callsWith([ new Map([[ 'a', '1' ]]) ]);
-  callsNoop(new Map([[ 'a', '1']]));
+  const callsNoop = tracker.callsWith([ new Map([[ 'a', '1' ]]), new Set([ 'a', 2]) ]);
+  callsNoop(new Map([[ 'a', '1']]), new Set([ 'a', 2]));
   tracker.verify();
 }


### PR DESCRIPTION
This PR adds a new `callTracker.callsWith`  function and its docs

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
