### PR TITLE
test: fix flaky test-https-server-close- tests

### DIFF
--- a/test/parallel/test-http-server-close-all.js
+++ b/test/parallel/test-http-server-close-all.js
@@ -26,32 +26,34 @@ server.listen(0, function() {
   // Create a first request but never finish it
   const client1 = connect(port);
 
+  client1.on('connect', common.mustCall(() => {
+    // Create a second request, let it finish but leave the connection opened using HTTP keep-alive
+    const client2 = connect(port);
+    let response = '';
+
+    client2.on('data', common.mustCall((chunk) => {
+      response += chunk.toString('utf-8');
+
+      if (response.endsWith('0\r\n\r\n')) {
+        assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));
+        assert.strictEqual(connections, 2);
+
+        server.closeAllConnections();
+        server.close(common.mustCall());
+
+        // This timer should never go off as the server.close should shut everything down
+        setTimeout(common.mustNotCall(), common.platformTimeout(1500)).unref();
+      }
+    }));
+
+    client2.on('close', common.mustCall());
+
+    client2.write('GET / HTTP/1.1\r\n\r\n');
+  }));
+
   client1.on('close', common.mustCall());
 
   client1.on('error', () => {});
 
   client1.write('GET / HTTP/1.1');
-
-  // Create a second request, let it finish but leave the connection opened using HTTP keep-alive
-  const client2 = connect(port);
-  let response = '';
-
-  client2.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
-
-    if (response.endsWith('0\r\n\r\n')) {
-      assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));
-      assert.strictEqual(connections, 2);
-
-      server.closeAllConnections();
-      server.close(common.mustCall());
-
-      // This timer should never go off as the server.close should shut everything down
-      setTimeout(common.mustNotCall(), common.platformTimeout(1500)).unref();
-    }
-  }));
-
-  client2.on('close', common.mustCall());
-
-  client2.write('GET / HTTP/1.1\r\n\r\n');
 });

--- a/test/parallel/test-http-server-close-idle.js
+++ b/test/parallel/test-http-server-close-idle.js
@@ -28,6 +28,39 @@ server.listen(0, function() {
   // Create a first request but never finish it
   const client1 = connect(port);
 
+  client1.on('connect', common.mustCall(() => {
+    // Create a second request, let it finish but leave the connection opened using HTTP keep-alive
+    const client2 = connect(port);
+    let response = '';
+
+    client2.on('data', common.mustCall((chunk) => {
+      response += chunk.toString('utf-8');
+
+      if (response.endsWith('0\r\n\r\n')) {
+        assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));
+        assert.strictEqual(connections, 2);
+
+        server.closeIdleConnections();
+        server.close(common.mustCall());
+
+        // Check that only the idle connection got closed
+        setTimeout(common.mustCall(() => {
+          assert(!client1Closed);
+          assert(client2Closed);
+
+          server.closeAllConnections();
+          server.close(common.mustCall());
+        }), common.platformTimeout(500)).unref();
+      }
+    }));
+
+    client2.on('close', common.mustCall(() => {
+      client2Closed = true;
+    }));
+
+    client2.write('GET / HTTP/1.1\r\n\r\n');
+  }));
+
   client1.on('close', common.mustCall(() => {
     client1Closed = true;
   }));
@@ -35,35 +68,4 @@ server.listen(0, function() {
   client1.on('error', () => {});
 
   client1.write('GET / HTTP/1.1');
-
-  // Create a second request, let it finish but leave the connection opened using HTTP keep-alive
-  const client2 = connect(port);
-  let response = '';
-
-  client2.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
-
-    if (response.endsWith('0\r\n\r\n')) {
-      assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));
-      assert.strictEqual(connections, 2);
-
-      server.closeIdleConnections();
-      server.close(common.mustCall());
-
-      // Check that only the idle connection got closed
-      setTimeout(common.mustCall(() => {
-        assert(!client1Closed);
-        assert(client2Closed);
-
-        server.closeAllConnections();
-        server.close(common.mustCall());
-      }), common.platformTimeout(500)).unref();
-    }
-  }));
-
-  client2.on('close', common.mustCall(() => {
-    client2Closed = true;
-  }));
-
-  client2.write('GET / HTTP/1.1\r\n\r\n');
 });

--- a/test/parallel/test-https-server-close-all.js
+++ b/test/parallel/test-https-server-close-all.js
@@ -37,32 +37,34 @@ server.listen(0, function() {
   // Create a first request but never finish it
   const client1 = connect({ port, rejectUnauthorized: false });
 
+  client1.on('connect', common.mustCall(() => {
+    // Create a second request, let it finish but leave the connection opened using HTTP keep-alive
+    const client2 = connect({ port, rejectUnauthorized: false });
+    let response = '';
+
+    client2.on('data', common.mustCall((chunk) => {
+      response += chunk.toString('utf-8');
+
+      if (response.endsWith('0\r\n\r\n')) {
+        assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));
+        assert.strictEqual(connections, 2);
+
+        server.closeAllConnections();
+        server.close(common.mustCall());
+
+        // This timer should never go off as the server.close should shut everything down
+        setTimeout(common.mustNotCall(), common.platformTimeout(1500)).unref();
+      }
+    }));
+
+    client2.on('close', common.mustCall());
+
+    client2.write('GET / HTTP/1.1\r\n\r\n');
+  }));
+
   client1.on('close', common.mustCall());
 
   client1.on('error', () => {});
 
   client1.write('GET / HTTP/1.1');
-
-  // Create a second request, let it finish but leave the connection opened using HTTP keep-alive
-  const client2 = connect({ port, rejectUnauthorized: false });
-  let response = '';
-
-  client2.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
-
-    if (response.endsWith('0\r\n\r\n')) {
-      assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));
-      assert.strictEqual(connections, 2);
-
-      server.closeAllConnections();
-      server.close(common.mustCall());
-
-      // This timer should never go off as the server.close should shut everything down
-      setTimeout(common.mustNotCall(), common.platformTimeout(1500)).unref();
-    }
-  }));
-
-  client2.on('close', common.mustCall());
-
-  client2.write('GET / HTTP/1.1\r\n\r\n');
 });

--- a/test/parallel/test-https-server-close-idle.js
+++ b/test/parallel/test-https-server-close-idle.js
@@ -39,6 +39,39 @@ server.listen(0, function() {
   // Create a first request but never finish it
   const client1 = connect({ port, rejectUnauthorized: false });
 
+  client1.on('connect', common.mustCall(() => {
+    // Create a second request, let it finish but leave the connection opened using HTTP keep-alive
+    const client2 = connect({ port, rejectUnauthorized: false });
+    let response = '';
+
+    client2.on('data', common.mustCall((chunk) => {
+      response += chunk.toString('utf-8');
+
+      if (response.endsWith('0\r\n\r\n')) {
+        assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));
+        assert.strictEqual(connections, 2);
+
+        server.closeIdleConnections();
+        server.close(common.mustCall());
+
+        // Check that only the idle connection got closed
+        setTimeout(common.mustCall(() => {
+          assert(!client1Closed);
+          assert(client2Closed);
+
+          server.closeAllConnections();
+          server.close(common.mustCall());
+        }), common.platformTimeout(500)).unref();
+      }
+    }));
+
+    client2.on('close', common.mustCall(() => {
+      client2Closed = true;
+    }));
+
+    client2.write('GET / HTTP/1.1\r\n\r\n');
+  }));
+
   client1.on('close', common.mustCall(() => {
     client1Closed = true;
   }));
@@ -46,35 +79,4 @@ server.listen(0, function() {
   client1.on('error', () => {});
 
   client1.write('GET / HTTP/1.1');
-
-  // Create a second request, let it finish but leave the connection opened using HTTP keep-alive
-  const client2 = connect({ port, rejectUnauthorized: false });
-  let response = '';
-
-  client2.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
-
-    if (response.endsWith('0\r\n\r\n')) {
-      assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));
-      assert.strictEqual(connections, 2);
-
-      server.closeIdleConnections();
-      server.close(common.mustCall());
-
-      // Check that only the idle connection got closed
-      setTimeout(common.mustCall(() => {
-        assert(!client1Closed);
-        assert(client2Closed);
-
-        server.closeAllConnections();
-        server.close(common.mustCall());
-      }), common.platformTimeout(500)).unref();
-    }
-  }));
-
-  client2.on('close', common.mustCall(() => {
-    client2Closed = true;
-  }));
-
-  client2.write('GET / HTTP/1.1\r\n\r\n');
 });


### PR DESCRIPTION
Don't initiate the second connection until the first has been
established.

Refs: https://github.com/nodejs/reliability/issues/289