### PR TITLE
tls: fix performance regression in `convertALPNProtocols()`

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -56,7 +56,6 @@ const internalUtil = require('internal/util');
 internalUtil.assertCrypto();
 const {
   isArrayBufferView,
-  isDataView,
   isUint8Array,
 } = require('internal/util/types');
 
@@ -148,16 +147,14 @@ exports.convertALPNProtocols = function convertALPNProtocols(protocols, out) {
   // If protocols is Array - translate it into buffer
   if (ArrayIsArray(protocols)) {
     out.ALPNProtocols = convertProtocols(protocols);
-  } else if (Buffer.isBuffer(protocols) || isUint8Array(protocols)) {
+  } else if (isUint8Array(protocols)) {
     // Copy new buffer not to be modified by user.
     out.ALPNProtocols = Buffer.from(protocols);
-  } else if (isDataView(protocols)) {
+  } else if (isArrayBufferView(protocols)) {
     out.ALPNProtocols = Buffer.from(protocols.buffer.slice(
       protocols.byteOffset,
       protocols.byteOffset + protocols.byteLength
     ));
-  } else if (isArrayBufferView(protocols)) {
-    out.ALPNProtocols = Buffer.from(protocols.slice().buffer);
   }
 };
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/43211#issuecomment-1141023694

`isUint8Array()` covers instances of `Buffer`
`isArrayBufferView()` path is cold and not worth additional check