### PR TITLE
wasi: use WasmMemoryObject handle for perf

### DIFF
--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -10,14 +10,12 @@ const {
 } = primordials;
 
 const {
-  ERR_INVALID_ARG_TYPE,
   ERR_WASI_ALREADY_STARTED
 } = require('internal/errors').codes;
 const {
   emitExperimentalWarning,
   kEmptyObject,
 } = require('internal/util');
-const { isArrayBuffer } = require('internal/util/types');
 const {
   validateArray,
   validateBoolean,
@@ -38,20 +36,6 @@ emitExperimentalWarning('WASI');
 function setupInstance(self, instance) {
   validateObject(instance, 'instance');
   validateObject(instance.exports, 'instance.exports');
-
-  // WASI::_SetMemory() in src/node_wasi.cc only expects that |memory| is
-  // an object. It will try to look up the .buffer property when needed
-  // and fail with UVWASI_EINVAL when the property is missing or is not
-  // an ArrayBuffer. Long story short, we don't need much validation here
-  // but we type-check anyway because it helps catch bugs in the user's
-  // code early.
-  validateObject(instance.exports.memory, 'instance.exports.memory');
-  if (!isArrayBuffer(instance.exports.memory.buffer)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'instance.exports.memory.buffer',
-      ['WebAssembly.Memory'],
-      instance.exports.memory.buffer);
-  }
 
   self[kInstance] = instance;
   self[kSetMemory](instance.exports.memory);

--- a/src/node_wasi.h
+++ b/src/node_wasi.h
@@ -94,7 +94,7 @@ class WASI : public BaseObject,
   inline void writeUInt64(char* memory, uint64_t value, uint32_t offset);
   uvwasi_errno_t backingStore(char** store, size_t* byte_length);
   uvwasi_t uvw_;
-  v8::Global<v8::Object> memory_;
+  v8::Global<v8::WasmMemoryObject> memory_;
   uvwasi_mem_t alloc_info_;
   size_t current_uvwasi_memory_ = 0;
 };

--- a/test/wasi/test-wasi-start-validation.js
+++ b/test/wasi/test-wasi-start-validation.js
@@ -47,7 +47,7 @@ const bufferSource = fixtures.readSync('simple.wasm');
 
     Object.defineProperty(instance, 'exports', {
       get() {
-        return { memory: new Uint8Array() };
+        return { memory: new WebAssembly.Memory({ initial: 1 }) };
       },
     });
     assert.throws(
@@ -70,7 +70,7 @@ const bufferSource = fixtures.readSync('simple.wasm');
         return {
           _start() {},
           _initialize() {},
-          memory: new Uint8Array(),
+          memory: new WebAssembly.Memory({ initial: 1 }),
         };
       }
     });
@@ -97,53 +97,9 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\.memory" property must be of type object/
+        message: /"instance\.exports\.memory" property must be a WebAssembly\.Memory object/
       }
     );
-  }
-
-  {
-    // Verify that a non-ArrayBuffer memory.buffer is rejected.
-    const wasi = new WASI({});
-    const wasm = await WebAssembly.compile(bufferSource);
-    const instance = await WebAssembly.instantiate(wasm);
-
-    Object.defineProperty(instance, 'exports', {
-      get() {
-        return {
-          _start() {},
-          memory: {},
-        };
-      }
-    });
-    // The error message is a little white lie because any object
-    // with a .buffer property of type ArrayBuffer is accepted,
-    // but 99% of the time a WebAssembly.Memory object is used.
-    assert.throws(
-      () => { wasi.start(instance); },
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\.memory\.buffer" property must be an WebAssembly\.Memory/
-      }
-    );
-  }
-
-  {
-    // Verify that an argument that duck-types as a WebAssembly.Instance
-    // is accepted.
-    const wasi = new WASI({});
-    const wasm = await WebAssembly.compile(bufferSource);
-    const instance = await WebAssembly.instantiate(wasm);
-
-    Object.defineProperty(instance, 'exports', {
-      get() {
-        return {
-          _start() {},
-          memory: { buffer: new ArrayBuffer(0) },
-        };
-      }
-    });
-    wasi.start(instance);
   }
 
   {


### PR DESCRIPTION
Store `WebAssembly.Memory` handle as a `WasmMemoryObject`, which lets us directly grab the `ArrayBuffer` instead of doing a property lookup in this hot path.