### PR TITLE
events: improve `Event` compatibility

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -96,13 +96,11 @@ class Event {
    *   composed?: boolean,
    * }} [options]
    */
-  constructor(type, options = null) {
+  constructor(type, options = kEmptyObject) {
     if (arguments.length === 0)
       throw new ERR_MISSING_ARGS('type');
-    validateObject(options, 'options', {
-      allowArray: true, allowFunction: true, nullable: true,
-    });
-    const { cancelable, bubbles, composed } = { ...options };
+    validateObject(options, 'options');
+    const { bubbles, cancelable, composed } = options;
     this.#cancelable = !!cancelable;
     this.#bubbles = !!bubbles;
     this.#composed = !!composed;

--- a/test/parallel/test-whatwg-events-event-constructors.js
+++ b/test/parallel/test-whatwg-events-event-constructors.js
@@ -1,0 +1,29 @@
+'use strict';
+
+require('../common');
+const { test, assert_equals, assert_array_equals } =
+  require('../common/wpt').harness;
+
+// Source: https://github.com/web-platform-tests/wpt/blob/6cef1d2087d6a07d7cc6cee8cf207eec92e27c5f/dom/events/Event-constructors.any.js#L91-L112
+test(function() {
+  const called = [];
+  const ev = new Event('Xx', {
+    get cancelable() {
+      called.push('cancelable');
+      return false;
+    },
+    get bubbles() {
+      called.push('bubbles');
+      return true;
+    },
+    get sweet() {
+      called.push('sweet');
+      return 'x';
+    },
+  });
+  assert_array_equals(called, ['bubbles', 'cancelable']);
+  assert_equals(ev.type, 'Xx');
+  assert_equals(ev.bubbles, true);
+  assert_equals(ev.cancelable, false);
+  assert_equals(ev.sweet, undefined);
+});


### PR DESCRIPTION
This fixes the `Event` constructor to improve `Event Web API` compatibility.

The test added was written by referring to [wpt@dom/events/Event-constructors.any.js](https://github.com/web-platform-tests/wpt/blob/6cef1d2087d6a07d7cc6cee8cf207eec92e27c5f/dom/events/Event-constructors.any.js#L91-L112)



Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
