### PR TITLE
fix: cjs-module-lexer WebAssembly out of memory fallback

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -64,8 +64,7 @@ async function initCJSParse() {
     try {
       await init();
       cjsParse = parse;
-    }
-    catch {
+    } catch {
       cjsParse = require('internal/deps/cjs-module-lexer/lexer').parse;
     }
   }

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -61,8 +61,13 @@ async function initCJSParse() {
   } else {
     const { parse, init } =
         require('internal/deps/cjs-module-lexer/dist/lexer');
-    await init();
-    cjsParse = parse;
+    try {
+      await init();
+      cjsParse = parse;
+    }
+    catch {
+      cjsParse = require('internal/deps/cjs-module-lexer/lexer').parse;
+    }
   }
 }
 


### PR DESCRIPTION
This implements a possible fix for the Wasm memory issues that have been coming up with hosts that are unable to run WebAssembly in v8 due to low memory requirements.

See the thread here - https://github.com/nodejs/cjs-module-lexer/issues/61, there have also been issues posted in core, some open and some closed.

I don't know why this took me so long, but we can just fallback to the JS lexer implementation if Wasm initialization fails, which this PR should provide.

//cc @nodejs/modules 