### PR TITLE
src: fix cppgc incompatibility in v8

### DIFF
--- a/src/base_object.h
+++ b/src/base_object.h
@@ -38,12 +38,7 @@ namespace worker {
 class TransferData;
 }
 
-// This just has to be different from the Chromium ones:
-// https://source.chromium.org/chromium/chromium/src/+/main:gin/public/gin_embedders.h;l=18-23;drc=5a758a97032f0b656c3c36a3497560762495501a
-// Otherwise, when Node is loaded in an isolate which uses cppgc, cppgc will
-// misinterpret the data stored in the embedder fields and try to garbage
-// collect them.
-static uint16_t kNodeEmbedderId = 0x90de;
+extern uint16_t kNodeEmbedderId;
 
 class BaseObject : public MemoryRetainer {
  public:

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -38,11 +38,18 @@ namespace worker {
 class TransferData;
 }
 
+// This just has to be different from the Chromium ones:
+// https://source.chromium.org/chromium/chromium/src/+/main:gin/public/gin_embedders.h;l=18-23;drc=5a758a97032f0b656c3c36a3497560762495501a
+// Otherwise, when Node is loaded in an isolate which uses cppgc, cppgc will
+// misinterpret the data stored in the embedder fields and try to garbage
+// collect them.
+static uint16_t kNodeEmbedderId = 0x90de;
+
 class BaseObject : public MemoryRetainer {
  public:
-  enum InternalFields { kSlot, kInternalFieldCount };
+  enum InternalFields { kEmbedderType, kSlot, kInternalFieldCount };
 
-  // Associates this object with `object`. It uses the 0th internal field for
+  // Associates this object with `object`. It uses the 1st internal field for
   // that, and in particular aborts if there is no such field.
   BaseObject(Environment* env, v8::Local<v8::Object> object);
   ~BaseObject() override;

--- a/src/env.cc
+++ b/src/env.cc
@@ -2080,7 +2080,6 @@ void BaseObject::MakeWeak() {
       WeakCallbackType::kParameter);
 }
 
-
 // This just has to be different from the Chromium ones:
 // https://source.chromium.org/chromium/chromium/src/+/main:gin/public/gin_embedders.h;l=18-23;drc=5a758a97032f0b656c3c36a3497560762495501a
 // Otherwise, when Node is loaded in an isolate which uses cppgc, cppgc will

--- a/src/env.cc
+++ b/src/env.cc
@@ -1744,6 +1744,7 @@ void Environment::EnqueueDeserializeRequest(DeserializeRequestCallback cb,
                                             Local<Object> holder,
                                             int index,
                                             InternalFieldInfo* info) {
+  DCHECK_EQ(index, BaseObject::kEmbedderType);
   DeserializeRequest request{cb, {isolate(), holder}, index, info};
   deserialize_requests_.push_back(std::move(request));
 }
@@ -2078,6 +2079,14 @@ void BaseObject::MakeWeak() {
       },
       WeakCallbackType::kParameter);
 }
+
+
+// This just has to be different from the Chromium ones:
+// https://source.chromium.org/chromium/chromium/src/+/main:gin/public/gin_embedders.h;l=18-23;drc=5a758a97032f0b656c3c36a3497560762495501a
+// Otherwise, when Node is loaded in an isolate which uses cppgc, cppgc will
+// misinterpret the data stored in the embedder fields and try to garbage
+// collect them.
+uint16_t kNodeEmbedderId = 0x90de;
 
 void BaseObject::LazilyInitializedJSTemplateConstructor(
     const FunctionCallbackInfo<Value>& args) {

--- a/src/env.cc
+++ b/src/env.cc
@@ -2026,7 +2026,9 @@ void Environment::RunWeakRefCleanup() {
 BaseObject::BaseObject(Environment* env, Local<Object> object)
     : persistent_handle_(env->isolate(), object), env_(env) {
   CHECK_EQ(false, object.IsEmpty());
-  CHECK_GT(object->InternalFieldCount(), 0);
+  CHECK_GE(object->InternalFieldCount(), BaseObject::kInternalFieldCount);
+  object->SetAlignedPointerInInternalField(BaseObject::kEmbedderType,
+                                           &kNodeEmbedderId);
   object->SetAlignedPointerInInternalField(BaseObject::kSlot,
                                            static_cast<void*>(this));
   env->AddCleanupHook(DeleteMe, static_cast<void*>(this));
@@ -2080,7 +2082,9 @@ void BaseObject::MakeWeak() {
 void BaseObject::LazilyInitializedJSTemplateConstructor(
     const FunctionCallbackInfo<Value>& args) {
   DCHECK(args.IsConstructCall());
-  DCHECK_GT(args.This()->InternalFieldCount(), 0);
+  CHECK_GE(args.This()->InternalFieldCount(), BaseObject::kInternalFieldCount);
+  args.This()->SetAlignedPointerInInternalField(BaseObject::kEmbedderType,
+                                                &kNodeEmbedderId);
   args.This()->SetAlignedPointerInInternalField(BaseObject::kSlot, nullptr);
 }
 

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -467,7 +467,7 @@ void BlobBindingData::Deserialize(
     Local<Object> holder,
     int index,
     InternalFieldInfo* info) {
-  DCHECK_EQ(index, BaseObject::kSlot);
+  DCHECK_EQ(index, BaseObject::kEmbedderType);
   HandleScope scope(context->GetIsolate());
   Environment* env = Environment::GetCurrent(context);
   BlobBindingData* binding =
@@ -482,7 +482,7 @@ void BlobBindingData::PrepareForSerialization(
 }
 
 InternalFieldInfo* BlobBindingData::Serialize(int index) {
-  DCHECK_EQ(index, BaseObject::kSlot);
+  DCHECK_EQ(index, BaseObject::kEmbedderType);
   InternalFieldInfo* info = InternalFieldInfo::New(type());
   return info;
 }

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2401,7 +2401,7 @@ void BindingData::Deserialize(Local<Context> context,
                               Local<Object> holder,
                               int index,
                               InternalFieldInfo* info) {
-  DCHECK_EQ(index, BaseObject::kSlot);
+  DCHECK_EQ(index, BaseObject::kEmbedderType);
   HandleScope scope(context->GetIsolate());
   Environment* env = Environment::GetCurrent(context);
   BindingData* binding = env->AddBindingData<BindingData>(context, holder);
@@ -2418,7 +2418,7 @@ void BindingData::PrepareForSerialization(Local<Context> context,
 }
 
 InternalFieldInfo* BindingData::Serialize(int index) {
-  DCHECK_EQ(index, BaseObject::kSlot);
+  DCHECK_EQ(index, BaseObject::kEmbedderType);
   InternalFieldInfo* info = InternalFieldInfo::New(type());
   return info;
 }

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -532,7 +532,7 @@ void BindingData::PrepareForSerialization(Local<Context> context,
 }
 
 InternalFieldInfo* BindingData::Serialize(int index) {
-  DCHECK_EQ(index, BaseObject::kSlot);
+  DCHECK_EQ(index, BaseObject::kEmbedderType);
   InternalFieldInfo* info = InternalFieldInfo::New(type());
   return info;
 }
@@ -541,7 +541,7 @@ void BindingData::Deserialize(Local<Context> context,
                               Local<Object> holder,
                               int index,
                               InternalFieldInfo* info) {
-  DCHECK_EQ(index, BaseObject::kSlot);
+  DCHECK_EQ(index, BaseObject::kEmbedderType);
   v8::HandleScope scope(context->GetIsolate());
   Environment* env = Environment::GetCurrent(context);
   // Recreate the buffer in the constructor.

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1089,10 +1089,20 @@ void DeserializeNodeInternalFields(Local<Object> holder,
                      static_cast<int>(index),
                      (*holder),
                      static_cast<int>(payload.raw_size));
+
+  if (payload.raw_size == 0) {
+    holder->SetAlignedPointerInInternalField(index, nullptr);
+    return;
+  }
+
+  DCHECK_EQ(index, BaseObject::kEmbedderType);
+
   Environment* env_ptr = static_cast<Environment*>(env);
   const InternalFieldInfo* info =
       reinterpret_cast<const InternalFieldInfo*>(payload.data);
-
+  // TODO(joyeecheung): we can add a constant kNodeEmbedderId to the
+  // beginning of every InternalFieldInfo to ensure that we don't
+  // step on payloads that were not serialized by Node.js.
   switch (info->type) {
 #define V(PropertyName, NativeTypeName)                                        \
   case EmbedderObjectType::k_##PropertyName: {                                 \
@@ -1113,21 +1123,44 @@ void DeserializeNodeInternalFields(Local<Object> holder,
 StartupData SerializeNodeContextInternalFields(Local<Object> holder,
                                                int index,
                                                void* env) {
-  void* ptr = holder->GetAlignedPointerFromInternalField(BaseObject::kSlot);
-  if (ptr == nullptr) {
+  // We only do one serialization for the kEmbedderType slot, the result
+  // contains everything necessary for deserializing the entire object,
+  // including the fields whose index is bigger than kEmbedderType
+  // (most importantly, BaseObject::kSlot).
+  // For Node.js this design is enough for all the native binding that are
+  // serializable.
+  if (index != BaseObject::kEmbedderType) {
     return StartupData{nullptr, 0};
   }
+
+  void* type_ptr = holder->GetAlignedPointerFromInternalField(index);
+  if (type_ptr == nullptr) {
+    return StartupData{nullptr, 0};
+  }
+
+  uint16_t type = *(static_cast<uint16_t*>(type_ptr));
+  per_process::Debug(DebugCategory::MKSNAPSHOT, "type = 0x%x\n", type);
+  if (type != kNodeEmbedderId) {
+    return StartupData{nullptr, 0};
+  }
+
   per_process::Debug(DebugCategory::MKSNAPSHOT,
                      "Serialize internal field, index=%d, holder=%p\n",
                      static_cast<int>(index),
                      *holder);
-  DCHECK(static_cast<BaseObject*>(ptr)->is_snapshotable());
-  SnapshotableObject* obj = static_cast<SnapshotableObject*>(ptr);
+
+  void* binding_ptr =
+      holder->GetAlignedPointerFromInternalField(BaseObject::kSlot);
+  per_process::Debug(DebugCategory::MKSNAPSHOT, "binding = %p\n", binding_ptr);
+  DCHECK(static_cast<BaseObject*>(binding_ptr)->is_snapshotable());
+  SnapshotableObject* obj = static_cast<SnapshotableObject*>(binding_ptr);
+
   per_process::Debug(DebugCategory::MKSNAPSHOT,
                      "Object %p is %s, ",
                      *holder,
                      obj->GetTypeNameChars());
   InternalFieldInfo* info = obj->Serialize(index);
+
   per_process::Debug(DebugCategory::MKSNAPSHOT,
                      "payload size=%d\n",
                      static_cast<int>(info->length));
@@ -1142,8 +1175,9 @@ void SerializeBindingData(Environment* env,
   env->ForEachBindingData([&](FastStringKey key,
                               BaseObjectPtr<BaseObject> binding) {
     per_process::Debug(DebugCategory::MKSNAPSHOT,
-                       "Serialize binding %i, %p, type=%s\n",
+                       "Serialize binding %i (%p), object=%p, type=%s\n",
                        static_cast<int>(i),
+                       binding.get(),
                        *(binding->object()),
                        key.c_str());
 

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -30,11 +30,6 @@ enum class EmbedderObjectType : uint8_t {
 // When serializing an embedder object, we'll serialize the native states
 // into a chunk that can be mapped into a subclass of InternalFieldInfo,
 // and pass it into the V8 callback as the payload of StartupData.
-// TODO(joyeecheung): the classification of types seem to be wrong.
-// We'd need a type for each field of each class of native object.
-// Maybe it's fine - we'll just use the type to invoke BaseObject constructors
-// and specify that the BaseObject has only one field for us to serialize.
-// And for non-BaseObject embedder objects, we'll use field-wise types.
 // The memory chunk looks like this:
 //
 // [   type   ] - EmbedderObjectType (a uint8_t)

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -124,7 +124,7 @@ void BindingData::Deserialize(Local<Context> context,
                               Local<Object> holder,
                               int index,
                               InternalFieldInfo* info) {
-  DCHECK_EQ(index, BaseObject::kSlot);
+  DCHECK_EQ(index, BaseObject::kEmbedderType);
   HandleScope scope(context->GetIsolate());
   Environment* env = Environment::GetCurrent(context);
   BindingData* binding = env->AddBindingData<BindingData>(context, holder);
@@ -132,7 +132,7 @@ void BindingData::Deserialize(Local<Context> context,
 }
 
 InternalFieldInfo* BindingData::Serialize(int index) {
-  DCHECK_EQ(index, BaseObject::kSlot);
+  DCHECK_EQ(index, BaseObject::kEmbedderType);
   InternalFieldInfo* info = InternalFieldInfo::New(type());
   return info;
 }


### PR DESCRIPTION
This fixes a crash that happens sporadically when Node is used in the same V8 Isolate as Blink. 

<details> <summary>Example Stacktrace</summary>

```
#
# Fatal error in ../../v8/src/objects/js-objects-inl.h, line 306
# Debug check failed: static_cast<unsigned>(index) < static_cast<unsigned>(GetEmbedderFieldCount()) (1 vs. 1).
#
#
#
#FailureMessage Object: 0x7ffee46fd1c0
0   Electron Framework                  0x00000001181c78d9 base::debug::CollectStackTrace(void**, unsigned long) + 9
1   Electron Framework                  0x00000001180ea633 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x000000011a04decd gin::(anonymous namespace)::PrintStackTrace() + 45
3   Electron Framework                  0x0000000119a9b416 V8_Fatal(char const*, int, char const*, ...) + 326
4   Electron Framework                  0x0000000119a9aeb5 v8::base::(anonymous namespace)::DefaultDcheckHandler(char const*, int, char const*) + 21
5   Electron Framework                  0x000000011530763f v8::internal::JSObject::GetEmbedderFieldOffset(int) + 207
6   Electron Framework                  0x00000001155f68e6 v8::internal::LocalEmbedderHeapTracer::EmbedderWriteBarrier(v8::internal::Heap*, v8::internal::JSObject) + 150
7   Electron Framework                  0x00000001152cd34f v8::Object::SetAlignedPointerInInternalField(int, void*) + 639
8   Electron Framework                  0x000000011d18df35 node::BaseObject::BaseObject(node::Environment*, v8::Local<v8::Object>) + 101
9   Electron Framework                  0x000000011d347b6e node::crypto::DiffieHellman::DiffieHellman(node::Environment*, v8::Local<v8::Object>) + 14
10  Electron Framework                  0x000000011d348413 node::crypto::DiffieHellman::New(v8::FunctionCallbackInfo<v8::Value> const&) + 147
[...]
```

</details>

This crash is happening because the V8 isolate in this scenario has cppgc enabled. When cppgc is enabled, V8 assumes that the first embedder field is a "type" pointer, the first 16 bits of which are the embedder ID. At the moment, Node.js does not adhere to this requirement. Mostly, this worked  by accident. If the first field in the BaseObject was a pointer to a bit of memory that happened to contain the two-byte little-endian value 0x0001, however, V8 would take that to mean that the object was a Blink object[1], and attempt to read the pointer in the second embedder slot, which would result in a CHECK.

This change adds an "embedder id" pointer as the first embedder field in all Node-managed objects. This ensures that cppgc will always skip over Node objects.

[1]: https://source.chromium.org/chromium/chromium/src/+/main:gin/public/gin_embedders.h;l=20;drc=5a758a97032f0b656c3c36a3497560762495501a

See also: https://source.chromium.org/chromium/chromium/src/+/main:v8/include/v8-cppgc.h;l=70-76;drc=5a758a97032f0b656c3c36a3497560762495501a

Upstreamed from our [existing patch](https://github.com/electron/electron/blob/db5a3c014ae17e464fcd1fa6bfcd05a40ea2ed71/patches/node/be_compatible_with_cppgc.patch#L1).
