### PR TITLE
readline: fix question stack overflow

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -143,9 +143,10 @@ Interface.prototype.question = function(query, options, cb) {
     const cleanup = () => {
       options.signal.removeEventListener(onAbort);
     };
+    const originalCb = cb;
     cb = typeof cb === 'function' ? (answer) => {
       cleanup();
-      return cb(answer);
+      return originalCb(answer);
     } : cleanup;
   }
 

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -1009,7 +1009,7 @@ for (let i = 0; i < 12; i++) {
   // Calling the question callback with abort signal
   {
     const [rli] = getInterface({ terminal });
-    const signal = new AbortController().signal;
+    const { signal } = new AbortController();
     rli.question('foo?', { signal }, common.mustCall((answer) => {
       assert.strictEqual(answer, 'bar');
     }));
@@ -1034,6 +1034,19 @@ for (let i = 0; i < 12; i++) {
     const [rli] = getInterface({ terminal });
     const question = util.promisify(rli.question).bind(rli);
     question('foo?')
+    .then(common.mustCall((answer) => {
+      assert.strictEqual(answer, 'bar');
+    }));
+    rli.write('bar\n');
+    rli.close();
+  }
+
+  // Calling the promisified question with abort signal
+  {
+    const [rli] = getInterface({ terminal });
+    const question = util.promisify(rli.question).bind(rli);
+    const { signal } = new AbortController();
+    question('foo?', { signal })
     .then(common.mustCall((answer) => {
       assert.strictEqual(answer, 'bar');
     }));

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -1006,6 +1006,17 @@ for (let i = 0; i < 12; i++) {
     rli.close();
   }
 
+  // Calling the question callback with abort signal
+  {
+    const [rli] = getInterface({ terminal });
+    const signal = new AbortController().signal;
+    rli.question('foo?', { signal }, common.mustCall((answer) => {
+      assert.strictEqual(answer, 'bar');
+    }));
+    rli.write('bar\n');
+    rli.close();
+  }
+
   // Calling the question multiple times
   {
     const [rli] = getInterface({ terminal });

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -912,7 +912,7 @@ for (let i = 0; i < 12; i++) {
   // Calling the question callback with abort signal
   {
     const [rli] = getInterface({ terminal });
-    const signal = new AbortController().signal;
+    const { signal } = new AbortController();
     rli.question('foo?', { signal }).then(common.mustCall((answer) => {
       assert.strictEqual(answer, 'bar');
     }));

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -909,6 +909,17 @@ for (let i = 0; i < 12; i++) {
     rli.close();
   }
 
+  // Calling the question callback with abort signal
+  {
+    const [rli] = getInterface({ terminal });
+    const signal = new AbortController().signal;
+    rli.question('foo?', { signal }).then(common.mustCall((answer) => {
+      assert.strictEqual(answer, 'bar');
+    }));
+    rli.write('bar\n');
+    rli.close();
+  }
+
   // Aborting a question
   {
     const ac = new AbortController();


### PR DESCRIPTION
This commit fixes readline interface's question callback wrapping when it is being called with `signal` option. Previous version completely overwrites passed callback and throws "Maximum call stack size exceeded" error.

Reproducible example:
```js
const rli = require('readline').createInterface(process.stdin, process.stdout);
const signal = new AbortController().signal;

rli.question('Hello? ', { signal }, (answer) => {
    console.log(`Hello, ${answer}`);
});
```
