### PR TITLE
lib: give names to promisified `exists()` and `question()`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -278,9 +278,9 @@ function exists(path, callback) {
 
 ObjectDefineProperty(exists, internalUtil.promisify.custom, {
   __proto__: null,
-  value: (path) => {
+  value: function exists(path) { // eslint-disable-line func-name-matching
     return new Promise((resolve) => fs.exists(path, resolve));
-  }
+  },
 });
 
 // fs.existsSync never throws, it only returns true or false.

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -153,7 +153,7 @@ Interface.prototype.question = function(query, options, cb) {
     FunctionPrototypeCall(superQuestion, this, query, cb);
   }
 };
-Interface.prototype.question[promisify.custom] = function(query, options) {
+Interface.prototype.question[promisify.custom] = function question(query, options) {
   options = typeof options === 'object' && options !== null ? options : {};
 
   if (options.signal && options.signal.aborted) {

--- a/test/parallel/test-util-promisify-custom-names.mjs
+++ b/test/parallel/test-util-promisify-custom-names.mjs
@@ -1,0 +1,40 @@
+import '../common/index.mjs';
+import assert from 'node:assert';
+import { promisify } from 'node:util';
+
+// Test that customly promisified methods in [util.promisify.custom]
+// have appropriate names
+
+import fs from 'node:fs';
+import readline from 'node:readline';
+import stream from 'node:stream';
+import timers from 'node:timers';
+
+
+assert.strictEqual(
+  promisify(fs.exists).name,
+  'exists'
+);
+
+assert.strictEqual(
+  promisify(readline.Interface.prototype.question).name,
+  'question',
+);
+
+assert.strictEqual(
+  promisify(stream.finished).name,
+  'finished'
+);
+assert.strictEqual(
+  promisify(stream.pipeline).name,
+  'pipeline'
+);
+
+assert.strictEqual(
+  promisify(timers.setImmediate).name,
+  'setImmediate'
+);
+assert.strictEqual(
+  promisify(timers.setTimeout).name,
+  'setTimeout'
+);


### PR DESCRIPTION
```mjs
import { promisify } from 'node:util';
import fs from 'node:fs';
import readline from 'node:readline';
[
        fs.exists,
        readline.createInterface({input:process.stdin}).question,
].forEach(fn=>console.log(promisify(fn).name));
```
Old:
```console
value
# empty string
```
New:
```console
exists
question
```