### PR TITLE
test,doc: improve coverage for internal/main/repl.js

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -597,6 +597,8 @@ module. String input is input via `--eval`, `--print`, or `STDIN`.
 
 Valid values are `"commonjs"` and `"module"`. The default is `"commonjs"`.
 
+The REPL does not support this option.
+
 ### `--inspect-brk[=[host:]port]`
 
 <!-- YAML

--- a/test/parallel/test-repl-unsupported-option.js
+++ b/test/parallel/test-repl-unsupported-option.js
@@ -1,0 +1,10 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const result = spawnSync(process.execPath, ['-i', '--input-type=module']);
+
+assert.match(result.stderr.toString(), /Cannot specify --input-type for REPL/);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR added a test for `internal/main/repl.js` to ensure repl doesn't support `--input-type` option. [coverage report](https://coverage.nodejs.org/coverage-5a8440bc51930d26/lib/internal/main/repl.js.html#L30)
https://github.com/nodejs/node/blob/f9db8840adf3732def416cc69c3ce6f115a20d6e/lib/internal/main/repl.js#L29-L34

| before | after |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/22386678/174621606-320d9584-9caa-4905-ae8f-f6b947988d82.png) | ![image](https://user-images.githubusercontent.com/22386678/174621521-d73aa23c-5663-4830-a3c7-fbcccefd2628.png) |

And this PR also documented that `--input-type` is not supported on repl.