### PR TITLE
tools: update `codecov/codecov-action` version

### DIFF
--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -60,6 +60,6 @@ jobs:
       - name: Clean tmp
         run: rm -rf coverage/tmp && rm -rf out
       - name: Upload
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           directory: ./coverage

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -61,6 +61,6 @@ jobs:
       - name: Clean tmp
         run: npx rimraf ./coverage/tmp
       - name: Upload
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           directory: ./coverage


### PR DESCRIPTION
Extracted from https://github.com/nodejs/node/pull/43284

## Breaking Changes

### [v3.0.0](https://github.com/codecov/codecov-action/releases/tag/v3.0.0)

- https://github.com/codecov/codecov-action/pull/689 Bump to node16 and small fixes

### [v2.0.0](https://github.com/codecov/codecov-action/releases/tag/v2.0.0)

On February 1, 2022, the v1 [uploader](https://github.com/codecov/uploader) will be full sunset and no longer function. This is due
to the deprecation of the underlying bash uploader. This version uses the new uploader.

The v2 Action downloads, verifies, and runs the Codecov binary.

- Multiple fields have not been transferred from the bash uploader or have been deprecated. Notably
many of the functionalities and gcov_ arguments have been removed. Please check the documentation
for the full list.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
