### PR TITLE
doc: update packages documentation for Node.js 12 EOL

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -376,7 +376,7 @@ import submodule from 'es-module-package/private-module.js';
 // Throws ERR_PACKAGE_PATH_NOT_EXPORTED
 ```
 
-#### Extensions in Subpaths
+#### Extensions in subpaths
 
 Package authors should provide either extensioned (`import 'pkg/subpath.js'`) or
 extensionless (`import 'pkg/subpath'`) subpaths in their exports. This ensures

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -399,8 +399,8 @@ Where compatibility with import maps is desired, it is recommended to use
 explicit file extensions when defining package subpaths so that package
 consumers write `import 'pkg/subpath.js'` instead of `import 'pkg/subpath'`.
 Instead of one individual mapping for each subpath entry, the corresponding
-import map can then use a folder mapping to map all export subpaths, instead
-of being bloated with a mapping per subpath.
+import map can then use a folder mapping to map multiple subpaths where
+possible for, instead of having the more bloated form of a mapping per subpath.
 
 The generated import map can be taken to be:
 

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -310,11 +310,6 @@ to only the specific feature exports exposed:
 }
 ```
 
-It is recommended to pick one of supporting extensioned or unextensioned
-subpaths for consistent usage. In the above example the extensioned form is used
-(ie via `import "my-package/feature/feat.js"`), which can be useful for better
-[interoperability with import maps][].
-
 ### Main entry point export
 
 When writing a new package supporting Node.js 12.20 and above (i.e. including
@@ -383,52 +378,24 @@ import submodule from 'es-module-package/private-module.js';
 // Throws ERR_PACKAGE_PATH_NOT_EXPORTED
 ```
 
-#### Interoperability with Import Maps
+#### Extensioned v Extensionless Subpaths
 
-[Import maps][] are a separate cross-platform standard for module resolution,
-already in use by some browsers, server-side JavaScript runtimes, and build
-tools. Although not currently implemented in Node.js, there are plans to provide
-import maps support in Node.js in future.
+It is recommended to pick either one of providing extensioned or unextensioned
+subpaths for a package to ensure consistent usage. This keeps the package
+contract clear for consumers, simplifies package subpath completions, and
+ensures all dependent packages import with the same specifier mappings.
 
-[Import maps][] are able to provide explicit specifier mappings for packages
-and package subpaths, and therefore all mappings defined by Node.js package
-exports and subpath exports can be mapped by a corresponding import map. In
-addition they support [folder mappings][] but not pattern mappings like
-Node.js supports.
+Ultimately, it is the choice of the package author which form of subpath to
+support - extensionless, like `import 'pkg/subpath'`, or extensioned, like
+`import 'pkg/subpath.js'` and per the exports example above. Both conventions
+are used in the Node.js ecosystem.
 
-Where interoperability with import maps is desired, it is recommended to use
-explicit file extensions when defining package subpaths so that package
-consumers write `import 'pkg/subpath.js'` instead of `import 'pkg/subpath'`.
-The corresponding import map can then use a folder mapping to map multiple
-subpaths where possible, instead of needing the more bloated form of a separate
-map entry for each package subpath.
-
-For example with the above package, the generated import map can be taken to be:
-
-```json
-{
-  "imports": {
-    "pkg": "/node_modules/pkg/index.js",
-    "pkg/": "/node_modules/pkg/src/"
-  }
-}
-```
-
-instead of the larger import map to handle adding each subpath file extension:
-
-```json
-{
-  "imports": {
-    "pkg": "/node_modules/pkg/index.js",
-    "pkg/submodule1": "/node_modules/pkg/src/submodule1.js",
-    "pkg/submodule2": "/node_modules/pkg/src/submodule2.js",
-    "pkg/submodule3": "/node_modules/pkg/src/submodule3.js",
-  }
-}
-```
-
-This also mirrors the requirement of using [the full specifier path][] in
-relative and absolute import specifiers.
+For packages where interoperability with [import maps][] is desired, using
+explicit file extensions when defining package subpaths can be preferable since
+the corresponding import map can then use a [folder mapping][] to map multiple
+subpaths where possible, instead of the more bloated form of a separate map
+entry for each package subpath. This also mirrors the requirement of using
+[the full specifier path][] in relative and absolute import specifiers.
 
 ### Exports sugar
 
@@ -463,11 +430,11 @@ added:
   - v12.19.0
 -->
 
-In addition to the [`"exports"`][] field, it is possible to define internal
-package import maps that only apply to import specifiers from within the package
-itself.
+In addition to the [`"exports"`][] field, there is a package `"imports"` field
+to create private mappings that only apply to import specifiers from within the
+package itself.
 
-Entries in the imports field must always start with `#` to ensure they are
+Entries in the `"imports"` field must always start with `#` to ensure they are
 disambiguated from external package specifiers.
 
 For example, the imports field can be used to gain the benefits of conditional
@@ -495,8 +462,8 @@ file `./dep-polyfill.js` relative to the package in other environments.
 Unlike the `"exports"` field, the `"imports"` field permits mapping to external
 packages.
 
-The resolution rules for the imports field are otherwise
-analogous to the exports field.
+The resolution rules for the imports field are otherwise analogous to the exports
+field.
 
 ### Subpath patterns
 
@@ -1360,7 +1327,6 @@ This field defines [subpath imports][] for the current package.
 [Corepack]: corepack.md
 [ES module]: esm.md
 [ES modules]: esm.md
-[Import maps]: https://github.com/WICG/import-maps
 [Node.js documentation for this section]: https://github.com/nodejs/node/blob/HEAD/doc/api/packages.md#conditions-definitions
 [`"exports"`]: #exports
 [`"imports"`]: #imports
@@ -1374,8 +1340,9 @@ This field defines [subpath imports][] for the current package.
 [`esm`]: https://github.com/standard-things/esm#readme
 [`package.json`]: #nodejs-packagejson-field-definitions
 [entry points]: #package-entry-points
-[folder mappings]: https://github.com/WICG/import-maps#extension-less-imports
+[folder mapping]: https://github.com/WICG/import-maps#extension-less-imports
 [folders as modules]: modules.md#folders-as-modules
+[import maps]: https://github.com/WICG/import-maps
 [interoperability with import maps]: #interoperability-with-import-maps
 [load ECMASCript modules from CommonJS modules]: modules.md#the-mjs-extension
 [loader hooks]: esm.md#loaders

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -520,9 +520,8 @@ import internalZ from '#internal/z.js';
 ```
 
 Including the `"*.js"` on both sides of the mapping allows restricting which
-file extensions can be resolved in the case of other files like source maps
-existing, while also retaining file extensions for the consumed subpath as is
-recommended.
+file extensions can be resolved in the case of there being other files like
+source maps existing.
 
 This is a direct static replacement without any special handling for file
 extensions. In the previous example, `pkg/features/x.json` would be resolved to

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -284,8 +284,10 @@ patterns:
   "exports": {
     ".": "./lib/index.js",
     "./lib": "./lib/index.js",
+    "./lib/*": "./lib/*.js",
     "./lib/*.js": "./lib/*.js",
     "./feature": "./feature/index.js",
+    "./feature/*": "./feature/*.js",
     "./feature/*.js": "./feature/*.js",
     "./package.json": "./package.json"
   }

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -237,9 +237,9 @@ between environments, and **preventing any other entry points besides those
 defined in [`"exports"`][]**. This encapsulation allows module authors to
 clearly define the public interface for their package.
 
-For new packages supporting Node.js 12+ the [`"exports"`][] field is
-recommended. For existing packages or packages supporting Node.js version 12.20
-or below, the [`"main"`][] field is recommended. If both [`"exports"`][] and
+For new packages targeting the currently supported versions of Node.js, the
+[`"exports"`][] field is recommended. For packages supporting Node.js 10 and
+below, the [`"main"`][] field is required. If both [`"exports"`][] and
 [`"main"`][] are defined, the [`"exports"`][] field takes precedence over
 [`"main"`][] in supported versions of Node.js.
 
@@ -312,9 +312,7 @@ to only the specific feature exports exposed:
 
 ### Main entry point export
 
-When writing a new package supporting Node.js 12.20 and above (i.e. including
-all current Node.js LTS releases), it is recommended to use the [`"exports"`][]
-field:
+When writing a new package, it is recommended to use the [`"exports"`][] field:
 
 ```json
 {
@@ -333,10 +331,10 @@ package. It is not a strong encapsulation since a direct require of any
 absolute subpath of the package such as
 `require('/path/to/node_modules/pkg/subpath.js')` will still load `subpath.js`.
 
-All supported versions of Node.js (since 12.7.0) and modern build tools
-support the `"exports"` field. For projects using an older version of Node.js
-or a related build tool, compatibility can be achieved by including the `"main"`
-field alongside `"exports"` pointing to the same module:
+All currently supported versions of Node.js and modern build tools support the
+`"exports"` field. For projects using an older version of Node.js or a related
+build tool, compatibility can be achieved by including the `"main"` field
+alongside `"exports"` pointing to the same module:
 
 ```json
 {
@@ -380,22 +378,23 @@ import submodule from 'es-module-package/private-module.js';
 
 #### Extensioned v Extensionless Subpaths
 
-It is recommended to pick either one of providing extensioned or unextensioned
-subpaths for a package to ensure consistent usage. This keeps the package
-contract clear for consumers, simplifies package subpath completions, and
-ensures all dependent packages import with the same specifier mappings.
+Package authors should provide either extensioned (`import 'pkg/subpath.js'`) or
+extensionless (`import 'pkg/subpath'`) subpaths in their exports. This ensures
+that there is only one subpath for each exported module so that all dependents
+import the same consistent specifier, keeping the package contract clear for
+consumers and simplifying package subpath completions.
 
-Ultimately, it is the choice of the package author which form of subpath to
-support - extensionless, like `import 'pkg/subpath'`, or extensioned, like
-`import 'pkg/subpath.js'` per the exports example above. Both conventions are
-used in the Node.js ecosystem.
+Traditionally, packages tended to use the extensionless style, which has the
+benefits of readability and of masking the true path of the file within the
+package.
 
-For packages where interoperability with [import maps][] is desired, using
-explicit file extensions when defining package subpaths can be preferable since
-the corresponding import map can then use a [packages folder mapping][] to map
-multiple subpaths where possible, instead of the more bloated form of a separate
-map entry for each package subpath. This also mirrors the requirement of using
-[the full specifier path][] in relative and absolute import specifiers.
+With [import maps][] now providing a standard for package resolution in browsers
+and other server-side runtimes, using the extensionless style can result in
+bloated import map definitions. Explicit file extensions can avoid this issue by
+enabling the import map to utilize a [packages folder mapping][] to map multiple
+subpaths where possible instead of a separate map entry per package subpath
+export. This also mirrors the requirement of using [the full specifier path][]
+in relative and absolute import specifiers.
 
 ### Exports sugar
 

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -400,9 +400,10 @@ explicit file extensions when defining package subpaths so that package
 consumers write `import 'pkg/subpath.js'` instead of `import 'pkg/subpath'`.
 Instead of one individual mapping for each subpath entry, the corresponding
 import map can then use a folder mapping to map multiple subpaths where
-possible for, instead of having the more bloated form of a mapping per subpath.
+possible, instead of having the more bloated form of a separate map entry for
+each package subpath.
 
-The generated import map can be taken to be:
+For example with the above package, the generated import map can be taken to be:
 
 ```json
 {
@@ -413,7 +414,7 @@ The generated import map can be taken to be:
 }
 ```
 
-instead of the larger:
+instead of the larger import map to handle adding each subpath file extension:
 
 ```json
 {

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -275,8 +275,8 @@ a project that previous exported `main`, `lib`,
 }
 ```
 
-Alternatively a project could choose to export entire folders using export
-patterns:
+Alternatively a project could choose to export entire folders both with and
+without extensioned subpaths using export patterns:
 
 ```json
 {
@@ -290,6 +290,21 @@ patterns:
     "./feature/*": "./feature/*.js",
     "./feature/*.js": "./feature/*.js",
     "./package.json": "./package.json"
+  }
+}
+```
+
+While the above supports good backwards-compatibility for package upgrades,
+a future major change for the package can then properly restrict the exports
+to only the specific feature exports exposed:
+
+```json
+{
+  "name": "my-package",
+  "exports": {
+    ".": "./lib/index.js",
+    "./feature/*.js": "./feature/*.js",
+    "./feature/internal/*": null
   }
 }
 ```

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1374,9 +1374,9 @@ This field defines [subpath imports][] for the current package.
 [`esm`]: https://github.com/standard-things/esm#readme
 [`package.json`]: #nodejs-packagejson-field-definitions
 [entry points]: #package-entry-points
-[interoperability with import maps]: #interoperability-with-import-maps
 [folder mappings]: https://github.com/WICG/import-maps#extension-less-imports
 [folders as modules]: modules.md#folders-as-modules
+[interoperability with import maps]: #interoperability-with-import-maps
 [load ECMASCript modules from CommonJS modules]: modules.md#the-mjs-extension
 [loader hooks]: esm.md#loaders
 [self-reference]: #self-referencing-a-package-using-its-name

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -392,9 +392,9 @@ used in the Node.js ecosystem.
 
 For packages where interoperability with [import maps][] is desired, using
 explicit file extensions when defining package subpaths can be preferable since
-the corresponding import map can then use a [folder mapping][] to map multiple
-subpaths where possible, instead of the more bloated form of a separate map
-entry for each package subpath. This also mirrors the requirement of using
+the corresponding import map can then use a [packages folder mapping][] to map
+multiple subpaths where possible, instead of the more bloated form of a separate
+map entry for each package subpath. This also mirrors the requirement of using
 [the full specifier path][] in relative and absolute import specifiers.
 
 ### Exports sugar
@@ -1340,12 +1340,12 @@ This field defines [subpath imports][] for the current package.
 [`esm`]: https://github.com/standard-things/esm#readme
 [`package.json`]: #nodejs-packagejson-field-definitions
 [entry points]: #package-entry-points
-[folder mapping]: https://github.com/WICG/import-maps#extension-less-imports
 [folders as modules]: modules.md#folders-as-modules
 [import maps]: https://github.com/WICG/import-maps
 [interoperability with import maps]: #interoperability-with-import-maps
 [load ECMASCript modules from CommonJS modules]: modules.md#the-mjs-extension
 [loader hooks]: esm.md#loaders
+[packages folder mapping]: https://github.com/WICG/import-maps#packages-via-trailing-slashes
 [self-reference]: #self-referencing-a-package-using-its-name
 [subpath exports]: #subpath-exports
 [subpath imports]: #subpath-imports

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -262,7 +262,7 @@ a project that previous exported `main`, `lib`,
 
 ```json
 {
-  "name": "my-mod",
+  "name": "my-package",
   "exports": {
     ".": "./lib/index.js",
     "./lib": "./lib/index.js",
@@ -280,13 +280,13 @@ patterns:
 
 ```json
 {
-  "name": "my-mod",
+  "name": "my-package",
   "exports": {
     ".": "./lib/index.js",
     "./lib": "./lib/index.js",
-    "./lib/*": "./lib/*",
+    "./lib/*.js": "./lib/*.js",
     "./feature": "./feature/index.js",
-    "./feature/*": "./feature/*",
+    "./feature/*.js": "./feature/*.js",
     "./package.json": "./package.json"
   }
 }
@@ -300,7 +300,7 @@ field:
 
 ```json
 {
-  "exports": "./main.js"
+  "exports": "./index.js"
 }
 ```
 
@@ -315,13 +315,14 @@ package. It is not a strong encapsulation since a direct require of any
 absolute subpath of the package such as
 `require('/path/to/node_modules/pkg/subpath.js')` will still load `subpath.js`.
 
-For packages supporting Node.js < 12.7.0 it is necessary to include the `"main"`
-field:
+All modern JS build tools support the `"exports"` field, but if necessary for
+compatibility with specific tooling or Node.js versions < 12.7.0, the `"main"`
+field can be included alongside `"exports"`:
 
 ```json
 {
-  "main": "./main.js",
-  "exports": "./main.js"
+  "main": "./index.js",
+  "exports": "./index.js"
 }
 ```
 
@@ -338,7 +339,7 @@ with the main entry point by treating the main entry point as the
 ```json
 {
   "exports": {
-    ".": "./main.js",
+    ".": "./index.js",
     "./submodule.js": "./src/submodule.js"
   }
 }
@@ -362,8 +363,8 @@ Even though subpaths provide an aribtrary string mapping to the package
 interface, it is recommended (but not required) to use explicit file extensions
 when defining package subpaths so that package consumers write
 `import 'pkg/subpath.js'` instead of `import 'pkg/subpath'` as this simplifies
-interop with other ecosystem tooling patterns such as when using import maps.
-This also mirrors the requirement of using [the full specifier path][] in
+interoperability with other ecosystem tooling patterns such as when using import
+maps. This also mirrors the requirement of using [the full specifier path][] in
 relative and absolute import specifiers.
 
 ### Exports sugar
@@ -378,7 +379,7 @@ for this case being the direct [`"exports"`][] field value.
 ```json
 {
   "exports": {
-    ".": "./main.js"
+    ".": "./index.js"
   }
 }
 ```
@@ -387,7 +388,7 @@ can be written:
 
 ```json
 {
-  "exports": "./main.js"
+  "exports": "./index.js"
 }
 ```
 
@@ -586,7 +587,7 @@ Conditional exports can also be extended to exports subpaths, for example:
 ```json
 {
   "exports": {
-    ".": "./main.js",
+    ".": "./index.js",
     "./feature.js": {
       "node": "./feature-node.js",
       "default": "./feature.js"
@@ -616,7 +617,6 @@ use in Node.js but not the browser:
 
 ```json
 {
-  "main": "./main.js",
   "exports": {
     "node": {
       "import": "./feature-node.mjs",
@@ -644,7 +644,7 @@ When running Node.js, custom user conditions can be added with the
 `--conditions` flag:
 
 ```bash
-node --conditions=development main.js
+node --conditions=development index.js
 ```
 
 which would then resolve the `"development"` condition in package imports and
@@ -717,7 +717,7 @@ For example, assuming the `package.json` is:
 {
   "name": "a-package",
   "exports": {
-    ".": "./main.mjs",
+    ".": "./index.mjs",
     "./foo.js": "./foo.js"
   }
 }
@@ -727,7 +727,7 @@ Then any module _in that package_ can reference an export in the package itself:
 
 ```js
 // ./a-module.mjs
-import { something } from 'a-package'; // Imports "something" from ./main.mjs.
+import { something } from 'a-package'; // Imports "something" from ./index.mjs.
 ```
 
 Self-referencing is available only if `package.json` has [`"exports"`][], and
@@ -1097,7 +1097,7 @@ added: v0.4.0
 
 ```json
 {
-  "main": "./main.js"
+  "main": "./index.js"
 }
 ```
 
@@ -1111,7 +1111,8 @@ It also defines the script that is used when the [package directory is loaded
 via `require()`](modules.md#folders-as-modules).
 
 ```cjs
-require('./path/to/directory'); // This resolves to ./path/to/directory/main.js.
+// This resolves to ./path/to/directory/index.js.
+require('./path/to/directory');
 ```
 
 ### `"packageManager"`

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -398,10 +398,9 @@ Node.js supports.
 Where interoperability with import maps is desired, it is recommended to use
 explicit file extensions when defining package subpaths so that package
 consumers write `import 'pkg/subpath.js'` instead of `import 'pkg/subpath'`.
-Instead of one individual mapping for each subpath entry, the corresponding
-import map can then use a folder mapping to map multiple subpaths where
-possible, instead of having the more bloated form of a separate map entry for
-each package subpath.
+The corresponding import map can then use a folder mapping to map multiple
+subpaths where possible, instead of needing the more bloated form of a separate
+map entry for each package subpath.
 
 For example with the above package, the generated import map can be taken to be:
 

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -519,13 +519,9 @@ import internalZ from '#internal/z.js';
 // Loads ./node_modules/es-module-package/src/internal/z.js
 ```
 
-Including the `"*.js"` on both sides of the mapping allows restricting which
-file extensions can be resolved in the case of there being other files like
-source maps existing.
-
-This is a direct static replacement without any special handling for file
-extensions. In the previous example, `pkg/features/x.json` would be resolved to
-`./src/features/x.json.js` in the mapping.
+This is a direct static matching and replacement without any special handling
+for file extensions. Including the `"*.js"` on both sides of the mapping
+restricts the exposed package exports to only JS files.
 
 The property of exports being statically enumerable is maintained with exports
 patterns since the individual exports for a package can be determined by

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -378,14 +378,14 @@ import submodule from 'es-module-package/private-module.js';
 // Throws ERR_PACKAGE_PATH_NOT_EXPORTED
 ```
 
-Even though subpaths provide an aribtrary string mapping to the package
+Even though subpaths provide an arbitrary string mapping to the package
 interface, it is recommended (but not required) to use explicit file extensions
 when defining package subpaths so that package consumers write
 `import 'pkg/subpath.js'` instead of `import 'pkg/subpath'` as this simplifies
 interoperability with [import maps][] and also mirrors the requirement of using
 [the full specifier path][] in relative and absolute import specifiers. Import
 maps are a cross-platform standard for module resolution, already in use by some
-browsers, server-side JavaScript runtimes and build tools.
+browsers, server-side JavaScript runtimes, and build tools.
 
 ### Exports sugar
 

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -442,6 +442,18 @@ analogous to the exports field.
 <!-- YAML
 added:
   - v14.13.0
+  - v12.20.0
+changes:
+  - version:
+    - v16.9.0
+    - v14.19.0
+    pr-url: https://github.com/nodejs/node/pull/39635
+    description: Support pattern trailers.
+  - version:
+    - v16.10.0
+    - v14.19.0
+    pr-url: https://github.com/nodejs/node/pull/40041
+    description: Support patterns in "imports" field.
 -->
 
 For packages with a small number of exports or imports, we recommend

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -445,15 +445,15 @@ added:
   - v12.20.0
 changes:
   - version:
-    - v16.9.0
-    - v14.19.0
-    pr-url: https://github.com/nodejs/node/pull/39635
-    description: Support pattern trailers.
-  - version:
     - v16.10.0
     - v14.19.0
     pr-url: https://github.com/nodejs/node/pull/40041
     description: Support pattern trailers in "imports" field.
+  - version:
+    - v16.9.0
+    - v14.19.0
+    pr-url: https://github.com/nodejs/node/pull/39635
+    description: Support pattern trailers.
 -->
 
 For packages with a small number of exports or imports, we recommend

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -310,10 +310,10 @@ to only the specific feature exports exposed:
 }
 ```
 
-Where it is then recommended to pick one of supporting extensioned or
-unextensioned subpaths for consistent usage. In the above example the
-extensioned form is used (ie via `import "my-package/feature/feat.js"`), which
-can be useful for better [interoperability with import maps][].
+It is recommended to pick one of supporting extensioned or unextensioned
+subpaths for consistent usage. In the above example the extensioned form is used
+(ie via `import "my-package/feature/feat.js"`), which can be useful for better
+[interoperability with import maps][].
 
 ### Main entry point export
 
@@ -387,7 +387,8 @@ import submodule from 'es-module-package/private-module.js';
 
 [Import maps][] are a separate cross-platform standard for module resolution,
 already in use by some browsers, server-side JavaScript runtimes, and build
-tools, although not currently implemented or supported in Node.js.
+tools. Although not currently implemented in Node.js, there are plans to provide
+import maps support in Node.js in future.
 
 [Import maps][] are able to provide explicit specifier mappings for packages
 and package subpaths, and therefore all mappings defined by Node.js package
@@ -1372,10 +1373,10 @@ This field defines [subpath imports][] for the current package.
 [`ERR_PACKAGE_PATH_NOT_EXPORTED`]: errors.md#err_package_path_not_exported
 [`esm`]: https://github.com/standard-things/esm#readme
 [`package.json`]: #nodejs-packagejson-field-definitions
-[interoperability with import maps]: #interoperability-with-import-maps
 [entry points]: #package-entry-points
-[folders as modules]: modules.md#folders-as-modules
+[interoperability with import maps]: #interoperability-with-import-maps
 [folder mappings]: https://github.com/WICG/import-maps#extension-less-imports
+[folders as modules]: modules.md#folders-as-modules
 [load ECMASCript modules from CommonJS modules]: modules.md#the-mjs-extension
 [loader hooks]: esm.md#loaders
 [self-reference]: #self-referencing-a-package-using-its-name

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -537,8 +537,8 @@ For example, a package that wants to provide different ES module exports for
 // package.json
 {
   "exports": {
-    "import": "./main-module.js",
-    "require": "./main-require.cjs"
+    "import": "./index-module.js",
+    "require": "./index-require.cjs"
   },
   "type": "module"
 }

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -315,9 +315,10 @@ package. It is not a strong encapsulation since a direct require of any
 absolute subpath of the package such as
 `require('/path/to/node_modules/pkg/subpath.js')` will still load `subpath.js`.
 
-All modern JS build tools support the `"exports"` field, but if necessary for
-compatibility with specific tooling or Node.js versions < 12.7.0, the `"main"`
-field can be included alongside `"exports"`:
+All supported versions of Node.js (since 12.7.0) and modern build tools
+support the `"exports"` field. For projects using an older version of Node.js
+or a related build tool, compatibility can be achieved by including the `"main"`
+field alongside `"exports"`:
 
 ```json
 {
@@ -363,9 +364,10 @@ Even though subpaths provide an aribtrary string mapping to the package
 interface, it is recommended (but not required) to use explicit file extensions
 when defining package subpaths so that package consumers write
 `import 'pkg/subpath.js'` instead of `import 'pkg/subpath'` as this simplifies
-interoperability with other ecosystem tooling patterns such as when using import
-maps. This also mirrors the requirement of using [the full specifier path][] in
-relative and absolute import specifiers.
+interoperability with [import maps][] and also mirrors the requirement of using
+[the full specifier path][] in relative and absolute import specifiers. Import
+maps are a cross-platform standard for module resolution, already in use by some
+browsers, server-side JavaScript runtimes and build tools.
 
 ### Exports sugar
 
@@ -1299,6 +1301,7 @@ This field defines [subpath imports][] for the current package.
 [`package.json`]: #nodejs-packagejson-field-definitions
 [entry points]: #package-entry-points
 [folders as modules]: modules.md#folders-as-modules
+[import maps]: https://github.com/WICG/import-maps
 [load ECMASCript modules from CommonJS modules]: modules.md#the-mjs-extension
 [loader hooks]: esm.md#loaders
 [self-reference]: #self-referencing-a-package-using-its-name

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -387,8 +387,8 @@ ensures all dependent packages import with the same specifier mappings.
 
 Ultimately, it is the choice of the package author which form of subpath to
 support - extensionless, like `import 'pkg/subpath'`, or extensioned, like
-`import 'pkg/subpath.js'` and per the exports example above. Both conventions
-are used in the Node.js ecosystem.
+`import 'pkg/subpath.js'` per the exports example above. Both conventions are
+used in the Node.js ecosystem.
 
 For packages where interoperability with [import maps][] is desired, using
 explicit file extensions when defining package subpaths can be preferable since

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -376,7 +376,7 @@ import submodule from 'es-module-package/private-module.js';
 // Throws ERR_PACKAGE_PATH_NOT_EXPORTED
 ```
 
-#### Extensioned v Extensionless Subpaths
+#### Extensions in Subpaths
 
 Package authors should provide either extensioned (`import 'pkg/subpath.js'`) or
 extensionless (`import 'pkg/subpath'`) subpaths in their exports. This ensures
@@ -389,7 +389,7 @@ benefits of readability and of masking the true path of the file within the
 package.
 
 With [import maps][] now providing a standard for package resolution in browsers
-and other server-side runtimes, using the extensionless style can result in
+and other JavaScript runtimes, using the extensionless style can result in
 bloated import map definitions. Explicit file extensions can avoid this issue by
 enabling the import map to utilize a [packages folder mapping][] to map multiple
 subpaths where possible instead of a separate map entry per package subpath

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -313,7 +313,7 @@ to only the specific feature exports exposed:
 Where it is then recommended to pick one of supporting extensioned or
 unextensioned subpaths for consistent usage. In the above example the
 extensioned form is used (ie via `import "my-package/feature/feat.js"`), which
-can be useful to ensure [compatibility with import maps][].
+can be useful for better [interoperability with import maps][].
 
 ### Main entry point export
 
@@ -383,7 +383,7 @@ import submodule from 'es-module-package/private-module.js';
 // Throws ERR_PACKAGE_PATH_NOT_EXPORTED
 ```
 
-#### Compatibility with Import Maps
+#### Interoperability with Import Maps
 
 [Import maps][] are a separate cross-platform standard for module resolution,
 already in use by some browsers, server-side JavaScript runtimes, and build
@@ -395,7 +395,7 @@ exports and subpath exports can be mapped by a corresponding import map. In
 addition they support [folder mappings][] but not pattern mappings like
 Node.js supports.
 
-Where compatibility with import maps is desired, it is recommended to use
+Where interoperability with import maps is desired, it is recommended to use
 explicit file extensions when defining package subpaths so that package
 consumers write `import 'pkg/subpath.js'` instead of `import 'pkg/subpath'`.
 Instead of one individual mapping for each subpath entry, the corresponding
@@ -1372,7 +1372,7 @@ This field defines [subpath imports][] for the current package.
 [`ERR_PACKAGE_PATH_NOT_EXPORTED`]: errors.md#err_package_path_not_exported
 [`esm`]: https://github.com/standard-things/esm#readme
 [`package.json`]: #nodejs-packagejson-field-definitions
-[compatibility with import maps]: #compatibility-with-import-maps
+[interoperability with import maps]: #interoperability-with-import-maps
 [entry points]: #package-entry-points
 [folders as modules]: modules.md#folders-as-modules
 [folder mappings]: https://github.com/WICG/import-maps#extension-less-imports

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -400,7 +400,9 @@ explicit file extensions when defining package subpaths so that package
 consumers write `import 'pkg/subpath.js'` instead of `import 'pkg/subpath'`.
 Instead of one individual mapping for each subpath entry, the corresponding
 import map can then use a folder mapping to map all export subpaths, instead
-of being bloated with a mapping per subpath:
+of being bloated with a mapping per subpath.
+
+The generated import map can be taken to be:
 
 ```json
 {

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -920,7 +920,7 @@ This approach is appropriate for any of the following use cases:
   refactor the package to isolate its state management. See the next section.
 
 A variant of this approach not requiring conditional exports for consumers could
-be to add an export, e.g. `"./module.mjs"`, to point to an all-ES module-syntax
+be to add an export, e.g. `"./module"`, to point to an all-ES module-syntax
 version of the package. This could be used via `import 'pkg/module'` by users
 who are certain that the CommonJS version will not be loaded anywhere in the
 application, such as by dependencies; or if the CommonJS version can be loaded
@@ -933,7 +933,7 @@ stateless):
   "type": "module",
   "exports": {
     ".": "./index.cjs",
-    "./module.mjs": "./wrapper.mjs"
+    "./module": "./wrapper.mjs"
   }
 }
 ```
@@ -1026,7 +1026,7 @@ execution between the CommonJS and ES module versions of a package.
 
 As with the previous approach, a variant of this approach not requiring
 conditional exports for consumers could be to add an export, e.g.
-`"./module.mjs"`, to point to an all-ES module-syntax version of the package:
+`"./module"`, to point to an all-ES module-syntax version of the package:
 
 ```json
 // ./node_modules/pkg/package.json
@@ -1034,7 +1034,7 @@ conditional exports for consumers could be to add an export, e.g.
   "type": "module",
   "exports": {
     ".": "./index.cjs",
-    "./module.mjs": "./index.mjs"
+    "./module": "./index.mjs"
   }
 }
 ```

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -269,6 +269,7 @@ a project that previous exported `main`, `lib`,
     "./lib/index": "./lib/index.js",
     "./lib/index.js": "./lib/index.js",
     "./feature": "./feature/index.js",
+    "./feature/index": "./feature/index.js",
     "./feature/index.js": "./feature/index.js",
     "./package.json": "./package.json"
   }

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -237,7 +237,7 @@ between environments, and **preventing any other entry points besides those
 defined in [`"exports"`][]**. This encapsulation allows module authors to
 clearly define the public interface for their package.
 
-For new packages supporting Node.js 12.+ the [`"exports"`][] field is
+For new packages supporting Node.js 12+ the [`"exports"`][] field is
 recommended. For existing packages or packages supporting Node.js version 12.20
 or below, the [`"main"`][] field is recommended. If both [`"exports"`][] and
 [`"main"`][] are defined, the [`"exports"`][] field takes precedence over
@@ -480,7 +480,7 @@ import internalZ from '#internal/z.js';
 Including the `"*.js"` on both sides of the mapping allows restricting which
 file extensions can be resolved in the case of other files like source maps
 existing, while also retaining file extensions for the consumed subpath as is
-recommend.
+recommended.
 
 This is a direct static replacement without any special handling for file
 extensions. In the previous example, `pkg/features/x.json` would be resolved to

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -462,8 +462,8 @@ file `./dep-polyfill.js` relative to the package in other environments.
 Unlike the `"exports"` field, the `"imports"` field permits mapping to external
 packages.
 
-The resolution rules for the imports field are otherwise analogous to the exports
-field.
+The resolution rules for the imports field are otherwise analogous to the
+exports field.
 
 ### Subpath patterns
 
@@ -1342,7 +1342,6 @@ This field defines [subpath imports][] for the current package.
 [entry points]: #package-entry-points
 [folders as modules]: modules.md#folders-as-modules
 [import maps]: https://github.com/WICG/import-maps
-[interoperability with import maps]: #interoperability-with-import-maps
 [load ECMASCript modules from CommonJS modules]: modules.md#the-mjs-extension
 [loader hooks]: esm.md#loaders
 [packages folder mapping]: https://github.com/WICG/import-maps#packages-via-trailing-slashes

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -237,11 +237,11 @@ between environments, and **preventing any other entry points besides those
 defined in [`"exports"`][]**. This encapsulation allows module authors to
 clearly define the public interface for their package.
 
-For new packages supporting Node.js 12.+ the [`"exports"`] field is recommended.
-For existing packages or packages supporting Node.js version 12.20 or below,
-the [`"main"`][] field is recommended. If both [`"exports"`][] and [`"main"`][]
-are defined, the [`"exports"`][] field takes precedence over [`"main"`][] in
-supported versions of Node.js.
+For new packages supporting Node.js 12.+ the [`"exports"`][] field is
+recommended. For existing packages or packages supporting Node.js version 12.20
+or below, the [`"main"`][] field is recommended. If both [`"exports"`][] and
+[`"main"`][] are defined, the [`"exports"`][] field takes precedence over
+[`"main"`][] in supported versions of Node.js.
 
 [Conditional exports][] can be used within [`"exports"`][] to define different
 package entry points per environment, including whether the package is
@@ -363,6 +363,8 @@ interface, it is recommended (but not required) to use explicit file extensions
 when defining package subpaths so that package consumers write
 `import 'pkg/subpath.js'` instead of `import 'pkg/subpath'` as this simplifies
 interop with other ecosystem tooling patterns such as when using import maps.
+This also mirrors the requirement of using [the full specifier path][] in
+relative and absolute import specifiers.
 
 ### Exports sugar
 

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -453,7 +453,7 @@ changes:
     - v16.10.0
     - v14.19.0
     pr-url: https://github.com/nodejs/node/pull/40041
-    description: Support patterns in "imports" field.
+    description: Support pattern trailers in "imports" field.
 -->
 
 For packages with a small number of exports or imports, we recommend


### PR DESCRIPTION
This updates the packages documentation to update some of the modules `"exports"` guidance with the Node.js 12 EOL, specifically:

- `"main"` is no longer required as a fallback when using `"exports"`, instead we explain how to decide which to use based on version support. I have gone quite strongly here in recommending the `"exports"` pattern - this guidance could certainly be relaxed to be more generous to keeping `"main"` around as well.
- In all `"exports"` examples, I've shifted to the pattern of including the file extension in the subpath, as has kind of come to be seen as the better approach to ensure interop with import maps. I've mentioned some brief notes around this and updated all the examples, including the patterns examples to use pattern trailers.
- I've updated the version history on subpath patterns to include the history for imports pattern support and pattern trailers support.
- I've moved the exports sugar section higher up, this should help make the linear flow a little easier to understand since we jump between forms.
- Added a new section on extensionless versus extensioned subpaths

/cc @nodejs/modules 