### PR TITLE
test: make node-api/test_buffer/test_finalizer not flaky

### DIFF
--- a/test/node-api/node-api.status
+++ b/test/node-api/node-api.status
@@ -5,6 +5,5 @@ prefix node-api
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
-test_buffer/test_finalizer : PASS,FLAKY
 
 [$system==win32]

--- a/test/node-api/test_buffer/test_finalizer.js
+++ b/test/node-api/test_buffer/test_finalizer.js
@@ -16,6 +16,10 @@ process.on('uncaughtException', common.mustCall((err) => {
       throw new Error('finalizer error');
     }));
   }
+  global.gc(true);
+  await tick(common.platformTimeout(100));
   global.gc();
-  await tick(10);
+  await tick(common.platformTimeout(100));
+  global.gc();
+  await tick(common.platformTimeout(100));
 })().then(common.mustCall());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Trying to improve the reliability of `test/node-api/test_buffer/test_finalizer.js` as it is very often failing.