### PR TITLE
cluster, net: fix listen pipe with readable and writable in cluster

### DIFF
--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -15,7 +15,7 @@ const { constants } = internalBinding('tcp_wrap');
 
 module.exports = RoundRobinHandle;
 
-function RoundRobinHandle(key, address, { port, fd, flags, backlog }) {
+function RoundRobinHandle(key, address, { port, fd, flags, backlog, readableAll, writableAll }) {
   this.key = key;
   this.all = new SafeMap();
   this.free = new SafeMap();
@@ -34,8 +34,12 @@ function RoundRobinHandle(key, address, { port, fd, flags, backlog }) {
       backlog,
     });
   } else
-    this.server.listen(address, backlog);  // UNIX socket path.
-
+    this.server.listen({
+      path: address,
+      backlog,
+      readableAll,
+      writableAll,
+    });  // UNIX socket path.
   this.server.once('listening', () => {
     this.handle = this.server._handle;
     this.handle.onconnection = (err, handle) => this.distribute(err, handle);

--- a/lib/net.js
+++ b/lib/net.js
@@ -1467,7 +1467,7 @@ function emitListeningNT(self) {
 
 
 function listenInCluster(server, address, port, addressType,
-                         backlog, fd, exclusive, flags) {
+                         backlog, fd, exclusive, flags, options) {
   exclusive = !!exclusive;
 
   if (cluster === undefined) cluster = require('cluster');
@@ -1487,8 +1487,8 @@ function listenInCluster(server, address, port, addressType,
     fd: fd,
     flags,
     backlog,
+    ...options,
   };
-
   // Get the primary's server handle, and listen on it
   cluster._getServer(server, serverQuery, listenOnPrimaryHandle);
 
@@ -1575,8 +1575,18 @@ Server.prototype.listen = function(...args) {
   if (options.path && isPipeName(options.path)) {
     const pipeName = this._pipeName = options.path;
     backlog = options.backlog || backlogFromArgs;
-    listenInCluster(this, pipeName, -1, -1,
-                    backlog, undefined, options.exclusive);
+    listenInCluster(this,
+                    pipeName,
+                    -1,
+                    -1,
+                    backlog,
+                    undefined,
+                    options.exclusive,
+                    undefined,
+                    {
+                      readableAll: options.readableAll,
+                      writableAll: options.writableAll,
+                    });
 
     if (!this._handle) {
       // Failed and an error shall be emitted in the next tick.

--- a/test/parallel/test-cluster-listen-pipe-readable-writable.js
+++ b/test/parallel/test-cluster-listen-pipe-readable-writable.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+
+if (common.isWindows) {
+  common.skip('skip on Windows');
+  return;
+}
+
+const assert = require('assert');
+const cluster = require('cluster');
+const net = require('net');
+const fs = require('fs');
+
+if (cluster.isPrimary) {
+  cluster.fork();
+} else {
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
+  const server = net.createServer().listen({
+    path: common.PIPE,
+    readableAll: true,
+    writableAll: true,
+  }, common.mustCall(() => {
+    const stat = fs.statSync(common.PIPE);
+    assert.strictEqual(stat.mode & 0o777, 0o777);
+    server.close();
+    process.disconnect();
+  }));
+}


### PR DESCRIPTION
fix listen pipe with readable and writable in cluster.

The bug can be triggered by code as follow.

```js
const cluster = require('cluster');
const net = require('net');
const { unlinkSync } = require('fs');

if (cluster.isPrimary) {
    cluster.fork();
} else {
    try {
        unlinkSync('test.sock');
    } catch(e) {}
    net.createServer(() => {}).listen({
        path: 'test.sock',
        readableAll: true,
        writableAll: true,
    });
}
```
The permissions of `test.sock` is `srwxr-xr-x` instead of `srwxrwxrwx` .

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Affected subsystem: cluster, net