### PR TITLE
util: add colorText method

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -77,7 +77,7 @@ callbackFunction((err, ret) => {
 added: REPLACEME
 -->
 
-* `format` {string} `format` one of the color format from `util.inspect.colors`
+* `format` {string} A color format defined in `util.inspect.colors`.
 * `text` {string} The text you would like to color
 * Returns: {string} colored text string
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -71,6 +71,25 @@ callbackFunction((err, ret) => {
 });
 ```
 
+## `util.colorText(format, text)`
+
+<!-- YAML
+added: v18.3.0
+-->
+
+* `format` {string} `format` one of the color format from `util.inspect.colors`
+* `text` {string} The text you would like to color
+* Returns: {string} colored text string
+
+Takes `format` and `text` and retuns the colored text form
+
+```js
+const util = require('node:util');
+
+console.log(util.colorText('red', 'This text shall be in red color'));
+// ^ '\u001b[31mThis text shall be in red color\u001b[39m'
+```
+
 ## `util.debuglog(section[, callback])`
 
 <!-- YAML

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -78,7 +78,7 @@ added: REPLACEME
 -->
 
 * `format` {string} A color format defined in `util.inspect.colors`.
-* `text` {string} The text you would like to color
+* `text` {string} The text to color.
 * Returns: {string} colored text string
 
 Takes `format` and `text` and retuns the colored text form

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -74,7 +74,7 @@ callbackFunction((err, ret) => {
 ## `util.colorText(format, text)`
 
 <!-- YAML
-added: v18.3.0
+added: REPLACEME
 -->
 
 * `format` {string} `format` one of the color format from `util.inspect.colors`

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -79,7 +79,7 @@ added: REPLACEME
 
 * `format` {string} A color format defined in `util.inspect.colors`.
 * `text` {string} The text to color.
-* Returns: {string} colored text string
+* Returns: {string} Colored text string.
 
 Takes `format` and `text` and retuns the colored text form
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -81,7 +81,7 @@ added: REPLACEME
 * `text` {string} The text to color.
 * Returns: {string} Colored text string.
 
-Takes `format` and `text` and retuns the colored text form
+Takes `format` and `text` and returns the colored text form
 
 ```js
 const util = require('node:util');

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,6 +64,7 @@ const { debuglog } = require('internal/util/debuglog');
 const {
   validateFunction,
   validateNumber,
+  validateString,
 } = require('internal/validators');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
 const { isBuffer } = require('buffer').Buffer;
@@ -331,12 +332,28 @@ function getSystemErrorName(err) {
   return internalErrorName(err);
 }
 
+/**
+ * @param {string} format
+ * @param {string} text
+ * @returns {string}
+ */
+function colorText(format, text) {
+  validateString(format, 'format');
+  validateString(text, 'text');
+  const formatCodes = inspect.colors[format];
+  if (!ArrayIsArray(formatCodes)) {
+    return text;
+  }
+  return `\u001b[${formatCodes[0]}m${text}\u001b[${formatCodes[1]}m`;
+}
+
 // Keep the `exports =` so that various functions can still be monkeypatched
 module.exports = {
   _errnoException: errnoException,
   _exceptionWithHostPort: exceptionWithHostPort,
   _extend,
   callbackify,
+  colorText,
   debug: debuglog,
   debuglog,
   deprecate,

--- a/test/parallel/test-util-colorText.js
+++ b/test/parallel/test-util-colorText.js
@@ -1,0 +1,33 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const util = require('util');
+
+[
+  undefined,
+  null,
+  false,
+  5n,
+  5,
+  Symbol(),
+].forEach((invalidOption) => {
+  assert.throws(() => {
+    util.colorText(invalidOption, 'test');
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+  assert.throws(() => {
+    util.colorText('red', invalidOption);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+assert.throws(() => {
+  util.colorText('red', undefined);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: 'The "text" argument must be of type string. Received undefined'
+});
+
+assert.strictEqual(util.colorText('red', 'test'), '\u001b[31mtest\u001b[39m');


### PR DESCRIPTION
This is with reference to the [comment](https://github.com/nodejs/node/issues/42770#issuecomment-1115256334) in  #42770 

A few things to finalize before completing this draft PR:

* Are we Ok to have such a method?
* Given that is it CLI only the name sounds fine?
* Can it be part of the `console` API? 

//cc @nodejs/util 
