### PR TITLE
tools: refactor `tools/license2rtf` to ESM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1096,7 +1096,7 @@ endif
 		$(MACOSOUTDIR)/dist/npm/usr/local/lib/node_modules
 	unlink $(MACOSOUTDIR)/dist/node/usr/local/bin/npm
 	unlink $(MACOSOUTDIR)/dist/node/usr/local/bin/npx
-	$(NODE) tools/license2rtf.js < LICENSE > \
+	$(NODE) tools/license2rtf.mjs < LICENSE > \
 		$(MACOSOUTDIR)/installer/productbuild/Resources/license.rtf
 	cp doc/osx_installer_logo.png $(MACOSOUTDIR)/installer/productbuild/Resources
 	pkgbuild --version $(FULLVERSION) \

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -405,7 +405,7 @@ if errorlevel 1 echo "Could not create junction to 'out\%config%'." & exit /B
 if not defined sign goto licensertf
 
 call tools\sign.bat Release\node.exe
-if errorlevel 1 echo Failed to sign exe&goto exit
+if errorlevel 1 echo Failed to sign exe, got error code %errorlevel%&goto exit
 
 :licensertf
 @rem Skip license.rtf generation if not requested.
@@ -426,12 +426,12 @@ if "%use_x64_node_exe%"=="true" (
     set exit_code=1
     goto exit
   )
-  %x64_node_exe% tools\license2rtf.js < LICENSE > %config%\license.rtf
+  %x64_node_exe% tools\license2rtf.mjs < LICENSE > %config%\license.rtf
 ) else (
-  %node_exe% tools\license2rtf.js < LICENSE > %config%\license.rtf
+  %node_exe% tools\license2rtf.mjs < LICENSE > %config%\license.rtf
 )
 
-if errorlevel 1 echo Failed to generate license.rtf&goto exit
+if errorlevel 1 echo Failed to generate license.rtf, got error code %errorlevel%&goto exit
 
 :stage_package
 if not defined stage_package goto install-doctools
@@ -538,7 +538,7 @@ if errorlevel 1 goto exit
 
 if not defined sign goto upload
 call tools\sign.bat node-v%FULLVERSION%-%target_arch%.msi
-if errorlevel 1 echo Failed to sign msi&goto exit
+if errorlevel 1 echo Failed to sign msi, got error code %errorlevel%&goto exit
 
 :upload
 @rem Skip upload if not requested


### PR DESCRIPTION
This pr reimplement https://github.com/nodejs/node/pull/43101: refactor license2rtf.js to ESM.

The last pr(43101) is reverted by https://github.com/nodejs/node/pull/43214 because it causes windows ci failure.

Refs: https://github.com/nodejs/node/issues/43213

# Windows

## Before the fix

```sh
C:\Users\Administrator\dev\node>git log -1           
commit c9f5078d8cb601624caeec656823445475050bc1 (HEAD -> master)
Author: Feng <F3n67u@outlook.com>
Date:   Sun May 29 12:14:26 2022 +0800

    Revert "Revert "tools: refactor `tools/license2rtf` to ESM""
    
    This reverts commit 331088f4a450e29f3ea8a28a9f98ccc9f8951386.

C:\Users\Administrator\dev\node>git --no-pager diff                                             

C:\Users\Administrator\dev\node>.\Release\node.exe tools\license2rtf.mjs < LICENSE > license.rtf

C:\Users\Administrator\dev\node>echo Exit Code is %errorlevel%
Exit Code is 13
```

The exit code of `.\Release\node.exe tools\license2rtf.mjs < LICENSE > license.rtf` command is 13 which cause windows ci failure: `Failed to generate license.rtf`(https://github.com/nodejs/node/issues/43213).

The `errorlevel` variable check of windows build is at:

https://github.com/nodejs/node/blob/ca0044bd1d221df7d3efbf735a1a98e2e1fef731/vcbuild.bat#L428

## After fix

```sh
C:\Users\Administrator\dev\node>git --no-pager diff
diff --git a/tools/license2rtf.mjs b/tools/license2rtf.mjs
index 0772b161ed..6f07e57c7f 100644
--- a/tools/license2rtf.mjs
+++ b/tools/license2rtf.mjs
@@ -289,11 +289,16 @@ class RtfGenerator extends Stream {
 stdin.setEncoding('utf-8');
 stdin.resume();
 
-await pipeline(
-  stdin,
-  new LineSplitter(),
-  new ParagraphParser(),
-  new Unwrapper(),
-  new RtfGenerator(),
-  stdout,
-);
+async function main() {
+  await pipeline(
+    stdin,
+    new LineSplitter(),
+    new ParagraphParser(),
+    new Unwrapper(),
+    new RtfGenerator(),
+    stdout,
+  );
+}
+
+main().catch(console.error);
+

C:\Users\Administrator\dev\node>.\Release\node.exe tools\license2rtf.mjs < LICENSE > license.rtf

C:\Users\Administrator\dev\node>echo Exit Code is %errorlevel%
Exit Code is 0
```

The exit code of .\Release\node.exe tools\license2rtf.mjs < LICENSE > license.rtf command is 0.

# MacOS

## Before the fix

```sh
$ git --no-pager log -1          
commit 255c643e136a1aa11c4cbb6667f76624e85b4721 (HEAD -> master, revert-revert-esm-license2rtf)
Author: Feng Yu <F3n67u@outlook.com>
Date:   Sun May 29 12:19:04 2022 +0800

    Revert "Revert "tools: refactor `tools/license2rtf` to ESM""
    
    This reverts commit 331088f4a450e29f3ea8a28a9f98ccc9f8951386.
$ ./node tools/license2rtf.mjs < LICENSE > license.rtf 
$ echo $?
13
```

The exit code of `./node tools/license2rtf.mjs < LICENSE > license.rtf` command is 13.

## After fix

```sh
$ git --no-pager diff            
diff --git a/tools/license2rtf.mjs b/tools/license2rtf.mjs
index 0772b161ed..4cdca33b60 100644
--- a/tools/license2rtf.mjs
+++ b/tools/license2rtf.mjs
@@ -289,11 +289,15 @@ class RtfGenerator extends Stream {
 stdin.setEncoding('utf-8');
 stdin.resume();
 
-await pipeline(
-  stdin,
-  new LineSplitter(),
-  new ParagraphParser(),
-  new Unwrapper(),
-  new RtfGenerator(),
-  stdout,
-);
+async function main() {
+  await pipeline(
+    stdin,
+    new LineSplitter(),
+    new ParagraphParser(),
+    new Unwrapper(),
+    new RtfGenerator(),
+    stdout,
+  );
+}
+
+main().catch(console.error);
$ ./node tools/license2rtf.mjs < LICENSE > license.rtf 
$ echo $?                                              
0
```

The exit code of `./node tools/license2rtf.mjs < LICENSE > license.rtf` command is 0.