### PR TITLE
http: fix http agent keep alive

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -342,7 +342,11 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
     installListeners(this, s, options);
     cb(null, s);
   });
-
+  // When keepAlive is true, pass the related options to createConnection
+  if (this.keepAlive) {
+    options.keepAlive = this.keepAlive;
+    options.keepAliveInitialDelay = this.keepAliveMsecs;
+  }
   const newSocket = this.createConnection(options, oncreate);
   if (newSocket)
     oncreate(null, newSocket);

--- a/test/parallel/test-http-agent-keepalive-delay.js
+++ b/test/parallel/test-http-agent-keepalive-delay.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const { Agent } = require('_http_agent');
+
+const agent = new Agent({
+  keepAlive: true,
+  keepAliveMsecs: 1000,
+});
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.end('ok');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const createConnection = agent.createConnection;
+  agent.createConnection = (options, ...args) => {
+    assert.strictEqual(options.keepAlive, true);
+    assert.strictEqual(options.keepAliveInitialDelay, agent.keepAliveMsecs);
+    return createConnection.call(agent, options, ...args);
+  };
+  http.get({
+    host: 'localhost',
+    port: server.address().port,
+    agent: agent,
+    path: '/'
+  }, common.mustCall((res) => {
+    // for emit end event
+    res.on('data', () => {});
+    res.on('end', () => {
+      server.close();
+    });
+  }));
+}));


### PR DESCRIPTION
When `options.keepAlive` in `createSocket` function is true it leads to a bug. because `createSocket` will call `this.createConnection(options, oncreate)`  which will create a socket and set two fields in socket.
```js
this[kSetKeepAlive] = Boolean(options.keepAlive); // true
this[kSetKeepAliveInitialDelay] = ~~(options.keepAliveInitialDelay / 1000); // 0
```
`this[kSetKeepAliveInitialDelay]` will be `0` because `options.keepAliveInitialDelay` is undefined. When the connection is finished, `afterConnect` will be called and use this two fields, the related code is as follow.
```js
if (self[kSetKeepAlive] && self._handle.setKeepAlive) {
      self._handle.setKeepAlive(true, self[kSetKeepAliveInitialDelay]);
}
```
It calls `setKeepAlive` with 0 (self[kSetKeepAliveInitialDelay]). 

Then when the `free` event of agent is emitted, agent will call `setKeepAlive` in `keepSocketAlive`, the code is as follow.
```js
// enable is true and this[kSetKeepAlive] is true too
if (this._handle.setKeepAlive && enable !== this[kSetKeepAlive]) {
    this[kSetKeepAlive] = enable;
    this[kSetKeepAliveInitialDelay] = initialDelay;
    this._handle.setKeepAlive(enable, initialDelay);
 }
```
`enable !== this[kSetKeepAlive]` will return false, so the agent do nothing which lead to a bug.

Currently http agent only set keepalive on some sockets (when `free` event is emitted). Maybe we can set keepalive for all sockets ? otherwise i think we should delete the `keepAlive` field of options before call `this.createConnection` in `createSocket`.

Refs: https://github.com/nodejs/node/issues/41965.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Affected subsystem: http