### PR TITLE
test: remove most of err.message check

### DIFF
--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-ascii.js
@@ -25,12 +25,9 @@ try {
 if (!binding.ensureAllocation(2 * kStringMaxLength))
   common.skip(skipMessage);
 
-const stringLengthHex = kStringMaxLength.toString(16);
 assert.throws(() => {
   buf.toString('ascii');
 }, {
-  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
-           'characters',
   code: 'ERR_STRING_TOO_LONG',
   name: 'Error'
 });

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-base64.js
@@ -25,12 +25,9 @@ try {
 if (!binding.ensureAllocation(2 * kStringMaxLength))
   common.skip(skipMessage);
 
-const stringLengthHex = kStringMaxLength.toString(16);
 assert.throws(() => {
   buf.toString('base64');
 }, {
-  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
-           'characters',
   code: 'ERR_STRING_TOO_LONG',
   name: 'Error'
 });

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary.js
@@ -26,12 +26,9 @@ try {
 if (!binding.ensureAllocation(2 * kStringMaxLength))
   common.skip(skipMessage);
 
-const stringLengthHex = kStringMaxLength.toString(16);
 assert.throws(() => {
   buf.toString('latin1');
 }, {
-  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
-           'characters',
   code: 'ERR_STRING_TOO_LONG',
   name: 'Error'
 });

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex.js
@@ -25,12 +25,9 @@ try {
 if (!binding.ensureAllocation(2 * kStringMaxLength))
   common.skip(skipMessage);
 
-const stringLengthHex = kStringMaxLength.toString(16);
 assert.throws(() => {
   buf.toString('hex');
 }, {
-  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
-           'characters',
   code: 'ERR_STRING_TOO_LONG',
   name: 'Error'
 });

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-utf8.js
@@ -25,15 +25,11 @@ try {
 if (!binding.ensureAllocation(2 * kStringMaxLength))
   common.skip(skipMessage);
 
-const stringLengthHex = kStringMaxLength.toString(16);
-
 assert.throws(() => {
   buf.toString();
 }, (e) => {
   if (e.message !== 'Array buffer allocation failed') {
     common.expectsError({
-      message: `Cannot create a string longer than 0x${stringLengthHex} ` +
-               'characters',
       code: 'ERR_STRING_TOO_LONG',
       name: 'Error'
     })(e);
@@ -45,8 +41,6 @@ assert.throws(() => {
 assert.throws(() => {
   buf.toString('utf8');
 }, {
-  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
-           'characters',
   code: 'ERR_STRING_TOO_LONG',
   name: 'Error'
 });

--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max.js
@@ -25,13 +25,9 @@ try {
 if (!binding.ensureAllocation(2 * kStringMaxLength))
   common.skip(skipMessage);
 
-const stringLengthHex = kStringMaxLength.toString(16);
-
 assert.throws(() => {
   buf.toString('utf16le');
 }, {
-  message: `Cannot create a string longer than 0x${stringLengthHex} ` +
-           'characters',
   code: 'ERR_STRING_TOO_LONG',
   name: 'Error'
 });

--- a/test/es-module/test-esm-cjs-named-error.mjs
+++ b/test/es-module/test-esm-cjs-named-error.mjs
@@ -3,73 +3,46 @@ import { rejects } from 'assert';
 
 const fixtureBase = '../fixtures/es-modules/package-cjs-named-error';
 
-const errTemplate = (specifier, name, namedImports) =>
-  `Named export '${name}' not found. The requested module` +
-  ` '${specifier}' is a CommonJS module, which may not support ` +
-  'all module.exports as named exports.\nCommonJS modules can ' +
-  'always be imported via the default export, for example using:' +
-  `\n\nimport pkg from '${specifier}';\n` + (namedImports ?
-    `const ${namedImports} = pkg;\n` : '');
-
-const expectedWithoutExample = errTemplate('./fail.cjs', 'comeOn');
-
-const expectedRelative = errTemplate('./fail.cjs', 'comeOn', '{ comeOn }');
-
-const expectedRenamed = errTemplate('./fail.cjs', 'comeOn',
-                                    '{ comeOn: comeOnRenamed }');
-
-const expectedPackageHack =
-    errTemplate('./json-hack/fail.js', 'comeOn', '{ comeOn }');
-
-const expectedBare = errTemplate('deep-fail', 'comeOn', '{ comeOn }');
-
 rejects(async () => {
   await import(`${fixtureBase}/single-quote.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedRelative
 }, 'should support relative specifiers with single quotes');
 
 rejects(async () => {
   await import(`${fixtureBase}/double-quote.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedRelative
 }, 'should support relative specifiers with double quotes');
 
 rejects(async () => {
   await import(`${fixtureBase}/renamed-import.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedRenamed
 }, 'should correctly format named imports with renames');
 
 rejects(async () => {
   await import(`${fixtureBase}/multi-line.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedWithoutExample,
 }, 'should correctly format named imports across multiple lines');
 
 rejects(async () => {
   await import(`${fixtureBase}/json-hack.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedPackageHack
 }, 'should respect recursive package.json for module type');
 
 rejects(async () => {
   await import(`${fixtureBase}/bare-import-single.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedBare
 }, 'should support bare specifiers with single quotes');
 
 rejects(async () => {
   await import(`${fixtureBase}/bare-import-double.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedBare
 }, 'should support bare specifiers with double quotes');
 
 rejects(async () => {

--- a/test/es-module/test-esm-data-urls.js
+++ b/test/es-module/test-esm-data-urls.js
@@ -76,7 +76,6 @@ function createBase64URL(mime, body) {
       import('data:application/json;foo="test,",0',
         { assert: { type: 'json' } }), {
       name: 'SyntaxError',
-      message: /Unexpected end of JSON input/
     });
   }
   {

--- a/test/es-module/test-esm-dns-promises.mjs
+++ b/test/es-module/test-esm-dns-promises.mjs
@@ -10,5 +10,4 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
   name: 'TypeError',
-  message: `The argument 'address' is invalid. Received '${invalidAddress}'`
 });

--- a/test/es-module/test-esm-invalid-data-urls.js
+++ b/test/es-module/test-esm-invalid-data-urls.js
@@ -5,17 +5,11 @@ const assert = require('assert');
 (async () => {
   await assert.rejects(import('data:text/plain,export default0'), {
     code: 'ERR_UNKNOWN_MODULE_FORMAT',
-    message:
-      'Unknown module format: text/plain for URL data:text/plain,' +
-      'export default0',
   });
   await assert.rejects(import('data:text/plain;base64,'), {
     code: 'ERR_UNKNOWN_MODULE_FORMAT',
-    message:
-      'Unknown module format: text/plain for URL data:text/plain;base64,',
   });
   await assert.rejects(import('data:text/css,.error { color: red; }'), {
     code: 'ERR_UNKNOWN_MODULE_FORMAT',
-    message: 'Unknown module format: text/css for URL data:text/css,.error { color: red; }',
   });
 })().then(common.mustCall());

--- a/test/es-module/test-esm-loader-invalid-format.mjs
+++ b/test/es-module/test-esm-loader-invalid-format.mjs
@@ -5,6 +5,5 @@ import assert from 'assert';
 import('../fixtures/es-modules/test-esm-ok.mjs')
 .then(assert.fail, expectsError({
   code: 'ERR_UNKNOWN_MODULE_FORMAT',
-  message: /Unknown module format: esm/
 }))
 .then(mustCall());

--- a/test/es-module/test-esm-loader-modulemap.js
+++ b/test/es-module/test-esm-loader-modulemap.js
@@ -58,7 +58,6 @@ const jsonModuleJob = new ModuleJob(loader, stubJsonModule.module,
   const errorObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /^The "url" argument must be of type string/
   };
 
   [{}, [], true, 1].forEach((value) => {
@@ -76,7 +75,6 @@ const jsonModuleJob = new ModuleJob(loader, stubJsonModule.module,
   const errorObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /^The "type" argument must be of type string/
   };
 
   [{}, [], true, 1].forEach((value) => {
@@ -94,7 +92,6 @@ const jsonModuleJob = new ModuleJob(loader, stubJsonModule.module,
     throws(() => moduleMap.set('', undefined, value), {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /^The "job" argument must be an instance of ModuleJob/
     });
   });
 }

--- a/test/es-module/test-esm-loader-search.js
+++ b/test/es-module/test-esm-loader-search.js
@@ -15,6 +15,5 @@ assert.rejects(
   {
     code: 'ERR_MODULE_NOT_FOUND',
     name: 'Error',
-    message: /Cannot find package 'target'/
   }
 );

--- a/test/fixtures/cycles/warning-skip-proxy-traps-b.js
+++ b/test/fixtures/cycles/warning-skip-proxy-traps-b.js
@@ -5,6 +5,5 @@ const object = require('./warning-skip-proxy-traps-a.js');
 assert.throws(() => {
   object.missingPropProxyTrap;
 }, {
-  message: 'get: missingPropProxyTrap',
   name: 'Error',
 });

--- a/test/internet/test-dns-lookup.js
+++ b/test/internet/test-dns-lookup.js
@@ -15,7 +15,6 @@ assert.rejects(
   }),
   {
     code: 'ENOTFOUND',
-    message: `getaddrinfo ENOTFOUND ${addresses.NOT_FOUND}`
   }
 );
 
@@ -27,7 +26,6 @@ assert.rejects(
   }),
   {
     code: 'ENOTFOUND',
-    message: `getaddrinfo ENOTFOUND ${addresses.NOT_FOUND}`
   }
 );
 

--- a/test/internet/test-dns-promises-resolve.js
+++ b/test/internet/test-dns-promises-resolve.js
@@ -12,7 +12,6 @@ const dnsPromises = require('dns').promises;
     {
       code: 'ERR_INVALID_ARG_VALUE',
       name: 'TypeError',
-      message: `The argument 'rrtype' is invalid. Received '${rrtype}'`
     }
   );
 }
@@ -25,8 +24,6 @@ const dnsPromises = require('dns').promises;
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "rrtype" argument must be of type string. ' +
-               `Received type ${typeof rrtype} (${rrtype})`
     }
   );
 }

--- a/test/js-native-api/test_bigint/test.js
+++ b/test/js-native-api/test_bigint/test.js
@@ -42,11 +42,9 @@ const {
 
 assert.throws(() => CreateTooBigBigInt(), {
   name: 'Error',
-  message: 'Invalid argument',
 });
 
 // Test that we correctly forward exceptions from the engine.
 assert.throws(() => MakeBigIntWordsThrow(), {
   name: 'RangeError',
-  message: 'Maximum BigInt size exceeded'
 });

--- a/test/js-native-api/test_error/test.js
+++ b/test/js-native-api/test_error/test.js
@@ -77,28 +77,24 @@ assert.throws(
   () => test_error.throwErrorCode(),
   {
     code: 'ERR_TEST_CODE',
-    message: 'Error [error]'
   });
 
 assert.throws(
   () => test_error.throwRangeErrorCode(),
   {
     code: 'ERR_TEST_CODE',
-    message: 'RangeError [range error]'
   });
 
 assert.throws(
   () => test_error.throwTypeErrorCode(),
   {
     code: 'ERR_TEST_CODE',
-    message: 'TypeError [type error]'
   });
 
 assert.throws(
   () => test_error.throwSyntaxErrorCode(),
   {
     code: 'ERR_TEST_CODE',
-    message: 'SyntaxError [syntax error]'
   });
 
 let error = test_error.createError();

--- a/test/js-native-api/test_general/test.js
+++ b/test/js-native-api/test_general/test.js
@@ -55,7 +55,7 @@ assert.strictEqual(test_general.testNapiTypeof(null), 'null');
 const x = {};
 test_general.wrap(x);
 assert.throws(() => test_general.wrap(x),
-              { name: 'Error', message: 'Invalid argument' });
+              { name: 'Error' });
 // Clean up here, otherwise derefItemWasCalled() will be polluted.
 test_general.removeWrap(x);
 

--- a/test/js-native-api/test_general/testFinalizer.js
+++ b/test/js-native-api/test_general/testFinalizer.js
@@ -14,11 +14,11 @@ test_general.addFinalizerOnly(finalized, callback);
 
 // Ensure attached items cannot be retrieved.
 assert.throws(() => test_general.unwrap(finalized),
-              { name: 'Error', message: 'Invalid argument' });
+              { name: 'Error' });
 
 // Ensure attached items cannot be removed.
 assert.throws(() => test_general.removeWrap(finalized),
-              { name: 'Error', message: 'Invalid argument' });
+              { name: 'Error' });
 finalized = null;
 global.gc();
 

--- a/test/known_issues/test-vm-timeout-escape-queuemicrotask.js
+++ b/test/known_issues/test-vm-timeout-escape-queuemicrotask.js
@@ -39,5 +39,4 @@ assert.throws(() => {
   );
 }, {
   code: 'ERR_SCRIPT_EXECUTION_TIMEOUT',
-  message: `Script execution timed out after ${timeout}ms`
 });

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -36,7 +36,6 @@ const invalidThenableFunc = () => {
   const errObj = {
     code: 'ERR_ASSERTION',
     name: 'AssertionError',
-    message: 'Failed'
   };
 
   // `assert.rejects` accepts a function or a promise
@@ -72,9 +71,6 @@ const invalidThenableFunc = () => {
   promises.push(assert.rejects(
     () => assert.rejects(Promise.reject(err), validate),
     {
-      message: 'The "validate" validation function is expected to ' +
-               "return \"true\". Received 'baz'\n\nCaught error:\n\n" +
-               'Error: foobar',
       code: 'ERR_ASSERTION',
       actual: err,
       expected: validate,
@@ -103,8 +99,6 @@ const invalidThenableFunc = () => {
   promises.push(assert.rejects(promise, {
     name: 'TypeError',
     code: 'ERR_INVALID_RETURN_VALUE',
-    message: 'Expected instance of Promise to be returned ' +
-             'from the "promiseFn" function but got type undefined.'
   }));
 
   promise = assert.rejects(Promise.resolve(), common.mustNotCall());
@@ -125,8 +119,6 @@ promises.push(assert.rejects(
   assert.rejects('fail', {}),
   {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "promiseFn" argument must be of type function or an ' +
-             "instance of Promise. Received type string ('fail')"
   }
 ));
 
@@ -161,8 +153,6 @@ promises.push(assert.rejects(
   /* eslint-disable no-restricted-syntax */
   let promise = assert.doesNotReject(() => new Map(), common.mustNotCall());
   promises.push(assert.rejects(promise, {
-    message: 'Expected instance of Promise to be returned ' +
-             'from the "promiseFn" function but got instance of Map.',
     code: 'ERR_INVALID_RETURN_VALUE',
     name: 'TypeError'
   }));
@@ -202,8 +192,6 @@ promises.push(assert.rejects(
     assert(err instanceof assert.AssertionError,
            `${err.name} is not instance of AssertionError`);
     assert.strictEqual(err.code, 'ERR_ASSERTION');
-    assert.strictEqual(err.message,
-                       'Got unwanted rejection.\nActual message: "Failed"');
     assert.strictEqual(err.operator, 'doesNotReject');
     assert.ok(err.stack);
     assert.ok(!err.stack.includes('at Function.doesNotReject'));
@@ -225,8 +213,6 @@ promises.push(assert.rejects(
     assert.doesNotReject(123),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "promiseFn" argument must be of type ' +
-               'function or an instance of Promise. Received type number (123)'
     }
   ));
   /* eslint-enable no-restricted-syntax */

--- a/test/parallel/test-async-hooks-constructor.js
+++ b/test/parallel/test-async-hooks-constructor.js
@@ -15,7 +15,6 @@ const nonFunctionArray = [null, -1, 1, {}, []];
       }, {
         code: 'ERR_ASYNC_CALLBACK',
         name: 'TypeError',
-        message: `hook.${functionName} must be a function`,
       });
     });
   });

--- a/test/parallel/test-async-wrap-constructor.js
+++ b/test/parallel/test-async-wrap-constructor.js
@@ -14,7 +14,6 @@ const async_hooks = require('async_hooks');
     }, {
       code: 'ERR_ASYNC_CALLBACK',
       name: 'TypeError',
-      message: `hook.${field} must be a function`
     });
   });
 });

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1064,19 +1064,13 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "target" argument must be an instance of Buffer or ' +
-             'Uint8Array. Received undefined'
   });
 
 assert.throws(() => Buffer.from(), {
   name: 'TypeError',
-  message: 'The first argument must be of type string or an instance of ' +
-  'Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined'
 });
 assert.throws(() => Buffer.from(null), {
   name: 'TypeError',
-  message: 'The first argument must be of type string or an instance of ' +
-  'Buffer, ArrayBuffer, or Array or an Array-like Object. Received null'
 });
 
 // Test prototype getters don't throw
@@ -1105,7 +1099,6 @@ assert.strictEqual(SlowBuffer.prototype.offset, undefined);
   const errMsg = common.expectsError({
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     name: 'RangeError',
-    message: '"offset" is outside of buffer bounds'
   });
   assert.throws(() => Buffer.from(new ArrayBuffer(0), -1 >>> 0), errMsg);
 }

--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -43,9 +43,6 @@ assert.throws(function() {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The first argument must be of type string or an instance of ' +
-           'Buffer, ArrayBuffer, or Array or an Array-like Object. Received ' +
-           'an instance of AB'
 });
 
 // Test the byteOffset and length arguments
@@ -67,12 +64,10 @@ assert.throws(function() {
   assert.throws(() => Buffer.from(ab.buffer, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     name: 'RangeError',
-    message: '"offset" is outside of buffer bounds'
   });
   assert.throws(() => Buffer.from(ab.buffer, 3, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     name: 'RangeError',
-    message: '"length" is outside of buffer bounds'
   });
 }
 
@@ -95,12 +90,10 @@ assert.throws(function() {
   assert.throws(() => Buffer(ab.buffer, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     name: 'RangeError',
-    message: '"offset" is outside of buffer bounds'
   });
   assert.throws(() => Buffer(ab.buffer, 3, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     name: 'RangeError',
-    message: '"length" is outside of buffer bounds'
   });
 }
 
@@ -122,7 +115,6 @@ assert.throws(function() {
   }, {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     name: 'RangeError',
-    message: '"offset" is outside of buffer bounds'
   });
 }
 
@@ -144,7 +136,6 @@ assert.throws(function() {
   }, {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     name: 'RangeError',
-    message: '"length" is outside of buffer bounds'
   });
 }
 

--- a/test/parallel/test-buffer-bigint64.js
+++ b/test/parallel/test-buffer-bigint64.js
@@ -39,8 +39,6 @@ const buf = Buffer.allocUnsafe(8);
     buf[`writeBigUInt64${endianness}`](val, 0);
   }, {
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "value" is out of range. It must be ' +
-      '>= 0n and < 2n ** 64n. Received 18_446_744_073_709_551_616n'
   });
 
   // Should throw a TypeError upon invalid input

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 const SlowBuffer = require('buffer').SlowBuffer;
 const vm = require('vm');
@@ -16,9 +15,6 @@ const vm = require('vm');
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "string" argument must be of type string or an instance ' +
-               'of Buffer or ArrayBuffer.' +
-               common.invalidArgTypeHelper(args[0])
     }
   );
 });

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -89,6 +89,4 @@ assert.throws(() => a.compare(b, -Infinity, Infinity), oor);
 assert.throws(() => a.compare(), {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "target" argument must be an instance of ' +
-           'Buffer or Uint8Array. Received undefined'
 });

--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -30,18 +30,12 @@ assert.strictEqual(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
 
 assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'), {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "buf2" argument must be an instance of Buffer or Uint8Array. ' +
-           "Received type string ('abc')"
 });
 assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)), {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "buf1" argument must be an instance of Buffer or Uint8Array. ' +
-           "Received type string ('abc')"
 });
 
 assert.throws(() => Buffer.alloc(1).compare('abc'), {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "target" argument must be an instance of ' +
-           "Buffer or Uint8Array. Received type string ('abc')"
 });

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -49,8 +49,6 @@ assert.strictEqual(flatLongLen.toString(), check);
     Buffer.concat(value);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "list" argument must be an instance of Array.' +
-             `${common.invalidArgTypeHelper(value)}`
   });
 });
 
@@ -59,8 +57,6 @@ assert.strictEqual(flatLongLen.toString(), check);
     Buffer.concat(value);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "list[0]" argument must be an instance of Buffer ' +
-             `or Uint8Array.${common.invalidArgTypeHelper(value[0])}`
   });
 });
 
@@ -68,8 +64,6 @@ assert.throws(() => {
   Buffer.concat([Buffer.from('hello'), 3]);
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "list[1]" argument must be an instance of Buffer ' +
-           'or Uint8Array. Received type number (3)'
 });
 
 // eslint-disable-next-line node-core/crypto-check

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -144,8 +144,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "targetStart" is out of range. ' +
-             'It must be >= 0. Received -1'
   }
 );
 
@@ -155,8 +153,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "sourceStart" is out of range. ' +
-             'It must be >= 0. Received -1'
   }
 );
 
@@ -176,8 +172,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "sourceEnd" is out of range. ' +
-             'It must be >= 0. Received -1'
   }
 );
 

--- a/test/parallel/test-buffer-equals.js
+++ b/test/parallel/test-buffer-equals.js
@@ -19,7 +19,5 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "otherBuffer" argument must be an instance of ' +
-             "Buffer or Uint8Array. Received type string ('abc')"
   }
 );

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -1,6 +1,5 @@
 // Flags: --expose-internals
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 const { codes: { ERR_OUT_OF_RANGE } } = require('internal/errors');
 const { internalBinding } = require('internal/test/binding');
@@ -199,7 +198,6 @@ assert.throws(
   {
     code: 'ERR_UNKNOWN_ENCODING',
     name: 'TypeError',
-    message: 'Unknown encoding: node rocks!'
   }
 );
 
@@ -211,8 +209,6 @@ assert.throws(
     () => buf1.fill(...args),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "encoding" argument must be of type ' +
-      `string.${common.invalidArgTypeHelper(args[3])}`
     }
   );
 });
@@ -222,7 +218,6 @@ assert.throws(
   {
     code: 'ERR_UNKNOWN_ENCODING',
     name: 'TypeError',
-    message: 'Unknown encoding: foo'
   }
 );
 
@@ -360,8 +355,6 @@ assert.throws(
     Buffer.alloc(1).fill(Buffer.alloc(1), 0, end);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "end" argument must be of type number. Received an ' +
-             'instance of Object'
   });
 }
 
@@ -383,7 +376,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_BUFFER_OUT_OF_BOUNDS',
   name: 'RangeError',
-  message: 'Attempt to access memory outside buffer bounds'
 });
 
 assert.deepStrictEqual(

--- a/test/parallel/test-buffer-from.js
+++ b/test/parallel/test-buffer-from.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const common = require('../common');
 const { deepStrictEqual, throws } = require('assert');
 const { runInNewContext } = require('vm');
 
@@ -52,9 +51,6 @@ deepStrictEqual(
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The first argument must be of type string or an instance of ' +
-             'Buffer, ArrayBuffer, or Array or an Array-like Object.' +
-             common.invalidArgTypeHelper(input)
   };
   throws(() => Buffer.from(input), errObj);
   throws(() => Buffer.from(input, 'hex'), errObj);

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -1,5 +1,4 @@
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 
 const b = Buffer.from('abcdef');
@@ -282,9 +281,6 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "value" argument must be one of type number or string ' +
-               'or an instance of Buffer or Uint8Array.' +
-               common.invalidArgTypeHelper(val)
     }
   );
 });

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -1,5 +1,4 @@
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 
 const b = Buffer.from('abcdef');
@@ -367,9 +366,6 @@ assert.strictEqual(Buffer.from('aaaaa').indexOf('b', 'ucs2'), -1);
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "value" argument must be one of type number or string ' +
-               'or an instance of Buffer or Uint8Array.' +
-               common.invalidArgTypeHelper(val)
     }
   );
 });
@@ -626,8 +622,5 @@ assert.strictEqual(reallyLong.lastIndexOf(pattern), 0);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "buffer" argument must be an instance of Buffer, ' +
-             'TypedArray, or DataView. ' +
-             'Received an instance of lastIndexOf'
   });
 }

--- a/test/parallel/test-buffer-new.js
+++ b/test/parallel/test-buffer-new.js
@@ -6,6 +6,4 @@ const assert = require('assert');
 assert.throws(() => new Buffer(42, 'utf8'), {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "string" argument must be of type string. Received type ' +
-           'number (42)'
 });

--- a/test/parallel/test-buffer-no-negative-allocation.js
+++ b/test/parallel/test-buffer-no-negative-allocation.js
@@ -7,7 +7,6 @@ const { SlowBuffer } = require('buffer');
 const msg = {
   code: 'ERR_INVALID_ARG_VALUE',
   name: 'RangeError',
-  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 
 // Test that negative Buffer length inputs throw errors.

--- a/test/parallel/test-buffer-over-max-length.js
+++ b/test/parallel/test-buffer-over-max-length.js
@@ -10,7 +10,6 @@ const kMaxLength = buffer.kMaxLength;
 const bufferMaxSizeMsg = {
   code: 'ERR_INVALID_ARG_VALUE',
   name: 'RangeError',
-  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 
 assert.throws(() => Buffer((-1 >>> 0) + 2), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-read.js
+++ b/test/parallel/test-buffer-read.js
@@ -60,7 +60,6 @@ const OOR_ERROR =
 const OOB_ERROR =
 {
   name: 'RangeError',
-  message: 'Attempt to access memory outside buffer bounds'
 };
 
 // Attempt to overflow buffers, similar to previous bug in array buffers

--- a/test/parallel/test-buffer-readdouble.js
+++ b/test/parallel/test-buffer-readdouble.js
@@ -118,8 +118,6 @@ assert.strictEqual(buffer.readDoubleLE(0), -Infinity);
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "offset" is out of range. ' +
-                 `It must be >= 0 and <= 0. Received ${offset}`
       });
   });
 
@@ -128,7 +126,6 @@ assert.strictEqual(buffer.readDoubleLE(0), -Infinity);
     {
       code: 'ERR_BUFFER_OUT_OF_BOUNDS',
       name: 'RangeError',
-      message: 'Attempt to access memory outside buffer bounds'
     });
 
   [NaN, 1.01].forEach((offset) => {
@@ -137,8 +134,6 @@ assert.strictEqual(buffer.readDoubleLE(0), -Infinity);
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "offset" is out of range. ' +
-                 `It must be an integer. Received ${offset}`
       });
   });
 });

--- a/test/parallel/test-buffer-readfloat.js
+++ b/test/parallel/test-buffer-readfloat.js
@@ -80,8 +80,6 @@ assert.strictEqual(buffer.readFloatLE(0), -Infinity);
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "offset" is out of range. ' +
-                 `It must be >= 0 and <= 0. Received ${offset}`
       });
   });
 
@@ -90,7 +88,6 @@ assert.strictEqual(buffer.readFloatLE(0), -Infinity);
     {
       code: 'ERR_BUFFER_OUT_OF_BOUNDS',
       name: 'RangeError',
-      message: 'Attempt to access memory outside buffer bounds'
     });
 
   [NaN, 1.01].forEach((offset) => {
@@ -99,8 +96,6 @@ assert.strictEqual(buffer.readFloatLE(0), -Infinity);
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "offset" is out of range. ' +
-                 `It must be an integer. Received ${offset}`
       });
   });
 });

--- a/test/parallel/test-buffer-readint.js
+++ b/test/parallel/test-buffer-readint.js
@@ -37,8 +37,6 @@ const assert = require('assert');
         {
           code: 'ERR_OUT_OF_RANGE',
           name: 'RangeError',
-          message: 'The value of "offset" is out of range. ' +
-                   `It must be an integer. Received ${offset}`
         });
     });
   });
@@ -142,8 +140,6 @@ const assert = require('assert');
         () => buffer[fn](0, byteLength),
         {
           code: 'ERR_OUT_OF_RANGE',
-          message: 'The value of "byteLength" is out of range. ' +
-                   `It must be >= 1 and <= 6. Received ${byteLength}`
         });
     });
 
@@ -153,8 +149,6 @@ const assert = require('assert');
         {
           code: 'ERR_OUT_OF_RANGE',
           name: 'RangeError',
-          message: 'The value of "byteLength" is out of range. ' +
-                   `It must be an integer. Received ${byteLength}`
         });
     });
   });
@@ -177,8 +171,6 @@ const assert = require('assert');
           {
             code: 'ERR_OUT_OF_RANGE',
             name: 'RangeError',
-            message: 'The value of "offset" is out of range. ' +
-                     `It must be >= 0 and <= ${8 - i}. Received ${offset}`
           });
       });
 
@@ -188,8 +180,6 @@ const assert = require('assert');
           {
             code: 'ERR_OUT_OF_RANGE',
             name: 'RangeError',
-            message: 'The value of "offset" is out of range. ' +
-                     `It must be an integer. Received ${offset}`
           });
       });
     });

--- a/test/parallel/test-buffer-readuint.js
+++ b/test/parallel/test-buffer-readuint.js
@@ -37,8 +37,6 @@ const assert = require('assert');
         {
           code: 'ERR_OUT_OF_RANGE',
           name: 'RangeError',
-          message: 'The value of "offset" is out of range. ' +
-                   `It must be an integer. Received ${offset}`
         });
     });
   });
@@ -110,8 +108,6 @@ const assert = require('assert');
         () => buffer[fn](0, byteLength),
         {
           code: 'ERR_OUT_OF_RANGE',
-          message: 'The value of "byteLength" is out of range. ' +
-                   `It must be >= 1 and <= 6. Received ${byteLength}`
         });
     });
 
@@ -121,8 +117,6 @@ const assert = require('assert');
         {
           code: 'ERR_OUT_OF_RANGE',
           name: 'RangeError',
-          message: 'The value of "byteLength" is out of range. ' +
-                   `It must be an integer. Received ${byteLength}`
         });
     });
   });
@@ -145,8 +139,6 @@ const assert = require('assert');
           {
             code: 'ERR_OUT_OF_RANGE',
             name: 'RangeError',
-            message: 'The value of "offset" is out of range. ' +
-                     `It must be >= 0 and <= ${8 - i}. Received ${offset}`
           });
       });
 
@@ -156,8 +148,6 @@ const assert = require('assert');
           {
             code: 'ERR_OUT_OF_RANGE',
             name: 'RangeError',
-            message: 'The value of "offset" is out of range. ' +
-                     `It must be an integer. Received ${offset}`
           });
       });
     });

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -43,7 +43,6 @@ try {
 const bufferInvalidTypeMsg = {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: /^The "size" argument must be of type number/,
 };
 assert.throws(() => SlowBuffer(), bufferInvalidTypeMsg);
 assert.throws(() => SlowBuffer({}), bufferInvalidTypeMsg);
@@ -54,7 +53,6 @@ assert.throws(() => SlowBuffer(true), bufferInvalidTypeMsg);
 const bufferMaxSizeMsg = {
   code: 'ERR_INVALID_ARG_VALUE',
   name: 'RangeError',
-  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 assert.throws(() => SlowBuffer(NaN), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer(Infinity), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-tostring-range.js
+++ b/test/parallel/test-buffer-tostring-range.js
@@ -89,12 +89,10 @@ assert.throws(() => {
 }, {
   code: 'ERR_UNKNOWN_ENCODING',
   name: 'TypeError',
-  message: 'Unknown encoding: 0'
 });
 assert.throws(() => {
   rangeBuffer.toString(null, 1, 2);
 }, {
   code: 'ERR_UNKNOWN_ENCODING',
   name: 'TypeError',
-  message: 'Unknown encoding: null'
 });

--- a/test/parallel/test-buffer-tostring-rangeerror.js
+++ b/test/parallel/test-buffer-tostring-rangeerror.js
@@ -12,7 +12,6 @@ const len = 1422561062959;
 const message = {
   code: 'ERR_INVALID_ARG_VALUE',
   name: 'RangeError',
-  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 assert.throws(() => Buffer(len).toString('utf8'), message);
 assert.throws(() => SlowBuffer(len).toString('utf8'), message);

--- a/test/parallel/test-buffer-tostring.js
+++ b/test/parallel/test-buffer-tostring.js
@@ -30,7 +30,6 @@ for (let i = 1; i < 10; i++) {
   const error = common.expectsError({
     code: 'ERR_UNKNOWN_ENCODING',
     name: 'TypeError',
-    message: `Unknown encoding: ${encoding}`
   });
   assert.ok(!Buffer.isEncoding(encoding));
   assert.throws(() => Buffer.from('foo').toString(encoding), error);

--- a/test/parallel/test-buffer-write.js
+++ b/test/parallel/test-buffer-write.js
@@ -9,8 +9,6 @@ const assert = require('assert');
     {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "offset" is out of range. ' +
-               `It must be >= 0 && <= 9. Received ${offset}`
     }
   );
 });
@@ -68,7 +66,6 @@ for (let i = 1; i < 10; i++) {
   const error = common.expectsError({
     code: 'ERR_UNKNOWN_ENCODING',
     name: 'TypeError',
-    message: `Unknown encoding: ${encoding}`
   });
 
   assert.ok(!Buffer.isEncoding(encoding));

--- a/test/parallel/test-buffer-writedouble.js
+++ b/test/parallel/test-buffer-writedouble.js
@@ -99,7 +99,6 @@ assert.ok(Number.isNaN(buffer.readDoubleLE(8)));
       {
         code: 'ERR_BUFFER_OUT_OF_BOUNDS',
         name: 'RangeError',
-        message: 'Attempt to access memory outside buffer bounds'
       });
 
     ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
@@ -114,8 +113,6 @@ assert.ok(Number.isNaN(buffer.readDoubleLE(8)));
         {
           code: 'ERR_OUT_OF_RANGE',
           name: 'RangeError',
-          message: 'The value of "offset" is out of range. ' +
-                     `It must be >= 0 and <= 8. Received ${offset}`
         });
     });
 
@@ -125,8 +122,6 @@ assert.ok(Number.isNaN(buffer.readDoubleLE(8)));
         {
           code: 'ERR_OUT_OF_RANGE',
           name: 'RangeError',
-          message: 'The value of "offset" is out of range. ' +
-                   `It must be an integer. Received ${offset}`
         });
     });
   });

--- a/test/parallel/test-buffer-writefloat.js
+++ b/test/parallel/test-buffer-writefloat.js
@@ -81,7 +81,6 @@ assert.ok(Number.isNaN(buffer.readFloatLE(4)));
       {
         code: 'ERR_BUFFER_OUT_OF_BOUNDS',
         name: 'RangeError',
-        message: 'Attempt to access memory outside buffer bounds'
       });
 
     ['', '0', null, {}, [], () => {}, true, false].forEach((off) => {
@@ -97,8 +96,6 @@ assert.ok(Number.isNaN(buffer.readFloatLE(4)));
         {
           code: 'ERR_OUT_OF_RANGE',
           name: 'RangeError',
-          message: 'The value of "offset" is out of range. ' +
-                   `It must be >= 0 and <= 4. Received ${offset}`
         }
       );
     });
@@ -109,8 +106,6 @@ assert.ok(Number.isNaN(buffer.readFloatLE(4)));
         {
           code: 'ERR_OUT_OF_RANGE',
           name: 'RangeError',
-          message: 'The value of "offset" is out of range. ' +
-                   `It must be an integer. Received ${offset}`
         });
     });
   });

--- a/test/parallel/test-buffer-writeint.js
+++ b/test/parallel/test-buffer-writeint.js
@@ -7,8 +7,6 @@ const assert = require('assert');
 const errorOutOfBounds = {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: new RegExp('^The value of "value" is out of range\\. ' +
-                      'It must be >= -\\d+ and <= \\d+\\. Received .+$')
 };
 
 // Test 8 bit
@@ -194,8 +192,6 @@ const errorOutOfBounds = {
         () => data[fn](23, 0, byteLength),
         {
           code: 'ERR_OUT_OF_RANGE',
-          message: 'The value of "byteLength" is out of range. ' +
-                   `It must be >= 1 and <= 6. Received ${byteLength}`
         }
       );
     });
@@ -206,8 +202,6 @@ const errorOutOfBounds = {
         {
           code: 'ERR_OUT_OF_RANGE',
           name: 'RangeError',
-          message: 'The value of "byteLength" is out of range. ' +
-                   `It must be an integer. Received ${byteLength}`
         });
     });
   });
@@ -217,21 +211,12 @@ const errorOutOfBounds = {
     ['writeIntBE', 'writeIntLE'].forEach((fn) => {
       const min = -(2 ** (i * 8 - 1));
       const max = 2 ** (i * 8 - 1) - 1;
-      let range = `>= ${min} and <= ${max}`;
-      if (i > 4) {
-        range = `>= -(2 ** ${i * 8 - 1}) and < 2 ** ${i * 8 - 1}`;
-      }
       [min - 1, max + 1].forEach((val) => {
-        const received = i > 4 ?
-          String(val).replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1_') :
-          val;
         assert.throws(() => {
           data[fn](val, 0, i);
         }, {
           code: 'ERR_OUT_OF_RANGE',
           name: 'RangeError',
-          message: 'The value of "value" is out of range. ' +
-                   `It must be ${range}. Received ${received}`
         });
       });
 
@@ -250,8 +235,6 @@ const errorOutOfBounds = {
           {
             code: 'ERR_OUT_OF_RANGE',
             name: 'RangeError',
-            message: 'The value of "offset" is out of range. ' +
-                     `It must be >= 0 and <= ${8 - i}. Received ${offset}`
           });
       });
 
@@ -261,8 +244,6 @@ const errorOutOfBounds = {
           {
             code: 'ERR_OUT_OF_RANGE',
             name: 'RangeError',
-            message: 'The value of "offset" is out of range. ' +
-                     `It must be an integer. Received ${offset}`
           });
       });
     });

--- a/test/parallel/test-buffer-writeuint.js
+++ b/test/parallel/test-buffer-writeuint.js
@@ -89,8 +89,6 @@ const assert = require('assert');
       () => data[fn](value, 0),
       {
         code: 'ERR_OUT_OF_RANGE',
-        message: 'The value of "value" is out of range. ' +
-                 `It must be >= 0 and <= 65535. Received ${value}`
       }
     );
   });
@@ -149,8 +147,6 @@ const assert = require('assert');
         () => data[fn](23, 0, byteLength),
         {
           code: 'ERR_OUT_OF_RANGE',
-          message: 'The value of "byteLength" is out of range. ' +
-                   `It must be >= 1 and <= 6. Received ${byteLength}`
         }
       );
     });
@@ -161,26 +157,18 @@ const assert = require('assert');
         {
           code: 'ERR_OUT_OF_RANGE',
           name: 'RangeError',
-          message: 'The value of "byteLength" is out of range. ' +
-                   `It must be an integer. Received ${byteLength}`
         });
     });
   });
 
   // Test 1 to 6 bytes.
   for (let i = 1; i <= 6; i++) {
-    const range = i < 5 ? `= ${val - 1}` : ` 2 ** ${i * 8}`;
-    const received = i > 4 ?
-      String(val).replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1_') :
-      val;
     ['writeUIntBE', 'writeUIntLE'].forEach((fn) => {
       assert.throws(() => {
         data[fn](val, 0, i);
       }, {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "value" is out of range. ' +
-                 `It must be >= 0 and <${range}. Received ${received}`
       });
 
       ['', '0', null, {}, [], () => {}, true, false].forEach((o) => {
@@ -198,8 +186,6 @@ const assert = require('assert');
           {
             code: 'ERR_OUT_OF_RANGE',
             name: 'RangeError',
-            message: 'The value of "offset" is out of range. ' +
-                     `It must be >= 0 and <= ${8 - i}. Received ${offset}`
           });
       });
 
@@ -209,8 +195,6 @@ const assert = require('assert');
           {
             code: 'ERR_OUT_OF_RANGE',
             name: 'RangeError',
-            message: 'The value of "offset" is out of range. ' +
-                     `It must be an integer. Received ${offset}`
           });
       });
     });

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -67,7 +67,6 @@ dns.lookup('::1', common.mustSucceed((result, addressType) => {
   const err = {
     code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: `The argument 'rrtype' is invalid. Received '${val}'`,
   };
 
   assert.throws(

--- a/test/parallel/test-child-process-advanced-serialization.js
+++ b/test/parallel/test-child-process-advanced-serialization.js
@@ -3,7 +3,6 @@ const common = require('../common');
 const assert = require('assert');
 const child_process = require('child_process');
 const { once } = require('events');
-const { inspect } = require('util');
 
 if (process.argv[2] !== 'child') {
   for (const value of [null, 42, Infinity, 'foo']) {
@@ -11,9 +10,6 @@ if (process.argv[2] !== 'child') {
       child_process.spawn(process.execPath, [], { serialization: value });
     }, {
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.serialization' " +
-        "must be one of: undefined, 'json', 'advanced'. " +
-        `Received ${inspect(value)}`
     });
   }
 

--- a/test/parallel/test-child-process-constructor.js
+++ b/test/parallel/test-child-process-constructor.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 const { ChildProcess } = require('child_process');
 assert.strictEqual(typeof ChildProcess, 'function');
@@ -15,8 +14,6 @@ assert.strictEqual(typeof ChildProcess, 'function');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options" argument must be of type object.' +
-               `${common.invalidArgTypeHelper(options)}`
     });
   });
 }
@@ -31,8 +28,6 @@ assert.strictEqual(typeof ChildProcess, 'function');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.file" property must be of type string.' +
-               `${common.invalidArgTypeHelper(file)}`
     });
   });
 }
@@ -47,8 +42,6 @@ assert.strictEqual(typeof ChildProcess, 'function');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.envPairs" property must be an instance of Array.' +
-              common.invalidArgTypeHelper(envPairs)
     });
   });
 }
@@ -63,8 +56,6 @@ assert.strictEqual(typeof ChildProcess, 'function');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.args" property must be an instance of Array.' +
-               common.invalidArgTypeHelper(args)
     });
   });
 }

--- a/test/parallel/test-child-process-fork-args.js
+++ b/test/parallel/test-child-process-fork-args.js
@@ -25,7 +25,6 @@ const expectedEnv = { foo: 'bar' };
     assert.throws(() => fork(modulePath), {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /^The "modulePath" argument must be of type string/
     });
   });
 

--- a/test/parallel/test-child-process-fork.js
+++ b/test/parallel/test-child-process-fork.js
@@ -41,19 +41,15 @@ n.on('message', (m) => {
 // returns "undefined" but JSON.parse() cannot parse that...
 assert.throws(() => n.send(undefined), {
   name: 'TypeError',
-  message: 'The "message" argument must be specified',
   code: 'ERR_MISSING_ARGS'
 });
 assert.throws(() => n.send(), {
   name: 'TypeError',
-  message: 'The "message" argument must be specified',
   code: 'ERR_MISSING_ARGS'
 });
 
 assert.throws(() => n.send(Symbol()), {
   name: 'TypeError',
-  message: 'The "message" argument must be one of type string,' +
-           ' object, number, or boolean. Received type symbol (Symbol())',
   code: 'ERR_INVALID_ARG_TYPE'
 });
 n.send({ hello: 'world' });

--- a/test/parallel/test-child-process-send-after-close.js
+++ b/test/parallel/test-child-process-send-after-close.js
@@ -13,7 +13,6 @@ child.on('close', common.mustCall((code, signal) => {
 
   const testError = common.expectsError({
     name: 'Error',
-    message: 'Channel closed',
     code: 'ERR_IPC_CHANNEL_CLOSED'
   }, 2);
 

--- a/test/parallel/test-common.js
+++ b/test/parallel/test-common.js
@@ -67,7 +67,6 @@ assert.throws(
   () => { assert.fail('fhqwhgads'); },
   {
     code: 'ERR_ASSERTION',
-    message: /^fhqwhgads$/
   });
 
 const fnOnce = common.mustCall(() => {});

--- a/test/parallel/test-console-group.js
+++ b/test/parallel/test-console-group.js
@@ -218,7 +218,6 @@ function teardown() {
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: /an integer/,
       }
     );
   });
@@ -234,7 +233,6 @@ function teardown() {
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: />= 0 && <= 1000/,
       }
     );
   });

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -48,7 +48,6 @@ assert.throws(
   {
     code: 'ERR_CONSOLE_WRITABLE_STREAM',
     name: 'TypeError',
-    message: /stdout/
   }
 );
 
@@ -62,7 +61,6 @@ assert.throws(
   {
     code: 'ERR_CONSOLE_WRITABLE_STREAM',
     name: 'TypeError',
-    message: /stderr/
   }
 );
 
@@ -140,8 +138,6 @@ out.write = err.write = (d) => {};
       });
     },
     {
-      message: 'The "options.inspectOptions" property must be of type object.' +
-               common.invalidArgTypeHelper(inspectOptions),
       code: 'ERR_INVALID_ARG_TYPE'
     }
   );

--- a/test/parallel/test-console-tty-colors.js
+++ b/test/parallel/test-console-tty-colors.js
@@ -57,7 +57,6 @@ check(false, false, false);
   });
 
   [0, 'true', null, {}, [], () => {}].forEach((colorMode) => {
-    const received = util.inspect(colorMode);
     assert.throws(
       () => {
         new Console({
@@ -67,7 +66,6 @@ check(false, false, false);
         });
       },
       {
-        message: `The argument 'colorMode' is invalid. Received ${received}`,
         code: 'ERR_INVALID_ARG_VALUE'
       }
     );
@@ -86,8 +84,6 @@ check(false, false, false);
         });
       },
       {
-        message: 'Option "options.inspectOptions.color" cannot be used in ' +
-                 'combination with option "colorMode"',
         code: 'ERR_INCOMPATIBLE_OPTION_PAIR'
       }
     );

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -26,7 +26,6 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const crypto = require('crypto');
-const { inspect } = require('util');
 const fixtures = require('../common/fixtures');
 
 crypto.DEFAULT_ENCODING = 'buffer';
@@ -245,7 +244,6 @@ for (const test of TEST_CASES) {
       decrypt.setAuthTag(Buffer.from('1'.repeat(length)));
     }, {
       name: 'TypeError',
-      message: /Invalid authentication tag length/
     });
 
     assert.throws(() => {
@@ -257,7 +255,6 @@ for (const test of TEST_CASES) {
                             });
     }, {
       name: 'TypeError',
-      message: /Invalid authentication tag length/
     });
 
     assert.throws(() => {
@@ -269,7 +266,6 @@ for (const test of TEST_CASES) {
                               });
     }, {
       name: 'TypeError',
-      message: /Invalid authentication tag length/
     });
   }
 }
@@ -304,7 +300,6 @@ for (const test of TEST_CASES) {
     decipher.setAuthTag(Buffer.from('1'.repeat(12)));
   }, {
     name: 'TypeError',
-    message: /Invalid authentication tag length/
   });
 
   // The Decipher object should be left intact.
@@ -330,8 +325,6 @@ for (const test of TEST_CASES) {
     }, {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.authTagLength' is invalid. " +
-               `Received ${inspect(authTagLength)}`
     });
 
     assert.throws(() => {
@@ -344,8 +337,6 @@ for (const test of TEST_CASES) {
     }, {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.authTagLength' is invalid. " +
-        `Received ${inspect(authTagLength)}`
     });
 
     if (!common.hasFipsCrypto) {
@@ -354,8 +345,6 @@ for (const test of TEST_CASES) {
       }, {
         name: 'TypeError',
         code: 'ERR_INVALID_ARG_VALUE',
-        message: "The property 'options.authTagLength' is invalid. " +
-          `Received ${inspect(authTagLength)}`
       });
 
       assert.throws(() => {
@@ -363,8 +352,6 @@ for (const test of TEST_CASES) {
       }, {
         name: 'TypeError',
         code: 'ERR_INVALID_ARG_VALUE',
-        message: "The property 'options.authTagLength' is invalid. " +
-          `Received ${inspect(authTagLength)}`
       });
     }
   }
@@ -454,8 +441,6 @@ for (const test of TEST_CASES) {
     }, {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.plaintextLength' is invalid. " +
-        `Received ${inspect(plaintextLength)}`
     });
   }
 }
@@ -695,7 +680,6 @@ for (const test of TEST_CASES) {
       crypto.createCipheriv('chacha20-poly1305', key, iv, { authTagLength });
     }, {
       code: 'ERR_CRYPTO_INVALID_AUTH_TAG',
-      message: errMessages.authTagLength
     });
   }
 }
@@ -737,7 +721,6 @@ for (const test of TEST_CASES) {
           decipher.setAuthTag(authTag);
         }, {
           code: 'ERR_CRYPTO_INVALID_AUTH_TAG',
-          message: `Invalid authentication tag length: ${authTagLength}`
         });
       }
     }

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -90,8 +90,6 @@ testCipher2(Buffer.from('0123456789abcdef'));
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "cipher" argument must be of type string. ' +
-               'Received null'
     });
 
   assert.throws(
@@ -127,8 +125,6 @@ testCipher2(Buffer.from('0123456789abcdef'));
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "cipher" argument must be of type string. ' +
-               'Received null'
     });
 
   assert.throws(
@@ -243,7 +239,6 @@ testCipher2(Buffer.from('0123456789abcdef'));
     {
       code: 'ERR_CRYPTO_INVALID_STATE',
       name: 'Error',
-      message: 'Invalid state for operation getAuthTag'
     }
   );
 
@@ -261,7 +256,6 @@ testCipher2(Buffer.from('0123456789abcdef'));
     {
       code: 'ERR_CRYPTO_INVALID_STATE',
       name: 'Error',
-      message: 'Invalid state for operation setAAD'
     });
 
   assert.throws(
@@ -269,7 +263,6 @@ testCipher2(Buffer.from('0123456789abcdef'));
     {
       code: 'ERR_CRYPTO_INVALID_STATE',
       name: 'Error',
-      message: 'Invalid state for operation setAuthTag'
     });
 
   assert.throws(
@@ -277,7 +270,6 @@ testCipher2(Buffer.from('0123456789abcdef'));
     {
       code: 'ERR_CRYPTO_INVALID_STATE',
       name: 'Error',
-      message: 'Invalid state for operation setAutoPadding'
     }
   );
 }

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -92,8 +92,6 @@ function testCipher3(key, iv) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "cipher" argument must be of type string. ' +
-               'Received null'
     });
 
   assert.throws(
@@ -125,8 +123,6 @@ function testCipher3(key, iv) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "cipher" argument must be of type string. ' +
-               'Received null'
     });
 
   assert.throws(
@@ -207,7 +203,6 @@ for (let n = minIvLength; n < maxIvLength; n += 1) {
     {
       name: 'Error',
       code: 'ERR_CRYPTO_UNKNOWN_CIPHER',
-      message: 'Unknown cipher'
     });
 
   // Passing a key with an invalid length should throw.

--- a/test/parallel/test-crypto-dh-curves.js
+++ b/test/parallel/test-crypto-dh-curves.js
@@ -53,7 +53,6 @@ if (availableCurves.has('prime256v1') && availableCurves.has('secp256k1')) {
     {
       code: 'ERR_CRYPTO_ECDH_INVALID_FORMAT',
       name: 'TypeError',
-      message: 'Invalid ECDH format: 10'
     });
 
   // ECDH should check that point is on curve
@@ -65,7 +64,6 @@ if (availableCurves.has('prime256v1') && availableCurves.has('secp256k1')) {
     {
       code: 'ERR_CRYPTO_ECDH_INVALID_PUBLIC_KEY',
       name: 'Error',
-      message: 'Public key is not valid for specified curve'
     });
 
   // ECDH should allow .setPrivateKey()/.setPublicKey()
@@ -178,7 +176,6 @@ if (availableCurves.has('prime256v1') && availableHashes.has('sha256')) {
     {
       code: 'ERR_CRYPTO_ECDH_INVALID_PUBLIC_KEY',
       name: 'Error',
-      message: 'Public key is not valid for specified curve'
     });
   // Check that signing operations are not impacted by the above error.
   const ecPrivateKey =

--- a/test/parallel/test-crypto-dh-stateless.js
+++ b/test/parallel/test-crypto-dh-stateless.js
@@ -9,21 +9,16 @@ const crypto = require('crypto');
 assert.throws(() => crypto.diffieHellman(), {
   name: 'TypeError',
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "options" argument must be of type object. Received undefined'
 });
 
 assert.throws(() => crypto.diffieHellman(null), {
   name: 'TypeError',
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "options" argument must be of type object. Received null'
 });
 
 assert.throws(() => crypto.diffieHellman([]), {
   name: 'TypeError',
   code: 'ERR_INVALID_ARG_TYPE',
-  message:
-    'The "options" argument must be of type object. ' +
-    'Received an instance of Array',
 });
 
 function test({ publicKey: alicePublicKey, privateKey: alicePrivateKey },
@@ -105,13 +100,11 @@ const bobPublicKey = crypto.createPublicKey({
 assert.throws(() => crypto.diffieHellman({ privateKey: alicePrivateKey }), {
   name: 'TypeError',
   code: 'ERR_INVALID_ARG_VALUE',
-  message: "The property 'options.publicKey' is invalid. Received undefined"
 });
 
 assert.throws(() => crypto.diffieHellman({ publicKey: alicePublicKey }), {
   name: 'TypeError',
   code: 'ERR_INVALID_ARG_VALUE',
-  message: "The property 'options.privateKey' is invalid. Received undefined"
 });
 
 const privateKey = Buffer.from(
@@ -242,5 +235,4 @@ assert.throws(() => {
 }, {
   name: 'Error',
   code: 'ERR_CRYPTO_INCOMPATIBLE_KEY',
-  message: 'Incompatible key types for Diffie-Hellman: x448 and x25519'
 });

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -27,15 +27,11 @@ assert.strictEqual(dh2.verifyError, 0);
 assert.throws(() => crypto.createDiffieHellman(13.37), {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "sizeOrKey" is out of range. ' +
-           'It must be an integer. Received 13.37',
 });
 
 assert.throws(() => crypto.createDiffieHellman('abcdef', 13.37), {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "generator" is out of range. ' +
-           'It must be an integer. Received 13.37',
 });
 
 for (const bits of [-1, 0, 1]) {
@@ -43,13 +39,11 @@ for (const bits of [-1, 0, 1]) {
     assert.throws(() => crypto.createDiffieHellman(bits), {
       code: 'ERR_OSSL_DH_MODULUS_TOO_SMALL',
       name: 'Error',
-      message: /modulus too small/,
     });
   } else {
     assert.throws(() => crypto.createDiffieHellman(bits), {
       code: 'ERR_OSSL_BN_BITS_TOO_SMALL',
       name: 'Error',
-      message: /bits too small/,
     });
   }
 }
@@ -65,7 +59,6 @@ for (const g of [-1, 1]) {
   const ex = {
     code: 'ERR_OSSL_DH_BAD_GENERATOR',
     name: 'Error',
-    message: /bad generator/,
   };
   assert.throws(() => crypto.createDiffieHellman('abcdef', g), ex);
   assert.throws(() => crypto.createDiffieHellman('abcdef', 'hex', g), ex);
@@ -79,7 +72,6 @@ for (const g of [Buffer.from([]),
   const ex = {
     code: 'ERR_OSSL_DH_BAD_GENERATOR',
     name: 'Error',
-    message: /bad generator/,
   };
   assert.throws(() => crypto.createDiffieHellman('abcdef', g), ex);
   assert.throws(() => crypto.createDiffieHellman('abcdef', 'hex', g), ex);
@@ -133,15 +125,12 @@ assert.strictEqual(secret1, secret4);
 let wrongBlockLength;
 if (common.hasOpenSSL3) {
   wrongBlockLength = {
-    message: 'error:1C80006B:Provider routines::wrong final block length',
     code: 'ERR_OSSL_WRONG_FINAL_BLOCK_LENGTH',
     library: 'Provider routines',
     reason: 'wrong final block length'
   };
 } else {
   wrongBlockLength = {
-    message: 'error:0606506D:digital envelope' +
-      ' routines:EVP_DecryptFinal_ex:wrong final block length',
     code: 'ERR_OSSL_EVP_WRONG_FINAL_BLOCK_LENGTH',
     library: 'digital envelope routines',
     reason: 'wrong final block length'
@@ -175,8 +164,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "curve" argument must be of type string. ' +
-            'Received undefined'
   });
 
 assert.throws(
@@ -186,7 +173,6 @@ assert.throws(
   {
     name: 'Error',
     code: 'ERR_CRYPTO_UNKNOWN_DH_GROUP',
-    message: 'Unknown DH group'
   },
   'crypto.getDiffieHellman(\'unknown-group\') ' +
   'failed to throw the expected error.'

--- a/test/parallel/test-crypto-ecdh-convert-key.js
+++ b/test/parallel/test-crypto-ecdh-convert-key.js
@@ -37,7 +37,6 @@ assert.throws(
   () => ECDH.convertKey(cafebabePubPtComp, 'badcurve'),
   {
     name: 'TypeError',
-    message: 'Invalid EC curve name'
   });
 
 if (getCurves().includes('secp256k1')) {
@@ -47,7 +46,6 @@ if (getCurves().includes('secp256k1')) {
     {
       code: 'ERR_CRYPTO_ECDH_INVALID_FORMAT',
       name: 'TypeError',
-      message: 'Invalid ECDH format: 10'
     });
 
   // Point formats.

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -119,7 +119,6 @@ assert.throws(
   }),
   {
     name: 'Error',
-    message: 'boom'
   });
 
 // Issue https://github.com/nodejs/node/issues/25487: error message for invalid
@@ -168,8 +167,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "algorithm" argument must be of type string. ' +
-             'Received undefined'
   }
 );
 

--- a/test/parallel/test-crypto-hkdf.js
+++ b/test/parallel/test-crypto-hkdf.js
@@ -17,61 +17,50 @@ const {
 {
   assert.throws(() => hkdf(), {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "digest" argument must be of type string/
   });
 
   [1, {}, [], false, Infinity].forEach((i) => {
     assert.throws(() => hkdf(i, 'a'), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "digest" argument must be of type string/
     });
     assert.throws(() => hkdfSync(i, 'a'), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "digest" argument must be of type string/
     });
   });
 
   [1, {}, [], false, Infinity].forEach((i) => {
     assert.throws(() => hkdf('sha256', i), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "ikm" argument must be /
     });
     assert.throws(() => hkdfSync('sha256', i), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "ikm" argument must be /
     });
   });
 
   [1, {}, [], false, Infinity].forEach((i) => {
     assert.throws(() => hkdf('sha256', 'secret', i), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "salt" argument must be /
     });
     assert.throws(() => hkdfSync('sha256', 'secret', i), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "salt" argument must be /
     });
   });
 
   [1, {}, [], false, Infinity].forEach((i) => {
     assert.throws(() => hkdf('sha256', 'secret', 'salt', i), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "info" argument must be /
     });
     assert.throws(() => hkdfSync('sha256', 'secret', 'salt', i), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "info" argument must be /
     });
   });
 
   ['test', {}, [], false].forEach((i) => {
     assert.throws(() => hkdf('sha256', 'secret', 'salt', 'info', i), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "length" argument must be of type number/
     });
     assert.throws(() => hkdfSync('sha256', 'secret', 'salt', 'info', i), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "length" argument must be of type number/
     });
   });
 

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -18,7 +18,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "hmac" argument must be of type string. Received null'
   });
 
 // This used to segfault. See: https://github.com/nodejs/node/issues/9819
@@ -28,7 +27,6 @@ assert.throws(
   }),
   {
     name: 'Error',
-    message: 'boom'
   });
 
 assert.throws(

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -40,8 +40,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   }, {
     name: 'RangeError',
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "key.byteLength" is out of range. ' +
-             'It must be > 0. Received 0'
   });
 }
 
@@ -52,7 +50,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.throws(() => new KeyObject(TYPE), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_VALUE',
-    message: `The argument 'type' is invalid. Received '${TYPE}'`
   });
 }
 
@@ -61,9 +58,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.throws(() => new KeyObject('secret', ''), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message:
-      'The "handle" argument must be of type object. Received type ' +
-      "string ('')"
   });
 }
 
@@ -71,9 +65,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.throws(() => KeyObject.from('invalid_key'), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message:
-      'The "key" argument must be an instance of CryptoKey. Received type ' +
-      "string ('invalid_key')"
   });
 }
 
@@ -109,7 +100,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.throws(() => createPublicKey(publicKey), {
     name: 'TypeError',
     code: 'ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE',
-    message: 'Invalid key object type public, expected private.'
   });
 
   // Constructing a private key from a public key should be impossible, even
@@ -206,7 +196,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
     assert.throws(() => publicKey.export(opt), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "options" argument must be of type object/
     });
   }
 
@@ -229,7 +218,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.throws(() => {
     privateKey.export({ format: 'jwk', passphrase: 'secret' });
   }, {
-    message: 'The selected key encoding jwk does not support encryption.',
     code: 'ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS'
   });
 
@@ -306,7 +294,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   }, common.hasOpenSSL3 ? {
     message: 'error:1E08010C:DECODER routines::unsupported',
   } : {
-    message: 'error:0909006C:PEM routines:get_name:no start line',
     code: 'ERR_OSSL_PEM_NO_START_LINE',
     reason: 'no start line',
     library: 'PEM routines',
@@ -318,7 +305,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
     createPrivateKey({ key: Buffer.alloc(0), format: 'der', type: 'spki' });
   }, {
     code: 'ERR_INVALID_ARG_VALUE',
-    message: "The property 'options.type' is invalid. Received 'spki'"
   });
 
   // Unlike SPKI, PKCS#1 is a valid encoding for private keys (and public keys),
@@ -330,10 +316,8 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
     });
     createPrivateKey({ key, format: 'der', type: 'pkcs1' });
   }, common.hasOpenSSL3 ? {
-    message: /error:1E08010C:DECODER routines::unsupported/,
     library: 'DECODER routines'
   } : {
-    message: /asn1 encoding/,
     library: 'asn1 encoding routines'
   });
 }
@@ -518,12 +502,9 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   // Reading an encrypted key without a passphrase should fail.
   assert.throws(() => createPrivateKey(privateDsa), common.hasOpenSSL3 ? {
     name: 'Error',
-    message: 'error:07880109:common libcrypto routines::interrupted or ' +
-             'cancelled',
   } : {
     name: 'TypeError',
     code: 'ERR_MISSING_PASSPHRASE',
-    message: 'Passphrase required for encrypted key'
   });
 
   // Reading an encrypted key with a passphrase that exceeds OpenSSL's buffer
@@ -776,7 +757,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   }, {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_VALUE',
-    message: "The property 'options.cipher' is invalid. Received undefined"
   });
 }
 
@@ -813,13 +793,11 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
     () => publicKey.export({ format: 'jwk' }),
     {
       code: 'ERR_CRYPTO_JWK_UNSUPPORTED_CURVE',
-      message: `Unsupported JWK EC curve: ${namedCurve}.`
     });
   assert.throws(
     () => privateKey.export({ format: 'jwk' }),
     {
       code: 'ERR_CRYPTO_JWK_UNSUPPORTED_CURVE',
-      message: `Unsupported JWK EC curve: ${namedCurve}.`
     });
 }
 
@@ -833,7 +811,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.throws(() => keyObject.equals(0), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "otherKeyObject" argument must be an instance of KeyObject. Received type number (0)'
   });
 
   assert(keyObject.equals(keyObject));

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -18,7 +18,7 @@ const {
   sign,
   verify
 } = require('crypto');
-const { inspect, promisify } = require('util');
+const { promisify } = require('util');
 
 // Asserts that the size of the given key (in chars or bytes) is within 10% of
 // the expected size.
@@ -213,12 +213,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     const publicKey = { key: publicKeyDER, ...publicKeyEncoding };
     const expectedError = common.hasOpenSSL3 ? {
       name: 'Error',
-      message: 'error:07880109:common libcrypto routines::interrupted or ' +
-               'cancelled'
     } : {
       name: 'TypeError',
       code: 'ERR_MISSING_PASSPHRASE',
-      message: 'Passphrase required for encrypted key'
     };
     assert.throws(() => testSignVerify(publicKey, privateKey), expectedError);
 
@@ -255,7 +252,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'TypeError',
       code: 'ERR_MISSING_PASSPHRASE',
-      message: 'Passphrase required for encrypted key'
     });
 
     // Signing should work with the correct password.
@@ -465,7 +461,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'TypeError',
       code: 'ERR_MISSING_PASSPHRASE',
-      message: 'Passphrase required for encrypted key'
     });
 
     // Signing should work with the correct password.
@@ -571,7 +566,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
                   } : {
                     name: 'TypeError',
                     code: 'ERR_MISSING_PASSPHRASE',
-                    message: 'Passphrase required for encrypted key'
                   });
 
     testSignVerify(publicKey, { key: privateKey, passphrase: 'secret' });
@@ -605,7 +599,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
                   } : {
                     name: 'TypeError',
                     code: 'ERR_MISSING_PASSPHRASE',
-                    message: 'Passphrase required for encrypted key'
                   });
 
     testSignVerify(publicKey, { key: privateKey, passphrase: 'secret' });
@@ -642,7 +635,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
                   } : {
                     name: 'TypeError',
                     code: 'ERR_MISSING_PASSPHRASE',
-                    message: 'Passphrase required for encrypted key'
                   });
 
     testSignVerify(publicKey, {
@@ -680,7 +672,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
                   } : {
                     name: 'TypeError',
                     code: 'ERR_MISSING_PASSPHRASE',
-                    message: 'Passphrase required for encrypted key'
                   });
 
     testSignVerify(publicKey, {
@@ -796,8 +787,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_VALUE',
-    message: "The property 'options.paramEncoding' is invalid. " +
-      "Received 'otherEncoding'"
   });
   assert.throws(() => generateKeyPairSync('dsa', {
     modulusLength: 4096,
@@ -810,7 +799,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }), {
     name: 'Error',
     code: 'ERR_CRYPTO_JWK_UNSUPPORTED_KEY_TYPE',
-    message: 'Unsupported JWK Key Type.'
   });
   assert.throws(() => generateKeyPairSync('ec', {
     namedCurve: 'secp224r1',
@@ -823,7 +811,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }), {
     name: 'Error',
     code: 'ERR_CRYPTO_JWK_UNSUPPORTED_CURVE',
-    message: 'Unsupported JWK EC curve: secp224r1.'
   });
 }
 
@@ -861,15 +848,12 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     assert.throws(() => generateKeyPairSync(type, {}), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "type" argument must be of type string.' +
-               common.invalidArgTypeHelper(type)
     });
   }
 
   assert.throws(() => generateKeyPairSync('rsa2', {}), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_VALUE',
-    message: "The argument 'type' must be a supported key type. Received 'rsa2'"
   });
 }
 
@@ -878,8 +862,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   assert.throws(() => generateKeyPair('rsa', common.mustNotCall()), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "options" argument must be of type object. ' +
-      'Received undefined'
   });
 
   // Even if no options are required, it should be impossible to pass anything
@@ -887,8 +869,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   assert.throws(() => generateKeyPair('ed448', 0, common.mustNotCall()), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "options" argument must be of type object. ' +
-      'Received type number (0)'
   });
 }
 
@@ -945,8 +925,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.publicKeyEncoding' is invalid. " +
-        `Received ${inspect(enc)}`
     });
   }
 
@@ -965,8 +943,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.publicKeyEncoding.type' is invalid. " +
-        `Received ${inspect(type)}`
     });
   }
 
@@ -985,8 +961,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.publicKeyEncoding.format' is invalid. " +
-        `Received ${inspect(format)}`
     });
   }
 
@@ -1002,8 +976,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.privateKeyEncoding' is invalid. " +
-        `Received ${inspect(enc)}`
     });
   }
 
@@ -1022,8 +994,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.privateKeyEncoding.type' is invalid. " +
-        `Received ${inspect(type)}`
     });
   }
 
@@ -1042,8 +1012,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.privateKeyEncoding.format' is invalid. " +
-        `Received ${inspect(format)}`
     });
   }
 
@@ -1063,8 +1031,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.privateKeyEncoding.cipher' is invalid. " +
-        `Received ${inspect(cipher)}`
     });
   }
 
@@ -1084,7 +1050,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }), {
     name: 'Error',
     code: 'ERR_CRYPTO_UNKNOWN_CIPHER',
-    message: 'Unknown cipher'
   });
 
   // Cipher, but no valid passphrase.
@@ -1104,8 +1069,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.privateKeyEncoding.passphrase' " +
-        `is invalid. Received ${inspect(passphrase)}`
     });
   }
 
@@ -1131,9 +1094,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, common.mustNotCall()), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message:
-        'The "options.modulusLength" property must be of type number.' +
-        common.invalidArgTypeHelper(modulusLength)
     });
   }
 
@@ -1144,10 +1104,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, common.mustNotCall()), {
       name: 'RangeError',
       code: 'ERR_OUT_OF_RANGE',
-      message:
-        'The value of "options.modulusLength" is out of range. ' +
-        'It must be an integer. ' +
-        `Received ${inspect(modulusLength)}`
     });
   }
 
@@ -1169,9 +1125,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, common.mustNotCall()), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message:
-        'The "options.publicExponent" property must be of type number.' +
-        common.invalidArgTypeHelper(publicExponent)
     });
   }
 
@@ -1183,10 +1136,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, common.mustNotCall()), {
       name: 'RangeError',
       code: 'ERR_OUT_OF_RANGE',
-      message:
-        'The value of "options.publicExponent" is out of range. ' +
-        'It must be an integer. ' +
-        `Received ${inspect(publicExponent)}`
     });
   }
 
@@ -1211,9 +1160,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, common.mustNotCall()), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message:
-        'The "options.modulusLength" property must be of type number.' +
-        common.invalidArgTypeHelper(modulusLength)
     });
   }
 
@@ -1245,9 +1191,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, common.mustNotCall()), {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message:
-        'The "options.divisorLength" property must be of type number.' +
-        common.invalidArgTypeHelper(divisorLength)
     });
   }
 
@@ -1259,10 +1202,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, common.mustNotCall()), {
       name: 'RangeError',
       code: 'ERR_OUT_OF_RANGE',
-      message:
-        'The value of "options.divisorLength" is out of range. ' +
-        'It must be an integer. ' +
-        `Received ${inspect(divisorLength)}`
     });
   }
 
@@ -1274,10 +1213,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, common.mustNotCall()), {
       name: 'RangeError',
       code: 'ERR_OUT_OF_RANGE',
-      message:
-        'The value of "options.divisorLength" is out of range. ' +
-        'It must be >= 0 && <= 2147483647. ' +
-        `Received ${inspect(divisorLength)}`
     });
   }
 }
@@ -1293,7 +1228,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     });
   }, {
     name: 'TypeError',
-    message: 'Invalid EC curve name'
   });
 
   // Test error type when curve is not a string
@@ -1307,9 +1241,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message:
-        'The "options.namedCurve" property must be of type string.' +
-        common.invalidArgTypeHelper(namedCurve)
     });
   }
 
@@ -1371,7 +1302,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "options" argument must be of type object. Received undefined'
   });
 
   assert.throws(() => {
@@ -1379,8 +1309,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, {
     name: 'TypeError',
     code: 'ERR_MISSING_OPTION',
-    message: 'At least one of the group, prime, or primeLength options is ' +
-             'required'
   });
 
   assert.throws(() => {
@@ -1390,7 +1318,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, {
     name: 'Error',
     code: 'ERR_CRYPTO_UNKNOWN_DH_GROUP',
-    message: 'Unknown DH group'
   });
 
   assert.throws(() => {
@@ -1400,9 +1327,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, {
     name: 'RangeError',
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "options.primeLength" is out of range. ' +
-             'It must be >= 0 && <= 2147483647. ' +
-             'Received 2147483648',
   });
 
   assert.throws(() => {
@@ -1412,9 +1336,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, {
     name: 'RangeError',
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "options.primeLength" is out of range. ' +
-             'It must be >= 0 && <= 2147483647. ' +
-             'Received -1',
   });
 
   assert.throws(() => {
@@ -1425,9 +1346,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, {
     name: 'RangeError',
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "options.generator" is out of range. ' +
-             'It must be >= 0 && <= 2147483647. ' +
-             'Received 2147483648',
   });
 
   assert.throws(() => {
@@ -1438,9 +1356,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, {
     name: 'RangeError',
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "options.generator" is out of range. ' +
-             'It must be >= 0 && <= 2147483647. ' +
-             'Received -1',
   });
 
   // Test incompatible options.
@@ -1465,8 +1380,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'TypeError',
       code: 'ERR_INCOMPATIBLE_OPTION_PAIR',
-      message: `Option "${opt1}" cannot be used in combination with option ` +
-               `"${opt2}"`
     });
   }
 }
@@ -1484,8 +1397,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.publicKeyEncoding.type' is invalid. " +
-        `Received ${inspect(type)}`
     });
   }
 
@@ -1499,9 +1410,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message:
-      'The "options.hashAlgorithm" property must be of type string.' +
-        common.invalidArgTypeHelper(hashValue)
     });
   }
 
@@ -1516,9 +1424,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, {
     name: 'RangeError',
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "options.saltLength" is out of range. ' +
-             'It must be >= 0 && <= 2147483647. ' +
-             'Received 2147483648'
   });
 
   assert.throws(() => {
@@ -1531,9 +1436,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, {
     name: 'RangeError',
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "options.saltLength" is out of range. ' +
-             'It must be >= 0 && <= 2147483647. ' +
-             'Received -1'
   });
 
   // Invalid private key type.
@@ -1547,8 +1449,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.privateKeyEncoding.type' is invalid. " +
-        `Received ${inspect(type)}`
     });
   }
 
@@ -1564,7 +1464,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'Error',
       code: 'ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS',
-      message: 'The selected key encoding pkcs1 can only be used for RSA keys.'
     });
 
     assert.throws(() => {
@@ -1577,7 +1476,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'Error',
       code: 'ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS',
-      message: 'The selected key encoding pkcs1 can only be used for RSA keys.'
     });
   }
 
@@ -1591,7 +1489,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'Error',
       code: 'ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS',
-      message: 'The selected key encoding sec1 can only be used for EC keys.'
     });
   }
 
@@ -1612,7 +1509,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }, {
       name: 'Error',
       code: 'ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS',
-      message: `The selected key encoding ${type} does not support encryption.`
     });
   }
 }
@@ -1647,10 +1543,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       {
         name: 'TypeError',
         code: 'ERR_INVALID_ARG_TYPE',
-        message:
-          'The "options.mgf1HashAlgorithm" property must be of type string.' +
-          common.invalidArgTypeHelper(mgf1HashAlgorithm)
-
       }
     );
   }
@@ -1687,11 +1579,9 @@ for (const type of ['pkcs1', 'pkcs8']) {
     }, common.hasOpenSSL3 ? {
       name: 'Error',
       code: 'ERR_OSSL_CRYPTO_INTERRUPTED_OR_CANCELLED',
-      message: 'error:07880109:common libcrypto routines::interrupted or cancelled'
     } : {
       name: 'TypeError',
       code: 'ERR_MISSING_PASSPHRASE',
-      message: 'Passphrase required for encrypted key'
     });
   }));
 }

--- a/test/parallel/test-crypto-padding.js
+++ b/test/parallel/test-crypto-padding.js
@@ -83,12 +83,9 @@ assert.throws(function() {
   // Input must have block length %.
   enc(ODD_LENGTH_PLAIN, false);
 }, common.hasOpenSSL3 ? {
-  message: 'error:1C80006B:Provider routines::wrong final block length',
   code: 'ERR_OSSL_WRONG_FINAL_BLOCK_LENGTH',
   reason: 'wrong final block length',
 } : {
-  message: 'error:0607F08A:digital envelope routines:EVP_EncryptFinal_ex:' +
-    'data not multiple of block length',
   code: 'ERR_OSSL_EVP_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH',
   reason: 'data not multiple of block length',
 }
@@ -110,12 +107,9 @@ assert.throws(function() {
   // Must have at least 1 byte of padding (PKCS):
   assert.strictEqual(dec(EVEN_LENGTH_ENCRYPTED_NOPAD, true), EVEN_LENGTH_PLAIN);
 }, common.hasOpenSSL3 ? {
-  message: 'error:1C800064:Provider routines::bad decrypt',
   reason: 'bad decrypt',
   code: 'ERR_OSSL_BAD_DECRYPT',
 } : {
-  message: 'error:06065064:digital envelope routines:EVP_DecryptFinal_ex:' +
-    'bad decrypt',
   reason: 'bad decrypt',
   code: 'ERR_OSSL_EVP_BAD_DECRYPT',
 });

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -80,8 +80,6 @@ for (const iterations of [-1, 0]) {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "keylen" argument must be of type number.' +
-               `${common.invalidArgTypeHelper(notNumber)}`
     });
 });
 
@@ -93,8 +91,6 @@ for (const iterations of [-1, 0]) {
     }, {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "keylen" is out of range. It ' +
-               `must be an integer. Received ${input}`
     });
 });
 
@@ -118,8 +114,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "digest" argument must be of type string. ' +
-             'Received undefined'
   });
 
 assert.throws(
@@ -127,8 +121,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "digest" argument must be of type string. ' +
-             'Received undefined'
   });
 
 assert.throws(
@@ -136,8 +128,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "digest" argument must be of type string. ' +
-             'Received null'
   });
 [1, {}, [], true, undefined, null].forEach((input) => {
   assert.throws(
@@ -174,13 +164,11 @@ assert.throws(
 });
 
 ['test', {}, [], true, undefined, null].forEach((i) => {
-  const received = common.invalidArgTypeHelper(i);
   assert.throws(
     () => crypto.pbkdf2('pass', 'salt', i, 8, 'sha256', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: `The "iterations" argument must be of type number.${received}`
     }
   );
 
@@ -189,7 +177,6 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: `The "iterations" argument must be of type number.${received}`
     }
   );
 });
@@ -206,7 +193,6 @@ assert.throws(
   {
     code: 'ERR_CRYPTO_INVALID_DIGEST',
     name: 'TypeError',
-    message: 'Invalid digest: md55'
   }
 );
 
@@ -215,7 +201,6 @@ assert.throws(
   {
     code: 'ERR_CRYPTO_INVALID_DIGEST',
     name: 'TypeError',
-    message: 'Invalid digest: md55'
   }
 );
 
@@ -235,7 +220,6 @@ if (!common.hasOpenSSL3) {
     {
       code: 'ERR_CRYPTO_INVALID_DIGEST',
       name: 'TypeError',
-      message: 'Invalid digest: %'
     }
   );
 }

--- a/test/parallel/test-crypto-prime.js
+++ b/test/parallel/test-crypto-prime.js
@@ -44,11 +44,9 @@ const pCheckPrime = promisify(checkPrime);
 [-1, 0, 2 ** 31, 2 ** 31 + 1, 2 ** 32 - 1, 2 ** 32].forEach((size) => {
   assert.throws(() => generatePrime(size, common.mustNotCall()), {
     code: 'ERR_OUT_OF_RANGE',
-    message: />= 1 && <= 2147483647/
   });
   assert.throws(() => generatePrimeSync(size), {
     code: 'ERR_OUT_OF_RANGE',
-    message: />= 1 && <= 2147483647/
   });
 });
 
@@ -78,20 +76,14 @@ const pCheckPrime = promisify(checkPrime);
 
   assert.throws(() => generatePrime(20, { add: -1n }, common.mustNotCall()), {
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "options.add" is out of range. It must be >= 0. ' +
-             'Received -1n'
   });
 
   assert.throws(() => generatePrime(20, { rem: -1n }, common.mustNotCall()), {
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "options.rem" is out of range. It must be >= 0. ' +
-             'Received -1n'
   });
 
   assert.throws(() => checkPrime(-1n, common.mustNotCall()), {
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "candidate" is out of range. It must be >= 0. ' +
-             'Received -1n'
   });
 }
 
@@ -191,7 +183,6 @@ generatePrime(
       generatePrimeSync(64, { add });
     }, {
       code: 'ERR_OUT_OF_RANGE',
-      message: 'invalid options.add'
     });
   }
 
@@ -201,7 +192,6 @@ generatePrime(
       generatePrimeSync(64, { add: 7n, rem });
     }, {
       code: 'ERR_OUT_OF_RANGE',
-      message: 'invalid options.rem'
     });
   }
 

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -43,8 +43,6 @@ common.expectWarning('DeprecationWarning',
       const errObj = {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "size" argument must be of type number.' +
-                 common.invalidArgTypeHelper(value)
       };
       assert.throws(() => f(value), errObj);
       assert.throws(() => f(value, common.mustNotCall()), errObj);
@@ -54,8 +52,6 @@ common.expectWarning('DeprecationWarning',
       const errObj = {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "size" is out of range. It must be >= 0 && <= ' +
-                 `${kMaxPossibleLength}. Received ${value}`
       };
       assert.throws(() => f(value), errObj);
       assert.throws(() => f(value, common.mustNotCall()), errObj);
@@ -230,8 +226,6 @@ common.expectWarning('DeprecationWarning',
     const typeErrObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "offset" argument must be of type number. ' +
-               "Received type string ('test')"
     };
 
     assert.throws(() => crypto.randomFillSync(buf, 'test'), typeErrObj);
@@ -240,7 +234,6 @@ common.expectWarning('DeprecationWarning',
       () => crypto.randomFill(buf, 'test', common.mustNotCall()),
       typeErrObj);
 
-    typeErrObj.message = typeErrObj.message.replace('offset', 'size');
     assert.throws(() => crypto.randomFillSync(buf, 0, 'test'), typeErrObj);
 
     assert.throws(
@@ -252,8 +245,6 @@ common.expectWarning('DeprecationWarning',
       const errObj = {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "offset" is out of range. ' +
-                 `It must be >= 0 && <= 10. Received ${offsetSize}`
       };
 
       assert.throws(() => crypto.randomFillSync(buf, offsetSize), errObj);
@@ -275,8 +266,6 @@ common.expectWarning('DeprecationWarning',
     const rangeErrObj = {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "size + offset" is out of range. ' +
-               'It must be <= 10. Received 11'
     };
     assert.throws(() => crypto.randomFillSync(buf, 1, 10), rangeErrObj);
 
@@ -295,8 +284,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "size" is out of range. ' +
-             `It must be >= 0 && <= ${kMaxPossibleLength}. Received 4294967296`
   }
 );
 
@@ -416,14 +403,10 @@ assert.throws(
     const invalidMinError = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "min" argument must be a safe integer.' +
-               `${common.invalidArgTypeHelper(i)}`,
     };
     const invalidMaxError = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "max" argument must be a safe integer.' +
-               `${common.invalidArgTypeHelper(i)}`,
     };
 
     assert.throws(
@@ -463,8 +446,6 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "min" argument must be a safe integer.' +
-      `${common.invalidArgTypeHelper(minInt - 1)}`,
     }
   );
 
@@ -473,8 +454,6 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "max" argument must be a safe integer.' +
-      `${common.invalidArgTypeHelper(maxInt + 1)}`,
     }
   );
 
@@ -484,9 +463,6 @@ assert.throws(
     assert.throws(() => crypto.randomInt(...arg, common.mustNotCall()), {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "max" is out of range. It must be greater than ' +
-      `the value of "min" (${arg[arg.length - 2] || 0}). ` +
-      `Received ${arg[arg.length - 1]}`
     });
   }
 
@@ -498,18 +474,12 @@ assert.throws(
     {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "max - min" is out of range. ' +
-               `It must be <= ${MAX_RANGE}. ` +
-               'Received 281_474_976_710_656'
     }
   );
 
   assert.throws(() => crypto.randomInt(MAX_RANGE + 1, common.mustNotCall()), {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "max" is out of range. ' +
-             `It must be <= ${MAX_RANGE}. ` +
-             'Received 281_474_976_710_656'
   });
 
   [true, NaN, null, {}, [], 10].forEach((i) => {

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -28,8 +28,6 @@ const dsaPkcs8KeyPem = fixtures.readKey('dsa_private_pkcs8.pem');
 const ec = new TextEncoder();
 
 const openssl1DecryptError = {
-  message: 'error:06065064:digital envelope routines:EVP_DecryptFinal_ex:' +
-    'bad decrypt',
   code: 'ERR_OSSL_EVP_BAD_DECRYPT',
   reason: 'bad decrypt',
   function: 'EVP_DecryptFinal_ex',

--- a/test/parallel/test-crypto-scrypt.js
+++ b/test/parallel/test-crypto-scrypt.js
@@ -113,39 +113,39 @@ const toobig = [
 const badargs = [
   {
     args: [],
-    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"password"/ },
+    expected: { code: 'ERR_INVALID_ARG_TYPE' },
   },
   {
     args: [null],
-    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"password"/ },
+    expected: { code: 'ERR_INVALID_ARG_TYPE' },
   },
   {
     args: [''],
-    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"salt"/ },
+    expected: { code: 'ERR_INVALID_ARG_TYPE' },
   },
   {
     args: ['', null],
-    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"salt"/ },
+    expected: { code: 'ERR_INVALID_ARG_TYPE' },
   },
   {
     args: ['', ''],
-    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"keylen"/ },
+    expected: { code: 'ERR_INVALID_ARG_TYPE' },
   },
   {
     args: ['', '', null],
-    expected: { code: 'ERR_INVALID_ARG_TYPE', message: /"keylen"/ },
+    expected: { code: 'ERR_INVALID_ARG_TYPE' },
   },
   {
     args: ['', '', .42],
-    expected: { code: 'ERR_OUT_OF_RANGE', message: /"keylen"/ },
+    expected: { code: 'ERR_OUT_OF_RANGE' },
   },
   {
     args: ['', '', -42],
-    expected: { code: 'ERR_OUT_OF_RANGE', message: /"keylen"/ },
+    expected: { code: 'ERR_OUT_OF_RANGE' },
   },
   {
     args: ['', '', 2147485780],
-    expected: { code: 'ERR_OUT_OF_RANGE', message: /"keylen"/ },
+    expected: { code: 'ERR_OUT_OF_RANGE' },
   },
 ];
 

--- a/test/parallel/test-crypto-secret-keygen.js
+++ b/test/parallel/test-crypto-secret-keygen.js
@@ -13,33 +13,27 @@ const {
 [1, true, [], {}, Infinity, null, undefined].forEach((i) => {
   assert.throws(() => generateKey(i, 1, common.mustNotCall()), {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "type" argument must be /
   });
   assert.throws(() => generateKeySync(i, 1), {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "type" argument must be /
   });
 });
 
 ['', true, [], null, undefined].forEach((i) => {
   assert.throws(() => generateKey('aes', i, common.mustNotCall()), {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "options" argument must be /
   });
   assert.throws(() => generateKeySync('aes', i), {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "options" argument must be /
   });
 });
 
 ['', true, {}, [], null, undefined].forEach((length) => {
   assert.throws(() => generateKey('hmac', { length }, common.mustNotCall()), {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "options\.length" property must be /
   });
   assert.throws(() => generateKeySync('hmac', { length }), {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "options\.length" property must be /
   });
 });
 
@@ -83,7 +77,6 @@ assert.throws(
 
 assert.throws(() => generateKeySync('aes', { length: 123 }), {
   code: 'ERR_INVALID_ARG_VALUE',
-  message: /The property 'options\.length' must be one of: 128, 192, 256/
 });
 
 {
@@ -128,10 +121,8 @@ assert.throws(() => generateKeySync('aes', { length: 123 }), {
 assert.throws(
   () => generateKey('unknown', { length: 123 }, common.mustNotCall()), {
     code: 'ERR_INVALID_ARG_VALUE',
-    message: /The argument 'type' must be a supported key type/
   });
 
 assert.throws(() => generateKeySync('unknown', { length: 123 }), {
   code: 'ERR_INVALID_ARG_VALUE',
-  message: /The argument 'type' must be a supported key type/
 });

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -78,7 +78,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: "The property 'options.padding' is invalid. Received null",
   });
 
 assert.throws(
@@ -89,7 +88,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: "The property 'options.saltLength' is invalid. Received null",
   });
 
 // Test signing and verifying
@@ -343,10 +341,8 @@ assert.throws(
       });
   }, common.hasOpenSSL3 ? {
     code: 'ERR_OSSL_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE',
-    message: /illegal or unsupported padding mode/,
   } : {
     code: 'ERR_OSSL_RSA_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE',
-    message: /illegal or unsupported padding mode/,
     opensslErrorStack: [
       'error:06089093:digital envelope routines:EVP_PKEY_CTX_ctrl:' +
       'command not supported',
@@ -372,8 +368,6 @@ assert.throws(
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "algorithm" argument must be of type string.' +
-               `${common.invalidArgTypeHelper(input)}`
     };
     assert.throws(() => crypto.createSign(input), errObj);
     assert.throws(() => crypto.createVerify(input), errObj);
@@ -753,6 +747,5 @@ assert.throws(
     crypto.sign('sha512', 'message', privateKey);
   }, {
     code: 'ERR_OSSL_RSA_DIGEST_TOO_BIG_FOR_RSA_KEY',
-    message: /digest too big for rsa key/
   });
 }

--- a/test/parallel/test-crypto-stream.js
+++ b/test/parallel/test-crypto-stream.js
@@ -72,11 +72,9 @@ const decipher = crypto.createDecipheriv('aes-128-cbc', badkey, iv);
 
 cipher.pipe(decipher)
   .on('error', common.expectsError(common.hasOpenSSL3 ? {
-    message: /bad decrypt/,
     library: 'Provider routines',
     reason: 'bad decrypt',
   } : {
-    message: /bad decrypt/,
     function: 'EVP_DecryptFinal_ex',
     library: 'digital envelope routines',
     reason: 'bad decrypt',

--- a/test/parallel/test-crypto-webcrypto-aes-decrypt-tag-too-small.js
+++ b/test/parallel/test-crypto-webcrypto-aes-decrypt-tag-too-small.js
@@ -24,6 +24,5 @@ crypto.subtle.importKey(
       }, k, new Uint8Array(0));
     }, {
       name: 'OperationError',
-      message: /The provided data is too small/,
     });
   });

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -180,8 +180,6 @@ testImmutability(crypto.getCurves);
 const encodingError = {
   code: 'ERR_INVALID_ARG_VALUE',
   name: 'TypeError',
-  message: "The argument 'encoding' is invalid for data of length 1." +
-           " Received 'hex'",
 };
 
 // Regression tests for https://github.com/nodejs/node-v0.x-archive/pull/5725:
@@ -236,11 +234,9 @@ assert.throws(() => {
     assert.ok(!('opensslErrorStack' in err));
   assert.throws(() => { throw err; }, common.hasOpenSSL3 ? {
     name: 'Error',
-    message: 'error:02000070:rsa routines::digest too big for rsa key',
     library: 'rsa routines',
   } : {
     name: 'Error',
-    message: /routines:RSA_sign:digest too big for rsa key$/,
     library: 'rsa routines',
     function: 'RSA_sign',
     reason: 'digest too big for rsa key',
@@ -262,8 +258,6 @@ if (!common.hasOpenSSL3) {
   }, (err) => {
     // Do the standard checks, but then do some custom checks afterwards.
     assert.throws(() => { throw err; }, {
-      message: 'error:0D0680A8:asn1 encoding routines:asn1_check_tlen:' +
-               'wrong tag',
       library: 'asn1 encoding routines',
       function: 'asn1_check_tlen',
       reason: 'wrong tag',

--- a/test/parallel/test-dgram-bind-fd-error.js
+++ b/test/parallel/test-dgram-bind-fd-error.js
@@ -26,7 +26,6 @@ const TYPE = 'udp4';
     }, {
       code: 'EEXIST',
       name: 'Error',
-      message: /^open EEXIST$/
     });
 
     socket.close();
@@ -49,7 +48,6 @@ const TYPE = 'udp4';
   }, {
     code: 'ERR_INVALID_FD_TYPE',
     name: 'TypeError',
-    message: /^Unsupported fd type: TCP$/
   });
 
   handle.close();

--- a/test/parallel/test-dgram-bind.js
+++ b/test/parallel/test-dgram-bind.js
@@ -32,7 +32,6 @@ socket.on('listening', common.mustCall(() => {
   }, {
     code: 'ERR_SOCKET_ALREADY_BOUND',
     name: 'Error',
-    message: /^Socket is already bound$/
   });
 
   socket.close();

--- a/test/parallel/test-dgram-connect.js
+++ b/test/parallel/test-dgram-connect.js
@@ -14,7 +14,6 @@ client.connect(PORT, common.mustCall(() => {
     client.connect(PORT, common.mustNotCall());
   }, {
     name: 'Error',
-    message: 'Already connected',
     code: 'ERR_SOCKET_DGRAM_IS_CONNECTED'
   });
 
@@ -23,7 +22,6 @@ client.connect(PORT, common.mustCall(() => {
     client.disconnect();
   }, {
     name: 'Error',
-    message: 'Not connected',
     code: 'ERR_SOCKET_DGRAM_NOT_CONNECTED'
   });
 
@@ -31,7 +29,6 @@ client.connect(PORT, common.mustCall(() => {
     client.remoteAddress();
   }, {
     name: 'Error',
-    message: 'Not connected',
     code: 'ERR_SOCKET_DGRAM_NOT_CONNECTED'
   });
 
@@ -43,7 +40,6 @@ assert.throws(() => {
   client.connect(PORT);
 }, {
   name: 'Error',
-  message: 'Already connected',
   code: 'ERR_SOCKET_DGRAM_IS_CONNECTED'
 });
 
@@ -51,7 +47,6 @@ assert.throws(() => {
   client.disconnect();
 }, {
   name: 'Error',
-  message: 'Not connected',
   code: 'ERR_SOCKET_DGRAM_NOT_CONNECTED'
 });
 
@@ -60,7 +55,6 @@ assert.throws(() => {
     client.connect(port);
   }, {
     name: 'RangeError',
-    message: /^Port should be > 0 and < 65536/,
     code: 'ERR_SOCKET_BAD_PORT'
   });
 });

--- a/test/parallel/test-dgram-createSocket-type.js
+++ b/test/parallel/test-dgram-createSocket-type.js
@@ -19,7 +19,6 @@ const validTypes = [
   { type: 'udp4' },
   { type: 'udp6' },
 ];
-const errMessage = /^Bad socket type specified\. Valid types are: udp4, udp6$/;
 
 // Error must be thrown with invalid types
 invalidTypes.forEach((invalidType) => {
@@ -28,7 +27,6 @@ invalidTypes.forEach((invalidType) => {
   }, {
     code: 'ERR_SOCKET_BAD_TYPE',
     name: 'TypeError',
-    message: errMessage
   });
 });
 

--- a/test/parallel/test-dgram-custom-lookup.js
+++ b/test/parallel/test-dgram-custom-lookup.js
@@ -41,8 +41,6 @@ const dns = require('dns');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "lookup" argument must be of type function.' +
-               common.invalidArgTypeHelper(value)
     });
   });
 }

--- a/test/parallel/test-dgram-membership.js
+++ b/test/parallel/test-dgram-membership.js
@@ -16,7 +16,6 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     }, {
       code: 'ERR_SOCKET_DGRAM_NOT_RUNNING',
       name: 'Error',
-      message: /^Not running$/
     });
   }));
 }
@@ -30,7 +29,6 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     }, {
       code: 'ERR_SOCKET_DGRAM_NOT_RUNNING',
       name: 'Error',
-      message: /^Not running$/
     });
   }));
 }
@@ -43,7 +41,6 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
   }, {
     code: 'ERR_MISSING_ARGS',
     name: 'TypeError',
-    message: /^The "multicastAddress" argument must be specified$/
   });
   socket.close();
 }
@@ -56,7 +53,6 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
   }, {
     code: 'ERR_MISSING_ARGS',
     name: 'TypeError',
-    message: /^The "multicastAddress" argument must be specified$/
   });
   socket.close();
 }
@@ -84,8 +80,6 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     socket.addSourceSpecificMembership(0, multicastAddress);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "sourceAddress" argument must be of type string. ' +
-    'Received type number (0)'
   });
   socket.close();
 }
@@ -97,8 +91,6 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     socket.addSourceSpecificMembership(multicastAddress, 0);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "groupAddress" argument must be of type string. ' +
-    'Received type number (0)'
   });
   socket.close();
 }
@@ -110,7 +102,6 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     socket.addSourceSpecificMembership(multicastAddress, '0');
   }, {
     code: 'EINVAL',
-    message: 'addSourceSpecificMembership EINVAL'
   });
   socket.close();
 }
@@ -122,8 +113,6 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     socket.dropSourceSpecificMembership(0, multicastAddress);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "sourceAddress" argument must be of type string. ' +
-    'Received type number (0)'
   });
   socket.close();
 }
@@ -135,8 +124,6 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     socket.dropSourceSpecificMembership(multicastAddress, 0);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "groupAddress" argument must be of type string. ' +
-    'Received type number (0)'
   });
   socket.close();
 }
@@ -148,7 +135,6 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
     socket.dropSourceSpecificMembership(multicastAddress, '0');
   }, {
     code: 'EINVAL',
-    message: 'dropSourceSpecificMembership EINVAL'
   });
   socket.close();
 }

--- a/test/parallel/test-dgram-multicast-setTTL.js
+++ b/test/parallel/test-dgram-multicast-setTTL.js
@@ -40,8 +40,6 @@ socket.on('listening', common.mustCall(() => {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "ttl" argument must be of type number. Received type string' +
-             " ('foo')"
   });
 
   // Close the socket

--- a/test/parallel/test-dgram-send-address-types.js
+++ b/test/parallel/test-dgram-send-address-types.js
@@ -37,8 +37,6 @@ const client = dgram.createSocket('udp4').bind(0, () => {
     const expectedError = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "address" argument must be of type string.' +
-               `${common.invalidArgTypeHelper(invalidInput)}`
     };
     assert.throws(() => client.send(buf, port, invalidInput), expectedError);
   });

--- a/test/parallel/test-dgram-send-bad-arguments.js
+++ b/test/parallel/test-dgram-send-bad-arguments.js
@@ -35,8 +35,6 @@ function checkArgs(connected) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "buffer" argument must be of type string or an instance ' +
-      'of Buffer, TypedArray, or DataView. Received undefined'
     }
   );
 
@@ -47,7 +45,6 @@ function checkArgs(connected) {
       {
         code: 'ERR_SOCKET_DGRAM_IS_CONNECTED',
         name: 'Error',
-        message: 'Already connected'
       }
     );
 
@@ -56,7 +53,6 @@ function checkArgs(connected) {
       {
         code: 'ERR_SOCKET_DGRAM_IS_CONNECTED',
         name: 'Error',
-        message: 'Already connected'
       }
     );
 
@@ -65,7 +61,6 @@ function checkArgs(connected) {
       {
         code: 'ERR_SOCKET_DGRAM_IS_CONNECTED',
         name: 'Error',
-        message: 'Already connected'
       }
     );
 
@@ -74,7 +69,6 @@ function checkArgs(connected) {
       {
         code: 'ERR_SOCKET_DGRAM_IS_CONNECTED',
         name: 'Error',
-        message: 'Already connected'
       }
     );
 
@@ -96,7 +90,6 @@ function checkArgs(connected) {
         {
           code: 'ERR_BUFFER_OUT_OF_BOUNDS',
           name: 'RangeError',
-          message: '"offset" is outside of buffer bounds',
         }
       );
 
@@ -105,7 +98,6 @@ function checkArgs(connected) {
         {
           code: 'ERR_BUFFER_OUT_OF_BOUNDS',
           name: 'RangeError',
-          message: '"length" is outside of buffer bounds',
         }
       );
 
@@ -114,7 +106,6 @@ function checkArgs(connected) {
         {
           code: 'ERR_BUFFER_OUT_OF_BOUNDS',
           name: 'RangeError',
-          message: '"length" is outside of buffer bounds',
         }
       );
     }
@@ -130,8 +121,6 @@ function checkArgs(connected) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "buffer" argument must be of type string or an instance ' +
-      'of Buffer, TypedArray, or DataView. Received type number (23)'
     }
   );
 
@@ -141,9 +130,6 @@ function checkArgs(connected) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "buffer list arguments" argument must be of type string ' +
-      'or an instance of Buffer, TypedArray, or DataView. ' +
-      'Received an instance of Array'
     }
   );
 }

--- a/test/parallel/test-dgram-sendto.js
+++ b/test/parallel/test-dgram-sendto.js
@@ -7,31 +7,21 @@ const socket = dgram.createSocket('udp4');
 const errObj = {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "offset" argument must be of type number. Received ' +
-           'undefined'
 };
 assert.throws(() => socket.sendto(), errObj);
 
-errObj.message = 'The "length" argument must be of type number. Received ' +
-                 "type string ('offset')";
 assert.throws(
   () => socket.sendto('buffer', 1, 'offset', 'port', 'address', 'cb'),
   errObj);
 
-errObj.message = 'The "offset" argument must be of type number. Received ' +
-                 "type string ('offset')";
 assert.throws(
   () => socket.sendto('buffer', 'offset', 1, 'port', 'address', 'cb'),
   errObj);
 
-errObj.message = 'The "address" argument must be of type string. Received ' +
-                 'type boolean (false)';
 assert.throws(
   () => socket.sendto('buffer', 1, 1, 10, false, 'cb'),
   errObj);
 
-errObj.message = 'The "port" argument must be of type number. Received ' +
-                 'type boolean (false)';
 assert.throws(
   () => socket.sendto('buffer', 1, 1, false, 'address', 'cb'),
   errObj);

--- a/test/parallel/test-dgram-setTTL.js
+++ b/test/parallel/test-dgram-setTTL.js
@@ -14,8 +14,6 @@ socket.on('listening', common.mustCall(() => {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "ttl" argument must be of type number. Received type string' +
-             " ('foo')"
   });
 
   // TTL must be a number from > 0 to < 256

--- a/test/parallel/test-dgram-socket-buffer-size.js
+++ b/test/parallel/test-dgram-socket-buffer-size.js
@@ -85,7 +85,6 @@ function getExpectedError(type) {
   const errorObj = {
     code: 'ERR_SOCKET_BAD_BUFFER_SIZE',
     name: 'TypeError',
-    message: /^Buffer size must be a positive integer$/
   };
 
   const badBufferSizes = [-1, Infinity, 'Doh!'];
@@ -132,8 +131,6 @@ function getExpectedError(type) {
   const errorObj = {
     code: 'ERR_SOCKET_BUFFER_SIZE',
     name: 'SystemError',
-    message: 'Could not get or set buffer size: uv_recv_buffer_size ' +
-             'returned EINVAL (invalid argument)',
     info
   };
   const socket = dgram.createSocket('udp4');
@@ -155,8 +152,6 @@ function getExpectedError(type) {
   const errorObj = {
     code: 'ERR_SOCKET_BUFFER_SIZE',
     name: 'SystemError',
-    message: 'Could not get or set buffer size: uv_send_buffer_size ' +
-             'returned EINVAL (invalid argument)',
     info
   };
   const socket = dgram.createSocket('udp4');

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -16,7 +16,6 @@ const dnsPromises = dns.promises;
   const err = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /^The "hostname" argument must be of type string\. Received type number/
   };
 
   assert.throws(() => dns.lookup(1, {}), err);
@@ -54,7 +53,6 @@ assert.throws(() => {
   const err = {
     code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: "The argument 'hints' is invalid. Received 100"
   };
   const options = {
     hints: 100,
@@ -73,7 +71,6 @@ assert.throws(() => {
   const err = {
     code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: `The property 'options.family' must be one of: 0, 4, 6. Received ${family}`
   };
   const options = {
     hints: 0,

--- a/test/parallel/test-dns-lookupService.js
+++ b/test/parallel/test-dns-lookupService.js
@@ -20,7 +20,6 @@ assert.throws(
   () => dns.lookupService('127.0.0.1', 80, common.mustNotCall()),
   {
     code: 'ENOENT',
-    message: 'getnameinfo ENOENT 127.0.0.1',
     syscall: 'getnameinfo'
   }
 );
@@ -29,7 +28,6 @@ assert.rejects(
   dns.promises.lookupService('127.0.0.1', 80),
   {
     code: 'ENOENT',
-    message: 'getnameinfo ENOENT 127.0.0.1',
     syscall: 'getnameinfo'
   }
 );

--- a/test/parallel/test-dns-resolvens-typeerror.js
+++ b/test/parallel/test-dns-resolvens-typeerror.js
@@ -35,7 +35,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /^The "name" argument must be of type string/
   }
 );
 assert.throws(
@@ -43,7 +42,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /^The "name" argument must be of type string/
   }
 );
 assert.throws(

--- a/test/parallel/test-dns-setserver-when-querying.js
+++ b/test/parallel/test-dns-setserver-when-querying.js
@@ -16,7 +16,6 @@ const localhost = [ '127.0.0.1' ];
 
     assert.throws(resolver.setServers.bind(resolver, localhost), {
       code: 'ERR_DNS_SET_SERVERS_FAILED',
-      message: /^c-ares failed to set servers: "There are pending queries\." \[.+\]$/g
     });
   }
 

--- a/test/parallel/test-dns-setservers-type-check.js
+++ b/test/parallel/test-dns-setservers-type-check.js
@@ -20,8 +20,6 @@ const promiseResolver = new dns.promises.Resolver();
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "servers" argument must be an instance of Array.' +
-               common.invalidArgTypeHelper(val)
     };
     assert.throws(
       () => {
@@ -60,8 +58,6 @@ const promiseResolver = new dns.promises.Resolver();
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "servers[0]" argument must be of type string.' +
-               common.invalidArgTypeHelper(val[0])
     };
     assert.throws(
       () => {
@@ -110,8 +106,6 @@ const promiseResolver = new dns.promises.Resolver();
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "servers[0]" argument must be of type string.' +
-              common.invalidArgTypeHelper(val[0])
     };
     assert.throws(() => {
       setServers(val);

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -99,12 +99,10 @@ assert.deepStrictEqual(dns.getServers(), goog);
 assert.throws(() => dns.setServers(['foobar']), {
   code: 'ERR_INVALID_IP_ADDRESS',
   name: 'TypeError',
-  message: 'Invalid IP address: foobar'
 });
 assert.throws(() => dns.setServers(['127.0.0.1:va']), {
   code: 'ERR_INVALID_IP_ADDRESS',
   name: 'TypeError',
-  message: 'Invalid IP address: 127.0.0.1:va'
 });
 assert.deepStrictEqual(dns.getServers(), goog);
 
@@ -143,8 +141,6 @@ assert.deepStrictEqual(dns.getServers(), []);
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "rrtype" argument must be of type string. ' +
-             'Received an instance of Array'
   };
   assert.throws(() => {
     dns.resolve('example.com', [], common.mustNotCall());
@@ -157,8 +153,6 @@ assert.deepStrictEqual(dns.getServers(), []);
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "name" argument must be of type string. ' +
-             'Received undefined'
   };
   assert.throws(() => {
     dnsPromises.resolve();
@@ -170,7 +164,6 @@ assert.deepStrictEqual(dns.getServers(), []);
   const errorReg = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /^The "hostname" argument must be of type string\. Received .*/
   };
 
   assert.throws(() => dns.lookup({}, common.mustNotCall()), errorReg);
@@ -218,7 +211,6 @@ assert.deepStrictEqual(dns.getServers(), []);
   const err = {
     code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: /The argument 'hints' is invalid\. Received \d+/
   };
 
   assert.throws(() => {
@@ -281,8 +273,6 @@ dns.lookup('', {
   const err = {
     code: 'ERR_MISSING_ARGS',
     name: 'TypeError',
-    message: 'The "address", "port", and "callback" arguments must be ' +
-    'specified'
   };
 
   assert.throws(() => dns.lookupService('0.0.0.0'), err);
@@ -295,7 +285,6 @@ dns.lookup('', {
   const err = {
     code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: `The argument 'address' is invalid. Received '${invalidAddress}'`
   };
 
   assert.throws(() => {
@@ -310,8 +299,6 @@ dns.lookup('', {
 const portErr = (port) => {
   const err = {
     code: 'ERR_SOCKET_BAD_PORT',
-    message:
-      `Port should be >= 0 and < 65536. Received ${port}.`,
     name: 'RangeError'
   };
 

--- a/test/parallel/test-domain-load-after-set-uncaught-exception-capture.js
+++ b/test/parallel/test-domain-load-after-set-uncaught-exception-capture.js
@@ -9,7 +9,6 @@ assert.throws(
   {
     code: 'ERR_DOMAIN_CALLBACK_NOT_AVAILABLE',
     name: 'Error',
-    message: /^A callback was registered.*with using the `domain` module/
   }
 );
 

--- a/test/parallel/test-domain-set-uncaught-exception-capture-after-load.js
+++ b/test/parallel/test-domain-set-uncaught-exception-capture-after-load.js
@@ -13,7 +13,6 @@ assert.throws(
       {
         code: 'ERR_DOMAIN_CANNOT_SET_UNCAUGHT_EXCEPTION_CAPTURE',
         name: 'Error',
-        message: /^The `domain` module is in use, which is mutually/
       }
     )(err);
 

--- a/test/parallel/test-errors-systemerror.js
+++ b/test/parallel/test-errors-systemerror.js
@@ -9,7 +9,6 @@ assert.throws(
   () => { new SystemError(); },
   {
     name: 'TypeError',
-    message: 'String.prototype.match called on null or undefined'
   }
 );
 
@@ -30,8 +29,6 @@ const { ERR_TEST } = codes;
     {
       code: 'ERR_TEST',
       name: 'SystemError',
-      message: 'custom message: syscall_test returned ETEST (code message)' +
-               ' /str => /str2',
       info: ctx
     }
   );
@@ -50,8 +47,6 @@ const { ERR_TEST } = codes;
     {
       code: 'ERR_TEST',
       name: 'SystemError',
-      message: 'custom message: syscall_test returned ETEST (code message)' +
-               ' /buf => /str2',
       info: ctx
     }
   );
@@ -70,8 +65,6 @@ const { ERR_TEST } = codes;
     {
       code: 'ERR_TEST',
       name: 'SystemError',
-      message: 'custom message: syscall_test returned ETEST (code message)' +
-               ' /buf => /buf2',
       info: ctx
     }
   );
@@ -127,8 +120,6 @@ const { ERR_TEST } = codes;
     {
       code: 'ERR_TEST',
       name: 'Foobar',
-      message: 'custom message: syscall_test returned ERR_TEST ' +
-               '(Error occurred)',
       info: ctx
     }
   );

--- a/test/parallel/test-event-capture-rejections.js
+++ b/test/parallel/test-event-capture-rejections.js
@@ -278,22 +278,14 @@ function resetCaptureOnThrowInError() {
 function argValidation() {
 
   function testType(obj) {
-    const received = obj.constructor.name !== 'Number' ?
-      `an instance of ${obj.constructor.name}` :
-      `type number (${obj})`;
-
     assert.throws(() => new EventEmitter({ captureRejections: obj }), {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.captureRejections" property must be of type ' +
-               `boolean. Received ${received}`
     });
 
     assert.throws(() => EventEmitter.captureRejections = obj, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "EventEmitter.captureRejections" property must be of ' +
-               `type boolean. Received ${received}`
     });
   }
 

--- a/test/parallel/test-event-emitter-emit-context.js
+++ b/test/parallel/test-event-emitter-emit-context.js
@@ -11,7 +11,7 @@ const EE = new EventEmitter();
   const ctx = Object.create(null);
   assert.throws(
     () => EE.emit.call(ctx, 'error', new Error('foo')),
-    common.expectsError({ name: 'Error', message: 'foo' })
+    common.expectsError({ name: 'Error' })
   );
 }
 

--- a/test/parallel/test-event-emitter-errors.js
+++ b/test/parallel/test-event-emitter-errors.js
@@ -11,7 +11,6 @@ assert.throws(
   {
     code: 'ERR_UNHANDLED_ERROR',
     name: 'Error',
-    message: "Unhandled error. ('Accepts a string')"
   }
 );
 
@@ -20,7 +19,6 @@ assert.throws(
   {
     code: 'ERR_UNHANDLED_ERROR',
     name: 'Error',
-    message: "Unhandled error. ({ message: 'Error!' })"
   }
 );
 
@@ -32,6 +30,5 @@ assert.throws(
   {
     code: 'ERR_UNHANDLED_ERROR',
     name: 'Error',
-    message: 'Unhandled error. ([object Object])'
   }
 );

--- a/test/parallel/test-event-emitter-invalid-listener.js
+++ b/test/parallel/test-event-emitter-invalid-listener.js
@@ -14,7 +14,5 @@ for (const method of eventsMethods) {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "listener" argument must be of type function. ' +
-             'Received null'
   }, `event.${method}('foo', null) should throw the proper error`);
 }

--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -23,7 +23,6 @@
 const common = require('../common');
 const assert = require('assert');
 const events = require('events');
-const { inspect } = require('util');
 const e = new events.EventEmitter();
 
 e.on('maxListeners', common.mustCall());
@@ -39,8 +38,6 @@ for (const obj of throwsObjs) {
     {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "n" is out of range. ' +
-               `It must be a non-negative number. Received ${inspect(obj)}`
     }
   );
 
@@ -49,8 +46,6 @@ for (const obj of throwsObjs) {
     {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "defaultMaxListeners" is out of range. ' +
-               `It must be a non-negative number. Received ${inspect(obj)}`
     }
   );
 }

--- a/test/parallel/test-events-on-async-iterator.js
+++ b/test/parallel/test-events-on-async-iterator.js
@@ -194,8 +194,6 @@ async function iterableThrow() {
     // No argument
     iterable.throw();
   }, {
-    message: 'The "EventEmitter.AsyncIterator" property must be' +
-    ' an instance of Error. Received undefined',
     name: 'TypeError'
   });
 

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -64,8 +64,6 @@ let asyncTest = Promise.resolve();
     throws(() => new Event('foo', i), {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options" argument must be of type object.' +
-               common.invalidArgTypeHelper(i)
     })
   ));
 }
@@ -234,7 +232,6 @@ let asyncTest = Promise.resolve();
 
 {
   const uncaughtException = common.mustCall((err, origin) => {
-    strictEqual(err.message, 'boom');
     strictEqual(origin, 'uncaughtException');
   }, 4);
 
@@ -293,24 +290,20 @@ let asyncTest = Promise.resolve();
     throws(() => target.dispatchEvent(i), {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "event" argument must be an instance of Event.' +
-               common.invalidArgTypeHelper(i)
     });
   });
 
-  const err = (arg) => ({
+  const err = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "listener" argument must be an instance of EventListener.' +
-             common.invalidArgTypeHelper(arg)
-  });
+  };
 
   [
     'foo',
     1,
     {},  // No handleEvent function
     false,
-  ].forEach((i) => throws(() => target.addEventListener('foo', i), err(i)));
+  ].forEach((i) => throws(() => target.addEventListener('foo', i), err));
 }
 
 {

--- a/test/parallel/test-file-write-stream.js
+++ b/test/parallel/test-file-write-stream.js
@@ -65,7 +65,6 @@ file
     file.write('should not work anymore', common.expectsError({
       code: 'ERR_STREAM_WRITE_AFTER_END',
       name: 'Error',
-      message: 'write after end'
     }));
     file.on('error', common.mustNotCall());
 

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -186,8 +186,6 @@ const run_test_4 = common.mustCall(function() {
   // Limit Number.MAX_SAFE_INTEGER
   const err = {
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "start" is out of range. ' +
-             `It must be >= 0 && <= ${Number.MAX_SAFE_INTEGER}. Received -5`,
     name: 'RangeError'
   };
   assert.throws(fn, err);
@@ -203,9 +201,6 @@ const run_test_5 = common.mustCall(function() {
   // Limit Number.MAX_SAFE_INTEGER
   const err = {
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "start" is out of range. It must be ' +
-             `>= 0 && <= ${Number.MAX_SAFE_INTEGER}. ` +
-             'Received 9_007_199_254_740_992',
     name: 'RangeError'
   };
   assert.throws(fn, err);

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -170,14 +170,12 @@ fs.accessSync(readWriteFile, mode);
     () => fs.access(readWriteFile, mode, common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /"mode" argument.+integer/
     }
   );
   assert.throws(
     () => fs.accessSync(readWriteFile, mode),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /"mode" argument.+integer/
     }
   );
 });
@@ -194,14 +192,12 @@ fs.accessSync(readWriteFile, mode);
     () => fs.access(readWriteFile, mode, common.mustNotCall()),
     {
       code: 'ERR_OUT_OF_RANGE',
-      message: /"mode".+It must be an integer >= 0 && <= 7/
     }
   );
   assert.throws(
     () => fs.accessSync(readWriteFile, mode),
     {
       code: 'ERR_OUT_OF_RANGE',
-      message: /"mode".+It must be an integer >= 0 && <= 7/
     }
   );
 });
@@ -211,10 +207,6 @@ assert.throws(
   (err) => {
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.path, doesNotExist);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, access '${doesNotExist}'`
-    );
     assert.strictEqual(err.constructor, Error);
     assert.strictEqual(err.syscall, 'access');
     assert.strictEqual(err.errno, UV_ENOENT);
@@ -227,10 +219,6 @@ assert.throws(
   (err) => {
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.path, doesNotExist);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, access '${doesNotExist}'`
-    );
     assert.strictEqual(err.constructor, Error);
     assert.strictEqual(err.syscall, 'access');
     assert.strictEqual(err.errno, UV_ENOENT);

--- a/test/parallel/test-fs-append-file-sync.js
+++ b/test/parallel/test-fs-append-file-sync.js
@@ -78,7 +78,7 @@ fs.writeFileSync(filename4, currentFileData, { mode: m });
 ].forEach((value) => {
   assert.throws(
     () => fs.appendFileSync(filename4, value, { mode: m }),
-    { message: /data/, code: 'ERR_INVALID_ARG_TYPE' }
+    { code: 'ERR_INVALID_ARG_TYPE' }
   );
 });
 fs.appendFileSync(filename4, `${num}`, { mode: m });

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -124,7 +124,6 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
 [false, 5, {}, null, undefined].forEach(async (data) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /"data"|"buffer"/
   };
   const filename = join(tmpdir.path, 'append-invalid-data.txt');
 
@@ -147,7 +146,6 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
     () => fs.statSync(filename),
     {
       code: 'ENOENT',
-      message: /no such file or directory/
     }
   );
 });

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -24,8 +24,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "path" argument must be of type string or an instance of ' +
-             'Buffer or URL. Received type boolean (true)'
   }
 );
 

--- a/test/parallel/test-fs-buffertype-writesync.js
+++ b/test/parallel/test-fs-buffertype-writesync.js
@@ -11,6 +11,6 @@ const fs = require('fs');
 ].forEach((value) => {
   assert.throws(
     () => fs.writeSync(1, value),
-    { message: /"buffer"/, code: 'ERR_INVALID_ARG_TYPE' }
+    { code: 'ERR_INVALID_ARG_TYPE' }
   );
 });

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -140,9 +140,6 @@ if (fs.lchmod) {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "path" argument must be of type string or an instance ' +
-             'of Buffer or URL.' +
-             common.invalidArgTypeHelper(input)
   };
   assert.throws(() => fs.chmod(input, 1, common.mustNotCall()), errObj);
   assert.throws(() => fs.chmodSync(input, 1), errObj);

--- a/test/parallel/test-fs-close-errors.js
+++ b/test/parallel/test-fs-close-errors.js
@@ -3,7 +3,6 @@
 // This tests that the errors thrown from fs.close and fs.closeSync
 // include the desired properties
 
-const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
@@ -11,8 +10,6 @@ const fs = require('fs');
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "fd" argument must be of type number.' +
-             common.invalidArgTypeHelper(input)
   };
   assert.throws(() => fs.close(input), errObj);
   assert.throws(() => fs.closeSync(input), errObj);

--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -82,16 +82,10 @@ fs.copyFile(src, dest, common.mustSucceed(() => {
   // Copy asynchronously with flags.
   fs.copyFile(src, dest, COPYFILE_EXCL, common.mustCall((err) => {
     if (err.code === 'ENOENT') {  // Could be ENOENT or EEXIST
-      assert.strictEqual(err.message,
-                         'ENOENT: no such file or directory, copyfile ' +
-                         `'${src}' -> '${dest}'`);
       assert.strictEqual(err.errno, UV_ENOENT);
       assert.strictEqual(err.code, 'ENOENT');
       assert.strictEqual(err.syscall, 'copyfile');
     } else {
-      assert.strictEqual(err.message,
-                         'EEXIST: file already exists, copyfile ' +
-                         `'${src}' -> '${dest}'`);
       assert.strictEqual(err.errno, UV_EEXIST);
       assert.strictEqual(err.code, 'EEXIST');
       assert.strictEqual(err.syscall, 'copyfile');
@@ -114,7 +108,6 @@ assert.throws(() => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /src/
     }
   );
   assert.throws(
@@ -122,7 +115,6 @@ assert.throws(() => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /dest/
     }
   );
   assert.throws(
@@ -130,7 +122,6 @@ assert.throws(() => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /src/
     }
   );
   assert.throws(
@@ -138,7 +129,6 @@ assert.throws(() => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /dest/
     }
   );
 });
@@ -148,7 +138,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: /mode/
 });
 
 assert.throws(() => {
@@ -156,8 +145,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "mode" is out of range. It must be an integer ' +
-           '>= 0 && <= 7. Received 8'
 });
 
 assert.throws(() => {
@@ -165,5 +152,4 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: /mode/
 });

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -70,9 +70,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, stat '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'stat');
@@ -91,9 +88,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, lstat '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'lstat');
@@ -110,7 +104,6 @@ function re(literals, ...values) {
 // fstat
 {
   const validateError = (err) => {
-    assert.strictEqual(err.message, 'EBADF: bad file descriptor, fstat');
     assert.strictEqual(err.errno, UV_EBADF);
     assert.strictEqual(err.code, 'EBADF');
     assert.strictEqual(err.syscall, 'fstat');
@@ -131,9 +124,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, lstat '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'lstat');
@@ -152,9 +142,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, realpath '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'realpath');
@@ -173,9 +160,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, readlink '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'readlink');
@@ -197,9 +181,6 @@ function re(literals, ...values) {
     // Could be resolved to an absolute path
     assert.ok(err.dest.endsWith('foo'),
               `expect ${err.dest} to end with 'foo'`);
-    const regexp = new RegExp('^ENOENT: no such file or directory, link ' +
-                              re`'${nonexistentFile}' -> ` + '\'.*foo\'');
-    assert.match(err.message, regexp);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'link');
@@ -219,10 +200,6 @@ function re(literals, ...values) {
   const validateError = (err) => {
     assert.strictEqual(existingFile, err.path);
     assert.strictEqual(existingFile2, err.dest);
-    assert.strictEqual(
-      err.message,
-      `EEXIST: file already exists, link '${existingFile}' -> ` +
-      `'${existingFile2}'`);
     assert.strictEqual(err.errno, UV_EEXIST);
     assert.strictEqual(err.code, 'EEXIST');
     assert.strictEqual(err.syscall, 'link');
@@ -242,10 +219,6 @@ function re(literals, ...values) {
   const validateError = (err) => {
     assert.strictEqual(existingFile, err.path);
     assert.strictEqual(existingFile2, err.dest);
-    assert.strictEqual(
-      err.message,
-      `EEXIST: file already exists, symlink '${existingFile}' -> ` +
-      `'${existingFile2}'`);
     assert.strictEqual(err.errno, UV_EEXIST);
     assert.strictEqual(err.code, 'EEXIST');
     assert.strictEqual(err.syscall, 'symlink');
@@ -264,9 +237,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, unlink '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'unlink');
@@ -288,9 +258,6 @@ function re(literals, ...values) {
     // Could be resolved to an absolute path
     assert.ok(err.dest.endsWith('foo'),
               `expect ${err.dest} to end with 'foo'`);
-    const regexp = new RegExp('ENOENT: no such file or directory, rename ' +
-                              re`'${nonexistentFile}' -> ` + '\'.*foo\'');
-    assert.match(err.message, regexp);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'rename');
@@ -314,10 +281,6 @@ function re(literals, ...values) {
     assert.strictEqual(err.syscall, 'rename');
     // Could be ENOTEMPTY, EEXIST, or EPERM, depending on the platform
     if (err.code === 'ENOTEMPTY') {
-      assert.strictEqual(
-        err.message,
-        `ENOTEMPTY: directory not empty, rename '${existingDir}' -> ` +
-        `'${existingDir2}'`);
       assert.strictEqual(err.errno, UV_ENOTEMPTY);
     } else if (err.code === 'EXDEV') {  // Not on the same mounted filesystem
       assert.strictEqual(
@@ -325,16 +288,8 @@ function re(literals, ...values) {
         `EXDEV: cross-device link not permitted, rename '${existingDir}' -> ` +
             `'${existingDir2}'`);
     } else if (err.code === 'EEXIST') {  // smartos and aix
-      assert.strictEqual(
-        err.message,
-        `EEXIST: file already exists, rename '${existingDir}' -> ` +
-        `'${existingDir2}'`);
       assert.strictEqual(err.errno, UV_EEXIST);
     } else {  // windows
-      assert.strictEqual(
-        err.message,
-        `EPERM: operation not permitted, rename '${existingDir}' -> ` +
-        `'${existingDir2}'`);
       assert.strictEqual(err.errno, UV_EPERM);
       assert.strictEqual(err.code, 'EPERM');
     }
@@ -353,9 +308,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, rmdir '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'rmdir');
@@ -376,14 +328,8 @@ function re(literals, ...values) {
     assert.strictEqual(existingFile, err.path);
     assert.strictEqual(err.syscall, 'rmdir');
     if (err.code === 'ENOTDIR') {
-      assert.strictEqual(
-        err.message,
-        `ENOTDIR: not a directory, rmdir '${existingFile}'`);
       assert.strictEqual(err.errno, UV_ENOTDIR);
     } else {  // windows
-      assert.strictEqual(
-        err.message,
-        `ENOENT: no such file or directory, rmdir '${existingFile}'`);
       assert.strictEqual(err.errno, UV_ENOENT);
       assert.strictEqual(err.code, 'ENOENT');
     }
@@ -402,9 +348,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(existingFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `EEXIST: file already exists, mkdir '${existingFile}'`);
     assert.strictEqual(err.errno, UV_EEXIST);
     assert.strictEqual(err.code, 'EEXIST');
     assert.strictEqual(err.syscall, 'mkdir');
@@ -423,9 +366,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, chmod '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'chmod');
@@ -444,9 +384,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, open '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'open');
@@ -465,7 +402,6 @@ function re(literals, ...values) {
 // close
 {
   const validateError = (err) => {
-    assert.strictEqual(err.message, 'EBADF: bad file descriptor, close');
     assert.strictEqual(err.errno, UV_EBADF);
     assert.strictEqual(err.code, 'EBADF');
     assert.strictEqual(err.syscall, 'close');
@@ -486,9 +422,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, open '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'open');
@@ -507,9 +440,6 @@ function re(literals, ...values) {
 {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, scandir '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'scandir');
@@ -530,10 +460,8 @@ function re(literals, ...values) {
     assert.strictEqual(err.syscall, 'ftruncate');
     // Could be EBADF or EINVAL, depending on the platform
     if (err.code === 'EBADF') {
-      assert.strictEqual(err.message, 'EBADF: bad file descriptor, ftruncate');
       assert.strictEqual(err.errno, UV_EBADF);
     } else {
-      assert.strictEqual(err.message, 'EINVAL: invalid argument, ftruncate');
       assert.strictEqual(err.errno, UV_EINVAL);
       assert.strictEqual(err.code, 'EINVAL');
     }
@@ -553,7 +481,6 @@ function re(literals, ...values) {
 // fdatasync
 {
   const validateError = (err) => {
-    assert.strictEqual(err.message, 'EBADF: bad file descriptor, fdatasync');
     assert.strictEqual(err.errno, UV_EBADF);
     assert.strictEqual(err.code, 'EBADF');
     assert.strictEqual(err.syscall, 'fdatasync');
@@ -573,7 +500,6 @@ function re(literals, ...values) {
 // fsync
 {
   const validateError = (err) => {
-    assert.strictEqual(err.message, 'EBADF: bad file descriptor, fsync');
     assert.strictEqual(err.errno, UV_EBADF);
     assert.strictEqual(err.code, 'EBADF');
     assert.strictEqual(err.syscall, 'fsync');
@@ -594,9 +520,6 @@ function re(literals, ...values) {
 if (!common.isWindows) {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, chown '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'chown');
@@ -617,9 +540,6 @@ if (!common.isWindows) {
 if (!common.isAIX) {
   const validateError = (err) => {
     assert.strictEqual(nonexistentFile, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, utime '${nonexistentFile}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'utime');
@@ -640,11 +560,6 @@ if (!common.isAIX) {
   const validateError = (err) => {
     const pathPrefix = new RegExp('^' + re`${nonexistentDir}`);
     assert.match(err.path, pathPrefix);
-
-    const prefix = new RegExp('^ENOENT: no such file or directory, mkdtemp ' +
-                              re`'${nonexistentDir}`);
-    assert.match(err.message, prefix);
-
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'mkdtemp');
@@ -662,7 +577,6 @@ if (!common.isAIX) {
 // Check copyFile with invalid modes.
 {
   const validateError = {
-    message: /"mode".+must be an integer >= 0 && <= 7\. Received -1/,
     code: 'ERR_OUT_OF_RANGE'
   };
 
@@ -680,16 +594,10 @@ if (!common.isAIX) {
 {
   const validateError = (err) => {
     if (err.code === 'ENOENT') {  // Could be ENOENT or EEXIST
-      assert.strictEqual(err.message,
-                         'ENOENT: no such file or directory, copyfile ' +
-                         `'${existingFile}' -> '${existingFile2}'`);
       assert.strictEqual(err.errno, UV_ENOENT);
       assert.strictEqual(err.code, 'ENOENT');
       assert.strictEqual(err.syscall, 'copyfile');
     } else {
-      assert.strictEqual(err.message,
-                         'EEXIST: file already exists, copyfile ' +
-                         `'${existingFile}' -> '${existingFile2}'`);
       assert.strictEqual(err.errno, UV_EEXIST);
       assert.strictEqual(err.code, 'EEXIST');
       assert.strictEqual(err.syscall, 'copyfile');
@@ -709,9 +617,6 @@ if (!common.isAIX) {
 // copyFile: the source does not exist.
 {
   const validateError = (err) => {
-    assert.strictEqual(err.message,
-                       'ENOENT: no such file or directory, copyfile ' +
-                       `'${nonexistentFile}' -> '${existingFile2}'`);
     assert.strictEqual(err.errno, UV_ENOENT);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'copyfile');
@@ -730,7 +635,6 @@ if (!common.isAIX) {
 // read
 {
   const validateError = (err) => {
-    assert.strictEqual(err.message, 'EBADF: bad file descriptor, read');
     assert.strictEqual(err.errno, UV_EBADF);
     assert.strictEqual(err.code, 'EBADF');
     assert.strictEqual(err.syscall, 'read');
@@ -751,7 +655,6 @@ if (!common.isAIX) {
 // fchmod
 {
   const validateError = (err) => {
-    assert.strictEqual(err.message, 'EBADF: bad file descriptor, fchmod');
     assert.strictEqual(err.errno, UV_EBADF);
     assert.strictEqual(err.code, 'EBADF');
     assert.strictEqual(err.syscall, 'fchmod');
@@ -771,7 +674,6 @@ if (!common.isAIX) {
 // fchown
 if (!common.isWindows) {
   const validateError = (err) => {
-    assert.strictEqual(err.message, 'EBADF: bad file descriptor, fchown');
     assert.strictEqual(err.errno, UV_EBADF);
     assert.strictEqual(err.code, 'EBADF');
     assert.strictEqual(err.syscall, 'fchown');
@@ -792,7 +694,6 @@ if (!common.isWindows) {
 // write buffer
 {
   const validateError = (err) => {
-    assert.strictEqual(err.message, 'EBADF: bad file descriptor, write');
     assert.strictEqual(err.errno, UV_EBADF);
     assert.strictEqual(err.code, 'EBADF');
     assert.strictEqual(err.syscall, 'write');
@@ -813,7 +714,6 @@ if (!common.isWindows) {
 // write string
 {
   const validateError = (err) => {
-    assert.strictEqual(err.message, 'EBADF: bad file descriptor, write');
     assert.strictEqual(err.errno, UV_EBADF);
     assert.strictEqual(err.code, 'EBADF');
     assert.strictEqual(err.syscall, 'write');
@@ -834,7 +734,6 @@ if (!common.isWindows) {
 // futimes
 if (!common.isAIX) {
   const validateError = (err) => {
-    assert.strictEqual(err.message, 'EBADF: bad file descriptor, futime');
     assert.strictEqual(err.errno, UV_EBADF);
     assert.strictEqual(err.code, 'EBADF');
     assert.strictEqual(err.syscall, 'futime');

--- a/test/parallel/test-fs-fchmod.js
+++ b/test/parallel/test-fs-fchmod.js
@@ -1,5 +1,4 @@
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
@@ -11,8 +10,6 @@ const fs = require('fs');
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "fd" argument must be of type number.' +
-             common.invalidArgTypeHelper(input)
   };
   assert.throws(() => fs.fchmod(input), errObj);
   assert.throws(() => fs.fchmodSync(input), errObj);
@@ -35,8 +32,6 @@ assert.throws(() => fs.fchmod(1, '123x'), {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "fd" is out of range. It must be >= 0 && <= ' +
-             `2147483647. Received ${input}`
   };
   assert.throws(() => fs.fchmod(input), errObj);
   assert.throws(() => fs.fchmodSync(input), errObj);
@@ -46,8 +41,6 @@ assert.throws(() => fs.fchmod(1, '123x'), {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "mode" is out of range. It must be >= 0 && <= ' +
-             `4294967295. Received ${input}`
   };
 
   assert.throws(() => fs.fchmod(1, input), errObj);
@@ -58,12 +51,9 @@ assert.throws(() => fs.fchmod(1, '123x'), {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "fd" is out of range. It must be an integer. ' +
-             `Received ${input}`
   };
   assert.throws(() => fs.fchmod(input), errObj);
   assert.throws(() => fs.fchmodSync(input), errObj);
-  errObj.message = errObj.message.replace('fd', 'mode');
   assert.throws(() => fs.fchmod(1, input), errObj);
   assert.throws(() => fs.fchmodSync(1, input), errObj);
 });
@@ -72,12 +62,9 @@ assert.throws(() => fs.fchmod(1, '123x'), {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "fd" is out of range. It must be an integer. ' +
-             `Received ${input}`
   };
   assert.throws(() => fs.fchmod(input), errObj);
   assert.throws(() => fs.fchmodSync(input), errObj);
-  errObj.message = errObj.message.replace('fd', 'mode');
   assert.throws(() => fs.fchmod(1, input), errObj);
   assert.throws(() => fs.fchmodSync(1, input), errObj);
 });

--- a/test/parallel/test-fs-fchown.js
+++ b/test/parallel/test-fs-fchown.js
@@ -23,7 +23,6 @@ function testGid(input, errObj) {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /fd|uid|gid/
   };
   testFd(input, errObj);
   testUid(input, errObj);
@@ -34,13 +33,9 @@ function testGid(input, errObj) {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "fd" is out of range. It must be an integer. ' +
-             `Received ${input}`
   };
   testFd(input, errObj);
-  errObj.message = errObj.message.replace('fd', 'uid');
   testUid(input, errObj);
-  errObj.message = errObj.message.replace('uid', 'gid');
   testGid(input, errObj);
 });
 
@@ -48,13 +43,8 @@ function testGid(input, errObj) {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "fd" is out of range. It must be ' +
-             `>= 0 && <= 2147483647. Received ${input}`
   };
   testFd(input, errObj);
-  errObj.message = 'The value of "uid" is out of range. It must be >= -1 && ' +
-    `<= 4294967295. Received ${input}`;
   testUid(input, errObj);
-  errObj.message = errObj.message.replace('uid', 'gid');
   testGid(input, errObj);
 });

--- a/test/parallel/test-fs-lchmod.js
+++ b/test/parallel/test-fs-lchmod.js
@@ -57,8 +57,6 @@ assert.throws(() => fs.lchmodSync(f, '123x'), {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "mode" is out of range. It must be >= 0 && <= ' +
-             `4294967295. Received ${input}`
   };
 
   assert.rejects(promises.lchmod(f, input, () => {}), errObj);

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -145,7 +145,6 @@ function nextdir() {
     () => { fs.mkdirSync(pathname, { recursive: true }); },
     {
       code: 'EEXIST',
-      message: /EEXIST: .*mkdir/,
       name: 'Error',
       syscall: 'mkdir',
     }
@@ -164,7 +163,6 @@ function nextdir() {
     () => { fs.mkdirSync(pathname, { recursive: true }); },
     {
       code: 'ENOTDIR',
-      message: /ENOTDIR: .*mkdir/,
       name: 'Error',
       syscall: 'mkdir',
       path: pathname // See: https://github.com/nodejs/node/issues/28015
@@ -226,7 +224,6 @@ if (common.isMainThread && (common.isLinux || common.isOSX)) {
     () => { fs.mkdirSync('X', { recursive: true }); },
     {
       code: 'ENOENT',
-      message: /ENOENT: .*mkdir/,
       name: 'Error',
       syscall: 'mkdir',
     }
@@ -242,14 +239,11 @@ if (common.isMainThread && (common.isLinux || common.isOSX)) {
 {
   const pathname = path.join(tmpdir.path, nextdir());
   ['', 1, {}, [], null, Symbol('test'), () => {}].forEach((recursive) => {
-    const received = common.invalidArgTypeHelper(recursive);
     assert.throws(
       () => fs.mkdir(pathname, { recursive }, common.mustNotCall()),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "options.recursive" property must be of type boolean.' +
-          received
       }
     );
     assert.throws(
@@ -257,8 +251,6 @@ if (common.isMainThread && (common.isLinux || common.isOSX)) {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "options.recursive" property must be of type boolean.' +
-          received
       }
     );
   });

--- a/test/parallel/test-fs-promises-file-handle-close-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-close-errors.js
@@ -49,7 +49,6 @@ async function checkCloseError(op) {
 
     await assert.rejects(op(filePath), {
       name: 'Error',
-      message: 'CLOSE_ERROR',
       code: 456,
     });
   } finally {

--- a/test/parallel/test-fs-promises-file-handle-op-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-op-errors.js
@@ -43,7 +43,6 @@ async function checkOperationError(op) {
 
     await assert.rejects(op(filePath), {
       name: 'Error',
-      message: 'INTERNAL_ERROR',
       code: 123,
     });
   } finally {

--- a/test/parallel/test-fs-promises-file-handle-sync.js
+++ b/test/parallel/test-fs-promises-file-handle-sync.js
@@ -14,13 +14,12 @@ async function validate() {
     copyFile(fixtures.path('baz.js'), dest, 'r'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /mode.*integer.*string/
     }
   );
   await copyFile(fixtures.path('baz.js'), dest);
   await assert.rejects(
     access(dest, 'r'),
-    { code: 'ERR_INVALID_ARG_TYPE', message: /mode/ }
+    { code: 'ERR_INVALID_ARG_TYPE' }
   );
   await access(dest);
   const handle = await open(dest, 'r+');

--- a/test/parallel/test-fs-promises-file-handle-write.js
+++ b/test/parallel/test-fs-promises-file-handle-write.js
@@ -62,7 +62,7 @@ async function validateNonStringValuesWrite() {
   for (const nonStringValue of nonStringValues) {
     await assert.rejects(
       fileHandle.write(nonStringValue),
-      { message: /"buffer"/, code: 'ERR_INVALID_ARG_TYPE' }
+      { code: 'ERR_INVALID_ARG_TYPE' }
     );
   }
 

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -56,7 +56,6 @@ assert.strictEqual(
     {
       code: 'ENOENT',
       name: 'Error',
-      message: /^ENOENT: no such file or directory, access/
     }
   );
 
@@ -64,7 +63,6 @@ assert.strictEqual(
     access(__filename, 8),
     {
       code: 'ERR_OUT_OF_RANGE',
-      message: /"mode".*must be an integer >= 0 && <= 7\. Received 8$/
     }
   );
 
@@ -72,7 +70,6 @@ assert.strictEqual(
     access(__filename, { [Symbol.toPrimitive]() { return 5; } }),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /"mode" argument.+integer\. Received an instance of Object$/
     }
   );
 }
@@ -208,8 +205,6 @@ async function executeOnHandle(dest, func) {
           {
             code: 'ERR_OUT_OF_RANGE',
             name: 'RangeError',
-            message: 'The value of "gid" is out of range. ' +
-                     'It must be >= -1 && <= 4294967295. Received -2'
           });
 
         await assert.rejects(
@@ -219,8 +214,6 @@ async function executeOnHandle(dest, func) {
           {
             code: 'ERR_OUT_OF_RANGE',
             name: 'RangeError',
-            message: 'The value of "gid" is out of range. ' +
-                      'It must be >= -1 && <= 4294967295. Received -2'
           });
       });
     }
@@ -291,7 +284,6 @@ async function executeOnHandle(dest, func) {
               common.expectsError({
                 code: 'ERR_METHOD_NOT_IMPLEMENTED',
                 name: 'Error',
-                message: 'The lchmod() method is not implemented'
               })
             ),
           ]);
@@ -377,7 +369,6 @@ async function executeOnHandle(dest, func) {
         mkdir(dir, { recursive: true }),
         {
           code: 'EEXIST',
-          message: /EEXIST: .*mkdir/,
           name: 'Error',
           syscall: 'mkdir',
         }
@@ -394,7 +385,6 @@ async function executeOnHandle(dest, func) {
         mkdir(dir, { recursive: true }),
         {
           code: 'ENOTDIR',
-          message: /ENOTDIR: .*mkdir/,
           name: 'Error',
           syscall: 'mkdir',
         }
@@ -453,7 +443,6 @@ async function executeOnHandle(dest, func) {
           async () => handle.write('abc', 0, 'hex'),
           {
             code: 'ERR_INVALID_ARG_VALUE',
-            message: /'encoding' is invalid for data of length 3/
           }
         );
 
@@ -467,7 +456,6 @@ async function executeOnHandle(dest, func) {
       await executeOnHandle(dest, async (handle) => {
         await assert.rejects(() => handle.stat.call({}), {
           code: 'ERR_INTERNAL_ASSERTION',
-          message: /handle must be an instance of FileHandle/
         });
       });
     }

--- a/test/parallel/test-fs-read-empty-buffer.js
+++ b/test/parallel/test-fs-read-empty-buffer.js
@@ -14,8 +14,6 @@ assert.throws(
   () => fs.readSync(fd, buffer, 0, 10, 0),
   {
     code: 'ERR_INVALID_ARG_VALUE',
-    message: 'The argument \'buffer\' is empty and cannot be written. ' +
-    'Received Uint8Array(0) []'
   }
 );
 
@@ -23,8 +21,6 @@ assert.throws(
   () => fs.read(fd, buffer, 0, 1, 0, common.mustNotCall()),
   {
     code: 'ERR_INVALID_ARG_VALUE',
-    message: 'The argument \'buffer\' is empty and cannot be written. ' +
-    'Received Uint8Array(0) []'
   }
 );
 
@@ -34,8 +30,6 @@ assert.throws(
     () => filehandle.read(buffer, 0, 1, 0),
     {
       code: 'ERR_INVALID_ARG_VALUE',
-      message: 'The argument \'buffer\' is empty and cannot be written. ' +
-               'Received Uint8Array(0) []'
     }
   );
 })().then(common.mustCall());

--- a/test/parallel/test-fs-read-stream-file-handle.js
+++ b/test/parallel/test-fs-read-stream-file-handle.js
@@ -59,7 +59,6 @@ fs.promises.open(file, 'r').then((handle) => {
   }, {
     code: 'ERR_METHOD_NOT_IMPLEMENTED',
     name: 'Error',
-    message: 'The FileHandle with fs method is not implemented'
   });
   return handle.close();
 }).then(common.mustCall());

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -158,8 +158,6 @@ assert.throws(
   },
   {
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "start" is out of range. It must be <= "end"' +
-             ' (here: 2). Received 10',
     name: 'RangeError'
   });
 

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -15,8 +15,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "buffer" argument must be an instance of Buffer, ' +
-             'TypedArray, or DataView. Received type number (4)'
   }
 );
 
@@ -56,8 +54,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "offset" is out of range. It must be an integer. ' +
-           'Received NaN'
 });
 
 assert.throws(() => {
@@ -70,8 +66,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "length" is out of range. ' +
-           'It must be >= 0. Received -1'
 });
 
 [true, () => {}, {}, ''].forEach((value) => {
@@ -128,8 +122,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "buffer" argument must be an instance of Buffer, ' +
-             'TypedArray, or DataView. Received type number (4)'
   }
 );
 
@@ -166,8 +158,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "offset" is out of range. It must be an integer. ' +
-           'Received NaN'
 });
 
 assert.throws(() => {
@@ -179,8 +169,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "length" is out of range. ' +
-           'It must be >= 0. Received -1'
 });
 
 assert.throws(() => {
@@ -192,8 +180,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "length" is out of range. ' +
-           'It must be <= 4. Received 5'
 });
 
 [true, () => {}, {}, ''].forEach((value) => {

--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -87,8 +87,6 @@ assert.throws(
   () => fs.readSync(fd, { buffer: null }),
   {
     name: 'TypeError',
-    message: 'The "buffer" argument must be an instance of Buffer, ' +
-    'TypedArray, or DataView. Received an instance of Object',
   },
   'throws when options.buffer is null'
 );
@@ -96,7 +94,6 @@ assert.throws(
 assert.throws(
   () => fs.read(null, Buffer.alloc(1), 0, 1, 0),
   {
-    message: 'The "fd" argument must be of type number. Received null',
     code: 'ERR_INVALID_ARG_TYPE',
   }
 );

--- a/test/parallel/test-fs-readdir-stack-overflow.js
+++ b/test/parallel/test-fs-readdir-stack-overflow.js
@@ -14,6 +14,5 @@ assert.throws(
   () => recurse(),
   {
     name: 'RangeError',
-    message: 'Maximum call stack size exceeded'
   }
 );

--- a/test/parallel/test-fs-readdir-types.js
+++ b/test/parallel/test-fs-readdir-types.js
@@ -59,7 +59,6 @@ fs.readdir(__filename, {
     {
       code: 'ENOTDIR',
       name: 'Error',
-      message: `ENOTDIR: not a directory, scandir '${__filename}'`
     }
   );
 }));

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -60,8 +60,6 @@ assert.throws(
   () => { fs.readFile(() => {}, common.mustNotCall()); },
   {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "path" argument must be of type string or an instance of ' +
-             'Buffer or URL. Received type function ([Function (anonymous)])',
     name: 'TypeError'
   }
 );

--- a/test/parallel/test-fs-rename-type-check.js
+++ b/test/parallel/test-fs-rename-type-check.js
@@ -5,14 +5,11 @@ const assert = require('assert');
 const fs = require('fs');
 
 [false, 1, [], {}, null, undefined].forEach((input) => {
-  const type = 'of type string or an instance of Buffer or URL.' +
-               common.invalidArgTypeHelper(input);
   assert.throws(
     () => fs.rename(input, 'does-not-exist', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: `The "oldPath" argument must be ${type}`
     }
   );
   assert.throws(
@@ -20,7 +17,6 @@ const fs = require('fs');
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: `The "newPath" argument must be ${type}`
     }
   );
   assert.throws(
@@ -28,7 +24,6 @@ const fs = require('fs');
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: `The "oldPath" argument must be ${type}`
     }
   );
   assert.throws(
@@ -36,7 +31,6 @@ const fs = require('fs');
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: `The "newPath" argument must be ${type}`
     }
   );
 });

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -168,7 +168,6 @@ if (isGitPresent) {
   }, {
     code: 'ENOENT',
     name: 'Error',
-    message: /^ENOENT: no such file or directory, stat/
   });
 
   // Should delete a file
@@ -231,7 +230,6 @@ if (isGitPresent) {
   ), {
     code: 'ENOENT',
     name: 'Error',
-    message: /^ENOENT: no such file or directory, stat/
   });
 
   // Should not fail if target does not exist and force option is true
@@ -307,7 +305,6 @@ if (isGitPresent) {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /^The "options" argument must be of type object\./
     });
   });
 
@@ -317,7 +314,6 @@ if (isGitPresent) {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /^The "options\.recursive" property must be of type boolean\./
     });
   });
 
@@ -327,7 +323,6 @@ if (isGitPresent) {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /^The "options\.force" property must be of type boolean\./
     });
   });
 
@@ -336,7 +331,6 @@ if (isGitPresent) {
   }, {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: /^The value of "options\.retryDelay" is out of range\./
   });
 
   assert.throws(() => {
@@ -344,7 +338,6 @@ if (isGitPresent) {
   }, {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: /^The value of "options\.maxRetries" is out of range\./
   });
 }
 

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -187,7 +187,6 @@ function removeAsync(dir) {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /^The "options" argument must be of type object\./
     });
   });
 
@@ -197,7 +196,6 @@ function removeAsync(dir) {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /^The "options\.recursive" property must be of type boolean\./
     });
   });
 
@@ -206,7 +204,6 @@ function removeAsync(dir) {
   }, {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: /^The value of "options\.retryDelay" is out of range\./
   });
 
   assert.throws(() => {
@@ -214,7 +211,6 @@ function removeAsync(dir) {
   }, {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: /^The value of "options\.maxRetries" is out of range\./
   });
 }
 

--- a/test/parallel/test-fs-stream-fs-options.js
+++ b/test/parallel/test-fs-stream-fs-options.js
@@ -28,8 +28,6 @@ const originalFs = { fs };
       () => fs.createWriteStream(file, opts), {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: `The "options.fs.${fn}" property must be of type function. ` +
-        'Received null'
       },
       `createWriteStream options.fs.${fn} should throw if isn't a function`
     );
@@ -46,8 +44,6 @@ const originalFs = { fs };
     () => fs.createWriteStream(file, opts), {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.fs.writev" property must be of type function. ' +
-        'Received type string (\'not a fn\')'
     },
     'createWriteStream options.fs.writev should throw if isn\'t a function'
   );
@@ -64,8 +60,6 @@ const originalFs = { fs };
       () => fs.createReadStream(file, opts), {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: `The "options.fs.${fn}" property must be of type function. ` +
-        'Received null'
       },
       `createReadStream options.fs.${fn} should throw if isn't a function`
     );

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -67,7 +67,6 @@ fs.symlink(linkData, linkPath, common.mustSucceed(() => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /target|path/
   };
   assert.throws(() => fs.symlink(input, '', common.mustNotCall()), errObj);
   assert.throws(() => fs.symlinkSync(input, ''), errObj);
@@ -79,8 +78,6 @@ fs.symlink(linkData, linkPath, common.mustSucceed(() => {
 const errObj = {
   code: 'ERR_FS_INVALID_SYMLINK_TYPE',
   name: 'Error',
-  message:
-    'Symlink type must be one of "dir", "file", or "junction". Received "🍏"'
 };
 assert.throws(() => fs.symlink('', '', '🍏', common.mustNotCall()), errObj);
 assert.throws(() => fs.symlinkSync('', '', '🍏'), errObj);

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -176,13 +176,11 @@ function testFtruncate(cb) {
   process.on('beforeExit', () => fs.closeSync(fd));
 
   ['', false, null, {}, []].forEach((input) => {
-    const received = common.invalidArgTypeHelper(input);
     assert.throws(
       () => fs.truncate(file5, input, common.mustNotCall()),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: `The "len" argument must be of type number.${received}`
       }
     );
 
@@ -191,7 +189,6 @@ function testFtruncate(cb) {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: `The "len" argument must be of type number.${received}`
       }
     );
   });
@@ -202,8 +199,6 @@ function testFtruncate(cb) {
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "len" is out of range. It must be ' +
-                  `an integer. Received ${input}`
       }
     );
 
@@ -212,8 +207,6 @@ function testFtruncate(cb) {
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "len" is out of range. It must be ' +
-                  `an integer. Received ${input}`
       }
     );
   });
@@ -245,9 +238,6 @@ function testFtruncate(cb) {
   const file8 = path.resolve(tmp, 'non-existent-truncate-file.txt');
   const validateError = (err) => {
     assert.strictEqual(file8, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, open '${file8}'`);
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.syscall, 'open');
     return true;
@@ -261,8 +251,6 @@ function testFtruncate(cb) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "len" argument must be of type number.' +
-               common.invalidArgTypeHelper(input)
     }
   );
 });
@@ -274,8 +262,6 @@ function testFtruncate(cb) {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "fd" argument must be of type number.' +
-                 common.invalidArgTypeHelper(input)
       }
     );
   });

--- a/test/parallel/test-fs-util-validateoffsetlength.js
+++ b/test/parallel/test-fs-util-validateoffsetlength.js
@@ -16,8 +16,6 @@ const {
     common.expectsError({
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "offset" is out of range. ' +
-                 `It must be >= 0. Received ${offset}`
     })
   );
 }
@@ -29,8 +27,6 @@ const {
     common.expectsError({
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "length" is out of range. ' +
-                 `It must be >= 0. Received ${length}`
     })
   );
 }
@@ -44,8 +40,6 @@ const {
     common.expectsError({
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "length" is out of range. ' +
-                 `It must be <= ${byteLength - offset}. Received ${length}`
     })
   );
 }
@@ -64,8 +58,6 @@ const kIoMaxLength = 2 ** 31 - 1;
     common.expectsError({
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "offset" is out of range. ' +
-               `It must be <= ${byteLength}. Received ${offset}`
     })
   );
 }
@@ -80,8 +72,6 @@ const kIoMaxLength = 2 ** 31 - 1;
     common.expectsError({
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "length" is out of range. ' +
-               `It must be <= ${byteLength - offset}. Received ${length}`
     })
   );
 }

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -195,8 +195,6 @@ const expectTypeError = {
 const expectRangeError = {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "fd" is out of range. ' +
-           'It must be >= 0 && <= 2147483647. Received -1'
 };
 // futimes-only error cases
 {

--- a/test/parallel/test-fs-whatwg-url.js
+++ b/test/parallel/test-fs-whatwg-url.js
@@ -5,7 +5,6 @@ const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const os = require('os');
 
 function pathToFileURL(p) {
   if (!path.isAbsolute(p))
@@ -35,7 +34,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_URL_SCHEME',
     name: 'TypeError',
-    message: 'The URL must be of scheme file'
   });
 
 // pct-encoded characters in the path will be decoded and checked
@@ -49,7 +47,6 @@ if (common.isWindows) {
       {
         code: 'ERR_INVALID_FILE_URL_PATH',
         name: 'TypeError',
-        message: 'File URL path must not include encoded \\ or / characters'
       }
     );
   });
@@ -60,8 +57,6 @@ if (common.isWindows) {
     {
       code: 'ERR_INVALID_ARG_VALUE',
       name: 'TypeError',
-      message: 'The argument \'path\' must be a string or Uint8Array without ' +
-               "null bytes. Received 'c:\\\\tmp\\\\\\x00test'"
     }
   );
 } else {
@@ -74,7 +69,6 @@ if (common.isWindows) {
       {
         code: 'ERR_INVALID_FILE_URL_PATH',
         name: 'TypeError',
-        message: 'File URL path must not include encoded / characters'
       });
   });
   assert.throws(
@@ -84,7 +78,6 @@ if (common.isWindows) {
     {
       code: 'ERR_INVALID_FILE_URL_HOST',
       name: 'TypeError',
-      message: `File URL host must be "localhost" or empty on ${os.platform()}`
     }
   );
   assert.throws(
@@ -94,8 +87,6 @@ if (common.isWindows) {
     {
       code: 'ERR_INVALID_ARG_VALUE',
       name: 'TypeError',
-      message: "The argument 'path' must be a string or Uint8Array without " +
-               "null bytes. Received '/tmp/\\x00test'"
     }
   );
 }

--- a/test/parallel/test-fs-write-buffer-large.js
+++ b/test/parallel/test-fs-write-buffer-large.js
@@ -32,8 +32,6 @@ fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
   }, {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "length" is out of range. ' +
-      'It must be >= 0 && <= 2147483647. Received 2147483648'
   });
 
   fs.closeSync(fd);

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -139,8 +139,6 @@ tmpdir.refresh();
     }, {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "offset" is out of range. ' +
-               'It must be an integer. Received NaN'
     });
 
     fs.closeSync(fd);

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -170,14 +170,12 @@ fs.open(fn4, 'w', 0o644, common.mustSucceed((fd) => {
     () => fs.write(1, data, common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /"buffer"/
     }
   );
   assert.throws(
     () => fs.writeSync(1, data),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /"buffer"/
     }
   );
 });
@@ -190,7 +188,6 @@ fs.open(fn4, 'w', 0o644, common.mustSucceed((fd) => {
     () => fs.writeSync(fd, 'abc', 0, 'hex'),
     {
       code: 'ERR_INVALID_ARG_VALUE',
-      message: /'encoding' is invalid for data of length 3/
     }
   );
 
@@ -198,7 +195,6 @@ fs.open(fn4, 'w', 0o644, common.mustSucceed((fd) => {
     () => fs.writeSync(fd, 'abc', 0, 'hex', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_VALUE',
-      message: /'encoding' is invalid for data of length 3/
     }
   );
 

--- a/test/parallel/test-http-aborted.js
+++ b/test/parallel/test-http-aborted.js
@@ -11,7 +11,6 @@ const assert = require('assert');
     }));
     req.on('error', common.mustCall(function(err) {
       assert.strictEqual(err.code, 'ECONNRESET');
-      assert.strictEqual(err.message, 'aborted');
       server.close();
     }));
     assert.strictEqual(req.aborted, false);
@@ -28,7 +27,6 @@ const assert = require('assert');
       }));
       res.on('error', common.expectsError({
         code: 'ECONNRESET',
-        message: 'aborted'
       }));
       req.abort();
     }));

--- a/test/parallel/test-http-agent-maxtotalsockets.js
+++ b/test/parallel/test-http-agent-maxtotalsockets.js
@@ -10,8 +10,6 @@ assert.throws(() => new http.Agent({
 }), {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "maxTotalSockets" argument must be of type number. ' +
-    "Received type string ('test')",
 });
 
 [-1, 0, NaN].forEach((item) => {
@@ -20,8 +18,6 @@ assert.throws(() => new http.Agent({
   }), {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "maxTotalSockets" is out of range. ' +
-      `It must be > 0. Received ${item}`,
   });
 });
 

--- a/test/parallel/test-http-client-abort3.js
+++ b/test/parallel/test-http-client-abort3.js
@@ -17,7 +17,7 @@ function createConnection() {
 {
   const req = http.get({ createConnection });
 
-  req.on('error', common.expectsError({ name: 'Error', message: 'Oops' }));
+  req.on('error', common.expectsError({ name: 'Error' }));
   req.abort();
 }
 
@@ -27,6 +27,6 @@ function createConnection() {
 
   const req = http.get({ agent: new CustomAgent() });
 
-  req.on('error', common.expectsError({ name: 'Error', message: 'Oops' }));
+  req.on('error', common.expectsError({ name: 'Error' }));
   req.abort();
 }

--- a/test/parallel/test-http-client-check-http-token.js
+++ b/test/parallel/test-http-client-check-http-token.js
@@ -23,8 +23,6 @@ server.listen(0, common.mustCall(() => {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.method" property must be of type string.' +
-               common.invalidArgTypeHelper(method)
     });
   });
 

--- a/test/parallel/test-http-client-parse-error.js
+++ b/test/parallel/test-http-client-parse-error.js
@@ -47,7 +47,6 @@ server.listen(0, common.mustCall(() => {
       assert.strictEqual(req.socket.listenerCount('end'), 1);
       common.expectsError({
         code: 'HPE_INVALID_CONSTANT',
-        message: 'Parse Error: Expected HTTP/'
       })(e);
       countdown.dec();
     }));

--- a/test/parallel/test-http-client-reject-unexpected-agent.js
+++ b/test/parallel/test-http-client-reject-unexpected-agent.js
@@ -52,9 +52,6 @@ server.listen(0, baseOptions.host, common.mustCall(function() {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "options.agent" property must be one of Agent-like ' +
-                 'Object, undefined, or false.' +
-                 common.invalidArgTypeHelper(agent)
       }
     );
   });

--- a/test/parallel/test-http-client-set-timeout.js
+++ b/test/parallel/test-http-client-set-timeout.js
@@ -34,7 +34,6 @@ server.listen(0, mustCall(() => {
   req.on('error', expectsError({
     name: 'Error',
     code: 'ECONNRESET',
-    message: 'socket hang up'
   }));
 
   req.on('close', mustCall(() => {

--- a/test/parallel/test-http-client-unescaped-path.js
+++ b/test/parallel/test-http-client-unescaped-path.js
@@ -31,7 +31,6 @@ for (let i = 0; i <= 32; i += 1) {
     {
       code: 'ERR_UNESCAPED_CHARACTERS',
       name: 'TypeError',
-      message: 'Request path contains unescaped characters'
     }
   );
 }

--- a/test/parallel/test-http-header-overflow.js
+++ b/test/parallel/test-http-header-overflow.js
@@ -26,7 +26,6 @@ server.on('connection', mustCall((socket) => {
   const legacy = getOptionValue('--http-parser') === 'legacy';
   socket.on('error', expectsError({
     name: 'Error',
-    message: 'Parse Error: Header overflow',
     code: 'HPE_HEADER_OVERFLOW',
     bytesParsed: maxHeaderSize + PAYLOAD_GET.length - (legacy ? -1 : 0),
     rawPacket: Buffer.from(PAYLOAD)

--- a/test/parallel/test-http-hostname-typechecking.js
+++ b/test/parallel/test-http-hostname-typechecking.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
@@ -9,15 +8,11 @@ const http = require('http');
 const vals = [{}, [], NaN, Infinity, -Infinity, true, false, 1, 0, new Date()];
 
 vals.forEach((v) => {
-  const received = common.invalidArgTypeHelper(v);
   assert.throws(
     () => http.request({ hostname: v }),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.hostname" property must be of ' +
-               'type string or one of undefined or null.' +
-               received
     }
   );
 
@@ -26,9 +21,6 @@ vals.forEach((v) => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.host" property must be of ' +
-               'type string or one of undefined or null.' +
-               received
     }
   );
 });

--- a/test/parallel/test-http-insecure-parser-per-stream.js
+++ b/test/parallel/test-http-insecure-parser-per-stream.js
@@ -87,8 +87,6 @@ const MakeDuplexPair = require('../common/duplexpair');
     () => http.request({ insecureHTTPParser: 0 }, common.mustNotCall()),
     common.expectsError({
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "options.insecureHTTPParser" property must be of' +
-      ' type boolean. Received type number (0)'
     })
   );
 }

--- a/test/parallel/test-http-invalid-path-chars.js
+++ b/test/parallel/test-http-invalid-path-chars.js
@@ -14,7 +14,6 @@ for (let i = 0; i <= theExperimentallyDeterminedNumber; i++) {
     }, {
       code: 'ERR_UNESCAPED_CHARACTERS',
       name: 'TypeError',
-      message: 'Request path contains unescaped characters'
     });
   }
 }

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -56,7 +56,6 @@ const s = http.createServer(common.mustCall((req, res) => {
         {
           code: 'ERR_INVALID_HTTP_TOKEN',
           name: 'TypeError',
-          message: 'Header name must be a valid HTTP token ["undefined"]'
         }
       );
       assert.throws(
@@ -64,7 +63,6 @@ const s = http.createServer(common.mustCall((req, res) => {
         {
           code: 'ERR_HTTP_INVALID_HEADER_VALUE',
           name: 'TypeError',
-          message: 'Invalid value "undefined" for header "someHeader"'
         }
       );
       assert.throws(
@@ -72,8 +70,6 @@ const s = http.createServer(common.mustCall((req, res) => {
         {
           code: 'ERR_INVALID_ARG_TYPE',
           name: 'TypeError',
-          message: 'The "name" argument must be of type string. ' +
-                   'Received undefined'
         }
       );
       assert.throws(
@@ -81,8 +77,6 @@ const s = http.createServer(common.mustCall((req, res) => {
         {
           code: 'ERR_INVALID_ARG_TYPE',
           name: 'TypeError',
-          message: 'The "name" argument must be of type string. ' +
-                   'Received undefined'
         }
       );
 
@@ -129,8 +123,6 @@ const s = http.createServer(common.mustCall((req, res) => {
           {
             code: 'ERR_INVALID_ARG_TYPE',
             name: 'TypeError',
-            message: 'The "name" argument must be of type string.' +
-                     common.invalidArgTypeHelper(val)
           }
         );
       });

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -19,7 +19,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_HTTP_TOKEN',
   name: 'TypeError',
-  message: 'Header name must be a valid HTTP token ["undefined"]'
 });
 
 assert.throws(() => {
@@ -28,7 +27,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_HTTP_INVALID_HEADER_VALUE',
   name: 'TypeError',
-  message: 'Invalid value "undefined" for header "test"'
 });
 
 assert.throws(() => {
@@ -37,7 +35,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_HTTP_TOKEN',
   name: 'TypeError',
-  message: 'Header name must be a valid HTTP token ["404"]'
 });
 
 assert.throws(() => {
@@ -46,7 +43,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_HTTP_HEADERS_SENT',
   name: 'Error',
-  message: 'Cannot set headers after they are sent to the client'
 });
 
 assert.throws(() => {
@@ -55,7 +51,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_CHAR',
   name: 'TypeError',
-  message: 'Invalid character in header content ["200"]'
 });
 
 // write
@@ -69,7 +64,6 @@ assert.throws(() => {
     {
       code: 'ERR_METHOD_NOT_IMPLEMENTED',
       name: 'Error',
-      message: 'The _implicitHeader() method is not implemented'
     }
   );
 }
@@ -80,8 +74,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "chunk" argument must be of type string or an instance of ' +
-           'Buffer or Uint8Array. Received undefined'
 });
 
 assert.throws(() => {
@@ -90,8 +82,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "chunk" argument must be of type string or an instance of ' +
-           'Buffer or Uint8Array. Received type number (1)'
 });
 
 assert.throws(() => {
@@ -117,7 +107,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_HTTP_TOKEN',
   name: 'TypeError',
-  message: 'Trailer name must be a valid HTTP token ["あ"]'
 });
 
 assert.throws(() => {
@@ -126,7 +115,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_CHAR',
   name: 'TypeError',
-  message: 'Invalid character in trailer content ["404"]'
 });
 
 {

--- a/test/parallel/test-http-outgoing-renderHeaders.js
+++ b/test/parallel/test-http-outgoing-renderHeaders.js
@@ -16,7 +16,6 @@ const OutgoingMessage = http.OutgoingMessage;
     {
       code: 'ERR_HTTP_HEADERS_SENT',
       name: 'Error',
-      message: 'Cannot render headers after they are sent to the client'
     }
   );
 }

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -100,7 +100,7 @@ function expectBody(expected) {
 
   assert.throws(
     () => { parser.execute(request, 0, request.length); },
-    { name: 'Error', message: 'hello world' }
+    { name: 'Error' }
   );
 }
 

--- a/test/parallel/test-http-request-invalid-method-error.js
+++ b/test/parallel/test-http-request-invalid-method-error.js
@@ -8,6 +8,5 @@ assert.throws(
   {
     code: 'ERR_INVALID_HTTP_TOKEN',
     name: 'TypeError',
-    message: 'Method must be a valid HTTP token ["\u0000"]'
   }
 );

--- a/test/parallel/test-http-response-add-header-after-sent.js
+++ b/test/parallel/test-http-response-add-header-after-sent.js
@@ -11,7 +11,6 @@ const server = http.createServer((req, res) => {
     {
       code: 'ERR_HTTP_HEADERS_SENT',
       name: 'Error',
-      message: 'Cannot set headers after they are sent to the client'
     }
   );
   res.end();

--- a/test/parallel/test-http-response-remove-header-after-sent.js
+++ b/test/parallel/test-http-response-remove-header-after-sent.js
@@ -11,7 +11,6 @@ const server = http.createServer((req, res) => {
     {
       code: 'ERR_HTTP_HEADERS_SENT',
       name: 'Error',
-      message: 'Cannot remove headers after they are sent to the client'
     }
   );
   res.end();

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -28,7 +28,6 @@ function test(res, code, key, value) {
     {
       code: 'ERR_INVALID_CHAR',
       name: 'TypeError',
-      message: `Invalid character in header content ["${key}"]`
     }
   );
 }

--- a/test/parallel/test-http-response-statuscode.js
+++ b/test/parallel/test-http-response-statuscode.js
@@ -7,60 +7,58 @@ const Countdown = require('../common/countdown');
 const MAX_REQUESTS = 13;
 let reqNum = 0;
 
-function test(res, header, code) {
+function test(res, header) {
   assert.throws(() => {
     res.writeHead(header);
   }, {
     code: 'ERR_HTTP_INVALID_STATUS_CODE',
     name: 'RangeError',
-    message: `Invalid status code: ${code}`
   });
 }
 
 const server = http.Server(common.mustCall(function(req, res) {
   switch (reqNum) {
     case 0:
-      test(res, -1, '-1');
+      test(res, -1);
       break;
     case 1:
-      test(res, Infinity, 'Infinity');
+      test(res, Infinity);
       break;
     case 2:
-      test(res, NaN, 'NaN');
+      test(res, NaN);
       break;
     case 3:
-      test(res, {}, '{}');
+      test(res, {});
       break;
     case 4:
-      test(res, 99, '99');
+      test(res, 99);
       break;
     case 5:
-      test(res, 1000, '1000');
+      test(res, 1000);
       break;
     case 6:
-      test(res, '1000', '1000');
+      test(res, '1000');
       break;
     case 7:
-      test(res, null, 'null');
+      test(res, null);
       break;
     case 8:
-      test(res, true, 'true');
+      test(res, true);
       break;
     case 9:
-      test(res, [], '[]');
+      test(res, []);
       break;
     case 10:
-      test(res, 'this is not valid', 'this is not valid');
+      test(res, 'this is not valid');
       break;
     case 11:
-      test(res, '404 this is not valid either', '404 this is not valid either');
+      test(res, '404 this is not valid either');
       break;
     case 12:
       assert.throws(() => { res.writeHead(); },
                     {
                       code: 'ERR_HTTP_INVALID_STATUS_CODE',
                       name: 'RangeError',
-                      message: 'Invalid status code: undefined'
                     });
       this.close();
       break;

--- a/test/parallel/test-http-server-de-chunked-trailer.js
+++ b/test/parallel/test-http-server-de-chunked-trailer.js
@@ -11,7 +11,6 @@ const server = http.createServer(common.mustCall(function(req, res) {
   res.setHeader('Trailer', 'baz');
   const trailerInvalidErr = {
     code: 'ERR_HTTP_TRAILER_INVALID',
-    message: 'Trailers are invalid with this transfer encoding',
     name: 'Error'
   };
   assert.throws(() => res.writeHead(200, { 'Content-Length': '2' }),

--- a/test/parallel/test-http-server-destroy-socket-on-client-error.js
+++ b/test/parallel/test-http-server-destroy-socket-on-client-error.js
@@ -14,7 +14,6 @@ const server = createServer();
 server.on('connection', mustCall((socket) => {
   socket.on('error', expectsError({
     name: 'Error',
-    message: 'Parse Error: Invalid method encountered',
     code: 'HPE_INVALID_METHOD',
     bytesParsed: 1,
     rawPacket: Buffer.from('FOO /\r\n')

--- a/test/parallel/test-http-socket-encoding-error.js
+++ b/test/parallel/test-http-socket-encoding-error.js
@@ -14,8 +14,6 @@ server.on('connection', common.mustCall((socket) => {
     {
       code: 'ERR_HTTP_SOCKET_ENCODING',
       name: 'Error',
-      message: 'Changing the socket encoding is not ' +
-        'allowed per RFC7230 Section 3.'
     }
   );
 

--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -61,7 +61,6 @@ server.listen(common.PIPE, common.mustCall(function() {
         assert.strictEqual(error, undefined);
         server.close(common.expectsError({
           code: 'ERR_SERVER_NOT_RUNNING',
-          message: 'Server is not running.',
           name: 'Error'
         }));
       }));

--- a/test/parallel/test-http-write-head.js
+++ b/test/parallel/test-http-write-head.js
@@ -37,7 +37,6 @@ const s = http.createServer(common.mustCall((req, res) => {
     {
       code: 'ERR_INVALID_HTTP_TOKEN',
       name: 'TypeError',
-      message: 'Header name must be a valid HTTP token ["3840"]'
     }
   );
 
@@ -47,7 +46,6 @@ const s = http.createServer(common.mustCall((req, res) => {
     {
       code: 'ERR_HTTP_INVALID_HEADER_VALUE',
       name: 'TypeError',
-      message: 'Invalid value "undefined" for header "foo"'
     }
   );
 
@@ -58,7 +56,6 @@ const s = http.createServer(common.mustCall((req, res) => {
   }, {
     code: 'ERR_HTTP_HEADERS_SENT',
     name: 'Error',
-    message: 'Cannot render headers after they are sent to the client'
   });
 
   res.end();

--- a/test/parallel/test-http2-altsvc.js
+++ b/test/parallel/test-http2-altsvc.js
@@ -33,8 +33,6 @@ server.on('session', common.mustCall((session) => {
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "originOrStream" is out of ' +
-                 `range. It must be > 0 && < 4294967296. Received ${input}`
       }
     );
   });
@@ -56,7 +54,6 @@ server.on('session', common.mustCall((session) => {
       {
         code: 'ERR_INVALID_CHAR',
         name: 'TypeError',
-        message: 'Invalid character in alt'
       }
     );
   });
@@ -82,7 +79,6 @@ server.on('session', common.mustCall((session) => {
       {
         code: 'ERR_HTTP2_ALTSVC_INVALID_ORIGIN',
         name: 'TypeError',
-        message: 'HTTP/2 ALTSVC frames require a valid origin'
       }
     );
   });
@@ -96,7 +92,6 @@ server.on('session', common.mustCall((session) => {
     {
       code: 'ERR_HTTP2_ALTSVC_LENGTH',
       name: 'TypeError',
-      message: 'HTTP/2 ALTSVC frames are limited to 16382 bytes'
     }
   );
 }));

--- a/test/parallel/test-http2-client-destroy.js
+++ b/test/parallel/test-http2-client-destroy.js
@@ -63,7 +63,6 @@ const { getEventListeners } = require('events');
     req.on('error', common.expectsError({
       code: 'ERR_HTTP2_STREAM_CANCEL',
       name: 'Error',
-      message: 'The pending stream has been canceled'
     }));
 
     client.destroy();
@@ -73,7 +72,6 @@ const { getEventListeners } = require('events');
     const sessionError = {
       name: 'Error',
       code: 'ERR_HTTP2_INVALID_SESSION',
-      message: 'The session has been destroyed'
     };
 
     assert.throws(() => client.setNextStreamID(), sessionError);
@@ -158,7 +156,6 @@ const { getEventListeners } = require('events');
     req.on('error', common.expectsError({
       code: 'ERR_HTTP2_GOAWAY_SESSION',
       name: 'Error',
-      message: 'New streams cannot be created after receiving a GOAWAY'
     }));
 
     client.close();

--- a/test/parallel/test-http2-client-http1-server.js
+++ b/test/parallel/test-http2-client-http1-server.js
@@ -30,14 +30,12 @@ server.listen(0, common.mustCall(() => {
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_ERROR',
     constructor: NghttpError,
-    message: 'Protocol error'
   }));
 
   client.on('error', common.expectsError({
     code: 'ERR_HTTP2_ERROR',
     constructor: NghttpError,
     name: 'Error',
-    message: 'Protocol error'
   }));
 
   client.on('close', common.mustCall(() => server.close()));

--- a/test/parallel/test-http2-client-onconnect-errors.js
+++ b/test/parallel/test-http2-client-onconnect-errors.js
@@ -30,8 +30,6 @@ const specificTests = [
     error: {
       code: 'ERR_HTTP2_OUT_OF_STREAMS',
       name: 'Error',
-      message: 'No stream ID is available because ' +
-               'maximum stream ID has been reached'
     },
     type: 'stream'
   },
@@ -40,7 +38,6 @@ const specificTests = [
     error: {
       code: 'ERR_HTTP2_STREAM_SELF_DEPENDENCY',
       name: 'Error',
-      message: 'A stream cannot depend on itself'
     },
     type: 'stream'
   },

--- a/test/parallel/test-http2-client-request-options-errors.js
+++ b/test/parallel/test-http2-client-request-options-errors.js
@@ -5,7 +5,6 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
-const { inspect } = require('util');
 
 // Check if correct errors are emitted when wrong type of data is passed
 // to certain options of ClientHttp2Session request method
@@ -49,8 +48,6 @@ server.listen(0, common.mustCall(() => {
           }), {
             name: 'TypeError',
             code: 'ERR_INVALID_ARG_VALUE',
-            message: `The property 'options.${option}' is invalid. ` +
-                    `Received ${inspect(types[type])}`
           });
       });
     });

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -23,8 +23,6 @@ server.listen(0, common.mustCall(() => {
     {
       name: 'RangeError',
       code: 'ERR_OUT_OF_RANGE',
-      message: 'The value of "code" is out of range. It must be ' +
-               '>= 0 && <= 4294967295. Received 4294967296'
     }
   );
   assert.strictEqual(req.closed, false);
@@ -59,7 +57,6 @@ server.listen(0, common.mustCall(() => {
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     name: 'Error',
-    message: 'Stream closed with error code NGHTTP2_PROTOCOL_ERROR'
   }));
 
   // The `response` event should not fire as the server should receive the

--- a/test/parallel/test-http2-client-setLocalWindowSize.js
+++ b/test/parallel/test-http2-client-setLocalWindowSize.js
@@ -33,8 +33,6 @@ const http2 = require('http2');
         {
           name: 'RangeError',
           code: 'ERR_OUT_OF_RANGE',
-          message: 'The value of "windowSize" is out of range.' +
-            ' It must be >= 0 && <= 2147483647. Received ' + outOfRangeNum
         }
       );
 
@@ -49,8 +47,6 @@ const http2 = require('http2');
           {
             name: 'TypeError',
             code: 'ERR_INVALID_ARG_TYPE',
-            message: 'The "windowSize" argument must be of type number.' +
-                    common.invalidArgTypeHelper(value)
           }
         );
       });

--- a/test/parallel/test-http2-client-setNextStreamID-errors.js
+++ b/test/parallel/test-http2-client-setNextStreamID-errors.js
@@ -33,8 +33,6 @@ server.listen(0, common.mustCall(() => {
       {
         name: 'RangeError',
         code: 'ERR_OUT_OF_RANGE',
-        message: 'The value of "id" is out of range.' +
-           ' It must be > 0 and <= 4294967295. Received ' + outOfRangeNum
       }
     );
 
@@ -49,8 +47,6 @@ server.listen(0, common.mustCall(() => {
         {
           name: 'TypeError',
           code: 'ERR_INVALID_ARG_TYPE',
-          message: 'The "id" argument must be of type number.' +
-                   common.invalidArgTypeHelper(value)
         }
       );
     });

--- a/test/parallel/test-http2-client-stream-destroy-before-connect.js
+++ b/test/parallel/test-http2-client-stream-destroy-before-connect.js
@@ -19,8 +19,6 @@ server.on('stream', (stream) => {
   // system specific timings.
   stream.on('error', (err) => {
     assert.strictEqual(err.code, 'ERR_HTTP2_STREAM_ERROR');
-    assert.strictEqual(err.message,
-                       'Stream closed with error code NGHTTP2_INTERNAL_ERROR');
   });
   stream.respond();
   stream.end();
@@ -39,7 +37,6 @@ server.listen(0, common.mustCall(() => {
 
   req.on('error', common.expectsError({
     name: 'Error',
-    message: 'test'
   }));
 
   req.on('close', common.mustCall(() => {

--- a/test/parallel/test-http2-client-unescaped-path.js
+++ b/test/parallel/test-http2-client-unescaped-path.js
@@ -27,7 +27,6 @@ server.listen(0, common.mustCall(() => {
     req.on('error', common.expectsError({
       code: 'ERR_HTTP2_STREAM_ERROR',
       name: 'Error',
-      message: 'Stream closed with error code NGHTTP2_PROTOCOL_ERROR'
     }));
     req.on('close', common.mustCall(() => countdown.dec()));
   }

--- a/test/parallel/test-http2-compat-serverrequest-headers.js
+++ b/test/parallel/test-http2-compat-serverrequest-headers.js
@@ -51,7 +51,6 @@ const h2 = require('http2');
         {
           code: 'ERR_INVALID_ARG_VALUE',
           name: 'TypeError',
-          message: "The argument 'method' is invalid. Received '   '"
         }
       );
       assert.throws(
@@ -59,8 +58,6 @@ const h2 = require('http2');
         {
           code: 'ERR_INVALID_ARG_TYPE',
           name: 'TypeError',
-          message: 'The "method" argument must be of type string. ' +
-                  'Received type boolean (true)'
         }
       );
 

--- a/test/parallel/test-http2-compat-serverresponse-destroy.js
+++ b/test/parallel/test-http2-compat-serverresponse-destroy.js
@@ -57,7 +57,6 @@ server.listen(0, common.mustCall(() => {
     req.on('error', common.expectsError({
       code: 'ERR_HTTP2_STREAM_ERROR',
       name: 'Error',
-      message: 'Stream closed with error code NGHTTP2_INTERNAL_ERROR'
     }));
     req.on('close', common.mustCall(() => countdown.dec()));
 
@@ -72,7 +71,6 @@ server.listen(0, common.mustCall(() => {
     req.on('error', common.expectsError({
       code: 'ERR_HTTP2_STREAM_ERROR',
       name: 'Error',
-      message: 'Stream closed with error code NGHTTP2_INTERNAL_ERROR'
     }));
     req.on('close', common.mustCall(() => countdown.dec()));
 

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -47,8 +47,6 @@ server.listen(0, common.mustCall(function() {
         {
           code: 'ERR_INVALID_ARG_TYPE',
           name: 'TypeError',
-          message: 'The "name" argument must be of type string. Received ' +
-                   'undefined'
         }
       );
     });
@@ -64,7 +62,6 @@ server.listen(0, common.mustCall(function() {
       {
         code: 'ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED',
         name: 'TypeError',
-        message: 'Cannot set HTTP/2 pseudo-headers'
       })
     );
     assert.throws(() => {
@@ -72,22 +69,18 @@ server.listen(0, common.mustCall(function() {
     }, {
       code: 'ERR_HTTP2_INVALID_HEADER_VALUE',
       name: 'TypeError',
-      message: 'Invalid value "null" for header "foo-bar"'
     });
     assert.throws(() => {
       response.setHeader(real, undefined);
     }, {
       code: 'ERR_HTTP2_INVALID_HEADER_VALUE',
       name: 'TypeError',
-      message: 'Invalid value "undefined" for header "foo-bar"'
     });
     assert.throws(
       () => response.setHeader(), // Header name undefined
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "name" argument must be of type string. Received ' +
-                 'undefined'
       }
     );
     assert.throws(
@@ -95,7 +88,6 @@ server.listen(0, common.mustCall(function() {
       {
         code: 'ERR_INVALID_HTTP_TOKEN',
         name: 'TypeError',
-        message: 'Header name must be a valid HTTP token [""]'
       }
     );
 
@@ -127,7 +119,6 @@ server.listen(0, common.mustCall(function() {
         {
           code: 'ERR_HTTP2_HEADERS_SENT',
           name: 'Error',
-          message: 'Response has already been initiated.'
         }
       );
       assert.throws(
@@ -135,7 +126,6 @@ server.listen(0, common.mustCall(function() {
         {
           code: 'ERR_HTTP2_HEADERS_SENT',
           name: 'Error',
-          message: 'Response has already been initiated.'
         }
       );
 
@@ -145,7 +135,6 @@ server.listen(0, common.mustCall(function() {
           {
             code: 'ERR_HTTP2_HEADERS_SENT',
             name: 'Error',
-            message: 'Response has already been initiated.'
           }
         );
         assert.throws(
@@ -153,7 +142,6 @@ server.listen(0, common.mustCall(function() {
           {
             code: 'ERR_HTTP2_HEADERS_SENT',
             name: 'Error',
-            message: 'Response has already been initiated.'
           }
         );
 

--- a/test/parallel/test-http2-compat-serverresponse-trailers.js
+++ b/test/parallel/test-http2-compat-serverresponse-trailers.js
@@ -20,7 +20,6 @@ server.listen(0, common.mustCall(() => {
       {
         code: 'ERR_INVALID_HTTP_TOKEN',
         name: 'TypeError',
-        message: 'Header name must be a valid HTTP token [""]'
       }
     );
     assert.throws(
@@ -28,7 +27,6 @@ server.listen(0, common.mustCall(() => {
       {
         code: 'ERR_HTTP2_INVALID_HEADER_VALUE',
         name: 'TypeError',
-        message: 'Invalid value "undefined" for header "test"'
       }
     );
     assert.throws(
@@ -36,7 +34,6 @@ server.listen(0, common.mustCall(() => {
       {
         code: 'ERR_HTTP2_INVALID_HEADER_VALUE',
         name: 'TypeError',
-        message: 'Invalid value "null" for header "test"'
       }
     );
     assert.throws(
@@ -44,8 +41,6 @@ server.listen(0, common.mustCall(() => {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "name" argument must be of type string. Received ' +
-                 'undefined'
       }
     );
     assert.throws(
@@ -53,7 +48,6 @@ server.listen(0, common.mustCall(() => {
       {
         code: 'ERR_INVALID_HTTP_TOKEN',
         name: 'TypeError',
-        message: 'Header name must be a valid HTTP token [""]'
       }
     );
 

--- a/test/parallel/test-http2-compat-socket-set.js
+++ b/test/parallel/test-http2-compat-socket-set.js
@@ -12,8 +12,6 @@ const h2 = require('http2');
 const errMsg = {
   code: 'ERR_HTTP2_NO_SOCKET_MANIPULATION',
   name: 'Error',
-  message: 'HTTP/2 sockets should not be directly manipulated ' +
-           '(e.g. read and written)'
 };
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-compat-socket.js
+++ b/test/parallel/test-http2-compat-socket.js
@@ -18,8 +18,6 @@ const { kTimeout } = require('internal/timers');
 const errMsg = {
   code: 'ERR_HTTP2_NO_SOCKET_MANIPULATION',
   name: 'Error',
-  message: 'HTTP/2 sockets should not be directly manipulated ' +
-           '(e.g. read and written)'
 };
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-connect-method.js
+++ b/test/parallel/test-http2-connect-method.js
@@ -61,7 +61,6 @@ server.listen(0, common.mustCall(() => {
       }),
       {
         code: 'ERR_HTTP2_CONNECT_AUTHORITY',
-        message: ':authority header is required for CONNECT requests'
       }
     );
     assert.throws(
@@ -72,7 +71,6 @@ server.listen(0, common.mustCall(() => {
       }),
       {
         code: 'ERR_HTTP2_CONNECT_SCHEME',
-        message: 'The :scheme header is forbidden for CONNECT requests'
       }
     );
     assert.throws(
@@ -83,7 +81,6 @@ server.listen(0, common.mustCall(() => {
       }),
       {
         code: 'ERR_HTTP2_CONNECT_PATH',
-        message: 'The :path header is forbidden for CONNECT requests'
       }
     );
 

--- a/test/parallel/test-http2-createsecureserver-options.js
+++ b/test/parallel/test-http2-createsecureserver-options.js
@@ -15,8 +15,6 @@ invalidOptions.forEach((invalidOption) => {
     {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "options" argument must be of type object.' +
-               common.invalidArgTypeHelper(invalidOption)
     }
   );
 });
@@ -28,8 +26,6 @@ invalidOptions.forEach((invalidSettingsOption) => {
     {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "options.settings" property must be of type object.' +
-               common.invalidArgTypeHelper(invalidSettingsOption)
     }
   );
 });

--- a/test/parallel/test-http2-createserver-options.js
+++ b/test/parallel/test-http2-createserver-options.js
@@ -15,8 +15,6 @@ invalidOptions.forEach((invalidOption) => {
     {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "options" argument must be of type object.' +
-               common.invalidArgTypeHelper(invalidOption)
     }
   );
 });
@@ -28,8 +26,6 @@ invalidOptions.forEach((invalidSettingsOption) => {
     {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "options.settings" property must be of type object.' +
-               common.invalidArgTypeHelper(invalidSettingsOption)
     }
   );
 });

--- a/test/parallel/test-http2-empty-frame-without-eof.js
+++ b/test/parallel/test-http2-empty-frame-without-eof.js
@@ -28,7 +28,6 @@ async function main() {
     } else {
       const expected = {
         code: 'ERR_HTTP2_TOO_MANY_INVALID_FRAMES',
-        message: 'Too many invalid HTTP/2 frames'
       };
       stream.on('error', common.expectsError(expected));
       client.on('error', common.expectsError(expected));

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -56,7 +56,6 @@ http2.getPackedSettings({ enablePush: false });
   }, {
     code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
     name: 'RangeError',
-    message: `Invalid value for setting "${i[0]}": ${i[1]}`
   });
 });
 
@@ -68,7 +67,6 @@ http2.getPackedSettings({ enablePush: false });
   }, {
     code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
     name: 'TypeError',
-    message: `Invalid value for setting "enablePush": ${i}`
   });
 });
 
@@ -80,7 +78,6 @@ http2.getPackedSettings({ enablePush: false });
   }, {
     code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
     name: 'TypeError',
-    message: `Invalid value for setting "enableConnectProtocol": ${i}`
   });
 });
 
@@ -132,9 +129,6 @@ http2.getPackedSettings({ enablePush: false });
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message:
-        'The "buf" argument must be an instance of Buffer or TypedArray.' +
-        common.invalidArgTypeHelper(input)
     });
   });
 
@@ -143,7 +137,6 @@ http2.getPackedSettings({ enablePush: false });
   }, {
     code: 'ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',
     name: 'RangeError',
-    message: 'Packed settings length must be a multiple of six'
   });
 
   const settings = http2.getUnpackedSettings(packed);
@@ -174,7 +167,6 @@ http2.getPackedSettings({ enablePush: false });
   }, {
     code: 'ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',
     name: 'RangeError',
-    message: 'Packed settings length must be a multiple of six'
   });
 
   const settings = http2.getUnpackedSettings(packed);
@@ -205,9 +197,6 @@ http2.getPackedSettings({ enablePush: false });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message:
-        'The "buf" argument must be an instance of Buffer or TypedArray.' +
-        common.invalidArgTypeHelper(packed)
   });
 }
 
@@ -253,6 +242,5 @@ http2.getPackedSettings({ enablePush: false });
   }, {
     code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
     name: 'RangeError',
-    message: 'Invalid value for setting "maxFrameSize": 16777216'
   });
 }

--- a/test/parallel/test-http2-head-request.js
+++ b/test/parallel/test-http2-head-request.js
@@ -9,7 +9,6 @@ const http2 = require('http2');
 const errCheck = common.expectsError({
   name: 'Error',
   code: 'ERR_STREAM_WRITE_AFTER_END',
-  message: 'write after end'
 }, 1);
 
 const {

--- a/test/parallel/test-http2-info-headers-errors.js
+++ b/test/parallel/test-http2-info-headers-errors.js
@@ -73,7 +73,6 @@ function runTest(test) {
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     name: 'Error',
-    message: 'Stream closed with error code NGHTTP2_INTERNAL_ERROR'
   }));
 
   req.on('close', common.mustCall(() => {

--- a/test/parallel/test-http2-info-headers.js
+++ b/test/parallel/test-http2-info-headers.js
@@ -11,25 +11,18 @@ const server = h2.createServer();
 // We use the lower-level API here
 server.on('stream', common.mustCall(onStream));
 
-const status101regex =
-  /^HTTP status code 101 \(Switching Protocols\) is forbidden in HTTP\/2$/;
-const afterRespondregex =
-  /^Cannot specify additional headers after response initiated$/;
-
 function onStream(stream, headers, flags) {
 
   assert.throws(() => stream.additionalHeaders({ ':status': 201 }),
                 {
                   code: 'ERR_HTTP2_INVALID_INFO_STATUS',
                   name: 'RangeError',
-                  message: /^Invalid informational status code: 201$/
                 });
 
   assert.throws(() => stream.additionalHeaders({ ':status': 101 }),
                 {
                   code: 'ERR_HTTP2_STATUS_101',
                   name: 'Error',
-                  message: status101regex
                 });
 
   assert.throws(
@@ -37,7 +30,6 @@ function onStream(stream, headers, flags) {
     {
       code: 'ERR_HTTP2_INVALID_PSEUDOHEADER',
       name: 'TypeError',
-      message: '":method" is an invalid pseudoheader or is used incorrectly'
     }
   );
 
@@ -54,7 +46,6 @@ function onStream(stream, headers, flags) {
                 {
                   code: 'ERR_HTTP2_HEADERS_AFTER_RESPOND',
                   name: 'Error',
-                  message: afterRespondregex
                 });
 
   stream.end('hello world');

--- a/test/parallel/test-http2-invalidargtypes-errors.js
+++ b/test/parallel/test-http2-invalidargtypes-errors.js
@@ -14,8 +14,6 @@ server.on('stream', common.mustCall((stream) => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "code" argument must be of type number. ' +
-               "Received type string ('string')"
     }
   );
   assert.throws(
@@ -23,8 +21,6 @@ server.on('stream', common.mustCall((stream) => {
     {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "code" is out of range. It must be an integer. ' +
-               'Received 1.01'
     }
   );
   [-1, 2 ** 32].forEach((code) => {
@@ -33,9 +29,6 @@ server.on('stream', common.mustCall((stream) => {
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "code" is out of range. ' +
-                 'It must be >= 0 && <= 4294967295. ' +
-                 `Received ${code}`
       }
     );
   });

--- a/test/parallel/test-http2-max-concurrent-streams.js
+++ b/test/parallel/test-http2-max-concurrent-streams.js
@@ -50,7 +50,6 @@ server.listen(0, common.mustCall(() => {
     req.on('error', common.expectsError({
       code: 'ERR_HTTP2_STREAM_ERROR',
       name: 'Error',
-      message: 'Stream closed with error code NGHTTP2_REFUSED_STREAM'
     }));
   }
 }));

--- a/test/parallel/test-http2-misbehaving-flow-control-paused.js
+++ b/test/parallel/test-http2-misbehaving-flow-control-paused.js
@@ -63,7 +63,6 @@ server.on('stream', (stream) => {
   stream.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     name: 'Error',
-    message: 'Stream closed with error code NGHTTP2_FLOW_CONTROL_ERROR'
   }));
   stream.on('close', common.mustCall(() => {
     server.close();

--- a/test/parallel/test-http2-misbehaving-flow-control.js
+++ b/test/parallel/test-http2-misbehaving-flow-control.js
@@ -69,7 +69,6 @@ server.on('stream', (stream) => {
   stream.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     name: 'Error',
-    message: 'Stream closed with error code NGHTTP2_FLOW_CONTROL_ERROR'
   }));
   stream.on('close', common.mustCall(() => {
     server.close(common.mustCall());

--- a/test/parallel/test-http2-misbehaving-multiplex.js
+++ b/test/parallel/test-http2-misbehaving-multiplex.js
@@ -32,7 +32,6 @@ server.on('stream', common.mustCall((stream) => {
         common.expectsError({
           constructor: NghttpError,
           code: 'ERR_HTTP2_ERROR',
-          message: 'Stream was already closed or invalid'
         });
         return;
       }
@@ -50,7 +49,6 @@ server.on('session', common.mustCall((session) => {
   session.on('error', common.expectsError({
     code: 'ERR_HTTP2_ERROR',
     constructor: NghttpError,
-    message: 'Stream was already closed or invalid'
   }));
 }));
 

--- a/test/parallel/test-http2-misc-util.js
+++ b/test/parallel/test-http2-misc-util.js
@@ -25,7 +25,6 @@ assert.throws(
   {
     code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
     name: 'RangeError',
-    message: 'Invalid value for setting "test": -1'
   });
 
 assertWithinRange('test', 1);
@@ -35,8 +34,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "test" argument must be of type object. Received ' +
-             "type string ('foo')"
   });
 
 assert.throws(
@@ -44,8 +41,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "test" argument must be an instance of Date. Received type ' +
-             "string ('foo')"
   });
 
 assertIsObject({}, 'test');

--- a/test/parallel/test-http2-multi-content-length.js
+++ b/test/parallel/test-http2-multi-content-length.js
@@ -33,7 +33,6 @@ server.listen(0, common.mustCall(() => {
     }, {
       code: 'ERR_HTTP2_HEADER_SINGLE_VALUE',
       name: 'TypeError',
-      message: 'Header field "content-length" must only have a single value'
     }
   );
 
@@ -59,7 +58,6 @@ server.listen(0, common.mustCall(() => {
     req.on('error', common.expectsError({
       code: 'ERR_HTTP2_STREAM_ERROR',
       name: 'Error',
-      message: 'Stream closed with error code NGHTTP2_PROTOCOL_ERROR'
     }));
   }
 }));

--- a/test/parallel/test-http2-no-more-streams.js
+++ b/test/parallel/test-http2-no-more-streams.js
@@ -44,8 +44,6 @@ server.listen(0, common.mustCall(() => {
       req.on('error', common.expectsError({
         code: 'ERR_HTTP2_OUT_OF_STREAMS',
         name: 'Error',
-        message:
-          'No stream ID is available because maximum stream ID has been reached'
       }));
       req.on('error', () => countdown.dec());
     }

--- a/test/parallel/test-http2-options-max-headers-block-length.js
+++ b/test/parallel/test-http2-options-max-headers-block-length.js
@@ -38,6 +38,5 @@ server.listen(0, common.mustCall(() => {
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     name: 'Error',
-    message: 'Stream closed with error code NGHTTP2_FRAME_SIZE_ERROR'
   }));
 }));

--- a/test/parallel/test-http2-options-max-headers-exceeds-nghttp2.js
+++ b/test/parallel/test-http2-options-max-headers-exceeds-nghttp2.js
@@ -25,7 +25,6 @@ server.listen(0, common.mustCall(() => {
   client.on('error', common.expectsError({
     code: 'ERR_HTTP2_SESSION_ERROR',
     name: 'Error',
-    message: 'Session closed with error code 9'
   }));
 
   const req = client.request({
@@ -42,7 +41,6 @@ server.listen(0, common.mustCall(() => {
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_SESSION_ERROR',
     name: 'Error',
-    message: 'Session closed with error code 9'
   }));
   req.end();
 }));

--- a/test/parallel/test-http2-ping-unsolicited-ack.js
+++ b/test/parallel/test-http2-ping-unsolicited-ack.js
@@ -19,7 +19,6 @@ server.on('stream', common.mustNotCall());
 server.on('session', common.mustCall((session) => {
   session.on('error', common.expectsError({
     code: 'ERR_HTTP2_ERROR',
-    message: 'Protocol error'
   }));
   session.on('close', common.mustCall(() => server.close()));
 }));

--- a/test/parallel/test-http2-ping.js
+++ b/test/parallel/test-http2-ping.js
@@ -76,7 +76,6 @@ server.listen(0, common.mustCall(() => {
     assert(!client.ping(common.expectsError({
       code: 'ERR_HTTP2_PING_CANCEL',
       name: 'Error',
-      message: 'HTTP2 ping cancelled'
     })));
 
     // Should throw if payload is not of type ArrayBufferView
@@ -87,9 +86,6 @@ server.listen(0, common.mustCall(() => {
           {
             name: 'TypeError',
             code: 'ERR_INVALID_ARG_TYPE',
-            message: 'The "payload" argument must be an instance of Buffer, ' +
-                     'TypedArray, or DataView.' +
-                     common.invalidArgTypeHelper(payload)
           }
         )
       );
@@ -105,7 +101,6 @@ server.listen(0, common.mustCall(() => {
           {
             name: 'RangeError',
             code: 'ERR_HTTP2_PING_LENGTH',
-            message: 'HTTP2 ping payload must be 8 bytes'
           }
         )
       );

--- a/test/parallel/test-http2-respond-errors.js
+++ b/test/parallel/test-http2-respond-errors.js
@@ -23,7 +23,6 @@ server.on('stream', common.mustCall((stream) => {
     {
       name: 'Error',
       code: 'ERR_HTTP2_HEADERS_SENT',
-      message: 'Response has already been initiated.'
     }
   );
 
@@ -34,7 +33,6 @@ server.on('stream', common.mustCall((stream) => {
     {
       name: 'Error',
       code: 'ERR_HTTP2_INVALID_STREAM',
-      message: 'The stream has been destroyed'
     }
   );
 }));

--- a/test/parallel/test-http2-respond-file-204.js
+++ b/test/parallel/test-http2-respond-file-204.js
@@ -24,7 +24,6 @@ server.on('stream', (stream) => {
   }, {
     code: 'ERR_HTTP2_PAYLOAD_FORBIDDEN',
     name: 'Error',
-    message: 'Responses with 204 status must not have a payload'
   });
   stream.respond({});
   stream.end();

--- a/test/parallel/test-http2-respond-file-404.js
+++ b/test/parallel/test-http2-respond-file-404.js
@@ -21,7 +21,6 @@ server.on('stream', (stream) => {
       common.expectsError({
         code: 'ENOENT',
         name: 'Error',
-        message: `ENOENT: no such file or directory, open '${file}'`
       })(err);
 
       stream.respond({ ':status': 404 });

--- a/test/parallel/test-http2-respond-file-error-dir.js
+++ b/test/parallel/test-http2-respond-file-error-dir.js
@@ -15,7 +15,6 @@ server.on('stream', (stream) => {
       common.expectsError({
         code: 'ERR_HTTP2_SEND_FILE',
         name: 'Error',
-        message: 'Directories cannot be sent'
       })(err);
 
       stream.respond({ ':status': 404 });

--- a/test/parallel/test-http2-respond-file-error-pipe-offset.js
+++ b/test/parallel/test-http2-respond-file-error-pipe-offset.js
@@ -31,7 +31,6 @@ server.on('stream', (stream) => {
       common.expectsError({
         code: 'ERR_HTTP2_SEND_FILE_NOSEEK',
         name: 'Error',
-        message: 'Offset or length can only be specified for regular files'
       })(err);
 
       stream.respond({ ':status': 404 });

--- a/test/parallel/test-http2-respond-file-errors.js
+++ b/test/parallel/test-http2-respond-file-errors.js
@@ -6,7 +6,6 @@ if (!common.hasCrypto)
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const http2 = require('http2');
-const { inspect } = require('util');
 
 const optionsWithTypeError = {
   offset: 'number',
@@ -46,8 +45,6 @@ server.on('stream', common.mustCall((stream) => {
         {
           name: 'TypeError',
           code: 'ERR_INVALID_ARG_VALUE',
-          message: `The property 'options.${option}' is invalid. ` +
-            `Received ${inspect(types[type])}`
         }
       );
     });
@@ -61,7 +58,6 @@ server.on('stream', common.mustCall((stream) => {
     }),
     {
       code: 'ERR_HTTP2_PAYLOAD_FORBIDDEN',
-      message: `Responses with ${status} status must not have a payload`
     }
   ));
 
@@ -73,7 +69,6 @@ server.on('stream', common.mustCall((stream) => {
     }),
     {
       code: 'ERR_HTTP2_HEADERS_SENT',
-      message: 'Response has already been initiated.'
     }
   );
 
@@ -85,7 +80,6 @@ server.on('stream', common.mustCall((stream) => {
     }),
     {
       code: 'ERR_HTTP2_INVALID_STREAM',
-      message: 'The stream has been destroyed'
     }
   );
 }));

--- a/test/parallel/test-http2-respond-file-fd-errors.js
+++ b/test/parallel/test-http2-respond-file-fd-errors.js
@@ -7,7 +7,6 @@ const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const http2 = require('http2');
 const fs = require('fs');
-const { inspect } = require('util');
 
 const optionsWithTypeError = {
   offset: 'number',
@@ -44,8 +43,6 @@ server.on('stream', common.mustCall((stream) => {
       {
         name: 'TypeError',
         code: 'ERR_INVALID_ARG_TYPE',
-        message: 'The "fd" argument must be of type number or an instance of' +
-                 ` FileHandle.${common.invalidArgTypeHelper(types[type])}`
       }
     );
   });
@@ -66,8 +63,6 @@ server.on('stream', common.mustCall((stream) => {
         {
           name: 'TypeError',
           code: 'ERR_INVALID_ARG_VALUE',
-          message: `The property 'options.${option}' is invalid. ` +
-            `Received ${inspect(types[type])}`
         }
       );
     });
@@ -82,7 +77,6 @@ server.on('stream', common.mustCall((stream) => {
     {
       code: 'ERR_HTTP2_PAYLOAD_FORBIDDEN',
       name: 'Error',
-      message: `Responses with ${status} status must not have a payload`
     }
   ));
 
@@ -95,7 +89,6 @@ server.on('stream', common.mustCall((stream) => {
     {
       code: 'ERR_HTTP2_HEADERS_SENT',
       name: 'Error',
-      message: 'Response has already been initiated.'
     }
   );
 
@@ -108,7 +101,6 @@ server.on('stream', common.mustCall((stream) => {
     {
       code: 'ERR_HTTP2_INVALID_STREAM',
       name: 'Error',
-      message: 'The stream has been destroyed'
     }
   );
 }));

--- a/test/parallel/test-http2-respond-file-fd-invalid.js
+++ b/test/parallel/test-http2-respond-file-fd-invalid.js
@@ -15,7 +15,6 @@ const {
 const errorCheck = common.expectsError({
   code: 'ERR_HTTP2_STREAM_ERROR',
   name: 'Error',
-  message: 'Stream closed with error code NGHTTP2_INTERNAL_ERROR'
 }, 2);
 
 const server = http2.createServer();

--- a/test/parallel/test-http2-respond-nghttperrors.js
+++ b/test/parallel/test-http2-respond-nghttperrors.js
@@ -81,7 +81,6 @@ function runTest(test) {
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     name: 'Error',
-    message: 'Stream closed with error code NGHTTP2_INTERNAL_ERROR'
   }));
   req.on('end', common.mustNotCall());
 

--- a/test/parallel/test-http2-respond-with-fd-errors.js
+++ b/test/parallel/test-http2-respond-with-fd-errors.js
@@ -89,7 +89,6 @@ function runTest(test) {
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     name: 'Error',
-    message: 'Stream closed with error code NGHTTP2_INTERNAL_ERROR'
   }));
   req.on('end', common.mustNotCall());
 

--- a/test/parallel/test-http2-server-http1-client.js
+++ b/test/parallel/test-http2-server-http1-client.js
@@ -17,7 +17,6 @@ server.on('session', common.mustCall((session) => {
   session.on('error', common.expectsError({
     code: 'ERR_HTTP2_ERROR',
     constructor: NghttpError,
-    message: 'Received bad client magic byte string'
   }));
 }));
 

--- a/test/parallel/test-http2-server-push-stream-errors-args.js
+++ b/test/parallel/test-http2-server-push-stream-errors-args.js
@@ -31,7 +31,6 @@ server.on('stream', common.mustCall((stream, headers) => {
     {
       code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
       name: 'TypeError',
-      message: 'HTTP/1 Connection specific headers are forbidden: "connection"'
     }
   );
 

--- a/test/parallel/test-http2-server-push-stream-head.js
+++ b/test/parallel/test-http2-server-push-stream-head.js
@@ -25,7 +25,6 @@ server.on('stream', common.mustCall((stream, headers) => {
       push.on('error', common.expectsError({
         name: 'Error',
         code: 'ERR_STREAM_WRITE_AFTER_END',
-        message: 'write after end'
       }));
       assert(!push.write('test'));
       stream.end('test');

--- a/test/parallel/test-http2-server-rst-stream.js
+++ b/test/parallel/test-http2-server-rst-stream.js
@@ -18,10 +18,10 @@ const {
 const tests = [
   [NGHTTP2_NO_ERROR, false],
   [NGHTTP2_NO_ERROR, false],
-  [NGHTTP2_PROTOCOL_ERROR, true, 'NGHTTP2_PROTOCOL_ERROR'],
+  [NGHTTP2_PROTOCOL_ERROR, true],
   [NGHTTP2_CANCEL, false],
-  [NGHTTP2_REFUSED_STREAM, true, 'NGHTTP2_REFUSED_STREAM'],
-  [NGHTTP2_INTERNAL_ERROR, true, 'NGHTTP2_INTERNAL_ERROR'],
+  [NGHTTP2_REFUSED_STREAM, true],
+  [NGHTTP2_INTERNAL_ERROR, true],
 ];
 
 const server = http2.createServer();
@@ -31,7 +31,6 @@ server.on('stream', (stream, headers) => {
     stream.on('error', common.expectsError({
       name: 'Error',
       code: 'ERR_HTTP2_STREAM_ERROR',
-      message: `Stream closed with error code ${test[2]}`
     }));
   }
   stream.close(headers.rstcode | 0);

--- a/test/parallel/test-http2-server-sessionerror.js
+++ b/test/parallel/test-http2-server-sessionerror.js
@@ -22,7 +22,6 @@ server.on('session', common.mustCall((session) => {
       server.on('error', common.mustNotCall());
       session.on('error', common.expectsError({
         name: 'Error',
-        message: 'test'
       }));
       session[kSocket].emit('error', new Error('test'));
       break;
@@ -46,14 +45,12 @@ server.listen(0, common.mustCall(() => {
   http2.connect(url)
     .on('error', common.expectsError({
       code: 'ERR_HTTP2_SESSION_ERROR',
-      message: 'Session closed with error code 2',
     }))
     .on('close', () => {
       server.removeAllListeners('error');
       http2.connect(url)
         .on('error', common.expectsError({
           code: 'ERR_HTTP2_SESSION_ERROR',
-          message: 'Session closed with error code 2',
         }))
         .on('close', () => server.close());
     });

--- a/test/parallel/test-http2-server-shutdown-options-errors.js
+++ b/test/parallel/test-http2-server-shutdown-options-errors.js
@@ -20,14 +20,11 @@ server.on('stream', common.mustCall((stream) => {
   const session = stream.session;
 
   types.forEach((input) => {
-    const received = common.invalidArgTypeHelper(input);
     assert.throws(
       () => session.goaway(input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "code" argument must be of type number.' +
-                 received
       }
     );
     assert.throws(
@@ -35,8 +32,6 @@ server.on('stream', common.mustCall((stream) => {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "lastStreamID" argument must be of type number.' +
-                 received
       }
     );
     assert.throws(
@@ -44,8 +39,6 @@ server.on('stream', common.mustCall((stream) => {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "opaqueData" argument must be an instance of Buffer, ' +
-                 `TypedArray, or DataView.${received}`
       }
     );
   });

--- a/test/parallel/test-http2-server-stream-session-destroy.js
+++ b/test/parallel/test-http2-server-stream-session-destroy.js
@@ -22,7 +22,6 @@ server.on('stream', common.mustCall((stream) => {
   const invalidStreamError = {
     name: 'Error',
     code: 'ERR_HTTP2_INVALID_STREAM',
-    message: 'The stream has been destroyed'
   };
   assert.throws(() => stream.additionalHeaders(), invalidStreamError);
   assert.throws(() => stream.priority(), invalidStreamError);
@@ -40,7 +39,6 @@ server.on('stream', common.mustCall((stream) => {
   assert.strictEqual(stream.write('data', common.expectsError({
     name: 'Error',
     code: 'ERR_STREAM_WRITE_AFTER_END',
-    message: 'write after end'
   })), false);
 }));
 

--- a/test/parallel/test-http2-session-settings.js
+++ b/test/parallel/test-http2-session-settings.js
@@ -112,7 +112,6 @@ server.listen(
           {
             name: 'RangeError',
             code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
-            message: `Invalid value for setting "${i[0]}": ${i[1]}`
           }
         );
       });
@@ -124,7 +123,6 @@ server.listen(
           {
             name: 'TypeError',
             code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
-            message: `Invalid value for setting "enablePush": ${i}`
           }
         );
       });

--- a/test/parallel/test-http2-single-headers.js
+++ b/test/parallel/test-http2-single-headers.js
@@ -33,7 +33,6 @@ server.listen(0, common.mustCall(() => {
       {
         code: 'ERR_HTTP2_HEADER_SINGLE_VALUE',
         name: 'TypeError',
-        message: `Header field "${i}" must only have a single value`
       }
     );
 
@@ -42,7 +41,6 @@ server.listen(0, common.mustCall(() => {
       {
         code: 'ERR_HTTP2_HEADER_SINGLE_VALUE',
         name: 'TypeError',
-        message: `Header field "${i}" must only have a single value`
       }
     );
   });

--- a/test/parallel/test-http2-socket-proxy.js
+++ b/test/parallel/test-http2-socket-proxy.js
@@ -17,8 +17,6 @@ const { kTimeout } = require('internal/timers');
 const errMsg = {
   code: 'ERR_HTTP2_NO_SOCKET_MANIPULATION',
   name: 'Error',
-  message: 'HTTP/2 sockets should not be directly manipulated ' +
-           '(e.g. read and written)'
 };
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-status-code-invalid.js
+++ b/test/parallel/test-http2-status-code-invalid.js
@@ -8,11 +8,10 @@ const http2 = require('http2');
 
 const server = http2.createServer();
 
-function expectsError(code) {
+function expectsError() {
   return common.expectsError({
     code: 'ERR_HTTP2_STATUS_INVALID',
     name: 'RangeError',
-    message: `Invalid status code: ${code}`
   });
 }
 
@@ -20,7 +19,7 @@ server.on('stream', common.mustCall((stream) => {
 
   // Anything lower than 100 and greater than 599 is rejected
   [ 99, 700, 1000 ].forEach((i) => {
-    assert.throws(() => stream.respond({ ':status': i }), expectsError(i));
+    assert.throws(() => stream.respond({ ':status': i }), expectsError());
   });
 
   stream.respond();

--- a/test/parallel/test-http2-timeouts.js
+++ b/test/parallel/test-http2-timeouts.js
@@ -21,9 +21,6 @@ server.on('stream', common.mustCall((stream) => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message:
-        'The "msecs" argument must be of type number. Received type string' +
-        " ('100')"
     }
   );
   assert.throws(

--- a/test/parallel/test-http2-too-large-headers.js
+++ b/test/parallel/test-http2-too-large-headers.js
@@ -21,7 +21,6 @@ for (const prototype of ['maxHeaderListSize', 'maxHeaderSize']) {
       req.on('error', common.expectsError({
         code: 'ERR_HTTP2_STREAM_ERROR',
         name: 'Error',
-        message: 'Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM'
       }));
       req.on('close', common.mustCall(() => {
         assert.strictEqual(req.rstCode, NGHTTP2_ENHANCE_YOUR_CALM);

--- a/test/parallel/test-http2-too-many-headers.js
+++ b/test/parallel/test-http2-too-many-headers.js
@@ -23,7 +23,6 @@ server.listen(0, common.mustCall(() => {
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     name: 'Error',
-    message: 'Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM'
   }));
   req.on('close', common.mustCall(() => {
     assert.strictEqual(req.rstCode, NGHTTP2_ENHANCE_YOUR_CALM);

--- a/test/parallel/test-http2-too-many-settings.js
+++ b/test/parallel/test-http2-too-many-settings.js
@@ -31,7 +31,6 @@ function doTest(session) {
     const client = h2.connect(`http://localhost:${server.address().port}`);
     client.on('error', common.expectsError({
       code: 'ERR_HTTP2_SESSION_ERROR',
-      message: 'Session closed with error code 2',
     }));
     client.on('close', common.mustCall(() => server.close()));
   }));

--- a/test/parallel/test-http2-update-settings.js
+++ b/test/parallel/test-http2-update-settings.js
@@ -37,15 +37,12 @@ function testUpdateSettingsWith({ server, newServerSettings }) {
   assert.deepStrictEqual(updatedServerSettings, { ...oldServerSettings,
                                                   ...newServerSettings });
   assert.throws(() => server.updateSettings(''), {
-    message: 'The "settings" argument must be of type object. ' +
-    'Received type string (\'\')',
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError'
   });
   assert.throws(() => server.updateSettings({
     'maxHeaderListSize': 'foo'
   }), {
-    message: 'Invalid value for setting "maxHeaderListSize": foo',
     code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
     name: 'RangeError'
   });

--- a/test/parallel/test-http2-util-assert-valid-pseudoheader.js
+++ b/test/parallel/test-http2-util-assert-valid-pseudoheader.js
@@ -20,5 +20,4 @@ mapToHeaders({ ':method': 'a' });
 assert.throws(() => mapToHeaders({ ':foo': 'a' }), {
   code: 'ERR_HTTP2_INVALID_PSEUDOHEADER',
   name: 'TypeError',
-  message: '":foo" is an invalid pseudoheader or is used incorrectly'
 });

--- a/test/parallel/test-http2-util-asserts.js
+++ b/test/parallel/test-http2-util-asserts.js
@@ -1,7 +1,6 @@
 // Flags: --expose-internals
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 const {
   assertIsObject,
@@ -31,8 +30,6 @@ const {
     () => assertIsObject(input, 'foo', 'Object'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "foo" argument must be of type object.' +
-                common.invalidArgTypeHelper(input)
     });
 });
 
@@ -41,5 +38,4 @@ assertWithinRange('foo', 1, 0, 2);
 assert.throws(() => assertWithinRange('foo', 1, 2, 3),
               {
                 code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
-                message: 'Invalid value for setting "foo": 1'
               });

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -184,7 +184,6 @@ const {
   assert.throws(() => mapToHeaders(headers), {
     code: 'ERR_HTTP2_HEADER_SINGLE_VALUE',
     name: 'TypeError',
-    message: 'Header field ":status" must only have a single value'
   });
 }
 
@@ -247,10 +246,8 @@ const {
   HTTP2_HEADER_USER_AGENT,
   HTTP2_HEADER_X_CONTENT_TYPE_OPTIONS,
 ].forEach((name) => {
-  const msg = `Header field "${name}" must only have a single value`;
   assert.throws(() => mapToHeaders({ [name]: [1, 2, 3] }), {
     code: 'ERR_HTTP2_HEADER_SINGLE_VALUE',
-    message: msg
   });
 });
 
@@ -307,24 +304,18 @@ const {
   assert.throws(() => mapToHeaders({ [name]: 'abc' }), {
     code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
     name: 'TypeError',
-    message: 'HTTP/1 Connection specific headers are forbidden: ' +
-             `"${name.toLowerCase()}"`
   });
 });
 
 assert.throws(() => mapToHeaders({ [HTTP2_HEADER_TE]: ['abc'] }), {
   code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
   name: 'TypeError',
-  message: 'HTTP/1 Connection specific headers are forbidden: ' +
-           `"${HTTP2_HEADER_TE}"`
 });
 
 assert.throws(
   () => mapToHeaders({ [HTTP2_HEADER_TE]: ['abc', 'trailers'] }), {
     code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
     name: 'TypeError',
-    message: 'HTTP/1 Connection specific headers are forbidden: ' +
-             `"${HTTP2_HEADER_TE}"`
   });
 
 // These should not throw

--- a/test/parallel/test-http2-util-nghttp2error.js
+++ b/test/parallel/test-http2-util-nghttp2error.js
@@ -12,7 +12,6 @@ throws(() => {
 }, {
   code: 'ERR_HTTP2_ERROR',
   constructor: NghttpError,
-  message: 'Invalid argument'
 });
 
 // Should convert the NghttpError object to string properly

--- a/test/parallel/test-https-insecure-parse-per-stream.js
+++ b/test/parallel/test-https-insecure-parse-per-stream.js
@@ -124,8 +124,6 @@ const certFixture = {
     () => https.request({ insecureHTTPParser: 0 }, common.mustNotCall()),
     common.expectsError({
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "options.insecureHTTPParser" property must be of' +
-      ' type boolean. Received type number (0)'
     })
   );
 }

--- a/test/parallel/test-https-options-boolean-check.js
+++ b/test/parallel/test-https-options-boolean-check.js
@@ -67,7 +67,7 @@ const caArrDataView = toDataView(caCert);
 });
 
 // Checks to ensure https.createServer predictably throws an error
-// Format ['key', 'cert', 'expected message']
+// Format ['key', 'cert']
 [
   [true, certBuff],
   [true, certStr],
@@ -77,20 +77,16 @@ const caArrDataView = toDataView(caCert);
   [true, false],
   [{ pem: keyBuff }, false],
   [1, false],
-  [[keyBuff, true], [certBuff, certBuff2], 1],
-  [[true, keyStr2], [certStr, certStr2], 0],
-  [[true, false], [certBuff, certBuff2], 0],
+  [[keyBuff, true], [certBuff, certBuff2]],
+  [[true, keyStr2], [certStr, certStr2]],
+  [[true, false], [certBuff, certBuff2]],
   [true, [certBuff, certBuff2]],
-].forEach(([key, cert, index]) => {
-  const val = index === undefined ? key : key[index];
+].forEach(([key, cert]) => {
   assert.throws(() => {
     https.createServer({ key, cert });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.key" property must be of type string or an ' +
-             'instance of Buffer, TypedArray, or DataView.' +
-             common.invalidArgTypeHelper(val)
   });
 });
 
@@ -103,20 +99,16 @@ const caArrDataView = toDataView(caCert);
   [false, true],
   [false, { pem: keyBuff }],
   [false, 1],
-  [[keyBuff, keyBuff2], [true, certBuff2], 0],
-  [[keyStr, keyStr2], [certStr, true], 1],
-  [[keyStr, keyStr2], [true, false], 0],
+  [[keyBuff, keyBuff2], [true, certBuff2]],
+  [[keyStr, keyStr2], [certStr, true]],
+  [[keyStr, keyStr2], [true, false]],
   [[keyStr, keyStr2], true],
-].forEach(([key, cert, index]) => {
-  const val = index === undefined ? cert : cert[index];
+].forEach(([key, cert]) => {
   assert.throws(() => {
     https.createServer({ key, cert });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.cert" property must be of type string or an ' +
-             'instance of Buffer, TypedArray, or DataView.' +
-             common.invalidArgTypeHelper(val)
   });
 });
 
@@ -141,16 +133,12 @@ const caArrDataView = toDataView(caCert);
   [keyBuff, certBuff, {}],
   [keyBuff, certBuff, 1],
   [keyBuff, certBuff, true],
-  [keyBuff, certBuff, [caCert, true], 1],
-].forEach(([key, cert, ca, index]) => {
-  const val = index === undefined ? ca : ca[index];
+  [keyBuff, certBuff, [caCert, true]],
+].forEach(([key, cert, ca]) => {
   assert.throws(() => {
     https.createServer({ key, cert, ca });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.ca" property must be of type string or an instance' +
-             ' of Buffer, TypedArray, or DataView.' +
-             common.invalidArgTypeHelper(val)
   });
 });

--- a/test/parallel/test-https-timeout.js
+++ b/test/parallel/test-https-timeout.js
@@ -52,7 +52,6 @@ const server = https.createServer(options, function() {
   });
 
   req.on('error', common.expectsError({
-    message: 'socket hang up',
     code: 'ECONNRESET',
     name: 'Error'
   }));

--- a/test/parallel/test-icu-punycode.js
+++ b/test/parallel/test-icu-punycode.js
@@ -43,7 +43,6 @@ const fixtures = require('../fixtures/icu-punycode-toascii.json');
         {
           code: 'ERR_INVALID_ARG_VALUE',
           name: 'TypeError',
-          message: 'Cannot convert name to ASCII'
         }
       );
       icu.toASCII(input, true); // Should not throw.

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -46,8 +46,6 @@ assert.throws(
   {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "source" argument must be an instance of Buffer ' +
-             'or Uint8Array. Received null'
   }
 );
 

--- a/test/parallel/test-inspector-module.js
+++ b/test/parallel/test-inspector-module.js
@@ -14,7 +14,6 @@ assert.throws(
   {
     code: 'ERR_INSPECTOR_NOT_CONNECTED',
     name: 'Error',
-    message: 'Session is not connected'
   }
 );
 
@@ -27,9 +26,6 @@ session.post('Runtime.evaluate', { expression: '2 + 2' });
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message:
-        'The "method" argument must be of type string.' +
-        common.invalidArgTypeHelper(i)
     }
   );
 });
@@ -40,9 +36,6 @@ session.post('Runtime.evaluate', { expression: '2 + 2' });
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message:
-        'The "params" argument must be of type object.' +
-        common.invalidArgTypeHelper(i)
     }
   );
 });
@@ -62,7 +55,6 @@ assert.throws(
   {
     code: 'ERR_INSPECTOR_ALREADY_CONNECTED',
     name: 'Error',
-    message: 'The inspector session is already connected'
   }
 );
 

--- a/test/parallel/test-internal-module-require.js
+++ b/test/parallel/test-internal-module-require.js
@@ -83,7 +83,6 @@ if (process.argv[2] === 'child') {
           require(id);
         }, {
           code: 'MODULE_NOT_FOUND',
-          message: `Cannot find module '${id}'`
         });
       } else {
         require(id);

--- a/test/parallel/test-internal-socket-list-send.js
+++ b/test/parallel/test-internal-socket-list-send.js
@@ -20,7 +20,6 @@ const key = 'test-key';
     common.expectsError({
       code: 'ERR_CHILD_CLOSED_BEFORE_REPLY',
       name: 'Error',
-      message: 'Child closed before reply received'
     })(err);
     assert.strictEqual(child.listenerCount('internalMessage'), 0);
   }));
@@ -62,7 +61,6 @@ const key = 'test-key';
     common.expectsError({
       code: 'ERR_CHILD_CLOSED_BEFORE_REPLY',
       name: 'Error',
-      message: 'Child closed before reply received'
     })(err);
     assert.strictEqual(child.listenerCount('internalMessage'), 0);
   }));
@@ -141,7 +139,6 @@ const key = 'test-key';
     common.expectsError({
       code: 'ERR_CHILD_CLOSED_BEFORE_REPLY',
       name: 'Error',
-      message: 'Child closed before reply received'
     })(err);
     assert.strictEqual(child.listenerCount('internalMessage'), 0);
   }));

--- a/test/parallel/test-internal-validators-validateoneof.js
+++ b/test/parallel/test-internal-validators-validateoneof.js
@@ -10,8 +10,6 @@ const { validateOneOf } = require('internal/validators');
   const allowed = [2, 3];
   assert.throws(() => validateOneOf(1, 'name', allowed), {
     code: 'ERR_INVALID_ARG_VALUE',
-    // eslint-disable-next-line quotes
-    message: `The argument 'name' must be one of: 2, 3. Received 1`
   });
 }
 
@@ -25,8 +23,6 @@ const { validateOneOf } = require('internal/validators');
   const allowed = ['b', 'c'];
   assert.throws(() => validateOneOf('a', 'name', allowed), {
     code: 'ERR_INVALID_ARG_VALUE',
-    // eslint-disable-next-line quotes
-    message: `The argument 'name' must be one of: 'b', 'c'. Received 'a'`
   });
 }
 
@@ -40,9 +36,6 @@ const { validateOneOf } = require('internal/validators');
   const allowed = [Symbol.for('b'), Symbol.for('c')];
   assert.throws(() => validateOneOf(Symbol.for('a'), 'name', allowed), {
     code: 'ERR_INVALID_ARG_VALUE',
-    // eslint-disable-next-line quotes
-    message: `The argument 'name' must be one of: Symbol(b), Symbol(c). ` +
-      'Received Symbol(a)'
   });
 }
 

--- a/test/parallel/test-loaders-hidden-from-users.js
+++ b/test/parallel/test-loaders-hidden-from-users.js
@@ -10,7 +10,6 @@ assert.throws(
     require('internal/bootstrap/loaders');
   }, {
     code: 'MODULE_NOT_FOUND',
-    message: /Cannot find module 'internal\/bootstrap\/loaders'/
   }
 );
 
@@ -22,6 +21,5 @@ assert.throws(
     require('owo');
   }, {
     code: 'MODULE_NOT_FOUND',
-    message: /Cannot find module 'owo'/
   }
 );

--- a/test/parallel/test-loaders-unknown-builtin-module.mjs
+++ b/test/parallel/test-loaders-unknown-builtin-module.mjs
@@ -7,6 +7,5 @@ const unknownBuiltinModule = 'node:unknown-builtin-module';
 import(unknownBuiltinModule)
 .then(assert.fail, expectsError({
   code: 'ERR_UNKNOWN_BUILTIN_MODULE',
-  message: `No such built-in module: ${unknownBuiltinModule}`
 }))
 .then(mustCall());

--- a/test/parallel/test-module-create-require.js
+++ b/test/parallel/test-module-create-require.js
@@ -28,6 +28,4 @@ assert.throws(() => {
   createRequire({});
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
-  message: 'The argument \'filename\' must be a file URL object, file URL ' +
-           'string, or absolute path string. Received {}'
 });

--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -64,14 +64,12 @@ assert.throws(
   }
 );
 
-const re = /^The "id" argument must be of type string\. Received /;
 [1, false, null, undefined, {}].forEach((value) => {
   assert.throws(
     () => { require(value); },
     {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message: re
     });
 });
 
@@ -81,13 +79,11 @@ assert.throws(
   {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_VALUE',
-    message: 'The argument \'id\' must be a non-empty string. Received \'\''
   });
 
 assert.throws(
   () => { require('../fixtures/packages/is-dir'); },
   {
     code: 'MODULE_NOT_FOUND',
-    message: /Cannot find module '\.\.\/fixtures\/packages\/is-dir'/
   }
 );

--- a/test/parallel/test-net-better-error-messages-path.js
+++ b/test/parallel/test-net-better-error-messages-path.js
@@ -10,7 +10,6 @@ const net = require('net');
   c.on('connect', common.mustNotCall());
   c.on('error', common.expectsError({
     code: 'ENOENT',
-    message: `connect ENOENT ${fp}`
   }));
 }
 

--- a/test/parallel/test-net-better-error-messages-port-hostname.js
+++ b/test/parallel/test-net-better-error-messages-port-hostname.js
@@ -30,7 +30,6 @@ c.on('error', common.mustCall((error) => {
     errno: mockedErrorCode,
     code: mockedErrorCode,
     name: 'Error',
-    message: 'getaddrinfo ENOTFOUND something.invalid',
     hostname: addresses.INVALID_HOST,
     syscall: 'getaddrinfo'
   });

--- a/test/parallel/test-net-connect-immediate-finish.js
+++ b/test/parallel/test-net-connect-immediate-finish.js
@@ -52,7 +52,6 @@ client.once('error', common.mustCall((error) => {
     errno: mockedErrorCode,
     syscall: mockedSysCall,
     hostname: addresses.INVALID_HOST,
-    message: 'getaddrinfo ENOTFOUND something.invalid'
   });
 }));
 

--- a/test/parallel/test-net-connect-no-arg.js
+++ b/test/parallel/test-net-connect-no-arg.js
@@ -10,26 +10,22 @@ assert.throws(() => {
   net.connect();
 }, {
   code: 'ERR_MISSING_ARGS',
-  message: 'The "options" or "port" or "path" argument must be specified',
 });
 
 assert.throws(() => {
   new net.Socket().connect();
 }, {
   code: 'ERR_MISSING_ARGS',
-  message: 'The "options" or "port" or "path" argument must be specified',
 });
 
 assert.throws(() => {
   net.connect({});
 }, {
   code: 'ERR_MISSING_ARGS',
-  message: 'The "options" or "port" or "path" argument must be specified',
 });
 
 assert.throws(() => {
   new net.Socket().connect({});
 }, {
   code: 'ERR_MISSING_ARGS',
-  message: 'The "options" or "port" or "path" argument must be specified',
 });

--- a/test/parallel/test-net-connect-options-invalid.js
+++ b/test/parallel/test-net-connect-options-invalid.js
@@ -14,14 +14,12 @@ const net = require('net');
       port: 8080,
       [invalidKey]: true
     };
-    const message = `The property 'options.${invalidKey}' is not supported. Received true`;
 
     assert.throws(() => {
       net.createConnection(option);
     }, {
       code: 'ERR_INVALID_ARG_VALUE',
       name: 'TypeError',
-      message: new RegExp(message)
     });
   });
 }

--- a/test/parallel/test-net-connect-options-port.js
+++ b/test/parallel/test-net-connect-options-port.js
@@ -66,7 +66,6 @@ const net = require('net');
     assert.throws(fn, {
       code: 'ERR_INVALID_ARG_VALUE',
       name: 'TypeError',
-      message: /The argument 'hints' is invalid\. Received \d+/
     });
   }
 }

--- a/test/parallel/test-net-options-lookup.js
+++ b/test/parallel/test-net-options-lookup.js
@@ -43,6 +43,5 @@ function connectDoesNotThrow(input) {
     code: 'ERR_INVALID_ADDRESS_FAMILY',
     host: 'localhost',
     port: 0,
-    message: 'Invalid address family: 100 localhost:0'
   }));
 }

--- a/test/parallel/test-net-server-listen-options.js
+++ b/test/parallel/test-net-server-listen-options.js
@@ -64,14 +64,12 @@ const listenOnPort = [
                     {
                       code: 'ERR_INVALID_ARG_VALUE',
                       name: 'TypeError',
-                      message: /^The argument 'options' must have the property "port" or "path"\. Received .+$/,
                     });
     } else {
       assert.throws(fn,
                     {
                       code: 'ERR_INVALID_ARG_VALUE',
                       name: 'TypeError',
-                      message: /^The argument 'options' is invalid\. Received .+$/,
                     });
     }
   }

--- a/test/parallel/test-net-socket-destroy-send.js
+++ b/test/parallel/test-net-socket-destroy-send.js
@@ -16,7 +16,6 @@ server.listen(0, common.mustCall(function() {
 
     conn.write(Buffer.from('kaboom'), common.expectsError({
       code: 'ERR_STREAM_DESTROYED',
-      message: 'Cannot call write after a stream was destroyed',
       name: 'Error'
     }));
     server.close();

--- a/test/parallel/test-net-socket-write-after-close.js
+++ b/test/parallel/test-net-socket-write-after-close.js
@@ -12,7 +12,6 @@ const net = require('net');
       client.on('error', common.mustCall((err) => {
         server.close();
         assert.strictEqual(err.constructor, Error);
-        assert.strictEqual(err.message, 'write EBADF');
       }));
       client._handle.close();
       client.write('foo');
@@ -28,7 +27,6 @@ const net = require('net');
     const client = net.connect({ port }, common.mustCall(() => {
       client.on('error', common.expectsError({
         code: 'ERR_SOCKET_CLOSED',
-        message: 'Socket is closed',
         name: 'Error'
       }));
 

--- a/test/parallel/test-net-write-after-end-nt.js
+++ b/test/parallel/test-net-write-after-end-nt.js
@@ -20,7 +20,6 @@ const server = net.createServer(mustCall((socket) => {
     client.on('end', mustCall(() => {
       const ret = client.write('hello', expectsError({
         code: 'EPIPE',
-        message: 'This socket has been ended by the other party',
         name: 'Error'
       }));
 

--- a/test/parallel/test-net-write-arguments.js
+++ b/test/parallel/test-net-write-arguments.js
@@ -11,7 +11,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_STREAM_NULL_VALUES',
   name: 'TypeError',
-  message: 'May not write null values to stream'
 });
 
 [
@@ -33,7 +32,5 @@ assert.throws(() => {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "chunk" argument must be of type string or an instance of ' +
-              `Buffer or Uint8Array.${common.invalidArgTypeHelper(value)}`
   });
 });

--- a/test/parallel/test-os-process-priority.js
+++ b/test/parallel/test-os-process-priority.js
@@ -27,7 +27,6 @@ assert.strictEqual(typeof PRIORITY_HIGHEST, 'number');
 [null, true, false, 'foo', {}, [], /x/].forEach((pid) => {
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "pid" argument must be of type number\./
   };
 
   assert.throws(() => {
@@ -43,7 +42,6 @@ assert.strictEqual(typeof PRIORITY_HIGHEST, 'number');
 [NaN, Infinity, -Infinity, 3.14, 2 ** 32].forEach((pid) => {
   const errObj = {
     code: 'ERR_OUT_OF_RANGE',
-    message: /The value of "pid" is out of range\./
   };
 
   assert.throws(() => {
@@ -61,7 +59,6 @@ assert.strictEqual(typeof PRIORITY_HIGHEST, 'number');
     os.setPriority(0, priority);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "priority" argument must be of type number\./
   });
 });
 
@@ -79,7 +76,6 @@ assert.strictEqual(typeof PRIORITY_HIGHEST, 'number');
     os.setPriority(0, priority);
   }, {
     code: 'ERR_OUT_OF_RANGE',
-    message: /The value of "priority" is out of range\./
   });
 });
 

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -20,7 +20,6 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 
@@ -219,8 +218,6 @@ function checkFormat(path, testCases) {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "pathObject" argument must be of type object.' +
-               common.invalidArgTypeHelper(pathObject)
     });
   });
 }

--- a/test/parallel/test-perf-hooks-resourcetiming.js
+++ b/test/parallel/test-perf-hooks-resourcetiming.js
@@ -64,7 +64,6 @@ function createTimingInfo({
 {
   assert.throws(() => new PerformanceResourceTiming(), {
     name: 'TypeError',
-    message: 'Illegal constructor',
     code: 'ERR_ILLEGAL_CONSTRUCTOR',
   });
 }

--- a/test/parallel/test-performance-function.js
+++ b/test/parallel/test-performance-function.js
@@ -70,7 +70,6 @@ const {
                   {
                     code: 'ERR_INVALID_ARG_TYPE',
                     name: 'TypeError',
-                    message: /The "fn" argument must be of type function/
                   });
   });
 }

--- a/test/parallel/test-performance-timeline.mjs
+++ b/test/parallel/test-performance-timeline.mjs
@@ -40,11 +40,9 @@ assert.strictEqual(performance.getEntriesByName(undefined).length, 1);
 assert.strictEqual(performance.getEntriesByType(undefined).length, 0);
 assert.throws(() => performance.getEntriesByName(), {
   name: 'TypeError',
-  message: 'The "name" argument must be specified',
   code: 'ERR_MISSING_ARGS'
 });
 assert.throws(() => performance.getEntriesByType(), {
   name: 'TypeError',
-  message: 'The "type" argument must be specified',
   code: 'ERR_MISSING_ARGS'
 });

--- a/test/parallel/test-performanceobserver.js
+++ b/test/parallel/test-performanceobserver.js
@@ -39,8 +39,6 @@ assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_HTTP2], 0);
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "options" argument must be of type object.' +
-                 common.invalidArgTypeHelper(input)
       });
   });
 

--- a/test/parallel/test-process-assert.js
+++ b/test/parallel/test-process-assert.js
@@ -14,12 +14,10 @@ assert.throws(() => {
 }, {
   code: 'ERR_ASSERTION',
   name: 'Error',
-  message: 'errorMessage'
 });
 assert.throws(() => {
   process.assert(false);
 }, {
   code: 'ERR_ASSERTION',
   name: 'Error',
-  message: 'assertion error'
 });

--- a/test/parallel/test-process-chdir-errormessage.js
+++ b/test/parallel/test-process-chdir-errormessage.js
@@ -12,7 +12,6 @@ assert.throws(
   {
     name: 'Error',
     code: 'ENOENT',
-    message: /ENOENT: no such file or directory, chdir .+ -> 'does-not-exist'/,
     path: process.cwd(),
     syscall: 'chdir',
     dest: 'does-not-exist'

--- a/test/parallel/test-process-chdir.js
+++ b/test/parallel/test-process-chdir.js
@@ -38,7 +38,6 @@ assert.strictEqual(process.cwd().normalize(),
 
 const err = {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: /The "directory" argument must be of type string/
 };
 assert.throws(function() { process.chdir({}); }, err);
 assert.throws(function() { process.chdir(); }, err);

--- a/test/parallel/test-process-cpuUsage.js
+++ b/test/parallel/test-process-cpuUsage.js
@@ -1,5 +1,4 @@
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 const result = process.cpuUsage();
 
@@ -38,8 +37,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "prevValue" argument must be of type object. ' +
-             'Received type number (1)'
   }
 );
 
@@ -54,8 +51,6 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "prevValue.user" property must be of type number.' +
-               common.invalidArgTypeHelper(value.user)
     }
   );
 });
@@ -69,8 +64,6 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "prevValue.system" property must be of type number.' +
-               common.invalidArgTypeHelper(value.system)
     }
   );
 });
@@ -85,8 +78,6 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_VALUE',
       name: 'RangeError',
-      message: "The property 'prevValue.user' is invalid. " +
-        `Received ${value.user}`,
     }
   );
 });
@@ -100,8 +91,6 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_VALUE',
       name: 'RangeError',
-      message: "The property 'prevValue.system' is invalid. " +
-        `Received ${value.system}`,
     }
   );
 });

--- a/test/parallel/test-process-env-ignore-getter-setter.js
+++ b/test/parallel/test-process-env-ignore-getter-setter.js
@@ -11,9 +11,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
     name: 'TypeError',
-    message: '\'process.env\' only accepts a ' +
-        'configurable, writable,' +
-        ' and enumerable data descriptor'
   }
 );
 
@@ -33,8 +30,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
     name: 'TypeError',
-    message: '\'process.env\' does not accept an' +
-        'accessor(getter/setter) descriptor'
   }
 );
 
@@ -50,9 +45,6 @@ attributes.forEach((attribute) => {
     {
       code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
       name: 'TypeError',
-      message: '\'process.env\' only accepts a ' +
-          'configurable, writable,' +
-          ' and enumerable data descriptor'
     }
   );
 });

--- a/test/parallel/test-process-euid-egid.js
+++ b/test/parallel/test-process-euid-egid.js
@@ -18,15 +18,12 @@ assert.throws(() => {
   process.seteuid({});
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "id" argument must be one of type number or string. ' +
-    'Received an instance of Object'
 });
 
 assert.throws(() => {
   process.seteuid('fhqwhgadshgnsdhjsdbkhsdabkfabkveyb');
 }, {
   code: 'ERR_UNKNOWN_CREDENTIAL',
-  message: 'User identifier does not exist: fhqwhgadshgnsdhjsdbkhsdabkfabkveyb'
 });
 
 // IBMi does not support below operations.

--- a/test/parallel/test-process-exception-capture-errors.js
+++ b/test/parallel/test-process-exception-capture-errors.js
@@ -7,8 +7,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "fn" argument must be of type function or null. ' +
-             'Received type number (42)'
   }
 );
 
@@ -19,6 +17,5 @@ assert.throws(
   {
     code: 'ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET',
     name: 'Error',
-    message: /setupUncaughtExceptionCapture.*called while a capture callback/
   }
 );

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -38,29 +38,24 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "time" argument must be an instance of Array. Received type ' +
-           'number (1)'
 });
 assert.throws(() => {
   process.hrtime([]);
 }, {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "time" is out of range. It must be 2. Received 0'
 });
 assert.throws(() => {
   process.hrtime([1]);
 }, {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "time" is out of range. It must be 2. Received 1'
 });
 assert.throws(() => {
   process.hrtime([1, 2, 3]);
 }, {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "time" is out of range. It must be 2. Received 3'
 });
 
 function validateTuple(tuple) {

--- a/test/parallel/test-process-initgroups.js
+++ b/test/parallel/test-process-initgroups.js
@@ -18,10 +18,6 @@ if (!common.isMainThread)
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message:
-        'The "user" argument must be ' +
-        'one of type number or string.' +
-        common.invalidArgTypeHelper(val)
     }
   );
 });
@@ -34,10 +30,6 @@ if (!common.isMainThread)
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message:
-        'The "extraGroup" argument must be ' +
-        'one of type number or string.' +
-        common.invalidArgTypeHelper(val)
     }
   );
 });
@@ -51,7 +43,5 @@ assert.throws(
   },
   {
     code: 'ERR_UNKNOWN_CREDENTIAL',
-    message:
-      'Group identifier does not exist: fhqwhgadshgnsdhjsdbkhsdabkfabkveyb'
   }
 );

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -20,7 +20,6 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 
 // Test variants of pid
@@ -42,8 +41,6 @@ const assert = require('assert');
   assert.throws(() => process.kill(val), {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "pid" argument must be of type number.' +
-             common.invalidArgTypeHelper(val)
   });
 });
 
@@ -51,14 +48,12 @@ const assert = require('assert');
 assert.throws(() => process.kill(0, 'test'), {
   code: 'ERR_UNKNOWN_SIGNAL',
   name: 'TypeError',
-  message: 'Unknown signal: test'
 });
 
 // Test that kill throws an error for invalid signal numbers
 assert.throws(() => process.kill(0, 987), {
   code: 'EINVAL',
   name: 'Error',
-  message: 'kill EINVAL'
 });
 
 // Test kill argument processing in valid cases.

--- a/test/parallel/test-process-setgroups.js
+++ b/test/parallel/test-process-setgroups.js
@@ -17,8 +17,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "groups" argument must be an instance of Array. ' +
-             'Received undefined'
   }
 );
 
@@ -40,9 +38,6 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "groups[0]" argument must be ' +
-               'one of type number or string.' +
-               common.invalidArgTypeHelper(val)
     }
   );
 });
@@ -51,5 +46,4 @@ assert.throws(() => {
   process.setgroups([1, 'fhqwhgadshgnsdhjsdbkhsdabkfabkveyb']);
 }, {
   code: 'ERR_UNKNOWN_CREDENTIAL',
-  message: 'Group identifier does not exist: fhqwhgadshgnsdhjsdbkhsdabkfabkveyb'
 });

--- a/test/parallel/test-process-uid-gid.js
+++ b/test/parallel/test-process-uid-gid.js
@@ -40,15 +40,12 @@ assert.throws(() => {
   process.setuid({});
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "id" argument must be one of type ' +
-    'number or string. Received an instance of Object'
 });
 
 assert.throws(() => {
   process.setuid('fhqwhgadshgnsdhjsdbkhsdabkfabkveyb');
 }, {
   code: 'ERR_UNKNOWN_CREDENTIAL',
-  message: 'User identifier does not exist: fhqwhgadshgnsdhjsdbkhsdabkfabkveyb'
 });
 
 // Passing -0 shouldn't crash the process

--- a/test/parallel/test-querystring-escape.js
+++ b/test/parallel/test-querystring-escape.js
@@ -18,7 +18,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_URI',
     name: 'URIError',
-    message: 'URI malformed'
   }
 );
 

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -297,7 +297,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_URI',
     name: 'URIError',
-    message: 'URI malformed'
   }
 );
 

--- a/test/parallel/test-readline-csi.js
+++ b/test/parallel/test-readline-csi.js
@@ -133,7 +133,6 @@ assert.throws(
   {
     name: 'TypeError',
     code: 'ERR_INVALID_CURSOR_POS',
-    message: 'Cannot set cursor row without setting its column'
   });
 assert.strictEqual(writable.data, '');
 

--- a/test/parallel/test-readline-input-onerror.js
+++ b/test/parallel/test-readline-input-onerror.js
@@ -21,7 +21,6 @@ const f = path.join(__dirname, 'file.txt');
 // catch-able SymbolAsyncIterator `errorListener` error
 processLineByLine_SymbolAsyncError(f).catch(common.expectsError({
   code: 'ENOENT',
-  message: `ENOENT: no such file or directory, open '${f}'`
 }));
 
 async function processLineByLine_InterfaceErrorEvent(filename) {
@@ -32,7 +31,6 @@ async function processLineByLine_InterfaceErrorEvent(filename) {
   });
   rl.on('error', common.expectsError({
     code: 'ENOENT',
-    message: `ENOENT: no such file or directory, open '${f}'`
   }));
 }
 

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -149,8 +149,6 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     }),
     {
       code: 'ERR_OUT_OF_RANGE',
-      message: 'The value of "tabSize" is out of range. ' +
-                'It must be an integer. Received 4.5'
     }
   );
 }

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -139,8 +139,6 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     }),
     {
       code: 'ERR_OUT_OF_RANGE',
-      message: 'The value of "tabSize" is out of range. ' +
-                'It must be an integer. Received 4.5'
     }
   );
 }

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -98,7 +98,6 @@ const r3 = () => repl.start({
 assert.throws(r3, {
   code: 'ERR_INVALID_REPL_EVAL_CONFIG',
   name: 'TypeError',
-  message: 'Cannot specify both "breakEvalOnSigint" and "eval" for REPL'
 });
 
 // 4, Verify that defaults are used when no arguments are provided

--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -17,7 +17,6 @@ m._initPaths();
 assert.throws(
   () => require('.'),
   {
-    message: /Cannot find module '\.'/,
     code: 'MODULE_NOT_FOUND'
   }
 );

--- a/test/parallel/test-require-json.js
+++ b/test/parallel/test-require-json.js
@@ -28,5 +28,4 @@ assert.throws(function() {
   require(fixtures.path('invalid.json'));
 }, {
   name: 'SyntaxError',
-  message: /test[/\\]fixtures[/\\]invalid\.json: /,
 });

--- a/test/parallel/test-require-mjs.js
+++ b/test/parallel/test-require-mjs.js
@@ -5,7 +5,6 @@ const assert = require('assert');
 assert.throws(
   () => require('../fixtures/es-modules/test-esm-ok.mjs'),
   {
-    message: /dynamic import\(\) which is available in all CommonJS modules/,
     code: 'ERR_REQUIRE_ESM'
   }
 );

--- a/test/parallel/test-require-node-prefix.js
+++ b/test/parallel/test-require-node-prefix.js
@@ -4,8 +4,6 @@ require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-const errUnknownBuiltinModuleRE = /^No such built-in module: /u;
-
 // For direct use of require expressions inside of CJS modules,
 // all kinds of specifiers should work without issue.
 {
@@ -16,7 +14,6 @@ const errUnknownBuiltinModuleRE = /^No such built-in module: /u;
     () => require('node:unknown'),
     {
       code: 'ERR_UNKNOWN_BUILTIN_MODULE',
-      message: errUnknownBuiltinModuleRE,
     },
   );
 
@@ -24,7 +21,6 @@ const errUnknownBuiltinModuleRE = /^No such built-in module: /u;
     () => require('node:internal/test/binding'),
     {
       code: 'ERR_UNKNOWN_BUILTIN_MODULE',
-      message: errUnknownBuiltinModuleRE,
     },
   );
 }

--- a/test/parallel/test-socket-options-invalid.js
+++ b/test/parallel/test-socket-options-invalid.js
@@ -13,7 +13,6 @@ const net = require('net');
     const option = {
       [invalidKey]: true
     };
-    const message = `The property 'options.${invalidKey}' is not supported. Received true`;
 
     assert.throws(() => {
       const socket = new net.Socket(option);
@@ -21,7 +20,6 @@ const net = require('net');
     }, {
       code: 'ERR_INVALID_ARG_VALUE',
       name: 'TypeError',
-      message: new RegExp(message)
     });
   });
 }

--- a/test/parallel/test-source-map-api.js
+++ b/test/parallel/test-source-map-api.js
@@ -1,7 +1,6 @@
 // Flags: --enable-source-maps
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 const { findSourceMap, SourceMap } = require('module');
 const { readFileSync } = require('fs');
@@ -14,8 +13,6 @@ const { readFileSync } = require('fs');
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "payload" argument must be of type object.' +
-               common.invalidArgTypeHelper(invalidArg)
       }
     )
   );

--- a/test/parallel/test-stream-base-typechecking.js
+++ b/test/parallel/test-stream-base-typechecking.js
@@ -10,7 +10,6 @@ const server = net.createServer().listen(0, common.mustCall(() => {
     }, {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'Second argument must be a buffer'
     });
     client.destroy();
     server.close();

--- a/test/parallel/test-stream-construct.js
+++ b/test/parallel/test-stream-construct.js
@@ -39,7 +39,6 @@ const assert = require('assert');
     })
   }).on('error', common.expectsError({
     name: 'Error',
-    message: 'test'
   }));
 }
 
@@ -52,7 +51,6 @@ const assert = require('assert');
     })
   }).on('error', common.expectsError({
     name: 'Error',
-    message: 'test'
   }));
 }
 
@@ -65,7 +63,6 @@ const assert = require('assert');
     })
   }).on('error', common.expectsError({
     name: 'Error',
-    message: 'test'
   }));
 }
 
@@ -78,7 +75,6 @@ const assert = require('assert');
     })
   }).on('error', common.expectsError({
     name: 'Error',
-    message: 'test'
   }));
 }
 

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -210,21 +210,18 @@ const http = require('http');
     () => finished(rs, 'foo'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /callback/
     }
   );
   assert.throws(
     () => finished(rs, 'foo', () => {}),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /options/
     }
   );
   assert.throws(
     () => finished(rs, {}, 'foo'),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /callback/
     }
   );
 

--- a/test/parallel/test-stream-inheritance.js
+++ b/test/parallel/test-stream-inheritance.js
@@ -53,7 +53,6 @@ assert.throws(
   {
     code: 'ERR_ASSERTION',
     constructor: assert.AssertionError,
-    message: 'undefined does not inherit from CustomWritable'
   }
 );
 

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -784,8 +784,6 @@ async function tests() {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "options" argument must be of type object. Received ' +
-                 'type number (42)',
       }
     );
   }

--- a/test/parallel/test-stream-readable-next-no-null.js
+++ b/test/parallel/test-stream-readable-next-no-null.js
@@ -11,7 +11,6 @@ const stream = Readable.from(generate());
 stream.on('error', expectsError({
   code: 'ERR_STREAM_NULL_VALUES',
   name: 'TypeError',
-  message: 'May not write null values to stream'
 }));
 
 stream.on('data', mustNotCall((chunk) => {}));

--- a/test/parallel/test-stream-readable-with-unimplemented-_read.js
+++ b/test/parallel/test-stream-readable-with-unimplemented-_read.js
@@ -8,6 +8,5 @@ readable.read();
 readable.on('error', common.expectsError({
   code: 'ERR_METHOD_NOT_IMPLEMENTED',
   name: 'Error',
-  message: 'The _read() method is not implemented'
 }));
 readable.on('close', common.mustCall());

--- a/test/parallel/test-stream-transform-callback-twice.js
+++ b/test/parallel/test-stream-transform-callback-twice.js
@@ -7,7 +7,6 @@ const stream = new Transform({
 
 stream.on('error', common.expectsError({
   name: 'Error',
-  message: 'Callback called multiple times',
   code: 'ERR_MULTIPLE_CALLBACK'
 }));
 

--- a/test/parallel/test-stream-transform-constructor-set-methods.js
+++ b/test/parallel/test-stream-transform-constructor-set-methods.js
@@ -13,7 +13,6 @@ assert.throws(
   {
     name: 'Error',
     code: 'ERR_METHOD_NOT_IMPLEMENTED',
-    message: 'The _transform() method is not implemented'
   }
 );
 

--- a/test/parallel/test-stream-transform-split-highwatermark.js
+++ b/test/parallel/test-stream-transform-split-highwatermark.js
@@ -69,8 +69,6 @@ testTransform(0, 0, {
   }, {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_VALUE',
-    message: "The property 'options.readableHighWaterMark' is invalid. " +
-      'Received NaN'
   });
 
   assert.throws(() => {
@@ -78,8 +76,6 @@ testTransform(0, 0, {
   }, {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_VALUE',
-    message: "The property 'options.writableHighWaterMark' is invalid. " +
-      'Received NaN'
   });
 }
 

--- a/test/parallel/test-stream-unshift-read-race.js
+++ b/test/parallel/test-stream-unshift-read-race.js
@@ -76,7 +76,6 @@ function pushError() {
   }, {
     code: 'ERR_STREAM_PUSH_AFTER_EOF',
     name: 'Error',
-    message: 'stream.push() after EOF'
   });
 }
 

--- a/test/parallel/test-stream-wrap-encoding.js
+++ b/test/parallel/test-stream-wrap-encoding.js
@@ -18,7 +18,6 @@ const Duplex = require('stream').Duplex;
   wrap.on('error', common.expectsError({
     name: 'Error',
     code: 'ERR_STREAM_WRAP',
-    message: 'Stream has StringDecoder set or is in objectMode'
   }));
 
   stream.push('ohai');
@@ -36,7 +35,6 @@ const Duplex = require('stream').Duplex;
   wrap.on('error', common.expectsError({
     name: 'Error',
     code: 'ERR_STREAM_WRAP',
-    message: 'Stream has StringDecoder set or is in objectMode'
   }));
 
   stream.push(new Error('foo'));

--- a/test/parallel/test-stream-writable-callback-twice.js
+++ b/test/parallel/test-stream-writable-callback-twice.js
@@ -7,7 +7,6 @@ const stream = new Writable({
 
 stream.on('error', common.expectsError({
   name: 'Error',
-  message: 'Callback called multiple times',
   code: 'ERR_MULTIPLE_CALLBACK'
 }));
 

--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -65,7 +65,6 @@ assert.throws(() => {
 }, {
   name: 'TypeError',
   code: 'ERR_UNKNOWN_ENCODING',
-  message: 'Unknown encoding: {}'
 });
 
 (function checkVariableCaseEncoding() {

--- a/test/parallel/test-stream-writable-constructor-set-methods.js
+++ b/test/parallel/test-stream-writable-constructor-set-methods.js
@@ -14,7 +14,6 @@ assert.throws(
   {
     name: 'Error',
     code: 'ERR_METHOD_NOT_IMPLEMENTED',
-    message: 'The _write() method is not implemented'
   }
 );
 

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -276,7 +276,6 @@ const assert = require('assert');
   write.write('asd', common.expectsError({
     name: 'Error',
     code: 'ERR_STREAM_DESTROYED',
-    message: 'Cannot call write after a stream was destroyed'
   }));
 }
 
@@ -295,13 +294,11 @@ const assert = require('assert');
   write.write('asd', common.expectsError({
     name: 'Error',
     code: 'ERR_STREAM_DESTROYED',
-    message: 'Cannot call write after a stream was destroyed'
   }));
   write.destroy();
   write.write('asd', common.expectsError({
     name: 'Error',
     code: 'ERR_STREAM_DESTROYED',
-    message: 'Cannot call write after a stream was destroyed'
   }));
   write.uncork();
 }

--- a/test/parallel/test-streams-highwatermark.js
+++ b/test/parallel/test-streams-highwatermark.js
@@ -3,7 +3,6 @@ const common = require('../common');
 
 const assert = require('assert');
 const stream = require('stream');
-const { inspect } = require('util');
 
 {
   // This test ensures that the stream implementation correctly handles values
@@ -27,8 +26,6 @@ const { inspect } = require('util');
       }, {
         name: 'TypeError',
         code: 'ERR_INVALID_ARG_VALUE',
-        message: "The property 'options.highWaterMark' is invalid. " +
-          `Received ${inspect(invalidHwm)}`
       });
     }
   }
@@ -80,8 +77,5 @@ const { inspect } = require('util');
 
   assert.throws(() => readable.read(hwm), common.expectsError({
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "size" is out of range.' +
-             ' It must be <= 1GiB. Received ' +
-             hwm,
   }));
 }

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -178,7 +178,6 @@ assert.throws(
   {
     code: 'ERR_UNKNOWN_ENCODING',
     name: 'TypeError',
-    message: 'Unknown encoding: 1'
   }
 );
 
@@ -187,7 +186,6 @@ assert.throws(
   {
     code: 'ERR_UNKNOWN_ENCODING',
     name: 'TypeError',
-    message: 'Unknown encoding: test'
   }
 );
 
@@ -196,8 +194,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "buf" argument must be an instance of Buffer, TypedArray,' +
-      ' or DataView. Received null'
   }
 );
 

--- a/test/parallel/test-timers-enroll-invalid-msecs.js
+++ b/test/parallel/test-timers-enroll-invalid-msecs.js
@@ -30,9 +30,6 @@ const timers = require('timers');
     {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
-      message: 'The value of "msecs" is out of range. ' +
-               'It must be a non-negative finite number. ' +
-               `Received ${val}`
     }
   );
 });

--- a/test/parallel/test-timers-immediate-queue-throw.js
+++ b/test/parallel/test-timers-immediate-queue-throw.js
@@ -20,7 +20,6 @@ const QUEUE = 10;
 
 const errObj = {
   name: 'Error',
-  message: 'setImmediate Err'
 };
 
 process.once('uncaughtException', common.mustCall((err, errorOrigin) => {

--- a/test/parallel/test-timers-promises-scheduler.js
+++ b/test/parallel/test-timers-promises-scheduler.js
@@ -33,7 +33,6 @@ async function testCancelableWait1() {
   ac.abort();
   await rejects(wait, {
     code: 'ABORT_ERR',
-    message: 'The operation was aborted',
   });
 }
 
@@ -43,7 +42,6 @@ async function testCancelableWait2() {
   const wait = scheduler.wait(10000, { signal: AbortSignal.abort() });
   await rejects(wait, {
     code: 'ABORT_ERR',
-    message: 'The operation was aborted',
   });
 }
 

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -12,8 +12,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.ciphers" property must be of type string.' +
-      ' Received type number (1)'
   });
 
 assert.throws(
@@ -21,8 +19,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.ciphers" property must be of type string.' +
-      ' Received type number (1)'
   });
 
 assert.throws(
@@ -30,7 +26,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /The "options\.passphrase" property must be of type string/
   });
 
 assert.throws(
@@ -38,7 +33,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /The "options\.passphrase" property must be of type string/
   });
 
 assert.throws(
@@ -46,7 +40,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /The "options\.ecdhCurve" property must be of type string/
   });
 
 assert.throws(
@@ -54,8 +47,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.handshakeTimeout" property must be of type number.' +
-              " Received type string ('abcd')"
   }
 );
 
@@ -64,7 +55,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /The "options\.sessionTimeout" property must be of type number/
   });
 
 assert.throws(
@@ -72,18 +62,15 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /The "options\.ticketKeys" property must be an instance of/
   });
 
 assert.throws(() => tls.createServer({ ticketKeys: Buffer.alloc(0) }), {
   code: 'ERR_INVALID_ARG_VALUE',
-  message: /The property 'options\.ticketKeys' must be exactly 48 bytes/
 });
 
 assert.throws(
   () => tls.createSecurePair({}),
   {
-    message: 'context must be a SecureContext',
     code: 'ERR_TLS_INVALID_CONTEXT',
     name: 'TypeError',
   }
@@ -118,8 +105,6 @@ assert.throws(
     () => tls.convertALPNProtocols(protocols, out),
     {
       code: 'ERR_OUT_OF_RANGE',
-      message: 'The byte length of the protocol at index 0 exceeds the ' +
-        'maximum length. It must be <= 255. Received 500'
     }
   );
 }

--- a/test/parallel/test-tls-client-renegotiation-13.js
+++ b/test/parallel/test-tls-client-renegotiation-13.js
@@ -29,9 +29,6 @@ connect({
 
   const ok = client.renegotiate({}, common.mustCall((err) => {
     assert.throws(() => { throw err; }, {
-      message: common.hasOpenSSL3 ?
-        'error:0A00010A:SSL routines::wrong ssl version' :
-        'error:1420410A:SSL routines:SSL_renegotiate:wrong ssl version',
       code: 'ERR_SSL_WRONG_SSL_VERSION',
       library: 'SSL routines',
       reason: 'wrong ssl version',

--- a/test/parallel/test-tls-clientcertengine-invalid-arg-type.js
+++ b/test/parallel/test-tls-clientcertengine-invalid-arg-type.js
@@ -10,6 +10,6 @@ const tls = require('tls');
 {
   assert.throws(
     () => { tls.createSecureContext({ clientCertEngine: 0 }); },
-    { code: 'ERR_INVALID_ARG_TYPE',
-      message: / Received type number \(0\)/ });
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  );
 }

--- a/test/parallel/test-tls-clientcertengine-unsupported.js
+++ b/test/parallel/test-tls-clientcertengine-unsupported.js
@@ -24,7 +24,6 @@ const tls = require('tls');
     () => { tls.createSecureContext({ clientCertEngine: 'Cannonmouth' }); },
     {
       code: 'ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED',
-      message: 'Custom engines not supported by this OpenSSL'
     }
   );
 }

--- a/test/parallel/test-tls-disable-renegotiation.js
+++ b/test/parallel/test-tls-disable-renegotiation.js
@@ -23,7 +23,6 @@ const server = tls.Server(options, common.mustCall((socket) => {
     common.expectsError({
       name: 'Error',
       code: 'ERR_TLS_RENEGOTIATION_DISABLED',
-      message: 'TLS session renegotiation disabled for this socket'
     })(err);
     socket.destroy();
     server.close();

--- a/test/parallel/test-tls-error-servername.js
+++ b/test/parallel/test-tls-error-servername.js
@@ -28,8 +28,6 @@ const client = connect({
     client.setServername(value);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "name" argument must be of type string.' +
-             common.invalidArgTypeHelper(value)
   });
 });
 
@@ -44,5 +42,4 @@ assert.throws(() => {
   server.setServername('localhost');
 }, {
   code: 'ERR_TLS_SNI_FROM_SERVER',
-  message: 'Cannot issue SNI from a TLS server-side socket'
 });

--- a/test/parallel/test-tls-exportkeyingmaterial.js
+++ b/test/parallel/test-tls-exportkeyingmaterial.js
@@ -26,7 +26,6 @@ const server = net.createServer(common.mustCall((s) => {
     tlsSocket.exportKeyingMaterial(128, 'label');
   }, {
     name: 'Error',
-    message: 'TLS socket connection must be securely established',
     code: 'ERR_TLS_INVALID_STATE'
   });
 

--- a/test/parallel/test-tls-keyengine-invalid-arg-type.js
+++ b/test/parallel/test-tls-keyengine-invalid-arg-type.js
@@ -12,13 +12,13 @@ assert.throws(
     tls.createSecureContext({ privateKeyEngine: 0,
                               privateKeyIdentifier: 'key' });
   },
-  { code: 'ERR_INVALID_ARG_TYPE',
-    message: / Received type number \(0\)$/ });
+  { code: 'ERR_INVALID_ARG_TYPE' }
+);
 
 assert.throws(
   () => {
     tls.createSecureContext({ privateKeyEngine: 'engine',
                               privateKeyIdentifier: 0 });
   },
-  { code: 'ERR_INVALID_ARG_TYPE',
-    message: / Received type number \(0\)$/ });
+  { code: 'ERR_INVALID_ARG_TYPE' }
+);

--- a/test/parallel/test-tls-keyengine-unsupported.js
+++ b/test/parallel/test-tls-keyengine-unsupported.js
@@ -29,7 +29,6 @@ const tls = require('tls');
     },
     {
       code: 'ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED',
-      message: 'Custom engines not supported by this OpenSSL'
     }
   );
 }

--- a/test/parallel/test-tls-no-cert-required.js
+++ b/test/parallel/test-tls-no-cert-required.js
@@ -44,8 +44,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options" argument must be of type object. ' +
-             "Received type string ('this is not valid')"
   }
 );
 

--- a/test/parallel/test-tls-no-sslv23.js
+++ b/test/parallel/test-tls-no-sslv23.js
@@ -10,7 +10,6 @@ assert.throws(function() {
   tls.createSecureContext({ secureProtocol: 'blargh' });
 }, {
   code: 'ERR_TLS_INVALID_PROTOCOL_METHOD',
-  message: 'Unknown method: blargh',
 });
 
 const errMessageSSLv2 = /SSLv2 methods disabled/;

--- a/test/parallel/test-tls-options-boolean-check.js
+++ b/test/parallel/test-tls-options-boolean-check.js
@@ -67,7 +67,7 @@ const caArrDataView = toDataView(caCert);
 });
 
 // Checks to ensure tls.createServer predictably throws an error
-// Format ['key', 'cert', 'expected message']
+// Format ['key', 'cert']
 [
   [true, certBuff],
   [true, certStr],
@@ -76,20 +76,16 @@ const caArrDataView = toDataView(caCert);
   [true, false],
   [true, false],
   [{ pem: keyBuff }, false],
-  [[keyBuff, true], [certBuff, certBuff2], 1],
-  [[true, keyStr2], [certStr, certStr2], 0],
-  [[true, false], [certBuff, certBuff2], 0],
+  [[keyBuff, true], [certBuff, certBuff2]],
+  [[true, keyStr2], [certStr, certStr2]],
+  [[true, false], [certBuff, certBuff2]],
   [true, [certBuff, certBuff2]],
-].forEach(([key, cert, index]) => {
-  const val = index === undefined ? key : key[index];
+].forEach(([key, cert]) => {
   assert.throws(() => {
     tls.createServer({ key, cert });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.key" property must be of type string or an ' +
-             'instance of Buffer, TypedArray, or DataView.' +
-             common.invalidArgTypeHelper(val)
   });
 });
 
@@ -102,20 +98,16 @@ const caArrDataView = toDataView(caCert);
   [false, true],
   [false, { pem: keyBuff }],
   [false, 1],
-  [[keyBuff, keyBuff2], [true, certBuff2], 0],
-  [[keyStr, keyStr2], [certStr, true], 1],
-  [[keyStr, keyStr2], [true, false], 0],
+  [[keyBuff, keyBuff2], [true, certBuff2]],
+  [[keyStr, keyStr2], [certStr, true]],
+  [[keyStr, keyStr2], [true, false]],
   [[keyStr, keyStr2], true],
-].forEach(([key, cert, index]) => {
-  const val = index === undefined ? cert : cert[index];
+].forEach(([key, cert]) => {
   assert.throws(() => {
     tls.createServer({ key, cert });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.cert" property must be of type string or an ' +
-             'instance of Buffer, TypedArray, or DataView.' +
-             common.invalidArgTypeHelper(val)
   });
 });
 
@@ -140,17 +132,13 @@ const caArrDataView = toDataView(caCert);
   [keyBuff, certBuff, {}],
   [keyBuff, certBuff, 1],
   [keyBuff, certBuff, true],
-  [keyBuff, certBuff, [caCert, true], 1],
-].forEach(([key, cert, ca, index]) => {
-  const val = index === undefined ? ca : ca[index];
+  [keyBuff, certBuff, [caCert, true]],
+].forEach(([key, cert, ca]) => {
   assert.throws(() => {
     tls.createServer({ key, cert, ca });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.ca" property must be of type string or an instance' +
-             ' of Buffer, TypedArray, or DataView.' +
-             common.invalidArgTypeHelper(val)
   });
 });
 

--- a/test/parallel/test-tls-snicallback-error.js
+++ b/test/parallel/test-tls-snicallback-error.js
@@ -9,6 +9,6 @@ const tls = require('tls');
 ['fhqwhgads', 42, {}, []].forEach((testValue) => {
   assert.throws(
     () => { tls.createServer({ SNICallback: testValue }); },
-    { code: 'ERR_INVALID_ARG_TYPE', message: /\boptions\.SNICallback\b/ }
+    { code: 'ERR_INVALID_ARG_TYPE' }
   );
 });

--- a/test/parallel/test-trace-events-dynamic-enable-workers-disabled.js
+++ b/test/parallel/test-trace-events-dynamic-enable-workers-disabled.js
@@ -21,8 +21,6 @@ session.post('NodeTracing.start', {
 }, common.mustCall((err) => {
   assert.deepStrictEqual(err, {
     code: -32000,
-    message:
-      'Tracing properties can only be changed through main thread sessions'
   });
 }));
 session.disconnect();

--- a/test/parallel/test-ttywrap-invalid-fd.js
+++ b/test/parallel/test-ttywrap-invalid-fd.js
@@ -15,7 +15,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_FD',
     name: 'RangeError',
-    message: '"fd" must be a positive integer: -1'
   }
 );
 
@@ -27,10 +26,6 @@ assert.throws(
     syscall: 'uv_tty_init'
   };
 
-  const suffix = common.isWindows ?
-    'EBADF (bad file descriptor)' : 'EINVAL (invalid argument)';
-  const message = `TTY initialization failed: uv_tty_init returned ${suffix}`;
-
   assert.throws(
     () => {
       common.runWithInvalidFD((fd) => {
@@ -39,7 +34,6 @@ assert.throws(
     }, {
       code: 'ERR_TTY_INIT_FAILED',
       name: 'SystemError',
-      message,
       info
     }
   );
@@ -52,7 +46,6 @@ assert.throws(
     }, {
       code: 'ERR_TTY_INIT_FAILED',
       name: 'SystemError',
-      message,
       info
     });
 }
@@ -62,6 +55,5 @@ assert.throws(
   {
     code: 'ERR_INVALID_FD',
     name: 'RangeError',
-    message: '"fd" must be a positive integer: -1'
   }
 );

--- a/test/parallel/test-url-format-invalid-input.js
+++ b/test/parallel/test-url-format-invalid-input.js
@@ -1,5 +1,4 @@
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 const url = require('url');
 
@@ -19,8 +18,6 @@ for (const urlObject of throwsObjsAndReportTypes) {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "urlObject" argument must be one of type object or string.' +
-             common.invalidArgTypeHelper(urlObject)
   });
 }
 assert.strictEqual(url.format(''), '');

--- a/test/parallel/test-url-format-whatwg.js
+++ b/test/parallel/test-url-format-whatwg.js
@@ -26,8 +26,6 @@ assert.strictEqual(
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "options" argument must be of type object.' +
-                 common.invalidArgTypeHelper(value)
       }
     );
   });

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -21,8 +21,6 @@ const url = require('url');
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "url" argument must be of type string.' +
-             common.invalidArgTypeHelper(val)
   });
 });
 

--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -252,8 +252,6 @@ const values = [
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "original" argument must be of type function.' +
-               common.invalidArgTypeHelper(value)
     });
   });
 }
@@ -274,8 +272,6 @@ const values = [
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The last argument must be of type function.' +
-               common.invalidArgTypeHelper(value)
     });
   });
 }

--- a/test/parallel/test-util-deprecate-invalid-code.js
+++ b/test/parallel/test-util-deprecate-invalid-code.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 const util = require('util');
 
@@ -8,7 +7,5 @@ const util = require('util');
   assert.throws(() => util.deprecate(() => {}, 'message', notString), {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "code" argument must be of type string.' +
-             common.invalidArgTypeHelper(notString)
   });
 });

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -529,6 +529,5 @@ assert.strictEqual(
     util.formatWithOptions(invalidOptions, { a: true });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /"inspectOptions".+object/
   });
 });

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -88,8 +88,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "superCtor.prototype" property must be of type object. ' +
-           'Received undefined'
 });
 
 assert.throws(() => {
@@ -97,8 +95,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "superCtor" argument must be of type function. ' +
-           'Received null'
 });
 
 assert.throws(() => {
@@ -106,5 +102,4 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "ctor" argument must be of type function. Received null'
 });

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1557,8 +1557,6 @@ if (typeof Symbol !== 'undefined') {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options" argument must be of type object. ' +
-             'Received null'
   }
   );
 
@@ -1567,8 +1565,6 @@ if (typeof Symbol !== 'undefined') {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options" argument must be of type object. ' +
-             "Received type string ('bad')"
   }
   );
 }

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -203,7 +203,5 @@ const stat = promisify(fs.stat);
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "original" argument must be of type function.' +
-               common.invalidArgTypeHelper(input)
     });
 });

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -21,7 +21,6 @@
 
 'use strict';
 // Flags: --expose-internals
-const common = require('../common');
 const assert = require('assert');
 const util = require('util');
 const errors = require('internal/errors');
@@ -183,6 +182,4 @@ assert.throws(() => {
   util.stripVTControlCharacters({});
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "str" argument must be of type string.' +
-           common.invalidArgTypeHelper({})
 });

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -1,7 +1,6 @@
 // Flags: --expose-internals
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 const {
   getSystemErrorName,
@@ -21,7 +20,6 @@ keys.forEach((key) => {
   assert.strictEqual(getSystemErrorName(uv[key]), name);
   assert.strictEqual(err.code, name);
   assert.strictEqual(err.code, getSystemErrorName(err.errno));
-  assert.strictEqual(err.message, `test ${name}`);
 });
 
 function runTest(fn) {
@@ -31,8 +29,6 @@ function runTest(fn) {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "err" argument must be of type number.' +
-                 common.invalidArgTypeHelper(err)
       });
   });
 
@@ -42,9 +38,6 @@ function runTest(fn) {
       {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',
-        message: 'The value of "err" is out of range. ' +
-                 'It must be a negative integer. ' +
-                 `Received ${err}`
       });
   });
 }

--- a/test/parallel/test-v8-flag-type-check.js
+++ b/test/parallel/test-v8-flag-type-check.js
@@ -1,5 +1,4 @@
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 const v8 = require('v8');
 
@@ -9,8 +8,6 @@ const v8 = require('v8');
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "flags" argument must be of type string.' +
-               common.invalidArgTypeHelper(value)
     }
   );
 });

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -150,7 +150,6 @@ const hostObject = new (internalBinding('js_stream').JSStream)();
 {
   assert.throws(() => v8.serialize(hostObject), {
     constructor: Error,
-    message: 'Unserializable host object: JSStream {}'
   });
 }
 
@@ -207,12 +206,10 @@ const hostObject = new (internalBinding('js_stream').JSStream)();
 {
   assert.throws(() => v8.Serializer(), {
     constructor: TypeError,
-    message: "Class constructor Serializer cannot be invoked without 'new'",
     code: 'ERR_CONSTRUCT_CALL_REQUIRED'
   });
   assert.throws(() => v8.Deserializer(), {
     constructor: TypeError,
-    message: "Class constructor Deserializer cannot be invoked without 'new'",
     code: 'ERR_CONSTRUCT_CALL_REQUIRED'
   });
 }

--- a/test/parallel/test-vm-basic.js
+++ b/test/parallel/test-vm-basic.js
@@ -20,7 +20,6 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
@@ -102,8 +101,6 @@ const vm = require('vm');
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options" argument must be of type object.' +
-             common.invalidArgTypeHelper(input)
   });
 });
 
@@ -113,8 +110,6 @@ const vm = require('vm');
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: `The "options.${propertyName}" property must be of type string. ` +
-             'Received null'
   });
 });
 
@@ -124,8 +119,6 @@ const vm = require('vm');
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: `The "options.${propertyName}" property must be of type string. ` +
-             'Received null'
   });
 });
 
@@ -152,15 +145,12 @@ const vm = require('vm');
     );
   }, {
     name: 'SyntaxError',
-    message: "Unexpected token '}'"
   });
 
   // Tests for failed argument validation
   assert.throws(() => vm.compileFunction(), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "code" argument must be of type string. ' +
-      'Received undefined'
   });
 
   vm.compileFunction(''); // Should pass without params or options
@@ -168,8 +158,6 @@ const vm = require('vm');
   assert.throws(() => vm.compileFunction('', null), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "params" argument must be an instance of Array. ' +
-      'Received null'
   });
 
   // vm.compileFunction('', undefined, null);
@@ -183,15 +171,11 @@ const vm = require('vm');
   };
 
   for (const option in optionTypes) {
-    const typeErrorMessage = `The "options.${option}" property must be ` +
-      (option === 'cachedData' ? 'an instance of' : 'of type');
     assert.throws(() => {
       vm.compileFunction('', undefined, { [option]: null });
     }, {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message: typeErrorMessage +
-        ` ${optionTypes[option]}. Received null`
     });
   }
 
@@ -203,8 +187,6 @@ const vm = require('vm');
       }, {
         name: 'TypeError',
         code: 'ERR_INVALID_ARG_TYPE',
-        message: 'The "options.parsingContext" property must be an instance ' +
-          `of Context.${common.invalidArgTypeHelper(value)}`
       });
     }
   );
@@ -217,8 +199,6 @@ const vm = require('vm');
       }, {
         name: 'TypeError',
         code: 'ERR_INVALID_ARG_TYPE',
-        message: 'The "params" argument must be an instance of Array.' +
-          common.invalidArgTypeHelper(value)
       });
     }
   );
@@ -237,8 +217,6 @@ const vm = require('vm');
   }, {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "options.contextExtensions" property must be an instance of' +
-       ' Array. Received null'
   });
 
   assert.throws(() => {
@@ -246,8 +224,6 @@ const vm = require('vm');
   }, {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "options.contextExtensions[0]" property must be of type ' +
-       'object. Received type number (0)'
   });
 
   const oldLimit = Error.stackTraceLimit;
@@ -257,7 +233,6 @@ const vm = require('vm');
   assert.throws(() => {
     vm.compileFunction('throw new Error("Sample Error")')();
   }, {
-    message: 'Sample Error',
     stack: 'Error: Sample Error\n    at <anonymous>:1:7'
   });
 
@@ -268,7 +243,6 @@ const vm = require('vm');
       { lineOffset: 3 }
     )();
   }, {
-    message: 'Sample Error',
     stack: 'Error: Sample Error\n    at <anonymous>:4:7'
   });
 
@@ -279,7 +253,6 @@ const vm = require('vm');
       { columnOffset: 3 }
     )();
   }, {
-    message: 'Sample Error',
     stack: 'Error: Sample Error\n    at <anonymous>:1:10'
   });
 
@@ -300,7 +273,6 @@ const vm = require('vm');
       []
     )();
   }, {
-    message: 'varInContext is not defined',
     stack: 'ReferenceError: varInContext is not defined\n    at <anonymous>:1:1'
   });
 

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -93,5 +93,4 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: /must be an instance of Buffer, TypedArray, or DataView/
 });

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -65,12 +65,10 @@ assert.strictEqual(gh1140Exception.toString(), 'Error');
 const nonContextualObjectError = {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: /must be of type object/
 };
 const contextifiedObjectError = {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: /The "contextifiedObject" argument must be an vm\.Context/
 };
 
 [

--- a/test/parallel/test-vm-module-basic.js
+++ b/test/parallel/test-vm-module-basic.js
@@ -88,7 +88,6 @@ const util = require('util');
     () => m[util.inspect.custom].call(Object.create(null)),
     {
       code: 'ERR_VM_MODULE_NOT_MODULE',
-      message: 'Provided module is not an instance of Module'
     },
   );
 }
@@ -120,7 +119,6 @@ const util = require('util');
 // Check the impossibility of creating an abstract instance of the Module.
 {
   assert.throws(() => new Module(), {
-    message: 'Module is not a constructor',
     name: 'TypeError'
   });
 }
@@ -128,9 +126,6 @@ const util = require('util');
 // Check to throws invalid exportNames
 {
   assert.throws(() => new SyntheticModule(undefined, () => {}, {}), {
-    message: 'The "exportNames" argument must be an ' +
-        'Array of unique strings.' +
-        ' Received undefined',
     name: 'TypeError'
   });
 }
@@ -139,7 +134,6 @@ const util = require('util');
 // https://github.com/nodejs/node/issues/32806
 {
   assert.throws(() => new SyntheticModule(['x', 'x'], () => {}, {}), {
-    message: 'The property \'exportNames.x\' is duplicated. Received \'x\'',
     name: 'TypeError',
   });
 }
@@ -147,8 +141,6 @@ const util = require('util');
 // Check to throws invalid evaluateCallback
 {
   assert.throws(() => new SyntheticModule([], undefined, {}), {
-    message: 'The "evaluateCallback" argument must be of type function.' +
-      ' Received undefined',
     name: 'TypeError'
   });
 }
@@ -156,8 +148,6 @@ const util = require('util');
 // Check to throws invalid options
 {
   assert.throws(() => new SyntheticModule([], () => {}, null), {
-    message: 'The "options" argument must be of type object.' +
-      ' Received null',
     name: 'TypeError'
   });
 }

--- a/test/parallel/test-vm-module-errors.js
+++ b/test/parallel/test-vm-module-errors.js
@@ -72,7 +72,6 @@ async function checkModuleState() {
     await m.evaluate();
   }, {
     code: 'ERR_VM_MODULE_STATUS',
-    message: 'Module status must be one of linked, evaluated, or errored'
   });
 
   await assert.rejects(async () => {
@@ -80,8 +79,6 @@ async function checkModuleState() {
     await m.evaluate(false);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "options" argument must be of type object. ' +
-             'Received type boolean (false)'
   });
 
   assert.throws(() => {
@@ -89,7 +86,6 @@ async function checkModuleState() {
     m.error; // eslint-disable-line no-unused-expressions
   }, {
     code: 'ERR_VM_MODULE_STATUS',
-    message: 'Module status must be errored'
   });
 
   await assert.rejects(async () => {
@@ -98,7 +94,6 @@ async function checkModuleState() {
     m.error; // eslint-disable-line no-unused-expressions
   }, {
     code: 'ERR_VM_MODULE_STATUS',
-    message: 'Module status must be errored'
   });
 
   assert.throws(() => {
@@ -106,7 +101,6 @@ async function checkModuleState() {
     m.namespace; // eslint-disable-line no-unused-expressions
   }, {
     code: 'ERR_VM_MODULE_STATUS',
-    message: 'Module status must not be unlinked or linking'
   });
 }
 
@@ -168,8 +162,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "options.importModuleDynamically" property must be of type ' +
-    "function. Received type string ('hucairz')"
 });
 
 // Check the JavaScript engine deals with exceptions correctly
@@ -205,9 +197,6 @@ async function checkInvalidOptionForEvaluate() {
     await m.evaluate({ breakOnSigint: 'a-string' });
   }, {
     name: 'TypeError',
-    message:
-      'The "options.breakOnSigint" property must be of type boolean. ' +
-      "Received type string ('a-string')",
     code: 'ERR_INVALID_ARG_TYPE'
   });
 
@@ -217,7 +206,6 @@ async function checkInvalidOptionForEvaluate() {
         await Module.prototype[method]();
       }, {
         code: 'ERR_VM_MODULE_NOT_MODULE',
-        message: /Provided module is not an instance of Module/
       });
     });
   }
@@ -225,15 +213,11 @@ async function checkInvalidOptionForEvaluate() {
 
 function checkInvalidCachedData() {
   [true, false, 'foo', {}, Array, function() {}].forEach((invalidArg) => {
-    const message = 'The "options.cachedData" property must be an ' +
-                    'instance of Buffer, TypedArray, or DataView.' +
-                    common.invalidArgTypeHelper(invalidArg);
     assert.throws(
       () => new SourceTextModule('import "foo";', { cachedData: invalidArg }),
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message,
       }
     );
   });
@@ -242,7 +226,6 @@ function checkInvalidCachedData() {
 function checkGettersErrors() {
   const expectedError = {
     code: 'ERR_VM_MODULE_NOT_MODULE',
-    message: /Provided module is not an instance of Module/
   };
   const getters = ['identifier', 'context', 'namespace', 'status', 'error'];
   getters.forEach((getter) => {

--- a/test/parallel/test-vm-module-synthetic.js
+++ b/test/parallel/test-vm-module-synthetic.js
@@ -71,7 +71,6 @@ const assert = require('assert');
       SyntheticModule.prototype.setExport.call({}, 'foo');
     }, {
       code: 'ERR_VM_MODULE_NOT_MODULE',
-      message: /Provided module is not an instance of Module/
     });
   }
 

--- a/test/parallel/test-vm-sigint-existing-handler.js
+++ b/test/parallel/test-vm-sigint-existing-handler.js
@@ -40,7 +40,6 @@ if (process.argv[2] === 'child') {
     () => { vm[method](script, ...args, options); },
     {
       code: 'ERR_SCRIPT_EXECUTION_INTERRUPTED',
-      message: 'Script execution was interrupted by `SIGINT`'
     });
   assert.strictEqual(firstHandlerCalled, 0);
   assert.strictEqual(onceHandlerCalled, 0);

--- a/test/parallel/test-vm-sigint.js
+++ b/test/parallel/test-vm-sigint.js
@@ -28,7 +28,6 @@ if (process.argv[2] === 'child') {
     () => { vm[method](script, ...args, options); },
     {
       code: 'ERR_SCRIPT_EXECUTION_INTERRUPTED',
-      message: 'Script execution was interrupted by `SIGINT`'
     });
   return;
 }

--- a/test/parallel/test-vm-timeout-escape-promise-2.js
+++ b/test/parallel/test-vm-timeout-escape-promise-2.js
@@ -34,5 +34,4 @@ assert.throws(() => {
   );
 }, {
   code: 'ERR_SCRIPT_EXECUTION_TIMEOUT',
-  message: 'Script execution timed out after 10ms'
 });

--- a/test/parallel/test-vm-timeout-escape-promise-module.js
+++ b/test/parallel/test-vm-timeout-escape-promise-module.js
@@ -38,5 +38,4 @@ assert.rejects(async () => {
   await module.evaluate({ timeout: 5 });
 }, {
   code: 'ERR_SCRIPT_EXECUTION_TIMEOUT',
-  message: 'Script execution timed out after 5ms'
 });

--- a/test/parallel/test-vm-timeout-escape-promise.js
+++ b/test/parallel/test-vm-timeout-escape-promise.js
@@ -35,5 +35,4 @@ assert.throws(() => {
   );
 }, {
   code: 'ERR_SCRIPT_EXECUTION_TIMEOUT',
-  message: 'Script execution timed out after 5ms'
 });

--- a/test/parallel/test-vm-timeout.js
+++ b/test/parallel/test-vm-timeout.js
@@ -31,7 +31,6 @@ assert.throws(
   },
   {
     code: 'ERR_SCRIPT_EXECUTION_TIMEOUT',
-    message: 'Script execution timed out after 100ms'
   });
 
 // Timeout of 1000ms, script finishes first
@@ -51,7 +50,6 @@ assert.throws(
   },
   {
     code: 'ERR_SCRIPT_EXECUTION_TIMEOUT',
-    message: 'Script execution timed out after 10ms'
   });
 
 // Nested vm timeouts, outer timeout is shorter and fires first.
@@ -67,7 +65,6 @@ assert.throws(
   },
   {
     code: 'ERR_SCRIPT_EXECUTION_TIMEOUT',
-    message: 'Script execution timed out after 100ms'
   });
 
 // Nested vm timeouts, inner script throws an error.

--- a/test/parallel/test-webcrypto-constructors.js
+++ b/test/parallel/test-webcrypto-constructors.js
@@ -11,21 +11,21 @@ const assert = require('assert');
 // Test CryptoKey constructor
 {
   assert.throws(() => new CryptoKey(), {
-    name: 'TypeError', message: 'Illegal constructor', code: 'ERR_ILLEGAL_CONSTRUCTOR'
+    name: 'TypeError', code: 'ERR_ILLEGAL_CONSTRUCTOR'
   });
 }
 
 // Test SubtleCrypto constructor
 {
   assert.throws(() => new SubtleCrypto(), {
-    name: 'TypeError', message: 'Illegal constructor', code: 'ERR_ILLEGAL_CONSTRUCTOR'
+    name: 'TypeError', code: 'ERR_ILLEGAL_CONSTRUCTOR'
   });
 }
 
 // Test Crypto constructor
 {
   assert.throws(() => new Crypto(), {
-    name: 'TypeError', message: 'Illegal constructor', code: 'ERR_ILLEGAL_CONSTRUCTOR'
+    name: 'TypeError', code: 'ERR_ILLEGAL_CONSTRUCTOR'
   });
 }
 

--- a/test/parallel/test-webcrypto-export-import.js
+++ b/test/parallel/test-webcrypto-export-import.js
@@ -40,7 +40,6 @@ const { subtle } = webcrypto;
         hash: 'SHA-256'
       }, false, ['deriveBits']), {
         name: 'SyntaxError',
-        message: 'Unsupported key usage for an HMAC key'
       });
     await assert.rejects(
       subtle.importKey('raw', keyData, {
@@ -49,7 +48,6 @@ const { subtle } = webcrypto;
         length: 0
       }, false, ['sign', 'verify']), {
         name: 'DataError',
-        message: 'Zero-length key is not supported'
       });
     await assert.rejects(
       subtle.importKey('raw', keyData, {
@@ -58,7 +56,6 @@ const { subtle } = webcrypto;
         length: 1
       }, false, ['sign', 'verify']), {
         name: 'DataError',
-        message: 'Invalid key length'
       });
     await assert.rejects(
       subtle.importKey('jwk', null, {
@@ -66,7 +63,6 @@ const { subtle } = webcrypto;
         hash: 'SHA-256',
       }, false, ['sign', 'verify']), {
         name: 'DataError',
-        message: 'Invalid JWK keyData'
       });
   }
 

--- a/test/parallel/test-webcrypto-sign-verify-hmac.js
+++ b/test/parallel/test-webcrypto-sign-verify-hmac.js
@@ -156,7 +156,6 @@ async function testSign({ hash,
     subtle.generateKey({ name }, false, []), {
       name: 'TypeError',
       code: 'ERR_MISSING_OPTION',
-      message: 'algorithm.hash is required'
     });
 
   // Test failure when no sign usage

--- a/test/parallel/test-whatwg-encoding-custom-fatal-streaming.js
+++ b/test/parallel/test-whatwg-encoding-custom-fatal-streaming.js
@@ -23,8 +23,6 @@ if (!common.hasIntl)
       }, {
         code: 'ERR_ENCODING_INVALID_ENCODED_DATA',
         name: 'TypeError',
-        message:
-          `The encoded data was not valid for encoding ${testCase.encoding}`
       }
     );
   });
@@ -42,8 +40,6 @@ if (!common.hasIntl)
     }, {
       code: 'ERR_ENCODING_INVALID_ENCODED_DATA',
       name: 'TypeError',
-      message:
-        'The encoded data was not valid for encoding utf-16le'
     }
   );
 
@@ -54,8 +50,6 @@ if (!common.hasIntl)
     }, {
       code: 'ERR_ENCODING_INVALID_ENCODED_DATA',
       name: 'TypeError',
-      message:
-        'The encoded data was not valid for encoding utf-16le'
     }
   );
 }

--- a/test/parallel/test-whatwg-encoding-custom-interop.js
+++ b/test/parallel/test-whatwg-encoding-custom-interop.js
@@ -48,7 +48,6 @@ assert(TextEncoder);
   const expectedError = {
     code: 'ERR_INVALID_THIS',
     name: 'TypeError',
-    message: 'Value of "this" must be of type TextEncoder'
   };
 
   inspectFn.call(instance, Infinity, {});

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -59,8 +59,6 @@ if (common.hasIntl) {
                   {
                     code: 'ERR_ENCODING_INVALID_ENCODED_DATA',
                     name: 'TypeError',
-                    message: 'The encoded data was not valid ' +
-                          'for encoding utf-8'
                   });
   });
 
@@ -75,7 +73,6 @@ if (common.hasIntl) {
     {
       code: 'ERR_NO_ICU',
       name: 'TypeError',
-      message: '"fatal" option is not supported on Node.js compiled without ICU'
     });
 }
 
@@ -163,7 +160,6 @@ if (common.hasIntl) {
   const expectedError = {
     code: 'ERR_INVALID_THIS',
     name: 'TypeError',
-    message: 'Value of "this" must be of type TextDecoder'
   };
 
   inspectFn.call(instance, Infinity, {});

--- a/test/parallel/test-whatwg-url-custom-searchparams-append.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-append.js
@@ -12,14 +12,12 @@ const assert = require('assert');
   }, {
     code: 'ERR_INVALID_THIS',
     name: 'TypeError',
-    message: 'Value of "this" must be of type URLSearchParams'
   });
   assert.throws(() => {
     params.append('a');
   }, {
     code: 'ERR_MISSING_ARGS',
     name: 'TypeError',
-    message: 'The "name" and "value" arguments must be specified'
   });
 
   const obj = {

--- a/test/parallel/test-whatwg-url-custom-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-constructor.js
@@ -17,12 +17,10 @@ function makeIterableFunc(array) {
   const iterableError = {
     code: 'ERR_ARG_NOT_ITERABLE',
     name: 'TypeError',
-    message: 'Query pairs must be iterable'
   };
   const tupleError = {
     code: 'ERR_INVALID_TUPLE',
     name: 'TypeError',
-    message: 'Each query pair must be an iterable [name, value] tuple'
   };
 
   let params;

--- a/test/parallel/test-whatwg-url-custom-searchparams-delete.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-delete.js
@@ -12,14 +12,12 @@ const assert = require('assert');
   }, {
     code: 'ERR_INVALID_THIS',
     name: 'TypeError',
-    message: 'Value of "this" must be of type URLSearchParams'
   });
   assert.throws(() => {
     params.delete();
   }, {
     code: 'ERR_MISSING_ARGS',
     name: 'TypeError',
-    message: 'The "name" argument must be specified'
   });
 
   const obj = {

--- a/test/parallel/test-whatwg-url-custom-searchparams-entries.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-entries.js
@@ -30,12 +30,10 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_THIS',
   name: 'TypeError',
-  message: 'Value of "this" must be of type URLSearchParamsIterator'
 });
 assert.throws(() => {
   params.entries.call(undefined);
 }, {
   code: 'ERR_INVALID_THIS',
   name: 'TypeError',
-  message: 'Value of "this" must be of type URLSearchParams'
 });

--- a/test/parallel/test-whatwg-url-custom-searchparams-foreach.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-foreach.js
@@ -12,6 +12,5 @@ const assert = require('assert');
   }, {
     code: 'ERR_INVALID_THIS',
     name: 'TypeError',
-    message: 'Value of "this" must be of type URLSearchParams'
   });
 }

--- a/test/parallel/test-whatwg-url-custom-searchparams-get.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-get.js
@@ -12,14 +12,12 @@ const assert = require('assert');
   }, {
     code: 'ERR_INVALID_THIS',
     name: 'TypeError',
-    message: 'Value of "this" must be of type URLSearchParams'
   });
   assert.throws(() => {
     params.get();
   }, {
     code: 'ERR_MISSING_ARGS',
     name: 'TypeError',
-    message: 'The "name" argument must be specified'
   });
 
   const obj = {

--- a/test/parallel/test-whatwg-url-custom-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-getall.js
@@ -12,14 +12,12 @@ const assert = require('assert');
   }, {
     code: 'ERR_INVALID_THIS',
     name: 'TypeError',
-    message: 'Value of "this" must be of type URLSearchParams'
   });
   assert.throws(() => {
     params.getAll();
   }, {
     code: 'ERR_MISSING_ARGS',
     name: 'TypeError',
-    message: 'The "name" argument must be specified'
   });
 
   const obj = {

--- a/test/parallel/test-whatwg-url-custom-searchparams-has.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-has.js
@@ -12,14 +12,12 @@ const assert = require('assert');
   }, {
     code: 'ERR_INVALID_THIS',
     name: 'TypeError',
-    message: 'Value of "this" must be of type URLSearchParams'
   });
   assert.throws(() => {
     params.has();
   }, {
     code: 'ERR_MISSING_ARGS',
     name: 'TypeError',
-    message: 'The "name" argument must be specified'
   });
 
   const obj = {

--- a/test/parallel/test-whatwg-url-custom-searchparams-keys.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-keys.js
@@ -32,12 +32,10 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_THIS',
   name: 'TypeError',
-  message: 'Value of "this" must be of type URLSearchParamsIterator'
 });
 assert.throws(() => {
   params.keys.call(undefined);
 }, {
   code: 'ERR_INVALID_THIS',
   name: 'TypeError',
-  message: 'Value of "this" must be of type URLSearchParams'
 });

--- a/test/parallel/test-whatwg-url-custom-searchparams-set.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-set.js
@@ -12,14 +12,12 @@ const assert = require('assert');
   }, {
     code: 'ERR_INVALID_THIS',
     name: 'TypeError',
-    message: 'Value of "this" must be of type URLSearchParams'
   });
   assert.throws(() => {
     params.set('a');
   }, {
     code: 'ERR_MISSING_ARGS',
     name: 'TypeError',
-    message: 'The "name" and "value" arguments must be specified'
   });
 
   const obj = {

--- a/test/parallel/test-whatwg-url-custom-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-stringifier.js
@@ -12,7 +12,6 @@ const assert = require('assert');
   }, {
     code: 'ERR_INVALID_THIS',
     name: 'TypeError',
-    message: 'Value of "this" must be of type URLSearchParams'
   });
 }
 

--- a/test/parallel/test-whatwg-url-custom-searchparams-values.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-values.js
@@ -32,12 +32,10 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_THIS',
   name: 'TypeError',
-  message: 'Value of "this" must be of type URLSearchParamsIterator'
 });
 assert.throws(() => {
   params.values.call(undefined);
 }, {
   code: 'ERR_INVALID_THIS',
   name: 'TypeError',
-  message: 'Value of "this" must be of type URLSearchParams'
 });

--- a/test/parallel/test-worker-message-port-close.js
+++ b/test/parallel/test-worker-message-port-close.js
@@ -36,7 +36,6 @@ function dummy() {}
   port2.close();
   assert.throws(() => moveMessagePortToContext(port2, {}), {
     code: 'ERR_CLOSED_MESSAGE_PORT',
-    message: 'Cannot send data on closed MessagePort'
   });
 }
 

--- a/test/parallel/test-worker-message-port-receive-message.js
+++ b/test/parallel/test-worker-message-port-receive-message.js
@@ -28,6 +28,5 @@ for (const value of [null, 0, -1, {}, []]) {
   assert.throws(() => receiveMessageOnPort(value), {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "port" argument must be a MessagePort instance'
   });
 }

--- a/test/parallel/test-worker-message-port-transfer-filehandle.js
+++ b/test/parallel/test-worker-message-port-transfer-filehandle.js
@@ -79,7 +79,6 @@ const { once } = require('events');
   assert.throws(() => {
     port1.postMessage(fh, [fh]);
   }, {
-    message: 'Cannot transfer FileHandle while in use',
     name: 'DataCloneError'
   });
 
@@ -96,7 +95,6 @@ const { once } = require('events');
   assert.throws(() => {
     port1.postMessage(fh, [fh]);
   }, {
-    message: 'Cannot transfer FileHandle while in use',
     name: 'DataCloneError'
   });
   await closePromise;

--- a/test/parallel/test-worker-message-port-transfer-native.js
+++ b/test/parallel/test-worker-message-port-transfer-native.js
@@ -16,7 +16,6 @@ const { internalBinding } = require('internal/test/binding');
     port1.postMessage(function foo() {});
   }, {
     name: 'DataCloneError',
-    message: /function foo\(\) \{\} could not be cloned\.$/
   });
   port1.close();
 }
@@ -31,7 +30,6 @@ const { internalBinding } = require('internal/test/binding');
     port1.postMessage(nativeObject);
   }, {
     name: 'DataCloneError',
-    message: /Cannot transfer object of unsupported type\.$/
   });
   port1.close();
 }

--- a/test/parallel/test-worker-message-port.js
+++ b/test/parallel/test-worker-message-port.js
@@ -95,7 +95,6 @@ const { MessageChannel, MessagePort } = require('worker_threads');
   const err = {
     constructor: TypeError,
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'Optional transferList argument must be an iterable'
   };
 
   assert.throws(() => port1.postMessage(5, 0), err);
@@ -106,7 +105,6 @@ const { MessageChannel, MessagePort } = require('worker_threads');
   const err2 = {
     constructor: TypeError,
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'Optional options.transfer argument must be an iterable'
   };
 
   assert.throws(() => port1.postMessage(5, { transfer: null }), err2);

--- a/test/parallel/test-worker-nested-uncaught.js
+++ b/test/parallel/test-worker-nested-uncaught.js
@@ -10,5 +10,4 @@ const w = new Worker(
   { eval: true });
 w.on('error', common.expectsError({
   name: 'Error',
-  message: 'uncaught'
 }));

--- a/test/parallel/test-worker-process-env.js
+++ b/test/parallel/test-worker-process-env.js
@@ -28,9 +28,6 @@ if (!workerData && process.argv[2] !== 'child') {
   }, {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "options.env" property must be of type object or ' +
-      'one of undefined, null, or worker_threads.SHARE_ENV. Received type ' +
-      'number (42)'
   });
 } else if (workerData === 'runInWorker') {
   // Env vars from the parent thread are inherited.
@@ -48,8 +45,6 @@ if (!workerData && process.argv[2] !== 'child') {
     {
       code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
       name: 'TypeError',
-      message: '\'process.env\' only accepts a configurable, ' +
-          'writable, and enumerable data descriptor'
     }
   );
 

--- a/test/parallel/test-worker-resource-limits.js
+++ b/test/parallel/test-worker-resource-limits.js
@@ -26,8 +26,6 @@ if (!process.env.HAS_STARTED_WORKER) {
   }));
   w.on('error', common.expectsError({
     code: 'ERR_WORKER_OUT_OF_MEMORY',
-    message: 'Worker terminated due to reaching memory limit: ' +
-    'JS heap out of memory'
   }));
   return;
 }

--- a/test/parallel/test-worker-stack-overflow-stack-size.js
+++ b/test/parallel/test-worker-stack-overflow-stack-size.js
@@ -26,7 +26,6 @@ async function runWorker(options = {}) {
   if (!options.skipErrorCheck) {
     common.expectsError({
       constructor: RangeError,
-      message: 'Maximum call stack size exceeded'
     })(error);
   }
 

--- a/test/parallel/test-worker-stack-overflow.js
+++ b/test/parallel/test-worker-stack-overflow.js
@@ -6,5 +6,4 @@ const worker = new Worker('function f() { f(); } f();', { eval: true });
 
 worker.on('error', common.expectsError({
   constructor: RangeError,
-  message: 'Maximum call stack size exceeded'
 }));

--- a/test/parallel/test-worker-type-check.js
+++ b/test/parallel/test-worker-type-check.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const common = require('../common');
 const assert = require('assert');
 const { Worker } = require('worker_threads');
 
@@ -20,9 +19,6 @@ const { Worker } = require('worker_threads');
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "filename" argument must be of type string ' +
-                 'or an instance of URL.' +
-                 common.invalidArgTypeHelper(val)
       }
     );
   });

--- a/test/parallel/test-worker-unsupported-things.js
+++ b/test/parallel/test-worker-unsupported-things.js
@@ -28,7 +28,6 @@ if (!process.env.HAS_STARTED_WORKER) {
     const mask = 0o600;
     assert.throws(() => { process.umask(mask); }, {
       code: 'ERR_WORKER_UNSUPPORTED_OPERATION',
-      message: 'Setting process.umask() is not supported in workers'
     });
   }
 
@@ -45,7 +44,6 @@ if (!process.env.HAS_STARTED_WORKER) {
       process[fn]();
     }, {
       code: 'ERR_WORKER_UNSUPPORTED_OPERATION',
-      message: `process.${fn}() is not supported in workers`
     });
   });
 
@@ -54,7 +52,6 @@ if (!process.env.HAS_STARTED_WORKER) {
       process[fn]; // eslint-disable-line no-unused-expressions
     }, {
       code: 'ERR_WORKER_UNSUPPORTED_OPERATION',
-      message: `process.${fn} is not supported in workers`
     });
   });
 

--- a/test/parallel/test-worker-workerdata-messageport.js
+++ b/test/parallel/test-worker-workerdata-messageport.js
@@ -55,7 +55,5 @@ const meowScript = () => 'meow';
     transferList: []
   }), {
     code: 'ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST',
-    message: 'Object that needs transfer was found in message but not ' +
-             'listed in transferList'
   });
 }

--- a/test/parallel/test-wrap-js-stream-exceptions.js
+++ b/test/parallel/test-wrap-js-stream-exceptions.js
@@ -19,5 +19,4 @@ const socket = new JSStreamWrap(new Duplex({
 socket.end('foo');
 socket.on('error', common.expectsError({
   name: 'Error',
-  message: 'write EPROTO'
 }));

--- a/test/parallel/test-x509-escaping.js
+++ b/test/parallel/test-x509-escaping.js
@@ -404,7 +404,6 @@ const { hasOpenSSL3 } = common;
       });
     }, {
       code: 'ERR_TLS_CERT_ALTNAME_FORMAT',
-      message: 'Invalid subject alternative name string'
     });
   }
 }
@@ -425,10 +424,6 @@ const { hasOpenSSL3 } = common;
   const err = tls.checkServerIdentity(hostname, { subjectaltname: san });
   assert(err);
   assert.strictEqual(err.code, 'ERR_TLS_CERT_ALTNAME_INVALID');
-  assert.strictEqual(err.message, 'Hostname/IP does not match certificate\'s ' +
-                                  'altnames: Host: b.example.com. is not in ' +
-                                  'the cert\'s altnames: DNS:"a.example.com, ' +
-                                  'DNS:b.example.com, DNS:c.example.com"');
 }
 
 // The subject MUST be ignored if a dNSName subject alternative name exists.
@@ -461,10 +456,6 @@ const { hasOpenSSL3 } = common;
     }, common.mustNotCall());
     socket.on('error', common.mustCall((err) => {
       assert.strictEqual(err.code, 'ERR_TLS_CERT_ALTNAME_INVALID');
-      assert.strictEqual(err.message, 'Hostname/IP does not match ' +
-                                      "certificate's altnames: Host: " +
-                                      "good.example.com. is not in the cert's" +
-                                      ' altnames: DNS:evil.example.com');
     }));
   })).unref();
 }

--- a/test/parallel/test-zlib-brotli.js
+++ b/test/parallel/test-zlib-brotli.js
@@ -41,7 +41,6 @@ const sampleBuffer = fixtures.readSync('/pss-vectors.json');
   }, {
     code: 'ERR_BROTLI_INVALID_PARAM',
     name: 'RangeError',
-    message: '10000 is not a valid Brotli parameter'
   });
 
   // Test that accidentally using duplicate keys fails.
@@ -55,7 +54,6 @@ const sampleBuffer = fixtures.readSync('/pss-vectors.json');
   }, {
     code: 'ERR_BROTLI_INVALID_PARAM',
     name: 'RangeError',
-    message: '00 is not a valid Brotli parameter'
   });
 
   assert.throws(() => {
@@ -68,7 +66,6 @@ const sampleBuffer = fixtures.readSync('/pss-vectors.json');
   }, {
     code: 'ERR_ZLIB_INITIALIZATION_FAILED',
     name: 'Error',
-    message: 'Initialization failed'
   });
 }
 
@@ -79,8 +76,6 @@ const sampleBuffer = fixtures.readSync('/pss-vectors.json');
   }, {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.flush" is out of range. It must be >= 0 ' +
-      'and <= 3. Received 4',
   });
 
   assert.throws(() => {
@@ -88,7 +83,5 @@ const sampleBuffer = fixtures.readSync('/pss-vectors.json');
   }, {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.finishFlush" is out of range. It must be ' +
-      '>= 0 and <= 3. Received 4',
   });
 }

--- a/test/parallel/test-zlib-convenience-methods.js
+++ b/test/parallel/test-zlib-convenience-methods.js
@@ -127,7 +127,5 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "callback" argument must be of type function. ' +
-             'Received undefined'
   }
 );

--- a/test/parallel/test-zlib-deflate-constructors.js
+++ b/test/parallel/test-zlib-deflate-constructors.js
@@ -18,8 +18,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.chunkSize" property must be of type number. ' +
-             "Received type string ('test')"
   }
 );
 
@@ -28,8 +26,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.chunkSize" is out of range. It must ' +
-             'be a finite number. Received -Infinity'
   }
 );
 
@@ -38,8 +34,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.chunkSize" is out of range. It must ' +
-             'be >= 64. Received 0'
   }
 );
 
@@ -52,8 +46,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.windowBits" property must be of type number. ' +
-             "Received type string ('test')"
   }
 );
 
@@ -62,8 +54,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.windowBits" is out of range. It must ' +
-             'be a finite number. Received -Infinity'
   }
 );
 
@@ -72,8 +62,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.windowBits" is out of range. It must ' +
-             'be a finite number. Received Infinity'
   }
 );
 
@@ -82,8 +70,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.windowBits" is out of range. It must ' +
-             'be >= 8 and <= 15. Received 0'
   }
 );
 
@@ -93,8 +79,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.level" property must be of type number. ' +
-             "Received type string ('test')"
   }
 );
 
@@ -103,8 +87,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.level" is out of range. It must ' +
-             'be a finite number. Received -Infinity'
   }
 );
 
@@ -113,8 +95,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.level" is out of range. It must ' +
-             'be a finite number. Received Infinity'
   }
 );
 
@@ -123,8 +103,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.level" is out of range. It must ' +
-             'be >= -1 and <= 9. Received -2'
   }
 );
 
@@ -134,8 +112,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "level" argument must be of type number. ' +
-             "Received type string ('test')"
   }
 );
 
@@ -144,8 +120,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "level" is out of range. It must ' +
-             'be a finite number. Received -Infinity'
   }
 );
 
@@ -154,8 +128,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "level" is out of range. It must ' +
-             'be a finite number. Received Infinity'
   }
 );
 
@@ -164,8 +136,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "level" is out of range. It must ' +
-             'be >= -1 and <= 9. Received -2'
   }
 );
 
@@ -175,8 +145,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.memLevel" property must be of type number. ' +
-             "Received type string ('test')"
   }
 );
 
@@ -185,8 +153,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.memLevel" is out of range. It must ' +
-             'be a finite number. Received -Infinity'
   }
 );
 
@@ -195,8 +161,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.memLevel" is out of range. It must ' +
-             'be a finite number. Received Infinity'
   }
 );
 
@@ -205,8 +169,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.memLevel" is out of range. It must ' +
-             'be >= 1 and <= 9. Received -2'
   }
 );
 
@@ -223,8 +185,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.strategy" property must be of type number. ' +
-             "Received type string ('test')"
   }
 );
 
@@ -233,8 +193,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.strategy" is out of range. It must ' +
-             'be a finite number. Received -Infinity'
   }
 );
 
@@ -243,8 +201,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.strategy" is out of range. It must ' +
-             'be a finite number. Received Infinity'
   }
 );
 
@@ -253,8 +209,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.strategy" is out of range. It must ' +
-             'be >= 0 and <= 4. Received -2'
   }
 );
 
@@ -264,8 +218,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "strategy" argument must be of type number. ' +
-             "Received type string ('test')"
   }
 );
 
@@ -274,8 +226,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "strategy" is out of range. It must ' +
-             'be a finite number. Received -Infinity'
   }
 );
 
@@ -284,8 +234,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "strategy" is out of range. It must ' +
-             'be a finite number. Received Infinity'
   }
 );
 
@@ -294,8 +242,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "strategy" is out of range. It must ' +
-             'be >= 0 and <= 4. Received -2'
   }
 );
 
@@ -305,8 +251,5 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.dictionary" property must be an instance of Buffer' +
-             ', TypedArray, DataView, or ArrayBuffer. Received type string ' +
-             "('not a buffer')"
   }
 );

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -10,8 +10,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.chunkSize" is out of range. It must ' +
-             'be >= 64. Received 0'
   }
 );
 
@@ -20,8 +18,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.windowBits" is out of range. It must ' +
-             'be >= 9 and <= 15. Received 0'
   }
 );
 
@@ -30,8 +26,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.memLevel" is out of range. It must ' +
-             'be >= 1 and <= 9. Received 0'
   }
 );
 

--- a/test/parallel/test-zlib-flush-flags.js
+++ b/test/parallel/test-zlib-flush-flags.js
@@ -10,8 +10,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.flush" property must be of type number. ' +
-             "Received type string ('foobar')"
   }
 );
 
@@ -20,8 +18,6 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.flush" is out of range. It must ' +
-             'be >= 0 and <= 5. Received 10000'
   }
 );
 
@@ -32,8 +28,6 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "options.finishFlush" property must be of type number. ' +
-             "Received type string ('foobar')"
   }
 );
 
@@ -42,7 +36,5 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.finishFlush" is out of range. It must ' +
-             'be >= 0 and <= 5. Received 10000'
   }
 );

--- a/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
+++ b/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
@@ -40,7 +40,6 @@ zlib.gunzip(data, common.mustCall((err, result) => {
   common.expectsError({
     code: 'Z_DATA_ERROR',
     name: 'Error',
-    message: 'unknown compression method'
   })(err);
   assert.strictEqual(result, undefined);
 }));
@@ -61,6 +60,5 @@ assert.throws(
 zlib.gunzip(data, common.mustCall((err, result) => {
   assert(err instanceof Error);
   assert.strictEqual(err.code, 'Z_DATA_ERROR');
-  assert.strictEqual(err.message, 'unknown compression method');
   assert.strictEqual(result, undefined);
 }));

--- a/test/parallel/test-zlib-maxOutputLength.js
+++ b/test/parallel/test-zlib-maxOutputLength.js
@@ -8,7 +8,6 @@ const encoded = Buffer.from('G38A+CXCIrFAIAM=', 'base64');
 // Async
 zlib.brotliDecompress(encoded, { maxOutputLength: 64 }, common.expectsError({
   code: 'ERR_BUFFER_TOO_LARGE',
-  message: 'Cannot create a Buffer larger than 64 bytes'
 }));
 
 // Sync

--- a/test/parallel/test-zlib-not-string-or-buffer.js
+++ b/test/parallel/test-zlib-not-string-or-buffer.js
@@ -3,7 +3,6 @@
 // Check the error condition testing for passing something other than a string
 // or buffer.
 
-const common = require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 
@@ -22,9 +21,6 @@ const zlib = require('zlib');
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "buffer" argument must be of type string or an instance ' +
-               'of Buffer, TypedArray, DataView, or ArrayBuffer.' +
-               common.invalidArgTypeHelper(input)
     }
   );
 });

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -29,6 +29,5 @@ zlib.gzip('hello', common.mustCall(function(err, out) {
   unzip.write('asd', common.expectsError({
     code: 'ERR_STREAM_DESTROYED',
     name: 'Error',
-    message: 'Cannot call write after a stream was destroyed'
   }));
 }));

--- a/test/parallel/test-zlib-zero-windowBits.js
+++ b/test/parallel/test-zlib-zero-windowBits.js
@@ -27,7 +27,5 @@ const zlib = require('zlib');
   assert.throws(() => zlib.createGzip({ windowBits: 0 }), {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "options.windowBits" is out of range. ' +
-             'It must be >= 9 and <= 15. Received 0'
   });
 }

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -31,8 +31,6 @@ const fixtures = require('../common/fixtures');
 assert.throws(() => zlib.gzipSync(Buffer.alloc(0), { windowBits: 8 }), {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: 'The value of "options.windowBits" is out of range. ' +
-           'It must be >= 9 and <= 15. Received 8',
 });
 
 let zlibPairs = [

--- a/test/pummel/test-fs-readfile-tostring-fail.js
+++ b/test/pummel/test-fs-readfile-tostring-fail.js
@@ -35,10 +35,7 @@ stream.on('finish', common.mustCall(function() {
   fs.readFile(file, 'utf8', common.mustCall(function(err, buf) {
     assert.ok(err instanceof Error);
     if (err.message !== 'Array buffer allocation failed') {
-      const stringLengthHex = kStringMaxLength.toString(16);
       common.expectsError({
-        message: 'Cannot create a string longer than ' +
-                 `0x${stringLengthHex} characters`,
         code: 'ERR_STRING_TOO_LONG',
         name: 'Error'
       })(err);

--- a/test/report/test-report-config.js
+++ b/test/report/test-report-config.js
@@ -76,13 +76,11 @@ if (!common.isWindows) {
     process.report.signal = 'foo';
   }, {
     code: 'ERR_UNKNOWN_SIGNAL',
-    message: 'Unknown signal: foo'
   });
   assert.throws(() => {
     process.report.signal = 'sigusr1';
   }, {
     code: 'ERR_UNKNOWN_SIGNAL',
-    message: 'Unknown signal: sigusr1 (signals must use all capital letters)'
   });
   assert.strictEqual(process.report.signal, 'SIGUSR2');
   process.report.signal = 'SIGUSR1';

--- a/test/sequential/test-crypto-timing-safe-equal.js
+++ b/test/sequential/test-crypto-timing-safe-equal.js
@@ -37,7 +37,6 @@ assert.throws(
   {
     code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
     name: 'RangeError',
-    message: 'Input buffers must have the same byte length'
   }
 );
 

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -135,7 +135,6 @@ function repeat(fn) {
     {
       name: 'Error',
       code: 'ERR_INTERNAL_ASSERTION',
-      message: /^handle must be a FSEvent/,
     }
   );
   oldhandle.close(); // clean up
@@ -157,7 +156,6 @@ function repeat(fn) {
     {
       name: 'Error',
       code: 'ERR_INTERNAL_ASSERTION',
-      message: /^handle must be a FSEvent/,
     }
   );
   oldhandle.close(); // clean up

--- a/test/sequential/test-heapdump.js
+++ b/test/sequential/test-heapdump.js
@@ -41,9 +41,6 @@ process.chdir(tmpdir.path);
   assert.throws(() => writeHeapSnapshot(i), {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "path" argument must be of type string or an instance of ' +
-             'Buffer or URL.' +
-             common.invalidArgTypeHelper(i)
   });
 });
 

--- a/test/sequential/test-http2-max-session-memory.js
+++ b/test/sequential/test-http2-max-session-memory.js
@@ -34,7 +34,6 @@ server.listen(0, common.mustCall(() => {
       req.on('error', common.expectsError({
         code: 'ERR_HTTP2_STREAM_ERROR',
         name: 'Error',
-        message: 'Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM'
       }));
       req.on('close', common.mustCall(() => {
         server.close();

--- a/test/sequential/test-inspector-runtime-evaluate-with-timeout.js
+++ b/test/sequential/test-inspector-runtime-evaluate-with-timeout.js
@@ -18,7 +18,6 @@ common.skipIfInspectorDisabled();
     }),
     {
       code: 'ERR_INSPECTOR_COMMAND',
-      message: 'Inspector error -32000: Execution was terminated'
     }
   );
   session.disconnect();

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -120,7 +120,6 @@ assert.throws(
   () => require('../fixtures/packages/missing-main-no-index'),
   {
     code: 'MODULE_NOT_FOUND',
-    message: /packages[/\\]missing-main-no-index[/\\]doesnotexist\.js'\. Please.+package\.json.+valid "main"/,
     path: /fixtures[/\\]packages[/\\]missing-main-no-index[/\\]package\.json/,
     requestPath: /^\.\.[/\\]fixtures[/\\]packages[/\\]missing-main-no-index$/
   }

--- a/test/sequential/test-vm-timeout-escape-promise-module-2.js
+++ b/test/sequential/test-vm-timeout-escape-promise-module-2.js
@@ -38,5 +38,4 @@ assert.rejects(async () => {
   await module.evaluate({ timeout: 10 });
 }, {
   code: 'ERR_SCRIPT_EXECUTION_TIMEOUT',
-  message: 'Script execution timed out after 10ms'
 });

--- a/test/wasi/test-wasi-initialize-validation.js
+++ b/test/wasi/test-wasi-initialize-validation.js
@@ -18,7 +18,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.initialize(); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance" argument must be of type object/
       }
     );
   }
@@ -34,7 +33,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.initialize(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports" property must be of type object/
       }
     );
   }
@@ -54,7 +52,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.initialize(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\._initialize" property must be of type function/
       }
     );
   }
@@ -78,8 +75,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.initialize(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: 'The "instance.exports._start" property must be' +
-          ' undefined. Received function _start',
       }
     );
   }
@@ -97,7 +92,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.initialize(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\.memory" property must be of type object/
       }
     );
   }
@@ -123,7 +117,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.initialize(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\.memory\.buffer" property must be an WebAssembly\.Memory/
       }
     );
   }
@@ -189,7 +182,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.initialize(instance); },
       {
         code: 'ERR_WASI_ALREADY_STARTED',
-        message: /^WASI instance has already started$/
       }
     );
   }

--- a/test/wasi/test-wasi-not-started.js
+++ b/test/wasi/test-wasi-not-started.js
@@ -21,7 +21,6 @@ if (process.argv[2] === 'wasi-child') {
   }, {
     name: 'Error',
     code: 'ERR_WASI_NOT_STARTED',
-    message: 'wasi.start() has not been called'
   });
 } else {
   const assert = require('assert');

--- a/test/wasi/test-wasi-options-validation.js
+++ b/test/wasi/test-wasi-options-validation.js
@@ -11,31 +11,31 @@ new WASI({});
 
 // If args is not an Array and not undefined, it should throw.
 assert.throws(() => { new WASI({ args: 'fhqwhgads' }); },
-              { code: 'ERR_INVALID_ARG_TYPE', message: /\bargs\b/ });
+              { code: 'ERR_INVALID_ARG_TYPE' });
 
 // If env is not an Object and not undefined, it should throw.
 assert.throws(() => { new WASI({ env: 'fhqwhgads' }); },
-              { code: 'ERR_INVALID_ARG_TYPE', message: /\benv\b/ });
+              { code: 'ERR_INVALID_ARG_TYPE' });
 
 // If preopens is not an Object and not undefined, it should throw.
 assert.throws(() => { new WASI({ preopens: 'fhqwhgads' }); },
-              { code: 'ERR_INVALID_ARG_TYPE', message: /\bpreopens\b/ });
+              { code: 'ERR_INVALID_ARG_TYPE' });
 
 // If returnOnExit is not a boolean and not undefined, it should throw.
 assert.throws(() => { new WASI({ returnOnExit: 'fhqwhgads' }); },
-              { code: 'ERR_INVALID_ARG_TYPE', message: /\breturnOnExit\b/ });
+              { code: 'ERR_INVALID_ARG_TYPE' });
 
 // If stdin is not an int32 and not undefined, it should throw.
 assert.throws(() => { new WASI({ stdin: 'fhqwhgads' }); },
-              { code: 'ERR_INVALID_ARG_TYPE', message: /\bstdin\b/ });
+              { code: 'ERR_INVALID_ARG_TYPE' });
 
 // If stdout is not an int32 and not undefined, it should throw.
 assert.throws(() => { new WASI({ stdout: 'fhqwhgads' }); },
-              { code: 'ERR_INVALID_ARG_TYPE', message: /\bstdout\b/ });
+              { code: 'ERR_INVALID_ARG_TYPE' });
 
 // If stderr is not an int32 and not undefined, it should throw.
 assert.throws(() => { new WASI({ stderr: 'fhqwhgads' }); },
-              { code: 'ERR_INVALID_ARG_TYPE', message: /\bstderr\b/ });
+              { code: 'ERR_INVALID_ARG_TYPE' });
 
 // If options is provided, but not an object, the constructor should throw.
 [null, 'foo', '', 0, NaN, Symbol(), true, false, () => {}].forEach((value) => {
@@ -46,4 +46,4 @@ assert.throws(() => { new WASI({ stderr: 'fhqwhgads' }); },
 // Verify that exceptions thrown from the binding layer are handled.
 assert.throws(() => {
   new WASI({ preopens: { '/sandbox': '__/not/real/path' } });
-}, { code: 'UVWASI_ENOENT', message: /uvwasi_init/ });
+}, { code: 'UVWASI_ENOENT' });

--- a/test/wasi/test-wasi-start-validation.js
+++ b/test/wasi/test-wasi-start-validation.js
@@ -18,7 +18,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance" argument must be of type object/
       }
     );
   }
@@ -34,7 +33,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports" property must be of type object/
       }
     );
   }
@@ -54,7 +52,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\._start" property must be of type function/
       }
     );
   }
@@ -78,8 +75,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: 'The "instance.exports._initialize" property must be' +
-          ' undefined. Received function _initialize',
       }
     );
   }
@@ -97,7 +92,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\.memory" property must be of type object/
       }
     );
   }
@@ -123,7 +117,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\.memory\.buffer" property must be an WebAssembly\.Memory/
       }
     );
   }
@@ -189,7 +182,6 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(instance); },
       {
         code: 'ERR_WASI_ALREADY_STARTED',
-        message: /^WASI instance has already started$/
       }
     );
   }


### PR DESCRIPTION
Some tests used `err.message` as the only check item, we need to replace them one by one.
I ignored some `err.message` that I wasn't sure would be decisive in the test.