### PR TITLE
doc: promote `0x` to tier 4

### DIFF
--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -118,9 +118,9 @@ The tools are currently assigned to Tiers as follows:
 
 ## Tier 4
 
-| Tool Type | Tool/API Name | Regular Testing in Node.js CI | Integrated with Node.js | Target Tier |
-| --------- | ------------- | ----------------------------- | ----------------------- | ----------- |
-|           |               |                               |                         |             |
+| Tool Type | Tool/API Name                                 | Regular Testing in Node.js CI | Integrated with Node.js | Target Tier |
+| --------- | --------------------------------------------- | ----------------------------- | ----------------------- | ----------- |
+| Profiling | [0x](https://github.com/davidmarkclements/0x) | No                            | No                      | 3           |
 
 ## Not yet classified
 
@@ -139,6 +139,5 @@ The tools are currently assigned to Tiers as follows:
 | Tracing   | Systemtap                 | No                            | Partial                 | ?           |
 | Profiling | DTrace                    | No                            | Partial                 | 3           |
 | Profiling | Windows Xperf             | No                            | ?                       | ?           |
-| Profiling | 0x                        | No                            | No                      | 4           |
 | F/P/T     | appmetrics                | No                            | No                      | ?           |
 | M/T       | eBPF tracing tool         | No                            | No                      | ?           |


### PR DESCRIPTION
Hey 👋 

## Context

The diagnostic working group currently works on an [initiative](https://github.com/nodejs/diagnostics/issues/532) to re-evaluate the diagnostic tooling list and its maturity.

> Note: it's normally the last batch of updates before closing the issue.

## Updated

In the previous instance, we examined the case of the `0x` module: [issue link](https://github.com/nodejs/diagnostics/issues/538).

The tool is widely used in the field and the latest Node.js version is supported. We’ve decided to move it to Tier 4 🎉 

But in case you have a different opinion, please share your thoughts in this PR 🙏.

With love ❤️  

cc @nodejs/diagnostics 