### PR TITLE
tools: refactor `avoid-prototype-pollution` lint rule

### DIFF
--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -23,7 +23,6 @@ const {
   ObjectKeys,
   ObjectValues,
   Promise,
-  PromisePrototypeCatch,
   PromisePrototypeThen,
   PromiseResolve,
   ReflectGetOwnPropertyDescriptor,
@@ -653,8 +652,8 @@ function createRepl(inspector) {
     }
 
     const inspectValue = (expr) =>
-      PromisePrototypeCatch(evalInCurrentContext(expr),
-                            (error) => `<${error.message}>`);
+      PromisePrototypeThen(evalInCurrentContext(expr), undefined,
+                           (error) => `<${error.message}>`);
     const lastIndex = watchedExpressions.length - 1;
 
     const values = await SafePromiseAll(watchedExpressions, inspectValue);

--- a/lib/internal/fs/cp/cp.js
+++ b/lib/internal/fs/cp/cp.js
@@ -6,11 +6,9 @@ const {
   ArrayPrototypeEvery,
   ArrayPrototypeFilter,
   Boolean,
-  PromiseAll,
-  PromisePrototypeCatch,
   PromisePrototypeThen,
   PromiseReject,
-  SafeArrayIterator,
+  SafePromiseAll,
   StringPrototypeSplit,
 } = primordials;
 const {
@@ -128,13 +126,13 @@ function getStats(src, dest, opts) {
   const statFunc = opts.dereference ?
     (file) => stat(file, { bigint: true }) :
     (file) => lstat(file, { bigint: true });
-  return PromiseAll(new SafeArrayIterator([
+  return SafePromiseAll([
     statFunc(src),
-    PromisePrototypeCatch(statFunc(dest), (err) => {
+    PromisePrototypeThen(statFunc(dest), undefined, (err) => {
       if (err.code === 'ENOENT') return null;
       throw err;
     }),
-  ]));
+  ]);
 }
 
 async function checkParentDir(destStat, src, dest, opts) {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -13,9 +13,8 @@ const {
   ObjectCreate,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
-  PromiseAll,
   RegExpPrototypeExec,
-  SafeArrayIterator,
+  SafePromiseAll,
   SafeWeakMap,
   StringPrototypeSlice,
   StringPrototypeToUpperCase,
@@ -525,7 +524,7 @@ class ESMLoader {
         .then(({ module }) => module.getNamespace());
     }
 
-    const namespaces = await PromiseAll(new SafeArrayIterator(jobs));
+    const namespaces = await SafePromiseAll(jobs);
 
     if (!wasArr) { return namespaces[0]; } // We can skip the pairing below
 

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -29,10 +29,16 @@ const IPv6Reg = new RegExp('^(' +
 ')(%[0-9a-zA-Z-.:]{1,})?$');
 
 function isIPv4(s) {
+  // TODO(aduh95): Replace RegExpPrototypeTest with RegExpPrototypeExec when it
+  // no longer creates a perf regression in the dns benchmark.
+  // eslint-disable-next-line node-core/avoid-prototype-pollution
   return RegExpPrototypeTest(IPv4Reg, s);
 }
 
 function isIPv6(s) {
+  // TODO(aduh95): Replace RegExpPrototypeTest with RegExpPrototypeExec when it
+  // no longer creates a perf regression in the dns benchmark.
+  // eslint-disable-next-line node-core/avoid-prototype-pollution
   return RegExpPrototypeTest(IPv6Reg, s);
 }
 

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const {
-  ArrayPrototypeMap,
-  PromiseAll,
   PromisePrototypeThen,
-  PromisePrototypeFinally,
   PromiseResolve,
+  SafePromiseAll,
+  SafePromisePrototypeFinally,
   Uint8Array,
 } = primordials;
 
@@ -165,7 +164,7 @@ function newWritableStreamFromStreamWritable(streamWritable) {
     async write(chunk) {
       if (streamWritable.writableNeedDrain || !streamWritable.write(chunk)) {
         backpressurePromise = createDeferredPromise();
-        return PromisePrototypeFinally(
+        return SafePromisePrototypeFinally(
           backpressurePromise.promise, () => {
             backpressurePromise = undefined;
           });
@@ -246,10 +245,9 @@ function newStreamWritableFromWritableStream(writableStream, options = kEmptyObj
         writer.ready,
         () => {
           return PromisePrototypeThen(
-            PromiseAll(
-              ArrayPrototypeMap(
-                chunks,
-                (data) => writer.write(data.chunk))),
+            SafePromiseAll(
+              chunks,
+              (data) => writer.write(data.chunk)),
             done,
             done);
         },
@@ -668,10 +666,9 @@ function newStreamDuplexFromReadableWritablePair(pair = kEmptyObject, options = 
         writer.ready,
         () => {
           return PromisePrototypeThen(
-            PromiseAll(
-              ArrayPrototypeMap(
-                chunks,
-                (data) => writer.write(data.chunk))),
+            SafePromiseAll(
+              chunks,
+              (data) => writer.write(data.chunk)),
             done,
             done);
         },
@@ -767,7 +764,7 @@ function newStreamDuplexFromReadableWritablePair(pair = kEmptyObject, options = 
 
       if (!writableClosed || !readableClosed) {
         PromisePrototypeThen(
-          PromiseAll([
+          SafePromiseAll([
             closeWriter(),
             closeReader(),
           ]),

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -19,8 +19,8 @@ const {
   PromisePrototypeThen,
   PromiseResolve,
   PromiseReject,
-  PromiseAll,
   ReflectConstruct,
+  SafePromiseAll,
   Symbol,
   SymbolAsyncIterator,
   SymbolToStringTag,
@@ -1334,7 +1334,7 @@ function readableStreamPipeTo(
     }
 
     shutdownWithAnAction(
-      async () => PromiseAll(actions.map((action) => action())),
+      () => SafePromiseAll(actions, (action) => action()),
       true,
       error);
   }

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -4,7 +4,6 @@ const {
   FunctionPrototypeBind,
   FunctionPrototypeCall,
   ObjectDefineProperties,
-  PromisePrototypeCatch,
   PromisePrototypeThen,
   PromiseResolve,
   ReflectConstruct,
@@ -496,19 +495,17 @@ function transformStreamDefaultControllerError(controller, error) {
   transformStreamError(controller[kState].stream, error);
 }
 
-function transformStreamDefaultControllerPerformTransform(controller, chunk) {
-  const transformPromise =
-    ensureIsPromise(
+async function transformStreamDefaultControllerPerformTransform(controller, chunk) {
+  try {
+    return await ensureIsPromise(
       controller[kState].transformAlgorithm,
       controller,
       chunk,
       controller);
-  return PromisePrototypeCatch(
-    transformPromise,
-    (error) => {
-      transformStreamError(controller[kState].stream, error);
-      throw error;
-    });
+  } catch (error) {
+    transformStreamError(controller[kState].stream, error);
+    throw error;
+  }
 }
 
 function transformStreamDefaultControllerTerminate(controller) {

--- a/test/parallel/test-eslint-avoid-prototype-pollution.js
+++ b/test/parallel/test-eslint-avoid-prototype-pollution.js
@@ -45,6 +45,9 @@ new RuleTester({
       'ReflectDefineProperty({}, "key", { "__proto__": null })',
       'ObjectDefineProperty({}, "key", { \'__proto__\': null })',
       'ReflectDefineProperty({}, "key", { \'__proto__\': null })',
+      'StringPrototypeReplace("some string", "some string", "some replacement")',
+      'StringPrototypeReplaceAll("some string", "some string", "some replacement")',
+      'StringPrototypeSplit("some string", "some string")',
       'new Proxy({}, otherObject)',
       'new Proxy({}, someFactory())',
       'new Proxy({}, { __proto__: null })',
@@ -168,7 +171,19 @@ new RuleTester({
         errors: [{ message: /looks up the Symbol\.match property/ }],
       },
       {
+        code: 'let v = StringPrototypeMatch("some string", /some regex/)',
+        errors: [{ message: /looks up the Symbol\.match property/ }],
+      },
+      {
+        code: 'let v = StringPrototypeMatch("some string", new RegExp("some regex"))',
+        errors: [{ message: /looks up the Symbol\.match property/ }],
+      },
+      {
         code: 'StringPrototypeMatchAll("some string", /some regex/)',
+        errors: [{ message: /looks up the Symbol\.matchAll property/ }],
+      },
+      {
+        code: 'let v = StringPrototypeMatchAll("some string", new RegExp("some regex"))',
         errors: [{ message: /looks up the Symbol\.matchAll property/ }],
       },
       {
@@ -176,7 +191,15 @@ new RuleTester({
         errors: [{ message: /looks up the Symbol\.replace property/ }],
       },
       {
+        code: 'StringPrototypeReplace("some string", new RegExp("some regex"), "some replacement")',
+        errors: [{ message: /looks up the Symbol\.replace property/ }],
+      },
+      {
         code: 'StringPrototypeReplaceAll("some string", /some regex/, "some replacement")',
+        errors: [{ message: /looks up the Symbol\.replace property/ }],
+      },
+      {
+        code: 'StringPrototypeReplaceAll("some string", new RegExp("some regex"), "some replacement")',
         errors: [{ message: /looks up the Symbol\.replace property/ }],
       },
       {


### PR DESCRIPTION
The lint rule was not catching all occurences of unsafe primordials use,
and was too strict on some methods.

Blocked on:
- https://github.com/nodejs/node/pull/43473
- https://github.com/nodejs/node/pull/43474
- https://github.com/nodejs/node/pull/43475

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
