### PR TITLE
doc: fix 404 link of BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -608,7 +608,7 @@ packages:
 * [NetWide Assembler](https://chocolatey.org/packages/nasm)
 
 To install Node.js prerequisites using
-[Boxstarter WebLauncher](https://boxstarter.org/WebLauncher), open
+[Boxstarter WebLauncher](https://boxstarter.org/weblauncher), open
 <https://boxstarter.org/package/nr/url?https://raw.githubusercontent.com/nodejs/node/HEAD/tools/bootstrap/windows_boxstarter>
 with Internet Explorer or Edge browser on the target machine.
 


### PR DESCRIPTION
https://boxstarter.org/WebLauncher is 404, change to https://boxstarter.org/weblauncher which is accessible now.

<img width="1233" alt="image" src="https://user-images.githubusercontent.com/12343178/170858224-f3de5f9c-e217-44c8-b4ff-fb50c0c1e141.png">
