### PR TITLE
fs: adjust truncate mode from `r+` to `a`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -673,7 +673,7 @@ try {
 ```
 
 If the file previously was shorter than `len` bytes, it is extended, and the
-extended part is filled with null bytes (`'\0'`):
+extended part is filled with null bytes (`'\0'`).
 
 If `len` is negative then `0` will be used.
 
@@ -1716,6 +1716,10 @@ can only point to directories.
 
 <!-- YAML
 added: v10.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43315
+    description: Creates a file if it didn't exist.
 -->
 
 * `path` {string|Buffer|URL}
@@ -4539,6 +4543,9 @@ $ tree .
 <!-- YAML
 added: v0.8.6
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43315
+    description: Creates a file if it didn't exist.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678
     description: Passing an invalid callback to the `callback` argument
@@ -6366,6 +6373,10 @@ this API: [`fs.symlink()`][].
 
 <!-- YAML
 added: v0.8.6
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43315
+    description: Creates a file if it didn't exist.
 -->
 
 * `path` {string|Buffer|URL}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1045,7 +1045,7 @@ function truncate(path, len, callback) {
   validateInteger(len, 'len');
   len = MathMax(0, len);
   validateFunction(callback, 'cb');
-  fs.open(path, 'r+', (er, fd) => {
+  fs.open(path, 'a', (er, fd) => {
     if (er) return callback(er);
     const req = new FSReqCallback();
     req.oncomplete = function oncomplete(er) {
@@ -1073,7 +1073,7 @@ function truncateSync(path, len) {
     len = 0;
   }
   // Allow error to be thrown, but still close fd.
-  const fd = fs.openSync(path, 'r+');
+  const fd = fs.openSync(path, 'a');
   try {
     fs.ftruncateSync(fd, len);
   } finally {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -784,7 +784,7 @@ async function rename(oldPath, newPath) {
 }
 
 async function truncate(path, len = 0) {
-  const fd = await open(path, 'r+');
+  const fd = await open(path, 'a');
   return handleFdClose(ftruncate(fd, len), fd.close);
 }
 

--- a/test/parallel/test-fs-truncate-nonreadable.js
+++ b/test/parallel/test-fs-truncate-nonreadable.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const common = require('../common');
+
+// This test ensures that truncate works on non-readable files
+
+const assert = require('assert');
+const fs = require('fs');
+const fsPromises = fs.promises;
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+const expected = Buffer.from('good');
+
+function checkContents(filepath) {
+  fs.chmodSync(filepath, 0o400);
+  assert.deepStrictEqual(
+    fs.readFileSync(filepath),
+    expected
+  );
+}
+
+(async () => {
+  const MODE = 0o200;
+  {
+    const filepath = path.resolve(tmpdir.path, 'promises.txt');
+    fs.writeFileSync(filepath, 'good bad');
+    fs.chmodSync(filepath, MODE);
+    await fsPromises.truncate(filepath, 4);
+    checkContents(filepath);
+  }
+  {
+    const filepath = path.resolve(tmpdir.path, 'callback.txt');
+    fs.writeFileSync(filepath, 'good bad');
+    fs.chmodSync(filepath, MODE);
+    fs.truncate(filepath, 4, common.mustSucceed(() => {
+      checkContents(filepath);
+    }));
+  }
+  {
+    const filepath = path.resolve(tmpdir.path, 'synchronous.txt');
+    fs.writeFileSync(filepath, 'good bad');
+    fs.chmodSync(filepath, MODE);
+    fs.truncateSync(filepath, 4);
+    checkContents(filepath);
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -242,17 +242,17 @@ function testFtruncate(cb) {
 }
 
 {
-  const file8 = path.resolve(tmp, 'non-existent-truncate-file.txt');
-  const validateError = (err) => {
-    assert.strictEqual(file8, err.path);
-    assert.strictEqual(
-      err.message,
-      `ENOENT: no such file or directory, open '${file8}'`);
-    assert.strictEqual(err.code, 'ENOENT');
-    assert.strictEqual(err.syscall, 'open');
-    return true;
-  };
-  fs.truncate(file8, 0, common.mustCall(validateError));
+  const file8 = path.resolve(tmp, 'non-existent-truncate-file-1.txt');
+  fs.truncate(file8, 0, common.mustSucceed(() => {
+    assert(fs.readFileSync(file8).equals(Buffer.from('')));
+  }));
+}
+
+{
+  const file9 = path.resolve(tmp, 'non-existent-truncate-file-2.txt');
+  fs.truncate(file9, 2, common.mustSucceed(() => {
+    assert(fs.readFileSync(file9).equals(Buffer.from('\u0000\u0000')));
+  }));
 }
 
 ['', false, null, {}, []].forEach((input) => {


### PR DESCRIPTION
This PR changes flags in [`fsPromises.truncate(path[, len])`](https://nodejs.org/api/fs.html#fspromisestruncatepath-len), [`fs.truncate(path[, len], callback)`](https://nodejs.org/api/fs.html#fstruncatepath-len-callback), and [`fs.truncateSync(path[, len])`](https://nodejs.org/api/fs.html#fstruncatesyncpath-len) from `r+` to `a`.

This change:
- Allows to truncate files without read permission (previously: `EACCES`)
- Allows to create a zero-filled file of specified length if it didn't exist at specified path

Creating file is not what pure [`truncate(2)`](https://man7.org/linux/man-pages/man2/truncate.2.html) does, but it is done by [`truncate(1)`](https://man7.org/linux/man-pages/man1/truncate.1.html) and kinda makes sense.

Alternatively, we can check for `W_OK` and throw `ENOENT` manually.