### PR TITLE
test: allow EOVERFLOW errors in fs position tests

### DIFF
--- a/test/parallel/test-fs-read-position-validation.mjs
+++ b/test/parallel/test-fs-read-position-validation.mjs
@@ -12,7 +12,7 @@ const offset = 0;
 const length = buffer.byteLength;
 
 // allowedErrors is an array of acceptable internal errors
-// For example, on some platforms read syscall might return -EFBIG
+// For example, on some platforms read syscall might return -EFBIG or -EOVERFLOW
 async function testValid(position, allowedErrors = []) {
   return new Promise((resolve, reject) => {
     fs.open(filepath, 'r', common.mustSucceed((fd) => {
@@ -71,9 +71,9 @@ async function testInvalid(code, position) {
   await testValid(1n);
   await testValid(9);
   await testValid(9n);
-  await testValid(Number.MAX_SAFE_INTEGER, [ 'EFBIG' ]);
+  await testValid(Number.MAX_SAFE_INTEGER, [ 'EFBIG', 'EOVERFLOW' ]);
 
-  await testValid(2n ** 63n - 1n - BigInt(length), [ 'EFBIG' ]);
+  await testValid(2n ** 63n - 1n - BigInt(length), [ 'EFBIG', 'EOVERFLOW' ]);
   await testInvalid('ERR_OUT_OF_RANGE', 2n ** 63n);
 
   // TODO(LiviaMedeiros): test `2n ** 63n - BigInt(length)`

--- a/test/parallel/test-fs-readSync-position-validation.mjs
+++ b/test/parallel/test-fs-readSync-position-validation.mjs
@@ -12,7 +12,7 @@ const offset = 0;
 const length = buffer.byteLength;
 
 // allowedErrors is an array of acceptable internal errors
-// For example, on some platforms read syscall might return -EFBIG
+// For example, on some platforms read syscall might return -EFBIG or -EOVERFLOW
 function testValid(position, allowedErrors = []) {
   let fdSync;
   try {
@@ -57,9 +57,9 @@ function testInvalid(code, position, internalCatch = false) {
   testValid(1n);
   testValid(9);
   testValid(9n);
-  testValid(Number.MAX_SAFE_INTEGER, [ 'EFBIG' ]);
+  testValid(Number.MAX_SAFE_INTEGER, [ 'EFBIG', 'EOVERFLOW' ]);
 
-  testValid(2n ** 63n - 1n - BigInt(length), [ 'EFBIG' ]);
+  testValid(2n ** 63n - 1n - BigInt(length), [ 'EFBIG', 'EOVERFLOW' ]);
   testInvalid('ERR_OUT_OF_RANGE', 2n ** 63n);
 
   // TODO(LiviaMedeiros): test `2n ** 63n - BigInt(length)`


### PR DESCRIPTION
Some platforms may return `EOVERFLOW` errors instead of `EFBIG`.

Refs: https://github.com/nodejs/node/pull/42999
Refs: https://github.com/nodejs/node/issues/43509
Refs: https://github.com/nodejs/node/issues/36925#issuecomment-760245723
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
