### PR TITLE
fs: refactor realpath with Map and Set

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -33,13 +33,13 @@ const {
   BigIntPrototypeToString,
   MathMax,
   Number,
-  ObjectCreate,
   ObjectDefineProperties,
   ObjectDefineProperty,
   Promise,
   ReflectApply,
   RegExpPrototypeExec,
   SafeMap,
+  SafeSet,
   String,
   StringPrototypeCharCodeAt,
   StringPrototypeIndexOf,
@@ -2486,8 +2486,8 @@ function realpathSync(p, options) {
     return maybeCachedResult;
   }
 
-  const seenLinks = ObjectCreate(null);
-  const knownHard = ObjectCreate(null);
+  const seenLinks = new SafeMap();
+  const knownHard = new SafeSet();
   const original = p;
 
   // Current character position in p
@@ -2508,7 +2508,7 @@ function realpathSync(p, options) {
     const ctx = { path: base };
     binding.lstat(pathModule.toNamespacedPath(base), false, undefined, ctx);
     handleErrorFromBinding(ctx);
-    knownHard[base] = true;
+    knownHard.add(base);
   }
 
   // Walk down the path, swapping out linked path parts for their real
@@ -2530,7 +2530,7 @@ function realpathSync(p, options) {
     }
 
     // Continue if not a symlink, break if a pipe/socket
-    if (knownHard[base] || cache?.get(base) === base) {
+    if (knownHard.has(base) || cache?.get(base) === base) {
       if (isFileType(binding.statValues, S_IFIFO) ||
           isFileType(binding.statValues, S_IFSOCK)) {
         break;
@@ -2552,7 +2552,7 @@ function realpathSync(p, options) {
       handleErrorFromBinding(ctx);
 
       if (!isFileType(stats, S_IFLNK)) {
-        knownHard[base] = true;
+        knownHard.add(base);
         cache?.set(base, base);
         continue;
       }
@@ -2565,8 +2565,8 @@ function realpathSync(p, options) {
         const dev = BigIntPrototypeToString(stats[0], 32);
         const ino = BigIntPrototypeToString(stats[7], 32);
         id = `${dev}:${ino}`;
-        if (seenLinks[id]) {
-          linkTarget = seenLinks[id];
+        if (seenLinks.has(id)) {
+          linkTarget = seenLinks.get(id);
         }
       }
       if (linkTarget === null) {
@@ -2579,7 +2579,7 @@ function realpathSync(p, options) {
       resolvedLink = pathModule.resolve(previous, linkTarget);
 
       cache?.set(base, resolvedLink);
-      if (!isWindows) seenLinks[id] = linkTarget;
+      if (!isWindows) seenLinks.set(id, linkTarget);
     }
 
     // Resolve the link, then start over
@@ -2590,11 +2590,11 @@ function realpathSync(p, options) {
     pos = current.length;
 
     // On windows, check that the root exists. On unix there is no need.
-    if (isWindows && !knownHard[base]) {
+    if (isWindows && !knownHard.has(base)) {
       const ctx = { path: base };
       binding.lstat(pathModule.toNamespacedPath(base), false, undefined, ctx);
       handleErrorFromBinding(ctx);
-      knownHard[base] = true;
+      knownHard.add(base);
     }
   }
 
@@ -2639,8 +2639,8 @@ function realpath(p, options, callback) {
   validatePath(p);
   p = pathModule.resolve(p);
 
-  const seenLinks = ObjectCreate(null);
-  const knownHard = ObjectCreate(null);
+  const seenLinks = new SafeMap();
+  const knownHard = new SafeSet();
 
   // Current character position in p
   let pos;
@@ -2655,10 +2655,10 @@ function realpath(p, options, callback) {
   pos = current.length;
 
   // On windows, check that the root exists. On unix there is no need.
-  if (isWindows && !knownHard[base]) {
+  if (isWindows && !knownHard.has(base)) {
     fs.lstat(base, (err, stats) => {
       if (err) return callback(err);
-      knownHard[base] = true;
+      knownHard.add(base);
       LOOP();
     });
   } else {
@@ -2688,7 +2688,7 @@ function realpath(p, options, callback) {
     }
 
     // Continue if not a symlink, break if a pipe/socket
-    if (knownHard[base]) {
+    if (knownHard.has(base)) {
       if (isFileType(binding.statValues, S_IFIFO) ||
           isFileType(binding.statValues, S_IFSOCK)) {
         return callback(null, encodeRealpathResult(p, options));
@@ -2704,7 +2704,7 @@ function realpath(p, options, callback) {
 
     // If not a symlink, skip to the next path part
     if (!stats.isSymbolicLink()) {
-      knownHard[base] = true;
+      knownHard.add(base);
       return process.nextTick(LOOP);
     }
 
@@ -2716,15 +2716,15 @@ function realpath(p, options, callback) {
       const dev = BigIntPrototypeToString(stats.dev, 32);
       const ino = BigIntPrototypeToString(stats.ino, 32);
       id = `${dev}:${ino}`;
-      if (seenLinks[id]) {
-        return gotTarget(null, seenLinks[id]);
+      if (seenLinks.has(id)) {
+        return gotTarget(null, seenLinks.get(id));
       }
     }
     fs.stat(base, (err) => {
       if (err) return callback(err);
 
       fs.readlink(base, (err, target) => {
-        if (!isWindows) seenLinks[id] = target;
+        if (!isWindows) seenLinks.set(id, target);
         gotTarget(err, target);
       });
     });
@@ -2743,10 +2743,10 @@ function realpath(p, options, callback) {
     pos = current.length;
 
     // On windows, check that the root exists. On unix there is no need.
-    if (isWindows && !knownHard[base]) {
+    if (isWindows && !knownHard.has(base)) {
       fs.lstat(base, (err) => {
         if (err) return callback(err);
-        knownHard[base] = true;
+        knownHard.add(base);
         LOOP();
       });
     } else {


### PR DESCRIPTION
Affecting non-native implementations of [`fs.realpath(path[, options], callback)`](https://nodejs.org/api/fs.html#fsrealpathpath-options-callback) and [`fs.realpathSync(path[, options])`](https://nodejs.org/api/fs.html#fsrealpathsyncpath-options).

Local benchmark, `!isWindows`, 256 runs:
```r
                                                     confidence improvement accuracy (*)   (**)  (***)
fs/bench-realpath.js pathType='relative' n=10000            ***     13.34 %       ±2.29% ±3.01% ±3.86%
fs/bench-realpath.js pathType='resolved' n=10000                     1.12 %       ±4.04% ±5.32% ±6.81%
fs/bench-realpathSync.js pathType='relative' n=10000        ***      7.61 %       ±0.33% ±0.44% ±0.56%
fs/bench-realpathSync.js pathType='resolved' n=10000        ***     10.21 %       ±0.37% ±0.49% ±0.63%
```