### PR TITLE
tools: fix unreachable code in grokdump.py

### DIFF
--- a/deps/v8/tools/grokdump.py
+++ b/deps/v8/tools/grokdump.py
@@ -3173,7 +3173,7 @@ class InspectionWebFormatter(object):
       object_info = self.padawan.SenseObject(maybe_address)
       if not object_info:
         continue
-        extra.append(html.escape(str(object_info)))
+      extra.append(html.escape(str(object_info)))
     if len(extra) == 0:
       return line
     return ("%s <span class=disasmcomment>;; %s</span>" %


### PR DESCRIPTION
In the annotate_disasm_addresses function in grokdump.py, extra.append is referred to within the object_info block and below the continue statement, preventing object_info from being appended to extra at all and thereby the function serving no purpose.