### PR TITLE
bootstrap: move policy setup code to internal/process/policy.js

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -5,7 +5,6 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
-  SafeMap,
   SafeWeakMap,
   StringPrototypeStartsWith,
   globalThis,
@@ -24,9 +23,6 @@ const {
 } = require('internal/util');
 
 const { Buffer } = require('buffer');
-const {
-  ERR_MANIFEST_ASSERT_INTEGRITY,
-} = require('internal/errors').codes;
 const assert = require('internal/assert');
 
 function prepareMainThreadExecution(expandArgv1 = false,
@@ -462,51 +458,12 @@ function initializeClusterIPC() {
 }
 
 function initializePolicy() {
-  const experimentalPolicy = getOptionValue('--experimental-policy');
-  if (experimentalPolicy) {
+  const policyPath = getOptionValue('--experimental-policy');
+  if (policyPath) {
     process.emitWarning('Policies are experimental.',
                         'ExperimentalWarning');
-    const { pathToFileURL, URL } = require('internal/url');
-    // URL here as it is slightly different parsing
-    // no bare specifiers for now
-    let manifestURL;
-    if (require('path').isAbsolute(experimentalPolicy)) {
-      manifestURL = new URL(`file://${experimentalPolicy}`);
-    } else {
-      const cwdURL = pathToFileURL(process.cwd());
-      cwdURL.pathname += '/';
-      manifestURL = new URL(experimentalPolicy, cwdURL);
-    }
-    const fs = require('fs');
-    const src = fs.readFileSync(manifestURL, 'utf8');
-    const experimentalPolicyIntegrity = getOptionValue('--policy-integrity');
-    if (experimentalPolicyIntegrity) {
-      const SRI = require('internal/policy/sri');
-      const { createHash, timingSafeEqual } = require('crypto');
-      const realIntegrities = new SafeMap();
-      const integrityEntries = SRI.parse(experimentalPolicyIntegrity);
-      let foundMatch = false;
-      for (let i = 0; i < integrityEntries.length; i++) {
-        const {
-          algorithm,
-          value: expected
-        } = integrityEntries[i];
-        const hash = createHash(algorithm);
-        hash.update(src);
-        const digest = hash.digest();
-        if (digest.length === expected.length &&
-          timingSafeEqual(digest, expected)) {
-          foundMatch = true;
-          break;
-        }
-        realIntegrities.set(algorithm, digest.toString('base64'));
-      }
-      if (!foundMatch) {
-        throw new ERR_MANIFEST_ASSERT_INTEGRITY(manifestURL, realIntegrities);
-      }
-    }
-    require('internal/process/policy')
-      .setup(src, manifestURL.href);
+    const policyIntegrity = getOptionValue('--policy-integrity');
+    require('internal/process/policy').setup(policyPath, policyIntegrity);
   }
 }
 

--- a/lib/internal/process/policy.js
+++ b/lib/internal/process/policy.js
@@ -4,34 +4,78 @@ const {
   JSONParse,
   ObjectFreeze,
   ReflectSetPrototypeOf,
+  SafeMap
 } = primordials;
 
 const {
   ERR_MANIFEST_TDZ,
+  ERR_MANIFEST_ASSERT_INTEGRITY
 } = require('internal/errors').codes;
 const { Manifest } = require('internal/policy/manifest');
+const { pathToFileURL, URL } = require('internal/url');
+const { readFileSync } = require('fs');
+const { isAbsolute } = require('path');
+const { parse } = require('internal/policy/sri');
+
 let manifest;
 let manifestSrc;
 let manifestURL;
 
 module.exports = ObjectFreeze({
   __proto__: null,
-  setup(src, url) {
-    manifestSrc = src;
-    manifestURL = url;
-    if (src === null) {
+  setup(policyPath, policyIntegrity) {
+    // URL here as it is slightly different parsing
+    // no bare specifiers for now
+    let manifestURLObject;
+    if (isAbsolute(policyPath)) {
+      manifestURLObject = new URL(`file://${policyPath}`);
+    } else {
+      const cwdURL = pathToFileURL(process.cwd());
+      cwdURL.pathname += '/';
+      manifestURLObject = new URL(policyPath, cwdURL);
+    }
+    manifestSrc = readFileSync(manifestURLObject, 'utf8');
+
+    if (policyIntegrity) {
+      // These should be loaded lazily in case the build does not have crypto.
+      const { createHash, timingSafeEqual } = require('crypto');
+      const realIntegrities = new SafeMap();
+      const integrityEntries = parse(policyIntegrity);
+      let foundMatch = false;
+      for (let i = 0; i < integrityEntries.length; i++) {
+        const {
+          algorithm,
+          value: expected
+        } = integrityEntries[i];
+        const hash = createHash(algorithm);
+        hash.update(manifestSrc);
+        const digest = hash.digest();
+        if (digest.length === expected.length &&
+          timingSafeEqual(digest, expected)) {
+          foundMatch = true;
+          break;
+        }
+        realIntegrities.set(algorithm, digest.toString('base64'));
+      }
+      if (!foundMatch) {
+        throw new ERR_MANIFEST_ASSERT_INTEGRITY(manifestURL, realIntegrities);
+      }
+    }
+    manifestURL = manifestURLObject.href;
+
+    if (manifestSrc === null) {
       manifest = null;
       return;
     }
 
-    const json = JSONParse(src, (_, o) => {
+    const json = JSONParse(manifestSrc, (_, o) => {
       if (o && typeof o === 'object') {
         ReflectSetPrototypeOf(o, null);
         ObjectFreeze(o);
       }
       return o;
     });
-    manifest = new Manifest(json, url);
+    manifest = new Manifest(json, manifestURL);
   },
 
   get manifest() {

--- a/lib/internal/process/policy.js
+++ b/lib/internal/process/policy.js
@@ -4,7 +4,7 @@ const {
   JSONParse,
   ObjectFreeze,
   ReflectSetPrototypeOf,
-  SafeMap
+  SafeMap,
 } = primordials;
 
 const {

--- a/lib/internal/process/policy.js
+++ b/lib/internal/process/policy.js
@@ -9,7 +9,7 @@ const {
 
 const {
   ERR_MANIFEST_TDZ,
-  ERR_MANIFEST_ASSERT_INTEGRITY
+  ERR_MANIFEST_ASSERT_INTEGRITY,
 } = require('internal/errors').codes;
 const { Manifest } = require('internal/policy/manifest');
 const { pathToFileURL, URL } = require('internal/url');


### PR DESCRIPTION
To keep pre_execution.js focusing on bootstrap instead of
domain-specific logic.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
