### PR TITLE
tools: fix `create-or-update-pull-request-action` hash on GHA

### DIFF
--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: '0'  # This is required to actually get all the authors
           persist-credentials: false
       - run: tools/update-authors.mjs  # Run the AUTHORS tool
-      - uses: gr2m/create-or-update-pull-request-action@466b1b84c3291c6c69bc56377a6de54a1f4a297c
+      - uses: gr2m/create-or-update-pull-request-action@6720400cad8e74d7adc64640e4e6ea6748b83d8f
         # Creates a PR or update the Action's existing PR, or
         # no-op if the base branch is already up-to-date.
         env:

--- a/.github/workflows/license-builder.yml
+++ b/.github/workflows/license-builder.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           persist-credentials: false
       - run: ./tools/license-builder.sh  # Run the license builder tool
-      - uses: gr2m/create-or-update-pull-request-action@466b1b84c3291c6c69bc56377a6de54a1f4a297c
+      - uses: gr2m/create-or-update-pull-request-action@6720400cad8e74d7adc64640e4e6ea6748b83d8f
         # Creates a PR or update the Action's existing PR, or
         # no-op if the base branch is already up-to-date.
         env:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           persist-credentials: false
       - run: ${{ matrix.run }}
-      - uses: gr2m/create-or-update-pull-request-action@466b1b84c3291c6c69bc56377a6de54a1f4a297c
+      - uses: gr2m/create-or-update-pull-request-action@6720400cad8e74d7adc64640e4e6ea6748b83d8f
         # Creates a PR or update the Action's existing PR, or
         # no-op if the base branch is already up-to-date.
         env:


### PR DESCRIPTION
> I think we should use https://github.com/gr2m/create-or-update-pull-request-action/commit/6720400cad8e74d7adc64640e4e6ea6748b83d8f instead.
https://github.com/gr2m/create-or-update-pull-request-action/blob/6720400cad8e74d7adc64640e4e6ea6748b83d8f/dist/index.js
> There's no `/dist/` in their master branch.

_Originally posted by @LiviaMedeiros in https://github.com/nodejs/node/issues/43377#issuecomment-1152883511_
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
