### PR TITLE
Use Keep-Alive by default in global agents and close idle connections in server

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1449,11 +1449,20 @@ type other than {net.Socket}.
 
 <!-- YAML
 added: v0.1.90
+changes:
+  - version:
+      - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43522
+    description: The method closes idle connections before returning.
+
 -->
 
 * `callback` {Function}
 
-Stops the server from accepting new connections. See [`net.Server.close()`][].
+Stops the server from accepting new connections and closes all connections
+connected to this server which are not sending a request or waiting for
+a response.
+See [`net.Server.close()`][].
 
 ### `server.closeAllConnections()`
 
@@ -3214,6 +3223,11 @@ server.listen(8000);
 
 <!-- YAML
 added: v0.5.9
+changes:
+  - version:
+      - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43522
+    description: The agent now uses HTTP Keep-Alive by default.
 -->
 
 * {http.Agent}

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -309,6 +309,11 @@ https.get('https://encrypted.google.com/', (res) => {
 
 <!-- YAML
 added: v0.5.9
+changes:
+  - version:
+      - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43522
+    description: The agent now uses HTTP Keep-Alive by default.
 -->
 
 Global instance of [`https.Agent`][] for all HTTPS client requests.

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -31,10 +31,12 @@ const {
   ArrayPrototypeSplice,
   FunctionPrototypeCall,
   NumberIsNaN,
+  NumberParseInt,
   ObjectCreate,
   ObjectKeys,
   ObjectSetPrototypeOf,
   ObjectValues,
+  RegExpPrototypeExec,
   StringPrototypeIndexOf,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -492,7 +494,24 @@ Agent.prototype.keepSocketAlive = function keepSocketAlive(socket) {
   socket.setKeepAlive(true, this.keepAliveMsecs);
   socket.unref();
 
-  const agentTimeout = this.options.timeout || 0;
+  let agentTimeout = this.options.timeout || 0;
+
+  if (socket._httpMessage?.res) {
+    const keepAliveHint = socket._httpMessage.res.headers['keep-alive'];
+
+    if (keepAliveHint) {
+      const hint = RegExpPrototypeExec(/^timeout=(\d+)/, keepAliveHint)?.[1];
+
+      if (hint) {
+        const serverHintTimeout = NumberParseInt(hint) * 1000;
+
+        if (serverHintTimeout < agentTimeout) {
+          agentTimeout = serverHintTimeout;
+        }
+      }
+    }
+  }
+
   if (socket.timeout !== agentTimeout) {
     socket.setTimeout(agentTimeout);
   }
@@ -542,5 +561,5 @@ function asyncResetHandle(socket) {
 
 module.exports = {
   Agent,
-  globalAgent: new Agent()
+  globalAgent: new Agent({ keepAlive: true, scheduling: 'lifo', timeout: 5000 })
 };

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -478,6 +478,7 @@ ObjectSetPrototypeOf(Server.prototype, net.Server.prototype);
 ObjectSetPrototypeOf(Server, net.Server);
 
 Server.prototype.close = function() {
+  this.closeIdleConnections();
   clearInterval(this[kConnectionsCheckingInterval]);
   ReflectApply(net.Server.prototype.close, this, arguments);
 };

--- a/lib/https.js
+++ b/lib/https.js
@@ -331,7 +331,7 @@ Agent.prototype._evictSession = function _evictSession(key) {
   delete this._sessionCache.map[key];
 };
 
-const globalAgent = new Agent();
+const globalAgent = new Agent({ keepAlive: true, scheduling: 'lifo', timeout: 5000 });
 
 /**
  * Makes a request to a secure web server.

--- a/test/async-hooks/test-graph.http.js
+++ b/test/async-hooks/test-graph.http.js
@@ -12,6 +12,7 @@ const hooks = initHooks();
 hooks.enable();
 
 const server = http.createServer(common.mustCall((req, res) => {
+  res.writeHead(200, { 'Connection': 'close' });
   res.end();
   server.close(common.mustCall());
 }));

--- a/test/parallel/test-http-agent-no-wait.js
+++ b/test/parallel/test-http-agent-no-wait.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(function(req, res) {
+  res.writeHead(200);
+  res.end();
+});
+
+server.listen(0, common.mustCall(() => {
+  const req = http.get({ port: server.address().port }, (res) => {
+    assert.strictEqual(res.statusCode, 200);
+
+    res.resume();
+    server.close();
+  });
+
+  req.end();
+}));
+
+// This timer should never go off as the server will close the socket
+setTimeout(common.mustNotCall(), 1000).unref();

--- a/test/parallel/test-http-client-agent.js
+++ b/test/parallel/test-http-client-agent.js
@@ -27,6 +27,7 @@ const Countdown = require('../common/countdown');
 
 let name;
 const max = 3;
+const agent = new http.Agent();
 
 const server = http.Server(common.mustCall((req, res) => {
   if (req.url === '/0') {
@@ -40,27 +41,28 @@ const server = http.Server(common.mustCall((req, res) => {
   }
 }, max));
 server.listen(0, common.mustCall(() => {
-  name = http.globalAgent.getName({ port: server.address().port });
+  name = agent.getName({ port: server.address().port });
   for (let i = 0; i < max; ++i)
     request(i);
 }));
 
 const countdown = new Countdown(max, () => {
-  assert(!(name in http.globalAgent.sockets));
-  assert(!(name in http.globalAgent.requests));
+  assert(!(name in agent.sockets));
+  assert(!(name in agent.requests));
   server.close();
 });
 
 function request(i) {
   const req = http.get({
     port: server.address().port,
-    path: `/${i}`
+    path: `/${i}`,
+    agent
   }, function(res) {
     const socket = req.socket;
     socket.on('close', common.mustCall(() => {
       countdown.dec();
       if (countdown.remaining > 0) {
-        assert.strictEqual(http.globalAgent.sockets[name].includes(socket),
+        assert.strictEqual(agent.sockets[name].includes(socket),
                            false);
       }
     }));

--- a/test/parallel/test-http-client-close-with-default-agent.js
+++ b/test/parallel/test-http-client-close-with-default-agent.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(function(req, res) {
+  res.writeHead(200);
+  res.end();
+});
+
+server.listen(0, common.mustCall(() => {
+  const req = http.get({ port: server.address().port }, (res) => {
+    assert.strictEqual(res.statusCode, 200);
+    res.resume();
+    server.close();
+  });
+
+  req.end();
+}));
+
+// This timer should never go off as the server will close the socket
+setTimeout(common.mustNotCall(), common.platformTimeout(10000)).unref();

--- a/test/parallel/test-http-client-headers-array.js
+++ b/test/parallel/test-http-client-headers-array.js
@@ -10,7 +10,7 @@ function execute(options) {
     const expectHeaders = {
       'x-foo': 'boom',
       'cookie': 'a=1; b=2; c=3',
-      'connection': 'close'
+      'connection': 'keep-alive'
     };
 
     // no Host header when you set headers an array
@@ -28,6 +28,7 @@ function execute(options) {
 
     assert.deepStrictEqual(req.headers, expectHeaders);
 
+    res.writeHead(200, { 'Connection': 'close' });
     res.end();
   }).listen(0, function() {
     options = Object.assign(options, {

--- a/test/parallel/test-http-client-keep-alive-hint.js
+++ b/test/parallel/test-http-client-keep-alive-hint.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(
+  { keepAliveTimeout: common.platformTimeout(60000) },
+  function(req, res) {
+    req.resume();
+    res.writeHead(200, { 'Connection': 'keep-alive', 'Keep-Alive': 'timeout=1' });
+    res.end('FOO');
+  }
+);
+
+server.listen(0, common.mustCall(() => {
+  http.get({ port: server.address().port }, (res) => {
+    assert.strictEqual(res.statusCode, 200);
+
+    res.resume();
+    server.close();
+  });
+}));
+
+
+// This timer should never go off as the agent will parse the hint and terminate earlier
+setTimeout(common.mustNotCall(), common.platformTimeout(3000)).unref();

--- a/test/parallel/test-http-client-spurious-aborted.js
+++ b/test/parallel/test-http-client-spurious-aborted.js
@@ -10,7 +10,7 @@ const N = 2;
 let abortRequest = true;
 
 const server = http.Server(common.mustCall((req, res) => {
-  const headers = { 'Content-Type': 'text/plain' };
+  const headers = { 'Content-Type': 'text/plain', 'Connection': 'close' };
   headers['Content-Length'] = 50;
   const socket = res.socket;
   res.writeHead(200, headers);

--- a/test/parallel/test-http-client-timeout-on-connect.js
+++ b/test/parallel/test-http-client-timeout-on-connect.js
@@ -13,7 +13,10 @@ const server = http.createServer((req, res) => {
 
 server.listen(0, common.localhostIPv4, common.mustCall(() => {
   const port = server.address().port;
-  const req = http.get(`http://${common.localhostIPv4}:${port}`);
+  const req = http.get(
+    `http://${common.localhostIPv4}:${port}`,
+    { agent: new http.Agent() }
+  );
 
   req.setTimeout(1);
   req.on('socket', common.mustCall((socket) => {

--- a/test/parallel/test-http-default-encoding.js
+++ b/test/parallel/test-http-default-encoding.js
@@ -32,9 +32,9 @@ const server = http.Server((req, res) => {
   req.on('data', (chunk) => {
     result += chunk;
   }).on('end', () => {
-    server.close();
     res.writeHead(200);
     res.end('hello world\n');
+    server.close();
   });
 
 });

--- a/test/parallel/test-http-max-headers-count.js
+++ b/test/parallel/test-http-max-headers-count.js
@@ -48,7 +48,7 @@ const server = http.createServer(function(req, res) {
     expected = maxAndExpected[requests][1];
     server.maxHeadersCount = max;
   }
-  res.writeHead(200, headers);
+  res.writeHead(200, { ...headers, 'Connection': 'close' });
   res.end();
 });
 server.maxHeadersCount = max;

--- a/test/parallel/test-http-outgoing-message-capture-rejection.js
+++ b/test/parallel/test-http-outgoing-message-capture-rejection.js
@@ -16,9 +16,11 @@ events.captureRejections = true;
 
     res.socket.on('error', common.mustCall((err) => {
       assert.strictEqual(err, _err);
+      server.close();
     }));
 
     // Write until there is space in the buffer
+    res.writeHead(200, { 'Connection': 'close' });
     while (res.write('hello'));
   }));
 
@@ -37,7 +39,6 @@ events.captureRejections = true;
         code: 'ECONNRESET'
       }));
       res.resume();
-      server.close();
     }));
   }));
 }

--- a/test/parallel/test-http-raw-headers.js
+++ b/test/parallel/test-http-raw-headers.js
@@ -34,13 +34,13 @@ http.createServer(function(req, res) {
     'x-BaR',
     'yoyoyo',
     'Connection',
-    'close',
+    'keep-alive',
   ];
   const expectHeaders = {
     'host': `localhost:${this.address().port}`,
     'transfer-encoding': 'CHUNKED',
     'x-bar': 'yoyoyo',
-    'connection': 'close'
+    'connection': 'keep-alive'
   };
   const expectRawTrailers = [
     'x-bAr',
@@ -65,6 +65,7 @@ http.createServer(function(req, res) {
   });
 
   req.resume();
+  res.setHeader('Keep-Alive', 'timeout=1');
   res.setHeader('Trailer', 'x-foo');
   res.addTrailers([
     ['x-fOo', 'xOxOxOx'],
@@ -86,22 +87,25 @@ http.createServer(function(req, res) {
   req.end('y b a r');
   req.on('response', function(res) {
     const expectRawHeaders = [
+      'Keep-Alive',
+      'timeout=1',
       'Trailer',
       'x-foo',
       'Date',
       null,
       'Connection',
-      'close',
+      'keep-alive',
       'Transfer-Encoding',
       'chunked',
     ];
     const expectHeaders = {
+      'keep-alive': 'timeout=1',
       'trailer': 'x-foo',
       'date': null,
-      'connection': 'close',
+      'connection': 'keep-alive',
       'transfer-encoding': 'chunked'
     };
-    res.rawHeaders[3] = null;
+    res.rawHeaders[5] = null;
     res.headers.date = null;
     assert.deepStrictEqual(res.rawHeaders, expectRawHeaders);
     assert.deepStrictEqual(res.headers, expectHeaders);

--- a/test/parallel/test-http-request-end.js
+++ b/test/parallel/test-http-request-end.js
@@ -36,9 +36,9 @@ const server = http.Server(function(req, res) {
 
   req.on('end', function() {
     assert.strictEqual(result, expected);
-    server.close();
     res.writeHead(200);
     res.end('hello world\n');
+    server.close();
   });
 
 });

--- a/test/parallel/test-http-should-keep-alive.js
+++ b/test/parallel/test-http-should-keep-alive.js
@@ -50,6 +50,10 @@ const getCountdownIndex = () => SERVER_RESPONSES.length - countdown.remaining;
 
 const server = net.createServer(function(socket) {
   socket.write(SERVER_RESPONSES[getCountdownIndex()]);
+
+  if (SHOULD_KEEP_ALIVE[getCountdownIndex()]) {
+    socket.end();
+  }
 }).listen(0, function() {
   function makeRequest() {
     const req = http.get({ port: server.address().port }, function(res) {

--- a/test/parallel/test-http-unix-socket-keep-alive.js
+++ b/test/parallel/test-http-unix-socket-keep-alive.js
@@ -20,7 +20,7 @@ server.listen(common.PIPE, common.mustCall(() =>
 function asyncLoop(fn, times, cb) {
   fn(function handler() {
     if (--times) {
-      fn(handler);
+      setTimeout(() => fn(handler), common.platformTimeout(10));
     } else {
       cb();
     }

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -19,6 +19,7 @@ const options = {
 
 // Create TLS1.2 server
 https.createServer(options, function(req, res) {
+  res.writeHead(200, { 'Connection': 'close' });
   res.end('ohai');
 }).listen(0, function() {
   first(this);
@@ -44,6 +45,7 @@ function first(server) {
 function faultyServer(port) {
   options.secureProtocol = 'TLSv1_method';
   https.createServer(options, function(req, res) {
+    res.writeHead(200, { 'Connection': 'close' });
     res.end('hello faulty');
   }).listen(port, function() {
     second(this);

--- a/test/parallel/test-https-max-headers-count.js
+++ b/test/parallel/test-https-max-headers-count.js
@@ -37,7 +37,7 @@ const server = https.createServer(serverOptions, common.mustCall((req, res) => {
     expected = maxAndExpected[requests][1];
     server.maxHeadersCount = max;
   }
-  res.writeHead(200, headers);
+  res.writeHead(200, { ...headers, 'Connection': 'close' });
   res.end();
 }, 3));
 server.maxHeadersCount = max;

--- a/test/parallel/test-stream-destroy.js
+++ b/test/parallel/test-stream-destroy.js
@@ -62,7 +62,8 @@ const http = require('http');
 
   server.listen(0, () => {
     const req = http.request({
-      port: server.address().port
+      port: server.address().port,
+      agent: new http.Agent()
     });
 
     req.write('asd');
@@ -96,7 +97,8 @@ const http = require('http');
 
   server.listen(0, () => {
     const req = http.request({
-      port: server.address().port
+      port: server.address().port,
+      agent: new http.Agent()
     });
 
     req.write('asd');

--- a/test/parallel/test-tls-over-http-tunnel.js
+++ b/test/parallel/test-tls-over-http-tunnel.js
@@ -62,7 +62,7 @@ const proxy = net.createServer((clientSocket) => {
                          'HTTP/1.1\r\n' +
                          'Proxy-Connections: keep-alive\r\n' +
                          `Host: localhost:${proxy.address().port}\r\n` +
-                         'Connection: close\r\n\r\n');
+                         'Connection: keep-alive\r\n\r\n');
 
       console.log('PROXY: got CONNECT request');
       console.log('PROXY: creating a tunnel');

--- a/test/parallel/test-tls-set-secure-context.js
+++ b/test/parallel/test-tls-set-secure-context.js
@@ -82,7 +82,8 @@ function makeRequest(port, id) {
       rejectUnauthorized: true,
       ca: credentialOptions[0].ca,
       servername: 'agent1',
-      headers: { id }
+      headers: { id },
+      agent: new https.Agent()
     };
 
     let errored = false;

--- a/test/sequential/test-http-econnrefused.js
+++ b/test/sequential/test-http-econnrefused.js
@@ -43,7 +43,7 @@ const server = http.createServer(function(req, res) {
 
   req.on('end', function() {
     assert.strictEqual(body, 'PING');
-    res.writeHead(200);
+    res.writeHead(200, { 'Connection': 'close' });
     res.end('PONG');
   });
 });


### PR DESCRIPTION
This PR introduces the following changes:

1. Both `http.globalAgent` and `https.globalAgent` use keep-alive by default.
2. Agent now parses and applies `Keep-Alive` headers received by the server (if smaller than the current agent timeout)
3. `http(s).Server.close` now calls `closeIdleConnections` internally.

Fixes: #37184 