### PR TITLE
deps: V8: cherry-pick 3ebf2052a1b2

### DIFF
--- a/deps/v8/src/codegen/mips64/assembler-mips64.h
+++ b/deps/v8/src/codegen/mips64/assembler-mips64.h
@@ -71,7 +71,6 @@ class Operand {
       : rm_(no_reg), rmode_(RelocInfo::EXTERNAL_REFERENCE) {
     value_.immediate = static_cast<int64_t>(f.address());
   }
-  V8_INLINE explicit Operand(const char* s);
   explicit Operand(Handle<HeapObject> handle);
   V8_INLINE explicit Operand(Smi value) : rm_(no_reg), rmode_(RelocInfo::NONE) {
     value_.immediate = static_cast<intptr_t>(value.ptr());


### PR DESCRIPTION
  Original commit message:

    [mips64] Remove a useless declaration of Operand.

    Change-Id: I5144d8315b5c1aca751d138e4d87240b703dc9e3
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3650359
    Commit-Queue: Zhao Jiazhong <zhaojiazhong-hf@loongson.cn>
    Auto-Submit: Yu Liu <liuyu@loongson.cn>
    Reviewed-by: Zhao Jiazhong <zhaojiazhong-hf@loongson.cn>
    Cr-Commit-Position: refs/heads/main@{#80585}

Refs: https://github.com/v8/v8/commit/3ebf2052a1b270393eafb093a98ceca844ad237a

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
