### PR TITLE
doc: fix Visual Studio 2019 download link

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -566,9 +566,9 @@ to run it again before invoking `make -j4`.
 
 * [Python 3.10](https://www.microsoft.com/en-us/p/python-310/9pjpw5ldxlz5)
 * The "Desktop development with C++" workload from
-  [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/) or
+  [Visual Studio 2019](https://visualstudio.microsoft.com/vs/older-downloads/#visual-studio-2019-and-other-products) or
   the "C++ build tools" workload from the
-  [Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019),
+  [Build Tools](https://aka.ms/vs/16/release/vs_buildtools.exe),
   with the default optional components
 * Basic Unix tools required for some tests,
   [Git for Windows](https://git-scm.com/download/win) includes Git Bash


### PR DESCRIPTION
**Background**: Building Node.js with Visual Studio 2022 is broken from Visual Studio 17.2, see https://github.com/nodejs/node/issues/43092.

The https://visualstudio.microsoft.com/downloads/ now link to the latest Visual Studio 2022 version instead of 2019 is incorrect. If our windows new contributor follows the link and downloads the Visual Studio 2022, build will fail.  I follow this link and download the 2022 version yesterday😂 and experience build failure.

~~https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019 link is also broken, I cannot find a link to  build-tools-for-visual-studio-2019 to replace it, so I delete the `[Build Tools]` link. If https://github.com/nodejs/node/issues/43092 is resolved, we could add it again.  or If anyone could find the link to build-tools-for-visual-studio-2019, please comment and I will add it.~~