### PR TITLE
src: fix crash on FSReqPromise destructor

### DIFF
--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -159,7 +159,7 @@ FSReqPromise<AliasedBufferT>::~FSReqPromise() {
   // Validate that the promise was explicitly resolved or rejected but only if
   // the Isolate is not terminating because in this case the promise might have
   // not finished.
-  if (!env()->is_stopping()) CHECK(finished_);
+  CHECK_IMPLIES(!finished_, !env()->can_call_into_js());
 }
 
 template <typename AliasedBufferT>


### PR DESCRIPTION
We are deciding whether to end `fs` promises by checking
`can_call_into_js()` whereas in the `FSReqPromise` destructor we're
using the `is_stopping()` check. Though this may look as semantically
correct it has issues because though both values are modified before
termination on `Environment::ExitEnv()` and both are atomic they are not
synchronized together so it may happen that when reaching the destructor
`call_into_js` may be set to `false` whereas `is_stopping` remains
`false` causing the crash. Fix this by using the same checks everywhere.

Fixes: https://github.com/nodejs/node/issues/43499