### PR TITLE
crypto: fix webcrypto WPT expected failures

### DIFF
--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -29,6 +29,10 @@ const {
 } = require('internal/crypto/keys');
 
 const {
+  lazyDOMException,
+} = require('internal/util');
+
+const {
   Buffer,
 } = require('buffer');
 
@@ -171,11 +175,22 @@ async function asyncDigest(algorithm, data) {
   if (algorithm.length !== undefined)
     validateUint32(algorithm.length, 'algorithm.length');
 
-  return jobPromise(new HashJob(
-    kCryptoJobAsync,
-    normalizeHashName(algorithm.name),
-    data,
-    algorithm.length));
+  switch (algorithm.name) {
+    case 'SHA-1':
+      // Fall through
+    case 'SHA-256':
+      // Fall through
+    case 'SHA-384':
+      // Fall through
+    case 'SHA-512':
+      return jobPromise(new HashJob(
+        kCryptoJobAsync,
+        normalizeHashName(algorithm.name),
+        data,
+        algorithm.length));
+  }
+
+  throw lazyDOMException('Unrecognized name.', 'NotSupportedError');
 }
 
 module.exports = {

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -176,7 +176,7 @@ async function rsaKeyGenerate(
   return new Promise((resolve, reject) => {
     generateKeyPair('rsa', {
       modulusLength,
-      publicExponentConverted,
+      publicExponent: publicExponentConverted,
     }, (err, pubKey, privKey) => {
       if (err) {
         return reject(lazyDOMException(

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -89,6 +89,11 @@ async function generateKey(
   algorithm = normalizeAlgorithm(algorithm);
   validateBoolean(extractable, 'extractable');
   validateArray(keyUsages, 'keyUsages');
+  if (keyUsages.length === 0) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key',
+      'SyntaxError');
+  }
   switch (algorithm.name) {
     case 'RSASSA-PKCS1-v1_5':
       // Fall through

--- a/test/parallel/test-webcrypto-digest.js
+++ b/test/parallel/test-webcrypto-digest.js
@@ -168,3 +168,9 @@ async function testDigest(size, name) {
 
   await Promise.all(variations);
 })().then(common.mustCall());
+
+(async () => {
+  assert.rejects(subtle.digest('RSA-OAEP', Buffer.alloc(1)), {
+    name: 'NotSupportedError',
+  });
+})().then(common.mustCall());

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -211,6 +211,14 @@ const vectors = {
       if (!vectors[name].usages.includes(usage))
         invalidUsages.push(usage);
     });
+    await assert.rejects(
+      subtle.generateKey(
+        {
+          name, ...vectors[name].algorithm
+        },
+        true,
+        []),
+      { message: /Usages cannot be empty/ });
     return assert.rejects(
       subtle.generateKey(
         {
@@ -340,6 +348,17 @@ const vectors = {
         hash
       }, true, usages), {
         code: 'ERR_INVALID_ARG_TYPE'
+      });
+    }));
+
+    await Promise.all([[1], [1, 0, 0]].map((publicExponent) => {
+      return assert.rejects(subtle.generateKey({
+        name,
+        modulusLength,
+        publicExponent: new Uint8Array(publicExponent),
+        hash
+      }, true, usages), {
+        name: 'OperationError',
       });
     }));
   }

--- a/test/parallel/test-webcrypto-sign-verify-hmac.js
+++ b/test/parallel/test-webcrypto-sign-verify-hmac.js
@@ -153,7 +153,7 @@ async function testSign({ hash,
   }
 
   await assert.rejects(
-    subtle.generateKey({ name }, false, []), {
+    subtle.generateKey({ name }, false, ['sign', 'verify']), {
       name: 'TypeError',
       code: 'ERR_MISSING_OPTION',
       message: 'algorithm.hash is required'


### PR DESCRIPTION
Since we skip a big chunk of WPTs these expected failures were not exhibited.

- digest() invalid algorithm which happens to collide with other `normalizeHashName` names
- empty usages in generateKey()
- invalid RSA algorithm publicExponent values in generateKey()