### PR TITLE
doc: promote Chrome Dev Tool to tier 3 (diagnostic tooling support tiers)

### DIFF
--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -114,6 +114,7 @@ The tools are currently assigned to Tiers as follows:
 | Profiling | V8 --interpreted-frames-native-stack | Yes                           | Yes                     | 2           |
 | Profiling | Linux perf                           | Yes                           | Partial                 | 2           |
 | Profiling | node-clinic                          | No                            | No                      | 3           |
+| Debugger  | Chrome Dev tools                     | No                            | No                      | 3           |
 
 ## Tier 4
 
@@ -132,7 +133,6 @@ The tools are currently assigned to Tiers as follows:
 | Debugger  | V8 Debug protocol (API)   | No                            | Yes                     | 1           |
 | Debugger  | Command line Debug Client | ?                             | Yes                     | 1           |
 | Debugger  | llnode                    | ?                             | No                      | 2           |
-| Debugger  | Chrome Dev tools          | ?                             | No                      | 3           |
 | Tracing   | trace\_events (API)       | No                            | Yes                     | 1           |
 | Tracing   | trace\_gc                 | No                            | Yes                     | 1           |
 | Tracing   | DTrace                    | No                            | Partial                 | 3           |


### PR DESCRIPTION
Hey node family 👋

## Context

The diagnostic working group currently works on an [initiative](https://github.com/nodejs/diagnostics/issues/532) to re-evaluate the diagnostic tooling list and its maturity.

## Updated

In the previous instance, we examined the case of the Chrome dev tool: [issue link](https://github.com/nodejs/diagnostics/issues/546).

Even if we didn't have a proper testing strategy for this tool, the community widely uses it. So then, we thought that tier 3 was more appropriate.

## Discuss

Feel free to share your thoughts, especially regarding testing 🧪 .

With love ❤️  

cc @nodejs/diagnostics 