### PR TITLE
fs: export constants from `fs/promises`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -789,8 +789,7 @@ with an {Error} object. The following example checks if the file
 `/etc/passwd` can be read and written by the current process.
 
 ```mjs
-import { access } from 'node:fs/promises';
-import { constants } from 'node:fs';
+import { access, constants } from 'node:fs/promises';
 
 try {
   await access('/etc/passwd', constants.R_OK | constants.W_OK);
@@ -892,8 +891,7 @@ error occurs after the destination file has been opened for writing, an attempt
 will be made to remove the destination.
 
 ```mjs
-import { constants } from 'node:fs';
-import { copyFile } from 'node:fs/promises';
+import { copyFile, constants } from 'node:fs/promises';
 
 try {
   await copyFile('source.txt', 'destination.txt');
@@ -1623,6 +1621,14 @@ try {
 
 Aborting an ongoing request does not abort individual operating
 system requests but rather the internal buffering `fs.writeFile` performs.
+
+### `fsPromises.constants`
+
+* {Object}
+
+Returns an object containing commonly used constants for file system
+operations. The object is the same as `fs.constants`. See [FS constants][]
+for more details.
 
 ## Callback API
 
@@ -6885,7 +6891,7 @@ operations.
 
 #### FS constants
 
-The following constants are exported by `fs.constants`.
+The following constants are exported by `fs.constants` and `fsPromises.constants`.
 
 Not every constant will be available on every operating system;
 this is especially important for Windows, where many of the POSIX specific
@@ -7590,6 +7596,7 @@ the file contents.
 
 [#25741]: https://github.com/nodejs/node/issues/25741
 [Common System Errors]: errors.md#common-system-errors
+[FS constants]: #fs-constants
 [File access constants]: #file-access-constants
 [MDN-Date]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
 [MDN-Number]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -17,13 +17,15 @@ const {
   Uint8Array,
 } = primordials;
 
+const { fs: constants } = internalBinding('constants');
 const {
   F_OK,
   O_SYMLINK,
   O_WRONLY,
   S_IFMT,
   S_IFREG
-} = internalBinding('constants').fs;
+} = constants;
+
 const binding = internalBinding('fs');
 const { Buffer } = require('buffer');
 
@@ -899,6 +901,7 @@ module.exports = {
     appendFile,
     readFile,
     watch,
+    constants,
   },
 
   FileHandle,

--- a/test/parallel/test-fs-promises-exists.js
+++ b/test/parallel/test-fs-promises-exists.js
@@ -2,5 +2,8 @@
 
 require('../common');
 const assert = require('assert');
+const fs = require('fs');
+const fsPromises = require('fs/promises');
 
-assert.strictEqual(require('fs/promises'), require('fs').promises);
+assert.strictEqual(fsPromises, fs.promises);
+assert.strictEqual(fsPromises.constants, fs.constants);


### PR DESCRIPTION
This pr re-export `constants` from `fs/promises`

## Motivation

see https://github.com/nodejs/node/issues/43140#issuecomment-1130087002

`constants` is only export from `fs`, but not export from `fs/promises`. 

When writing code that uses the promise based fs library via `fs/promises`, if fs constants is used, we have to add another import module which is not convenient:

```
import fs from 'fs/promise';
import { constants } from 'fs';
```

If we re-export `constants` from `fs/promises`, then we could reduce two import to one:

```
import fs, { constants } from 'fs/promises';
```
