### PR TITLE
stream: pass error on legacy destroy

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -319,7 +319,7 @@ function destroyer(stream, err) {
     // TODO: Don't lose err?
     stream.close();
   } else if (err) {
-    process.nextTick(emitErrorCloseLegacy, stream);
+    process.nextTick(emitErrorCloseLegacy, stream, err);
   } else {
     process.nextTick(emitCloseLegacy, stream);
   }


### PR DESCRIPTION
While looking at [readable-stream](https://github.com/nodejs/readable-stream/blob/main/lib/internal/streams/destroy.js#L316) source, I've found a possible missed argument while emitting an error toward legacy streams.

- [x] Include tests for any bug fixes or new features.
- [ ] Update documentation if relevant.
- [x] Ensure that `make lint` passes.
- [x] Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.