### PR TITLE
[v14.x backport] src,deps,build,test: add OpenSSL config appname

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -52,6 +52,7 @@ file a new issue.
   * [Build with a specific ICU](#build-with-a-specific-icu)
     * [Unix/macOS](#unixmacos-3)
     * [Windows](#windows-4)
+* [Configuring OpenSSL config appname](#configure-openssl-appname)
 * [Building Node.js with FIPS-compliant OpenSSL](#building-nodejs-with-fips-compliant-openssl)
 * [Building Node.js with external core modules](#building-nodejs-with-external-core-modules)
   * [Unix/macOS](#unixmacos-4)
@@ -764,6 +765,19 @@ as `deps/icu` (You'll have: `deps/icu/source/...`)
 
 ```console
 > .\vcbuild full-icu
+```
+
+### Configure OpenSSL appname
+
+Node.js can use an OpenSSL configuration file by specifying the environment
+variable `OPENSSL_CONF`, or using the command line option `--openssl-conf`, and
+if none of those are specified will default to reading the default OpenSSL
+configuration file `openssl.cnf`. Node.js will only read a section that is by
+default named `nodejs_conf`, but this name can be overridden using the following
+configure option:
+
+```console
+$ ./configure --openssl-conf-name=<some_conf_name>
 ```
 
 ## Building Node.js with FIPS-compliant OpenSSL

--- a/configure.py
+++ b/configure.py
@@ -176,6 +176,12 @@ parser.add_option("--link-module",
          "e.g. /root/x/y.js will be referenced via require('root/x/y'). "
          "Can be used multiple times")
 
+parser.add_option("--openssl-conf-name",
+    action="store",
+    dest="openssl_conf_name",
+    default='nodejs_conf',
+    help="The OpenSSL config appname (config section name) used by Node.js")
+
 parser.add_option('--openssl-default-cipher-list',
     action='store',
     dest='openssl_default_cipher_list',
@@ -1336,6 +1342,8 @@ def configure_openssl(o):
 
   if options.openssl_no_asm:
     variables['openssl_no_asm'] = 1
+
+  o['defines'] += ['NODE_OPENSSL_CONF_NAME=' + options.openssl_conf_name]
 
   if options.without_ssl:
     def without_ssl_error(option):

--- a/test/fixtures/openssl_fips_disabled.cnf
+++ b/test/fixtures/openssl_fips_disabled.cnf
@@ -1,6 +1,6 @@
 # Skeleton openssl.cnf for testing with FIPS
 
-openssl_conf = openssl_conf_section
+nodejs_conf = openssl_conf_section
 authorityKeyIdentifier=keyid:always,issuer:always
 
 [openssl_conf_section]

--- a/test/fixtures/openssl_fips_enabled.cnf
+++ b/test/fixtures/openssl_fips_enabled.cnf
@@ -1,6 +1,6 @@
 # Skeleton openssl.cnf for testing with FIPS
 
-openssl_conf = openssl_conf_section
+nodejs_conf = openssl_conf_section
 authorityKeyIdentifier=keyid:always,issuer:always
 
 [openssl_conf_section]

--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -64,7 +64,7 @@ testHelper(
   [],
   FIPS_DISABLED,
   'require("crypto").getFips()',
-  { ...process.env, 'OPENSSL_CONF': '' });
+  { ...process.env, 'OPENSSL_CONF': ' ' });
 
 // --enable-fips should turn FIPS mode on
 testHelper(


### PR DESCRIPTION
This commit adds the setting of an appname (configuration section
name), 'nodejs_conf', to be used when reading OpenSSL configuration
files.

The motivation for this is that currently the default OpenSSL
configuration, 'openssl_conf', element will be used which may be
undesirable as it might configure OpenSSL in unwanted ways. With this
commit it is still possible to use a default openssl.cnf file but the
only section that Node.js will read from is a section named
'nodejs_conf'.

PR-URL: https://github.com/nodejs/node/pull/43124
Refs: https://github.com/nodejs/node/issues/40366
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Rich Trott <rtrott@gmail.com>
Reviewed-By: Rafael Gonzaga <rafael.nunu@hotmail.com>
Reviewed-By: Beth Griggs <bgriggs@redhat.com>

