### PR TITLE
lib: refactor to avoid unsafe regex primordials

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -31,7 +31,7 @@ const {
   ObjectKeys,
   ObjectSetPrototypeOf,
   ReflectApply,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   String,
   StringPrototypeCharCodeAt,
   StringPrototypeIncludes,
@@ -165,7 +165,7 @@ function ClientRequest(input, options, cb) {
 
   if (options.path) {
     const path = String(options.path);
-    if (RegExpPrototypeTest(INVALID_PATH_REGEX, path))
+    if (RegExpPrototypeExec(INVALID_PATH_REGEX, path) !== null)
       throw new ERR_UNESCAPED_CHARACTERS('Request path');
   }
 

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -24,7 +24,7 @@
 const {
   MathMin,
   Symbol,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
 } = primordials;
 const { setImmediate } = require('timers');
 
@@ -208,7 +208,7 @@ const tokenRegExp = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/;
  * See https://tools.ietf.org/html/rfc7230#section-3.2.6
  */
 function checkIsHttpToken(val) {
-  return RegExpPrototypeTest(tokenRegExp, val);
+  return RegExpPrototypeExec(tokenRegExp, val) !== null;
 }
 
 const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/;
@@ -219,7 +219,7 @@ const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/;
  *  field-vchar    = VCHAR / obs-text
  */
 function checkInvalidHeaderChar(val) {
-  return RegExpPrototypeTest(headerCharRegex, val);
+  return RegExpPrototypeExec(headerCharRegex, val) !== null;
 }
 
 function cleanParser(parser) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -33,7 +33,7 @@ const {
   ObjectValues,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   SafeSet,
   StringPrototypeToLowerCase,
   Symbol,
@@ -542,7 +542,7 @@ function matchHeader(self, state, field, value) {
     case 'connection':
       state.connection = true;
       self._removedConnection = false;
-      if (RegExpPrototypeTest(RE_CONN_CLOSE, value))
+      if (RegExpPrototypeExec(RE_CONN_CLOSE, value) !== null)
         self._last = true;
       else
         self.shouldKeepAlive = true;
@@ -550,7 +550,7 @@ function matchHeader(self, state, field, value) {
     case 'transfer-encoding':
       state.te = true;
       self._removedTE = false;
-      if (RegExpPrototypeTest(RE_TE_CHUNKED, value))
+      if (RegExpPrototypeExec(RE_TE_CHUNKED, value) !== null)
         self.chunkedEncoding = true;
       break;
     case 'content-length':

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -26,7 +26,7 @@ const {
   Error,
   ObjectKeys,
   ObjectSetPrototypeOf,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   ReflectApply,
   Symbol,
   SymbolFor,
@@ -193,8 +193,8 @@ function ServerResponse(req) {
   this._expect_continue = false;
 
   if (req.httpVersionMajor < 1 || req.httpVersionMinor < 1) {
-    this.useChunkedEncodingByDefault = RegExpPrototypeTest(chunkExpression,
-                                                           req.headers.te);
+    this.useChunkedEncodingByDefault = RegExpPrototypeExec(chunkExpression,
+                                                           req.headers.te) !== null;
     this.shouldKeepAlive = false;
   }
 
@@ -971,7 +971,7 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
     } else if (req.headers.expect !== undefined) {
       handled = true;
 
-      if (RegExpPrototypeTest(continueExpression, req.headers.expect)) {
+      if (RegExpPrototypeExec(continueExpression, req.headers.expect) !== null) {
         res._expect_continue = true;
 
         if (server.listenerCount('checkContinue') > 0) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -31,8 +31,9 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
   RegExp,
-  RegExpPrototypeTest,
-  StringPrototypeReplace,
+  RegExpPrototypeExec,
+  RegExpPrototypeSymbolReplace,
+  StringPrototypeReplaceAll,
   StringPrototypeSlice,
   Symbol,
   SymbolFor,
@@ -425,8 +426,8 @@ function onerror(err) {
     owner.destroy(err);
   } else if (owner._tlsOptions?.isServer &&
              owner._rejectUnauthorized &&
-             RegExpPrototypeTest(/peer did not return a certificate/,
-                                 err.message)) {
+             RegExpPrototypeExec(/peer did not return a certificate/,
+                                 err.message) !== null) {
     // Ignore server's authorization errors
     owner.destroy();
   } else {
@@ -1447,9 +1448,9 @@ Server.prototype.addContext = function(servername, context) {
     throw new ERR_TLS_REQUIRED_SERVER_NAME();
   }
 
-  const re = new RegExp('^' + StringPrototypeReplace(
-    StringPrototypeReplace(servername, /([.^$+?\-\\[\]{}])/g, '\\$1'),
-    /\*/g, '[^.]*'
+  const re = new RegExp('^' + StringPrototypeReplaceAll(
+    RegExpPrototypeSymbolReplace(/([.^$+?\-\\[\]{}])/g, servername, '\\$1'),
+    '*', '[^.]*'
   ) + '$');
   ArrayPrototypePush(this._contexts,
                      [re, tls.createSecureContext(context).context]);
@@ -1473,7 +1474,7 @@ function SNICallback(servername, callback) {
 
   for (let i = contexts.length - 1; i >= 0; --i) {
     const elem = contexts[i];
-    if (RegExpPrototypeTest(elem[0], servername)) {
+    if (RegExpPrototypeExec(elem[0], servername) !== null) {
       callback(null, elem[1]);
       return;
     }

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -35,7 +35,8 @@ const {
   ObjectKeys,
   ObjectPrototypeIsPrototypeOf,
   ReflectApply,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
+  RegExpPrototypeSymbolReplace,
   SafeMap,
   String,
   StringPrototypeCharCodeAt,
@@ -345,7 +346,7 @@ function getErrMessage(message, fn) {
     // Always normalize indentation, otherwise the message could look weird.
     if (StringPrototypeIncludes(message, '\n')) {
       if (EOL === '\r\n') {
-        message = StringPrototypeReplace(message, /\r\n/g, '\n');
+        message = RegExpPrototypeSymbolReplace(/\r\n/g, message, '\n');
       }
       const frames = StringPrototypeSplit(message, '\n');
       message = ArrayPrototypeShift(frames);
@@ -606,7 +607,7 @@ class Comparison {
         if (actual !== undefined &&
             typeof actual[key] === 'string' &&
             isRegExp(obj[key]) &&
-            RegExpPrototypeTest(obj[key], actual[key])) {
+            RegExpPrototypeExec(obj[key], actual[key]) !== null) {
           this[key] = actual[key];
         } else {
           this[key] = obj[key];
@@ -652,7 +653,7 @@ function expectedException(actual, expected, message, fn) {
     // Handle regular expressions.
     if (isRegExp(expected)) {
       const str = String(actual);
-      if (RegExpPrototypeTest(expected, str))
+      if (RegExpPrototypeExec(expected, str) !== null)
         return;
 
       if (!message) {
@@ -687,7 +688,7 @@ function expectedException(actual, expected, message, fn) {
       for (const key of keys) {
         if (typeof actual[key] === 'string' &&
             isRegExp(expected[key]) &&
-            RegExpPrototypeTest(expected[key], actual[key])) {
+            RegExpPrototypeExec(expected[key], actual[key]) !== null) {
           continue;
         }
         compareExceptionKey(actual, expected, key, message, keys, fn);
@@ -851,7 +852,7 @@ function hasMatchingError(actual, expected) {
   if (typeof expected !== 'function') {
     if (isRegExp(expected)) {
       const str = String(actual);
-      return RegExpPrototypeTest(expected, str);
+      return RegExpPrototypeExec(expected, str) !== null;
     }
     throw new ERR_INVALID_ARG_TYPE(
       'expected', ['Function', 'RegExp'], expected
@@ -1000,7 +1001,7 @@ function internalMatch(string, regexp, message, fn) {
   }
   const match = fn === assert.match;
   if (typeof string !== 'string' ||
-      RegExpPrototypeTest(regexp, string) !== match) {
+      RegExpPrototypeExec(regexp, string) !== null !== match) {
     if (message instanceof Error) {
       throw message;
     }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -37,8 +37,8 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  RegExpPrototypeSymbolReplace,
   StringPrototypeCharCodeAt,
-  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeToLowerCase,
   StringPrototypeTrim,
@@ -837,8 +837,8 @@ Buffer.prototype[customInspectSymbol] = function inspect(recurseTimes, ctx) {
   const max = INSPECT_MAX_BYTES;
   const actualMax = MathMin(max, this.length);
   const remaining = this.length - max;
-  let str = StringPrototypeTrim(StringPrototypeReplace(
-    this.hexSlice(0, actualMax), /(.{2})/g, '$1 '));
+  let str = StringPrototypeTrim(RegExpPrototypeSymbolReplace(
+    /(.{2})/g, this.hexSlice(0, actualMax), '$1 '));
   if (remaining > 0)
     str += ` ... ${remaining} more byte${remaining > 1 ? 's' : ''}`;
   // Inspect special properties as well, if possible.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -36,7 +36,7 @@ const {
   ObjectAssign,
   ObjectDefineProperty,
   ObjectPrototypeHasOwnProperty,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   SafeSet,
   StringPrototypeSlice,
   StringPrototypeToUpperCase,
@@ -571,7 +571,7 @@ function normalizeSpawnArguments(file, args, options) {
       else
         file = process.env.comspec || 'cmd.exe';
       // '/d /s /c' is used only for cmd.exe.
-      if (RegExpPrototypeTest(/^(?:.*\\)?cmd(?:\.exe)?$/i, file)) {
+      if (RegExpPrototypeExec(/^(?:.*\\)?cmd(?:\.exe)?$/i, file) !== null) {
         args = ['/d', '/s', '/c', `"${command}"`];
         windowsVerbatimArguments = true;
       } else {

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -9,8 +9,8 @@ const {
   PromiseReject,
   SafePromisePrototypeFinally,
   ReflectConstruct,
+  RegExpPrototypeExec,
   RegExpPrototypeSymbolReplace,
-  RegExpPrototypeTest,
   StringPrototypeToLowerCase,
   StringPrototypeSplit,
   Symbol,
@@ -165,7 +165,7 @@ class Blob {
     this[kLength] = length;
 
     type = `${type}`;
-    this[kType] = RegExpPrototypeTest(disallowedTypeCharacters, type) ?
+    this[kType] = RegExpPrototypeExec(disallowedTypeCharacters, type) !== null ?
       '' : StringPrototypeToLowerCase(type);
 
     // eslint-disable-next-line no-constructor-return
@@ -247,7 +247,7 @@ class Blob {
     end |= 0;
 
     contentType = `${contentType}`;
-    if (RegExpPrototypeTest(disallowedTypeCharacters, contentType)) {
+    if (RegExpPrototypeExec(disallowedTypeCharacters, contentType) !== null) {
       contentType = '';
     } else {
       contentType = StringPrototypeToLowerCase(contentType);

--- a/lib/internal/cluster/primary.js
+++ b/lib/internal/cluster/primary.js
@@ -6,7 +6,7 @@ const {
   ArrayPrototypeSome,
   ObjectKeys,
   ObjectValues,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   SafeMap,
   StringPrototypeStartsWith,
 } = primordials;
@@ -121,8 +121,8 @@ function createWorkerProcess(id, env) {
   const nodeOptions = process.env.NODE_OPTIONS || '';
 
   if (ArrayPrototypeSome(execArgv,
-                         (arg) => RegExpPrototypeTest(debugArgRegex, arg)) ||
-      RegExpPrototypeTest(debugArgRegex, nodeOptions)) {
+                         (arg) => RegExpPrototypeExec(debugArgRegex, arg) !== null) ||
+      RegExpPrototypeExec(debugArgRegex, nodeOptions) !== null) {
     let inspectPort;
     if ('inspectPort' in cluster.settings) {
       if (typeof cluster.settings.inspectPort === 'function')

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -24,13 +24,13 @@ const {
   ReflectApply,
   ReflectConstruct,
   ReflectOwnKeys,
+  RegExpPrototypeSymbolReplace,
   SafeArrayIterator,
   SafeMap,
   SafeWeakMap,
   StringPrototypeIncludes,
   StringPrototypePadStart,
   StringPrototypeRepeat,
-  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeSplit,
   Symbol,
@@ -279,7 +279,7 @@ ObjectDefineProperties(Console.prototype, {
 
       if (groupIndent.length !== 0) {
         if (StringPrototypeIncludes(string, '\n')) {
-          string = StringPrototypeReplace(string, /\n/g, `\n${groupIndent}`);
+          string = RegExpPrototypeSymbolReplace(/\n/g, string, `\n${groupIndent}`);
         }
         string = groupIndent + string;
       }

--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -15,9 +15,8 @@ const {
   PromisePrototypeThen,
   PromiseResolve,
   Proxy,
-  RegExpPrototypeSymbolMatch,
+  RegExpPrototypeExec,
   RegExpPrototypeSymbolSplit,
-  RegExpPrototypeTest,
   StringPrototypeEndsWith,
   StringPrototypeSplit,
 } = primordials;
@@ -91,7 +90,7 @@ async function runScript(script, scriptArgs, inspectHost, inspectPort,
   return new Promise((resolve) => {
     function waitForListenHint(text) {
       output += text;
-      const debug = RegExpPrototypeSymbolMatch(debugRegex, output);
+      const debug = RegExpPrototypeExec(debugRegex, output);
       if (debug) {
         const host = debug[1];
         const port = Number(debug[2]);
@@ -282,8 +281,8 @@ function parseArgv(args) {
   let script = target;
   let scriptArgs = args;
 
-  const hostMatch = RegExpPrototypeSymbolMatch(/^([^:]+):(\d+)$/, target);
-  const portMatch = RegExpPrototypeSymbolMatch(/^--port=(\d+)$/, target);
+  const hostMatch = RegExpPrototypeExec(/^([^:]+):(\d+)$/, target);
+  const portMatch = RegExpPrototypeExec(/^--port=(\d+)$/, target);
 
   if (hostMatch) {
     // Connecting to remote debugger
@@ -296,7 +295,7 @@ function parseArgv(args) {
     port = Number(portMatch[1]);
     script = args[0];
     scriptArgs = ArrayPrototypeSlice(args, 1);
-  } else if (args.length === 1 && RegExpPrototypeTest(/^\d+$/, args[0]) &&
+  } else if (args.length === 1 && RegExpPrototypeExec(/^\d+$/, args[0]) !== null &&
              target === '-p') {
     // Start debugger against a given pid
     const pid = Number(args[0]);

--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -29,7 +29,7 @@ const {
   PromiseResolve,
   ReflectGetOwnPropertyDescriptor,
   ReflectOwnKeys,
-  RegExpPrototypeSymbolMatch,
+  RegExpPrototypeExec,
   RegExpPrototypeSymbolReplace,
   SafeArrayIterator,
   SafeMap,
@@ -114,7 +114,7 @@ takeHeapSnapshot(filepath = 'node.heapsnapshot')
 const FUNCTION_NAME_PATTERN = /^(?:function\*? )?([^(\s]+)\(/;
 function extractFunctionName(description) {
   const fnNameMatch =
-    RegExpPrototypeSymbolMatch(FUNCTION_NAME_PATTERN, description);
+    RegExpPrototypeExec(FUNCTION_NAME_PATTERN, description);
   return fnNameMatch ? `: ${fnNameMatch[1]}` : '';
 }
 
@@ -171,7 +171,7 @@ function markSourceColumn(sourceText, position, useColors) {
 
 function extractErrorMessage(stack) {
   if (!stack) return '<unknown>';
-  const m = RegExpPrototypeSymbolMatch(/^\w+: ([^\n]+)/, stack);
+  const m = RegExpPrototypeExec(/^\w+: ([^\n]+)/, stack);
   return m?.[1] ?? stack;
 }
 
@@ -578,7 +578,7 @@ function createRepl(inspector) {
   function prepareControlCode(input) {
     if (input === '\n') return lastCommand;
     // Add parentheses: exec process.title => exec("process.title");
-    const match = RegExpPrototypeSymbolMatch(/^\s*(?:exec|p)\s+([^\n]*)/, input);
+    const match = RegExpPrototypeExec(/^\s*(?:exec|p)\s+([^\n]*)/, input);
     if (match) {
       lastCommand = `exec(${JSONStringify(match[1])})`;
     } else {

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -7,8 +7,8 @@ const {
   ArrayPrototypePush,
   FunctionPrototypeBind,
   NumberParseInt,
-  StringPrototypeMatch,
-  StringPrototypeReplace,
+  RegExpPrototypeExec,
+  RegExpPrototypeSymbolReplace,
 } = primordials;
 
 const errors = require('internal/errors');
@@ -86,7 +86,7 @@ class Resolver {
       if (ipVersion !== 0)
         return ArrayPrototypePush(newSet, [ipVersion, serv, IANA_DNS_PORT]);
 
-      const match = StringPrototypeMatch(serv, IPv6RE);
+      const match = RegExpPrototypeExec(IPv6RE, serv);
 
       // Check for an IPv6 in brackets.
       if (match) {
@@ -94,13 +94,13 @@ class Resolver {
 
         if (ipVersion !== 0) {
           const port = NumberParseInt(
-            StringPrototypeReplace(serv, addrSplitRE, '$2')) || IANA_DNS_PORT;
+            RegExpPrototypeSymbolReplace(addrSplitRE, serv, '$2')) || IANA_DNS_PORT;
           return ArrayPrototypePush(newSet, [ipVersion, match[1], port]);
         }
       }
 
       // addr::port
-      const addrSplitMatch = StringPrototypeMatch(serv, addrSplitRE);
+      const addrSplitMatch = RegExpPrototypeExec(addrSplitRE, serv);
 
       if (addrSplitMatch) {
         const hostIP = addrSplitMatch[1];

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -42,14 +42,14 @@ const {
   ObjectPrototypeHasOwnProperty,
   RangeError,
   ReflectApply,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
+  RegExpPrototypeSymbolMatch,
   SafeArrayIterator,
   SafeMap,
   SafeWeakMap,
   String,
   StringPrototypeEndsWith,
   StringPrototypeIncludes,
-  StringPrototypeMatch,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -438,8 +438,8 @@ function getMessage(key, args, self) {
     return ReflectApply(msg, self, args);
   }
 
-  const expectedLength =
-    (StringPrototypeMatch(msg, /%[dfijoOs]/g) || []).length;
+  // eslint-disable-next-line node-core/avoid-prototype-pollution
+  const expectedLength = RegExpPrototypeSymbolMatch(/%[dfijoOs]/g, msg).length;
   assert(
     expectedLength === args.length,
     `Code: ${key}; The provided arguments length (${args.length}) does not ` +
@@ -1177,7 +1177,7 @@ E('ERR_INVALID_ARG_TYPE',
              'All expected entries have to be of type string');
       if (ArrayPrototypeIncludes(kTypes, value)) {
         ArrayPrototypePush(types, StringPrototypeToLowerCase(value));
-      } else if (RegExpPrototypeTest(classRegExp, value)) {
+      } else if (RegExpPrototypeExec(classRegExp, value) !== null) {
         ArrayPrototypePush(instances, value);
       } else {
         assert(value !== 'object',

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -17,9 +17,9 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
   ReflectOwnKeys,
+  RegExpPrototypeSymbolReplace,
   StringPrototypeEndsWith,
   StringPrototypeIncludes,
-  StringPrototypeReplace,
   Symbol,
   TypedArrayPrototypeIncludes,
 } = primordials;
@@ -396,7 +396,7 @@ function preprocessSymlinkDestination(path, type, linkPath) {
     return pathModule.toNamespacedPath(path);
   }
   // Windows symlinks don't tolerate forward slashes.
-  return StringPrototypeReplace(path, /\//g, '\\');
+  return RegExpPrototypeSymbolReplace(/\//g, path, '\\');
 }
 
 // Constructor for file stats.

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -23,7 +23,7 @@ const {
   ReflectGet,
   ReflectGetPrototypeOf,
   ReflectSet,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   SafeArrayIterator,
   SafeMap,
   SafeSet,
@@ -1665,7 +1665,7 @@ class ServerHttp2Session extends Http2Session {
     }
 
     validateString(alt, 'alt');
-    if (!RegExpPrototypeTest(kQuotedString, alt))
+    if (RegExpPrototypeExec(kQuotedString, alt) === null)
       throw new ERR_INVALID_CHAR('alt');
 
     // Max length permitted for ALTSVC

--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -8,11 +8,11 @@ const {
   MathMax,
   ObjectKeys,
   RegExp,
+  RegExpPrototypeSymbolReplace,
   StringPrototypeLocaleCompare,
   StringPrototypeSlice,
   StringPrototypeTrimLeft,
   StringPrototypeRepeat,
-  StringPrototypeReplace,
   SafeMap,
 } = primordials;
 
@@ -77,14 +77,15 @@ const envVars = new SafeMap(ArrayPrototypeConcat([
 
 
 function indent(text, depth) {
-  return StringPrototypeReplace(text, /^/gm, StringPrototypeRepeat(' ', depth));
+  return RegExpPrototypeSymbolReplace(/^/gm, text, StringPrototypeRepeat(' ', depth));
 }
 
 function fold(text, width) {
-  return StringPrototypeReplace(text,
-                                new RegExp(`([^\n]{0,${width}})( |$)`, 'g'),
-                                (_, newLine, end) =>
-                                  newLine + (end === ' ' ? '\n' : ''));
+  return RegExpPrototypeSymbolReplace(
+    new RegExp(`([^\n]{0,${width}})( |$)`, 'g'),
+    text,
+    (_, newLine, end) => newLine + (end === ' ' ? '\n' : '')
+  );
 }
 
 function getArgDescription(type) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -49,7 +49,6 @@ const {
   ReflectApply,
   ReflectSet,
   RegExpPrototypeExec,
-  RegExpPrototypeTest,
   SafeMap,
   SafeWeakMap,
   String,
@@ -58,7 +57,6 @@ const {
   StringPrototypeEndsWith,
   StringPrototypeLastIndexOf,
   StringPrototypeIndexOf,
-  StringPrototypeMatch,
   StringPrototypeRepeat,
   StringPrototypeSlice,
   StringPrototypeSplit,
@@ -79,7 +77,7 @@ const {
   maybeCacheSourceMap,
 } = require('internal/source_map/source_map_cache');
 const { pathToFileURL, fileURLToPath, isURLInstance } = require('internal/url');
-const { deprecate } = require('internal/util');
+const { deprecate, kEmptyObject } = require('internal/util');
 const vm = require('vm');
 const assert = require('internal/assert');
 const fs = require('fs');
@@ -478,7 +476,7 @@ const EXPORTS_PATTERN = /^((?:@[^/\\%]+\/)?[^./\\%][^/\\%]*)(\/.*)?$/;
 function resolveExports(nmPath, request) {
   // The implementation's behavior is meant to mirror resolution in ESM.
   const { 1: name, 2: expansion = '' } =
-    StringPrototypeMatch(request, EXPORTS_PATTERN) || [];
+    RegExpPrototypeExec(EXPORTS_PATTERN, request) || kEmptyObject;
   if (!name)
     return;
   const pkgPath = path.resolve(nmPath, name);
@@ -515,7 +513,7 @@ Module._findPath = function(request, paths, isMain) {
     StringPrototypeCharCodeAt(request, request.length - 1) ===
     CHAR_FORWARD_SLASH;
   if (!trailingSlash) {
-    trailingSlash = RegExpPrototypeTest(trailingSlashRegex, request);
+    trailingSlash = RegExpPrototypeExec(trailingSlashRegex, request) !== null;
   }
 
   // For each path
@@ -956,7 +954,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 };
 
 function finalizeEsmResolution(resolved, parentPath, pkgPath) {
-  if (RegExpPrototypeTest(encodedSepRegEx, resolved))
+  if (RegExpPrototypeExec(encodedSepRegEx, resolved) !== null)
     throw new ERR_INVALID_MODULE_SPECIFIER(
       resolved, 'must not include encoded "/" or "\\" characters', parentPath);
   const filename = fileURLToPath(resolved);

--- a/lib/internal/modules/esm/formats.js
+++ b/lib/internal/modules/esm/formats.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
 } = primordials;
 const { getOptionValue } = require('internal/options');
 
@@ -35,10 +35,10 @@ if (experimentalWasmModules) {
  */
 function mimeToFormat(mime) {
   if (
-    RegExpPrototypeTest(
+    RegExpPrototypeExec(
       /\s*(text|application)\/javascript\s*(;\s*charset=utf-?8\s*)?/i,
       mime
-    )
+    ) !== null
   ) return 'module';
   if (mime === 'application/json') return 'json';
   if (experimentalWasmModules && mime === 'application/wasm') return 'wasm';

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -12,12 +12,11 @@ const {
   PromiseResolve,
   PromisePrototypeCatch,
   ReflectApply,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
+  RegExpPrototypeSymbolReplace,
   SafeArrayIterator,
   SafeSet,
   StringPrototypeIncludes,
-  StringPrototypeMatch,
-  StringPrototypeReplace,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
 } = primordials;
@@ -136,14 +135,14 @@ class ModuleJob {
           StringPrototypeIncludes(e.message,
                                   ' does not provide an export named')) {
         const splitStack = StringPrototypeSplit(e.stack, '\n');
-        const parentFileUrl = StringPrototypeReplace(
-          splitStack[0],
+        const parentFileUrl = RegExpPrototypeSymbolReplace(
           /:\d+$/,
+          splitStack[0],
           ''
         );
-        const { 1: childSpecifier, 2: name } = StringPrototypeMatch(
-          e.message,
-          /module '(.*)' does not provide an export named '(.+)'/);
+        const { 1: childSpecifier, 2: name } = RegExpPrototypeExec(
+          /module '(.*)' does not provide an export named '(.+)'/,
+          e.message);
         const { url: childFileURL } = await this.loader.resolve(
           childSpecifier, parentFileUrl,
         );
@@ -164,9 +163,9 @@ class ModuleJob {
           // line which causes the error. For multi-line import statements we
           // cannot generate an equivalent object destructuring assignment by
           // just parsing the error stack.
-          const oneLineNamedImports = StringPrototypeMatch(importStatement, /{.*}/);
+          const oneLineNamedImports = RegExpPrototypeExec(/{.*}/, importStatement);
           const destructuringAssignment = oneLineNamedImports &&
-            StringPrototypeReplace(oneLineNamedImports, /\s+as\s+/g, ': ');
+            RegExpPrototypeSymbolReplace(/\s+as\s+/g, oneLineNamedImports, ': ');
           e.message = `Named export '${name}' not found. The requested module` +
             ` '${childSpecifier}' is a CommonJS module, which may not support` +
             ' all module.exports as named exports.\nCommonJS modules can ' +
@@ -206,7 +205,7 @@ class ModuleJob {
 
         const packageConfig =
           StringPrototypeStartsWith(this.module.url, 'file://') &&
-            RegExpPrototypeTest(/\.js(\?[^#]*)?(#.*)?$/, this.module.url) &&
+            RegExpPrototypeExec(/\.js(\?[^#]*)?(#.*)?$/, this.module.url) !== null &&
             require('internal/modules/esm/resolve')
               .getPackageScopeConfig(this.module.url);
         if (packageConfig.type === 'module') {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -13,7 +13,6 @@ const {
   RegExp,
   RegExpPrototypeExec,
   RegExpPrototypeSymbolReplace,
-  RegExpPrototypeTest,
   SafeMap,
   SafeSet,
   String,
@@ -370,7 +369,7 @@ const encodedSepRegEx = /%2F|%5C/i;
  * @returns {URL | undefined}
  */
 function finalizeResolution(resolved, base, preserveSymlinks) {
-  if (RegExpPrototypeTest(encodedSepRegEx, resolved.pathname))
+  if (RegExpPrototypeExec(encodedSepRegEx, resolved.pathname) !== null)
     throw new ERR_INVALID_MODULE_SPECIFIER(
       resolved.pathname, 'must not include encoded "/" or "\\" characters',
       fileURLToPath(base));
@@ -499,7 +498,7 @@ function resolvePackageTargetString(
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
   }
 
-  if (RegExpPrototypeTest(invalidSegmentRegEx, StringPrototypeSlice(target, 2)))
+  if (RegExpPrototypeExec(invalidSegmentRegEx, StringPrototypeSlice(target, 2)) !== null)
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
 
   const resolved = new URL(target, packageJSONUrl);
@@ -511,7 +510,7 @@ function resolvePackageTargetString(
 
   if (subpath === '') return resolved;
 
-  if (RegExpPrototypeTest(invalidSegmentRegEx, subpath)) {
+  if (RegExpPrototypeExec(invalidSegmentRegEx, subpath) !== null) {
     const request = pattern ?
       StringPrototypeReplace(match, '*', () => subpath) : match + subpath;
     throwInvalidSubpath(request, packageJSONUrl, internal, base);

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -2,7 +2,7 @@
 
 const {
   RegExp,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   Symbol,
 } = primordials;
 
@@ -29,11 +29,11 @@ const IPv6Reg = new RegExp('^(' +
 ')(%[0-9a-zA-Z-.:]{1,})?$');
 
 function isIPv4(s) {
-  return RegExpPrototypeTest(IPv4Reg, s);
+  return RegExpPrototypeExec(IPv4Reg, s) !== null;
 }
 
 function isIPv6(s) {
-  return RegExpPrototypeTest(IPv6Reg, s);
+  return RegExpPrototypeExec(IPv6Reg, s) !== null;
 }
 
 function isIP(s) {

--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -10,12 +10,11 @@ const {
   ObjectKeys,
   ObjectSetPrototypeOf,
   RegExpPrototypeExec,
-  RegExpPrototypeTest,
   SafeMap,
   SafeSet,
+  RegExpPrototypeSymbolReplace,
   StringPrototypeEndsWith,
   StringPrototypeStartsWith,
-  StringPrototypeReplace,
   Symbol,
   uncurryThis,
 } = primordials;
@@ -202,7 +201,7 @@ class DependencyMapperInstance {
         let ret;
         if (parsedURLs && parsedURLs.has(to)) {
           ret = parsedURLs.get(to);
-        } else if (RegExpPrototypeTest(kRelativeURLStringPattern, to)) {
+        } else if (RegExpPrototypeExec(kRelativeURLStringPattern, to) !== null) {
           ret = resolve(to, manifest.href);
         } else {
           ret = resolve(to);
@@ -301,7 +300,7 @@ function findScopeHREF(href, scopeStore, allowSame) {
   if (href !== '') {
     // default URL parser does some stuff to special urls... skip if this is
     // just the protocol
-    if (RegExpPrototypeTest(/^[^:]*[:]$/, href)) {
+    if (RegExpPrototypeExec(/^[^:]*[:]$/, href) !== null) {
       protocol = href;
     } else {
       let currentURL = new URL(href);
@@ -669,7 +668,7 @@ module.exports = ObjectFreeze({ Manifest });
  */
 function canonicalizeSpecifier(specifier, base) {
   try {
-    if (RegExpPrototypeTest(kRelativeURLStringPattern, specifier)) {
+    if (RegExpPrototypeExec(kRelativeURLStringPattern, specifier) !== null) {
       return resolve(specifier, base).href;
     }
     return resolve(specifier).href;
@@ -690,13 +689,13 @@ const emptyOrProtocolOrResolve = (resourceHREF, base) => {
   if (resourceHREF === '') return '';
   if (StringPrototypeEndsWith(resourceHREF, ':')) {
     // URL parse will trim these anyway, save the compute
-    resourceHREF = StringPrototypeReplace(
-      resourceHREF,
+    resourceHREF = RegExpPrototypeSymbolReplace(
       // eslint-disable-next-line
       /^[\x00-\x1F\x20]|\x09\x0A\x0D|[\x00-\x1F\x20]$/g,
+      resourceHREF,
       ''
     );
-    if (RegExpPrototypeTest(/^[a-zA-Z][a-zA-Z+\-.]*:$/, resourceHREF)) {
+    if (RegExpPrototypeExec(/^[a-zA-Z][a-zA-Z+\-.]*:$/, resourceHREF) !== null) {
       return resourceHREF;
     }
   }
@@ -718,7 +717,7 @@ const resolve = (originalHREF, base) => {
   parsedURLs = parsedURLs ?? new SafeMap();
   if (parsedURLs.has(originalHREF)) {
     return parsedURLs.get(originalHREF);
-  } else if (RegExpPrototypeTest(kRelativeURLStringPattern, originalHREF)) {
+  } else if (RegExpPrototypeExec(kRelativeURLStringPattern, originalHREF) !== null) {
     const resourceURL = new URL(originalHREF, base);
     parsedURLs.set(resourceURL.href, resourceURL);
     return resourceURL;

--- a/lib/internal/policy/sri.js
+++ b/lib/internal/policy/sri.js
@@ -10,7 +10,6 @@ const {
   ObjectSetPrototypeOf,
   RegExp,
   RegExpPrototypeExec,
-  RegExpPrototypeTest,
   StringPrototypeSlice,
 } = primordials;
 
@@ -62,7 +61,7 @@ const parse = (str) => {
   }
 
   if (prevIndex !== str.length) {
-    if (!RegExpPrototypeTest(kAllWSP, StringPrototypeSlice(str, prevIndex))) {
+    if (RegExpPrototypeExec(kAllWSP, StringPrototypeSlice(str, prevIndex)) === null) {
       throw new ERR_SRI_PARSE(str, str[prevIndex], prevIndex);
     }
   }

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -16,7 +16,7 @@ const {
   NumberMAX_SAFE_INTEGER,
   ObjectFreeze,
   ReflectApply,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   SafeArrayIterator,
   Set,
   SetPrototypeEntries,
@@ -339,7 +339,7 @@ function buildAllowedFlags() {
       // not.
       if (typeof key === 'string') {
         key = StringPrototypeReplace(key, replaceUnderscoresRegex, '-');
-        if (RegExpPrototypeTest(leadingDashesRegex, key)) {
+        if (RegExpPrototypeExec(leadingDashesRegex, key) !== null) {
           key = StringPrototypeReplace(key, trailingValuesRegex, '');
           return ArrayPrototypeIncludes(this[kInternal].array, key);
         }

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -21,12 +21,12 @@ const {
   NumberIsFinite,
   NumberIsNaN,
   ObjectSetPrototypeOf,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
+  RegExpPrototypeSymbolReplace,
+  RegExpPrototypeSymbolSplit,
   StringPrototypeCodePointAt,
   StringPrototypeEndsWith,
-  StringPrototypeMatch,
   StringPrototypeRepeat,
-  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -590,12 +590,12 @@ class Interface extends InterfaceConstructor {
       this[kSawReturnAt] &&
       DateNow() - this[kSawReturnAt] <= this.crlfDelay
     ) {
-      string = StringPrototypeReplace(string, /^\n/, '');
+      string = RegExpPrototypeSymbolReplace(/^\n/, string, '');
       this[kSawReturnAt] = 0;
     }
 
     // Run test() on the new string chunk, not on the entire line buffer.
-    const newPartContainsEnding = RegExpPrototypeTest(lineEnding, string);
+    const newPartContainsEnding = RegExpPrototypeExec(lineEnding, string) !== null;
 
     if (this[kLine_buffer]) {
       string = this[kLine_buffer] + string;
@@ -738,7 +738,7 @@ class Interface extends InterfaceConstructor {
         ArrayPrototypeReverse(ArrayFrom(leading)),
         ''
       );
-      const match = StringPrototypeMatch(reversed, /^\s*(?:[^\w\s]+|\w+)?/);
+      const match = RegExpPrototypeExec(/^\s*(?:[^\w\s]+|\w+)?/, reversed);
       this[kMoveCursor](-match[0].length);
     }
   }
@@ -746,7 +746,7 @@ class Interface extends InterfaceConstructor {
   [kWordRight]() {
     if (this.cursor < this.line.length) {
       const trailing = StringPrototypeSlice(this.line, this.cursor);
-      const match = StringPrototypeMatch(trailing, /^(?:\s+|[^\w\s]+|\w+)\s*/);
+      const match = RegExpPrototypeExec(/^(?:\s+|[^\w\s]+|\w+)\s*/, trailing);
       this[kMoveCursor](match[0].length);
     }
   }
@@ -791,7 +791,7 @@ class Interface extends InterfaceConstructor {
         ArrayPrototypeReverse(ArrayFrom(leading)),
         ''
       );
-      const match = StringPrototypeMatch(reversed, /^\s*(?:[^\w\s]+|\w+)?/);
+      const match = RegExpPrototypeExec(/^\s*(?:[^\w\s]+|\w+)?/, reversed);
       leading = StringPrototypeSlice(
         leading,
         0,
@@ -809,7 +809,7 @@ class Interface extends InterfaceConstructor {
     if (this.cursor < this.line.length) {
       this[kBeforeEdit](this.line, this.cursor);
       const trailing = StringPrototypeSlice(this.line, this.cursor);
-      const match = StringPrototypeMatch(trailing, /^(?:\s+|\W+|\w+)\s*/);
+      const match = RegExpPrototypeExec(/^(?:\s+|\W+|\w+)\s*/, trailing);
       this.line =
         StringPrototypeSlice(this.line, 0, this.cursor) +
         StringPrototypeSlice(trailing, match[0].length);
@@ -1322,7 +1322,7 @@ class Interface extends InterfaceConstructor {
         // falls through
         default:
           if (typeof s === 'string' && s) {
-            const lines = StringPrototypeSplit(s, /\r\n|\n|\r/);
+            const lines = RegExpPrototypeSymbolSplit(/\r\n|\n|\r/, s);
             for (let i = 0, len = lines.length; i < len; i++) {
               if (i > 0) {
                 this[kLine]();

--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -3,11 +3,10 @@
 const {
   ArrayPrototypeSlice,
   ArrayPrototypeSort,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   StringFromCharCode,
   StringPrototypeCharCodeAt,
   StringPrototypeCodePointAt,
-  StringPrototypeMatch,
   StringPrototypeSlice,
   StringPrototypeToLowerCase,
   Symbol,
@@ -190,11 +189,11 @@ function* emitKeys(stream) {
         const cmd = StringPrototypeSlice(s, cmdStart);
         let match;
 
-        if ((match = StringPrototypeMatch(cmd, /^(\d\d?)(;(\d))?([~^$])$/))) {
+        if ((match = RegExpPrototypeExec(/^(\d\d?)(;(\d))?([~^$])$/, cmd))) {
           code += match[1] + match[4];
           modifier = (match[3] || 1) - 1;
         } else if (
-          (match = StringPrototypeMatch(cmd, /^((\d;)?(\d))?([A-Za-z])$/))
+          (match = RegExpPrototypeExec(/^((\d;)?(\d))?([A-Za-z])$/, cmd))
         ) {
           code += match[4];
           modifier = (match[3] || 1) - 1;
@@ -340,10 +339,10 @@ function* emitKeys(stream) {
         StringPrototypeCharCodeAt(ch) + StringPrototypeCharCodeAt('a') - 1
       );
       key.ctrl = true;
-    } else if (RegExpPrototypeTest(/^[0-9A-Za-z]$/, ch)) {
+    } else if (RegExpPrototypeExec(/^[0-9A-Za-z]$/, ch) !== null) {
       // Letter, number, shift+letter
       key.name = StringPrototypeToLowerCase(ch);
-      key.shift = RegExpPrototypeTest(/^[A-Z]$/, ch);
+      key.shift = RegExpPrototypeExec(/^[A-Z]$/, ch) !== null;
       key.meta = escaped;
     } else if (escaped) {
       // Escape sequence timeout

--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -4,7 +4,7 @@ const {
   ArrayPrototypeJoin,
   Boolean,
   FunctionPrototype,
-  StringPrototypeSplit,
+  RegExpPrototypeSymbolSplit,
   StringPrototypeTrim,
 } = primordials;
 
@@ -90,7 +90,7 @@ function setupHistory(repl, historyPath, ready) {
     }
 
     if (data) {
-      repl.history = StringPrototypeSplit(data, /[\n\r]+/, repl.historySize);
+      repl.history = RegExpPrototypeSymbolSplit(/[\n\r]+/, data, repl.historySize);
     } else {
       repl.history = [];
     }

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -7,13 +7,13 @@ const {
   Boolean,
   FunctionPrototypeBind,
   MathMin,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   SafeSet,
   SafeStringIterator,
   StringPrototypeEndsWith,
   StringPrototypeIndexOf,
   StringPrototypeLastIndexOf,
-  StringPrototypeReplace,
+  StringPrototypeReplaceAll,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
   StringPrototypeToLowerCase,
@@ -68,7 +68,7 @@ function isRecoverableError(e, code) {
   // curly brace with parenthesis.  Note: only the open parenthesis is added
   // here as the point is to test for potentially valid but incomplete
   // expressions.
-  if (RegExpPrototypeTest(/^\s*\{/, code) &&
+  if (RegExpPrototypeExec(/^\s*\{/, code) !== null &&
       isRecoverableError(e, `(${code}`))
     return true;
 
@@ -114,8 +114,8 @@ function isRecoverableError(e, code) {
                 const token = StringPrototypeSlice(this.input,
                                                    this.lastTokStart, this.pos);
                 // See https://www.ecma-international.org/ecma-262/#sec-line-terminators
-                if (RegExpPrototypeTest(/\\(?:\r\n?|\n|\u2028|\u2029)$/,
-                                        token)) {
+                if (RegExpPrototypeExec(/\\(?:\r\n?|\n|\u2028|\u2029)$/,
+                                        token) !== null) {
                   recoverable = true;
                 }
               }
@@ -288,9 +288,9 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
   function isInStrictMode(repl) {
     return repl.replMode === REPL_MODE_STRICT || ArrayPrototypeIncludes(
       ArrayPrototypeMap(process.execArgv,
-                        (e) => StringPrototypeReplace(
+                        (e) => StringPrototypeReplaceAll(
                           StringPrototypeToLowerCase(e),
-                          /_/g,
+                          '_',
                           '-'
                         )),
       '--use-strict');

--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -5,9 +5,9 @@ const {
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
   ErrorPrototypeToString,
+  RegExpPrototypeSymbolSplit,
   StringPrototypeRepeat,
   StringPrototypeSlice,
-  StringPrototypeSplit,
   StringPrototypeStartsWith,
   SafeStringIterator,
 } = primordials;
@@ -152,7 +152,7 @@ function getErrorSource(
     sourceMap.payload,
     originalSourcePathNoScheme
   );
-  const lines = StringPrototypeSplit(source, /\r?\n/, originalLine + 1);
+  const lines = RegExpPrototypeSymbolSplit(/\r?\n/, source, originalLine + 1);
   const line = lines[originalLine];
   if (!line) return exceptionLine;
 

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -7,9 +7,9 @@ const {
   ObjectKeys,
   ObjectGetOwnPropertyDescriptor,
   ObjectPrototypeHasOwnProperty,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
+  RegExpPrototypeSymbolSplit,
   SafeMap,
-  StringPrototypeMatch,
   StringPrototypeSplit,
 } = primordials;
 
@@ -82,9 +82,9 @@ function maybeCacheSourceMap(filename, content, cjsModuleInstance) {
     debug(err);
     return;
   }
-  const match = StringPrototypeMatch(
+  const match = RegExpPrototypeExec(
+    /\/[*/]#\s+sourceMappingURL=(?<sourceMappingURL>[^\s]+)/,
     content,
-    /\/[*/]#\s+sourceMappingURL=(?<sourceMappingURL>[^\s]+)/
   );
   if (match) {
     const data = dataFromUrl(filename, match.groups.sourceMappingURL);
@@ -133,7 +133,7 @@ function lineLengths(content) {
   // We purposefully keep \r as part of the line-length calculation, in
   // cases where there is a \r\n separator, so that this can be taken into
   // account in coverage calculations.
-  return ArrayPrototypeMap(StringPrototypeSplit(content, /\n|\u2028|\u2029/), (line) => {
+  return ArrayPrototypeMap(RegExpPrototypeSymbolSplit(/\n|\u2028|\u2029/, content), (line) => {
     return line.length;
   });
 }
@@ -219,7 +219,7 @@ function appendCJSCache(obj) {
 }
 
 function findSourceMap(sourceURL) {
-  if (!RegExpPrototypeTest(/^\w+:\/\//, sourceURL)) {
+  if (RegExpPrototypeExec(/^\w+:\/\//, sourceURL) === null) {
     sourceURL = pathToFileURL(sourceURL).href;
   }
   if (!SourceMap) {

--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -24,7 +24,7 @@
 
 const {
   ArrayPrototypeSome,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   StringPrototypeSplit,
   StringPrototypeToLowerCase,
 } = primordials;
@@ -174,14 +174,14 @@ function getColorDepth(env = process.env) {
   }
 
   if ('TEAMCITY_VERSION' in env) {
-    return RegExpPrototypeTest(/^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/, env.TEAMCITY_VERSION) ?
+    return RegExpPrototypeExec(/^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/, env.TEAMCITY_VERSION) !== null ?
       COLORS_16 : COLORS_2;
   }
 
   switch (env.TERM_PROGRAM) {
     case 'iTerm.app':
       if (!env.TERM_PROGRAM_VERSION ||
-        RegExpPrototypeTest(/^[0-2]\./, env.TERM_PROGRAM_VERSION)
+        RegExpPrototypeExec(/^[0-2]\./, env.TERM_PROGRAM_VERSION) !== null
       ) {
         return COLORS_256;
       }
@@ -198,7 +198,7 @@ function getColorDepth(env = process.env) {
   }
 
   if (env.TERM) {
-    if (RegExpPrototypeTest(/^xterm-256/, env.TERM)) {
+    if (RegExpPrototypeExec(/^xterm-256/, env.TERM) !== null) {
       return COLORS_256;
     }
 
@@ -208,7 +208,7 @@ function getColorDepth(env = process.env) {
       return TERM_ENVS[termEnv];
     }
     if (ArrayPrototypeSome(TERM_ENVS_REG_EXP,
-                           (term) => RegExpPrototypeTest(term, termEnv))) {
+                           (term) => RegExpPrototypeExec(term, termEnv) !== null)) {
       return COLORS_16;
     }
   }

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -19,7 +19,6 @@ const {
   ReflectApply,
   ReflectConstruct,
   RegExpPrototypeExec,
-  RegExpPrototypeTest,
   SafeMap,
   SafeSet,
   StringPrototypeReplace,
@@ -430,9 +429,9 @@ function isInsideNodeModules() {
       const filename = frame.getFileName();
       // If a filename does not start with / or contain \,
       // it's likely from Node.js core.
-      if (!RegExpPrototypeTest(/^\/|\\/, filename))
+      if (RegExpPrototypeExec(/^\/|\\/, filename) === null)
         continue;
-      return RegExpPrototypeTest(kNodeModulesRE, filename);
+      return RegExpPrototypeExec(kNodeModulesRE, filename) !== null;
     }
   }
   return false;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -49,7 +49,8 @@ const {
   ObjectSetPrototypeOf,
   ReflectOwnKeys,
   RegExp,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
+  RegExpPrototypeSymbolReplace,
   RegExpPrototypeToString,
   SafeStringIterator,
   SafeMap,
@@ -64,7 +65,6 @@ const {
   StringPrototypePadEnd,
   StringPrototypePadStart,
   StringPrototypeRepeat,
-  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeToLowerCase,
@@ -150,7 +150,7 @@ let hexSlice;
 const builtInObjects = new SafeSet(
   ArrayPrototypeFilter(
     ObjectGetOwnPropertyNames(globalThis),
-    (e) => RegExpPrototypeTest(/^[A-Z][a-zA-Z0-9]+$/, e)
+    (e) => RegExpPrototypeExec(/^[A-Z][a-zA-Z0-9]+$/, e) !== null
   )
 );
 
@@ -499,10 +499,10 @@ function strEscape(str) {
   }
 
   // Some magic numbers that worked out fine while benchmarking with v8 6.0
-  if (str.length < 5000 && !RegExpPrototypeTest(escapeTest, str))
+  if (str.length < 5000 && RegExpPrototypeExec(escapeTest, str) === null)
     return addQuotes(str, singleQuote);
   if (str.length > 100) {
-    str = StringPrototypeReplace(str, escapeReplace, escapeFn);
+    str = RegExpPrototypeSymbolReplace(escapeReplace, str, escapeFn);
     return addQuotes(str, singleQuote);
   }
 
@@ -1627,9 +1627,10 @@ function formatArrayBuffer(ctx, value) {
   }
   if (hexSlice === undefined)
     hexSlice = uncurryThis(require('buffer').Buffer.prototype.hexSlice);
-  let str = StringPrototypeTrim(StringPrototypeReplace(
+  let str = StringPrototypeTrim(RegExpPrototypeSymbolReplace(
+    /(.{2})/g,
     hexSlice(buffer, 0, MathMin(ctx.maxArrayLength, buffer.length)),
-    /(.{2})/g, '$1 '));
+    '$1 '));
   const remaining = buffer.length - ctx.maxArrayLength;
   if (remaining > 0)
     str += ` ... ${remaining} more byte${remaining > 1 ? 's' : ''}`;
@@ -1861,18 +1862,19 @@ function formatProperty(ctx, value, recurseTimes, key, type, desc,
     return str;
   }
   if (typeof key === 'symbol') {
-    const tmp = StringPrototypeReplace(
+    const tmp = RegExpPrototypeSymbolReplace(
+      strEscapeSequencesReplacer,
       SymbolPrototypeToString(key),
-      strEscapeSequencesReplacer, escapeFn
+      escapeFn
     );
     name = `[${ctx.stylize(tmp, 'symbol')}]`;
   } else if (key === '__proto__') {
     name = "['__proto__']";
   } else if (desc.enumerable === false) {
-    const tmp = StringPrototypeReplace(key,
-                                       strEscapeSequencesReplacer, escapeFn);
+    const tmp = RegExpPrototypeSymbolReplace(
+      strEscapeSequencesReplacer, key, escapeFn);
     name = `[${tmp}]`;
-  } else if (RegExpPrototypeTest(keyStrRegExp, key)) {
+  } else if (RegExpPrototypeExec(keyStrRegExp, key) !== null) {
     name = ctx.stylize(key, 'name');
   } else {
     name = ctx.stylize(strEscape(key), 'string');

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -9,7 +9,7 @@ const {
   NumberMAX_SAFE_INTEGER,
   NumberMIN_SAFE_INTEGER,
   NumberParseInt,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   String,
   StringPrototypeToUpperCase,
   StringPrototypeTrim,
@@ -58,7 +58,7 @@ const modeDesc = 'must be a 32-bit unsigned integer or an octal string';
 function parseFileMode(value, name, def) {
   value ??= def;
   if (typeof value === 'string') {
-    if (!RegExpPrototypeTest(octalReg, value)) {
+    if (RegExpPrototypeExec(octalReg, value) === null) {
       throw new ERR_INVALID_ARG_VALUE(name, value, modeDesc);
     }
     value = NumberParseInt(value, 8);

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -13,7 +13,7 @@ const {
   Promise,
   PromiseResolve,
   ReflectApply,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   SafeArrayIterator,
   SafeMap,
   String,
@@ -158,7 +158,7 @@ class Worker extends EventEmitter {
           filename
         );
       } else if (path.isAbsolute(filename) ||
-                 RegExpPrototypeTest(/^\.\.?[\\/]/, filename)) {
+                 RegExpPrototypeExec(/^\.\.?[\\/]/, filename) !== null) {
         filename = path.resolve(filename);
         url = pathToFileURL(filename);
       } else {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -78,17 +78,16 @@ const {
   ReflectApply,
   RegExp,
   RegExpPrototypeExec,
+  RegExpPrototypeSymbolMatch,
   RegExpPrototypeSymbolReplace,
-  RegExpPrototypeTest,
+  RegExpPrototypeSymbolSplit,
   SafeSet,
   SafeWeakSet,
   StringPrototypeCharAt,
   StringPrototypeCodePointAt,
   StringPrototypeEndsWith,
   StringPrototypeIncludes,
-  StringPrototypeMatch,
   StringPrototypeRepeat,
-  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -423,8 +422,8 @@ function REPLServer(prompt,
     // to wrap it in parentheses, so that it will be interpreted as
     // an expression.  Note that if the above condition changes,
     // lib/internal/repl/utils.js needs to be changed to match.
-    if (RegExpPrototypeTest(/^\s*{/, code) &&
-        !RegExpPrototypeTest(/;\s*$/, code)) {
+    if (RegExpPrototypeExec(/^\s*{/, code) !== null &&
+        RegExpPrototypeExec(/;\s*$/, code) === null) {
       code = `(${StringPrototypeTrim(code)})\n`;
       wrappedCmd = true;
     }
@@ -499,7 +498,7 @@ function REPLServer(prompt,
       while (true) {
         try {
           if (self.replMode === module.exports.REPL_MODE_STRICT &&
-              !RegExpPrototypeTest(/^\s*$/, code)) {
+              RegExpPrototypeExec(/^\s*$/, code) === null) {
             // "void 0" keeps the repl from returning "use strict" as the result
             // value for statements and declarations that don't return a value.
             code = `'use strict'; void 0;\n${code}`;
@@ -683,22 +682,24 @@ function REPLServer(prompt,
         if (e.stack) {
           if (e.name === 'SyntaxError') {
             // Remove stack trace.
-            e.stack = StringPrototypeReplace(StringPrototypeReplace(e.stack,
-                                                                    /^REPL\d+:\d+\r?\n/, ''),
-                                             /^\s+at\s.*\n?/gm, '');
+            e.stack = RegExpPrototypeSymbolReplace(
+              /^\s+at\s.*\n?/gm,
+              RegExpPrototypeSymbolReplace(/^REPL\d+:\d+\r?\n/, e.stack, ''),
+              '');
             const importErrorStr = 'Cannot use import statement outside a ' +
               'module';
             if (StringPrototypeIncludes(e.message, importErrorStr)) {
               e.message = 'Cannot use import statement inside the Node.js ' +
                 'REPL, alternatively use dynamic import';
-              e.stack = StringPrototypeReplace(e.stack,
-                                               /SyntaxError:.*\n/,
-                                               `SyntaxError: ${e.message}\n`);
+              e.stack = RegExpPrototypeSymbolReplace(
+                /SyntaxError:.*\n/,
+                e.stack,
+                `SyntaxError: ${e.message}\n`);
             }
           } else if (self.replMode === module.exports.REPL_MODE_STRICT) {
-            e.stack = StringPrototypeReplace(
-              e.stack,
+            e.stack = RegExpPrototypeSymbolReplace(
               /(\s+at\s+REPL\d+:)(\d+)/,
+              e.stack,
               (_, pre, line) => pre + (line - 1)
             );
           }
@@ -728,13 +729,13 @@ function REPLServer(prompt,
       if (errStack === '') {
         errStack = self.writer(e);
       }
-      const lines = StringPrototypeSplit(errStack, /(?<=\n)/);
+      const lines = RegExpPrototypeSymbolSplit(/(?<=\n)/, errStack);
       let matched = false;
 
       errStack = '';
       ArrayPrototypeForEach(lines, (line) => {
         if (!matched &&
-            RegExpPrototypeTest(/^\[?([A-Z][a-z0-9_]*)*Error/, line)) {
+            RegExpPrototypeExec(/^\[?([A-Z][a-z0-9_]*)*Error/, line) !== null) {
           errStack += writer.options.breakLength >= line.length ?
             `Uncaught ${line}` :
             `Uncaught:\n${line}`;
@@ -862,7 +863,7 @@ function REPLServer(prompt,
 
       // code alignment
       const matches = self._sawKeyPress ?
-        StringPrototypeMatch(cmd, /^\s+/) : null;
+        RegExpPrototypeExec(/^\s+/, cmd) : null;
       if (matches) {
         const prefix = matches[0];
         self.write(prefix);
@@ -882,7 +883,7 @@ function REPLServer(prompt,
       if (StringPrototypeCharAt(trimmedCmd, 0) === '.' &&
           StringPrototypeCharAt(trimmedCmd, 1) !== '.' &&
           NumberIsNaN(NumberParseFloat(trimmedCmd))) {
-        const matches = StringPrototypeMatch(trimmedCmd, /^\.([^\s]+)\s*(.*)$/);
+        const matches = RegExpPrototypeExec(/^\.([^\s]+)\s*(.*)$/, trimmedCmd);
         const keyword = matches && matches[1];
         const rest = matches && matches[2];
         if (ReflectApply(_parseREPLKeyword, self, [keyword, rest]) === true) {
@@ -1262,9 +1263,9 @@ function gracefulReaddir(...args) {
   }
 }
 
-function completeFSFunctions(line) {
+function completeFSFunctions(match) {
   let baseName = '';
-  let filePath = StringPrototypeMatch(line, fsAutoCompleteRE)[1];
+  let filePath = match[1];
   let fileList = gracefulReaddir(filePath, { withFileTypes: true });
 
   if (!fileList) {
@@ -1303,16 +1304,17 @@ function complete(line, callback) {
   line = StringPrototypeTrimLeft(line);
 
   let filter = '';
+
+  let match;
   // REPL commands (e.g. ".break").
-  if (RegExpPrototypeTest(/^\s*\.(\w*)$/, line)) {
+  if ((match = RegExpPrototypeExec(/^\s*\.(\w*)$/, line)) !== null) {
     ArrayPrototypePush(completionGroups, ObjectKeys(this.commands));
-    completeOn = StringPrototypeMatch(line, /^\s*\.(\w*)$/)[1];
+    completeOn = match[1];
     if (completeOn.length) {
       filter = completeOn;
     }
-  } else if (RegExpPrototypeTest(requireRE, line)) {
+  } else if ((match = RegExpPrototypeExec(requireRE, line)) !== null) {
     // require('...<Tab>')
-    const match = StringPrototypeMatch(line, requireRE);
     completeOn = match[1];
     filter = completeOn;
     if (this.allowBlockingCompletions) {
@@ -1329,7 +1331,7 @@ function complete(line, callback) {
         group = ['./', '../'];
       } else if (completeOn === '..') {
         group = ['../'];
-      } else if (RegExpPrototypeTest(/^\.\.?\//, completeOn)) {
+      } else if (RegExpPrototypeExec(/^\.\.?\//, completeOn) !== null) {
         paths = [process.cwd()];
       } else {
         paths = ArrayPrototypeConcat(module.paths, CJSModule.globalPaths);
@@ -1339,7 +1341,7 @@ function complete(line, callback) {
         dir = path.resolve(dir, subdir);
         const dirents = gracefulReaddir(dir, { withFileTypes: true }) || [];
         ArrayPrototypeForEach(dirents, (dirent) => {
-          if (RegExpPrototypeTest(versionedFileNamesRe, dirent.name) ||
+          if (RegExpPrototypeExec(versionedFileNamesRe, dirent.name) !== null ||
               dirent.name === '.npm') {
             // Exclude versioned names that 'npm' installs.
             return;
@@ -1369,9 +1371,8 @@ function complete(line, callback) {
     }
 
     ArrayPrototypePush(completionGroups, _builtinLibs, nodeSchemeBuiltinLibs);
-  } else if (RegExpPrototypeTest(importRE, line)) {
+  } else if ((match = RegExpPrototypeExec(importRE, line)) !== null) {
     // import('...<Tab>')
-    const match = StringPrototypeMatch(line, importRE);
     completeOn = match[1];
     filter = completeOn;
     if (this.allowBlockingCompletions) {
@@ -1392,7 +1393,7 @@ function complete(line, callback) {
         group = ['./', '../'];
       } else if (completeOn === '..') {
         group = ['../'];
-      } else if (RegExpPrototypeTest(/^\.\.?\//, completeOn)) {
+      } else if (RegExpPrototypeExec(/^\.\.?\//, completeOn) !== null) {
         paths = [process.cwd()];
       } else {
         paths = ArrayPrototypeSlice(module.paths);
@@ -1404,7 +1405,7 @@ function complete(line, callback) {
         const dirents = gracefulReaddir(dir, { withFileTypes: true }) || [];
         ArrayPrototypeForEach(dirents, (dirent) => {
           const { name } = dirent;
-          if (RegExpPrototypeTest(versionedFileNamesRe, name) ||
+          if (RegExpPrototypeExec(versionedFileNamesRe, name) !== null ||
               name === '.npm') {
             // Exclude versioned names that 'npm' installs.
             return;
@@ -1437,9 +1438,9 @@ function complete(line, callback) {
     }
 
     ArrayPrototypePush(completionGroups, _builtinLibs, nodeSchemeBuiltinLibs);
-  } else if (RegExpPrototypeTest(fsAutoCompleteRE, line) &&
+  } else if ((match = RegExpPrototypeExec(fsAutoCompleteRE, line)) !== null &&
              this.allowBlockingCompletions) {
-    ({ 0: completionGroups, 1: completeOn } = completeFSFunctions(line));
+    ({ 0: completionGroups, 1: completeOn } = completeFSFunctions(match));
   // Handle variable member lookup.
   // We support simple chained expressions like the following (no function
   // calls, etc.). That is for simplicity and also because we *eval* that
@@ -1451,7 +1452,7 @@ function complete(line, callback) {
   //   foo<|>         # all scope vars with filter 'foo'
   //   foo.<|>        # completions for 'foo' with filter ''
   } else if (line.length === 0 ||
-             RegExpPrototypeTest(/\w|\.|\$/, line[line.length - 1])) {
+             RegExpPrototypeExec(/\w|\.|\$/, line[line.length - 1]) !== null) {
     const { 0: match } = RegExpPrototypeExec(simpleExpressionRE, line) || [''];
     if (line.length !== 0 && !match) {
       completionGroupsLoaded();
@@ -1643,11 +1644,11 @@ function _memory(cmd) {
 
   // Going down is { and (   e.g. function() {
   // going up is } and )
-  let dw = StringPrototypeMatch(cmd, /[{(]/g);
-  let up = StringPrototypeMatch(cmd, /[})]/g);
-  up = up ? up.length : 0;
-  dw = dw ? dw.length : 0;
-  let depth = dw - up;
+  // eslint-disable-next-line node-core/avoid-prototype-pollution
+  const dw = RegExpPrototypeSymbolMatch(/[{(]/g, cmd);
+  // eslint-disable-next-line node-core/avoid-prototype-pollution
+  const up = RegExpPrototypeSymbolMatch(/[})]/g, cmd);
+  let depth = dw.length - up.length;
 
   if (depth) {
     (function workIt() {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -34,13 +34,12 @@ const {
   ObjectDefineProperty,
   ObjectFreeze,
   RegExpPrototypeExec,
-  RegExpPrototypeTest,
+  RegExpPrototypeSymbolReplace,
   StringFromCharCode,
   StringPrototypeCharCodeAt,
   StringPrototypeEndsWith,
   StringPrototypeIncludes,
   StringPrototypeIndexOf,
-  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -159,7 +158,7 @@ exports.convertALPNProtocols = function convertALPNProtocols(protocols, out) {
 };
 
 function unfqdn(host) {
-  return StringPrototypeReplace(host, /[.]$/, '');
+  return RegExpPrototypeSymbolReplace(/[.]$/, host, '');
 }
 
 // String#toLowerCase() is locale-sensitive so we use
@@ -170,7 +169,7 @@ function toLowerCase(c) {
 
 function splitHost(host) {
   return StringPrototypeSplit(
-    StringPrototypeReplace(unfqdn(host), /[A-Z]/g, toLowerCase),
+    RegExpPrototypeSymbolReplace(/[A-Z]/g, unfqdn(host), toLowerCase),
     '.'
   );
 }
@@ -193,7 +192,7 @@ function check(hostParts, pattern, wildcards) {
   // good way to detect their encoding or normalize them so we simply
   // reject them.  Control characters and blanks are rejected as well
   // because nothing good can come from accepting them.
-  const isBad = (s) => RegExpPrototypeTest(/[^\u0021-\u007F]/u, s);
+  const isBad = (s) => RegExpPrototypeExec(/[^\u0021-\u007F]/u, s) !== null;
   if (ArrayPrototypeSome(patternParts, isBad))
     return false;
 


### PR DESCRIPTION
Left over from https://github.com/nodejs/node/pull/43393 (lint rule fix coming in a follow up PR)
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
