### PR TITLE
module: add preImport loader hook

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1036,8 +1036,9 @@ function wrapSafe(filename, content, cjsModuleInstance) {
       displayErrors: true,
       importModuleDynamically: async (specifier, _, importAssertions) => {
         const loader = asyncESM.esmLoader;
-        return loader.import(specifier, normalizeReferrerURL(filename),
-                             importAssertions);
+        return loader.import(specifier,
+                             normalizeReferrerURL(filename),
+                             importAssertions, true);
       },
     });
   }
@@ -1052,8 +1053,9 @@ function wrapSafe(filename, content, cjsModuleInstance) {
       filename,
       importModuleDynamically(specifier, _, importAssertions) {
         const loader = asyncESM.esmLoader;
-        return loader.import(specifier, normalizeReferrerURL(filename),
-                             importAssertions);
+        return loader.import(specifier,
+                             normalizeReferrerURL(filename),
+                             importAssertions, true);
       },
     });
   } catch (err) {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -502,7 +502,7 @@ class ESMLoader {
       conditions: DEFAULT_CONDITIONS,
       dynamic,
       importAssertions: this.#hasLoaderHooks ?
-          ObjectAssign(ObjectCreate(null), importAssertions) : importAssertions,
+        ObjectAssign(ObjectCreate(null), importAssertions) : importAssertions,
       parentURL
     });
     await PromiseAll(new SafeArrayIterator(ArrayPrototypeMap(
@@ -787,7 +787,7 @@ class ESMLoader {
     const context = ObjectFreeze({
       conditions: DEFAULT_CONDITIONS,
       importAssertions: this.#hasLoaderHooks ?
-          ObjectAssign(ObjectCreate(null), importAssertions) : importAssertions,
+        ObjectAssign(ObjectCreate(null), importAssertions) : importAssertions,
       parentURL,
     });
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -4,15 +4,15 @@
 require('internal/modules/cjs/loader');
 
 const {
-  Array,
-  ArrayIsArray,
   ArrayPrototypeJoin,
+  ArrayPrototypeMap,
   ArrayPrototypePush,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
   ObjectAssign,
   ObjectCreate,
   ObjectDefineProperty,
+  ObjectFreeze,
   ObjectSetPrototypeOf,
   PromiseAll,
   PromiseResolve,
@@ -195,12 +195,19 @@ function nextHookFactory(chain, meta, { validateArgs, validateOutput }) {
  */
 class ESMLoader {
   /**
+   * Whether this loader has userland hooks.
+   * @private
+   * @property {boolean} hasLoaderHooks
+   */
+  #hasLoaderHooks = false;
+
+  /**
    * Prior to ESM loading. These are called once before any modules are started.
    * @private
-   * @property {KeyedHook[]} globalPreloaders Last-in-first-out
+   * @property {KeyedHook[]} globalPreloadHooks Last-in-first-out
    *  list of preload hooks.
    */
-  #globalPreloaders = [];
+  #globalPreloadHooks = [];
 
   /**
    * Phase 2 of 2 in ESM loading.
@@ -208,12 +215,14 @@ class ESMLoader {
    * @property {KeyedHook[]} loaders Last-in-first-out
    *  collection of loader hooks.
    */
-  #loaders = [
+  #loadHooks = [
     {
       fn: defaultLoad,
       url: 'node:internal/modules/esm/load',
     },
   ];
+
+  #preImportHooks = [];
 
   /**
    * Phase 1 of 2 in ESM loading.
@@ -221,7 +230,7 @@ class ESMLoader {
    * @property {KeyedHook[]} resolvers Last-in-first-out
    *  collection of resolver hooks.
    */
-  #resolvers = [
+  #resolveHooks = [
     {
       fn: defaultResolve,
       url: 'node:internal/modules/esm/resolve',
@@ -270,71 +279,6 @@ class ESMLoader {
   }
 
   /**
-   *
-   * @param {ModuleExports} exports
-   * @returns {ExportedHooks}
-   */
-  static pluckHooks({
-    globalPreload,
-    resolve,
-    load,
-    // obsolete hooks:
-    dynamicInstantiate,
-    getFormat,
-    getGlobalPreloadCode,
-    getSource,
-    transformSource,
-  }) {
-    const obsoleteHooks = [];
-    const acceptedHooks = ObjectCreate(null);
-
-    if (getGlobalPreloadCode) {
-      globalPreload ??= getGlobalPreloadCode;
-
-      process.emitWarning(
-        'Loader hook "getGlobalPreloadCode" has been renamed to "globalPreload"'
-      );
-    }
-    if (dynamicInstantiate) ArrayPrototypePush(
-      obsoleteHooks,
-      'dynamicInstantiate'
-    );
-    if (getFormat) ArrayPrototypePush(
-      obsoleteHooks,
-      'getFormat',
-    );
-    if (getSource) ArrayPrototypePush(
-      obsoleteHooks,
-      'getSource',
-    );
-    if (transformSource) ArrayPrototypePush(
-      obsoleteHooks,
-      'transformSource',
-    );
-
-    if (obsoleteHooks.length) process.emitWarning(
-      `Obsolete loader hook(s) supplied and will be ignored: ${
-        ArrayPrototypeJoin(obsoleteHooks, ', ')
-      }`,
-      'DeprecationWarning',
-    );
-
-    // Use .bind() to avoid giving access to the Loader instance when called.
-    if (globalPreload) {
-      acceptedHooks.globalPreloader =
-        FunctionPrototypeBind(globalPreload, null);
-    }
-    if (resolve) {
-      acceptedHooks.resolver = FunctionPrototypeBind(resolve, null);
-    }
-    if (load) {
-      acceptedHooks.loader = FunctionPrototypeBind(load, null);
-    }
-
-    return acceptedHooks;
-  }
-
-  /**
    * Collect custom/user-defined hook(s). After all hooks have been collected,
    * calls global preload hook(s).
    * @param {KeyedExports} customLoaders
@@ -349,42 +293,82 @@ class ESMLoader {
         exports,
         url,
       } = customLoaders[i];
-      const {
-        globalPreloader,
-        resolver,
-        loader,
-      } = ESMLoader.pluckHooks(exports);
 
-      if (globalPreloader) {
+      const obsoleteHooks = [];
+
+      if (exports.getGlobalPreloadCode) {
+        process.emitWarning(
+          'exports hook "getGlobalPreloadCode" has been renamed to "globalPreload"'
+        );
+      }
+      if (exports.dynamicInstantiate) ArrayPrototypePush(
+        obsoleteHooks,
+        'dynamicInstantiate'
+      );
+      if (exports.getFormat) ArrayPrototypePush(
+        obsoleteHooks,
+        'getFormat',
+      );
+      if (exports.getSource) ArrayPrototypePush(
+        obsoleteHooks,
+        'getSource',
+      );
+      if (exports.transformSource) ArrayPrototypePush(
+        obsoleteHooks,
+        'transformSource',
+      );
+
+      if (obsoleteHooks.length) process.emitWarning(
+        `Obsolete loader hook(s) supplied and will be ignored: ${
+          ArrayPrototypeJoin(obsoleteHooks, ', ')
+        }`,
+        'DeprecationWarning',
+      );
+
+      const globalPreloadHook = exports.getGlobalPreloadCode ?? exports.globalPreload;
+      const preImportHook = exports.preImport;
+      const resolveHook = exports.resolve;
+      const loadHook = exports.load;
+
+      // [1] ensure hook function is not bound to ESMLoader instance
+      if (globalPreloadHook) {
+        this.#hasLoaderHooks = true;
         ArrayPrototypePush(
-          this.#globalPreloaders,
+          this.#globalPreloadHooks,
           {
-            fn: FunctionPrototypeBind(globalPreloader), // [1]
+            fn: FunctionPrototypeBind(globalPreloadHook), // [1]
             url,
           },
         );
       }
-      if (resolver) {
+      if (preImportHook) {
+        this.#hasLoaderHooks = true;
         ArrayPrototypePush(
-          this.#resolvers,
+          this.#preImportHooks,
+          FunctionPrototypeBind(preImportHook), // [1]
+        );
+      }
+      if (resolveHook) {
+        this.#hasLoaderHooks = true;
+        ArrayPrototypePush(
+          this.#resolveHooks,
           {
-            fn: FunctionPrototypeBind(resolver), // [1]
+            fn: FunctionPrototypeBind(resolveHook), // [1]
             url,
           },
         );
       }
-      if (loader) {
+      if (loadHook) {
+        this.#hasLoaderHooks = true;
         ArrayPrototypePush(
-          this.#loaders,
+          this.#loadHooks,
           {
-            fn: FunctionPrototypeBind(loader), // [1]
+            fn: FunctionPrototypeBind(loadHook), // [1]
             url,
           },
         );
       }
     }
-
-    // [1] ensure hook function is not bound to ESMLoader instance
 
     this.preload();
   }
@@ -398,7 +382,7 @@ class ESMLoader {
       const module = new ModuleWrap(url, undefined, source, 0, 0);
       callbackMap.set(module, {
         importModuleDynamically: (specifier, { url }, importAssertions) => {
-          return this.import(specifier, url, importAssertions);
+          return this.import(specifier, url, importAssertions, true);
         }
       });
 
@@ -428,22 +412,10 @@ class ESMLoader {
    * @returns {Promise<ModuleJob>} The (possibly pending) module job
    */
   async getModuleJob(specifier, parentURL, importAssertions) {
-    let importAssertionsForResolve;
-
-    // By default, `this.#loaders` contains just the Node default load hook
-    if (this.#loaders.length !== 1) {
-      // We can skip cloning if there are no user-provided loaders because
-      // the Node.js default resolve hook does not use import assertions.
-      importAssertionsForResolve = ObjectAssign(
-        ObjectCreate(null),
-        importAssertions,
-      );
-    }
-
     const { format, url } = this.resolve(
       specifier,
       parentURL,
-      importAssertionsForResolve,
+      importAssertions,
     );
 
     let job = this.moduleMap.get(url, importAssertions.type);
@@ -517,48 +489,29 @@ class ESMLoader {
    * This method must NOT be renamed: it functions as a dynamic import on a
    * loader module.
    *
-   * @param {string | string[]} specifiers Path(s) to the module.
-   * @param {string} parentURL Path of the parent importing the module.
+   * @param {string} specifier Imported specifier
+   * @param {string} parentURL URL of the parent importing the module.
    * @param {Record<string, string>} importAssertions Validations for the
    *                                                  module import.
-   * @returns {Promise<ExportedHooks | KeyedExports[]>}
-   *  A collection of module export(s) or a list of collections of module
-   *  export(s).
+   * @param {boolean} dynamic Whether the import is a dynamic `import()`.
+   * @returns {Promise<ModuleNamespace>}
    */
-  async import(specifiers, parentURL, importAssertions) {
-    // For loaders, `import` is passed multiple things to process, it returns a
-    // list pairing the url and exports collected. This is especially useful for
-    // error messaging, to identity from where an export came. But, in most
-    // cases, only a single url is being "imported" (ex `import()`), so there is
-    // only 1 possible url from which the exports were collected and it is
-    // already known to the caller. Nesting that in a list would only ever
-    // create redundant work for the caller, so it is later popped off the
-    // internal list.
-    const wasArr = ArrayIsArray(specifiers);
-    if (!wasArr) { specifiers = [specifiers]; }
-
-    const count = specifiers.length;
-    const jobs = new Array(count);
-
-    for (let i = 0; i < count; i++) {
-      jobs[i] = this.getModuleJob(specifiers[i], parentURL, importAssertions)
-        .then((job) => job.run())
-        .then(({ module }) => module.getNamespace());
-    }
-
-    const namespaces = await PromiseAll(new SafeArrayIterator(jobs));
-
-    if (!wasArr) { return namespaces[0]; } // We can skip the pairing below
-
-    for (let i = 0; i < count; i++) {
-      const namespace = ObjectCreate(null);
-      namespace.url = specifiers[i];
-      namespace.exports = namespaces[i];
-
-      namespaces[i] = namespace;
-    }
-
-    return namespaces;
+  async import(specifier, parentURL,
+               importAssertions = ObjectCreate(null), dynamic = false) {
+    const context = ObjectFreeze({
+      conditions: DEFAULT_CONDITIONS,
+      dynamic,
+      importAssertions: this.#hasLoaderHooks ?
+          ObjectAssign(ObjectCreate(null), importAssertions) : importAssertions,
+      parentURL
+    });
+    await PromiseAll(new SafeArrayIterator(ArrayPrototypeMap(
+      this.#preImportHooks,
+      (preImportHook) => preImportHook(specifier, context)
+    )));
+    const job = await this.getModuleJob(specifier, parentURL, importAssertions);
+    const { module } = await job.run();
+    return module.getNamespace();
   }
 
   /**
@@ -573,7 +526,7 @@ class ESMLoader {
    * @returns {{ format: ModuleFormat, source: ModuleSource }}
    */
   async load(url, context = {}) {
-    const chain = this.#loaders;
+    const chain = this.#loadHooks;
     const meta = {
       chainFinished: null,
       hookErrIdentifier: '',
@@ -702,7 +655,7 @@ class ESMLoader {
   }
 
   preload() {
-    for (let i = this.#globalPreloaders.length - 1; i >= 0; i--) {
+    for (let i = this.#globalPreloadHooks.length - 1; i >= 0; i--) {
       const channel = new MessageChannel();
       const {
         port1: insidePreload,
@@ -715,7 +668,7 @@ class ESMLoader {
       const {
         fn: preloader,
         url: specifier,
-      } = this.#globalPreloaders[i];
+      } = this.#globalPreloadHooks[i];
 
       const preload = preloader({
         port: insideLoader,
@@ -822,7 +775,7 @@ class ESMLoader {
         parentURL,
       );
     }
-    const chain = this.#resolvers;
+    const chain = this.#resolveHooks;
     const meta = {
       chainFinished: null,
       hookErrIdentifier: '',
@@ -831,11 +784,12 @@ class ESMLoader {
       isChainAsync: false,
       shortCircuited: false,
     };
-    const context = {
+    const context = ObjectFreeze({
       conditions: DEFAULT_CONDITIONS,
-      importAssertions,
+      importAssertions: this.#hasLoaderHooks ?
+          ObjectAssign(ObjectCreate(null), importAssertions) : importAssertions,
       parentURL,
-    };
+    });
 
     const validateArgs = (hookErrIdentifier, { 0: suppliedSpecifier, 1: ctx }) => {
       validateString(

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -103,7 +103,7 @@ function errPath(url) {
 }
 
 async function importModuleDynamically(specifier, { url }, assertions) {
-  return asyncESM.esmLoader.import(specifier, url, assertions);
+  return asyncESM.esmLoader.import(specifier, url, assertions, true);
 }
 
 // Strategy for loading a standard JavaScript module.

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -1,7 +1,10 @@
 'use strict';
 
 const {
+  ArrayPrototypeMap,
   ObjectCreate,
+  PromiseAll,
+  SafeArrayIterator,
 } = primordials;
 
 const {
@@ -66,11 +69,16 @@ async function initializeLoader() {
   const internalEsmLoader = new ESMLoader();
 
   // Importation must be handled by internal loader to avoid poluting userland
-  const keyedExportsList = await internalEsmLoader.import(
-    customLoaders,
-    pathToFileURL(cwd).href,
-    ObjectCreate(null),
-  );
+  const parentURL = pathToFileURL(cwd).href;
+  const importAssertions = ObjectCreate(null);
+
+  const keyedExportsList = await PromiseAll(new SafeArrayIterator(
+    ArrayPrototypeMap(customLoaders, async (url) => {
+      const exports = await internalEsmLoader.import(url, parentURL,
+                                                     importAssertions);
+      return { exports, url };
+    })
+  ));
 
   // Hooks must then be added to external/public loader
   // (so they're triggered in userland)

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -79,7 +79,7 @@ function evalScript(name, body, breakFirstLine, print) {
       [kVmBreakFirstLineSymbol]: !!breakFirstLine,
       importModuleDynamically(specifier, _, importAssertions) {
         const loader = asyncESM.esmLoader;
-        return loader.import(specifier, baseUrl, importAssertions);
+        return loader.import(specifier, baseUrl, importAssertions, true);
       }
     }));
   if (print) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -465,7 +465,7 @@ function REPLServer(prompt,
               displayErrors: true,
               importModuleDynamically: (specifier, _, importAssertions) => {
                 return asyncESM.esmLoader.import(specifier, parentURL,
-                                                 importAssertions);
+                                                 importAssertions, true);
               }
             });
           } catch (fallbackError) {
@@ -509,7 +509,7 @@ function REPLServer(prompt,
             displayErrors: true,
             importModuleDynamically: (specifier, _, importAssertions) => {
               return asyncESM.esmLoader.import(specifier, parentURL,
-                                               importAssertions);
+                                               importAssertions, true);
             }
           });
         } catch (e) {


### PR DESCRIPTION
Adds a new `preImport` loader hook which is called before each top-level import operation (dynamic and host-defined).

In the chaining model these hooks run in parallel and block subsequent module pipeline work for the graph until they all resolve. This allows tracking and resolution cache preparation.

The goal for this PR is to land an acceptable API that can then lead to the async resolve hook being entirely deprecated. If we can get to such a point we will then be able to obtain full alignment on `import.meta.resolve` being sync.

This is a draft PR for now, with the docs and API changes untested simply to illustrate the concept. Tests will be fleshed out after further review if there is agreement on the overall shape.

//cc @nodejs/modules @nodejs/loaders 