### PR TITLE
lib: use null-prototype objects for property descriptors

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -132,11 +132,13 @@ addBufferPrototypeMethods(Buffer.prototype);
 
 const constants = ObjectDefineProperties({}, {
   MAX_LENGTH: {
+    __proto__: null,
     value: kMaxLength,
     writable: false,
     enumerable: true
   },
   MAX_STRING_LENGTH: {
+    __proto__: null,
     value: kStringMaxLength,
     writable: false,
     enumerable: true

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1181,9 +1181,9 @@ function createTeeReadableStream(start, pull, cancel) {
       setupReadableStreamDefaultControllerFromSource(
         this,
         ObjectCreate(null, {
-          start: { value: start },
-          pull: { value: pull },
-          cancel: { value: cancel }
+          start: { __proto__: null, value: start },
+          pull: { __proto__: null, value: pull },
+          cancel: { __proto__: null, value: cancel }
         }),
         1,
         () => 1);

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -49,11 +49,13 @@ const kType = Symbol('kType');
 
 const AsyncIterator = ObjectCreate(AsyncIteratorPrototype, {
   next: {
+    __proto__: null,
     configurable: true,
     enumerable: true,
     writable: true,
   },
   return: {
+    __proto__: null,
     configurable: true,
     enumerable: true,
     writable: true,


### PR DESCRIPTION
Left over from https://github.com/nodejs/node/pull/43270 (lint rule fix coming in a follow up PR)
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
