### PR TITLE
net: add drop event for net server

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -281,6 +281,23 @@ added: v0.1.90
 
 Emitted when the server has been bound after calling [`server.listen()`][].
 
+### Event: `'drop'`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+When the number of connections reaches the threshold of `server.maxConnections`,
+the server will drop new connections and emit `'drop'` event instead. If it is a
+TCP server, the argument is as follows, otherwise the argument is `undefined`.
+
+* `data` {Object} The argument passed to event listener.
+  * `localAddress` {string}  Local address.
+  * `localPort` {number} Local port.
+  * `remoteAddress` {string} Remote address.
+  * `remotePort` {number} Remote port.
+  * `remoteFamily` {string} Remote IP family. `'IPv4'` or `'IPv6'`.
+
 ### `server.address()`
 
 <!-- YAML

--- a/lib/net.js
+++ b/lib/net.js
@@ -31,6 +31,7 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Symbol,
+  ObjectCreate,
 } = primordials;
 
 const EventEmitter = require('events');
@@ -1647,6 +1648,25 @@ function onconnection(err, clientHandle) {
   }
 
   if (self.maxConnections && self._connections >= self.maxConnections) {
+    if (clientHandle.getsockname || clientHandle.getpeername) {
+      const data = ObjectCreate(null);
+      if (clientHandle.getsockname) {
+        const localInfo = ObjectCreate(null);
+        clientHandle.getsockname(localInfo);
+        data.localAddress = localInfo.address;
+        data.localPort = localInfo.port;
+      }
+      if (clientHandle.getpeername) {
+        const remoteInfo = ObjectCreate(null);
+        clientHandle.getpeername(remoteInfo);
+        data.remoteAddress = remoteInfo.address;
+        data.remotePort = remoteInfo.port;
+        data.remoteFamily = remoteInfo.family;
+      }
+      self.emit('drop', data);
+    } else {
+      self.emit('drop');
+    }
     clientHandle.close();
     return;
   }

--- a/test/parallel/test-net-server-drop-connections.js
+++ b/test/parallel/test-net-server-drop-connections.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+let firstSocket;
+const server = net.createServer(common.mustCall((socket) => {
+  firstSocket = socket;
+}));
+
+server.maxConnections = 1;
+
+server.on('drop', common.mustCall((data) => {
+  assert.strictEqual(!!data.localAddress, true);
+  assert.strictEqual(!!data.localPort, true);
+  assert.strictEqual(!!data.remoteAddress, true);
+  assert.strictEqual(!!data.remotePort, true);
+  assert.strictEqual(!!data.remoteFamily, true);
+  firstSocket.destroy();
+  server.close();
+}));
+
+server.listen(0, () => {
+  net.createConnection(server.address().port);
+  net.createConnection(server.address().port);
+});


### PR DESCRIPTION
add `drop` event for net server to notify user when the connection is dropped. 

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Affected subsystem: net