### PR TITLE
[v16.x backport] tools: update V8 gypfiles for 9.6

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -607,7 +607,8 @@
                       '<(V8_ROOT)/src/trap-handler/handler-inside-posix.h',
                     ],
                   }],
-                  ['_toolset=="host" and host_arch=="x64" and (OS=="linux" or OS=="mac" or OS=="win")', {
+                  # TODO(targos): Replace False with OS=="win" if handler-outside-simulator.cc becomes compatible with MSVC.
+                  ['_toolset=="host" and host_arch=="x64" and (OS=="linux" or OS=="mac" or False)', {
                     'sources': [
                       '<(V8_ROOT)/src/trap-handler/trap-handler-simulator.h',
                     ],
@@ -827,13 +828,15 @@
                     '<(V8_ROOT)/src/trap-handler/handler-outside-posix.cc',
                   ],
                 }],
-                ['_toolset=="host" and host_arch=="x64" and OS=="win"', {
+                # TODO(targos): Replace False with OS=="win" if handler-outside-simulator.cc becomes compatible with MSVC.
+                ['_toolset=="host" and host_arch=="x64" and False', {
                   'sources': [
                     '<(V8_ROOT)/src/trap-handler/handler-inside-win.cc',
                     '<(V8_ROOT)/src/trap-handler/handler-outside-win.cc',
                   ],
                 }],
-                ['_toolset=="host" and host_arch=="x64" and (OS=="linux" or OS=="mac" or OS=="win")', {
+                # TODO(targos): Replace False with OS=="win" if handler-outside-simulator.cc becomes compatible with MSVC.
+                ['_toolset=="host" and host_arch=="x64" and (OS=="linux" or OS=="mac" or False)', {
                   'sources': [
                     '<(V8_ROOT)/src/trap-handler/handler-outside-simulator.cc',
                   ],

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -50,12 +50,12 @@
     {
       'target_name': 'run_torque',
       'type': 'none',
+      'toolsets': ['host', 'target'],
       'conditions': [
         ['want_separate_host_toolset', {
           'dependencies': ['torque#host'],
-          'toolsets': ['host', 'target'],
         }, {
-          'dependencies': ['torque'],
+          'dependencies': ['torque#target'],
         }],
       ],
       'hard_dependency': 1,
@@ -110,11 +110,9 @@
     {
       'target_name': 'v8_maybe_icu',
       'type': 'none',
+      'toolsets': ['host', 'target'],
       'hard_dependency': 1,
       'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
         ['v8_enable_i18n_support==1', {
           'dependencies': [
             '<(icu_gyp_path):icui18n',
@@ -130,11 +128,7 @@
     {
       'target_name': 'torque_runtime_support',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'direct_dependent_settings': {
         'sources': [
           '<(V8_ROOT)/src/torque/runtime-support.h',
@@ -144,12 +138,8 @@
     {
       'target_name': 'torque_generated_initializers',
       'type': 'none',
+      'toolsets': ['host', 'target'],
       'hard_dependency': 1,
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
       'dependencies': [
         'generate_bytecode_builtins_list',
         'run_torque',
@@ -171,12 +161,8 @@
     {
       'target_name': 'torque_generated_definitions',
       'type': 'none',
+      'toolsets': ['host', 'target'],
       'hard_dependency': 1,
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
       'dependencies': [
         'generate_bytecode_builtins_list',
         'run_torque',
@@ -204,12 +190,12 @@
       'target_name': 'generate_bytecode_builtins_list',
       'type': 'none',
       'hard_dependency': 1,
+      'toolsets': ['host', 'target'],
       'conditions': [
         ['want_separate_host_toolset', {
           'dependencies': ['bytecode_builtins_list_generator#host'],
-          'toolsets': ['host', 'target'],
         }, {
-          'dependencies': ['bytecode_builtins_list_generator'],
+          'dependencies': ['bytecode_builtins_list_generator#target'],
         }],
       ],
       'direct_dependent_settings': {
@@ -242,11 +228,7 @@
     {
       'target_name': 'v8_init',
       'type': 'static_library',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'generate_bytecode_builtins_list',
         'run_torque',
@@ -261,6 +243,7 @@
     {
       'target_name': 'v8_initializers',
       'type': 'static_library',
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'torque_generated_initializers',
         'v8_base_without_compiler',
@@ -274,9 +257,6 @@
         '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_initializers.*?sources = ")',
       ],
       'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
         ['v8_enable_webassembly==1', {
           'sources': [
             '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_initializers.*?v8_enable_webassembly.*?sources \\+= ")',
@@ -466,11 +446,7 @@
     {
       'target_name': 'v8_version',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'direct_dependent_settings': {
         'sources': [
           '<(V8_ROOT)/include/v8-value-serializer-version.h',
@@ -482,11 +458,7 @@
     {
       'target_name': 'v8_config_headers',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'direct_dependent_settings': {
         'sources': [
           '<(V8_ROOT)/include/v8-platform.h',
@@ -497,11 +469,7 @@
     {
       'target_name': 'v8_headers',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'v8_config_headers',
         'cppgc_headers',
@@ -524,11 +492,7 @@
     {
       'target_name': 'v8_shared_internal_headers',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'v8_headers',
         'v8_libbase',
@@ -544,11 +508,7 @@
     {
       'target_name': 'v8_flags',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'v8_shared_internal_headers',
       ],
@@ -562,11 +522,7 @@
     {
       'target_name': 'v8_internal_headers',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'torque_runtime_support',
         'v8_flags',
@@ -644,14 +600,23 @@
                   '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_header_set.\\"v8_internal_headers\\".*?v8_current_cpu == \\"arm64\\".*?v8_control_flow_integrity.*?sources \\+= ")',
                 ],
               }],
-              ['v8_enable_webassembly==1 and OS=="mac"', {
-                'sources': [
-                  '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_header_set.\\"v8_internal_headers\\".*?v8_current_cpu == \\"arm64\\".*?v8_enable_webassembly.*?is_mac.*?sources \\+= ")',
+              ['v8_enable_webassembly==1', {
+                'conditions': [
+                  ['OS=="mac" or (_toolset=="host" and host_arch=="x64" and OS=="linux")', {
+                    'sources': [
+                      '<(V8_ROOT)/src/trap-handler/handler-inside-posix.h',
+                    ],
+                  }],
+                  ['_toolset=="host" and host_arch=="x64" and (OS=="linux" or OS=="mac" or OS=="win")', {
+                    'sources': [
+                      '<(V8_ROOT)/src/trap-handler/trap-handler-simulator.h',
+                    ],
+                  }],
                 ],
               }],
               ['OS=="win"', {
                 'sources': [
-                  '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_header_set.\\"v8_internal_headers\\".*?v8_current_cpu == \\"arm64\\".*?is_win.*?sources \\+= ")',
+                  '<(V8_ROOT)/src/diagnostics/unwinding-info-win64.h',
                 ],
               }],
             ],
@@ -692,6 +657,7 @@
     {
       'target_name': 'v8_compiler_opt',
       'type': 'static_library',
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'generate_bytecode_builtins_list',
         'run_torque',
@@ -703,9 +669,6 @@
       ],
       'sources': ['<@(v8_compiler_sources)'],
       'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
         ['OS=="win"', {
           'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
           'msvs_precompiled_source': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.cc',
@@ -719,6 +682,7 @@
     {
       'target_name': 'v8_compiler',
       'type': 'static_library',
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'generate_bytecode_builtins_list',
         'run_torque',
@@ -730,9 +694,6 @@
       ],
       'sources': ['<@(v8_compiler_sources)'],
       'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
         ['OS=="win"', {
           'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
           'msvs_precompiled_source': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.cc',
@@ -746,6 +707,7 @@
     {
       'target_name': 'v8_compiler_for_mksnapshot',
       'type': 'none',
+      'toolsets': ['host', 'target'],
       'hard_dependency': 1,
       'dependencies': [
         'generate_bytecode_builtins_list',
@@ -753,9 +715,6 @@
         'v8_maybe_icu',
       ],
       'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
         ['is_component_build and not v8_optimized_debug and v8_enable_fast_mksnapshot', {
           'dependencies': [
             'v8_compiler_opt',
@@ -776,6 +735,7 @@
     {
       'target_name': 'v8_base_without_compiler',
       'type': 'static_library',
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'torque_generated_definitions',
         'v8_bigint',
@@ -818,9 +778,6 @@
             '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_base_without_compiler.*?v8_enable_webassembly.*?sources \\+= ")',
           ],
         }],
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
         ['v8_target_arch=="ia32"', {
           'sources': [
             '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_base_without_compiler.*?v8_current_cpu == \\"x86.*?sources \\+= ")',
@@ -862,15 +819,30 @@
             '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_base_without_compiler.*?v8_current_cpu == \\"arm64\\".*?sources \\+= ")',
           ],
           'conditions': [
-            ['OS=="mac"', {
-              'sources': [
-                "<(V8_ROOT)/src/trap-handler/handler-inside-posix.cc",
-                "<(V8_ROOT)/src/trap-handler/handler-outside-posix.cc",
+            ['v8_enable_webassembly==1', {
+              'conditions': [
+                ['OS=="mac" or (_toolset=="host" and host_arch=="x64" and OS=="linux")', {
+                  'sources': [
+                    '<(V8_ROOT)/src/trap-handler/handler-inside-posix.cc',
+                    '<(V8_ROOT)/src/trap-handler/handler-outside-posix.cc',
+                  ],
+                }],
+                ['_toolset=="host" and host_arch=="x64" and OS=="win"', {
+                  'sources': [
+                    '<(V8_ROOT)/src/trap-handler/handler-inside-win.cc',
+                    '<(V8_ROOT)/src/trap-handler/handler-outside-win.cc',
+                  ],
+                }],
+                ['_toolset=="host" and host_arch=="x64" and (OS=="linux" or OS=="mac" or OS=="win")', {
+                  'sources': [
+                    '<(V8_ROOT)/src/trap-handler/handler-outside-simulator.cc',
+                  ],
+                }],
               ],
             }],
             ['OS=="win"', {
               'sources': [
-                "<(V8_ROOT)/src/diagnostics/unwinding-info-win64.cc",
+                '<(V8_ROOT)/src/diagnostics/unwinding-info-win64.cc',
               ],
             }],
           ],
@@ -980,11 +952,7 @@
     {
       'target_name': 'v8_base',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'v8_base_without_compiler',
         'v8_compiler',
@@ -993,11 +961,7 @@
     {
       'target_name': 'torque_base',
       'type': 'static_library',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'sources': [
         '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"torque_base.*?sources = ")',
       ],
@@ -1024,11 +988,7 @@
     {
       'target_name': 'torque_ls_base',
       'type': 'static_library',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'sources': [
         '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"torque_ls_base.*?sources = ")',
       ],
@@ -1054,6 +1014,7 @@
     {
       'target_name': 'v8_libbase',
       'type': 'static_library',
+      'toolsets': ['host', 'target'],
       'sources': [
         '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_libbase.*?sources = ")',
       ],
@@ -1063,9 +1024,6 @@
       ],
 
       'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
         ['is_component_build', {
           'defines': ["BUILDING_V8_BASE_SHARED"],
         }],
@@ -1312,6 +1270,7 @@
     {
       'target_name': 'v8_libplatform',
       'type': 'static_library',
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'v8_libbase',
       ],
@@ -1343,9 +1302,6 @@
         '<(V8_ROOT)/src/libplatform/worker-thread.h',
       ],
       'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
         ['component=="shared_library"', {
           'direct_dependent_settings': {
             'defines': ['USING_V8_PLATFORM_SHARED'],
@@ -1392,11 +1348,7 @@
     {
       'target_name': 'v8_libsampler',
       'type': 'static_library',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'dependencies': [
         'v8_libbase',
       ],
@@ -1536,12 +1488,12 @@
     {
       'target_name': 'run_gen-regexp-special-case',
       'type': 'none',
+      'toolsets': ['host', 'target'],
       'conditions': [
         ['want_separate_host_toolset', {
           'dependencies': ['gen-regexp-special-case#host'],
-          'toolsets': ['host', 'target'],
         }, {
-          'dependencies': ['gen-regexp-special-case'],
+          'dependencies': ['gen-regexp-special-case#target'],
         }],
       ],
       'actions': [
@@ -1565,11 +1517,7 @@
     {
       'target_name': 'cppgc_headers',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'direct_dependent_settings': {
         'sources': [
           '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_header_set.\\"cppgc_headers.*?sources = ")',
@@ -1579,11 +1527,7 @@
     {
       'target_name': 'cppgc_base',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'direct_dependent_settings': {
         'sources': [
           '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_source_set.\\"cppgc_base.*?sources = ")',
@@ -1593,11 +1537,7 @@
     {
       'target_name': 'v8_bigint',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'direct_dependent_settings': {
         'sources': [
           '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_source_set.\\"v8_bigint.*?sources = ")',
@@ -1814,11 +1754,7 @@
     {
       'target_name': 'postmortem-metadata',
       'type': 'none',
-      'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
-      ],
+      'toolsets': ['host', 'target'],
       'dependencies': ['run_torque'],
       'variables': {
         'heapobject_files': [
@@ -1912,10 +1848,8 @@
     {
       'target_name': 'v8_zlib',
       'type': 'static_library',
+      'toolsets': ['host', 'target'],
       'conditions': [
-        ['want_separate_host_toolset', {
-          'toolsets': ['host', 'target'],
-        }],
         ['OS=="win"', {
           'conditions': [
             ['"<(target_arch)"=="arm64" and _toolset=="target"', {


### PR DESCRIPTION
This is a clean cherry-pick of https://github.com/nodejs/node/commit/6ac1cccf9fd565f92f9e1cc5c7d792d5410a7c54 and https://github.com/nodejs/node/commit/4d2d44f2f553d83920725f6f125d4fd87919e795. With this change, it
is possible to cross-compile from `x86_64` to `ARM64` on macOS.

Fixes: https://github.com/nodejs/node/issues/40350

cc @targos 

---

Original commit messages:

*
  tools: update V8 gypfiles for 9.6

  PR-URL: https://github.com/nodejs/node/pull/40488
  Reviewed-By: Jiawen Geng <technicalcute@gmail.com>
  Reviewed-By: James M Snell <jasnell@gmail.com>

*
  tools: disable trap handler for Windows cross-compiler

  `handler-outside-simulator.cc` uses inline assembly, which is not
  supported by MSVC.

  PR-URL: https://github.com/nodejs/node/pull/40488
  Reviewed-By: Jiawen Geng <technicalcute@gmail.com>
  Reviewed-By: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
