### PR TITLE
src,lib: migrate to console on context's extra binding

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -37,7 +37,8 @@ const {
   open,
   url,
   isEnabled,
-  waitForDebugger
+  waitForDebugger,
+  console,
 } = internalBinding('inspector');
 
 const connectionSymbol = Symbol('connectionProperty');
@@ -188,8 +189,6 @@ module.exports = {
   close: process._debugEnd,
   url,
   waitForDebugger: inspectorWaitForDebugger,
-  // This is dynamically added during bootstrap,
-  // where the console from the VM is still available
-  console: require('internal/util/inspector').consoleFromVM,
+  console,
   Session
 };

--- a/lib/internal/bootstrap/browser.js
+++ b/lib/internal/bootstrap/browser.js
@@ -12,11 +12,9 @@ const {
 } = require('internal/util');
 const config = internalBinding('config');
 
-// Override global console from the one provided by the VM
-// to the one implemented by Node.js
 // https://console.spec.whatwg.org/#console-namespace
 exposeNamespace(globalThis, 'console',
-                createGlobalConsole(globalThis.console));
+                createGlobalConsole());
 
 const { URL, URLSearchParams } = require('internal/url');
 // https://url.spec.whatwg.org/#url
@@ -71,16 +69,14 @@ defineOperation(globalThis, 'setTimeout', timers.setTimeout);
 defineReplacableAttribute(globalThis, 'performance',
                           require('perf_hooks').performance);
 
-function createGlobalConsole(consoleFromVM) {
+function createGlobalConsole() {
   const consoleFromNode =
     require('internal/console/global');
   if (config.hasInspector) {
     const inspector = require('internal/util/inspector');
-    // This will be exposed by `require('inspector').console` later.
-    inspector.consoleFromVM = consoleFromVM;
     // TODO(joyeecheung): postpone this until the first time inspector
     // is activated.
-    inspector.wrapConsole(consoleFromNode, consoleFromVM);
+    inspector.wrapConsole(consoleFromNode);
     const { setConsoleExtensionInstaller } = internalBinding('inspector');
     // Setup inspector command line API.
     setConsoleExtensionInstaller(inspector.installConsoleExtensions);

--- a/lib/internal/util/inspector.js
+++ b/lib/internal/util/inspector.js
@@ -38,8 +38,8 @@ function installConsoleExtensions(commandLineApi) {
 }
 
 // Wrap a console implemented by Node.js with features from the VM inspector
-function wrapConsole(consoleFromNode, consoleFromVM) {
-  const { consoleCall } = internalBinding('inspector');
+function wrapConsole(consoleFromNode) {
+  const { consoleCall, console: consoleFromVM } = internalBinding('inspector');
   for (const key of ObjectKeys(consoleFromVM)) {
     // If global console has the same method as inspector console,
     // then wrap these two methods into one. Native wrapper will preserve
@@ -61,16 +61,8 @@ function wrapConsole(consoleFromNode, consoleFromVM) {
   }
 }
 
-// Stores the console from VM, should be set during bootstrap.
-let consoleFromVM;
 module.exports = {
   installConsoleExtensions,
   sendInspectorCommand,
   wrapConsole,
-  get consoleFromVM() {
-    return consoleFromVM;
-  },
-  set consoleFromVM(val) {
-    consoleFromVM = val;
-  }
 };

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -343,6 +343,18 @@ void Initialize(Local<Object> target, Local<Value> unused,
   env->SetMethod(target, "registerAsyncHook", RegisterAsyncHookWrapper);
   env->SetMethodNoSideEffect(target, "isEnabled", IsEnabled);
 
+  Local<String> console_string =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "console");
+
+  // Grab the console from the binding object and expose those to our binding
+  // layer.
+  Local<Object> binding = context->GetExtrasBindingObject();
+  target
+      ->Set(context,
+            console_string,
+            binding->Get(context, console_string).ToLocalChecked())
+      .Check();
+
   JSBindingsConnection<LocalConnection>::Bind(env, target);
   JSBindingsConnection<MainThreadConnection>::Bind(env, target);
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Since `globalThis.console` is not an ECMAScript defined builtin, V8's globally installed `console` implementation is been moved to the context's extra binding object: https://source.chromium.org/chromium/chromium/src/+/main:v8/src/init/bootstrapper.cc;l=4429?q=bootstrapper.cc

We need to migrate to that one before the globally installed console object is removed in V8.
