### PR TITLE
test: refactor into async-await

### DIFF
--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -288,6 +288,12 @@ Deletable* MainThreadInterface::GetObjectIfExists(int id) {
   return iterator->second.get();
 }
 
+
+// v8::Isolate *isolate = v8::Isolate::TryGetCurrent();
+//   CHECK_NOT_NULL(isolate);
+//   uint16_t *buffer;
+//   v8::String::NewFromUtf8(isolate, message.data())->Write(buffer);
+
 std::unique_ptr<StringBuffer> Utf8ToStringView(const std::string& message) {
   icu::UnicodeString utf16 = icu::UnicodeString::fromUTF8(
       icu::StringPiece(message.data(), message.length()));

--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -288,12 +288,6 @@ Deletable* MainThreadInterface::GetObjectIfExists(int id) {
   return iterator->second.get();
 }
 
-
-// v8::Isolate *isolate = v8::Isolate::TryGetCurrent();
-//   CHECK_NOT_NULL(isolate);
-//   uint16_t *buffer;
-//   v8::String::NewFromUtf8(isolate, message.data())->Write(buffer);
-
 std::unique_ptr<StringBuffer> Utf8ToStringView(const std::string& message) {
   icu::UnicodeString utf16 = icu::UnicodeString::fromUTF8(
       icu::StringPiece(message.data(), message.length()));

--- a/test/parallel/test-debugger-address.js
+++ b/test/parallel/test-debugger-address.js
@@ -53,21 +53,22 @@ function launchTarget(...args) {
     assert.ifError(error);
   }
 
-  return launchTarget('--inspect=0', script)
-    .then(({ childProc, host, port }) => {
+  (async () => {
+    try {
+      const { childProc, host, port } = await launchTarget('--inspect=0', script);
       target = childProc;
       cli = startCLI([`${host || '127.0.0.1'}:${port}`]);
-      return cli.waitForPrompt();
-    })
-    .then(() => cli.command('sb("alive.js", 3)'))
-    .then(() => cli.waitFor(/break/))
-    .then(() => cli.waitForPrompt())
-    .then(() => {
+      await cli.waitForPrompt();      
+      await cli.command('sb("alive.js", 3)');
+      await cli.waitFor(/break/);
+      await cli.waitForPrompt();
       assert.match(
         cli.output,
         /> 3 {3}\+\+x;/,
-        'marks the 3rd line');
-    })
-    .then(() => cleanup())
-    .then(null, cleanup);
+        'marks the 3rd line'
+      );
+    } finally {
+      cleanup();
+    }
+  })();
 }

--- a/test/parallel/test-debugger-address.js
+++ b/test/parallel/test-debugger-address.js
@@ -53,7 +53,6 @@ function launchTarget(...args) {
     assert.ifError(error);
   }
 
-  // test comment
   (async () => {
     try {
       const { childProc, host, port } = await launchTarget('--inspect=0', script);

--- a/test/parallel/test-debugger-address.js
+++ b/test/parallel/test-debugger-address.js
@@ -53,6 +53,7 @@ function launchTarget(...args) {
     assert.ifError(error);
   }
 
+  // test comment
   (async () => {
     try {
       const { childProc, host, port } = await launchTarget('--inspect=0', script);

--- a/test/parallel/test-debugger-address.js
+++ b/test/parallel/test-debugger-address.js
@@ -58,7 +58,7 @@ function launchTarget(...args) {
       const { childProc, host, port } = await launchTarget('--inspect=0', script);
       target = childProc;
       cli = startCLI([`${host || '127.0.0.1'}:${port}`]);
-      await cli.waitForPrompt();      
+      await cli.waitForPrompt();
       await cli.command('sb("alive.js", 3)');
       await cli.waitFor(/break/);
       await cli.waitForPrompt();
@@ -70,5 +70,5 @@ function launchTarget(...args) {
     } finally {
       cleanup();
     }
-  })();
+  })().then(common.mustCall());
 }

--- a/test/parallel/test-debugger-extract-function-name.js
+++ b/test/parallel/test-debugger-extract-function-name.js
@@ -10,28 +10,25 @@ const assert = require('assert');
 
 const cli = startCLI([fixtures.path('debugger', 'three-lines.js')]);
 
-function onFatal(error) {
-  cli.quit();
-  throw error;
-}
-
-cli.waitForInitialBreak()
-  .then(() => cli.waitForPrompt())
-  .then(() => cli.command('exec a = function func() {}; a;'))
-  .then(() => assert.match(cli.output, /\[Function: func\]/))
-  .then(() => cli.command('exec a = function func () {}; a;'))
-  .then(() => assert.match(cli.output, /\[Function\]/))
-  .then(() => cli.command('exec a = function() {}; a;'))
-  .then(() => assert.match(cli.output, /\[Function: function\]/))
-  .then(() => cli.command('exec a = () => {}; a;'))
-  .then(() => assert.match(cli.output, /\[Function\]/))
-  .then(() => cli.command('exec a = function* func() {}; a;'))
-  .then(() => assert.match(cli.output, /\[GeneratorFunction: func\]/))
-  .then(() => cli.command('exec a = function *func() {}; a;'))
-  .then(() => assert.match(cli.output, /\[GeneratorFunction: \*func\]/))
-  .then(() => cli.command('exec a = function*func() {}; a;'))
-  .then(() => assert.match(cli.output, /\[GeneratorFunction: function\*func\]/))
-  .then(() => cli.command('exec a = function * func() {}; a;'))
-  .then(() => assert.match(cli.output, /\[GeneratorFunction\]/))
-  .then(() => cli.quit())
-  .then(null, onFatal);
+(async () => {
+  await cli.waitForInitialBreak();
+  await cli.waitForPrompt();
+  await cli.command('exec a = function func() {}; a;');
+  assert.match(cli.output, /\[Function: func\]/);
+  await cli.command('exec a = function func () {}; a;');
+  assert.match(cli.output, /\[Function\]/);
+  await cli.command('exec a = function() {}; a;');
+  assert.match(cli.output, /\[Function: function\]/);
+  await cli.command('exec a = () => {}; a;');
+  assert.match(cli.output, /\[Function\]/);
+  await cli.command('exec a = function* func() {}; a;');
+  assert.match(cli.output, /\[GeneratorFunction: func\]/);
+  await cli.command('exec a = function *func() {}; a;');
+  assert.match(cli.output, /\[GeneratorFunction: \*func\]/);
+  await cli.command('exec a = function*func() {}; a;');
+  assert.match(cli.output, /\[GeneratorFunction: function\*func\]/);
+  await cli.command('exec a = function * func() {}; a;');
+  assert.match(cli.output, /\[GeneratorFunction\]/);
+})()
+.finally(() => cli.quit())
+.then(common.mustCall());


### PR DESCRIPTION
This refactors a long chain of `then`s and converts it to `async-await` syntax.