### PR TITLE
build: enable pointer authentication on arm64 for branch protection

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1231,6 +1231,10 @@ def configure_node(o):
 
   o['variables']['want_separate_host_toolset'] = int(cross_compiling)
 
+  # Enable branch protection for arm64
+  if target_arch == 'arm64':
+    o['cflags']+=['-msign-return-address=all']
+
   if options.node_snapshot_main is not None:
     if options.shared:
       # This should be possible to fix, but we will need to refactor the


### PR DESCRIPTION
### What is the problem this feature will solve?

ARM64v8.3 supports [Pointer Authentication](https://www.qualcomm.com/media/documents/files/whitepaper-pointer-authentication-on-armv8-3.pdf) with the PACIASP and AUTIASP instructions which are interpreted as NOP instructions on pre-8.3 architectures.  These instructions sign the stack pointer and validate the stack pointer prior to return to mitigate [return oriented programming](https://en.wikipedia.org/wiki/Return-oriented_programming).

GCC supports these [options](https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html) on arm64 / aarch64.  The legacy option was `-msign-return-address=[all | non-leaf | none]` and the modern option is `-mbranch-protection=none|standard|pac-ret[+leaf+b-key]|bti`

I would like to suggest that the arm64 build be modified to include `-mbranch-protection=pac-ret` with the `-march` being set to ARMv8.2 or earlier or not configured, so that GCC will generate [PACIASP](https://developer.arm.com/documentation/100076/0100/A64-Instruction-Set-Reference/A64-General-Instructions/PACIA--PACIZA--PACIA1716--PACIASP--PACIAZ?lang=en) and [AUTIASP](https://developer.arm.com/documentation/100076/0100/A64-Instruction-Set-Reference/A64-General-Instructions/AUTIA--AUTIZA--AUTIA1716--AUTIASP--AUTIAZ?lang=en) instructions.  It is critical that `-march=armv8.3` or higher not be passed or the non-backwards compatible RETAA instruction will be generated.

### What is the feature you are proposing to solve the problem?

The benefit of enabling pointer authentication for the stack pointer on ARM64 would be to mitigate [return oriented programming](https://en.wikipedia.org/wiki/Return-oriented_programming) attacks against the Node.js runtime.

### What alternatives have you considered?

Presently we are pursuing custom compiles of the Node.js runtime for the new Graviton3 CPUs that support pointer authentication in AWS.

As feature requested in: https://github.com/nodejs/node/issues/42888

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
