### PR TITLE
build,test: increase stack size limit on Windows

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -172,6 +172,12 @@
           'RandomizedBaseAddress': 2, # enable ASLR
           'DataExecutionPrevention': 2, # enable DEP
           'AllowIsolation': 'true',
+          # By default, the MSVC linker only reserves 1 MiB of stack memory for
+          # each thread, whereas other platforms typically allow much larger
+          # stack memory sections. We raise the limit to make it more consistent
+          # across platforms and to support the few use cases that require large
+          # amounts of stack memory, without having to modify the node binary.
+          'StackReserveSize': 0x800000,
         },
       },
 

--- a/test/parallel/test-stack-size-limit.js
+++ b/test/parallel/test-stack-size-limit.js
@@ -1,0 +1,26 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+// The default --stack-size is 984, which is below Windows' default stack size
+// limit of 1 MiB. However, even a slight increase would cause node to exceed
+// the 1 MiB limit and thus to crash with the exit code STATUS_STACK_OVERFLOW.
+// Newer versions of Node.js allow the stack size to grow to up to 8 MiB, which
+// better aligns with default limits on other platforms and which is commonly
+// used for browsers on Windows.
+// See https://github.com/nodejs/node/issues/43630.
+
+const { status, signal, stderr } = spawnSync(process.execPath, [
+  '--stack-size=2000',
+  '-e',
+  '(function explode() { return explode(); })()',
+], {
+  encoding: 'utf8'
+});
+
+assert.strictEqual(status, 1);
+assert.strictEqual(signal, null);
+assert.match(stderr, /Maximum call stack size exceeded/);


### PR DESCRIPTION
Increase the virtual stack space available to each thread from 1 MiB to 8 MiB.

Fixes: https://github.com/nodejs/node/issues/43630

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
