### PR TITLE
crypto: disable ciphers not supported by EVP

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -791,6 +791,14 @@ when an error occurs (and is caught) during the creation of the
 context, for example, when the allocation fails or the maximum call stack
 size is reached when the context is created.
 
+<a id="ERR_CRYPTO_CIPHER_DISABLED"></a>
+
+### `ERR_CRYPTO_CIPHER_DISABLED`
+
+A cipher was requested that does not conform to OpenSSL's standard
+EVP interface for AEAD ciphers and requires usage of undocumented
+interfaces.
+
 <a id="ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED"></a>
 
 ### `ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED`

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -24,6 +24,7 @@ const {
 
 const {
   codes: {
+    ERR_CRYPTO_CIPHER_DISABLED,
     ERR_CRYPTO_INVALID_STATE,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
@@ -108,6 +109,14 @@ function getUIntOption(options, key) {
 }
 
 function createCipherBase(cipher, credential, options, decipher, iv) {
+  switch (cipher.toLowerCase()) {
+    case 'aes-128-cbc-hmac-sha1':
+    case 'aes-128-cbc-hmac-sha256':
+    case 'aes-256-cbc-hmac-sha1':
+    case 'aes-256-cbc-hmac-sha256':
+      throw new ERR_CRYPTO_CIPHER_DISABLED(cipher);
+  }
+
   const authTagLength = getUIntOption(options, 'authTagLength');
   this[kHandle] = new CipherBase(decipher);
   if (iv === undefined) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -936,6 +936,9 @@ E('ERR_CHILD_PROCESS_STDIO_MAXBUFFER', '%s maxBuffer length exceeded',
 E('ERR_CONSOLE_WRITABLE_STREAM',
   'Console expects a writable stream instance for %s', TypeError);
 E('ERR_CONTEXT_NOT_INITIALIZED', 'context used is not initialized', Error);
+E('ERR_CRYPTO_CIPHER_DISABLED',
+  'Cipher %s is disabled as it\'s not compatible with OpenSSL\'s ' +
+  'EVP AEAD interfaces', Error);
 E('ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED',
   'Custom engines not supported by this OpenSSL', Error);
 E('ERR_CRYPTO_ECDH_INVALID_FORMAT', 'Invalid ECDH format: %s', TypeError);

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -129,10 +129,22 @@ for (const algo of cryptoCiphers) {
     options = { authTagLength: 8 };
   else if (mode === 'ocb' || algo === 'chacha20-poly1305')
     options = { authTagLength: 16 };
-  crypto.createCipheriv(algo,
-                        crypto.randomBytes(keyLength),
-                        crypto.randomBytes(ivLength || 0),
-                        options);
+
+  const create_cipher = () =>
+    crypto.createCipheriv(algo,
+                          crypto.randomBytes(keyLength),
+                          crypto.randomBytes(ivLength || 0),
+                          options);
+
+  // Disabled ciphers will throw
+  if (algo.includes('hmac-sha'))
+    assert.throws(create_cipher, {
+      code: 'ERR_CRYPTO_CIPHER_DISABLED',
+      name: 'Error',
+      message: `Cipher ${algo} is disabled as it's not compatible with OpenSSL's EVP AEAD interfaces`
+    });
+  else
+    create_cipher();
 }
 
 // Assume that we have at least AES256-SHA.


### PR DESCRIPTION
OpenSSL lists certain ciphers as not conforming with the standard
EVP AEAD interface and these ciphers should be avoided,

    aes-128-cbc-hmac-sha1
    aes-128-cbc-hmac-sha256
    aes-256-cbc-hmac-sha1
    aes-256-cbc-hmac-sha256

While experimenting with these, the cipher text produced by Node
for `aes-128-cbc-hmac-sha1` does not differ from cipher text
produced by `aes-128-cbc` meaning that the HMAC is not automatically
taken into account. Since there is no facility to set the HMAC key
in Node, it's best to have these disabled when using crypto.Cipher
as all usage is wrong by definition.

Fixes: https://github.com/nodejs/node/issues/43040
Reference: https://www.openssl.org/docs/man1.1.1/man3/EVP_aes_128_cbc_hmac_sha1.html

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
