### PR TITLE
trace_events: add example for docs

### DIFF
--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -226,6 +226,48 @@ t2.enable();
 console.log(trace_events.getEnabledCategories());
 ```
 
+## Examples
+
+### Collect trace events data by inspector
+
+```js
+'use strict';
+
+const { Session } = require('inspector');
+const session = new Session();
+session.connect();
+
+function post(message, data) {
+  return new Promise((resolve, reject) => {
+    session.post(message, data, (err, result) => {
+      if (err)
+        reject(new Error(JSON.stringify(err)));
+      else
+        resolve(result);
+    });
+  });
+}
+
+async function collect() {
+  const data = [];
+  session.on('NodeTracing.dataCollected', (chunk) => data.push(chunk));
+  session.on('NodeTracing.tracingComplete', () => {
+    // done
+  });
+  const traceConfig = { includedCategories: ['v8'] };
+  await post('NodeTracing.start', { traceConfig });
+  // do something
+  setTimeout(() => {
+    post('NodeTracing.stop').then(() => {
+      session.disconnect();
+      console.log(data);
+    });
+  }, 1000);
+}
+
+collect();
+```
+
 [Performance API]: perf_hooks.md
 [V8]: v8.md
 [`Worker`]: worker_threads.md#class-worker


### PR DESCRIPTION
add example for docs.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
