### PR TITLE
benchmark: forcefully close processes

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -294,7 +294,7 @@ function sendResult(data) {
       // a second after completing, forcefully close it.
       setTimeout(() => {
         process.exit(0);
-      }, 1000).unref();
+      }, 5000).unref();
     });
   } else {
     // Otherwise report by stdout

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -289,7 +289,13 @@ function formatResult(data) {
 function sendResult(data) {
   if (process.send) {
     // If forked, report by process send
-    process.send(data);
+    process.send(data, () => {
+      // If, for any reason, the process is unable to self close within
+      // a second after completing, forcefully close it.
+      setTimeout(() => {
+        process.exit(0);
+      }, 1000).unref();
+    });
   } else {
     // Otherwise report by stdout
     process.stdout.write(formatResult(data));


### PR DESCRIPTION
This PR makes sure a benchmark always exit after reporting results.
The timer is created in order to allow the process to exit normally.

This solves situations in which some resources are wrongfully reported as active (like HTTP sockets closed in a bad way by wrk) and prevent the benchmarks to continue.

Fixes: nodejs/build#2968