### PR TITLE
events: improve `EventListener` validation

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -4,7 +4,6 @@ const {
   ArrayFrom,
   Boolean,
   Error,
-  FunctionPrototypeBind,
   FunctionPrototypeCall,
   NumberIsInteger,
   ObjectAssign,
@@ -381,7 +380,10 @@ class Listener {
       this.callback = listener;
       this.listener = listener;
     } else {
-      this.callback = FunctionPrototypeBind(listener.handleEvent, listener);
+      this.callback = async (...args) => {
+        if (listener.handleEvent)
+          await ReflectApply(listener.handleEvent, listener, args);
+      };
       this.listener = listener;
     }
   }
@@ -463,7 +465,7 @@ class EventTarget {
     if (arguments.length < 2)
       throw new ERR_MISSING_ARGS('type', 'listener');
 
-    // We validateOptions before the shouldAddListeners check because the spec
+    // We validateOptions before the validateListener check because the spec
     // requires us to hit getters.
     const {
       once,
@@ -474,7 +476,7 @@ class EventTarget {
       weak,
     } = validateEventListenerOptions(options);
 
-    if (!shouldAddListener(listener)) {
+    if (!validateEventListener(listener)) {
       // The DOM silently allows passing undefined as a second argument
       // No error code for this since it is a Warning
       // eslint-disable-next-line no-restricted-syntax
@@ -547,7 +549,7 @@ class EventTarget {
   removeEventListener(type, listener, options = kEmptyObject) {
     if (!isEventTarget(this))
       throw new ERR_INVALID_THIS('EventTarget');
-    if (!shouldAddListener(listener))
+    if (!validateEventListener(listener))
       return;
 
     type = String(type);
@@ -856,7 +858,7 @@ ObjectDefineProperties(NodeEventTarget.prototype, {
 
 // EventTarget API
 
-function shouldAddListener(listener) {
+function validateEventListener(listener) {
   if (typeof listener === 'function' ||
       typeof listener?.handleEvent === 'function') {
     return true;
@@ -864,6 +866,11 @@ function shouldAddListener(listener) {
 
   if (listener == null)
     return false;
+
+  if (typeof listener === 'object') {
+    // Require `handleEvent` lazily.
+    return true;
+  }
 
   throw new ERR_INVALID_ARG_TYPE('listener', 'EventListener', listener);
 }

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -233,6 +233,30 @@ let asyncTest = Promise.resolve();
 }
 
 {
+  const target = new EventTarget();
+  const listener = {};
+  // AddEventListener should not require handleEvent to be
+  // defined on an EventListener.
+  target.addEventListener('foo', listener);
+  listener.handleEvent = common.mustCall(function(event) {
+    strictEqual(event.type, 'foo');
+    strictEqual(this, listener);
+  });
+  target.dispatchEvent(new Event('foo'));
+}
+
+{
+  const target = new EventTarget();
+  const listener = {};
+  // do not throw
+  target.removeEventListener('foo', listener);
+  target.addEventListener('foo', listener);
+  target.removeEventListener('foo', listener);
+  listener.handleEvent = common.mustNotCall();
+  target.dispatchEvent(new Event('foo'));
+}
+
+{
   const uncaughtException = common.mustCall((err, origin) => {
     strictEqual(err.message, 'boom');
     strictEqual(origin, 'uncaughtException');
@@ -308,7 +332,6 @@ let asyncTest = Promise.resolve();
   [
     'foo',
     1,
-    {},  // No handleEvent function
     false,
   ].forEach((i) => throws(() => target.addEventListener('foo', i), err(i)));
 }

--- a/test/parallel/test-whatwg-events-eventtarget-this-of-listener.js
+++ b/test/parallel/test-whatwg-events-eventtarget-this-of-listener.js
@@ -1,0 +1,119 @@
+'use strict';
+
+require('../common');
+const { test, assert_equals, assert_unreached } =
+  require('../common/wpt').harness;
+
+// Manually ported from: https://github.com/web-platform-tests/wpt/blob/6cef1d2087d6a07d7cc6cee8cf207eec92e27c5f/dom/events/EventTarget-this-of-listener.html
+
+// Mock document
+const document = {
+  createElement: () => new EventTarget(),
+  createTextNode: () => new EventTarget(),
+  createDocumentFragment: () => new EventTarget(),
+  createComment: () => new EventTarget(),
+  createProcessingInstruction: () => new EventTarget(),
+};
+
+test(() => {
+  const nodes = [
+    document.createElement('p'),
+    document.createTextNode('some text'),
+    document.createDocumentFragment(),
+    document.createComment('a comment'),
+    document.createProcessingInstruction('target', 'data'),
+  ];
+
+  let callCount = 0;
+  for (const node of nodes) {
+    node.addEventListener('someevent', function() {
+      ++callCount;
+      assert_equals(this, node);
+    });
+
+    node.dispatchEvent(new Event('someevent'));
+  }
+
+  assert_equals(callCount, nodes.length);
+}, 'the this value inside the event listener callback should be the node');
+
+test(() => {
+  const nodes = [
+    document.createElement('p'),
+    document.createTextNode('some text'),
+    document.createDocumentFragment(),
+    document.createComment('a comment'),
+    document.createProcessingInstruction('target', 'data'),
+  ];
+
+  let callCount = 0;
+  for (const node of nodes) {
+    const handler = {};
+
+    node.addEventListener('someevent', handler);
+    handler.handleEvent = function() {
+      ++callCount;
+      assert_equals(this, handler);
+    };
+
+    node.dispatchEvent(new Event('someevent'));
+  }
+
+  assert_equals(callCount, nodes.length);
+}, 'addEventListener should not require handleEvent to be defined on object listeners');
+
+test(() => {
+  const nodes = [
+    document.createElement('p'),
+    document.createTextNode('some text'),
+    document.createDocumentFragment(),
+    document.createComment('a comment'),
+    document.createProcessingInstruction('target', 'data'),
+  ];
+
+  let callCount = 0;
+  for (const node of nodes) {
+    function handler() {
+      ++callCount;
+      assert_equals(this, node);
+    }
+
+    handler.handleEvent = () => {
+      assert_unreached('should not call the handleEvent method on a function');
+    };
+
+    node.addEventListener('someevent', handler);
+
+    node.dispatchEvent(new Event('someevent'));
+  }
+
+  assert_equals(callCount, nodes.length);
+}, 'handleEvent properties added to a function before addEventListener are not reached');
+
+test(() => {
+  const nodes = [
+    document.createElement('p'),
+    document.createTextNode('some text'),
+    document.createDocumentFragment(),
+    document.createComment('a comment'),
+    document.createProcessingInstruction('target', 'data'),
+  ];
+
+  let callCount = 0;
+  for (const node of nodes) {
+    function handler() {
+      ++callCount;
+      assert_equals(this, node);
+    }
+
+    node.addEventListener('someevent', handler);
+
+    handler.handleEvent = () => {
+      assert_unreached('should not call the handleEvent method on a function');
+    };
+
+    node.dispatchEvent(new Event('someevent'));
+  }
+
+  assert_equals(callCount, nodes.length);
+}, 'handleEvent properties added to a function after addEventListener are not reached');


### PR DESCRIPTION
This fixes validating `EventListener` given to `addEventListener` to improve the compatibility.

According to [the WPT test](https://github.com/web-platform-tests/wpt/blob/6cef1d2087d6a07d7cc6cee8cf207eec92e27c5f/dom/events/EventTarget-this-of-listener.html#L95-L120) result failed with the current validation, `addEventListener` 
should not require `handleEvent` to be defined on an `EventListener`.  IIUC, the same can 
be applied to `removeEventListener` also.

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
