### PR TITLE
doc: add source community condition definition

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -660,6 +660,9 @@ is provided below to assist with ecosystem coordination.
 
 * `"types"` - can be used by typing systems to resolve the typing file for
   the given export. _This condition should always be included first._
+* `"source"` - can be used to reference unminified / unoptimized source versions
+  to use for debugging workflows, that will behave identically to any non-source
+  variants.
 * `"deno"` - indicates a variation for the Deno platform.
 * `"browser"` - any web browser environment.
 * `"development"` - can be used to define a development-only environment


### PR DESCRIPTION
I'd like to propose a new `"source"` condition in the `"exports"` field.

Currently, Node.js applications tend to assume that what is published to npm and imported from `node_modules` should be readable JS code and generally isn't minified and optimized by default.

In Node.js this is because minification and optimization doesn't provide a huge benefit for runtime performance.

On the other hand, when running JS code in the browser, minification and single-file optimizations are an absolute necessity.

When specifying a `"browser"` exports condition in the package.json, there's then a sort of implicit assumption that one should reference a minified source file, in contrast to an unminified version for Node.js.

This disparity is something package authors often have to wrestle with in making individual decisions for environments in this way.

A `"source"` condition would be defined as the uncompiled version of the code that runs the original source directly, useful for debugging workflows. By permitting packages to define this condition, we are encouraging packages to publish their original sources beyond just questionable source maps support, but actually in a form that can allow debugging back to the original readable code in all environments, while still being able to publish optimized JS code to npm.

The existing `"development"` and `"production"` conditions don't capture this condition because they refer to the execution mode, not the execution performance. Things like single-file-optimizations, minification and removing comments can be seen as optimizations that apply to both builds.

By using a `"source"` condition over a `"optimized"` condition or otherwise, we make it clear that the default mode for sources should really be to publish the most optimized version, and that switching back into a source condition is something that is done under special circumstances.

I've found this pattern incredibly useful for local development, running local tests via both `node test/test.js` and `node -C source test/test.js` when source maps are not sufficient to trace the error, and live code editing to add comments or further analysis is needed directly on the original sources to track the bug.

//cc @nodejs/modules 