### PR TITLE
doc: remove ETW tool from tier list

### DIFF
--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -137,7 +137,6 @@ The tools are currently assigned to Tiers as follows:
 | Tracing   | trace\_gc                 | No                            | Yes                     | 1           |
 | Tracing   | DTrace                    | No                            | Partial                 | 3           |
 | Tracing   | LTTng                     | No                            | Removed?                | N/A         |
-| Tracing   | ETW                       | No                            | Partial                 | 3           |
 | Tracing   | Systemtap                 | No                            | Partial                 | ?           |
 | Profiling | DTrace                    | No                            | Partial                 | 3           |
 | Profiling | Windows Xperf             | No                            | ?                       | ?           |


### PR DESCRIPTION
Hey 👋 Guess who's back?

## Context

The diagnostic working group currently works on an [initiative](https://github.com/nodejs/diagnostics/issues/532) to re-evaluate the diagnostic tooling list and its maturity.

## Updated

In the previous instance, we examined the case of the `ETW` module: [issue link](https://github.com/nodejs/diagnostics/issues/542).

We decide to remove it, as anyone in the instance has an idea about a potential usage in the field. We prefer to have a list that contains fewer items but is trustable. In case you have a different opinion, please share your thoughts in this PR 🙏.

## Discuss

As usual, feel free to share your thoughts on that and your experience with this tool.

With love ❤️  

cc @nodejs/diagnostics 