### PR TITLE
src: remove a stale comment in `async_hooks`

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -179,8 +179,6 @@ inline bool AsyncHooks::pop_async_context(double async_id) {
 
   // Ask for the async_id to be restored as a check that the stack
   // hasn't been corrupted.
-  // Since async_hooks is experimental, do only perform the check
-  // when async_hooks is enabled.
   if (UNLIKELY(fields_[kCheck] > 0 &&
                async_id_fields_[kExecutionAsyncId] != async_id)) {
     FailWithCorruptedAsyncStack(async_id);


### PR DESCRIPTION
This removes a comment relevant to runtime checks for `async_hooks`.

Even if `async_hooks` is experimental, the check pointed by the comment
is performed as default unless `--no-force-async-hooks-checks` is given 
from CLI arguments.

Refs: https://github.com/nodejs/node/pull/16318
Refs: https://github.com/nodejs/node/pull/15454#issuecomment-337840053

Plus, the comment conflicts with the following L1071.
https://github.com/nodejs/node/blob/45d7ca95cd53bbf4045182d5d3419955185e87a1/src/env.cc#L1071-L1076

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
