### PR TITLE
src: convey potential exceptions during StreamPipe construction

### DIFF
--- a/src/stream_pipe.h
+++ b/src/stream_pipe.h
@@ -13,10 +13,9 @@ class StreamPipe : public AsyncWrap {
 
   void Unpipe(bool is_in_deletion = false);
 
-  // TODO(RaisinTen): Just like MessagePort, add the following overload:
-  // static StreamPipe* New(StreamBase* source, StreamBase* sink,
-  //                        v8::Local<v8::Object> obj);
-  // so that we can indicate if there is a pending exception/termination.
+  static v8::Maybe<StreamPipe*> New(StreamBase* source,
+                                    StreamBase* sink,
+                                    v8::Local<v8::Object> obj);
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Unpipe(const v8::FunctionCallbackInfo<v8::Value>& args);


### PR DESCRIPTION
This moves the V8 calls during the StreamPipe construction to an
overload of `StreamPipe::New()`, so that it is possible to indicate if
there is a pending exception/termination.

Refs: https://github.com/nodejs/node/pull/40425#discussion_r726975901
Signed-off-by: Darshan Sen <raisinten@gmail.com>

cc @addaleax 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
