### PR TITLE
crypto: use ByteSource::Builder in To*Copy

### DIFF
--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -747,19 +747,17 @@ class ArrayBufferOrViewContents {
 
   inline ByteSource ToCopy() const {
     if (size() == 0) return ByteSource();
-    char* buf = MallocOpenSSL<char>(size());
-    CHECK_NOT_NULL(buf);
-    memcpy(buf, data(), size());
-    return ByteSource::Allocated(buf, size());
+    ByteSource::Builder buf(size());
+    memcpy(buf.data<void>(), data(), size());
+    return std::move(buf).release();
   }
 
   inline ByteSource ToNullTerminatedCopy() const {
     if (size() == 0) return ByteSource();
-    char* buf = MallocOpenSSL<char>(size() + 1);
-    CHECK_NOT_NULL(buf);
-    buf[size()] = 0;
-    memcpy(buf, data(), size());
-    return ByteSource::Allocated(buf, size());
+    ByteSource::Builder buf(size() + 1);
+    memcpy(buf.data<void>(), data(), size());
+    buf.data<char>()[size()] = 0;
+    return std::move(buf).release(size());
   }
 
   template <typename M>


### PR DESCRIPTION
Avoid manual calls to `MallocOpenSSL` in `ArrayBufferOrViewContents` and use the new `ByteSource::Builder` instead.

Refs: https://github.com/nodejs/node/pull/43202

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
