### PR TITLE
crypto: handle webcrypto generateKey() usages edge case

### DIFF
--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -89,19 +89,18 @@ async function generateKey(
   algorithm = normalizeAlgorithm(algorithm);
   validateBoolean(extractable, 'extractable');
   validateArray(keyUsages, 'keyUsages');
-  if (keyUsages.length === 0) {
-    throw lazyDOMException(
-      'Usages cannot be empty when creating a key',
-      'SyntaxError');
-  }
+  let result;
+  let resultType;
   switch (algorithm.name) {
     case 'RSASSA-PKCS1-v1_5':
       // Fall through
     case 'RSA-PSS':
       // Fall through
     case 'RSA-OAEP':
-      return lazyRequire('internal/crypto/rsa')
+      resultType = 'CryptoKeyPair';
+      result = await lazyRequire('internal/crypto/rsa')
         .rsaKeyGenerate(algorithm, extractable, keyUsages);
+      break;
     case 'Ed25519':
       // Fall through
     case 'Ed448':
@@ -109,16 +108,22 @@ async function generateKey(
     case 'X25519':
       // Fall through
     case 'X448':
-      return lazyRequire('internal/crypto/cfrg')
+      resultType = 'CryptoKeyPair';
+      result = await lazyRequire('internal/crypto/cfrg')
         .cfrgGenerateKey(algorithm, extractable, keyUsages);
+      break;
     case 'ECDSA':
       // Fall through
     case 'ECDH':
-      return lazyRequire('internal/crypto/ec')
+      resultType = 'CryptoKeyPair';
+      result = await lazyRequire('internal/crypto/ec')
         .ecGenerateKey(algorithm, extractable, keyUsages);
+      break;
     case 'HMAC':
-      return lazyRequire('internal/crypto/mac')
+      resultType = 'CryptoKey';
+      result = await lazyRequire('internal/crypto/mac')
         .hmacGenerateKey(algorithm, extractable, keyUsages);
+      break;
     case 'AES-CTR':
       // Fall through
     case 'AES-CBC':
@@ -126,11 +131,26 @@ async function generateKey(
     case 'AES-GCM':
       // Fall through
     case 'AES-KW':
-      return lazyRequire('internal/crypto/aes')
+      resultType = 'CryptoKey';
+      result = await lazyRequire('internal/crypto/aes')
         .aesGenerateKey(algorithm, extractable, keyUsages);
+      break;
     default:
       throw lazyDOMException('Unrecognized name.');
   }
+
+  if (
+    (resultType === 'CryptoKey' &&
+      (result.type === 'secret' || result.type === 'private') &&
+      result.usages.length === 0) ||
+    (resultType === 'CryptoKeyPair' && result.privateKey.usages.length === 0)
+  ) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key.',
+      'SyntaxError');
+  }
+
+  return result;
 }
 
 async function deriveBits(algorithm, baseKey, length) {

--- a/test/parallel/test-webcrypto-derivebits-ecdh.js
+++ b/test/parallel/test-webcrypto-derivebits-ecdh.js
@@ -201,7 +201,7 @@ async function prepareKeys() {
       {
         name: 'ECDSA',
         namedCurve: 'P-521'
-      }, false, ['verify']);
+      }, false, ['sign', 'verify']);
 
     await assert.rejects(subtle.deriveBits({
       name: 'ECDH',

--- a/test/parallel/test-webcrypto-derivekey-ecdh.js
+++ b/test/parallel/test-webcrypto-derivekey-ecdh.js
@@ -165,7 +165,7 @@ async function prepareKeys() {
         namedCurve: 'P-521'
       },
       false,
-      ['verify']);
+      ['sign', 'verify']);
 
     await assert.rejects(
       subtle.deriveKey(

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -29,49 +29,49 @@ const allUsages = [
 const vectors = {
   'AES-CTR': {
     algorithm: { length: 256 },
+    result: 'CryptoKey',
     usages: [
       'encrypt',
       'decrypt',
       'wrapKey',
       'unwrapKey',
     ],
-    mandatoryUsages: []
   },
   'AES-CBC': {
     algorithm: { length: 256 },
+    result: 'CryptoKey',
     usages: [
       'encrypt',
       'decrypt',
       'wrapKey',
       'unwrapKey',
     ],
-    mandatoryUsages: []
   },
   'AES-GCM': {
     algorithm: { length: 256 },
+    result: 'CryptoKey',
     usages: [
       'encrypt',
       'decrypt',
       'wrapKey',
       'unwrapKey',
     ],
-    mandatoryUsages: []
   },
   'AES-KW': {
     algorithm: { length: 256 },
+    result: 'CryptoKey',
     usages: [
       'wrapKey',
       'unwrapKey',
     ],
-    mandatoryUsages: []
   },
   'HMAC': {
     algorithm: { length: 256, hash: 'SHA-256' },
+    result: 'CryptoKey',
     usages: [
       'sign',
       'verify',
     ],
-    mandatoryUsages: []
   },
   'RSASSA-PKCS1-v1_5': {
     algorithm: {
@@ -79,11 +79,11 @@ const vectors = {
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: 'SHA-256'
     },
+    result: 'CryptoKeyPair',
     usages: [
       'sign',
       'verify',
     ],
-    mandatoryUsages: ['sign'],
   },
   'RSA-PSS': {
     algorithm: {
@@ -91,11 +91,11 @@ const vectors = {
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: 'SHA-256'
     },
+    result: 'CryptoKeyPair',
     usages: [
       'sign',
       'verify',
     ],
-    mandatoryUsages: ['sign']
   },
   'RSA-OAEP': {
     algorithm: {
@@ -103,69 +103,57 @@ const vectors = {
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: 'SHA-256'
     },
+    result: 'CryptoKeyPair',
     usages: [
       'encrypt',
       'decrypt',
       'wrapKey',
       'unwrapKey',
     ],
-    mandatoryUsages: [
-      'decrypt',
-      'unwrapKey',
-    ]
   },
   'ECDSA': {
     algorithm: { namedCurve: 'P-521' },
+    result: 'CryptoKeyPair',
     usages: [
       'sign',
       'verify',
     ],
-    mandatoryUsages: ['sign']
   },
   'ECDH': {
     algorithm: { namedCurve: 'P-521' },
+    result: 'CryptoKeyPair',
     usages: [
       'deriveKey',
       'deriveBits',
     ],
-    mandatoryUsages: [
-      'deriveKey',
-      'deriveBits',
-    ]
   },
   'Ed25519': {
+    result: 'CryptoKeyPair',
     usages: [
       'sign',
       'verify',
     ],
-    mandatoryUsages: ['sign']
   },
   'Ed448': {
+    result: 'CryptoKeyPair',
     usages: [
       'sign',
       'verify',
     ],
-    mandatoryUsages: ['sign']
   },
   'X25519': {
+    result: 'CryptoKeyPair',
     usages: [
       'deriveKey',
       'deriveBits',
     ],
-    mandatoryUsages: [
-      'deriveKey',
-      'deriveBits',
-    ]
   },
   'X448': {
+    result: 'CryptoKeyPair',
     usages: [
       'deriveKey',
       'deriveBits',
     ],
-    mandatoryUsages: [
-      'deriveKey',
-      'deriveBits',
-    ]
   },
 };
 
@@ -218,6 +206,25 @@ const vectors = {
         true,
         []),
       { message: /Usages cannot be empty/ });
+
+    // For CryptoKeyPair results the private key
+    // usages must not be empty.
+    // - ECDH(-like) algorithm key pairs only have private key usages
+    // - Signing algorithm key pairs may pass a non-empty array but
+    //   with only a public key usage
+    if (
+      vectors[name].result === 'CryptoKeyPair' &&
+      vectors[name].usages.includes('verify')
+    ) {
+      await assert.rejects(
+        subtle.generateKey(
+          {
+            name, ...vectors[name].algorithm
+          },
+          true,
+          ['verify']),
+        { message: /Usages cannot be empty/ });
+    }
 
     const invalidUsages = [];
     allUsages.forEach((usage) => {


### PR DESCRIPTION
As per spec:
<img width="799" alt="Screenshot 2022-06-16 at 22 18 24" src="https://user-images.githubusercontent.com/241506/174156761-5aa25d13-5d0c-4d29-b383-1e9f0218cb57.png">

chrome:
<img width="641" alt="image" src="https://user-images.githubusercontent.com/241506/174157251-6a116cd6-9fc2-4f2c-b714-9763b43489eb.png">

The current check has an edge case with signing algorithms where only public key usages could be provided.