### PR TITLE
domain: fix vm promise tracking while keeping isolation

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -39,6 +39,7 @@ const {
   Promise,
   ReflectApply,
   SafeMap,
+  SafeWeakMap,
   Symbol,
 } = primordials;
 
@@ -69,6 +70,7 @@ ObjectDefineProperty(process, 'domain', {
   }
 });
 
+const vmPromises = new SafeWeakMap();
 const pairing = new SafeMap();
 const asyncHook = createHook({
   init(asyncId, type, triggerAsyncId, resource) {
@@ -85,6 +87,11 @@ const asyncHook = createHook({
           value: process.domain,
           writable: true
         });
+      // Because promises from other contexts don't get a domain field,
+      // the domain needs to be held alive another way. Stuffing it in a
+      // weakmap connected to the promise lifetime can fix that.
+      } else {
+        vmPromises.set(resource, process.domain);
       }
     }
   },

--- a/test/parallel/test-domain-vm-promise-isolation.js
+++ b/test/parallel/test-domain-vm-promise-isolation.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+const vm = require('vm');
+
+// A promise created in a VM should not include a domain field but
+// domains should still be able to propagate through them.
+//
+// See; https://github.com/nodejs/node/issues/40999
+
+const context = vm.createContext({});
+
+function run(code) {
+  const d = domain.createDomain();
+  d.run(common.mustCall(() => {
+    const p = vm.runInContext(code, context)();
+    assert.strictEqual(p.domain, undefined);
+    p.then(common.mustCall(() => {
+      assert.strictEqual(process.domain, d);
+    }));
+  }));
+}
+
+for (let i = 0; i < 1000; i++) {
+  run('async () => null');
+}


### PR DESCRIPTION
So the prior fix I did to prevent domain fields from leaking into vm contexts through promises had a bug in that _not_ attaching the field meant the domain no longer had the lifetime connection, so when the before/after events to track domains through into chained promises back in the parent context try to resume the domain it crashes. By stuffing the domain into a weak map pinned to the promise lifetime, the reference is held long enough for it to resume.

I'm not sure if this is the _best_ way to fix it, but it is _a_ fix. 😅 

Fixes #40999 