### PR TITLE
doc: fix chromium document link in pull-requests.md

### DIFF
--- a/doc/contributing/pull-requests.md
+++ b/doc/contributing/pull-requests.md
@@ -319,7 +319,7 @@ There are a number of more advanced mechanisms for managing commits using
 Feel free to post a comment in the pull request to ping reviewers if you are
 awaiting an answer on something. If you encounter words or acronyms that
 seem unfamiliar, refer to this
-[glossary](https://sites.google.com/a/chromium.org/dev/glossary).
+[glossary](https://chromium.googlesource.com/chromiumos/docs/+/HEAD/glossary.md).
 
 #### Approval and request changes workflow
 


### PR DESCRIPTION
[chromium document link](https://sites.google.com/a/chromium.org/dev/glossary) in pull-requests.md was moved.
this PR changes it to the [new link](https://chromium.googlesource.com/chromiumos/docs/+/HEAD/glossary.md).

