### PR TITLE
perf_hooks: fix function wrapped by performance.timerify to work correctly

### DIFF
--- a/lib/internal/perf/timerify.js
+++ b/lib/internal/perf/timerify.js
@@ -65,7 +65,7 @@ function timerify(fn, options = {}) {
   }
 
   function timerified(...args) {
-    const isConstructorCall = !!new.target;
+    const isConstructorCall = new.target !== undefined;
     const start = now();
     const result = isConstructorCall ?
       ReflectConstruct(fn, args, fn) :

--- a/lib/internal/perf/timerify.js
+++ b/lib/internal/perf/timerify.js
@@ -21,10 +21,6 @@ const {
 } = require('internal/histogram');
 
 const {
-  isConstructor,
-} = internalBinding('util');
-
-const {
   codes: {
     ERR_INVALID_ARG_TYPE,
   },
@@ -68,14 +64,13 @@ function timerify(fn, options = {}) {
       histogram);
   }
 
-  const constructor = isConstructor(fn);
-
   function timerified(...args) {
+    const isConstructorCall = !!new.target;
     const start = now();
-    const result = constructor ?
+    const result = isConstructorCall ?
       ReflectConstruct(fn, args, fn) :
       ReflectApply(fn, this, args);
-    if (!constructor && typeof result?.finally === 'function') {
+    if (!isConstructorCall && typeof result?.finally === 'function') {
       return result.finally(
         FunctionPrototypeBind(
           processComplete,

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -289,11 +289,6 @@ static void GuessHandleType(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(OneByteString(env->isolate(), type));
 }
 
-static void IsConstructor(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[0]->IsFunction());
-  args.GetReturnValue().Set(args[0].As<v8::Function>()->IsConstructor());
-}
-
 static void ToUSVString(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CHECK_GE(args.Length(), 2);
@@ -344,7 +339,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(WeakReference::IncRef);
   registry->Register(WeakReference::DecRef);
   registry->Register(GuessHandleType);
-  registry->Register(IsConstructor);
   registry->Register(ToUSVString);
 }
 
@@ -384,7 +378,6 @@ void Initialize(Local<Object> target,
   env->SetMethodNoSideEffect(target, "getConstructorName", GetConstructorName);
   env->SetMethodNoSideEffect(target, "getExternalValue", GetExternalValue);
   env->SetMethod(target, "sleep", Sleep);
-  env->SetMethodNoSideEffect(target, "isConstructor", IsConstructor);
 
   env->SetMethod(target, "arrayBufferViewHasBuffer", ArrayBufferViewHasBuffer);
   Local<Object> constants = Object::New(env->isolate());

--- a/test/parallel/test-performance-function.js
+++ b/test/parallel/test-performance-function.js
@@ -123,3 +123,22 @@ const {
     });
   });
 })().then(common.mustCall());
+
+// Regression tests for https://github.com/nodejs/node/issues/40623
+{
+  assert.strictEqual(performance.timerify(function func() {
+    return 1;
+  })(), 1);
+  assert.strictEqual(performance.timerify(function() {
+    return 1;
+  })(), 1);
+  assert.strictEqual(performance.timerify(() => {
+    return 1;
+  })(), 1);
+  class C {}
+  const wrap = performance.timerify(C);
+  assert.ok(new wrap() instanceof C);
+  assert.throws(() => wrap(), {
+    name: 'TypeError',
+  });
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixed #40623
(#40625 also fixes this issue but it has been stale and seems not expected to be updated.)

This issue introduced by the refactoring on #37136. [The previous implementation](https://github.com/nodejs/node/pull/37136/files#diff-6c526b90d8e9ed83f267edd4ae7e26045969736c0a74c22ffe83126cebdab42fL388-L393) was checking whether a function or class is called using the new operator to proxy a function call.

https://github.com/nodejs/node/blob/74227bbc4aa3da2446d5d8398081f3225dd68b64/src/node_perf.cc#L380-L393

This PR fixed to align with the previous behavior that a function works the same as if it was called directly.