### PR TITLE
lib: add `internalUtil.kEmptyObject`

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -54,7 +54,10 @@ const {
     ERR_OUT_OF_RANGE,
   },
 } = require('internal/errors');
-const { once } = require('internal/util');
+const {
+  kEmptyObject,
+  once,
+} = require('internal/util');
 const {
   validateNumber,
   validateOneOf,
@@ -220,7 +223,7 @@ Agent.defaultMaxSockets = Infinity;
 Agent.prototype.createConnection = net.createConnection;
 
 // Get the key for a given set of request options
-Agent.prototype.getName = function getName(options = {}) {
+Agent.prototype.getName = function getName(options = kEmptyObject) {
   let name = options.host || 'localhost';
 
   name += ':';

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -43,7 +43,10 @@ const {
 
 const net = require('net');
 const assert = require('internal/assert');
-const { once } = require('internal/util');
+const {
+  kEmptyObject,
+  once,
+} = require('internal/util');
 const {
   _checkIsHttpToken: checkIsHttpToken,
   freeParser,
@@ -133,7 +136,7 @@ function ClientRequest(input, options, cb) {
 
   if (typeof options === 'function') {
     cb = options;
-    options = input || {};
+    options = input || kEmptyObject;
   } else {
     options = ObjectAssign(input || {}, options);
   }

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -48,6 +48,10 @@ const {
 } = internalBinding('constants');
 
 const {
+  kEmptyObject,
+} = require('internal/util');
+
+const {
   validateInteger,
 } = require('internal/validators');
 
@@ -93,7 +97,7 @@ function SecureContext(secureProtocol, secureOptions, minVersion, maxVersion) {
 }
 
 function createSecureContext(options) {
-  if (!options) options = {};
+  if (!options) options = kEmptyObject;
 
   const {
     honorCipherOrder,

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -40,7 +40,8 @@ const {
 
 const {
   assertCrypto,
-  deprecate
+  deprecate,
+  kEmptyObject,
 } = require('internal/util');
 
 assertCrypto();
@@ -1182,9 +1183,9 @@ function Server(options, listener) {
 
   if (typeof options === 'function') {
     listener = options;
-    options = {};
+    options = kEmptyObject;
   } else if (options == null || typeof options === 'object') {
-    options = options || {};
+    options = options ?? kEmptyObject;
   } else {
     throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
   }

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -20,6 +20,7 @@ const {
   ERR_ASYNC_TYPE,
   ERR_INVALID_ASYNC_ID
 } = require('internal/errors').codes;
+const { kEmptyObject } = require('internal/util');
 const {
   validateFunction,
   validateString,
@@ -156,7 +157,7 @@ function createHook(fns) {
 const destroyedSymbol = Symbol('destroyed');
 
 class AsyncResource {
-  constructor(type, opts = {}) {
+  constructor(type, opts = kEmptyObject) {
     validateString(type, 'type');
 
     let triggerAsyncId = opts;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -43,10 +43,11 @@ const {
 } = primordials;
 
 const {
-  promisify,
   convertToValidSignal,
   createDeferredPromise,
-  getSystemErrorName
+  getSystemErrorName,
+  kEmptyObject,
+  promisify,
 } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 let debug = require('internal/util/debuglog').debuglog(
@@ -510,7 +511,7 @@ function normalizeSpawnArguments(file, args, options) {
   }
 
   if (options === undefined)
-    options = {};
+    options = kEmptyObject;
   else
     validateObject(options, 'options');
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -52,6 +52,9 @@ const {
   SymbolAsyncIterator,
 } = primordials;
 const kRejection = SymbolFor('nodejs.rejection');
+
+const { kEmptyObject } = require('internal/util');
+
 const { inspect } = require('internal/util/inspect');
 
 let spliceOne;
@@ -945,7 +948,7 @@ function getEventListeners(emitterOrTarget, type) {
  * @param {{ signal: AbortSignal; }} [options]
  * @returns {Promise}
  */
-async function once(emitter, name, options = {}) {
+async function once(emitter, name, options = kEmptyObject) {
   const signal = options?.signal;
   validateAbortSignal(signal, 'options.signal');
   if (signal?.aborted)

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -83,7 +83,14 @@ const {
 
 const { FSReqCallback } = binding;
 const { toPathIfFileURL } = require('internal/url');
-const internalUtil = require('internal/util');
+const {
+  customPromisifyArgs: kCustomPromisifyArgsSymbol,
+  deprecate,
+  kEmptyObject,
+  promisify: {
+    custom: kCustomPromisifiedSymbol,
+  },
+} = require('internal/util');
 const {
   constants: {
     kIoMaxLength,
@@ -164,7 +171,7 @@ const isWindows = process.platform === 'win32';
 const isOSX = process.platform === 'darwin';
 
 
-const showStringCoercionDeprecation = internalUtil.deprecate(
+const showStringCoercionDeprecation = deprecate(
   () => {},
   'Implicit coercion of objects with own toString property is deprecated.',
   'DEP0162'
@@ -276,7 +283,7 @@ function exists(path, callback) {
   }
 }
 
-ObjectDefineProperty(exists, internalUtil.promisify.custom, {
+ObjectDefineProperty(exists, kCustomPromisifiedSymbol, {
   __proto__: null,
   value: function exists(path) { // eslint-disable-line func-name-matching
     return new Promise((resolve) => fs.exists(path, resolve));
@@ -623,7 +630,7 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
       if (!isArrayBufferView(buffer)) {
         // This is fs.read(fd, params, callback)
         params = buffer;
-        ({ buffer = Buffer.alloc(16384) } = params ?? ObjectCreate(null));
+        ({ buffer = Buffer.alloc(16384) } = params ?? kEmptyObject);
       }
       callback = offsetOrOptions;
     } else {
@@ -636,7 +643,7 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
       offset = 0,
       length = buffer.byteLength - offset,
       position = null,
-    } = params ?? ObjectCreate(null));
+    } = params ?? kEmptyObject);
   }
 
   validateBuffer(buffer);
@@ -679,7 +686,7 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
   binding.read(fd, buffer, offset, length, position, req);
 }
 
-ObjectDefineProperty(read, internalUtil.customPromisifyArgs,
+ObjectDefineProperty(read, kCustomPromisifyArgsSymbol,
                      { __proto__: null, value: ['bytesRead', 'buffer'], enumerable: false });
 
 /**
@@ -701,7 +708,7 @@ function readSync(fd, buffer, offset, length, position) {
 
   if (arguments.length <= 3) {
     // Assume fs.readSync(fd, buffer, options)
-    const options = offset || ObjectCreate(null);
+    const options = offset || kEmptyObject;
 
     ({
       offset = 0,
@@ -772,7 +779,7 @@ function readv(fd, buffers, position, callback) {
   return binding.readBuffers(fd, buffers, position, req);
 }
 
-ObjectDefineProperty(readv, internalUtil.customPromisifyArgs,
+ObjectDefineProperty(readv, kCustomPromisifyArgsSymbol,
                      { __proto__: null, value: ['bytesRead', 'buffers'], enumerable: false });
 
 /**
@@ -829,7 +836,7 @@ function write(fd, buffer, offsetOrOptions, length, position, callback) {
         offset = 0,
         length = buffer.byteLength - offset,
         position = null,
-      } = offsetOrOptions ?? ObjectCreate(null));
+      } = offsetOrOptions ?? kEmptyObject);
     }
 
     if (offset == null || typeof offset === 'function') {
@@ -872,7 +879,7 @@ function write(fd, buffer, offsetOrOptions, length, position, callback) {
   return binding.writeString(fd, str, offset, length, req);
 }
 
-ObjectDefineProperty(write, internalUtil.customPromisifyArgs,
+ObjectDefineProperty(write, kCustomPromisifyArgsSymbol,
                      { __proto__: null, value: ['bytesWritten', 'buffer'], enumerable: false });
 
 /**
@@ -899,7 +906,7 @@ function writeSync(fd, buffer, offsetOrOptions, length, position) {
         offset = 0,
         length = buffer.byteLength - offset,
         position = null,
-      } = offsetOrOptions ?? ObjectCreate(null));
+      } = offsetOrOptions ?? kEmptyObject);
     }
     if (position === undefined)
       position = null;
@@ -962,7 +969,7 @@ function writev(fd, buffers, position, callback) {
   return binding.writeBuffers(fd, buffers, position, req);
 }
 
-ObjectDefineProperty(writev, internalUtil.customPromisifyArgs, {
+ObjectDefineProperty(writev, kCustomPromisifyArgsSymbol, {
   __proto__: null,
   value: ['bytesWritten', 'buffer'],
   enumerable: false
@@ -1405,7 +1412,7 @@ function mkdirSync(path, options) {
  */
 function readdir(path, options, callback) {
   callback = makeCallback(typeof options === 'function' ? options : callback);
-  options = getOptions(options, {});
+  options = getOptions(options);
   path = getValidatedPath(path);
 
   const req = new FSReqCallback();
@@ -1434,7 +1441,7 @@ function readdir(path, options, callback) {
  * @returns {string | Buffer[] | Dirent[]}
  */
 function readdirSync(path, options) {
-  options = getOptions(options, {});
+  options = getOptions(options);
   path = getValidatedPath(path);
   const ctx = { path };
   const result = binding.readdir(pathModule.toNamespacedPath(path),
@@ -1458,7 +1465,7 @@ function readdirSync(path, options) {
 function fstat(fd, options = { bigint: false }, callback) {
   if (typeof options === 'function') {
     callback = options;
-    options = {};
+    options = kEmptyObject;
   }
   fd = getValidatedFd(fd);
   callback = makeStatsCallback(callback);
@@ -1482,7 +1489,7 @@ function fstat(fd, options = { bigint: false }, callback) {
 function lstat(path, options = { bigint: false }, callback) {
   if (typeof options === 'function') {
     callback = options;
-    options = {};
+    options = kEmptyObject;
   }
   callback = makeStatsCallback(callback);
   path = getValidatedPath(path);
@@ -1505,7 +1512,7 @@ function lstat(path, options = { bigint: false }, callback) {
 function stat(path, options = { bigint: false }, callback) {
   if (typeof options === 'function') {
     callback = options;
-    options = {};
+    options = kEmptyObject;
   }
   callback = makeStatsCallback(callback);
   path = getValidatedPath(path);
@@ -1603,7 +1610,7 @@ function statSync(path, options = { bigint: false, throwIfNoEntry: true }) {
  */
 function readlink(path, options, callback) {
   callback = makeCallback(typeof options === 'function' ? options : callback);
-  options = getOptions(options, {});
+  options = getOptions(options);
   path = getValidatedPath(path, 'oldPath');
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -1618,7 +1625,7 @@ function readlink(path, options, callback) {
  * @returns {string | Buffer}
  */
 function readlinkSync(path, options) {
-  options = getOptions(options, {});
+  options = getOptions(options);
   path = getValidatedPath(path, 'oldPath');
   const ctx = { path };
   const result = binding.readlink(pathModule.toNamespacedPath(path),
@@ -2295,7 +2302,7 @@ function watch(filename, options, listener) {
   if (typeof options === 'function') {
     listener = options;
   }
-  options = getOptions(options, {});
+  options = getOptions(options);
 
   // Don't make changes directly on options object
   options = copyObject(options);
@@ -2458,8 +2465,6 @@ if (isWindows) {
   };
 }
 
-const emptyObj = ObjectCreate(null);
-
 /**
  * Returns the resolved pathname.
  * @param {string | Buffer | URL} p
@@ -2467,7 +2472,7 @@ const emptyObj = ObjectCreate(null);
  * @returns {string | Buffer}
  */
 function realpathSync(p, options) {
-  options = getOptions(options, emptyObj);
+  options = getOptions(options);
   p = toPathIfFileURL(p);
   if (typeof p !== 'string') {
     p += '';
@@ -2604,7 +2609,7 @@ function realpathSync(p, options) {
  * @returns {string | Buffer}
  */
 realpathSync.native = (path, options) => {
-  options = getOptions(options, {});
+  options = getOptions(options);
   path = getValidatedPath(path);
   const ctx = { path };
   const result = binding.realpath(path, options.encoding, undefined, ctx);
@@ -2625,7 +2630,7 @@ realpathSync.native = (path, options) => {
  */
 function realpath(p, options, callback) {
   callback = typeof options === 'function' ? options : maybeCallback(callback);
-  options = getOptions(options, {});
+  options = getOptions(options);
   p = toPathIfFileURL(p);
 
   if (typeof p !== 'string') {
@@ -2763,7 +2768,7 @@ function realpath(p, options, callback) {
  */
 realpath.native = (path, options, callback) => {
   callback = makeCallback(callback || options);
-  options = getOptions(options, {});
+  options = getOptions(options);
   path = getValidatedPath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -2782,7 +2787,7 @@ realpath.native = (path, options, callback) => {
  */
 function mkdtemp(prefix, options, callback) {
   callback = makeCallback(typeof options === 'function' ? options : callback);
-  options = getOptions(options, {});
+  options = getOptions(options);
 
   validateString(prefix, 'prefix');
   nullCheck(prefix, 'prefix');
@@ -2799,7 +2804,7 @@ function mkdtemp(prefix, options, callback) {
  * @returns {string}
  */
 function mkdtempSync(prefix, options) {
-  options = getOptions(options, {});
+  options = getOptions(options);
 
   validateString(prefix, 'prefix');
   nullCheck(prefix, 'prefix');

--- a/lib/https.js
+++ b/lib/https.js
@@ -34,7 +34,11 @@ const {
   ReflectConstruct,
 } = primordials;
 
-require('internal/util').assertCrypto();
+const {
+  assertCrypto,
+  kEmptyObject,
+} = require('internal/util');
+assertCrypto();
 
 const tls = require('tls');
 const { Agent: HttpAgent } = require('_http_agent');
@@ -206,7 +210,7 @@ Agent.prototype.createConnection = createConnection;
  *   }} [options]
  * @returns {string}
  */
-Agent.prototype.getName = function getName(options = {}) {
+Agent.prototype.getName = function getName(options = kEmptyObject) {
   let name = FunctionPrototypeCall(HttpAgent.prototype.getName, this, options);
 
   name += ':';

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -44,6 +44,7 @@ const {
 const {
   createDeferredPromise,
   customInspectSymbol: kInspect,
+  kEmptyObject,
 } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
 
@@ -134,7 +135,7 @@ class Blob {
    * }} [options]
    * @constructs {Blob}
    */
-  constructor(sources = [], options = {}) {
+  constructor(sources = [], options = kEmptyObject) {
     if (sources === null ||
         typeof sources[SymbolIterator] !== 'function' ||
         typeof sources === 'string') {

--- a/lib/internal/cluster/worker.js
+++ b/lib/internal/cluster/worker.js
@@ -7,6 +7,8 @@ const {
 
 const EventEmitter = require('events');
 
+const { kEmptyObject } = require('internal/util');
+
 module.exports = Worker;
 
 // Common Worker implementation shared between the cluster primary and workers.
@@ -17,7 +19,7 @@ function Worker(options) {
   ReflectApply(EventEmitter, this, []);
 
   if (options === null || typeof options !== 'object')
-    options = {};
+    options = kEmptyObject;
 
   this.exitedAfterDisconnect = undefined;
 

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -38,7 +38,10 @@ const {
   kAesKeyLengths,
 } = require('internal/crypto/util');
 
-const { customPromisifyArgs } = require('internal/util');
+const {
+  customPromisifyArgs,
+  kEmptyObject,
+} = require('internal/util');
 
 const {
   validateFunction,
@@ -119,7 +122,7 @@ function handleError(ret) {
   };
 }
 
-function parseKeyEncoding(keyType, options = {}) {
+function parseKeyEncoding(keyType, options = kEmptyObject) {
   const { publicKeyEncoding, privateKeyEncoding } = options;
 
   let publicFormat, publicType;

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -26,6 +26,7 @@ const {
 } = internalBinding('crypto');
 
 const {
+  kEmptyObject,
   lazyDOMException,
 } = require('internal/util');
 
@@ -399,7 +400,7 @@ function randomUUID(options) {
     validateObject(options, 'options');
   const {
     disableEntropyCache = false,
-  } = options || {};
+  } = options || kEmptyObject;
 
   validateBoolean(disableEntropyCache, 'options.disableEntropyCache');
 
@@ -464,7 +465,7 @@ function generatePrime(size, options, callback) {
   validateInt32(size, 'size', 1);
   if (typeof options === 'function') {
     callback = options;
-    options = {};
+    options = kEmptyObject;
   }
   validateFunction(callback, 'callback');
 
@@ -482,7 +483,7 @@ function generatePrime(size, options, callback) {
   job.run();
 }
 
-function generatePrimeSync(size, options = {}) {
+function generatePrimeSync(size, options = kEmptyObject) {
   validateInt32(size, 'size', 1);
 
   const job = createRandomPrimeJob(kCryptoJobSync, size, options);
@@ -506,7 +507,7 @@ function unsignedBigIntToBuffer(bigint, name) {
   return Buffer.from(padded, 'hex');
 }
 
-function checkPrime(candidate, options = {}, callback) {
+function checkPrime(candidate, options = kEmptyObject, callback) {
   if (typeof candidate === 'bigint')
     candidate = unsignedBigIntToBuffer(candidate, 'candidate');
   if (!isAnyArrayBuffer(candidate) && !isArrayBufferView(candidate)) {
@@ -524,7 +525,7 @@ function checkPrime(candidate, options = {}, callback) {
   }
   if (typeof options === 'function') {
     callback = options;
-    options = {};
+    options = kEmptyObject;
   }
   validateFunction(callback, 'callback');
   validateObject(options, 'options');
@@ -539,7 +540,7 @@ function checkPrime(candidate, options = {}, callback) {
   job.run();
 }
 
-function checkPrimeSync(candidate, options = {}) {
+function checkPrimeSync(candidate, options = kEmptyObject) {
   if (typeof candidate === 'bigint')
     candidate = unsignedBigIntToBuffer(candidate, 'candidate');
   if (!isAnyArrayBuffer(candidate) && !isArrayBufferView(candidate)) {

--- a/lib/internal/crypto/x509.js
+++ b/lib/internal/crypto/x509.js
@@ -23,6 +23,7 @@ const {
 
 const {
   customInspectSymbol: kInspect,
+  kEmptyObject,
 } = require('internal/util');
 
 const {
@@ -64,7 +65,7 @@ function isX509Certificate(value) {
   return value[kInternalState] !== undefined;
 }
 
-function getFlags(options = {}) {
+function getFlags(options = kEmptyObject) {
   validateObject(options, 'options');
   const {
     subject = 'default',  // Can be 'default', 'always', or 'never'

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -33,6 +33,7 @@ const kEncoder = Symbol('encoder');
 const {
   getConstructorOf,
   customInspectSymbol: inspect,
+  kEmptyObject,
   kEnumerableProperty,
 } = require('internal/util');
 
@@ -379,7 +380,7 @@ function makeTextDecoderICU() {
   } = internalBinding('icu');
 
   class TextDecoder {
-    constructor(encoding = 'utf-8', options = {}) {
+    constructor(encoding = 'utf-8', options = kEmptyObject) {
       encoding = `${encoding}`;
       validateObject(options, 'options', {
         nullable: true,
@@ -408,7 +409,7 @@ function makeTextDecoderICU() {
     }
 
 
-    decode(input = empty, options = {}) {
+    decode(input = empty, options = kEmptyObject) {
       validateDecoder(this);
       if (isAnyArrayBuffer(input)) {
         input = lazyBuffer().from(input);
@@ -453,7 +454,7 @@ function makeTextDecoderJS() {
   }
 
   class TextDecoder {
-    constructor(encoding = 'utf-8', options = {}) {
+    constructor(encoding = 'utf-8', options = kEmptyObject) {
       encoding = `${encoding}`;
       validateObject(options, 'options', {
         nullable: true,
@@ -481,7 +482,7 @@ function makeTextDecoderJS() {
       this[kBOMSeen] = false;
     }
 
-    decode(input = empty, options = {}) {
+    decode(input = empty, options = kEmptyObject) {
       validateDecoder(this);
       if (isAnyArrayBuffer(input)) {
         input = lazyBuffer().from(input);

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -35,7 +35,11 @@ const {
 } = require('internal/errors');
 const { validateObject, validateString } = require('internal/validators');
 
-const { customInspectSymbol, kEnumerableProperty } = require('internal/util');
+const {
+  customInspectSymbol,
+  kEmptyObject,
+  kEnumerableProperty,
+} = require('internal/util');
 const { inspect } = require('util');
 
 const kIsEventTarget = SymbolFor('nodejs.event_target');
@@ -453,7 +457,7 @@ class EventTarget {
    *   signal?: AbortSignal
    * }} [options]
    */
-  addEventListener(type, listener, options = {}) {
+  addEventListener(type, listener, options = kEmptyObject) {
     if (!isEventTarget(this))
       throw new ERR_INVALID_THIS('EventTarget');
     if (arguments.length < 2)
@@ -540,7 +544,7 @@ class EventTarget {
    *   capture?: boolean,
    * }} [options]
    */
-  removeEventListener(type, listener, options = {}) {
+  removeEventListener(type, listener, options = kEmptyObject) {
     if (!isEventTarget(this))
       throw new ERR_INVALID_THIS('EventTarget');
     if (!shouldAddListener(listener))
@@ -869,7 +873,7 @@ function validateEventListenerOptions(options) {
     return { capture: options };
 
   if (options === null)
-    return {};
+    return kEmptyObject;
   validateObject(options, 'options', {
     allowArray: true, allowFunction: true,
   });

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -5,7 +5,6 @@ const {
   Error,
   MathMax,
   MathMin,
-  ObjectCreate,
   NumberIsSafeInteger,
   Promise,
   PromisePrototypeThen,
@@ -81,7 +80,11 @@ const {
   validateString,
 } = require('internal/validators');
 const pathModule = require('path');
-const { lazyDOMException, promisify } = require('internal/util');
+const {
+  kEmptyObject,
+  lazyDOMException,
+  promisify,
+} = require('internal/util');
 const { EventEmitterMixin } = require('internal/event_target');
 const { watch } = require('internal/fs/watchers');
 const { isIterable } = require('internal/streams/utils');
@@ -519,7 +522,7 @@ async function read(handle, bufferOrParams, offset, length, position) {
       offset = 0,
       length = buffer.byteLength - offset,
       position = null,
-    } = bufferOrParams ?? ObjectCreate(null));
+    } = bufferOrParams ?? kEmptyObject);
 
     validateBuffer(buffer);
   }
@@ -582,7 +585,7 @@ async function write(handle, buffer, offsetOrOptions, length, position) {
         offset = 0,
         length = buffer.byteLength - offset,
         position = null,
-      } = offsetOrOptions ?? ObjectCreate(null));
+      } = offsetOrOptions ?? kEmptyObject);
     }
 
     if (offset == null) {
@@ -678,7 +681,7 @@ async function mkdir(path, options) {
   const {
     recursive = false,
     mode = 0o777
-  } = options || {};
+  } = options || kEmptyObject;
   path = getValidatedPath(path);
   validateBoolean(recursive, 'options.recursive');
 
@@ -688,7 +691,7 @@ async function mkdir(path, options) {
 }
 
 async function readdir(path, options) {
-  options = getOptions(options, {});
+  options = getOptions(options);
   path = getValidatedPath(path);
   const result = await binding.readdir(pathModule.toNamespacedPath(path),
                                        options.encoding,
@@ -700,7 +703,7 @@ async function readdir(path, options) {
 }
 
 async function readlink(path, options) {
-  options = getOptions(options, {});
+  options = getOptions(options);
   path = getValidatedPath(path, 'oldPath');
   return binding.readlink(pathModule.toNamespacedPath(path),
                           options.encoding, kUsePromises);
@@ -812,13 +815,13 @@ async function lutimes(path, atime, mtime) {
 }
 
 async function realpath(path, options) {
-  options = getOptions(options, {});
+  options = getOptions(options);
   path = getValidatedPath(path);
   return binding.realpath(path, options.encoding, kUsePromises);
 }
 
 async function mkdtemp(prefix, options) {
-  options = getOptions(options, {});
+  options = getOptions(options);
 
   validateString(prefix, 'prefix');
   nullCheck(prefix);

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -16,7 +16,10 @@ const {
   ERR_OUT_OF_RANGE,
   ERR_METHOD_NOT_IMPLEMENTED,
 } = require('internal/errors').codes;
-const { deprecate } = require('internal/util');
+const {
+  deprecate,
+  kEmptyObject,
+} = require('internal/util');
 const {
   validateFunction,
   validateInteger,
@@ -147,7 +150,7 @@ function ReadStream(path, options) {
     return new ReadStream(path, options);
 
   // A little bit bigger buffer and water marks by default
-  options = copyObject(getOptions(options, {}));
+  options = copyObject(getOptions(options, kEmptyObject));
   if (options.highWaterMark === undefined)
     options.highWaterMark = 64 * 1024;
 
@@ -305,7 +308,7 @@ function WriteStream(path, options) {
   if (!(this instanceof WriteStream))
     return new WriteStream(path, options);
 
-  options = copyObject(getOptions(options, {}));
+  options = copyObject(getOptions(options, kEmptyObject));
 
   // Only buffers are supported.
   options.decodeStrings = true;

--- a/lib/internal/fs/sync_write_stream.js
+++ b/lib/internal/fs/sync_write_stream.js
@@ -4,6 +4,7 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
 } = primordials;
+const { kEmptyObject } = require('internal/util');
 
 const { Writable } = require('stream');
 const { closeSync, writeSync } = require('fs');
@@ -11,7 +12,7 @@ const { closeSync, writeSync } = require('fs');
 function SyncWriteStream(fd, options) {
   ReflectApply(Writable, this, [{ autoDestroy: true }]);
 
-  options = options || {};
+  options = options || kEmptyObject;
 
   this.fd = fd;
   this.readable = false;

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -43,7 +43,10 @@ const {
   isDate,
   isBigUint64Array
 } = require('internal/util/types');
-const { once } = require('internal/util');
+const {
+  kEmptyObject,
+  once,
+} = require('internal/util');
 const { toPathIfFileURL } = require('internal/url');
 const {
   validateAbortSignal,
@@ -312,9 +315,8 @@ function getDirent(path, name, type, callback) {
   }
 }
 
-function getOptions(options, defaultOptions) {
-  if (options === null || options === undefined ||
-      typeof options === 'function') {
+function getOptions(options, defaultOptions = kEmptyObject) {
+  if (options == null || typeof options === 'function') {
     return defaultOptions;
   }
 

--- a/lib/internal/histogram.js
+++ b/lib/internal/histogram.js
@@ -17,6 +17,7 @@ const {
 
 const {
   customInspectSymbol: kInspect,
+  kEmptyObject,
 } = require('internal/util');
 
 const { inspect } = require('util');
@@ -352,7 +353,7 @@ internalRecordableHistogram.prototype[kDeserialize] = () => {};
  * }} [options]
  * @returns {RecordableHistogram}
  */
-function createHistogram(options = {}) {
+function createHistogram(options = kEmptyObject) {
   validateObject(options, 'options');
   const {
     lowest = 1,

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -37,7 +37,8 @@ const {
 const {
   assertCrypto,
   customInspectSymbol: kInspect,
-  promisify
+  kEmptyObject,
+  promisify,
 } = require('internal/util');
 
 assertCrypto();
@@ -3332,7 +3333,7 @@ function getPackedSettings(settings) {
   return binding.packSettings();
 }
 
-function getUnpackedSettings(buf, options = {}) {
+function getUnpackedSettings(buf, options = kEmptyObject) {
   if (!isArrayBufferView(buf) || buf.length === undefined) {
     throw new ERR_INVALID_ARG_TYPE('buf',
                                    ['Buffer', 'TypedArray'], buf);

--- a/lib/internal/perf/event_loop_delay.js
+++ b/lib/internal/perf/event_loop_delay.js
@@ -28,6 +28,10 @@ const {
 } = require('internal/histogram');
 
 const {
+  kEmptyObject,
+} = require('internal/util');
+
+const {
   makeTransferable,
 } = require('internal/worker/js_transferable');
 
@@ -69,7 +73,7 @@ class ELDHistogram extends Histogram {
  * }} [options]
  * @returns {ELDHistogram}
  */
-function monitorEventLoopDelay(options = {}) {
+function monitorEventLoopDelay(options = kEmptyObject) {
   validateObject(options, 'options');
 
   const { resolution = 10 } = options;

--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -55,6 +55,7 @@ const {
   customInspectSymbol: kInspect,
   deprecate,
   lazyDOMException,
+  kEmptyObject,
 } = require('internal/util');
 
 const {
@@ -212,7 +213,7 @@ class PerformanceObserver {
     this.#callback = callback;
   }
 
-  observe(options = {}) {
+  observe(options = kEmptyObject) {
     validateObject(options, 'options');
     const {
       entryTypes,

--- a/lib/internal/perf/timerify.js
+++ b/lib/internal/perf/timerify.js
@@ -34,6 +34,10 @@ const {
   enqueue,
 } = require('internal/perf/observe');
 
+const {
+  kEmptyObject,
+} = require('internal/util');
+
 function processComplete(name, start, args, histogram) {
   const duration = now() - start;
   if (histogram !== undefined)
@@ -52,7 +56,7 @@ function processComplete(name, start, args, histogram) {
   enqueue(entry);
 }
 
-function timerify(fn, options = {}) {
+function timerify(fn, options = kEmptyObject) {
   validateFunction(fn, 'fn');
 
   validateObject(options, 'options');

--- a/lib/internal/perf/usertiming.js
+++ b/lib/internal/perf/usertiming.js
@@ -27,7 +27,10 @@ const {
 } = require('internal/errors');
 
 const { structuredClone } = require('internal/structured_clone');
-const { lazyDOMException } = require('internal/util');
+const {
+  kEmptyObject,
+  lazyDOMException,
+} = require('internal/util');
 
 const markTimings = new SafeMap();
 
@@ -61,7 +64,7 @@ class PerformanceMark extends InternalPerformanceEntry {
     name = `${name}`;
     if (nodeTimingReadOnlyAttributes.has(name))
       throw new ERR_INVALID_ARG_VALUE('name', name);
-    options ??= {};
+    options ??= kEmptyObject;
     validateObject(options, 'options');
     const startTime = options.startTime ?? now();
     validateNumber(startTime, 'startTime');
@@ -91,7 +94,7 @@ class PerformanceMeasure extends InternalPerformanceEntry {
   }
 }
 
-function mark(name, options = {}) {
+function mark(name, options = kEmptyObject) {
   const mark = new PerformanceMark(name, options);
   enqueue(mark);
   return mark;

--- a/lib/internal/promise_hooks.js
+++ b/lib/internal/promise_hooks.js
@@ -11,6 +11,7 @@ const {
 const { setPromiseHooks } = internalBinding('async_wrap');
 const { triggerUncaughtException } = internalBinding('errors');
 
+const { kEmptyObject } = require('internal/util');
 const { validatePlainFunction } = require('internal/validators');
 
 const hooks = {
@@ -101,7 +102,7 @@ const onBefore = makeUseHook('before');
 const onAfter = makeUseHook('after');
 const onSettled = makeUseHook('settled');
 
-function createHook({ init, before, after, settled } = {}) {
+function createHook({ init, before, after, settled } = kEmptyObject) {
   const hooks = [];
 
   if (init) ArrayPrototypePush(hooks, onInit(init));

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -48,6 +48,7 @@ const {
   validateString,
   validateUint32,
 } = require('internal/validators');
+const { kEmptyObject } = require('internal/util');
 const {
   inspect,
   getStringWidth,
@@ -1053,7 +1054,7 @@ class Interface extends InterfaceConstructor {
   // Handle a write from the tty
   [kTtyWrite](s, key) {
     const previousKey = this[kPreviousKey];
-    key = key || {};
+    key = key || kEmptyObject;
     this[kPreviousKey] = key;
 
     if (!key.meta || key.name !== 'y') {

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -11,7 +11,10 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_STREAM_PREMATURE_CLOSE
 } = codes;
-const { once } = require('internal/util');
+const {
+  kEmptyObject,
+  once,
+} = require('internal/util');
 const {
   validateAbortSignal,
   validateFunction,
@@ -43,9 +46,9 @@ const nop = () => {};
 function eos(stream, options, callback) {
   if (arguments.length === 2) {
     callback = options;
-    options = {};
+    options = kEmptyObject;
   } else if (options == null) {
-    options = {};
+    options = kEmptyObject;
   } else {
     validateObject(options, 'options');
   }

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -4,7 +4,6 @@ const {
   ArrayPrototypeShift,
   FunctionPrototype,
   Number,
-  ObjectCreate,
   SafeMap,
 } = primordials;
 const { AsyncResource } = require('async_hooks');
@@ -16,7 +15,10 @@ const {
 } = require('internal/errors');
 const { getOptionValue } = require('internal/options');
 const { TapStream } = require('internal/test_runner/tap_stream');
-const { createDeferredPromise } = require('internal/util');
+const {
+  createDeferredPromise,
+  kEmptyObject,
+} = require('internal/util');
 const { isPromise } = require('internal/util/types');
 const { isUint32 } = require('internal/validators');
 const { cpus } = require('os');
@@ -198,7 +200,7 @@ class Test extends AsyncResource {
     }
 
     if (options === null || typeof options !== 'object') {
-      options = ObjectCreate(null);
+      options = kEmptyObject;
     }
 
     let parent = this;

--- a/lib/internal/tls/secure-context.js
+++ b/lib/internal/tls/secure-context.js
@@ -18,6 +18,10 @@ const {
 } = require('internal/errors');
 
 const {
+  kEmptyObject,
+} = require('internal/util');
+
+const {
   isArrayBufferView,
 } = require('internal/util/types');
 
@@ -117,7 +121,7 @@ function processCiphers(ciphers, name) {
   return { cipherList, cipherSuites };
 }
 
-function configSecureContext(context, options = {}, name = 'options') {
+function configSecureContext(context, options = kEmptyObject, name = 'options') {
   validateObject(options, name);
 
   const {

--- a/lib/internal/tls/secure-pair.js
+++ b/lib/internal/tls/secure-pair.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EventEmitter = require('events');
+const { kEmptyObject } = require('internal/util');
 const { Duplex } = require('stream');
 const _tls_wrap = require('_tls_wrap');
 const _tls_common = require('_tls_common');
@@ -57,7 +58,7 @@ class SecurePair extends EventEmitter {
               isServer = false,
               requestCert = !isServer,
               rejectUnauthorized = false,
-              options = {}) {
+              options = kEmptyObject) {
     super();
     const { socket1, socket2 } = new DuplexPair();
 

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -13,6 +13,7 @@ const {
   ObjectGetOwnPropertyDescriptor,
   ObjectGetOwnPropertyDescriptors,
   ObjectGetPrototypeOf,
+  ObjectFreeze,
   ObjectSetPrototypeOf,
   Promise,
   ReflectApply,
@@ -504,6 +505,8 @@ const lazyDOMException = hideStackFrames((message, name) => {
 const kEnumerableProperty = ObjectCreate(null);
 kEnumerableProperty.enumerable = true;
 
+const kEmptyObject = ObjectFreeze(ObjectCreate(null));
+
 module.exports = {
   assertCrypto,
   cachedResult,
@@ -544,5 +547,6 @@ module.exports = {
   kIsEncodingSymbol: Symbol('kIsEncodingSymbol'),
   kVmBreakFirstLineSymbol: Symbol('kVmBreakFirstLineSymbol'),
 
+  kEmptyObject,
   kEnumerableProperty,
 };

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -24,9 +24,10 @@ const {
   isArrayBufferView,
 } = require('internal/util/types');
 const {
-  getConstructorOf,
   customInspectSymbol,
   emitExperimentalWarning,
+  getConstructorOf,
+  kEmptyObject,
 } = require('internal/util');
 const {
   ERR_INVALID_ARG_TYPE,
@@ -199,7 +200,7 @@ class Module {
     this[kWrap].instantiate();
   }
 
-  async evaluate(options = {}) {
+  async evaluate(options = kEmptyObject) {
     if (this[kWrap] === undefined) {
       throw new ERR_VM_MODULE_NOT_MODULE();
     }
@@ -258,7 +259,7 @@ class SourceTextModule extends Module {
   #error = kNoError;
   #statusOverride;
 
-  constructor(sourceText, options = {}) {
+  constructor(sourceText, options = kEmptyObject) {
     validateString(sourceText, 'sourceText');
     validateObject(options, 'options');
 
@@ -387,7 +388,7 @@ class SourceTextModule extends Module {
 }
 
 class SyntheticModule extends Module {
-  constructor(exportNames, evaluateCallback, options = {}) {
+  constructor(exportNames, evaluateCallback, options = kEmptyObject) {
     if (!ArrayIsArray(exportNames) ||
       ArrayPrototypeSome(exportNames, (e) => typeof e !== 'string')) {
       throw new ERR_INVALID_ARG_TYPE('exportNames',

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -55,6 +55,7 @@ const {
 
 const {
   createDeferredPromise,
+  kEmptyObject,
 } = require('internal/util');
 
 const {
@@ -198,7 +199,7 @@ function newWritableStreamFromStreamWritable(streamWritable) {
  * }} [options]
  * @returns {Writable}
  */
-function newStreamWritableFromWritableStream(writableStream, options = {}) {
+function newStreamWritableFromWritableStream(writableStream, options = kEmptyObject) {
   if (!isWritableStream(writableStream)) {
     throw new ERR_INVALID_ARG_TYPE(
       'writableStream',
@@ -441,7 +442,7 @@ function newReadableStreamFromStreamReadable(streamReadable) {
  * }} [options]
  * @returns {Readable}
  */
-function newStreamReadableFromReadableStream(readableStream, options = {}) {
+function newStreamReadableFromReadableStream(readableStream, options = kEmptyObject) {
   if (!isReadableStream(readableStream)) {
     throw new ERR_INVALID_ARG_TYPE(
       'readableStream',
@@ -585,7 +586,7 @@ function newReadableWritablePairFromDuplex(duplex) {
  * }} [options]
  * @returns {Duplex}
  */
-function newStreamDuplexFromReadableWritablePair(pair = {}, options = {}) {
+function newStreamDuplexFromReadableWritablePair(pair = kEmptyObject, options = kEmptyObject) {
   validateObject(pair, 'pair');
   const {
     readable: readableStream,
@@ -876,7 +877,7 @@ function newWritableStreamFromStreamBase(streamBase, strategy) {
  * @param {QueuingStrategy} strategy
  * @returns {ReadableStream}
  */
-function newReadableStreamFromStreamBase(streamBase, strategy, options = {}) {
+function newReadableStreamFromStreamBase(streamBase, strategy, options = kEmptyObject) {
   validateObject(streamBase, 'streamBase');
   validateObject(options, 'options');
 

--- a/lib/internal/webstreams/encoding.js
+++ b/lib/internal/webstreams/encoding.js
@@ -24,6 +24,7 @@ const {
 
 const {
   customInspectSymbol: kInspect,
+  kEmptyObject,
   kEnumerableProperty,
 } = require('internal/util');
 
@@ -114,7 +115,7 @@ class TextDecoderStream {
    *   ignoreBOM? : boolean,
    * }} [options]
    */
-  constructor(encoding = 'utf-8', options = {}) {
+  constructor(encoding = 'utf-8', options = kEmptyObject) {
     this[kType] = 'TextDecoderStream';
     this[kHandle] = new TextDecoder(encoding, options);
     this[kTransform] = new TransformStream({

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -50,6 +50,7 @@ const {
 const {
   createDeferredPromise,
   customInspectSymbol: kInspect,
+  kEmptyObject,
   kEnumerableProperty,
 } = require('internal/util');
 
@@ -206,7 +207,7 @@ class ReadableStream {
    * @param {UnderlyingSource} [source]
    * @param {QueuingStrategy} [strategy]
    */
-  constructor(source = {}, strategy = {}) {
+  constructor(source = {}, strategy = kEmptyObject) {
     if (source === null)
       throw new ERR_INVALID_ARG_VALUE('source', 'Object', source);
     this[kState] = {
@@ -296,7 +297,7 @@ class ReadableStream {
    * }} [options]
    * @returns {ReadableStreamReader}
    */
-  getReader(options = {}) {
+  getReader(options = kEmptyObject) {
     if (!isReadableStream(this))
       throw new ERR_INVALID_THIS('ReadableStream');
     validateObject(options, 'options', { nullable: true, allowFunction: true });
@@ -315,7 +316,7 @@ class ReadableStream {
    * @param {StreamPipeOptions} [options]
    * @returns {ReadableStream}
    */
-  pipeThrough(transform, options = {}) {
+  pipeThrough(transform, options = kEmptyObject) {
     if (!isReadableStream(this))
       throw new ERR_INVALID_THIS('ReadableStream');
     const readable = transform?.readable;
@@ -365,7 +366,7 @@ class ReadableStream {
    * @param {StreamPipeOptions} [options]
    * @returns {Promise<void>}
    */
-  pipeTo(destination, options = {}) {
+  pipeTo(destination, options = kEmptyObject) {
     try {
       if (!isReadableStream(this))
         throw new ERR_INVALID_THIS('ReadableStream');
@@ -416,7 +417,7 @@ class ReadableStream {
    * }} [options]
    * @returns {AsyncIterable}
    */
-  values(options = {}) {
+  values(options = kEmptyObject) {
     if (!isReadableStream(this))
       throw new ERR_INVALID_THIS('ReadableStream');
     validateObject(options, 'options');

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -55,6 +55,7 @@ const {
 } = workerIo;
 const { deserializeError } = require('internal/error_serdes');
 const { fileURLToPath, isURLInstance, pathToFileURL } = require('internal/url');
+const { kEmptyObject } = require('internal/util');
 const { validateArray } = require('internal/validators');
 
 const {
@@ -118,7 +119,7 @@ function assignEnvironmentData(data) {
 }
 
 class Worker extends EventEmitter {
-  constructor(filename, options = {}) {
+  constructor(filename, options = kEmptyObject) {
     super();
     debug(`[${threadId}] create new worker`, filename, options);
     if (options.execArgv)

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -18,7 +18,10 @@ const {
   SymbolFor,
 } = primordials;
 
-const { kEnumerableProperty } = require('internal/util');
+const {
+  kEmptyObject,
+  kEnumerableProperty,
+} = require('internal/util');
 
 const {
   handle_onclose: handleOnCloseSymbol,
@@ -123,7 +126,7 @@ class MessageEvent extends Event {
     lastEventId = '',
     source = null,
     ports = [],
-  } = {}) {
+  } = kEmptyObject) {
     super(type);
     this[kData] = data;
     this[kOrigin] = `${origin}`;

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -47,7 +47,10 @@ const {
 const {
   inspect,
 } = require('internal/util/inspect');
-const { promisify } = require('internal/util');
+const {
+  kEmptyObject,
+  promisify,
+} = require('internal/util');
 const { validateAbortSignal } = require('internal/validators');
 
 /**
@@ -128,7 +131,9 @@ const superQuestion = _Interface.prototype.question;
  */
 Interface.prototype.question = function(query, options, cb) {
   cb = typeof options === 'function' ? options : cb;
-  options = typeof options === 'object' && options !== null ? options : {};
+  if (options === null || typeof options !== 'object') {
+    options = kEmptyObject;
+  }
 
   if (options.signal) {
     validateAbortSignal(options.signal, 'options.signal');
@@ -154,7 +159,9 @@ Interface.prototype.question = function(query, options, cb) {
   }
 };
 Interface.prototype.question[promisify.custom] = function question(query, options) {
-  options = typeof options === 'object' && options !== null ? options : {};
+  if (options === null || typeof options !== 'object') {
+    options = kEmptyObject;
+  }
 
   if (options.signal && options.signal.aborted) {
     return PromiseReject(
@@ -457,7 +464,7 @@ Interface.prototype._moveCursor = _Interface.prototype[kMoveCursor];
 Interface.prototype._ttyWrite = _Interface.prototype[kTtyWrite];
 
 function _ttyWriteDumb(s, key) {
-  key = key || {};
+  key = key || kEmptyObject;
 
   if (key.name === 'escape') return;
 

--- a/lib/readline/promises.js
+++ b/lib/readline/promises.js
@@ -18,12 +18,16 @@ const {
 } = require('internal/errors');
 const { validateAbortSignal } = require('internal/validators');
 
+const {
+  kEmptyObject,
+} = require('internal/util');
+
 class Interface extends _Interface {
   // eslint-disable-next-line no-useless-constructor
   constructor(input, output, completer, terminal) {
     super(input, output, completer, terminal);
   }
-  question(query, options = {}) {
+  question(query, options = kEmptyObject) {
     return new Promise((resolve, reject) => {
       let cb = resolve;
 

--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -35,6 +35,10 @@ const {
   validateObject,
 } = require('internal/validators');
 
+const {
+  kEmptyObject,
+} = require('internal/util');
+
 const kScheduler = Symbol('kScheduler');
 
 function cancelListenerHandler(clear, reject, signal) {
@@ -44,7 +48,7 @@ function cancelListenerHandler(clear, reject, signal) {
   }
 }
 
-function setTimeout(after, value, options = {}) {
+function setTimeout(after, value, options = kEmptyObject) {
   const args = value !== undefined ? [value] : value;
   if (options == null || typeof options !== 'object') {
     return PromiseReject(
@@ -88,7 +92,7 @@ function setTimeout(after, value, options = {}) {
       () => signal.removeEventListener('abort', oncancel)) : ret;
 }
 
-function setImmediate(value, options = {}) {
+function setImmediate(value, options = kEmptyObject) {
   if (options == null || typeof options !== 'object') {
     return PromiseReject(
       new ERR_INVALID_ARG_TYPE(
@@ -132,7 +136,7 @@ function setImmediate(value, options = {}) {
       () => signal.removeEventListener('abort', oncancel)) : ret;
 }
 
-async function* setInterval(after, value, options = {}) {
+async function* setInterval(after, value, options = kEmptyObject) {
   validateObject(options, 'options');
   const { signal, ref = true } = options;
   validateAbortSignal(signal, 'options.signal');

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -57,13 +57,14 @@ const {
   validateUint32,
 } = require('internal/validators');
 const {
-  kVmBreakFirstLineSymbol,
   emitExperimentalWarning,
+  kEmptyObject,
+  kVmBreakFirstLineSymbol,
 } = require('internal/util');
 const kParsingContext = Symbol('script parsing context');
 
 class Script extends ContextifyScript {
-  constructor(code, options = {}) {
+  constructor(code, options = kEmptyObject) {
     code = `${code}`;
     if (typeof options === 'string') {
       options = { filename: options };
@@ -152,7 +153,7 @@ function validateContext(contextifiedObject) {
   }
 }
 
-function getRunInContextArgs(options = {}) {
+function getRunInContextArgs(options = kEmptyObject) {
   validateObject(options, 'options');
 
   let timeout = options.timeout;
@@ -212,7 +213,7 @@ function isContext(object) {
 }
 
 let defaultContextNameIndex = 1;
-function createContext(contextObject = {}, options = {}) {
+function createContext(contextObject = {}, options = kEmptyObject) {
   if (isContext(contextObject)) {
     return contextObject;
   }
@@ -305,7 +306,7 @@ function runInThisContext(code, options) {
   return createScript(code, options).runInThisContext(options);
 }
 
-function compileFunction(code, params, options = {}) {
+function compileFunction(code, params, options = kEmptyObject) {
   validateString(code, 'code');
   if (params !== undefined) {
     validateArray(params, 'params');
@@ -395,7 +396,7 @@ const measureMemoryExecutions = {
   eager: constants.measureMemory.execution.EAGER,
 };
 
-function measureMemory(options = {}) {
+function measureMemory(options = kEmptyObject) {
   emitExperimentalWarning('vm.measureMemory');
   validateObject(options, 'options');
   const { mode = 'summary', execution = 'default' } = options;

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -13,7 +13,10 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_WASI_ALREADY_STARTED
 } = require('internal/errors').codes;
-const { emitExperimentalWarning } = require('internal/util');
+const {
+  emitExperimentalWarning,
+  kEmptyObject,
+} = require('internal/util');
 const { isArrayBuffer } = require('internal/util/types');
 const {
   validateArray,
@@ -55,7 +58,7 @@ function setupInstance(self, instance) {
 }
 
 class WASI {
-  constructor(options = {}) {
+  constructor(options = kEmptyObject) {
     validateObject(options, 'options');
 
     if (options.args !== undefined)

--- a/test/parallel/test-internal-util-objects.js
+++ b/test/parallel/test-internal-util-objects.js
@@ -1,0 +1,90 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+
+// Test helper objects from internal/util
+
+const assert = require('assert');
+const {
+  kEnumerableProperty,
+  kEmptyObject,
+} = require('internal/util');
+
+Object.prototype.blep = 'blop';
+
+{
+  assert.strictEqual(
+    kEnumerableProperty.blep,
+    undefined
+  );
+  assert.strictEqual(
+    kEnumerableProperty.enumerable,
+    true
+  );
+  assert.strictEqual(
+    Object.getPrototypeOf(kEnumerableProperty),
+    null
+  );
+  assert.deepStrictEqual(
+    Object.getOwnPropertyNames(kEnumerableProperty),
+    [ 'enumerable' ]
+  );
+}
+
+{
+  assert.strictEqual(
+    kEmptyObject.blep,
+    undefined
+  );
+  assert.strictEqual(
+    kEmptyObject.prototype,
+    undefined
+  );
+  assert.strictEqual(
+    Object.getPrototypeOf(kEmptyObject),
+    null
+  );
+  assert.strictEqual(
+    kEmptyObject instanceof Object,
+    false
+  );
+  assert.deepStrictEqual(
+    Object.getOwnPropertyDescriptors(kEmptyObject),
+    {}
+  );
+  assert.deepStrictEqual(
+    Object.getOwnPropertyNames(kEmptyObject),
+    []
+  );
+  assert.deepStrictEqual(
+    Object.getOwnPropertySymbols(kEmptyObject),
+    []
+  );
+  assert.strictEqual(
+    Object.isExtensible(kEmptyObject),
+    false
+  );
+  assert.strictEqual(
+    Object.isSealed(kEmptyObject),
+    true
+  );
+  assert.strictEqual(
+    Object.isFrozen(kEmptyObject),
+    true
+  );
+
+  assert.throws(
+    () => kEmptyObject.foo = 'bar',
+    TypeError
+  );
+  assert.throws(
+    () => Object.assign(kEmptyObject, { foo: 'bar' }),
+    TypeError
+  );
+  assert.throws(
+    () => Object.defineProperty(kEmptyObject, 'foo', {}),
+    TypeError
+  );
+}
+
+delete Object.prototype.blep;


### PR DESCRIPTION
### Problem
There are lots of places in core where we have to pass an optional "pre-ES6 map"-style object with optional properties.

To avoid verbose boilerplate code or overusing of optional chaining, and to allow destructuring, we need a fallback value of `{}`, thus creating a throwaway object:
```js
function fn({ foo = 'defaultFoo', bar } = {}) { // still unsafe
}
function fn(options = {}) {
  let foo = 'defaultFoo';
  if (options != null) // still have to check or validate
    foo = options.foo ?? 'defaultFoo';
  const bar = options?.bar;
 }
function fn(options) {
  options ??= {};
  const foo = options.foo || 'defaultFoo';
  const { bar } = options;
}
function fn(options) {
  const { foo = 'defaultFoo`, bar } = options ?? {};
}
```
It is also highly affected by prototype tampering, e.g.
```mjs
import tls from 'node:tls';
Object.assign(Object.prototype,{rejectUnauthorized:!1,ca:'pwned',passphrase:'gwak'});
console.log((new tls.Server).ca);
console.log(tls.createServer().passphrase);
```
So we have to prefer `Object.create(null)`, which is slower and still creates a throwaway object on every usage.

### Solution
```mjs
export const kEmptyObject = Object.freeze(Object.create(null));

const { foo, bar } = options ?? kEmptyObject;
```
A single immutable object that guarantees any property to be `undefined`.