### PR TITLE
readline: fix the REPL on editor mode crashing during tab completion

### DIFF
--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -366,6 +366,9 @@ function* emitKeys(stream) {
 
 // This runs in O(n log n).
 function commonPrefix(strings) {
+  if (strings.length === 0) {
+    return '';
+  }
   if (strings.length === 1) {
     return strings[0];
   }

--- a/test/parallel/test-repl-tab-complete-on-editor-mode.js
+++ b/test/parallel/test-repl-tab-complete-on-editor-mode.js
@@ -1,0 +1,21 @@
+'use strict';
+
+require('../common');
+const ArrayStream = require('../common/arraystream');
+const repl = require('repl');
+
+const stream = new ArrayStream();
+const replServer = repl.start({
+  input: stream,
+  output: stream,
+  terminal: true,
+});
+
+// Editor mode
+replServer.write('.editor\n');
+
+// Regression test for https://github.com/nodejs/node/issues/43528
+replServer.write('a');
+replServer.write(null, { name: 'tab' }); // Should not throw
+
+replServer.close();


### PR DESCRIPTION
Fixes #43528. This PR fixes the REPL on editor mode crashing during tab completion.

The root cause of this issue is that [`commonPrefix`](https://github.com/nodejs/node/blob/main/lib/internal/readline/utils.js#L368) could receive an empty array of completions because of #41632.

On editor mode, the completions are converted into the common prefix string in [`REPLServer.prototype.completeOnEditorModeL1603`](https://github.com/nodejs/node/blob/6f924ac6914b3e09c992a2b7b4cd5adb9eb7aa96/lib/repl.js#L1603) (I'm not sure why this wrapper is needed). And then `[kTabCompleter]()` is called as a callback with the completion as its argument.

https://github.com/nodejs/node/blob/6f924ac6914b3e09c992a2b7b4cd5adb9eb7aa96/lib/repl.js#L1596-L1607

For example, the completions for `a` are `['async', 'await', 'Array', ...]` (note that #41632 made REPL case-incentive) and their common prefix string is `''` (the return value of `commonPrefix(['async', 'await', 'Array', ...])`).
This means the completions is `['']` when `[kTabCompleter]()` is called, and `commonPrefix([])` will be called at L670.

https://github.com/nodejs/node/blob/6f924ac6914b3e09c992a2b7b4cd5adb9eb7aa96/lib/internal/readline/interface.js#L662-L672

