### PR TITLE
process: make process.config read only

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2889,12 +2889,15 @@ Prefer [`message.socket`][] over [`message.connection`][].
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43627
+    description: End-of-Life.
   - version: v16.0.0
     pr-url: https://github.com/nodejs/node/pull/36902
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 The `process.config` property provides access to Node.js compile-time settings.
 However, the property is mutable and therefore subject to tampering. The ability

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1041,6 +1041,9 @@ This feature is not available in [`Worker`][] threads.
 <!-- YAML
 added: v0.7.7
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43627
+    description: The `process.config` object is now frozen.
   - version: v16.0.0
     pr-url: https://github.com/nodejs/node/pull/36902
     description: Modifying process.config has been deprecated.
@@ -1048,10 +1051,10 @@ changes:
 
 * {Object}
 
-The `process.config` property returns an `Object` containing the JavaScript
-representation of the configure options used to compile the current Node.js
-executable. This is the same as the `config.gypi` file that was produced when
-running the `./configure` script.
+The `process.config` property returns a frozen `Object` containing the
+JavaScript representation of the configure options used to compile the current
+Node.js executable. This is the same as the `config.gypi` file that was produced
+when running the `./configure` script.
 
 An example of the possible output looks like:
 
@@ -1084,14 +1087,6 @@ An example of the possible output looks like:
    }
 }
 ```
-
-The `process.config` property is **not** read-only and there are existing
-modules in the ecosystem that are known to extend, modify, or entirely replace
-the value of `process.config`.
-
-Modifying the `process.config` property, or any child-property of the
-`process.config` object has been deprecated. The `process.config` will be made
-read-only in a future release.
 
 ## `process.connected`
 

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -46,10 +46,8 @@ const {
   JSONParse,
   ObjectDefineProperty,
   ObjectGetPrototypeOf,
-  ObjectPreventExtensions,
   ObjectSetPrototypeOf,
-  ReflectGet,
-  ReflectSet,
+  ObjectFreeze,
   SymbolToStringTag,
   globalThis,
 } = primordials;
@@ -72,75 +70,18 @@ process._exiting = false;
 // process.config is serialized config.gypi
 const nativeModule = internalBinding('native_module');
 
-// TODO(@jasnell): Once this has gone through one full major
-// release cycle, remove the Proxy and setter and update the
-// getter to either return a read-only object or always return
-// a freshly parsed version of nativeModule.config.
-
-const deprecationHandler = {
-  warned: false,
-  message: 'Setting process.config is deprecated. ' +
-           'In the future the property will be read-only.',
-  code: 'DEP0150',
-  maybeWarn() {
-    if (!this.warned) {
-      process.emitWarning(this.message, {
-        type: 'DeprecationWarning',
-        code: this.code
-      });
-      this.warned = true;
-    }
-  },
-
-  defineProperty(target, key, descriptor) {
-    this.maybeWarn();
-    return ObjectDefineProperty(target, key, descriptor);
-  },
-
-  deleteProperty(target, key) {
-    this.maybeWarn();
-    delete target[key];
-  },
-
-  preventExtensions(target) {
-    this.maybeWarn();
-    return ObjectPreventExtensions(target);
-  },
-
-  set(target, key, value) {
-    this.maybeWarn();
-    return ReflectSet(target, key, value);
-  },
-
-  get(target, key, receiver) {
-    const val = ReflectGet(target, key, receiver);
-    if (val != null && typeof val === 'object') {
-      // eslint-disable-next-line node-core/prefer-primordials
-      return new Proxy(val, deprecationHandler);
-    }
-    return val;
-  },
-
-  setPrototypeOf(target, proto) {
-    this.maybeWarn();
-    return ObjectSetPrototypeOf(target, proto);
-  }
-};
-
-// eslint-disable-next-line node-core/prefer-primordials
-let processConfig = new Proxy(
-  JSONParse(nativeModule.config),
-  deprecationHandler);
+const processConfig = JSONParse(nativeModule.config, (_key, value) => {
+  // The `reviver` argument of the JSONParse method will visit all the values of
+  // the parsed config, including the "root" object, so there is no need to
+  // explicitly freeze the config outside of this method
+  return ObjectFreeze(value);
+});
 
 ObjectDefineProperty(process, 'config', {
   __proto__: null,
   enumerable: true,
   configurable: true,
-  get() { return processConfig; },
-  set(value) {
-    deprecationHandler.maybeWarn();
-    processConfig = value;
-  }
+  value: processConfig,
 });
 
 require('internal/worker/js_transferable').setup();

--- a/test/abort/test-abort-fatal-error.js
+++ b/test/abort/test-abort-fatal-error.js
@@ -28,7 +28,7 @@ const assert = require('assert');
 const exec = require('child_process').exec;
 
 let cmdline = `ulimit -c 0; ${process.execPath}`;
-cmdline += ' --max-old-space-size=4 --max-semi-space-size=1';
+cmdline += ' --max-old-space-size=16 --max-semi-space-size=4';
 cmdline += ' -e "a = []; for (i = 0; i < 1e9; i++) { a.push({}) }"';
 
 exec(cmdline, function(err, stdout, stderr) {

--- a/test/fixtures/overwrite-config-preload-module.js
+++ b/test/fixtures/overwrite-config-preload-module.js
@@ -2,4 +2,5 @@
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
+delete process.config;
 process.config = {};

--- a/test/parallel/test-process-config.js
+++ b/test/parallel/test-process-config.js
@@ -36,6 +36,9 @@ assert(Object.hasOwn(process, 'config'));
 // Ensure that `process.config` is an Object.
 assert.strictEqual(Object(process.config), process.config);
 
+// Ensure that you can't change config values
+assert.throws(() => { process.config.variables = 42; }, TypeError);
+
 const configPath = path.resolve(__dirname, '..', '..', 'config.gypi');
 
 if (!fs.existsSync(configPath)) {


### PR DESCRIPTION
Small clean up for the `process.config`. This part of the code already went through one major release cycle so it should be okay to remove. There were two suggested approaches to this, I decided to go with making the whole config read only as this feel a bit more performant than parsing it every time on access.

/cc @jasnell 

Fixes: https://github.com/nodejs/node/issues/43581

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
