### PR TITLE
crypto: multiple webcrypto fixes

### DIFF
--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -230,13 +230,17 @@ async function aesGenerateKey(algorithm, extractable, keyUsages) {
   validateInteger(length, 'algorithm.length');
   validateOneOf(length, 'algorithm.length', kAesKeyLengths);
 
-  const usageSet = new SafeSet(keyUsages);
+  const checkUsages = ['wrapKey', 'unwrapKey'];
+  if (name !== 'AES-KW')
+    ArrayPrototypePush(checkUsages, 'encrypt', 'decrypt');
 
-  if (hasAnyNotIn(usageSet, ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'])) {
+  const usagesSet = new SafeSet(keyUsages);
+  if (hasAnyNotIn(usagesSet, checkUsages)) {
     throw lazyDOMException(
       'Unsupported key usage for an AES key',
       'SyntaxError');
   }
+
   return new Promise((resolve, reject) => {
     generateKey('aes', { length }, (err, key) => {
       if (err) {
@@ -249,7 +253,7 @@ async function aesGenerateKey(algorithm, extractable, keyUsages) {
       resolve(new InternalCryptoKey(
         key,
         { name, length },
-        ArrayFrom(usageSet),
+        ArrayFrom(usagesSet),
         extractable));
     });
   });

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -3,7 +3,7 @@
 const {
   ArrayBufferPrototypeSlice,
   FunctionPrototypeCall,
-  MathFloor,
+  MathCeil,
   ObjectDefineProperty,
   Promise,
   SafeSet,
@@ -386,9 +386,9 @@ async function asyncDeriveBitsECDH(algorithm, baseKey, length) {
   if (length === null)
     return bits;
 
-  // If the length is not a multiple of 8, it will be truncated
-  // down to the nearest multiple of 8.
-  length = MathFloor(length / 8);
+  // If the length is not a multiple of 8 the nearest ceiled
+  // multiple of 8 is sliced.
+  length = MathCeil(length / 8);
   const { byteLength } = bits;
 
   // If the length is larger than the derived secret, throw.

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -29,6 +29,10 @@ const {
 } = require('internal/crypto/keys');
 
 const {
+  lazyDOMException,
+} = require('internal/util');
+
+const {
   Buffer,
 } = require('buffer');
 
@@ -171,11 +175,22 @@ async function asyncDigest(algorithm, data) {
   if (algorithm.length !== undefined)
     validateUint32(algorithm.length, 'algorithm.length');
 
-  return jobPromise(new HashJob(
-    kCryptoJobAsync,
-    normalizeHashName(algorithm.name),
-    data,
-    algorithm.length));
+  switch (algorithm.name) {
+    case 'SHA-1':
+      // Fall through
+    case 'SHA-256':
+      // Fall through
+    case 'SHA-384':
+      // Fall through
+    case 'SHA-512':
+      return jobPromise(new HashJob(
+        kCryptoJobAsync,
+        normalizeHashName(algorithm.name),
+        data,
+        algorithm.length));
+  }
+
+  throw lazyDOMException('Unrecognized name.', 'NotSupportedError');
 }
 
 module.exports = {

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -176,7 +176,7 @@ async function rsaKeyGenerate(
   return new Promise((resolve, reject) => {
     generateKeyPair('rsa', {
       modulusLength,
-      publicExponentConverted,
+      publicExponent: publicExponentConverted,
     }, (err, pubKey, privKey) => {
       if (err) {
         return reject(lazyDOMException(

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -89,6 +89,11 @@ async function generateKey(
   algorithm = normalizeAlgorithm(algorithm);
   validateBoolean(extractable, 'extractable');
   validateArray(keyUsages, 'keyUsages');
+  if (keyUsages.length === 0) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key',
+      'SyntaxError');
+  }
   switch (algorithm.name) {
     case 'RSASSA-PKCS1-v1_5':
       // Fall through

--- a/test/parallel/test-webcrypto-derivebits-cfrg.js
+++ b/test/parallel/test-webcrypto-derivebits-cfrg.js
@@ -133,7 +133,7 @@ async function prepareKeys() {
 
         assert.strictEqual(
           Buffer.from(bits).toString('hex'),
-          result.slice(0, -4));
+          result.slice(0, -2));
       }
     }));
 

--- a/test/parallel/test-webcrypto-derivebits-ecdh.js
+++ b/test/parallel/test-webcrypto-derivebits-ecdh.js
@@ -154,7 +154,7 @@ async function prepareKeys() {
 
         assert.strictEqual(
           Buffer.from(bits).toString('hex'),
-          result.slice(0, -4));
+          result.slice(0, -2));
       }
     }));
 

--- a/test/parallel/test-webcrypto-digest.js
+++ b/test/parallel/test-webcrypto-digest.js
@@ -168,3 +168,9 @@ async function testDigest(size, name) {
 
   await Promise.all(variations);
 })().then(common.mustCall());
+
+(async () => {
+  await assert.rejects(subtle.digest('RSA-OAEP', Buffer.alloc(1)), {
+    name: 'NotSupportedError',
+  });
+})().then(common.mustCall());

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -210,6 +210,15 @@ const vectors = {
 // Test bad usages
 {
   async function test(name) {
+    await assert.rejects(
+      subtle.generateKey(
+        {
+          name, ...vectors[name].algorithm
+        },
+        true,
+        []),
+      { message: /Usages cannot be empty/ });
+
     const invalidUsages = [];
     allUsages.forEach((usage) => {
       if (!vectors[name].usages.includes(usage))

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -211,14 +211,16 @@ const vectors = {
       if (!vectors[name].usages.includes(usage))
         invalidUsages.push(usage);
     });
-    return assert.rejects(
-      subtle.generateKey(
-        {
-          name, ...vectors[name].algorithm
-        },
-        true,
-        invalidUsages),
-      { message: /Unsupported key usage/ });
+    for (const invalidUsage of invalidUsages) {
+      await assert.rejects(
+        subtle.generateKey(
+          {
+            name, ...vectors[name].algorithm
+          },
+          true,
+          [...vectors[name].usages, invalidUsage]),
+        { message: /Unsupported key usage/ });
+    }
   }
 
   const tests = Object.keys(vectors).map(test);

--- a/test/parallel/test-webcrypto-sign-verify-hmac.js
+++ b/test/parallel/test-webcrypto-sign-verify-hmac.js
@@ -153,7 +153,7 @@ async function testSign({ hash,
   }
 
   await assert.rejects(
-    subtle.generateKey({ name }, false, []), {
+    subtle.generateKey({ name }, false, ['sign', 'verify']), {
       name: 'TypeError',
       code: 'ERR_MISSING_OPTION',
       message: 'algorithm.hash is required'


### PR DESCRIPTION
While working on updating WPTs (#43421 put on hold) I have found the following issues.


- digest() invalid algorithm which happens to collide with other `normalizeHashName` names was accepted
- empty usages in generateKey() were accepted
- generateKey() publicExponent was not used
- deriveBits() ECDH / X25519 / X448 returned incorrect slice when non multiple of 8 length was requested
- generateKey() AES-KW accepted invalid usages

Review individual commits, will land as separate commits (https://github.com/nodejs/node/labels/commit-queue-rebase)