### PR TITLE
stream: fix Transform with hwm 0 regression

### DIFF
--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -165,12 +165,12 @@ Transform.prototype._write = function(chunk, encoding, callback) {
       wState.ended || // Backwards compat.
       length === rState.length || // Backwards compat.
       rState.length < rState.highWaterMark ||
-      rState.highWaterMark === 0 ||
       rState.length === 0
     ) {
       callback();
     } else {
       this[kCallback] = callback;
+      rState.needReadable = true; // Always call _read() on the next read() call
     }
   });
 };

--- a/test/parallel/test-stream-transform-hwm0.js
+++ b/test/parallel/test-stream-transform-hwm0.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Transform } = require('stream');
+
+const t = new Transform({
+  objectMode: true, highWaterMark: 0,
+  transform(chunk, enc, callback) {
+    process.nextTick(() => callback(null, chunk, enc));
+  }
+});
+
+assert.strictEqual(t.write(1), false);
+t.on('drain', common.mustCall(() => {
+  assert.strictEqual(t.write(2), false);
+  t.end();
+}));
+
+t.once('readable', common.mustCall(() => {
+  assert.strictEqual(t.read(), 1);
+  setImmediate(common.mustCall(() => {
+    assert.strictEqual(t.read(), null);
+    t.once('readable', common.mustCall(() => {
+      assert.strictEqual(t.read(), 2);
+    }));
+  }));
+}));


### PR DESCRIPTION
This undoes a patch from #40947, and reworks it to continue handling backpressure when `highWaterMark: 0`, as described in https://github.com/nodejs/node/issues/42457#issuecomment-1172157557.

The new test fails on node releases with the patch from #40947, like v16.4, and passes on node v14 and node v16.3 from before it was introduced. It is also designed, so that it will fail if `highWaterMark: 1` is set instead.