### PR TITLE
assert: change callTracker.calls signature to use an object param instead of positional arguments

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -249,7 +249,7 @@ const tracker = new assert.CallTracker();
 function func() {}
 
 // callsfunc() must be called exactly 1 time before tracker.verify().
-const callsfunc = tracker.calls(func, 1);
+const callsfunc = tracker.calls({ fn: func, exact: 1 });
 
 callsfunc();
 
@@ -268,7 +268,7 @@ const tracker = new assert.CallTracker();
 function func() {}
 
 // callsfunc() must be called exactly 1 time before tracker.verify().
-const callsfunc = tracker.calls(func, 1);
+const callsfunc = tracker.calls({ fn: func, exact: 1 });
 
 callsfunc();
 
@@ -279,7 +279,7 @@ process.on('exit', () => {
 });
 ```
 
-### `tracker.calls([fn][, exact])`
+### `tracker.calls(options)`
 
 <!-- YAML
 added:
@@ -287,8 +287,9 @@ added:
   - v12.19.0
 -->
 
-* `fn` {Function} **Default:** A no-op function.
-* `exact` {number} **Default:** `1`.
+* `options` {Object}
+  * `fn` {Function} **Default:** A no-op function.
+  * `exact` {number} **Default:** `1`.
 * Returns: {Function} that wraps `fn`.
 
 The wrapper function is expected to be called exactly `exact` times. If the
@@ -306,7 +307,7 @@ function func() {}
 
 // Returns a function that wraps func() that must be called exact times
 // before tracker.verify().
-const callsfunc = tracker.calls(func);
+const callsfunc = tracker.calls({ fn: func });
 ```
 
 ```cjs
@@ -319,7 +320,7 @@ function func() {}
 
 // Returns a function that wraps func() that must be called exact times
 // before tracker.verify().
-const callsfunc = tracker.calls(func);
+const callsfunc = tracker.calls({ fn: func });
 ```
 
 ### `tracker.report()`
@@ -355,7 +356,7 @@ function foo() {}
 
 // Returns a function that wraps func() that must be called exact times
 // before tracker.verify().
-const callsfunc = tracker.calls(func, 2);
+const callsfunc = tracker.calls({ fn: func, exact: 2 });
 
 // Returns an array containing information on callsfunc()
 tracker.report();
@@ -383,7 +384,7 @@ function foo() {}
 
 // Returns a function that wraps func() that must be called exact times
 // before tracker.verify().
-const callsfunc = tracker.calls(func, 2);
+const callsfunc = tracker.calls({ fn: func, exact: 2 });
 
 // Returns an array containing information on callsfunc()
 tracker.report();
@@ -421,7 +422,7 @@ function func() {}
 
 // Returns a function that wraps func() that must be called exact times
 // before tracker.verify().
-const callsfunc = tracker.calls(func, 2);
+const callsfunc = tracker.calls({ fn: func, exact: 2 });
 
 callsfunc();
 
@@ -439,7 +440,7 @@ function func() {}
 
 // Returns a function that wraps func() that must be called exact times
 // before tracker.verify().
-const callsfunc = tracker.calls(func, 2);
+const callsfunc = tracker.calls({ fn: func, exact: 2 });
 
 callsfunc();
 
@@ -2475,7 +2476,7 @@ argument.
 [`assert.throws()`]: #assertthrowsfn-error-message
 [`getColorDepth()`]: tty.md#writestreamgetcolordepthenv
 [`process.on('exit')`]: process.md#event-exit
-[`tracker.calls()`]: #trackercallsfn-exact
+[`tracker.calls()`]: #trackercallsoptions
 [`tracker.verify()`]: #trackerverify
 [enumerable "own" properties]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties
 [prototype-spec]: https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots

--- a/lib/internal/assert/calltracker.js
+++ b/lib/internal/assert/calltracker.js
@@ -24,15 +24,9 @@ class CallTracker {
 
   #callChecks = new SafeSet();
 
-  calls(fn, exact = 1) {
+  calls({ fn = noop, exact = 1 } = { fn: noop, exact: 1 }) {
     if (process._exiting)
       throw new ERR_UNAVAILABLE_DURING_EXIT();
-    if (typeof fn === 'number') {
-      exact = fn;
-      fn = noop;
-    } else if (fn === undefined) {
-      fn = noop;
-    }
 
     validateUint32(exact, 'exact', true);
 

--- a/test/parallel/test-assert-calltracker-calls.js
+++ b/test/parallel/test-assert-calltracker-calls.js
@@ -14,31 +14,46 @@ const err = {
 
 // Ensures calls() throws on invalid input types.
 assert.throws(() => {
-  const callsbar = tracker.calls(bar, '1');
+  const callsbar = tracker.calls({
+    fn: bar,
+    exact: '1'
+  });
   callsbar();
 }, err
 );
 
 assert.throws(() => {
-  const callsbar = tracker.calls(bar, 0.1);
+  const callsbar = tracker.calls({
+    fn: bar,
+    exact: 0.1
+  });
   callsbar();
 }, { code: 'ERR_OUT_OF_RANGE' }
 );
 
 assert.throws(() => {
-  const callsbar = tracker.calls(bar, true);
+  const callsbar = tracker.calls({
+    fn: bar,
+    exact: true
+  });
   callsbar();
 }, err
 );
 
 assert.throws(() => {
-  const callsbar = tracker.calls(bar, () => {});
+  const callsbar = tracker.calls({
+    fn: bar,
+    exact: () => {}
+  });
   callsbar();
 }, err
 );
 
 assert.throws(() => {
-  const callsbar = tracker.calls(bar, null);
+  const callsbar = tracker.calls({
+    fn: bar,
+    exact: null
+  });
   callsbar();
 }, err
 );
@@ -46,7 +61,10 @@ assert.throws(() => {
 // Expects an error as tracker.calls() cannot be called within a process exit
 // handler.
 process.on('exit', () => {
-  assert.throws(() => tracker.calls(bar, 1), {
+  assert.throws(() => tracker.calls({
+    fn: bar,
+    exact: 1
+  }), {
     code: 'ERR_UNAVAILABLE_DURING_EXIT',
   });
 });
@@ -57,7 +75,10 @@ function func() {
   throw new Error(msg);
 }
 
-const callsfunc = tracker.calls(func, 1);
+const callsfunc = tracker.calls({
+  fn: func,
+  exact: 1
+});
 
 // Expects callsfunc() to call func() which throws an error.
 assert.throws(
@@ -67,14 +88,35 @@ assert.throws(
 
 {
   const tracker = new assert.CallTracker();
-  const callsNoop = tracker.calls(1);
+  const callsNoop = tracker.calls({
+    exact: 1
+  });
   callsNoop();
   tracker.verify();
 }
 
 {
   const tracker = new assert.CallTracker();
-  const callsNoop = tracker.calls(undefined, 1);
+  const callsNoop = tracker.calls({
+    fn: bar
+  });
+  callsNoop('abc');
+  tracker.verify();
+}
+
+{
+  const tracker = new assert.CallTracker();
+  const callsNoop = tracker.calls({
+    fn: undefined,
+    exact: 1
+  });
+  callsNoop();
+  tracker.verify();
+}
+
+{
+  const tracker = new assert.CallTracker();
+  const callsNoop = tracker.calls();
   callsNoop();
   tracker.verify();
 }

--- a/test/parallel/test-assert-calltracker-report.js
+++ b/test/parallel/test-assert-calltracker-report.js
@@ -8,7 +8,10 @@ const tracker = new assert.CallTracker();
 
 function foo() {}
 
-const callsfoo = tracker.calls(foo, 1);
+const callsfoo = tracker.calls({
+  fn: foo,
+  exact: 1
+});
 
 // Ensures that foo was added to the callChecks array.
 assert.strictEqual(tracker.report()[0].operator, 'foo');

--- a/test/parallel/test-assert-calltracker-verify.js
+++ b/test/parallel/test-assert-calltracker-verify.js
@@ -10,7 +10,10 @@ const msg = 'Function(s) were not called the expected number of times';
 
 function foo() {}
 
-const callsfoo = tracker.calls(foo, 1);
+const callsfoo = tracker.calls({
+  fn: foo,
+  exact: 1
+});
 
 // Expects an error as callsfoo() was called less than one time.
 assert.throws(

--- a/test/parallel/test-whatwg-webstreams-transfer.js
+++ b/test/parallel/test-whatwg-webstreams-transfer.js
@@ -393,14 +393,18 @@ const theData = 'hello';
       tracker.verify();
     });
 
-    parentPort.onmessage = tracker.calls(({ data }) => {
-      assert(isReadableStream(data));
-      const reader = data.getReader();
-      reader.read().then(tracker.calls((result) => {
-        assert(!result.done);
-        assert(result.value instanceof Uint8Array);
-      }));
-      parentPort.close();
+    parentPort.onmessage = tracker.calls({
+      fn: ({ data }) => {
+        assert(isReadableStream(data));
+        const reader = data.getReader();
+        reader.read().then(tracker.calls({
+          fn: (result) => {
+            assert(!result.done);
+            assert(result.value instanceof Uint8Array);
+          }
+        }));
+        parentPort.close();
+      }
     });
     parentPort.onmessageerror = () => assert.fail('should not be called');
   `, { eval: true });


### PR DESCRIPTION
it changes the calls function from the callTracker API, its docs, and tests that use this module. This is a breaking change as the calls function was changed

Refs: https://github.com/nodejs/node/issues/43161

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
