### PR TITLE
doc: update v8 doc link to v8.dev

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3449,7 +3449,7 @@ The native call from `process.cpuUsage` could not be processed.
 [Node.js error codes]: #nodejs-error-codes
 [RFC 7230 Section 3]: https://tools.ietf.org/html/rfc7230#section-3
 [Subresource Integrity specification]: https://www.w3.org/TR/SRI/#the-integrity-attribute
-[V8's stack trace API]: https://github.com/v8/v8/wiki/Stack-Trace-API
+[V8's stack trace API]: https://v8.dev/docs/stack-trace-api
 [WHATWG Supported Encodings]: util.md#whatwg-supported-encodings
 [WHATWG URL API]: url.md#the-whatwg-url-api
 [`"exports"`]: packages.md#exports

--- a/doc/contributing/maintaining-V8.md
+++ b/doc/contributing/maintaining-V8.md
@@ -423,8 +423,8 @@ This would require some tooling to:
 [NodeJS-Backport-Review-V8]: https://bugs.chromium.org/p/v8/issues/list?can=1&q=label%3ANodeJS-Backport-Review
 [V8 CI]: https://ci.nodejs.org/job/node-test-commit-v8-linux/
 [V8ActiveBranches]: https://build.chromium.org/p/client.v8.branches/console
-[V8Contributing]: https://github.com/v8/v8/wiki/Contributing
-[V8MergingPatching]: https://github.com/v8/v8/wiki/Merging%20&%20Patching
+[V8Contributing]: https://v8.dev/docs/contribute
+[V8MergingPatching]: https://v8.dev/docs/merge-patch
 [V8TemplateMergeRequest]: https://bugs.chromium.org/p/v8/issues/entry?template=Node.js%20merge%20request
 [V8TemplateUpstreamBug]: https://bugs.chromium.org/p/v8/issues/entry?template=Node.js%20upstream%20bug
 [`git-node`]: https://github.com/nodejs/node-core-utils/blob/HEAD/docs/git-node.md#git-node-v8


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

v8 has move all doc from github wiki to v8.dev, this pr update v8 link to v8.dev

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/12343178/174464587-3ab20b10-e75e-40ed-8d19-7b25bc162f12.png">

