### PR TITLE
test_runner: fix `skip` and `todo`

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -376,7 +376,8 @@ no-op.
 added: v18.0.0
 -->
 
-Exactly the same as `context.test([name][, options][, fn])`, but adds `skip: true` in the options.
+Exactly the same as `context.test([name][, options][, fn])`,
+but adds `skip: true` in the options.
 This function causes the test's output to indicate the test as skipped.
 Calling `skip()` does
 not terminate execution of the test function. This function does not return a
@@ -388,7 +389,8 @@ value.
 added: v18.0.0
 -->
 
-Exactly the same as `context.test([name][, options][, fn])`, but adds `todo: true` in the options.
+Exactly the same as `context.test([name][, options][, fn])`,
+but adds `todo: true` in the options.
 This function causes the test's output to indicate the test as skipped.
 Calling `skip()` does
 not terminate execution of the test function. This function does not return a

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -370,16 +370,15 @@ have the `only` option set. Otherwise, all tests are run. If Node.js was not
 started with the [`--test-only`][] command-line option, this function is a
 no-op.
 
-### `context.skip([message])`
+### `context.skip([name][, options][, fn])`
 
 <!-- YAML
 added: v18.0.0
 -->
 
-* `message` {string} Optional skip message to be displayed in TAP output.
-
-This function causes the test's output to indicate the test as skipped. If
-`message` is provided, it is included in the TAP output. Calling `skip()` does
+Exactly the same as `context.test([name][, options][, fn])`, but adds `skip: true` in the options.
+This function causes the test's output to indicate the test as skipped.
+Calling `skip()` does
 not terminate execution of the test function. This function does not return a
 value.
 
@@ -389,11 +388,11 @@ value.
 added: v18.0.0
 -->
 
-* `message` {string} Optional `TODO` message to be displayed in TAP output.
-
-This function adds a `TODO` directive to the test's output. If `message` is
-provided, it is included in the TAP output. Calling `todo()` does not terminate
-execution of the test function. This function does not return a value.
+Exactly the same as `context.test([name][, options][, fn])`, but adds `todo: true` in the options.
+This function causes the test's output to indicate the test as skipped.
+Calling `skip()` does
+not terminate execution of the test function. This function does not return a
+value.
 
 ### `context.test([name][, options][, fn])`
 

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -53,7 +53,7 @@ function parseTestProps(parent, name, options, fn) {
 
   // If this test has already ended, attach this test to the root test so
   // that the error can be properly reported.
-  if (this.finished) {
+  if (parent.finished) {
     while (parent.parent !== null) {
       parent = parent.parent;
     }

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -36,6 +36,32 @@ const testOnlyFlag = !isTestRunner && getOptionValue('--test-only');
 // TODO(cjihrig): Use uv_available_parallelism() once it lands.
 const rootConcurrency = isTestRunner ? cpus().length : 1;
 
+
+function parseTestProps(parent, name, options, fn) {
+  if (typeof name === 'function') {
+    fn = name;
+  } else if (name !== null && typeof name === 'object') {
+    fn = options;
+    options = name;
+  } else if (typeof options === 'function') {
+    fn = options;
+  }
+
+  if (options === null || typeof options !== 'object') {
+    options = kEmptyObject;
+  }
+
+  // If this test has already ended, attach this test to the root test so
+  // that the error can be properly reported.
+  if (this.finished) {
+    while (parent.parent !== null) {
+      parent = parent.parent;
+    }
+  }
+
+  return { fn, name, parent, ...options };
+}
+
 class TestContext {
   #test;
 
@@ -51,17 +77,18 @@ class TestContext {
     this.#test.runOnlySubtests = !!value;
   }
 
-  skip(message) {
-    this.#test.skip(message);
+  skip(...props) {
+    const { name, options, fn } = parseTestProps(this.#test, ...props);
+    this.test(name, { ...options, skip: true }, fn);
   }
 
-  todo(message) {
-    this.#test.todo(message);
+  todo(...props) {
+    const { name, options, fn } = parseTestProps(this.#test, ...props);
+    this.test(name, { ...options, todo: true }, fn);
   }
 
   test(name, options, fn) {
     const subtest = this.#test.createSubtest(name, options, fn);
-
     return subtest.start();
   }
 }
@@ -189,34 +216,11 @@ class Test extends AsyncResource {
     }
   }
 
-  createSubtest(name, options, fn) {
-    if (typeof name === 'function') {
-      fn = name;
-    } else if (name !== null && typeof name === 'object') {
-      fn = options;
-      options = name;
-    } else if (typeof options === 'function') {
-      fn = options;
-    }
+  createSubtest(...props) {
+    const test = new Test(parseTestProps(this, ...props));
 
-    if (options === null || typeof options !== 'object') {
-      options = kEmptyObject;
-    }
-
-    let parent = this;
-
-    // If this test has already ended, attach this test to the root test so
-    // that the error can be properly reported.
-    if (this.finished) {
-      while (parent.parent !== null) {
-        parent = parent.parent;
-      }
-    }
-
-    const test = new Test({ fn, name, parent, ...options });
-
-    if (parent.waitingOn === 0) {
-      parent.waitingOn = test.testNumber;
+    if (test.parent.waitingOn === 0) {
+      test.parent.waitingOn = test.testNumber;
     }
 
     if (this.finished) {
@@ -228,7 +232,7 @@ class Test extends AsyncResource {
       );
     }
 
-    ArrayPrototypePush(parent.subtests, test);
+    ArrayPrototypePush(test.parent.subtests, test);
     return test;
   }
 
@@ -263,16 +267,6 @@ class Test extends AsyncResource {
 
     this.endTime = hrtime();
     this.passed = true;
-  }
-
-  skip(message) {
-    this.skipped = true;
-    this.message = message;
-  }
-
-  todo(message) {
-    this.isTodo = true;
-    this.message = message;
   }
 
   diagnostic(message) {

--- a/test/parallel/test-runner-skip.js
+++ b/test/parallel/test-runner-skip.js
@@ -1,0 +1,19 @@
+'use strict';
+require('../common');
+const test = require('node:test');
+const assert = require('assert');
+
+
+const tracker = new assert.CallTracker();
+const func = tracker.calls(() => {}, 1);
+
+test('test skip recipes', async (t) => {
+  await t.skip('skip using test.skip', func);
+  await t.test('skip using options', { skip: true }, func);
+  await t.test('skip internally using context', (t) => {
+    t.skip();
+    func();
+  });
+
+  tracker.verify();
+});


### PR DESCRIPTION
fix `node:test` skip method to better match existing well known APIs


before this change,
skipping worked only this way:
```js
test('a', {skip: true}, () => {});
test('a', (t) => {
	t.skip();
});
```

after this fix, both these ways still skip the test the same way,
but you can also skip using `test.skip('name', fn)` which did not work before.

also - the docs was taken from [tap docs ](https://node-tap.org/docs/api/#tskipname-options-function) since this follows the same behavior