### PR TITLE
http: defer reentrant execution of Parser::Execute

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -117,7 +117,7 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   return parser.onIncoming(incoming, shouldKeepAlive);
 }
 
-function parserOnBody(b, start, len) {
+function parserOnBody(b) {
   const stream = this.incoming;
 
   // If the stream has already been removed, then drop it.
@@ -125,7 +125,7 @@ function parserOnBody(b, start, len) {
     return;
 
   // Pretend this was the result of a stream._read call.
-  if (len > 0 && !stream._dumped) {
+  if (!stream._dumped) {
     const ret = stream.push(b);
     if (!ret)
       readStop(this.socket);

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -126,8 +126,7 @@ function parserOnBody(b, start, len) {
 
   // Pretend this was the result of a stream._read call.
   if (len > 0 && !stream._dumped) {
-    const slice = b.slice(start, start + len);
-    const ret = stream.push(slice);
+    const ret = stream.push(b);
     if (!ret)
       readStop(this.socket);
   }

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -980,7 +980,6 @@ class Parser : public AsyncWrap, public StreamListener {
   bool got_exception_;
   size_t current_buffer_len_;
   const char* current_buffer_data_;
-  unsigned int execute_depth_ = 0;
   bool headers_completed_ = false;
   bool pending_pause_ = false;
   uint64_t header_nread_ = 0;

--- a/test/parallel/test-http-parser-multiple-execute.js
+++ b/test/parallel/test-http-parser-multiple-execute.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { HTTPParser } = process.binding('http_parser');
+
+let second = false;
+const parser = new HTTPParser(HTTPParser.RESPONSE, false);
+
+parser.initialize(HTTPParser.RESPONSE, {}, 0, 0);
+
+parser[HTTPParser.kOnHeadersComplete] = common.mustCall(
+  function(_versionMajor, _versionMinor, _headers, _method, _url, statusCode) {
+    if (!second) {
+      second = true;
+
+      assert.strictEqual(statusCode, 100);
+      parser.execute(Buffer.from('HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'));
+    } else {
+      assert.strictEqual(statusCode, 200);
+    }
+  },
+  2
+);
+
+parser.execute(Buffer.from('HTTP/1.1 100 Continue\r\n\r\n'));

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -62,8 +62,8 @@ function newParser(type) {
 
 
 function expectBody(expected) {
-  return mustCall(function(buf, start, len) {
-    const body = String(buf.slice(start, start + len));
+  return mustCall(function(buf) {
+    const body = String(buf);
     assert.strictEqual(body, expected);
   });
 }
@@ -126,8 +126,8 @@ function expectBody(expected) {
     assert.strictEqual(statusMessage, 'OK');
   };
 
-  const onBody = (buf, start, len) => {
-    const body = String(buf.slice(start, start + len));
+  const onBody = (buf) => {
+    const body = String(buf);
     assert.strictEqual(body, 'pong');
   };
 
@@ -195,8 +195,8 @@ function expectBody(expected) {
     parser[kOnHeaders] = mustCall(onHeaders);
   };
 
-  const onBody = (buf, start, len) => {
-    const body = String(buf.slice(start, start + len));
+  const onBody = (buf) => {
+    const body = String(buf);
     assert.strictEqual(body, 'ping');
     seen_body = true;
   };
@@ -291,8 +291,8 @@ function expectBody(expected) {
     assert.strictEqual(versionMinor, 1);
   };
 
-  const onBody = (buf, start, len) => {
-    const body = String(buf.slice(start, start + len));
+  const onBody = (buf) => {
+    const body = String(buf);
     assert.strictEqual(body, 'foo=42&bar=1337');
   };
 
@@ -332,8 +332,8 @@ function expectBody(expected) {
   let body_part = 0;
   const body_parts = ['123', '123456', '1234567890'];
 
-  const onBody = (buf, start, len) => {
-    const body = String(buf.slice(start, start + len));
+  const onBody = (buf) => {
+    const body = String(buf);
     assert.strictEqual(body, body_parts[body_part++]);
   };
 
@@ -371,8 +371,8 @@ function expectBody(expected) {
   const body_parts =
           ['123', '123456', '123456789', '123456789ABC', '123456789ABCDEF'];
 
-  const onBody = (buf, start, len) => {
-    const body = String(buf.slice(start, start + len));
+  const onBody = (buf) => {
+    const body = String(buf);
     assert.strictEqual(body, body_parts[body_part++]);
   };
 
@@ -428,8 +428,8 @@ function expectBody(expected) {
 
     let expected_body = '123123456123456789123456789ABC123456789ABCDEF';
 
-    const onBody = (buf, start, len) => {
-      const chunk = String(buf.slice(start, start + len));
+    const onBody = (buf) => {
+      const chunk = String(buf);
       assert.strictEqual(expected_body.indexOf(chunk), 0);
       expected_body = expected_body.slice(chunk.length);
     };
@@ -445,9 +445,7 @@ function expectBody(expected) {
 
   for (let i = 1; i < request.length - 1; ++i) {
     const a = request.slice(0, i);
-    console.error(`request.slice(0, ${i}) = ${JSON.stringify(a.toString())}`);
     const b = request.slice(i);
-    console.error(`request.slice(${i}) = ${JSON.stringify(b.toString())}`);
     test(a, b);
   }
 }
@@ -488,8 +486,8 @@ function expectBody(expected) {
 
   let expected_body = '123123456123456789123456789ABC123456789ABCDEF';
 
-  const onBody = (buf, start, len) => {
-    const chunk = String(buf.slice(start, start + len));
+  const onBody = (buf) => {
+    const chunk = String(buf);
     assert.strictEqual(expected_body.indexOf(chunk), 0);
     expected_body = expected_body.slice(chunk.length);
   };


### PR DESCRIPTION
This PR fixes an edge case in which `Parser::Execute` is called within the callback of one of its events.

Fixes: #39671