### PR TITLE
doc: remove windows xperf from tierlist

### DIFF
--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -136,6 +136,5 @@ The tools are currently assigned to Tiers as follows:
 | Tracing   | trace\_gc                 | No                            | Yes                     | 1           |
 | Tracing   | LTTng                     | No                            | Removed?                | N/A         |
 | Tracing   | Systemtap                 | No                            | Partial                 | ?           |
-| Profiling | Windows Xperf             | No                            | ?                       | ?           |
 | F/P/T     | appmetrics                | No                            | No                      | ?           |
 | M/T       | eBPF tracing tool         | No                            | No                      | ?           |


### PR DESCRIPTION
Hey 👋 

## Context

The diagnostic working group currently works on an [initiative](https://github.com/nodejs/diagnostics/issues/532) to re-evaluate the diagnostic tooling list and its maturity.

> Note: it's normally the last batch of updates before closing the issue.

## Updated

In the previous instance, we examined the case of the `Windows xperf` module: [issue link](https://github.com/nodejs/diagnostics/issues/539).

As anyone in the instance has an idea about a potential usage in the field, we decided to remove it. As said in the previous PRs, we prefer to have a list that contains fewer items but is trustable.

But in case you have a different opinion, please share your thoughts in this PR 🙏.

## Discuss

As usual, feel free to share your thoughts on that and your experience with this tool.

With love ❤️  

cc @nodejs/diagnostics 