### PR TITLE
test: replace gc(true) with gc({ type: 'minor' })

### DIFF
--- a/test/node-api/test_buffer/test_finalizer.js
+++ b/test/node-api/test_buffer/test_finalizer.js
@@ -16,7 +16,7 @@ process.on('uncaughtException', common.mustCall((err) => {
       throw new Error('finalizer error');
     }));
   }
-  global.gc(true);
+  global.gc({ type: 'minor' });
   await tick(common.platformTimeout(100));
   global.gc();
   await tick(common.platformTimeout(100));

--- a/test/parallel/test-net-write-fully-async-buffer.js
+++ b/test/parallel/test-net-write-fully-async-buffer.js
@@ -23,7 +23,7 @@ const server = net.createServer(common.mustCall(function(conn) {
       }
 
       while (conn.write(Buffer.from(data)));
-      global.gc(true);
+      global.gc({ type: 'minor' });
       // The buffer allocated above should still be alive.
     }
 

--- a/test/parallel/test-net-write-fully-async-hex-string.js
+++ b/test/parallel/test-net-write-fully-async-hex-string.js
@@ -21,7 +21,7 @@ const server = net.createServer(common.mustCall(function(conn) {
       }
 
       while (conn.write(data, 'hex'));
-      global.gc(true);
+      global.gc({ type: 'minor' });
       // The buffer allocated inside the .write() call should still be alive.
     }
 


### PR DESCRIPTION
V8 considers `gc(true)` legacy, and the new signature is much more expressive.

https://github.com/nodejs/node/blob/94020ac387713050150a9faed152f90bcf1ced54/deps/v8/src/extensions/gc-extension.cc#L42-L79

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
