### PR TITLE
dns: make promise API fully constructed from `lib/internal/dns/promises`

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -439,8 +439,6 @@ ObjectDefineProperties(module.exports, {
     get() {
       if (promises === null) {
         promises = require('internal/dns/promises');
-        promises.setServers = defaultResolverSetServers;
-        promises.setDefaultResultOrder = setDefaultResultOrder;
       }
       return promises;
     }

--- a/lib/dns/promises.js
+++ b/lib/dns/promises.js
@@ -1,5 +1,3 @@
 'use strict';
 
-const dnsPromises = require('internal/dns/promises');
-dnsPromises.setServers = require('dns').setServers;
-module.exports = dnsPromises;
+module.exports = require('internal/dns/promises');

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -17,6 +17,8 @@ const {
   emitInvalidHostnameWarning,
   getDefaultVerbatim,
   errorCodes: dnsErrorCodes,
+  setDefaultResultOrder,
+  setDefaultResolver,
 } = require('internal/dns/utils');
 const {
   NODATA,
@@ -349,11 +351,20 @@ Resolver.prototype.resolve = function resolve(hostname, rrtype) {
   return ReflectApply(resolver, this, [hostname]);
 };
 
+function defaultResolverSetServers(servers) {
+  const resolver = new Resolver();
+
+  resolver.setServers(servers);
+  setDefaultResolver(resolver);
+  bindDefaultResolver(module.exports, Resolver.prototype);
+}
 
 module.exports = {
   lookup,
   lookupService,
   Resolver,
+  setDefaultResultOrder,
+  setServers: defaultResolverSetServers,
 
   // ERROR CODES
   NODATA,


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This pr makes the whole promise API be fully constructed from `lib/internal/dns/promises.js`, it should not be split between `lib/dns.js` and `lib/internal/dns/promises.js`.

Refs: https://github.com/nodejs/node/discussions/43198
