### PR TITLE
test:  improving code coverage for SourceMap class

### DIFF
--- a/test/parallel/test-source-map-api.js
+++ b/test/parallel/test-source-map-api.js
@@ -99,17 +99,17 @@ const { readFileSync } = require('fs');
   assert.notStrictEqual(payload.sources, sourceMap.payload.sources);
 }
 
-// findEntry() must return empty object instead error when 
+// findEntry() must return empty object instead error when
 // receive a malformed mappings.
 {
   const payload = JSON.parse(readFileSync(
     require.resolve('../fixtures/source-map/disk.map'), 'utf8'
   ));
-  payload.mappings = ";;;;;;;;;"
+  payload.mappings = ';;;;;;;;;';
 
   const sourceMap = new SourceMap(payload);
   const result = sourceMap.findEntry(0, 5);
-  assert.strictEqual(typeof result, "object");
+  assert.strictEqual(typeof result, 'object');
   assert.strictEqual(Object.keys(result).length, 0);
 }
 

--- a/test/parallel/test-source-map-api.js
+++ b/test/parallel/test-source-map-api.js
@@ -99,6 +99,20 @@ const { readFileSync } = require('fs');
   assert.notStrictEqual(payload.sources, sourceMap.payload.sources);
 }
 
+// findEntry() must return empty object instead error when 
+// receive a malformed mappings.
+{
+  const payload = JSON.parse(readFileSync(
+    require.resolve('../fixtures/source-map/disk.map'), 'utf8'
+  ));
+  payload.mappings = ";;;;;;;;;"
+
+  const sourceMap = new SourceMap(payload);
+  const result = sourceMap.findEntry(0, 5);
+  assert.strictEqual(typeof result, "object");
+  assert.strictEqual(Object.keys(result).length, 0);
+}
+
 // Test various known decodings to ensure decodeVLQ works correctly.
 {
   function makeMinimalMap(column) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


Improve code coverage for [SourceMap class](https://github.com/nodejs/node/blob/29c64cebef268f2a04bbf2cc3efcaf364941df37/lib/internal/source_map/source_map.js#L123)

refs:
I noted we don't cover the malformed mapping scenario like [this](https://github.com/ampproject/remapping/issues/116) or [this](https://github.com/rollup/rollup/issues/2615)

so I would like to cover this lines
- [line 196](https://coverage.nodejs.org/coverage-7ad5b420aebc1bcd/lib/internal/source_map/source_map.js.html#L196)
<img width="920" alt="Captura de Tela 2022-06-01 às 12 23 48" src="https://user-images.githubusercontent.com/12226189/171440937-a15e21e9-ad92-4aca-ba67-e24f8c3bff54.png">

- [line 170-176](https://coverage.nodejs.org/coverage-7ad5b420aebc1bcd/lib/internal/source_map/source_map.js.html#L176)
<img width="1193" alt="Captura de Tela 2022-06-01 às 12 25 46" src="https://user-images.githubusercontent.com/12226189/171441347-ceab11c4-471d-4e35-8c0e-27dedaec8d50.png">

- [line 123-133](https://coverage.nodejs.org/coverage-7ad5b420aebc1bcd/lib/internal/source_map/source_map.js.html#L123) <img width="1021" alt="Captura de Tela 2022-06-01 às 12 22 38" src="https://user-images.githubusercontent.com/12226189/171440642-0d8dee74-7b79-45a2-b1e7-af20a8eb3a44.png">





