### PR TITLE
test: improve code coverage of `util.parseArgs ` 

### DIFF
--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -91,6 +91,14 @@ test('handles short-option groups with "short" alias configured', () => {
   assert.deepStrictEqual(result, expected);
 });
 
+test('handles short-option followed by its value', () => {
+  const args = ['-fFILE'];
+  const options = { foo: { short: 'f', type: 'string' } };
+  const expected = { values: { __proto__: null, foo: 'FILE' }, positionals: [] };
+  const result = parseArgs({ strict: false, args, options });
+  assert.deepStrictEqual(result, expected);
+});
+
 test('Everything after a bare `--` is considered a positional argument', () => {
   const args = ['--', 'barepositionals', 'mopositionals'];
   const expected = { values: { __proto__: null }, positionals: ['barepositionals', 'mopositionals'] };


### PR DESCRIPTION
This PR improves code coverage of `lib/internal/util/parse_args`.

https://coverage.nodejs.org/coverage-c977ad6baacaf644/lib/internal/util/parse_args/parse_args.js.html#L248

| before | after |
| -- | -- |
| <img width="856" alt="image" src="https://user-images.githubusercontent.com/22386678/172824078-eec806eb-be38-4410-a7f2-c49a33acf01a.png"> | <img width="857" alt="image" src="https://user-images.githubusercontent.com/22386678/172824114-42d996fb-d1ce-4c64-ad15-710ca7b5204c.png"> |
