### PR TITLE
test: improve code coverage for performance_entry.js

### DIFF
--- a/test/parallel/test-perf-hooks-resourcetiming.js
+++ b/test/parallel/test-perf-hooks-resourcetiming.js
@@ -2,6 +2,7 @@
 
 const common = require('../common');
 const assert = require('assert');
+const util = require('util');
 const {
   PerformanceObserver,
   PerformanceEntry,
@@ -14,6 +15,7 @@ const {
 
 assert(PerformanceObserver);
 assert(PerformanceEntry);
+assert.throws(() => new PerformanceEntry(), { code: 'ERR_ILLEGAL_CONSTRUCTOR' });
 assert(PerformanceResourceTiming);
 assert(clearResourceTimings);
 assert(markResourceTiming);
@@ -173,6 +175,54 @@ function createTimingInfo({
     encodedBodySize: 0,
     decodedBodySize: 0,
   });
+  assert.strictEqual(util.inspect(performance.getEntries()), `[
+  PerformanceResourceTiming {
+    name: 'http://localhost:8080',
+    entryType: 'resource',
+    startTime: 0,
+    duration: 0,
+    initiatorType: 'fetch',
+    nextHopProtocol: [],
+    workerStart: 0,
+    redirectStart: 0,
+    redirectEnd: 0,
+    fetchStart: 0,
+    domainLookupStart: 0,
+    domainLookupEnd: 0,
+    connectStart: 0,
+    connectEnd: 0,
+    secureConnectionStart: 0,
+    requestStart: 0,
+    responseStart: 0,
+    responseEnd: 0,
+    transferSize: 0,
+    encodedBodySize: 0,
+    decodedBodySize: 0
+  }
+]`);
+  assert.strictEqual(util.inspect(resource), `PerformanceResourceTiming {
+  name: 'http://localhost:8080',
+  entryType: 'resource',
+  startTime: 0,
+  duration: 0,
+  initiatorType: 'fetch',
+  nextHopProtocol: [],
+  workerStart: 0,
+  redirectStart: 0,
+  redirectEnd: 0,
+  fetchStart: 0,
+  domainLookupStart: 0,
+  domainLookupEnd: 0,
+  connectStart: 0,
+  connectEnd: 0,
+  secureConnectionStart: 0,
+  requestStart: 0,
+  responseStart: 0,
+  responseEnd: 0,
+  transferSize: 0,
+  encodedBodySize: 0,
+  decodedBodySize: 0
+}`);
 
   assert(resource instanceof PerformanceEntry);
   assert(resource instanceof PerformanceResourceTiming);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR added util inspection tests to improve code coverage for perf hooks.

This covers
- [constructor](https://coverage.nodejs.org/coverage-5ca2ab1ff56bc220/lib/internal/perf/performance_entry.js.html#L31)
- [string representation for debugging](https://coverage.nodejs.org/coverage-5ca2ab1ff56bc220/lib/internal/perf/performance_entry.js.html#L45)

| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/22386678/173849947-a848905b-b186-4caf-a355-5be51a0ec6d4.png) | ![image](https://user-images.githubusercontent.com/22386678/173849875-428ed738-9160-489a-8151-227ca6deedc2.png)|

