### PR TITLE
cluster: fix fd leak

### DIFF
--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -210,6 +210,8 @@ function onconnection(message, handle) {
 
   if (accepted)
     server.onconnection(0, handle);
+  else
+    handle.close();
 }
 
 function send(message, cb) {

--- a/test/parallel/test-cluster-worker-handle-close.js
+++ b/test/parallel/test-cluster-worker-handle-close.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const cluster = require('cluster');
+const net = require('net');
+
+if (cluster.isPrimary) {
+  cluster.schedulingPolicy = cluster.SCHED_RR;
+  cluster.fork();
+} else {
+  const server = net.createServer(common.mustNotCall());
+  server.listen(0, common.mustCall(() => {
+    net.connect(server.address().port);
+  }));
+  process.prependListener('internalMessage', common.mustCallAtLeast((message, handle) => {
+    if (message.act !== 'newconn') {
+      return;
+    }
+    // Make the worker drops the connection, see `rr` and `onconnection` in child.js
+    server.close();
+    const close = handle.close;
+    handle.close = common.mustCall(() => {
+      close.call(handle, common.mustCall(() => {
+        process.exit();
+      }));
+    });
+  }));
+}


### PR DESCRIPTION
The worker should close the handle when the connections is not accepted.
cc @cjihrig

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Affected subsystem: cluster