### PR TITLE
assert: callTracker throw a specific error message when possible

### DIFF
--- a/lib/internal/assert/calltracker.js
+++ b/lib/internal/assert/calltracker.js
@@ -88,12 +88,17 @@ class CallTracker {
 
   verify() {
     const errors = this.report();
-    if (errors.length > 0) {
-      throw new AssertionError({
-        message: 'Function(s) were not called the expected number of times',
-        details: errors,
-      });
+    if (!errors.length) {
+      return;
     }
+    let message = 'Function(s) were not called the expected number of times';
+    if (errors.length === 1) {
+      message = errors[0].message;
+    }
+    throw new AssertionError({
+      message,
+      details: errors,
+    });
   }
 }
 

--- a/lib/internal/assert/calltracker.js
+++ b/lib/internal/assert/calltracker.js
@@ -88,13 +88,12 @@ class CallTracker {
 
   verify() {
     const errors = this.report();
-    if (!errors.length) {
+    if (errors.length === 0) {
       return;
     }
-    let message = 'Function(s) were not called the expected number of times';
-    if (errors.length === 1) {
-      message = errors[0].message;
-    }
+    const message = errors.length === 1 ?
+      errors[0].message :
+      'Functions were not called the expected number of times';
     throw new AssertionError({
       message,
       details: errors,

--- a/test/parallel/test-assert-calltracker-verify.js
+++ b/test/parallel/test-assert-calltracker-verify.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 
 const tracker = new assert.CallTracker();
 
-const generic_msg = 'Function(s) were not called the expected number of times';
+const generic_msg = 'Functions were not called the expected number of times';
 
 function foo() {}
 

--- a/test/parallel/test-assert-calltracker-verify.js
+++ b/test/parallel/test-assert-calltracker-verify.js
@@ -6,27 +6,42 @@ const assert = require('assert');
 
 const tracker = new assert.CallTracker();
 
-const msg = 'Function(s) were not called the expected number of times';
+const generic_msg = 'Function(s) were not called the expected number of times';
 
 function foo() {}
 
-const callsfoo = tracker.calls(foo, 1);
+function bar() {}
 
-// Expects an error as callsfoo() was called less than one time.
+const callsfoo = tracker.calls(foo, 1);
+const callsbar = tracker.calls(bar, 1);
+
+// Expects an error as callsfoo() and callsbar() were called less than one time.
 assert.throws(
   () => tracker.verify(),
-  { message: msg }
+  { message: generic_msg }
 );
 
 callsfoo();
 
-// Will throw an error if callsfoo() isn't called exactly once.
-tracker.verify();
+// Expects an error as callsbar() was called less than one time.
+assert.throws(
+  () => tracker.verify(),
+  { message: 'Expected the bar function to be executed 1 time(s) but was executed 0 time(s).' }
+);
 
 callsfoo();
 
-// Expects an error as callsfoo() was called more than once.
+// Expects an error as callsfoo() was called more than once and callsbar() was called less than one time.
 assert.throws(
   () => tracker.verify(),
-  { message: msg }
+  { message: generic_msg }
+);
+
+callsbar();
+
+
+// Expects an error as callsfoo() was called more than once
+assert.throws(
+  () => tracker.verify(),
+  { message: 'Expected the foo function to be executed 1 time(s) but was executed 2 time(s).' }
 );

--- a/test/parallel/test-assert-calltracker-verify.js
+++ b/test/parallel/test-assert-calltracker-verify.js
@@ -28,16 +28,22 @@ assert.throws(
   () => tracker.verify(),
   { message: 'Expected the bar function to be executed 1 time(s) but was executed 0 time(s).' }
 );
+callsbar();
+
+// Will throw an error if callsfoo() and callsbar isn't called exactly once.
+tracker.verify();
+
+const callsfoobar = tracker.calls(foo, 1);
 
 callsfoo();
 
-// Expects an error as callsfoo() was called more than once and callsbar() was called less than one time.
+// Expects an error as callsfoo() was called more than once and callsfoobar() was called less than one time.
 assert.throws(
   () => tracker.verify(),
   { message: generic_msg }
 );
 
-callsbar();
+callsfoobar();
 
 
 // Expects an error as callsfoo() was called more than once


### PR DESCRIPTION
currently `callTracker.verify()` throws a very generic error message when a tracked function isn't called the expected amount of times.

this change propeses to throw a more specific message in case there was a single-tracked function that did not match the expected call counts