### PR TITLE
util: add colorize functionality

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -239,7 +239,47 @@ The `--throw-deprecation` command-line flag and `process.throwDeprecation`
 property take precedence over `--trace-deprecation` and
 `process.traceDeprecation`.
 
-## `util.format(format[, ...args])`
+## `util.colorize`
+<!-- YAML
+added: REPLACEME
+-->
+
+The `util.colorize` object provides functions that add ansi color codes to the
+provided string. These may be used to style terminal output.
+
+### `util.colorize.<style>[. ...<style>](string[, ...string])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `string` {string} The string that is formatted by the chosen style.
+* Returns: {string} The formatted string
+
+The API allows to be used with a builder/chaining pattern to add multiple styles
+in one call. Nesting color codes is supported.
+
+```js
+const { colorize } = util;
+
+console.log(
+  `${colorize.green('Heads up')}: only the "Heads up" is green`
+);
+
+console.log(
+  colorize.green('green', colorize.yellow('yellow'), 'green')
+)
+
+console.log(
+  colorize.bold.underline.red('bold red underline')
+)
+
+const info = colorize.italics.blue.bgYellow;
+console.log(
+  info('italic blue with yellow background')
+)
+```
+
+## `util.format(format[, args...])`
 
 <!-- YAML
 added: v0.5.3

--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -56,7 +56,10 @@ const vm = require('vm');
 const { fileURLToPath } = require('internal/url');
 
 const { customInspectSymbol } = require('internal/util');
-const { inspect: utilInspect } = require('internal/util/inspect');
+const {
+  inspect: utilInspect,
+  colorize
+} = require('internal/util/inspect');
 const debuglog = require('internal/util/debuglog').debuglog('inspect');
 
 const SHORTCUTS = {
@@ -162,7 +165,7 @@ function markSourceColumn(sourceText, position, useColors) {
   // Colourize char if stdout supports colours
   if (useColors) {
     tail = RegExpPrototypeSymbolReplace(/(.+?)([^\w]|$)/, tail,
-                                        '\u001b[32m$1\u001b[39m$2');
+                                        `${colorize.gray('$1')}$2`);
   }
 
   // Return source line with coloured char at `position`

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -268,7 +268,7 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
       completionPreview = suffix;
 
       const result = repl.useColors ?
-        `\u001b[90m${suffix}\u001b[39m` :
+      colorize.gray(suffix) :
         ` // ${suffix}`;
 
       const { cursorPos, displayPos } = getPreviewPos();
@@ -443,7 +443,7 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
       }
 
       const result = repl.useColors ?
-        `\u001b[90m${inspected}\u001b[39m` :
+        colorize.gray(inspected) :
         `// ${inspected}`;
 
       const { cursorPos, displayPos } = getPreviewPos();

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -439,6 +439,82 @@ defineColorAlias('inverse', 'swapColors');
 defineColorAlias('inverse', 'swapcolors');
 defineColorAlias('doubleunderline', 'doubleUnderline');
 
+// TODO(BridgeAR): Consider using a class instead and require the user to instantiate it
+// before using to declare their color support (or use a default, if none
+// provided).
+const colorize = {};
+
+function defineColorGetter({ style, codes, enumerable }) {
+  function color(...strings) {
+    let result = '';
+    const ansiCodes = this.ansiCodes
+    let string = strings[0];
+    for (let i = 1; i < strings.length; i++) {
+      string += ' ' + strings[i];
+    }
+
+    // Fast path
+    const searchCode = ansiCodes.length === 1 ? ansiCodes[0].end : '\u001b[';
+    const ansiCodeStart = string.indexOf(searchCode);
+    if (ansiCodeStart === -1) {
+      for (const code of ansiCodes) {
+        result += code.start;
+      }
+    } else {
+      // Slow path
+      const start = string.slice(0, ansiCodeStart - 1);
+      let middle = string.slice(ansiCodeStart - 1, -4);
+      const end = string.slice(-4);
+
+      for (const code of ansiCodes) {
+        result += code.start;
+        // Continue former colors by finding end points and continuing from there.
+        middle = middle.replaceAll(code.end, `$&${code.start}`)
+      }
+      string = `${start}${middle}${end}`;
+    }
+
+    result += string;
+    for (let i = ansiCodes.length - 1; i >= 0; i--) {
+      result += ansiCodes[i].end;
+    }
+
+    return result;
+  }
+
+  Object.defineProperty(colorize, style, {
+    __proto__: null,
+    get: function () {
+      if (typeof this === 'function') {
+        this.ansiCodes.push(codes);
+        return this;
+      }
+      const ansiCodes = [codes];
+      const context = {
+        ansiCodes
+      };
+      let boundColor = color.bind(context);
+      // Enable chaining.
+      Object.setPrototypeOf(boundColor, colorize);
+      boundColor.ansiCodes = ansiCodes;
+      return boundColor;
+    },
+    enumerable,
+  });
+}
+
+for (const [style, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(inspect.colors))) {
+  const value = descriptor.value ?? descriptor.get.call(inspect.colors);
+  defineColorGetter({
+    style,
+    codes: {
+      start: `\u001b[${value[0]}m`,
+      end: `\u001b[${value[1]}m`
+    },
+    enumerable: descriptor.enumerable
+  });
+}
+
 // TODO(BridgeAR): Add function style support for more complex styles.
 // Don't use 'blue' not visible on cmd.exe
 inspect.styles = ObjectAssign(ObjectCreate(null), {
@@ -2290,6 +2366,7 @@ function stripVTControlCharacters(str) {
 }
 
 module.exports = {
+  colorize,
   inspect,
   format,
   formatWithOptions,


### PR DESCRIPTION
The colorize object allows to format strings with ansi color codes
so that the string is stylized on a terminal.

This is a utility function that should not yet be exposed to the
users to allow some further polishing first.
This should be exposed under a completely new formatter module instead of adding new functionality to util.
Adding this functionality was discussed at the collaborator summit.

I played around with different builder APIs such as:

```js
new Colorize().bold.green('bold green')
colorize().bold().green('bold green')
colorize.bold.green('bold green')
```

In the end I went with the latter, especially, due to chalk already using this.

Refs: https://github.com/nodejs/node/issues/43382

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

@nodejs/util @nodejs/tooling PTAL.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
