### PR TITLE
events: add null check for the signal of EventTarget 

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -575,6 +575,10 @@ class EventTarget {
     }
     type = String(type);
 
+    if (signal === null) {
+      throw new ERR_INVALID_ARG_TYPE('options.signal', 'AbortSignal', signal);
+    }
+
     if (signal) {
       if (signal.aborted) {
         return;

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -34,7 +34,7 @@ const {
     ERR_INVALID_THIS,
   }
 } = require('internal/errors');
-const { validateObject, validateString, validateInternalField } = require('internal/validators');
+const { validateAbortSignal, validateObject, validateString, validateInternalField } = require('internal/validators');
 
 const {
   customInspectSymbol,
@@ -575,9 +575,7 @@ class EventTarget {
     }
     type = String(type);
 
-    if (signal === null) {
-      throw new ERR_INVALID_ARG_TYPE('options.signal', 'AbortSignal', signal);
-    }
+    validateAbortSignal(signal, 'options.signal');
 
     if (signal) {
       if (signal.aborted) {

--- a/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
+++ b/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
@@ -160,7 +160,7 @@ const {
 }
 {
   const et = new EventTarget();
-  [1, {}, null, false, 'hi'].forEach((signal) => {
+  [1, 1n, {}, [], null, true, 'hi', Symbol(), () => {}].forEach((signal) => {
     throws(() => et.addEventListener('foo', () => {}, { signal }), {
       name: 'TypeError',
     });

--- a/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
+++ b/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
@@ -161,6 +161,6 @@ const {
 {
   const et = new EventTarget();
   throws(() => et.addEventListener('foo', () => {}, { signal: null }), {
-    message: 'The "options.signal" property must be an instance of AbortSignal. Received null',
+    name: 'TypeError',
   });
 }

--- a/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
+++ b/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
@@ -4,7 +4,7 @@ require('../common');
 
 const {
   strictEqual,
-  throws
+  throws,
 } = require('assert');
 
 // Manually ported from: wpt@dom/events/AddEventListenerOptions-signal.any.js

--- a/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
+++ b/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
@@ -160,7 +160,9 @@ const {
 }
 {
   const et = new EventTarget();
-  throws(() => et.addEventListener('foo', () => {}, { signal: null }), {
-    name: 'TypeError',
+  [1, {}, null, false, 'hi'].forEach((signal) => {
+    throws(() => et.addEventListener('foo', () => {}, { signal }), {
+      name: 'TypeError',
+    });
   });
 }

--- a/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
+++ b/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
@@ -4,6 +4,7 @@ require('../common');
 
 const {
   strictEqual,
+  throws
 } = require('assert');
 
 // Manually ported from: wpt@dom/events/AddEventListenerOptions-signal.any.js
@@ -156,4 +157,8 @@ const {
     et.dispatchEvent(new Event('foo'));
   }, { once: true });
   et.dispatchEvent(new Event('foo'));
+}
+{
+  const et = new EventTarget();
+  throws(() => et.addEventListener('foo', () => {}, {signal: null}));
 }

--- a/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
+++ b/test/parallel/test-whatwg-events-add-event-listener-options-signal.js
@@ -160,5 +160,7 @@ const {
 }
 {
   const et = new EventTarget();
-  throws(() => et.addEventListener('foo', () => {}, {signal: null}));
+  throws(() => et.addEventListener('foo', () => {}, { signal: null }), {
+    message: 'The "options.signal" property must be an instance of AbortSignal. Received null',
+  });
 }

--- a/test/wpt/status/dom/events.json
+++ b/test/wpt/status/dom/events.json
@@ -11,7 +11,6 @@
   "AddEventListenerOptions-signal.any.js": {
     "fail": {
       "expected": [
-        "Passing null as the signal should throw",
         "Passing null as the signal should throw (listener is also null)"
       ]
     }


### PR DESCRIPTION
To improve Web compatibility, passing null as the signal should throw an error.
WPT says "Passing null as the signal should throw".
Please see https://github.com/web-platform-tests/wpt/blob/master/dom/events/AddEventListenerOptions-signal.any.js

Node doesn't check it.
This may occur the breaking change so don't hesitate to tell me if this should not be fixed.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
