### PR TITLE
tls: fix convertALPNProtocols accepting ArrayBufferViews

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -54,7 +54,11 @@ const {
 } = require('internal/errors').codes;
 const internalUtil = require('internal/util');
 internalUtil.assertCrypto();
-const { isArrayBufferView } = require('internal/util/types');
+const {
+  isArrayBufferView,
+  isDataView,
+  isUint8Array,
+} = require('internal/util/types');
 
 const net = require('net');
 const { getOptionValue } = require('internal/options');
@@ -143,9 +147,16 @@ exports.convertALPNProtocols = function convertALPNProtocols(protocols, out) {
   // If protocols is Array - translate it into buffer
   if (ArrayIsArray(protocols)) {
     out.ALPNProtocols = convertProtocols(protocols);
-  } else if (isArrayBufferView(protocols)) {
+  } else if (Buffer.isBuffer(protocols) || isUint8Array(protocols)) {
     // Copy new buffer not to be modified by user.
     out.ALPNProtocols = Buffer.from(protocols);
+  } else if (isDataView(protocols)) {
+    out.ALPNProtocols = Buffer.from(protocols.buffer.slice(
+      protocols.byteOffset,
+      protocols.byteOffset + protocols.byteLength
+    ));
+  } else if (isArrayBufferView(protocols)) {
+    out.ALPNProtocols = Buffer.from(protocols.slice().buffer);
   }
 };
 

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -103,8 +103,11 @@ assert.throws(
   const inputBuffer = Buffer.from(arrayBufferViewStr.repeat(8), 'utf8');
   for (const expectView of common.getArrayBufferViews(inputBuffer)) {
     const out = {};
+    const expected = Buffer.from(expectView.buffer.slice(),
+                                 expectView.byteOffset,
+                                 expectView.byteLength);
     tls.convertALPNProtocols(expectView, out);
-    assert(out.ALPNProtocols.equals(Buffer.from(expectView)));
+    assert(out.ALPNProtocols.equals(expected));
   }
 }
 


### PR DESCRIPTION
Fix for `ArrayBufferView`s that are not `Uint8Array`.

I believe it should be eventually adjusted on `buffer` side, but not sure if it would be easy or worth potential breakage.

Audit through `make test` gave me two misuses, both test-only and safe:
https://github.com/nodejs/node/blob/a346572b952e7942078af4105d34e049d28d3ea2/test/parallel/test-buffer-alloc.js#L46-L47
https://github.com/nodejs/node/blob/a346572b952e7942078af4105d34e049d28d3ea2/test/parallel/test-webcrypto-random.js#L50-L51

However, there could still be similar bugs within `crypto` in places where [`Buffer.from(buffer)`](https://nodejs.org/api/buffer.html#static-method-bufferfrombuffer) is used.

/cc @nodejs/crypto 