### PR TITLE
tools: update clang-format 1.7.0 to 1.8.0

### DIFF
--- a/tools/clang-format/package-lock.json
+++ b/tools/clang-format/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "clang-format": "^1.7.0"
+        "clang-format": "^1.8.0"
       }
     },
     "node_modules/async": {
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/clang-format": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.7.0.tgz",
-      "integrity": "sha512-BNuK+rXAK/Fk0rOQ1DW6bpSQUAZz6tpbZHTQn6m4PsgEkE1SNr6AQ/hhFK/b4KJrl4zjcl68molP+rEaKSZRAQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.8.0.tgz",
+      "integrity": "sha512-pK8gzfu55/lHzIpQ1givIbWfn3eXnU7SfxqIwVgnn5jEM6j4ZJYjpFqFs4iSBPNedzRMmfjYjuQhu657WAXHXw==",
       "dependencies": {
         "async": "^3.2.3",
         "glob": "^7.0.0",
@@ -202,9 +202,9 @@
       }
     },
     "clang-format": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.7.0.tgz",
-      "integrity": "sha512-BNuK+rXAK/Fk0rOQ1DW6bpSQUAZz6tpbZHTQn6m4PsgEkE1SNr6AQ/hhFK/b4KJrl4zjcl68molP+rEaKSZRAQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.8.0.tgz",
+      "integrity": "sha512-pK8gzfu55/lHzIpQ1givIbWfn3eXnU7SfxqIwVgnn5jEM6j4ZJYjpFqFs4iSBPNedzRMmfjYjuQhu657WAXHXw==",
       "requires": {
         "async": "^3.2.3",
         "glob": "^7.0.0",

--- a/tools/clang-format/package.json
+++ b/tools/clang-format/package.json
@@ -4,6 +4,6 @@
   "description": "Formatting C++ files for Node.js core",
   "license": "MIT",
   "dependencies": {
-    "clang-format": "^1.7.0"
+    "clang-format": "^1.8.0"
   }
 }


### PR DESCRIPTION
v1.7.0 was shipping ARM64 binaries for macOS which doesn't run on Intel
Macs. v1.8.0 moved back to x86_64 binaries which works on both Intel
and M1 Macs.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
