### PR TITLE
net: fix net keepalive and noDelay

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -554,7 +554,16 @@ Socket.prototype.setKeepAlive = function(enable, initialDelayMsecs) {
     return this;
   }
 
-  if (this._handle.setKeepAlive && enable !== this[kSetKeepAlive]) {
+  if (!this._handle.setKeepAlive) {
+    return this;
+  }
+
+  if (enable !== this[kSetKeepAlive] ||
+      (
+        enable &&
+        this[kSetKeepAliveInitialDelay] !== initialDelay
+      )
+  ) {
     this[kSetKeepAlive] = enable;
     this[kSetKeepAliveInitialDelay] = initialDelay;
     this._handle.setKeepAlive(enable, initialDelay);
@@ -1660,9 +1669,12 @@ function onconnection(err, clientHandle) {
   });
 
   if (self.noDelay && clientHandle.setNoDelay) {
+    socket[kSetNoDelay] = true;
     clientHandle.setNoDelay(true);
   }
   if (self.keepAlive && clientHandle.setKeepAlive) {
+    socket[kSetKeepAlive] = true;
+    socket[kSetKeepAliveInitialDelay] = self.keepAliveInitialDelay;
     clientHandle.setKeepAlive(true, self.keepAliveInitialDelay);
   }
 

--- a/test/parallel/test-net-server-keepalive.js
+++ b/test/parallel/test-net-server-keepalive.js
@@ -7,6 +7,15 @@ const server = net.createServer({
   keepAlive: true,
   keepAliveInitialDelay: 1000
 }, common.mustCall((socket) => {
+  const setKeepAlive = socket._handle.setKeepAlive;
+  socket._handle.setKeepAlive = common.mustCall((enable, initialDelay) => {
+    assert.strictEqual(enable, true);
+    assert.match(String(initialDelay), /^2|3$/);
+    return setKeepAlive.call(socket._handle, enable, initialDelay);
+  }, 2);
+  socket.setKeepAlive(true, 1000);
+  socket.setKeepAlive(true, 2000);
+  socket.setKeepAlive(true, 3000);
   socket.destroy();
   server.close();
 })).listen(0, common.mustCall(() => {
@@ -20,6 +29,7 @@ server._handle.onconnection = common.mustCall((err, clientHandle) => {
     assert.strictEqual(enable, server.keepAlive);
     assert.strictEqual(initialDelayMsecs, server.keepAliveInitialDelay);
     setKeepAlive.call(clientHandle, enable, initialDelayMsecs);
+    clientHandle.setKeepAlive = setKeepAlive;
   });
   onconnection.call(server._handle, err, clientHandle);
 });

--- a/test/parallel/test-net-server-nodelay.js
+++ b/test/parallel/test-net-server-nodelay.js
@@ -6,6 +6,8 @@ const net = require('net');
 const server = net.createServer({
   noDelay: true
 }, common.mustCall((socket) => {
+  socket._handle.setNoDelay = common.mustNotCall();
+  socket.setNoDelay(true);
   socket.destroy();
   server.close();
 })).listen(0, common.mustCall(() => {
@@ -18,6 +20,7 @@ server._handle.onconnection = common.mustCall((err, clientHandle) => {
   clientHandle.setNoDelay = common.mustCall((enable) => {
     assert.strictEqual(enable, server.noDelay);
     setNoDelay.call(clientHandle, enable);
+    clientHandle.setNoDelay = setNoDelay;
   });
   onconnection.call(server._handle, err, clientHandle);
 });


### PR DESCRIPTION
1. support call setKeepAlive again with different delay value.
2. set keepalive and nodelay to socket which is created by server.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Affected subsystem: net