### PR TITLE
util: add `AggregateError.prototype.errors` to inspect output

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1294,6 +1294,11 @@ function formatError(err, constructor, tag, ctx, keys) {
     keys.push('cause');
   }
 
+  // Print errors aggregated into AggregateError
+  if (err.errors && (keys.length === 0 || !keys.includes('errors'))) {
+    keys.push('errors');
+  }
+
   stack = improveStack(stack, constructor, name, tag);
 
   // Ignore the error message if it's contained in the stack.

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1295,7 +1295,8 @@ function formatError(err, constructor, tag, ctx, keys) {
   }
 
   // Print errors aggregated into AggregateError
-  if (err.errors && (keys.length === 0 || !keys.includes('errors'))) {
+  if (ArrayIsArray(err.errors) &&
+      (keys.length === 0 || !keys.includes('errors'))) {
     keys.push('errors');
   }
 

--- a/test/message/error_aggregateTwoErrors.out
+++ b/test/message/error_aggregateTwoErrors.out
@@ -9,7 +9,29 @@ AggregateError: original
     at Module._load (node:internal/modules/cjs/loader:*:*)
     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:*:*)
     at node:internal/main/run_main_module:*:* {
-  code: 'ERR0'
+  code: 'ERR0',
+  [errors]: [
+    Error: original
+        at Object.<anonymous> (*test*message*error_aggregateTwoErrors.js:*:*)
+        at Module._compile (node:internal/modules/cjs/loader:*:*)
+        at Module._extensions..js (node:internal/modules/cjs/loader:*:*)
+        at Module.load (node:internal/modules/cjs/loader:*:*)
+        at Module._load (node:internal/modules/cjs/loader:*:*)
+        at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:*:*)
+        at node:internal/main/run_main_module:*:* {
+      code: 'ERR0'
+    },
+    Error: second error
+        at Object.<anonymous> (*test*message*error_aggregateTwoErrors.js:*:*)
+        at Module._compile (node:internal/modules/cjs/loader:*:*)
+        at Module._extensions..js (node:internal/modules/cjs/loader:*:*)
+        at Module.load (node:internal/modules/cjs/loader:*:*)
+        at Module._load (node:internal/modules/cjs/loader:*:*)
+        at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:*:*)
+        at node:internal/main/run_main_module:*:* {
+      code: 'ERR1'
+    }
+  ]
 }
 
 Node.js *


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/43645

Old:
```js
> (()=>{throw new AggregateError([new TypeError('blep'), new RangeError('blop')],'gwak')})()
Uncaught AggregateError: gwak
    at REPL1:1:13
```
New:
```js
> (()=>{throw new AggregateError([new TypeError('blep'), new RangeError('blop')],'gwak')})()
Uncaught AggregateError: gwak
    at REPL1:1:13 {
  [errors]: [
    TypeError: blep
        at REPL1:1:33
        at REPL1:1:89
        at Script.runInThisContext (node:vm:130:12)
        at REPLServer.defaultEval (node:repl:572:29)
        at bound (node:domain:426:15)
        at REPLServer.runBound [as eval] (node:domain:437:12)
        at REPLServer.onLine (node:repl:902:10)
        at REPLServer.emit (node:events:549:35)
        at REPLServer.emit (node:domain:482:12)
        at [_onLine] [as _onLine] (node:internal/readline/interface:425:12),
    RangeError: blop
        at REPL1:1:56
        at REPL1:1:89
        at Script.runInThisContext (node:vm:130:12)
        at REPLServer.defaultEval (node:repl:572:29)
        at bound (node:domain:426:15)
        at REPLServer.runBound [as eval] (node:domain:437:12)
        at REPLServer.onLine (node:repl:902:10)
        at REPLServer.emit (node:events:549:35)
        at REPLServer.emit (node:domain:482:12)
        at [_onLine] [as _onLine] (node:internal/readline/interface:425:12)
  ]
}
```