### PR TITLE
doc: make minor adjustments

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -539,7 +539,7 @@ When modifying only the JS layer in `lib`, it is possible to externally load it
 without modifying the executable:
 
 ```console
-$ ./configure --node-builtin-modules-path $(pwd)
+$ ./configure --node-builtin-modules-path "$(pwd)"
 ```
 
 The resulting binary won't include any JS files and will try to load them from

--- a/doc/api/async_context.md
+++ b/doc/api/async_context.md
@@ -439,7 +439,7 @@ class DBQuery extends AsyncResource {
 }
 ```
 
-### Static method: `AsyncResource.bind(fn[, type, [thisArg]])`
+### Static method: `AsyncResource.bind(fn[, type[, thisArg]])`
 
 <!-- YAML
 added:

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -521,7 +521,7 @@ added:
 
 The total size of the `Blob` in bytes.
 
-### `blob.slice([start, [end, [type]]])`
+### `blob.slice([start[, end[, type]]])`
 
 <!-- YAML
 added:

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -57,7 +57,7 @@ successfully retrieved.
 When running outside of an existing project (for example when running
 `yarn init`), Corepack will by default use predefined versions roughly
 corresponding to the latest stable releases from each tool. Those versions can
-be overriden by running the [`corepack prepare`][] command along with the
+be overridden by running the [`corepack prepare`][] command along with the
 package manager version you wish to set:
 
 ```bash

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2912,7 +2912,7 @@ is currently in use. Setting to true requires a FIPS build of Node.js.
 This property is deprecated. Please use `crypto.setFips()` and
 `crypto.getFips()` instead.
 
-### `crypto.checkPrime(candidate[, options, [callback]])`
+### `crypto.checkPrime(candidate[, options[, callback]])`
 
 <!-- YAML
 added: v15.8.0

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -556,7 +556,7 @@ changes:
 added: v10.0.0
 -->
 
-* Returns: {Promise} Fufills with `undefined` upon success.
+* Returns: {Promise} Fulfills with `undefined` upon success.
 
 Request that all data for the open file descriptor is flushed to the storage
 device. The specific implementation is operating system and device specific.

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -462,7 +462,7 @@ const options = {
       return err;
     }
 
-    // Pin the public key, similar to HPKP pin-sha25 pinning
+    // Pin the public key, similar to HPKP pin-sha256 pinning
     const pubkey256 = 'pL1+qb9HTMRZJmuC/bB/ZI9d302BYrrqiVuRyW+DGrU=';
     if (sha256(cert.pubkey) !== pubkey256) {
       const msg = 'Certificate verification error: ' +

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2237,7 +2237,7 @@ result from the calculation on the previous element. It returns a promise for
 the final value of the reduction.
 
 The reducer function iterates the stream element-by-element which means that
-there is no `concurrency` parameter or parallism. To perform a `reduce`
+there is no `concurrency` parameter or parallelism. To perform a `reduce`
 concurrently, it can be chained to the [`readable.map`][] method.
 
 If no `initial` value is supplied the first chunk of the stream is used as the

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -238,7 +238,7 @@ files also qualify as affecting the `node` binary:
 * `configure`
 * `configure.py`
 * `Makefile`
-* `vcbuilt.bat`
+* `vcbuild.bat`
 
 </details>
 

--- a/doc/contributing/commit-queue.md
+++ b/doc/contributing/commit-queue.md
@@ -50,7 +50,7 @@ work for more complex pull requests. These are the currently known limitations
 of the commit queue:
 
 1. All commits in a pull request must either be following commit message
-   guidelines or be a valid [`fixup!`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupltcommitgt)
+   guidelines or be a valid [`fixup!`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordltcommitgt)
    commit that will be correctly handled by the [`--autosquash`](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash)
    option
 2. A CI must've ran and succeeded since the last change on the PR

--- a/doc/contributing/maintaining-shared-library-support.md
+++ b/doc/contributing/maintaining-shared-library-support.md
@@ -21,9 +21,9 @@ Currently, shared library support has only been tested on:
 
 ## Building with shared library option
 
-On non-Windows platoforms, Node.js is built with the shared library
+On non-Windows platforms, Node.js is built with the shared library
 option by adding `--shared` to the configure step. On Windows
-platofrms Node.js is built with the shared library option by
+platforms Node.js is built with the shared library option by
 adding `dll` to the vcbuild command line.
 
 Once built there are two key components:

--- a/doc/contributing/writing-and-running-benchmarks.md
+++ b/doc/contributing/writing-and-running-benchmarks.md
@@ -570,5 +570,5 @@ Supported options keys are:
 [git-for-windows]: https://git-scm.com/download/win
 [nghttp2.org]: https://nghttp2.org
 [node-benchmark-compare]: https://github.com/targos/node-benchmark-compare
-[t-test]: https://en.wikipedia.org/wiki/Student%27s_t-test#Equal_or_unequal_sample_sizes%2C_unequal_variances_\(sX1_%3E_2sX2_or_sX2_%3E_2sX1\)
+[t-test]: https://en.wikipedia.org/wiki/Student%27s_t-test#Equal_or_unequal_sample_sizes%2C_unequal_variances_%28sX1_%3E_2sX2_or_sX2_%3E_2sX1%29
 [wrk]: https://github.com/wg/wrk

--- a/doc/contributing/writing-and-running-benchmarks.md
+++ b/doc/contributing/writing-and-running-benchmarks.md
@@ -570,5 +570,5 @@ Supported options keys are:
 [git-for-windows]: https://git-scm.com/download/win
 [nghttp2.org]: https://nghttp2.org
 [node-benchmark-compare]: https://github.com/targos/node-benchmark-compare
-[t-test]: https://en.wikipedia.org/wiki/Student%27s_t-test#Equal_or_unequal_sample_sizes.2C_unequal_variances
+[t-test]: https://en.wikipedia.org/wiki/Student%27s_t-test#Equal_or_unequal_sample_sizes%2C_unequal_variances_\(sX1_%3E_2sX2_or_sX2_%3E_2sX1\)
 [wrk]: https://github.com/wg/wrk


### PR DESCRIPTION
Mostly just random typos.

HTTP Public Key Pinning is obsolete so neither SHA v25 or quinary hashes are expected to be supported. :)