### PR TITLE
tools,doc: add guards against prototype pollution when creating proxies

### DIFF
--- a/doc/contributing/primordials.md
+++ b/doc/contributing/primordials.md
@@ -705,3 +705,27 @@ class SomeClass {
 ObjectDefineProperty(SomeClass.prototype, 'readOnlyProperty', kEnumerableProperty);
 console.log(new SomeClass().readOnlyProperty); // genuine data
 ```
+
+### Defining a `Proxy` handler
+
+When defining a `Proxy`, the handler object could be at risk of prototype
+pollution when using a plain object literal:
+
+```js
+// User-land
+Object.prototype.get = () => 'Unrelated user-provided data';
+
+// Core
+const objectToProxy = { someProperty: 'genuine value' };
+
+const proxyWithPlainObjectLiteral = new Proxy(objectToProxy, {
+  has() { return false; },
+});
+console.log(proxyWithPlainObjectLiteral.someProperty); // Unrelated user-provided data
+
+const proxyWithNullPrototypeObject = new Proxy(objectToProxy, {
+  __proto__: null,
+  has() { return false; },
+});
+console.log(proxyWithNullPrototypeObject.someProperty); // genuine value
+```

--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -117,6 +117,7 @@ function createAgentProxy(domain, client) {
   };
 
   return new Proxy(agent, {
+    __proto__: null,
     get(target, name) {
       if (name in target) return target[name];
       return function callVirtualMethod(params) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -987,6 +987,7 @@ function trackAssignmentsTypedArray(typedArray) {
   }
 
   return new Proxy(typedArray, {
+    __proto__: null,
     get(obj, prop, receiver) {
       if (prop === 'copyAssigned') {
         return copyAssigned;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -210,6 +210,8 @@ const wrapper = [
 ];
 
 let wrapperProxy = new Proxy(wrapper, {
+  __proto__: null,
+
   set(target, property, value, receiver) {
     patched = true;
     return ReflectSet(target, property, value, receiver);
@@ -718,6 +720,8 @@ function emitCircularRequireWarning(prop) {
 // A Proxy that can be used as the prototype of a module.exports object and
 // warns when non-existent properties are accessed.
 const CircularRequirePrototypeWarningProxy = new Proxy({}, {
+  __proto__: null,
+
   get(target, prop) {
     // Allow __esModule access in any case because it is used in the output
     // of transpiled code to determine whether something comes from an

--- a/test/parallel/test-eslint-avoid-prototype-pollution.js
+++ b/test/parallel/test-eslint-avoid-prototype-pollution.js
@@ -45,6 +45,10 @@ new RuleTester({
       'ReflectDefineProperty({}, "key", { "__proto__": null })',
       'ObjectDefineProperty({}, "key", { \'__proto__\': null })',
       'ReflectDefineProperty({}, "key", { \'__proto__\': null })',
+      'new Proxy({}, otherObject)',
+      'new Proxy({}, someFactory())',
+      'new Proxy({}, { __proto__: null })',
+      'new Proxy({}, { __proto__: null, ...{} })',
     ],
     invalid: [
       {
@@ -182,6 +186,22 @@ new RuleTester({
       {
         code: 'StringPrototypeSplit("some string", /some regex/)',
         errors: [{ message: /looks up the Symbol\.split property/ }],
+      },
+      {
+        code: 'new Proxy({}, {})',
+        errors: [{ message: /null-prototype/ }]
+      },
+      {
+        code: 'new Proxy({}, { [`__proto__`]: null })',
+        errors: [{ message: /null-prototype/ }]
+      },
+      {
+        code: 'new Proxy({}, { __proto__: Object.prototype })',
+        errors: [{ message: /null-prototype/ }]
+      },
+      {
+        code: 'new Proxy({}, { ...{ __proto__: null } })',
+        errors: [{ message: /null-prototype/ }]
       },
     ]
   });

--- a/tools/eslint-rules/avoid-prototype-pollution.js
+++ b/tools/eslint-rules/avoid-prototype-pollution.js
@@ -128,6 +128,23 @@ module.exports = {
       ...createUnsafeStringMethodReport(context, 'StringPrototypeReplaceAll', 'Symbol.replace'),
       ...createUnsafeStringMethodReport(context, 'StringPrototypeSearch', 'Symbol.search'),
       ...createUnsafeStringMethodReport(context, 'StringPrototypeSplit', 'Symbol.split'),
+
+      'NewExpression[callee.name="Proxy"][arguments.1.type="ObjectExpression"]'(node) {
+        for (const { key, value } of node.arguments[1].properties) {
+          if (
+            key != null && value != null &&
+            ((key.type === 'Identifier' && key.name === '__proto__') ||
+              (key.type === 'Literal' && key.value === '__proto__')) &&
+            value.type === 'Literal' && value.value === null
+          ) {
+            return;
+          }
+        }
+        context.report({
+          node,
+          message: 'Proxy handler must be a null-prototype object'
+        });
+      }
     };
   },
 };


### PR DESCRIPTION
When defining a `Proxy`, the handler object could be at risk of prototype
pollution when using a plain object literal:

```js
// User-land
Object.prototype.get = () => 'Unrelated user-provided data';
// Core
const objectToProxy = { someProperty: 'genuine value' };
const proxyWithPlainObjectLiteral = new Proxy(objectToProxy, {
  has() { return false; },
});
console.log(proxyWithPlainObjectLiteral.someProperty); // Unrelated user-provided data
const proxyWithNullPrototypeObject = new Proxy(objectToProxy, {
  __proto__: null,
  has() { return false; },
});
console.log(proxyWithNullPrototypeObject.someProperty); // genuine value
```
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
