### PR TITLE
test: use mustSucceed instead of mustCall with assert.ifError

### DIFF
--- a/test/parallel/test-fs-options-immutable.js
+++ b/test/parallel/test-fs-options-immutable.js
@@ -6,19 +6,17 @@ const common = require('../common');
 //
 // Refer: https://github.com/nodejs/node/issues/7655
 
-const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const errHandler = (e) => assert.ifError(e);
 const options = Object.freeze({});
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-fs.readFile(__filename, options, common.mustCall(errHandler));
+fs.readFile(__filename, options, common.mustSucceed());
 fs.readFileSync(__filename, options);
 
-fs.readdir(__dirname, options, common.mustCall(errHandler));
+fs.readdir(__dirname, options, common.mustSucceed());
 fs.readdirSync(__dirname, options);
 
 if (common.canCreateSymLink()) {
@@ -28,20 +26,20 @@ if (common.canCreateSymLink()) {
   fs.writeFileSync(sourceFile, '');
   fs.symlinkSync(sourceFile, linkFile);
 
-  fs.readlink(linkFile, options, common.mustCall(errHandler));
+  fs.readlink(linkFile, options, common.mustSucceed());
   fs.readlinkSync(linkFile, options);
 }
 
 {
   const fileName = path.resolve(tmpdir.path, 'writeFile');
   fs.writeFileSync(fileName, 'ABCD', options);
-  fs.writeFile(fileName, 'ABCD', options, common.mustCall(errHandler));
+  fs.writeFile(fileName, 'ABCD', options, common.mustSucceed());
 }
 
 {
   const fileName = path.resolve(tmpdir.path, 'appendFile');
   fs.appendFileSync(fileName, 'ABCD', options);
-  fs.appendFile(fileName, 'ABCD', options, common.mustCall(errHandler));
+  fs.appendFile(fileName, 'ABCD', options, common.mustSucceed());
 }
 
 if (!common.isIBMi) { // IBMi does not support fs.watch()
@@ -56,13 +54,13 @@ if (!common.isIBMi) { // IBMi does not support fs.watch()
 
 {
   fs.realpathSync(__filename, options);
-  fs.realpath(__filename, options, common.mustCall(errHandler));
+  fs.realpath(__filename, options, common.mustSucceed());
 }
 
 {
   const tempFileName = path.resolve(tmpdir.path, 'mkdtemp-');
   fs.mkdtempSync(tempFileName, options);
-  fs.mkdtemp(tempFileName, options, common.mustCall(errHandler));
+  fs.mkdtemp(tempFileName, options, common.mustSucceed());
 }
 
 {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Use mustSucceed instead of mustCall + ifError.