### PR TITLE
crypto: fix webcrypto import of cfrg raw public keys

### DIFF
--- a/lib/internal/crypto/cfrg.js
+++ b/lib/internal/crypto/cfrg.js
@@ -72,13 +72,6 @@ function verifyAcceptableCfrgKeyUse(name, type, usages) {
   }
 }
 
-function createECPublicKeyRaw(name, keyData) {
-  const handle = new KeyObjectHandle();
-  keyData = getArrayBufferOrView(keyData, 'keyData');
-  if (handle.initECRaw(name.toLowerCase(), keyData))
-    return new PublicKeyObject(handle);
-}
-
 function createCFRGRawKey(name, keyData, isPublic) {
   const handle = new KeyObjectHandle();
   keyData = getArrayBufferOrView(keyData, 'keyData');
@@ -295,7 +288,7 @@ async function cfrgImportKey(
     }
     case 'raw': {
       verifyAcceptableCfrgKeyUse(name, 'public', usagesSet);
-      keyObject = createECPublicKeyRaw(name, keyData);
+      keyObject = createCFRGRawKey(name, keyData, true);
       if (keyObject === undefined)
         throw lazyDOMException('Unable to import CFRG key', 'OperationError');
       break;

--- a/test/parallel/test-webcrypto-export-import-cfrg.js
+++ b/test/parallel/test-webcrypto-export-import-cfrg.js
@@ -261,6 +261,20 @@ async function testImportJwk({ name, publicUsages, privateUsages }, extractable)
   }
 }
 
+async function testImportRaw({ name, publicUsages }) {
+  const jwk = keyData[name].jwk;
+
+  const publicKey = await subtle.importKey(
+    'raw',
+    Buffer.from(jwk.x, 'base64url'),
+    { name },
+    true, publicUsages);
+
+  assert.strictEqual(publicKey.type, 'public');
+  assert.deepStrictEqual(publicKey.usages, publicUsages);
+  assert.strictEqual(publicKey.algorithm.name, name);
+}
+
 (async function() {
   const tests = [];
   testVectors.forEach((vector) => {
@@ -269,6 +283,7 @@ async function testImportJwk({ name, publicUsages, privateUsages }, extractable)
       tests.push(testImportPkcs8(vector, extractable));
       tests.push(testImportJwk(vector, extractable));
     });
+    tests.push(testImportRaw(vector));
   });
 
   await Promise.all(tests);


### PR DESCRIPTION
Fixes import of raw CFRG public keys in Web Crypto API.

Before:

```js
const x = Buffer.from(crypto.generateKeyPairSync('ed25519').publicKey.export({ format: 'jwk' }).x, 'base64')
await crypto.subtle.importKey('raw', x, 'Ed25519', true, ['verify'])
```

```
DOMException [OperationError]: Unable to import CFRG key
    at new DOMException (node:internal/per_context/domexception:53:5)
    at __node_internal_ (node:internal/util:502:10)
    at Object.cfrgImportKey (node:internal/crypto/cfrg:300:15)
    at SubtleCrypto.importKey (node:internal/crypto/webcrypto:528:10)
```

After:

```
CryptoKey {
  type: 'public',
  extractable: true,
  algorithm: { name: 'Ed25519' },
  usages: [ 'verify' ]
}
```