### PR TITLE
inspector: add missing initialization

### DIFF
--- a/src/inspector/tracing_agent.h
+++ b/src/inspector/tracing_agent.h
@@ -31,7 +31,7 @@ class TracingAgent : public NodeTracing::Backend {
   Environment* env_;
   std::shared_ptr<MainThreadHandle> main_thread_;
   tracing::AgentWriterHandle trace_writer_;
-  int frontend_object_id_;
+  int frontend_object_id_ = 0;
   std::shared_ptr<NodeTracing::Frontend> frontend_;
 };
 


### PR DESCRIPTION
Add missing initialization reported by coverity. With
proper usage it looks like it will be initialized but
still good to have it initialized to a known state in
case that changes or invalide usage.

The method used to create object ids newObjectId() starts
at 1 so initializing to 0 should be safe and what we get
now when compiled in a way that auto initializes (for example
debug)

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
