### PR TITLE
perf_hooks: add initiatorType getter

### DIFF
--- a/lib/internal/perf/resource_timing.js
+++ b/lib/internal/perf/resource_timing.js
@@ -46,6 +46,10 @@ class InternalPerformanceResourceTiming extends InternalPerformanceEntry {
     return this[kTimingInfo].endTime - this[kTimingInfo].startTime;
   }
 
+  get initiatorType() {
+    return this[kInitiatorType];
+  }
+
   get workerStart() {
     return this[kTimingInfo].finalServiceWorkerStartTime;
   }

--- a/test/parallel/test-perf-hooks-resourcetiming.js
+++ b/test/parallel/test-perf-hooks-resourcetiming.js
@@ -134,6 +134,7 @@ function createTimingInfo({
   assert.ok(typeof resource.cacheMode === 'undefined', 'cacheMode does not have a getter');
   assert.strictEqual(resource.startTime, timingInfo.startTime);
   assert.strictEqual(resource.duration, 0);
+  assert.strictEqual(resource.initiatorType, initiatorType);
   assert.strictEqual(resource.workerStart, 0);
   assert.strictEqual(resource.redirectStart, 0);
   assert.strictEqual(resource.redirectEnd, 0);


### PR DESCRIPTION
It's missing the getter for `initiatorType`. ref: https://w3c.github.io/resource-timing/#dfn-initiator-type