### PR TITLE
test: fill `DOMException` names

### DIFF
--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -245,7 +245,10 @@ const { setTimeout: sleep } = require('timers/promises');
 
 {
   // Test abortSignal.throwIfAborted()
-  throws(() => AbortSignal.abort().throwIfAborted(), { code: 20 });
+  throws(() => AbortSignal.abort().throwIfAborted(), {
+    code: 20,
+    name: 'AbortError',
+  });
 
   // Does not throw because it's not aborted.
   const ac = new AbortController();

--- a/test/parallel/test-filehandle-readablestream.js
+++ b/test/parallel/test-filehandle-readablestream.js
@@ -80,7 +80,8 @@ const check = readFileSync(__filename, { encoding: 'utf8' });
   const mc = new MessageChannel();
   mc.port1.onmessage = common.mustNotCall();
   assert.throws(() => mc.port2.postMessage(file, [file]), {
-    code: 25  // DataCloneError
+    code: 25,
+    name: 'DataCloneError',
   });
   mc.port1.close();
   await file.close();

--- a/test/parallel/test-fs-promises-file-handle-read-worker.js
+++ b/test/parallel/test-fs-promises-file-handle-read-worker.js
@@ -29,6 +29,7 @@ if (isMainThread || !workerData) {
         });
       }, {
         code: 25,
+        name: 'DataCloneError',
       });
     } finally {
       await handle.close();

--- a/test/parallel/test-webcrypto-random.js
+++ b/test/parallel/test-webcrypto-random.js
@@ -63,8 +63,9 @@ for (const ctor of intTypedConstructors) {
   }
 
   if (kData !== undefined) {
-    assert.throws(() => webcrypto.getRandomValues(kData), {
-      code: 22
-    });
+    assert.throws(
+      () => webcrypto.getRandomValues(kData),
+      { name: 'QuotaExceededError', code: 22 },
+    );
   }
 }

--- a/test/parallel/test-whatwg-webstreams-transfer.js
+++ b/test/parallel/test-whatwg-webstreams-transfer.js
@@ -253,14 +253,16 @@ const theData = 'hello';
     start(c) { controller = c; },
 
     cancel: common.mustCall((error) => {
-      assert.strictEqual(error.code, 25);  // DataCloneError
+      assert.strictEqual(error.code, 25);
+      assert.strictEqual(error.name, 'DataCloneError');
     }),
   });
 
   port1.onmessage = ({ data }) => {
     const reader = data.getReader();
     assert.rejects(reader.read(), {
-      code: 25,  // DataCloneError
+      code: 25,
+      name: 'DataCloneError',
     });
     port1.close();
   };
@@ -354,7 +356,10 @@ const theData = 'hello';
 
   const source = {
     abort: common.mustCall((error) => {
-      process.nextTick(() => assert.strictEqual(error.code, 25));
+      process.nextTick(() => {
+        assert.strictEqual(error.code, 25);
+        assert.strictEqual(error.name, 'DataCloneError');
+      });
     })
   };
 
@@ -366,7 +371,8 @@ const theData = 'hello';
     const m = new WebAssembly.Memory({ initial: 1 });
 
     assert.rejects(writer.abort(m), {
-      code: 25
+      code: 25,
+      name: 'DataCloneError',
     });
     port1.close();
   });
@@ -437,7 +443,10 @@ const theData = 'hello';
 {
   const source = {
     cancel: common.mustCall((error) => {
-      process.nextTick(() => assert(error.code, 25));
+      process.nextTick(() => {
+        assert.strictEqual(error.code, 25);
+        assert.strictEqual(error.name, 'DataCloneError');
+      });
     }),
   };
 
@@ -455,7 +464,8 @@ const theData = 'hello';
     reader.closed.then(common.mustCall());
 
     assert.rejects(cancel, {
-      code: 25
+      code: 25,
+      name: 'DataCloneError',
     });
 
     port1.close();
@@ -469,6 +479,7 @@ const theData = 'hello';
     abort: common.mustCall((error) => {
       process.nextTick(() => {
         assert.strictEqual(error.code, 25);
+        assert.strictEqual(error.name, 'DataCloneError');
       });
     }),
   };
@@ -481,7 +492,7 @@ const theData = 'hello';
     const m = new WebAssembly.Memory({ initial: 1 });
     const writer = data.getWriter();
     const write = writer.write(m);
-    assert.rejects(write, { code: 25 });
+    assert.rejects(write, { code: 25, name: 'DataCloneError' });
     port1.close();
   });
 
@@ -492,12 +503,14 @@ const theData = 'hello';
   const readable = new ReadableStream();
   readable.getReader();
   assert.throws(() => readable[kTransfer](), {
-    code: 25
+    code: 25,
+    name: 'DataCloneError',
   });
 
   const writable = new WritableStream();
   writable.getWriter();
   assert.throws(() => writable[kTransfer](), {
-    code: 25
+    code: 25,
+    name: 'DataCloneError',
   });
 }


### PR DESCRIPTION
`DOMException.name` is preferable over `DOMException.code`. Also this makes affected tests a bit more self-documented.

Note that instead of numbers we can use legacy constants exposed as `DOMException` properties.
And for testing compatibility with Web APIs we can explicitly check that error is not Node.js-specific by asserting its `constructor`.
```js
  throws(
    () => AbortSignal.abort().throwIfAborted(),
    {
      constructor: DOMException,
      code: DOMException.ABORT_ERR,
      name: 'AbortError',
    }
  );
```