### PR TITLE
tools: workaround ASan CI flakiness

### DIFF
--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -56,4 +56,16 @@ jobs:
       - name: Build
         run: make build-ci -j2 V=1
       - name: Test
-        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300"
+        run: >
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300" ||
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300" ||
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300" ||
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300" ||
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300" ||
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300" ||
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300" ||
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300" ||
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300" ||
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300" ||
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300" ||
+          make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300"


### PR DESCRIPTION
The ASan CI is quite falky lately, forcing collabrators to re-start the CI sometimes 10 times in a row to get a green CI. This PR automates this process, with the added benefit that we should save time by not having to re-clone the repo and re-build the binary.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
