### PR TITLE
crypto: pass all WebCryptoAPI WPTs

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3541,6 +3541,9 @@ and it will be impossible to extract the private key from the returned object.
 <!-- YAML
 added: v11.6.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43656
+    description: The key can now be zero-length.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: The key can also be an ArrayBuffer or string. The encoding
@@ -4208,6 +4211,9 @@ web-compatible code use [`crypto.webcrypto.getRandomValues()`][] instead.
 <!-- YAML
 added: v15.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43656
+    description: The input keying material can now be zero-length.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678
     description: Passing an invalid callback to the `callback` argument
@@ -4267,6 +4273,10 @@ hkdf('sha512', 'key', 'salt', 'info', 64, (err, derivedKey) => {
 
 <!-- YAML
 added: v15.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43656
+    description: The input keying material can now be zero-length.
 -->
 
 * `digest` {string} The digest algorithm to use.

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -4217,7 +4217,7 @@ changes:
 
 * `digest` {string} The digest algorithm to use.
 * `ikm` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject} The input
-  keying material. It must be at least one byte in length.
+  keying material. Must be provided but can be zero-length.
 * `salt` {string|ArrayBuffer|Buffer|TypedArray|DataView} The salt value. Must
   be provided but can be zero-length.
 * `info` {string|ArrayBuffer|Buffer|TypedArray|DataView} Additional info value.
@@ -4271,7 +4271,7 @@ added: v15.0.0
 
 * `digest` {string} The digest algorithm to use.
 * `ikm` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject} The input
-  keying material. It must be at least one byte in length.
+  keying material. Must be provided but can be zero-length.
 * `salt` {string|ArrayBuffer|Buffer|TypedArray|DataView} The salt value. Must
   be provided but can be zero-length.
 * `info` {string|ArrayBuffer|Buffer|TypedArray|DataView} Additional info value.

--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -60,11 +60,6 @@ const {
   generateKey,
 } = require('internal/crypto/keygen');
 
-const {
-  validateInteger,
-  validateOneOf,
-} = require('internal/validators');
-
 const kMaxCounterLength = 128;
 const kTagLengths = [32, 64, 96, 104, 112, 120, 128];
 
@@ -227,8 +222,11 @@ function aesCipher(mode, key, data, algorithm) {
 
 async function aesGenerateKey(algorithm, extractable, keyUsages) {
   const { name, length } = algorithm;
-  validateInteger(length, 'algorithm.length');
-  validateOneOf(length, 'algorithm.length', kAesKeyLengths);
+  if (!ArrayPrototypeIncludes(kAesKeyLengths, length)) {
+    throw lazyDOMException(
+      'AES key length must be 128, 192, or 256 bits',
+      'OperationError');
+  }
 
   const checkUsages = ['wrapKey', 'unwrapKey'];
   if (name !== 'AES-KW')

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  ArrayPrototypeIncludes,
   ObjectKeys,
   Promise,
   SafeSet,
@@ -16,11 +17,6 @@ const {
   kSignJobModeVerify,
   kSigEncP1363,
 } = internalBinding('crypto');
-
-const {
-  validateOneOf,
-  validateString,
-} = require('internal/validators');
 
 const {
   codes: {
@@ -88,11 +84,12 @@ function createECPublicKeyRaw(namedCurve, keyData) {
 
 async function ecGenerateKey(algorithm, extractable, keyUsages) {
   const { name, namedCurve } = algorithm;
-  validateString(namedCurve, 'algorithm.namedCurve');
-  validateOneOf(
-    namedCurve,
-    'algorithm.namedCurve',
-    ObjectKeys(kNamedCurveAliases));
+
+  if (!ArrayPrototypeIncludes(ObjectKeys(kNamedCurveAliases), namedCurve)) {
+    throw lazyDOMException(
+      'Unrecognized namedCurve',
+      'NotSupportedError');
+  }
 
   const usageSet = new SafeSet(keyUsages);
   switch (name) {
@@ -168,11 +165,13 @@ async function ecImportKey(
   keyUsages) {
 
   const { name, namedCurve } = algorithm;
-  validateString(namedCurve, 'algorithm.namedCurve');
-  validateOneOf(
-    namedCurve,
-    'algorithm.namedCurve',
-    ObjectKeys(kNamedCurveAliases));
+
+  if (!ArrayPrototypeIncludes(ObjectKeys(kNamedCurveAliases), namedCurve)) {
+    throw lazyDOMException(
+      'Unrecognized namedCurve',
+      'NotSupportedError');
+  }
+
   let keyObject;
   const usagesSet = new SafeSet(keyUsages);
   switch (format) {

--- a/lib/internal/crypto/hkdf.js
+++ b/lib/internal/crypto/hkdf.js
@@ -142,7 +142,6 @@ function hkdfSync(hash, key, salt, info, length) {
 }
 
 async function hkdfDeriveBits(algorithm, baseKey, length) {
-  validateUint32(length, 'length');
   const { hash } = algorithm;
   const salt = getArrayBufferOrView(algorithm.salt, 'algorithm.salt');
   const info = getArrayBufferOrView(algorithm.info, 'algorithm.info');
@@ -153,6 +152,9 @@ async function hkdfDeriveBits(algorithm, baseKey, length) {
   if (length !== undefined) {
     if (length === 0)
       throw lazyDOMException('length cannot be zero', 'OperationError');
+    if (length === null)
+      throw lazyDOMException('length cannot be null', 'OperationError');
+    validateUint32(length, 'length');
     if (length % 8) {
       throw lazyDOMException(
         'length must be a multiple of 8',

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -38,7 +38,6 @@ const {
     ERR_ILLEGAL_CONSTRUCTOR,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
-    ERR_OUT_OF_RANGE,
   }
 } = require('internal/errors');
 
@@ -588,8 +587,6 @@ function prepareSecretKey(key, encoding, bufferOnly = false) {
 
 function createSecretKey(key, encoding) {
   key = prepareSecretKey(key, encoding, true);
-  if (key.byteLength === 0)
-    throw new ERR_OUT_OF_RANGE('key.byteLength', '> 0', key.byteLength);
   const handle = new KeyObjectHandle();
   handle.init(kKeyTypeSecret, key);
   return new SecretKeyObject(handle);

--- a/lib/internal/crypto/mac.js
+++ b/lib/internal/crypto/mac.js
@@ -100,9 +100,6 @@ async function hmacImportKey(
     case 'raw': {
       const checkLength = keyData.byteLength * 8;
 
-      if (checkLength === 0 || algorithm.length === 0)
-        throw lazyDOMException('Zero-length key is not supported', 'DataError');
-
       // The Web Crypto spec allows for key lengths that are not multiples of
       // 8. We don't. Our check here is stricter than that defined by the spec
       // in that we require that algorithm.length match keyData.length * 8 if

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -98,13 +98,16 @@ function check(password, salt, iterations, keylen, digest) {
 }
 
 async function pbkdf2DeriveBits(algorithm, baseKey, length) {
-  validateUint32(length, 'length');
   const { iterations } = algorithm;
   let { hash } = algorithm;
   const salt = getArrayBufferOrView(algorithm.salt, 'algorithm.salt');
   if (hash === undefined)
     throw new ERR_MISSING_OPTION('algorithm.hash');
-  validateInteger(iterations, 'algorithm.iterations', 1);
+  validateInteger(iterations, 'algorithm.iterations');
+  if (iterations === 0)
+    throw lazyDOMException(
+      'iterations cannot be zero',
+      'OperationError');
 
   hash = normalizeHashName(hash.name);
 
@@ -114,6 +117,9 @@ async function pbkdf2DeriveBits(algorithm, baseKey, length) {
   if (length !== undefined) {
     if (length === 0)
       throw lazyDOMException('length cannot be zero', 'OperationError');
+    if (length === null)
+      throw lazyDOMException('length cannot be null', 'OperationError');
+    validateUint32(length, 'length');
     if (length % 8) {
       throw lazyDOMException(
         'length must be a multiple of 8',

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -278,7 +278,11 @@ const validateByteSource = hideStackFrames((val, name) => {
 });
 
 function onDone(resolve, reject, err, result) {
-  if (err) return reject(err);
+  if (err) {
+    return reject(lazyDOMException(
+      'The operation failed for an operation-specific reason',
+      'OperationError'));
+  }
   resolve(result);
 }
 

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -494,9 +494,6 @@ async function importGenericSecretKey(
 
       const checkLength = keyData.byteLength * 8;
 
-      if (checkLength === 0 || length === 0)
-        throw lazyDOMException('Zero-length key is not supported', 'DataError');
-
       // The Web Crypto spec allows for key lengths that are not multiples of
       // 8. We don't. Our check here is stricter than that defined by the spec
       // in that we require that algorithm.length match keyData.length * 8 if

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -96,7 +96,7 @@ Maybe<bool> HKDFTraits::AdditionalConfig(
   return Just(true);
 }
 
-char salt[EVP_MAX_KEY_LENGTH];
+char salt[EVP_MAX_KEY_LENGTH] = {0};
 
 bool HKDFTraits::DeriveBits(
     Environment* env,
@@ -136,7 +136,7 @@ bool HKDFTraits::DeriveBits(
         return false;
       }
     } else {
-      if (HMAC(params.digest, salt, len, nullptr, 0, temp_key, &len) ==
+      if (HMAC(params.digest, salt, sizeof(salt), nullptr, 0, temp_key, &len) ==
           nullptr) {
         return false;
       }

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -96,6 +96,8 @@ Maybe<bool> HKDFTraits::AdditionalConfig(
   return Just(true);
 }
 
+char salt[EVP_MAX_KEY_LENGTH];
+
 bool HKDFTraits::DeriveBits(
     Environment* env,
     const HKDFConfig& params,
@@ -134,13 +136,8 @@ bool HKDFTraits::DeriveBits(
         return false;
       }
     } else {
-      if (HMAC(params.digest,
-               new char[len]{},
-               len,
-               nullptr,
-               0,
-               temp_key,
-               &len) == nullptr) {
+      if (HMAC(params.digest, salt, len, nullptr, 0, temp_key, &len) ==
+          nullptr) {
         return false;
       }
     }

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -109,7 +109,7 @@ bool HKDFTraits::DeriveBits(
     return false;
   }
 
-  // TODO: Once support for OpenSSL 1.1.1 is dropped the whole
+  // TODO(panva): Once support for OpenSSL 1.1.1 is dropped the whole
   // of HKDFTraits::DeriveBits can be refactored to use
   // EVP_KDF which does handle zero length key.
   if (params.key->GetSymmetricKeySize() != 0) {

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -123,7 +123,7 @@ bool HKDFTraits::DeriveBits(
   } else {
     unsigned char temp_key[EVP_MAX_MD_SIZE];
     unsigned int len = sizeof(temp_key);
-    if (params.salt.size()) {
+    if (params.salt.size() != 0) {
       if (HMAC(params.digest,
                params.salt.data(),
                params.salt.size(),
@@ -134,9 +134,14 @@ bool HKDFTraits::DeriveBits(
         return false;
       }
     } else {
-      char salt[EVP_MAX_KEY_LENGTH] = {0};
-      if (HMAC(params.digest, salt, sizeof(salt), nullptr, 0, temp_key, &len) ==
-          nullptr) {
+      char salt[EVP_MAX_MD_SIZE] = {0};
+      if (HMAC(params.digest,
+               salt,
+               EVP_MD_size(params.digest),
+               nullptr,
+               0,
+               temp_key,
+               &len) == nullptr) {
         return false;
       }
     }

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -96,8 +96,6 @@ Maybe<bool> HKDFTraits::AdditionalConfig(
   return Just(true);
 }
 
-char salt[EVP_MAX_KEY_LENGTH] = {0};
-
 bool HKDFTraits::DeriveBits(
     Environment* env,
     const HKDFConfig& params,
@@ -136,6 +134,7 @@ bool HKDFTraits::DeriveBits(
         return false;
       }
     } else {
+      char salt[EVP_MAX_KEY_LENGTH] = {0};
       if (HMAC(params.digest, salt, sizeof(salt), nullptr, 0, temp_key, &len) ==
           nullptr) {
         return false;

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -109,6 +109,9 @@ bool HKDFTraits::DeriveBits(
     return false;
   }
 
+  // TODO: Once support for OpenSSL 1.1.1 is dropped the whole
+  // of HKDFTraits::DeriveBits can be refactored to use
+  // EVP_KDF which does handle zero length key.
   if (params.key->GetSymmetricKeySize() != 0) {
     if (!EVP_PKEY_CTX_hkdf_mode(ctx.get(),
                                 EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND) ||
@@ -121,6 +124,7 @@ bool HKDFTraits::DeriveBits(
       return false;
     }
   } else {
+    // Workaround for EVP_PKEY_derive HKDF not handling zero length keys.
     unsigned char temp_key[EVP_MAX_MD_SIZE];
     unsigned int len = sizeof(temp_key);
     if (params.salt.size() != 0) {

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -103,18 +103,41 @@ bool HKDFTraits::DeriveBits(
   EVPKeyCtxPointer ctx =
       EVPKeyCtxPointer(EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, nullptr));
   if (!ctx || !EVP_PKEY_derive_init(ctx.get()) ||
-      !EVP_PKEY_CTX_hkdf_mode(ctx.get(),
-                              EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND) ||
       !EVP_PKEY_CTX_set_hkdf_md(ctx.get(), params.digest) ||
-      !EVP_PKEY_CTX_set1_hkdf_salt(
-          ctx.get(), params.salt.data<unsigned char>(), params.salt.size()) ||
-      !EVP_PKEY_CTX_set1_hkdf_key(
-          ctx.get(),
-          reinterpret_cast<const unsigned char*>(params.key->GetSymmetricKey()),
-          params.key->GetSymmetricKeySize()) ||
       !EVP_PKEY_CTX_add1_hkdf_info(
           ctx.get(), params.info.data<unsigned char>(), params.info.size())) {
     return false;
+  }
+
+  if (params.key->GetSymmetricKeySize() != 0) {
+    if (!EVP_PKEY_CTX_hkdf_mode(ctx.get(),
+                                EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND) ||
+        !EVP_PKEY_CTX_set1_hkdf_salt(
+            ctx.get(), params.salt.data<unsigned char>(), params.salt.size()) ||
+        !EVP_PKEY_CTX_set1_hkdf_key(ctx.get(),
+                                    reinterpret_cast<const unsigned char*>(
+                                        params.key->GetSymmetricKey()),
+                                    params.key->GetSymmetricKeySize())) {
+      return false;
+    }
+  } else {
+    unsigned int len = EVP_MD_size(params.digest);
+    uint8_t tempKey[len];  // NOLINT(runtime/arrays)
+    if (params.salt.size()) {
+      HMAC(params.digest,
+           params.salt.data(),
+           params.salt.size(),
+           nullptr,
+           0,
+           tempKey,
+           &len);
+    } else {
+      HMAC(params.digest, new char[len]{}, len, nullptr, 0, tempKey, &len);
+    }
+    if (!EVP_PKEY_CTX_hkdf_mode(ctx.get(), EVP_PKEY_HKDEF_MODE_EXPAND_ONLY) ||
+        !EVP_PKEY_CTX_set1_hkdf_key(ctx.get(), tempKey, len)) {
+      return false;
+    }
   }
 
   size_t length = params.length;

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -125,24 +125,24 @@ bool HKDFTraits::DeriveBits(
     unsigned int len = sizeof(temp_key);
     if (params.salt.size()) {
       if (HMAC(params.digest,
-           params.salt.data(),
-           params.salt.size(),
-           nullptr,
-           0,
-           temp_key,
-           &len) == nullptr) {
-             return false;
-           }
+               params.salt.data(),
+               params.salt.size(),
+               nullptr,
+               0,
+               temp_key,
+               &len) == nullptr) {
+        return false;
+      }
     } else {
       if (HMAC(params.digest,
-           new char[len]{},
-           len,
-           nullptr,
-           0,
-           temp_key,
-           &len) == nullptr) {
-             return false;
-           }
+               new char[len]{},
+               len,
+               nullptr,
+               0,
+               temp_key,
+               &len) == nullptr) {
+        return false;
+      }
     }
     if (!EVP_PKEY_CTX_hkdf_mode(ctx.get(), EVP_PKEY_HKDEF_MODE_EXPAND_ONLY) ||
         !EVP_PKEY_CTX_set1_hkdf_key(ctx.get(), temp_key, len)) {

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -121,21 +121,31 @@ bool HKDFTraits::DeriveBits(
       return false;
     }
   } else {
-    unsigned int len = EVP_MD_size(params.digest);
-    uint8_t tempKey[len];  // NOLINT(runtime/arrays)
+    unsigned char temp_key[EVP_MAX_MD_SIZE];
+    unsigned int len = sizeof(temp_key);
     if (params.salt.size()) {
-      HMAC(params.digest,
+      if (HMAC(params.digest,
            params.salt.data(),
            params.salt.size(),
            nullptr,
            0,
-           tempKey,
-           &len);
+           temp_key,
+           &len) == nullptr) {
+             return false;
+           }
     } else {
-      HMAC(params.digest, new char[len]{}, len, nullptr, 0, tempKey, &len);
+      if (HMAC(params.digest,
+           new char[len]{},
+           len,
+           nullptr,
+           0,
+           temp_key,
+           &len) == nullptr) {
+             return false;
+           }
     }
     if (!EVP_PKEY_CTX_hkdf_mode(ctx.get(), EVP_PKEY_HKDEF_MODE_EXPAND_ONLY) ||
-        !EVP_PKEY_CTX_set1_hkdf_key(ctx.get(), tempKey, len)) {
+        !EVP_PKEY_CTX_set1_hkdf_key(ctx.get(), temp_key, len)) {
       return false;
     }
   }

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -871,7 +871,6 @@ void KeyObjectData::MemoryInfo(MemoryTracker* tracker) const {
 }
 
 std::shared_ptr<KeyObjectData> KeyObjectData::CreateSecret(ByteSource key) {
-  CHECK(key);
   return std::shared_ptr<KeyObjectData>(new KeyObjectData(std::move(key)));
 }
 

--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -368,7 +368,7 @@ class WPTRunner {
 
   // TODO(joyeecheung): work with the upstream to port more tests in .html
   // to .js.
-  runJsTests() {
+  async runJsTests() {
     let queue = [];
 
     // If the tests are run as `node test/wpt/test-something.js subset.any.js`,
@@ -459,6 +459,12 @@ class WPTRunner {
         );
         this.inProgress.delete(testFileName);
       });
+
+      await new Promise((resolve) => {
+        worker.on('exit', () => {
+          resolve()
+        })
+      })
     }
 
     process.on('exit', () => {

--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -462,9 +462,9 @@ class WPTRunner {
 
       await new Promise((resolve) => {
         worker.on('exit', () => {
-          resolve()
-        })
-      })
+          resolve();
+        });
+      });
     }
 
     process.on('exit', () => {

--- a/test/fixtures/wpt/README.md
+++ b/test/fixtures/wpt/README.md
@@ -29,7 +29,7 @@ Last update:
 - user-timing: https://github.com/web-platform-tests/wpt/tree/df24fb604e/user-timing
 - wasm/jsapi: https://github.com/web-platform-tests/wpt/tree/1dd414c796/wasm/jsapi
 - wasm/webapi: https://github.com/web-platform-tests/wpt/tree/fd1b23eeaa/wasm/webapi
-- WebCryptoAPI: https://github.com/web-platform-tests/wpt/tree/cdd0f03df4/WebCryptoAPI
+- WebCryptoAPI: https://github.com/web-platform-tests/wpt/tree/edca84af42/WebCryptoAPI
 - webidl/ecmascript-binding/es-exceptions: https://github.com/web-platform-tests/wpt/tree/a370aad338/webidl/ecmascript-binding/es-exceptions
 
 [Web Platform Tests]: https://github.com/web-platform-tests/wpt

--- a/test/fixtures/wpt/WebCryptoAPI/algorithm-discards-context.https.window.js
+++ b/test/fixtures/wpt/WebCryptoAPI/algorithm-discards-context.https.window.js
@@ -1,0 +1,213 @@
+// META: title=WebCryptoAPI: Properties discard the context in algorithm normalization
+
+let nextTest = 0;
+let tests = {};
+function closeChild(testId) {
+  if (tests[testId]) {
+    let {child, t} = tests[testId];
+    delete tests[testId];
+    document.body.removeChild(child);
+    t.done();
+  }
+}
+
+function runInChild(t, childScript) {
+  let testId = nextTest++;
+  const preamble = `
+let testId = ${testId};
+function closeChildOnAccess(obj, key) {
+  const oldValue = obj[key];
+  Object.defineProperty(obj, key, {get: () => {
+    top.closeChild(testId);
+    return oldValue;
+  }});
+}
+`;
+  childScript = preamble + childScript;
+
+  let child = document.createElement("iframe");
+  tests[testId] = {t, child};
+  document.body.appendChild(child);
+  let script = document.createElement("script");
+  script.textContent = childScript;
+  child.contentDocument.body.appendChild(script);
+}
+
+async_test((t) => {
+  const childScript = `
+let algorithm = {name: "AES-GCM", length: 128};
+closeChildOnAccess(algorithm, "name");
+crypto.subtle.generateKey(algorithm, true, ["encrypt", "decrypt"]);`;
+  runInChild(t, childScript);
+}, "Context is discarded in generateKey");
+
+async_test((t) => {
+  const childScript = `
+let algorithm = {name: "AES-GCM"};
+closeChildOnAccess(algorithm, "name");
+crypto.subtle.importKey("raw", new Uint8Array(16), algorithm, true,
+                        ["encrypt", "decrypt"]);`;
+  runInChild(t, childScript);
+}, "Context is discarded in importKey");
+
+async_test((t) => {
+  const childScript = `
+(async () => {
+  let key = await crypto.subtle.generateKey(
+     {name: "AES-GCM", length: 128}, true, ["encrypt", "decrypt"]);
+  let algorithm = {name: "AES-GCM", iv: new Uint8Array(12)};
+  closeChildOnAccess(algorithm, "name");
+  crypto.subtle.encrypt(algorithm, key, new Uint8Array());
+})();`;
+  runInChild(t, childScript);
+}, "Context is discarded in encrypt");
+
+async_test((t) => {
+  const childScript = `
+(async () => {
+  let key = await crypto.subtle.generateKey(
+     {name: "AES-GCM", length: 128}, true, ["encrypt", "decrypt"]);
+  let algorithm = {name: "AES-GCM", iv: new Uint8Array(12)};
+  let encrypted = await crypto.subtle.encrypt(algorithm, key, new Uint8Array());
+  closeChildOnAccess(algorithm, "name");
+  crypto.subtle.decrypt(algorithm, key, encrypted);
+})();`;
+  runInChild(t, childScript);
+}, "Context is discarded in decrypt");
+
+async_test((t) => {
+  const childScript = `
+let algorithm = {name: "SHA-256"};
+closeChildOnAccess(algorithm, "name");
+crypto.subtle.digest(algorithm, new Uint8Array());`;
+  runInChild(t, childScript);
+}, "Context is discarded in digest");
+
+async_test((t) => {
+  const childScript = `
+(async () => {
+  let key = await crypto.subtle.generateKey(
+      {name: "ECDSA", namedCurve: "P-256"}, true, ["sign", "verify"]);
+  let algorithm = {name: "ECDSA", hash: "SHA-256"};
+  closeChildOnAccess(algorithm, "name");
+  crypto.subtle.sign(algorithm, key.privateKey, new Uint8Array());
+})();`;
+  runInChild(t, childScript);
+}, "Context is discarded in sign");
+
+async_test((t) => {
+  const childScript = `
+(async () => {
+  let key = await crypto.subtle.generateKey(
+      {name: "ECDSA", namedCurve: "P-256"}, true, ["sign", "verify"]);
+  let algorithm = {name: "ECDSA", hash: "SHA-256"};
+  let data = new Uint8Array();
+  let signature = await crypto.subtle.sign(algorithm, key.privateKey, data);
+  closeChildOnAccess(algorithm, "name");
+  crypto.subtle.verify(algorithm, key.publicKey, signature, data);
+})();`;
+  runInChild(t, childScript);
+}, "Context is discarded in verify");
+
+async_test((t) => {
+  const childScript = `
+(async () => {
+  let key = await crypto.subtle.importKey(
+      "raw", new Uint8Array(16), "HKDF", false, ["deriveBits"]);
+  let algorithm = {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: new Uint8Array(),
+      info: new Uint8Array(),
+  };
+  closeChildOnAccess(algorithm, "name");
+  crypto.subtle.deriveBits(algorithm, key, 16);
+})();`;
+  runInChild(t, childScript);
+}, "Context is discarded in deriveBits");
+
+async_test((t) => {
+  const childScript = `
+(async () => {
+  let key = await crypto.subtle.importKey(
+      "raw", new Uint8Array(16), "HKDF", false, ["deriveKey"]);
+  let algorithm = {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: new Uint8Array(),
+      info: new Uint8Array(),
+  };
+  let derivedAlgorithm = {name: "AES-GCM", length: 128};
+  closeChildOnAccess(algorithm, "name");
+  crypto.subtle.deriveKey(algorithm, key, derivedAlgorithm, true,
+                          ["encrypt", "decrypt"]);
+})();`;
+  runInChild(t, childScript);
+}, "Context is discarded in deriveKey");
+
+async_test((t) => {
+  const childScript = `
+(async () => {
+  let key = await crypto.subtle.importKey(
+      "raw", new Uint8Array(16), "HKDF", false, ["deriveKey"]);
+  let algorithm = {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: new Uint8Array(),
+      info: new Uint8Array(),
+  };
+  let derivedAlgorithm = {name: "AES-GCM", length: 128};
+  closeChildOnAccess(derivedAlgorithm, "name");
+  crypto.subtle.deriveKey(algorithm, key, derivedAlgorithm, true,
+                          ["encrypt", "decrypt"]);
+})();`;
+  runInChild(t, childScript);
+}, "Context is discarded in deriveKey (2)");
+
+async_test((t) => {
+  const childScript = `
+(async () => {
+  let wrapKey = await crypto.subtle.generateKey(
+      {name: "AES-GCM", length: 128}, true, ["wrapKey", "unwrapKey"]);
+  let key = await crypto.subtle.generateKey(
+      {name: "AES-GCM", length: 128}, true, ["encrypt", "decrypt"]);
+  let wrapAlgorithm = {name: "AES-GCM", iv: new Uint8Array(12)};
+  closeChildOnAccess(wrapAlgorithm, "name");
+  crypto.subtle.wrapKey("raw", key, wrapKey, wrapAlgorithm);
+})();`;
+  runInChild(t, childScript);
+}, "Context is discarded in wrapKey");
+
+async_test((t) => {
+  const childScript = `
+(async () => {
+  let wrapKey = await crypto.subtle.generateKey(
+      {name: "AES-GCM", length: 128}, true, ["wrapKey", "unwrapKey"]);
+  let keyAlgorithm = {name: "AES-GCM", length: 128};
+  let keyUsages = ["encrypt", "decrypt"];
+  let key = await crypto.subtle.generateKey(keyAlgorithm, true, keyUsages);
+  let wrapAlgorithm = {name: "AES-GCM", iv: new Uint8Array(12)};
+  let wrapped = await crypto.subtle.wrapKey("raw", key, wrapKey, wrapAlgorithm);
+  closeChildOnAccess(wrapAlgorithm, "name");
+  crypto.subtle.unwrapKey(
+      "raw", wrapped, wrapKey, wrapAlgorithm, keyAlgorithm, true, keyUsages);
+})();`;
+  runInChild(t, childScript);
+}, "Context is discarded in unwrapKey");
+
+async_test((t) => {
+  const childScript = `
+(async () => {
+  let wrapKey = await crypto.subtle.generateKey(
+      {name: "AES-GCM", length: 128}, true, ["wrapKey", "unwrapKey"]);
+  let keyAlgorithm = {name: "AES-GCM", length: 128};
+  let keyUsages = ["encrypt", "decrypt"];
+  let key = await crypto.subtle.generateKey(keyAlgorithm, true, keyUsages);
+  let wrapAlgorithm = {name: "AES-GCM", iv: new Uint8Array(12)};
+  let wrapped = await crypto.subtle.wrapKey("raw", key, wrapKey, wrapAlgorithm);
+  closeChildOnAccess(keyAlgorithm, "name");
+  crypto.subtle.unwrapKey(
+      "raw", wrapped, wrapKey, wrapAlgorithm, keyAlgorithm, true, keyUsages);
+})();`;
+  runInChild(t, childScript);
+}, "Context is discarded in unwrapKey (2)");

--- a/test/fixtures/wpt/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.https.any.js
@@ -1,0 +1,9 @@
+// META: title=WebCryptoAPI: deriveBits() Using ECDH with CFRG Elliptic Curves
+// META: script=cfrg_curves_bits.js
+
+// Define subtests from a `promise_test` to ensure the harness does not
+// complete before the subtests are available. `explicit_done` cannot be used
+// for this purpose because the global `done` function is automatically invoked
+// by the WPT infrastructure in dedicated worker tests defined using the
+// "multi-global" pattern.
+promise_test(define_tests, 'setup - define tests');

--- a/test/fixtures/wpt/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.js
+++ b/test/fixtures/wpt/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.js
@@ -1,0 +1,245 @@
+
+function define_tests() {
+  // May want to test prefixed implementations.
+  var subtle = self.crypto.subtle;
+
+  var pkcs8 = {
+      "X25519": new Uint8Array([48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 110, 4, 34, 4, 32, 200, 131, 142, 118, 208, 87, 223, 183, 216, 201, 90, 105, 225, 56, 22, 10, 221, 99, 115, 253, 113, 164, 210, 118, 187, 86, 227, 168, 27, 100, 255, 97]),
+      "X448": new Uint8Array([48, 70, 2, 1, 0, 48, 5, 6, 3, 43, 101, 111, 4, 58, 4, 56, 88, 199, 210, 154, 62, 181, 25, 178, 157, 0, 207, 177, 145, 187, 100, 252, 109, 138, 66, 216, 241, 113, 118, 39, 43, 137, 242, 39, 45, 24, 25, 41, 92, 101, 37, 192, 130, 150, 113, 176, 82, 239, 7, 39, 83, 15, 24, 142, 49, 208, 204, 83, 191, 38, 146, 158])
+  };
+
+  var spki = {
+      "X25519": new Uint8Array([48, 42, 48, 5, 6, 3, 43, 101, 110, 3, 33, 0, 28, 242, 177, 230, 2, 46, 197, 55, 55, 30, 215, 245, 62, 84, 250, 17, 84, 216, 62, 152, 235, 100, 234, 81, 250, 229, 179, 48, 124, 254, 151, 6]),
+      "X448": new Uint8Array([48, 66, 48, 5, 6, 3, 43, 101, 111, 3, 57, 0, 182, 4, 161, 209, 165, 205, 29, 148, 38, 213, 97, 239, 99, 10, 158, 177, 108, 190, 105, 213, 185, 202, 97, 94, 220, 83, 99, 62, 251, 82, 234, 49, 230, 230, 160, 161, 219, 172, 198, 231, 108, 188, 230, 72, 45, 126, 75, 163, 213, 93, 158, 128, 39, 101, 206, 111])
+  };
+
+  var sizes = {
+      "X25519": 32,
+      "X448": 56
+  };
+
+  var derivations = {
+      "X25519": new Uint8Array([39, 104, 64, 157, 250, 185, 158, 194, 59, 140, 137, 185, 63, 245, 136, 2, 149, 247, 97, 118, 8, 143, 137, 228, 61, 254, 190, 126, 161, 149, 0, 8]),
+      "X448": new Uint8Array([240, 246, 197, 241, 127, 148, 244, 41, 30, 171, 113, 120, 134, 109, 55, 236, 137, 6, 221, 108, 81, 65, 67, 220, 133, 190, 124, 242, 141, 239, 243, 155, 114, 110, 15, 109, 207, 129, 14, 181, 148, 220, 169, 123, 72, 130, 189, 68, 196, 62, 167, 220, 103, 244, 154, 78])
+  };
+
+  return importKeys(pkcs8, spki, sizes)
+  .then(function(results) {
+      publicKeys = results.publicKeys;
+      privateKeys = results.privateKeys;
+      noDeriveBitsKeys = results.noDeriveBitsKeys;
+
+      Object.keys(sizes).forEach(function(algorithmName) {
+          // Basic success case
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName, public: publicKeys[algorithmName]}, privateKeys[algorithmName], 8 * sizes[algorithmName])
+              .then(function(derivation) {
+                  assert_true(equalBuffers(derivation, derivations[algorithmName]), "Derived correct bits");
+              }, function(err) {
+                  assert_unreached("deriveBits failed with error " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " good parameters");
+
+          // Case insensitivity check
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName.toLowerCase(), public: publicKeys[algorithmName]}, privateKeys[algorithmName], 8 * sizes[algorithmName])
+              .then(function(derivation) {
+                  assert_true(equalBuffers(derivation, derivations[algorithmName]), "Derived correct bits");
+              }, function(err) {
+                  assert_unreached("deriveBits failed with error " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " mixed case parameters");
+
+          // Null length
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName, public: publicKeys[algorithmName]}, privateKeys[algorithmName], null)
+              .then(function(derivation) {
+                  assert_true(equalBuffers(derivation, derivations[algorithmName]), "Derived correct bits");
+              }, function(err) {
+                  assert_unreached("deriveBits failed with error " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " with null length");
+
+          // Shorter than entire derivation per algorithm
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName, public: publicKeys[algorithmName]}, privateKeys[algorithmName], 8 * sizes[algorithmName] - 32)
+              .then(function(derivation) {
+                  assert_true(equalBuffers(derivation, derivations[algorithmName], 8 * sizes[algorithmName] - 32), "Derived correct bits");
+              }, function(err) {
+                  assert_unreached("deriveBits failed with error " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " short result");
+
+          // Non-multiple of 8
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName, public: publicKeys[algorithmName]}, privateKeys[algorithmName], 8 * sizes[algorithmName] - 11)
+              .then(function(derivation) {
+                  assert_true(equalBuffers(derivation, derivations[algorithmName], 8 * sizes[algorithmName] - 11), "Derived correct bits");
+              }, function(err) {
+                  assert_unreached("deriveBits failed with error " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " non-multiple of 8 bits");
+
+          // Errors to test:
+
+          // - missing public property TypeError
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName}, privateKeys[algorithmName], 8 * sizes[algorithmName])
+              .then(function(derivation) {
+                  assert_unreached("deriveBits succeeded but should have failed with TypeError");
+              }, function(err) {
+                  assert_equals(err.name, "TypeError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " missing public property");
+
+          // - Non CryptoKey public property TypeError
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName, public: {message: "Not a CryptoKey"}}, privateKeys[algorithmName], 8 * sizes[algorithmName])
+              .then(function(derivation) {
+                  assert_unreached("deriveBits succeeded but should have failed with TypeError");
+              }, function(err) {
+                  assert_equals(err.name, "TypeError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " public property of algorithm is not a CryptoKey");
+
+          // - wrong algorithm
+          promise_test(function(test) {
+              publicKey = publicKeys["X25519"];
+              if (algorithmName === "X25519") {
+                  publicKey = publicKeys["X448"];
+              }
+              return subtle.deriveBits({name: algorithmName, public: publicKey}, privateKeys[algorithmName], 8 * sizes[algorithmName])
+              .then(function(derivation) {
+                  assert_unreached("deriveBits succeeded but should have failed with InvalidAccessError");
+              }, function(err) {
+                  assert_equals(err.name, "InvalidAccessError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " mismatched algorithms");
+
+          // - No deriveBits usage in baseKey InvalidAccessError
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName, public: publicKeys[algorithmName]}, noDeriveBitsKeys[algorithmName], 8 * sizes[algorithmName])
+              .then(function(derivation) {
+                  assert_unreached("deriveBits succeeded but should have failed with InvalidAccessError");
+              }, function(err) {
+                  assert_equals(err.name, "InvalidAccessError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " no deriveBits usage for base key");
+
+          // - Use public key for baseKey InvalidAccessError
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName, public: publicKeys[algorithmName]}, publicKeys[algorithmName], 8 * sizes[algorithmName])
+              .then(function(derivation) {
+                  assert_unreached("deriveBits succeeded but should have failed with InvalidAccessError");
+              }, function(err) {
+                  assert_equals(err.name, "InvalidAccessError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " base key is not a private key");
+
+          // - Use private key for public property InvalidAccessError
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName, public: privateKeys[algorithmName]}, privateKeys[algorithmName], 8 * sizes[algorithmName])
+              .then(function(derivation) {
+                  assert_unreached("deriveBits succeeded but should have failed with InvalidAccessError");
+              }, function(err) {
+                  assert_equals(err.name, "InvalidAccessError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " public property value is a private key");
+
+          // - Use secret key for public property InvalidAccessError
+          promise_test(function(test) {
+              return subtle.generateKey({name: "AES-CBC", length: 128}, true, ["encrypt", "decrypt"])
+              .then(function(secretKey) {
+                  subtle.deriveBits({name: algorithmName, public: secretKey}, privateKeys[algorithmName], 8 * sizes[algorithmName])
+                  .then(function(derivation) {
+                      assert_unreached("deriveBits succeeded but should have failed with InvalidAccessError");
+                  }, function(err) {
+                      assert_equals(err.name, "InvalidAccessError", "Should throw correct error, not " + err.name + ": " + err.message);
+                  });
+              });
+          }, algorithmName + " public property value is a secret key");
+
+          // - Length greater than possible for particular curves OperationError
+          promise_test(function(test) {
+              return subtle.deriveBits({name: algorithmName, public: publicKeys[algorithmName]}, privateKeys[algorithmName], 8 * sizes[algorithmName] + 8)
+              .then(function(derivation) {
+                  assert_unreached("deriveBits succeeded but should have failed with OperationError");
+              }, function(err) {
+                  assert_equals(err.name, "OperationError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " asking for too many bits");
+      });
+  });
+
+  function importKeys(pkcs8, spki, sizes) {
+      var privateKeys = {};
+      var publicKeys = {};
+      var noDeriveBitsKeys = {};
+
+      var promises = [];
+      Object.keys(pkcs8).forEach(function(algorithmName) {
+          var operation = subtle.importKey("pkcs8", pkcs8[algorithmName],
+                                          {name: algorithmName},
+                                          false, ["deriveBits", "deriveKey"])
+                          .then(function(key) {
+                              privateKeys[algorithmName] = key;
+                          });
+          promises.push(operation);
+      });
+      Object.keys(pkcs8).forEach(function(algorithmName) {
+          var operation = subtle.importKey("pkcs8", pkcs8[algorithmName],
+                                          {name: algorithmName},
+                                          false, ["deriveKey"])
+                          .then(function(key) {
+                              noDeriveBitsKeys[algorithmName] = key;
+                          });
+          promises.push(operation);
+      });
+      Object.keys(spki).forEach(function(algorithmName) {
+          var operation = subtle.importKey("spki", spki[algorithmName],
+                                          {name: algorithmName},
+                                          false, [])
+                          .then(function(key) {
+                              publicKeys[algorithmName] = key;
+                          });
+          promises.push(operation);
+      });
+
+      return Promise.all(promises)
+             .then(function(results) {return {privateKeys: privateKeys, publicKeys: publicKeys, noDeriveBitsKeys: noDeriveBitsKeys}});
+  }
+
+  // Compares two ArrayBuffer or ArrayBufferView objects. If bitCount is
+  // omitted, the two values must be the same length and have the same contents
+  // in every byte. If bitCount is included, only that leading number of bits
+  // have to match.
+  function equalBuffers(a, b, bitCount) {
+      var remainder;
+
+      if (typeof bitCount === "undefined" && a.byteLength !== b.byteLength) {
+          return false;
+      }
+
+      var aBytes = new Uint8Array(a);
+      var bBytes = new Uint8Array(b);
+
+      var length = a.byteLength;
+      if (typeof bitCount !== "undefined") {
+          length = Math.floor(bitCount / 8);
+      }
+
+      for (var i=0; i<length; i++) {
+          if (aBytes[i] !== bBytes[i]) {
+              return false;
+          }
+      }
+
+      if (typeof bitCount !== "undefined") {
+          remainder = bitCount % 8;
+          return aBytes[length] >> (8 - remainder) === bBytes[length] >> (8 - remainder);
+      }
+
+      return true;
+  }
+
+}

--- a/test/fixtures/wpt/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.https.any.js
@@ -1,0 +1,9 @@
+// META: title=WebCryptoAPI: deriveKey() Using ECDH with CFRG Elliptic Curves
+// META: script=cfrg_curves_keys.js
+
+// Define subtests from a `promise_test` to ensure the harness does not
+// complete before the subtests are available. `explicit_done` cannot be used
+// for this purpose because the global `done` function is automatically invoked
+// by the WPT infrastructure in dedicated worker tests defined using the
+// "multi-global" pattern.
+promise_test(define_tests, 'setup - define tests');

--- a/test/fixtures/wpt/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.js
+++ b/test/fixtures/wpt/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.js
@@ -1,0 +1,213 @@
+
+function define_tests() {
+  // May want to test prefixed implementations.
+  var subtle = self.crypto.subtle;
+
+  var pkcs8 = {
+    "X25519": new Uint8Array([48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 110, 4, 34, 4, 32, 200, 131, 142, 118, 208, 87, 223, 183, 216, 201, 90, 105, 225, 56, 22, 10, 221, 99, 115, 253, 113, 164, 210, 118, 187, 86, 227, 168, 27, 100, 255, 97]),
+    "X448": new Uint8Array([48, 70, 2, 1, 0, 48, 5, 6, 3, 43, 101, 111, 4, 58, 4, 56, 88, 199, 210, 154, 62, 181, 25, 178, 157, 0, 207, 177, 145, 187, 100, 252, 109, 138, 66, 216, 241, 113, 118, 39, 43, 137, 242, 39, 45, 24, 25, 41, 92, 101, 37, 192, 130, 150, 113, 176, 82, 239, 7, 39, 83, 15, 24, 142, 49, 208, 204, 83, 191, 38, 146, 158])
+  };
+
+  var spki = {
+      "X25519": new Uint8Array([48, 42, 48, 5, 6, 3, 43, 101, 110, 3, 33, 0, 28, 242, 177, 230, 2, 46, 197, 55, 55, 30, 215, 245, 62, 84, 250, 17, 84, 216, 62, 152, 235, 100, 234, 81, 250, 229, 179, 48, 124, 254, 151, 6]),
+      "X448": new Uint8Array([48, 66, 48, 5, 6, 3, 43, 101, 111, 3, 57, 0, 182, 4, 161, 209, 165, 205, 29, 148, 38, 213, 97, 239, 99, 10, 158, 177, 108, 190, 105, 213, 185, 202, 97, 94, 220, 83, 99, 62, 251, 82, 234, 49, 230, 230, 160, 161, 219, 172, 198, 231, 108, 188, 230, 72, 45, 126, 75, 163, 213, 93, 158, 128, 39, 101, 206, 111])
+  };
+
+  var sizes = {
+      "X25519": 32,
+      "X448": 56
+  };
+
+  var derivations = {
+      "X25519": new Uint8Array([39, 104, 64, 157, 250, 185, 158, 194, 59, 140, 137, 185, 63, 245, 136, 2, 149, 247, 97, 118, 8, 143, 137, 228, 61, 254, 190, 126, 161, 149, 0, 8]),
+      "X448": new Uint8Array([240, 246, 197, 241, 127, 148, 244, 41, 30, 171, 113, 120, 134, 109, 55, 236, 137, 6, 221, 108, 81, 65, 67, 220, 133, 190, 124, 242, 141, 239, 243, 155, 114, 110, 15, 109, 207, 129, 14, 181, 148, 220, 169, 123, 72, 130, 189, 68, 196, 62, 167, 220, 103, 244, 154, 78])
+  };
+
+  return importKeys(pkcs8, spki, sizes)
+  .then(function(results) {
+      publicKeys = results.publicKeys;
+      privateKeys = results.privateKeys;
+      noDeriveKeyKeys = results.noDeriveKeyKeys;
+
+      Object.keys(sizes).forEach(function(algorithmName) {
+          // Basic success case
+          promise_test(function(test) {
+              return subtle.deriveKey({name: algorithmName, public: publicKeys[algorithmName]}, privateKeys[algorithmName], {name: "HMAC", hash: "SHA-256", length: 256}, true, ["sign", "verify"])
+              .then(function(key) {return crypto.subtle.exportKey("raw", key);})
+              .then(function(exportedKey) {
+                  assert_true(equalBuffers(exportedKey, derivations[algorithmName], 8 * exportedKey.length), "Derived correct key");
+              }, function(err) {
+                  assert_unreached("deriveKey failed with error " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " good parameters");
+
+          // Case insensitivity check
+          promise_test(function(test) {
+              return subtle.deriveKey({name: algorithmName.toLowerCase(), public: publicKeys[algorithmName]}, privateKeys[algorithmName], {name: "HMAC", hash: "SHA-256", length: 256}, true, ["sign", "verify"])
+              .then(function(key) {return crypto.subtle.exportKey("raw", key);})
+              .then(function(exportedKey) {
+                  assert_true(equalBuffers(exportedKey, derivations[algorithmName], 8 * exportedKey.length), "Derived correct key");
+              }, function(err) {
+                  assert_unreached("deriveKey failed with error " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " mixed case parameters");
+          // Errors to test:
+
+          // - missing public property TypeError
+          promise_test(function(test) {
+              return subtle.deriveKey({name: algorithmName}, privateKeys[algorithmName], {name: "HMAC", hash: "SHA-256", length: 256}, true, ["sign", "verify"])
+              .then(function(key) {return crypto.subtle.exportKey("raw", key);})
+              .then(function(exportedKey) {
+                  assert_unreached("deriveKey succeeded but should have failed with TypeError");
+              }, function(err) {
+                  assert_equals(err.name, "TypeError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " missing public property");
+
+          // - Non CryptoKey public property TypeError
+          promise_test(function(test) {
+              return subtle.deriveKey({name: algorithmName, public: {message: "Not a CryptoKey"}}, privateKeys[algorithmName], {name: "HMAC", hash: "SHA-256", length: 256}, true, ["sign", "verify"])
+              .then(function(key) {return crypto.subtle.exportKey("raw", key);})
+              .then(function(exportedKey) {
+                  assert_unreached("deriveKey succeeded but should have failed with TypeError");
+              }, function(err) {
+                  assert_equals(err.name, "TypeError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " public property of algorithm is not a CryptoKey");
+
+          // - wrong algorithm
+          promise_test(function(test) {
+              publicKey = publicKeys["X25519"];
+              if (algorithmName === "X25519") {
+                  publicKey = publicKeys["X448"];
+              }
+              return subtle.deriveKey({name: algorithmName, public: publicKey}, privateKeys[algorithmName], {name: "HMAC", hash: "SHA-256", length: 256}, true, ["sign", "verify"])
+              .then(function(key) {return crypto.subtle.exportKey("raw", key);})
+              .then(function(exportedKey) {
+                  assert_unreached("deriveKey succeeded but should have failed with InvalidAccessError");
+              }, function(err) {
+                  assert_equals(err.name, "InvalidAccessError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " mismatched algorithms");
+
+          // - No deriveKey usage in baseKey InvalidAccessError
+          promise_test(function(test) {
+              return subtle.deriveKey({name: algorithmName, public: publicKeys[algorithmName]}, noDeriveKeyKeys[algorithmName], {name: "HMAC", hash: "SHA-256", length: 256}, true, ["sign", "verify"])
+              .then(function(key) {return crypto.subtle.exportKey("raw", key);})
+              .then(function(exportedKey) {
+                  assert_unreached("deriveKey succeeded but should have failed with InvalidAccessError");
+              }, function(err) {
+                  assert_equals(err.name, "InvalidAccessError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " no deriveKey usage for base key");
+
+          // - Use public key for baseKey InvalidAccessError
+          promise_test(function(test) {
+              return subtle.deriveKey({name: algorithmName, public: publicKeys[algorithmName]}, publicKeys[algorithmName], {name: "HMAC", hash: "SHA-256", length: 256}, true, ["sign", "verify"])
+              .then(function(key) {return crypto.subtle.exportKey("raw", key);})
+              .then(function(exportedKey) {
+                  assert_unreached("deriveKey succeeded but should have failed with InvalidAccessError");
+              }, function(err) {
+                  assert_equals(err.name, "InvalidAccessError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " base key is not a private key");
+
+          // - Use private key for public property InvalidAccessError
+          promise_test(function(test) {
+              return subtle.deriveKey({name: algorithmName, public: privateKeys[algorithmName]}, privateKeys[algorithmName], {name: "HMAC", hash: "SHA-256", length: 256}, true, ["sign", "verify"])
+              .then(function(key) {return crypto.subtle.exportKey("raw", key);})
+              .then(function(exportedKey) {
+                  assert_unreached("deriveKey succeeded but should have failed with InvalidAccessError");
+              }, function(err) {
+                  assert_equals(err.name, "InvalidAccessError", "Should throw correct error, not " + err.name + ": " + err.message);
+              });
+          }, algorithmName + " public property value is a private key");
+
+          // - Use secret key for public property InvalidAccessError
+          promise_test(function(test) {
+              return subtle.generateKey({name: "HMAC", hash: "SHA-256", length: 256}, true, ["sign", "verify"])
+              .then(function(secretKey) {
+                  subtle.deriveKey({name: algorithmName, public: secretKey}, privateKeys[algorithmName], {name: "AES-CBC", length: 256}, true, ["sign", "verify"])
+                  .then(function(key) {return crypto.subtle.exportKey("raw", key);})
+                  .then(function(exportedKey) {
+                      assert_unreached("deriveKey succeeded but should have failed with InvalidAccessError");
+                  }, function(err) {
+                      assert_equals(err.name, "InvalidAccessError", "Should throw correct error, not " + err.name + ": " + err.message);
+                  });
+              });
+          }, algorithmName + " public property value is a secret key");
+      });
+  });
+
+  function importKeys(pkcs8, spki, sizes) {
+      var privateKeys = {};
+      var publicKeys = {};
+      var noDeriveKeyKeys = {};
+
+      var promises = [];
+      Object.keys(pkcs8).forEach(function(algorithmName) {
+          var operation = subtle.importKey("pkcs8", pkcs8[algorithmName],
+                                          {name: algorithmName},
+                                          false, ["deriveBits", "deriveKey"])
+                          .then(function(key) {
+                              privateKeys[algorithmName] = key;
+                          });
+          promises.push(operation);
+      });
+      Object.keys(pkcs8).forEach(function(algorithmName) {
+          var operation = subtle.importKey("pkcs8", pkcs8[algorithmName],
+                                          {name: algorithmName},
+                                          false, ["deriveBits"])
+                          .then(function(key) {
+                              noDeriveKeyKeys[algorithmName] = key;
+                          });
+          promises.push(operation);
+      });
+      Object.keys(spki).forEach(function(algorithmName) {
+          var operation = subtle.importKey("spki", spki[algorithmName],
+                                          {name: algorithmName},
+                                          false, [])
+                          .then(function(key) {
+                              publicKeys[algorithmName] = key;
+                          });
+          promises.push(operation);
+      });
+
+      return Promise.all(promises)
+             .then(function(results) {return {privateKeys: privateKeys, publicKeys: publicKeys, noDeriveKeyKeys: noDeriveKeyKeys}});
+  }
+
+  // Compares two ArrayBuffer or ArrayBufferView objects. If bitCount is
+  // omitted, the two values must be the same length and have the same contents
+  // in every byte. If bitCount is included, only that leading number of bits
+  // have to match.
+  function equalBuffers(a, b, bitCount) {
+      var remainder;
+
+      if (typeof bitCount === "undefined" && a.byteLength !== b.byteLength) {
+          return false;
+      }
+
+      var aBytes = new Uint8Array(a);
+      var bBytes = new Uint8Array(b);
+
+      var length = a.byteLength;
+      if (typeof bitCount !== "undefined") {
+          length = Math.floor(bitCount / 8);
+      }
+
+      for (var i=0; i<length; i++) {
+          if (aBytes[i] !== bBytes[i]) {
+              return false;
+          }
+      }
+
+      if (typeof bitCount !== "undefined") {
+          remainder = bitCount % 8;
+          return aBytes[length] >> (8 - remainder) === bBytes[length] >> (8 - remainder);
+      }
+
+      return true;
+  }
+
+}

--- a/test/fixtures/wpt/WebCryptoAPI/generateKey/failures.js
+++ b/test/fixtures/wpt/WebCryptoAPI/generateKey/failures.js
@@ -31,7 +31,11 @@ function run_test(algorithmNames) {
         {name: "RSA-PSS",  resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
         {name: "RSA-OAEP", resultType: "CryptoKeyPair", usages: ["encrypt", "decrypt", "wrapKey", "unwrapKey"], mandatoryUsages: ["decrypt", "unwrapKey"]},
         {name: "ECDSA",    resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
-        {name: "ECDH",     resultType: "CryptoKeyPair", usages: ["deriveKey", "deriveBits"], mandatoryUsages: ["deriveKey", "deriveBits"]}
+        {name: "ECDH",     resultType: "CryptoKeyPair", usages: ["deriveKey", "deriveBits"], mandatoryUsages: ["deriveKey", "deriveBits"]},
+        {name: "Ed25519",  resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
+        {name: "Ed448",    resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
+        {name: "X25519",   resultType: "CryptoKeyPair", usages: ["deriveKey", "deriveBits"], mandatoryUsages: ["deriveKey", "deriveBits"]},
+        {name: "X448",     resultType: "CryptoKeyPair", usages: ["deriveKey", "deriveBits"], mandatoryUsages: ["deriveKey", "deriveBits"]},
     ];
 
     var testVectors = [];

--- a/test/fixtures/wpt/WebCryptoAPI/generateKey/failures_Ed25519.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/generateKey/failures_Ed25519.https.any.js
@@ -1,0 +1,5 @@
+// META: title=WebCryptoAPI: generateKey() for Failures
+// META: timeout=long
+// META: script=../util/helpers.js
+// META: script=failures.js
+run_test(["Ed25519"]);

--- a/test/fixtures/wpt/WebCryptoAPI/generateKey/failures_Ed448.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/generateKey/failures_Ed448.https.any.js
@@ -1,0 +1,5 @@
+// META: title=WebCryptoAPI: generateKey() for Failures
+// META: timeout=long
+// META: script=../util/helpers.js
+// META: script=failures.js
+run_test(["Ed448"]);

--- a/test/fixtures/wpt/WebCryptoAPI/generateKey/failures_X25519.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/generateKey/failures_X25519.https.any.js
@@ -1,0 +1,5 @@
+// META: title=WebCryptoAPI: generateKey() for Failures
+// META: timeout=long
+// META: script=../util/helpers.js
+// META: script=failures.js
+run_test(["X25519"]);

--- a/test/fixtures/wpt/WebCryptoAPI/generateKey/failures_X448.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/generateKey/failures_X448.https.any.js
@@ -1,0 +1,5 @@
+// META: title=WebCryptoAPI: generateKey() for Failures
+// META: timeout=long
+// META: script=../util/helpers.js
+// META: script=failures.js
+run_test(["X448"]);

--- a/test/fixtures/wpt/WebCryptoAPI/generateKey/successes.js
+++ b/test/fixtures/wpt/WebCryptoAPI/generateKey/successes.js
@@ -26,7 +26,11 @@ function run_test(algorithmNames, slowTest) {
         {name: "RSA-PSS",  resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
         {name: "RSA-OAEP", resultType: "CryptoKeyPair", usages: ["encrypt", "decrypt", "wrapKey", "unwrapKey"], mandatoryUsages: ["decrypt", "unwrapKey"]},
         {name: "ECDSA",    resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
-        {name: "ECDH",     resultType: "CryptoKeyPair", usages: ["deriveKey", "deriveBits"], mandatoryUsages: ["deriveKey", "deriveBits"]}
+        {name: "ECDH",     resultType: "CryptoKeyPair", usages: ["deriveKey", "deriveBits"], mandatoryUsages: ["deriveKey", "deriveBits"]},
+        {name: "Ed25519",  resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
+        {name: "Ed448",    resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
+        {name: "X25519",   resultType: "CryptoKeyPair", usages: ["deriveKey", "deriveBits"], mandatoryUsages: ["deriveKey", "deriveBits"]},
+        {name: "X448",     resultType: "CryptoKeyPair", usages: ["deriveKey", "deriveBits"], mandatoryUsages: ["deriveKey", "deriveBits"]},
     ];
 
     var testVectors = [];

--- a/test/fixtures/wpt/WebCryptoAPI/generateKey/successes_Ed25519.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/generateKey/successes_Ed25519.https.any.js
@@ -1,0 +1,6 @@
+// META: title=WebCryptoAPI: generateKey() Successful Calls
+// META: timeout=long
+// META: script=../util/helpers.js
+// META: script=/common/subset-tests.js
+// META: script=successes.js
+run_test(["Ed25519"]);

--- a/test/fixtures/wpt/WebCryptoAPI/generateKey/successes_Ed448.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/generateKey/successes_Ed448.https.any.js
@@ -1,0 +1,6 @@
+// META: title=WebCryptoAPI: generateKey() Successful Calls
+// META: timeout=long
+// META: script=../util/helpers.js
+// META: script=/common/subset-tests.js
+// META: script=successes.js
+run_test(["Ed448"]);

--- a/test/fixtures/wpt/WebCryptoAPI/generateKey/successes_X25519.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/generateKey/successes_X25519.https.any.js
@@ -1,0 +1,6 @@
+// META: title=WebCryptoAPI: generateKey() Successful Calls
+// META: timeout=long
+// META: script=../util/helpers.js
+// META: script=/common/subset-tests.js
+// META: script=successes.js
+run_test(["X25519"]);

--- a/test/fixtures/wpt/WebCryptoAPI/generateKey/successes_X448.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/generateKey/successes_X448.https.any.js
@@ -1,0 +1,6 @@
+// META: title=WebCryptoAPI: generateKey() Successful Calls
+// META: timeout=long
+// META: script=../util/helpers.js
+// META: script=/common/subset-tests.js
+// META: script=successes.js
+run_test(["X448"]);

--- a/test/fixtures/wpt/WebCryptoAPI/getRandomValues.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/getRandomValues.any.js
@@ -8,12 +8,24 @@ test(function() {
     }, "Float64Array")
 
     assert_throws_dom("TypeMismatchError", function() {
-        self.crypto.getRandomValues(new Float32Array(65537))
+        const len = 65536 / Float32Array.BYTES_PER_ELEMENT + 1;
+        self.crypto.getRandomValues(new Float32Array(len));
     }, "Float32Array (too long)")
     assert_throws_dom("TypeMismatchError", function() {
-        self.crypto.getRandomValues(new Float64Array(65537))
+        const len = 65536 / Float64Array.BYTES_PER_ELEMENT + 1;
+        self.crypto.getRandomValues(new Float64Array(len))
     }, "Float64Array (too long)")
-}, "Float arrays")
+}, "Float arrays");
+
+test(function() {
+    assert_throws_dom("TypeMismatchError", function() {
+        self.crypto.getRandomValues(new DataView(new ArrayBuffer(6)))
+    }, "DataView")
+
+    assert_throws_dom("TypeMismatchError", function() {
+        self.crypto.getRandomValues(new DataView(new ArrayBuffer(65536 + 1)))
+    }, "DataView (too long)")
+}, "DataView");
 
 const arrays = [
     'Int8Array',

--- a/test/fixtures/wpt/WebCryptoAPI/import_export/okp_importKey.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/import_export/okp_importKey.https.any.js
@@ -1,0 +1,282 @@
+// META: title=WebCryptoAPI: importKey() for OKP keys
+// META: timeout=long
+
+// Test importKey and exportKey for OKP algorithms. Only "happy paths" are
+// currently tested - those where the operation should succeed.
+
+    var subtle = crypto.subtle;
+
+    var keyData = {
+        "Ed25519": {
+            spki: new Uint8Array([48, 42, 48, 5, 6, 3, 43, 101, 112, 3, 33, 0, 216, 225, 137, 99, 216, 9, 212, 135, 217, 84, 154, 204, 174, 198, 116, 46, 126, 235, 162, 77, 138, 13, 59, 20, 183, 227, 202, 234, 6, 137, 61, 204]),
+            pkcs8: new Uint8Array([48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32, 243, 200, 244, 196, 141, 248, 120, 20, 110, 140, 211, 191, 109, 244, 229, 14, 56, 155, 167, 7, 78, 21, 194, 53, 45, 205, 93, 48, 141, 76, 168, 31]),
+            jwk: {
+                crv: "Ed25519",
+                d: "88j0xI34eBRujNO_bfTlDjibpwdOFcI1Lc1dMI1MqB8",
+                x: "2OGJY9gJ1IfZVJrMrsZ0Ln7rok2KDTsUt-PK6gaJPcw",
+                kty: "OKP"
+            }
+        },
+
+        "Ed448": {
+            spki: new Uint8Array([48, 67, 48, 5, 6, 3, 43, 101, 113, 3, 58, 0, 171, 75, 184, 133, 253, 125, 44, 90, 242, 78, 131, 113, 12, 255, 160, 199, 74, 87, 226, 116, 128, 29, 178, 5, 123, 11, 220, 94, 160, 50, 182, 254, 107, 199, 139, 128, 69, 54, 90, 235, 38, 232, 110, 31, 20, 253, 52, 157, 7, 196, 132, 149, 245, 164, 106, 90, 128]),
+            pkcs8: new Uint8Array([48, 71, 2, 1, 0, 48, 5, 6, 3, 43, 101, 113, 4, 59, 4, 57, 14, 255, 3, 69, 140, 40, 224, 23, 156, 82, 29, 227, 18, 201, 105, 183, 131, 67, 72, 236, 171, 153, 26, 96, 227, 178, 233, 167, 158, 76, 217, 228, 128, 239, 41, 23, 18, 210, 200, 61, 4, 114, 114, 213, 201, 244, 40, 102, 79, 105, 109, 38, 112, 69, 143, 29, 46]),
+            jwk: {
+                crv: "Ed448",
+                d: "Dv8DRYwo4BecUh3jEslpt4NDSOyrmRpg47Lpp55M2eSA7ykXEtLIPQRyctXJ9ChmT2ltJnBFjx0u",
+                x: "q0u4hf19LFryToNxDP-gx0pX4nSAHbIFewvcXqAytv5rx4uARTZa6ybobh8U_TSdB8SElfWkalqA",
+                kty: "OKP"
+            }
+        },
+
+        "X25519": {
+            spki: new Uint8Array([48, 42, 48, 5, 6, 3, 43, 101, 110, 3, 33, 0, 28, 242, 177, 230, 2, 46, 197, 55, 55, 30, 215, 245, 62, 84, 250, 17, 84, 216, 62, 152, 235, 100, 234, 81, 250, 229, 179, 48, 124, 254, 151, 6]),
+            pkcs8: new Uint8Array([48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 110, 4, 34, 4, 32, 200, 131, 142, 118, 208, 87, 223, 183, 216, 201, 90, 105, 225, 56, 22, 10, 221, 99, 115, 253, 113, 164, 210, 118, 187, 86, 227, 168, 27, 100, 255, 97]),
+            jwk: {
+                crv: "X25519",
+                d: "yIOOdtBX37fYyVpp4TgWCt1jc_1xpNJ2u1bjqBtk_2E",
+                x: "HPKx5gIuxTc3Htf1PlT6EVTYPpjrZOpR-uWzMHz-lwY",
+                kty: "OKP"
+            }
+        },
+
+        "X448": {
+            spki: new Uint8Array([48, 66, 48, 5, 6, 3, 43, 101, 111, 3, 57, 0, 182, 4, 161, 209, 165, 205, 29, 148, 38, 213, 97, 239, 99, 10, 158, 177, 108, 190, 105, 213, 185, 202, 97, 94, 220, 83, 99, 62, 251, 82, 234, 49, 230, 230, 160, 161, 219, 172, 198, 231, 108, 188, 230, 72, 45, 126, 75, 163, 213, 93, 158, 128, 39, 101, 206, 111]),
+            pkcs8: new Uint8Array([48, 70, 2, 1, 0, 48, 5, 6, 3, 43, 101, 111, 4, 58, 4, 56, 88, 199, 210, 154, 62, 181, 25, 178, 157, 0, 207, 177, 145, 187, 100, 252, 109, 138, 66, 216, 241, 113, 118, 39, 43, 137, 242, 39, 45, 24, 25, 41, 92, 101, 37, 192, 130, 150, 113, 176, 82, 239, 7, 39, 83, 15, 24, 142, 49, 208, 204, 83, 191, 38, 146, 158]),
+            jwk: {
+                crv: "X448",
+                d: "WMfSmj61GbKdAM-xkbtk_G2KQtjxcXYnK4nyJy0YGSlcZSXAgpZxsFLvBydTDxiOMdDMU78mkp4",
+                x: "tgSh0aXNHZQm1WHvYwqesWy-adW5ymFe3FNjPvtS6jHm5qCh26zG52y85kgtfkuj1V2egCdlzm8",
+                kty: "OKP"
+            }
+        },
+
+    };
+
+    // combinations to test
+    var testVectors = [
+        {name: "Ed25519", privateUsages: ["sign"], publicUsages: ["verify"]},
+        {name: "Ed448", privateUsages: ["sign"], publicUsages: ["verify"]},
+        {name: "X25519",  privateUsages: ["deriveKey", "deriveBits"], publicUsages: []},
+        {name: "X448",  privateUsages: ["deriveKey", "deriveBits"], publicUsages: []},
+    ];
+
+    // TESTS ARE HERE:
+    // Test every test vector, along with all available key data
+    testVectors.forEach(function(vector) {
+        [true, false].forEach(function(extractable) {
+
+            // Test public keys first
+            [[]].forEach(function(usages) { // Only valid usages argument is empty array
+                ['spki', 'jwk'].forEach(function(format) {
+                    var algorithm = {name: vector.name};
+                    var data = keyData[vector.name];
+                    if (format === "jwk") { // Not all fields used for public keys
+                        data = {jwk: {kty: keyData[vector.name].jwk.kty, crv: keyData[vector.name].jwk.crv, x: keyData[vector.name].jwk.x}};
+                    }
+
+                    testFormat(format, algorithm, data, vector.name, usages, extractable);
+                });
+
+            });
+
+            // Next, test private keys
+            allValidUsages(vector.privateUsages, []).forEach(function(usages) {
+                ['pkcs8', 'jwk'].forEach(function(format) {
+                    var algorithm = {name: vector.name};
+                    var data = keyData[vector.name];
+
+                    testFormat(format, algorithm, data, vector.name, usages, extractable);
+                });
+            });
+        });
+    });
+
+
+    // Test importKey with a given key format and other parameters. If
+    // extrable is true, export the key and verify that it matches the input.
+    function testFormat(format, algorithm, keyData, keySize, usages, extractable) {
+        promise_test(function(test) {
+            return subtle.importKey(format, keyData[format], algorithm, extractable, usages).
+            then(function(key) {
+                assert_equals(key.constructor, CryptoKey, "Imported a CryptoKey object");
+                if (!extractable) {
+                    return;
+                }
+
+                return subtle.exportKey(format, key).
+                then(function(result) {
+                    if (format !== "jwk") {
+                        assert_true(equalBuffers(keyData[format], result), "Round trip works");
+                    } else {
+                        assert_true(equalJwk(keyData[format], result), "Round trip works");
+                    }
+                }, function(err) {
+                    assert_unreached("Threw an unexpected error: " + err.toString());
+                });
+            }, function(err) {
+                assert_unreached("Threw an unexpected error: " + err.toString());
+            });
+        }, "Good parameters: " + keySize.toString() + " bits " + parameterString(format, keyData[format], algorithm, extractable, usages));
+    }
+
+
+
+    // Helper methods follow:
+
+    // Are two array buffers the same?
+    function equalBuffers(a, b) {
+        if (a.byteLength !== b.byteLength) {
+            return false;
+        }
+
+        var aBytes = new Uint8Array(a);
+        var bBytes = new Uint8Array(b);
+
+        for (var i=0; i<a.byteLength; i++) {
+            if (aBytes[i] !== bBytes[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // Are two Jwk objects "the same"? That is, does the object returned include
+    // matching values for each property that was expected? It's okay if the
+    // returned object has extra methods; they aren't checked.
+    function equalJwk(expected, got) {
+        var fields = Object.keys(expected);
+        var fieldName;
+
+        for(var i=0; i<fields.length; i++) {
+            fieldName = fields[i];
+            if (!(fieldName in got)) {
+                return false;
+            }
+            if (expected[fieldName] !== got[fieldName]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // Build minimal Jwk objects from raw key data and algorithm specifications
+    function jwkData(keyData, algorithm) {
+        var result = {
+            kty: "oct",
+            k: byteArrayToUnpaddedBase64(keyData)
+        };
+
+        if (algorithm.name.substring(0, 3) === "AES") {
+            result.alg = "A" + (8 * keyData.byteLength).toString() + algorithm.name.substring(4);
+        } else if (algorithm.name === "HMAC") {
+            result.alg = "HS" + algorithm.hash.substring(4);
+        }
+        return result;
+    }
+
+    // Jwk format wants Base 64 without the typical padding at the end.
+    function byteArrayToUnpaddedBase64(byteArray){
+        var binaryString = "";
+        for (var i=0; i<byteArray.byteLength; i++){
+            binaryString += String.fromCharCode(byteArray[i]);
+        }
+        var base64String = btoa(binaryString);
+
+        return base64String.replace(/=/g, "");
+    }
+
+    // Want to test every valid combination of usages. Start by creating a list
+    // of all non-empty subsets to possible usages.
+    function allNonemptySubsetsOf(arr) {
+        var results = [];
+        var firstElement;
+        var remainingElements;
+
+        for(var i=0; i<arr.length; i++) {
+            firstElement = arr[i];
+            remainingElements = arr.slice(i+1);
+            results.push([firstElement]);
+
+            if (remainingElements.length > 0) {
+                allNonemptySubsetsOf(remainingElements).forEach(function(combination) {
+                    combination.push(firstElement);
+                    results.push(combination);
+                });
+            }
+        }
+
+        return results;
+    }
+
+    // Return a list of all valid usage combinations, given the possible ones
+    // and the ones that are required for a particular operation.
+    function allValidUsages(possibleUsages, requiredUsages) {
+        var allUsages = [];
+
+        allNonemptySubsetsOf(possibleUsages).forEach(function(usage) {
+            for (var i=0; i<requiredUsages.length; i++) {
+                if (!usage.includes(requiredUsages[i])) {
+                    return;
+                }
+            }
+            allUsages.push(usage);
+        });
+
+        return allUsages;
+    }
+
+    // Convert method parameters to a string to uniquely name each test
+    function parameterString(format, data, algorithm, extractable, usages) {
+        if ("byteLength" in data) {
+            data = "buffer(" + data.byteLength.toString() + ")";
+        } else {
+            data = "object(" + Object.keys(data).join(", ") + ")";
+        }
+        var result = "(" +
+                        objectToString(format) + ", " +
+                        objectToString(data) + ", " +
+                        objectToString(algorithm) + ", " +
+                        objectToString(extractable) + ", " +
+                        objectToString(usages) +
+                     ")";
+
+        return result;
+    }
+
+    // Character representation of any object we may use as a parameter.
+    function objectToString(obj) {
+        var keyValuePairs = [];
+
+        if (Array.isArray(obj)) {
+            return "[" + obj.map(function(elem){return objectToString(elem);}).join(", ") + "]";
+        } else if (typeof obj === "object") {
+            Object.keys(obj).sort().forEach(function(keyName) {
+                keyValuePairs.push(keyName + ": " + objectToString(obj[keyName]));
+            });
+            return "{" + keyValuePairs.join(", ") + "}";
+        } else if (typeof obj === "undefined") {
+            return "undefined";
+        } else {
+            return obj.toString();
+        }
+
+        var keyValuePairs = [];
+
+        Object.keys(obj).sort().forEach(function(keyName) {
+            var value = obj[keyName];
+            if (typeof value === "object") {
+                value = objectToString(value);
+            } else if (typeof value === "array") {
+                value = "[" + value.map(function(elem){return objectToString(elem);}).join(", ") + "]";
+            } else {
+                value = value.toString();
+            }
+
+            keyValuePairs.push(keyName + ": " + value);
+        });
+
+        return "{" + keyValuePairs.join(", ") + "}";
+    }

--- a/test/fixtures/wpt/WebCryptoAPI/randomUUID.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/randomUUID.https.any.js
@@ -14,7 +14,7 @@ function randomUUID() {
 
 // UUID is in namespace format (16 bytes separated by dashes):
 test(function() {
-    const UUIDRegex = /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/
+    const UUIDRegex = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/
     for (let i = 0; i < iterations; i++) {
         assert_true(UUIDRegex.test(randomUUID()));
     }

--- a/test/fixtures/wpt/WebCryptoAPI/sign_verify/eddsa.https.any.js
+++ b/test/fixtures/wpt/WebCryptoAPI/sign_verify/eddsa.https.any.js
@@ -1,0 +1,6 @@
+// META: title=WebCryptoAPI: sign() and verify() Using EdDSA
+// META: script=eddsa_vectors.js
+// META: script=eddsa.js
+// META: timeout=long
+
+run_test();

--- a/test/fixtures/wpt/WebCryptoAPI/sign_verify/eddsa.js
+++ b/test/fixtures/wpt/WebCryptoAPI/sign_verify/eddsa.js
@@ -1,0 +1,422 @@
+
+function run_test() {
+  setup({explicit_done: true});
+
+  var subtle = self.crypto.subtle; // Change to test prefixed implementations
+
+  // When are all these tests really done? When all the promises they use have resolved.
+  var all_promises = [];
+
+  // Source file [algorithm_name]_vectors.js provides the getTestVectors method
+  // for the algorithm that drives these tests.
+  var testVectors = getTestVectors();
+
+  // Test verification first, because signing tests rely on that working
+  testVectors.forEach(function(vector) {
+      var promise = importVectorKeys(vector, ["verify"], ["sign"])
+      .then(function(vectors) {
+          var algorithm = {name: vector.algorithmName};
+          promise_test(function(test) {
+              var operation = subtle.verify(algorithm, vector.publicKey, vector.signature, vector.data)
+              .then(function(is_verified) {
+                  assert_true(is_verified, "Signature verified");
+              }, function(err) {
+                  assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              });
+
+              return operation;
+          }, vector.name + " verification");
+
+      }, function(err) {
+          // We need a failed test if the importVectorKey operation fails, so
+          // we know we never tested verification.
+          promise_test(function(test) {
+              assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+          }, "importVectorKeys step: " + vector.name + " verification");
+      });
+
+      all_promises.push(promise);
+  });
+
+  // Test verification with an altered buffer after call
+  testVectors.forEach(function(vector) {
+      var promise = importVectorKeys(vector, ["verify"], ["sign"])
+      .then(function(vectors) {
+          var algorithm = {name: vector.algorithmName};
+          promise_test(function(test) {
+              var signature = copyBuffer(vector.signature);
+              var operation = subtle.verify(algorithm, vector.publicKey, signature, vector.data)
+              .then(function(is_verified) {
+                  assert_true(is_verified, "Signature verified");
+              }, function(err) {
+                  assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              });
+
+              signature[0] = 255 - signature[0];
+              return operation;
+          }, vector.name + " verification with altered signature after call");
+      }, function(err) {
+          promise_test(function(test) {
+              assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+          }, "importVectorKeys step: " + vector.name + " verification with altered signature after call");
+      });
+
+      all_promises.push(promise);
+  });
+
+  // Check for successful verification even if data is altered after call.
+  testVectors.forEach(function(vector) {
+      var promise = importVectorKeys(vector, ["verify"], ["sign"])
+      .then(function(vectors) {
+          var algorithm = {name: vector.algorithmName};
+          promise_test(function(test) {
+              var data = copyBuffer(vector.data);
+              var operation = subtle.verify(algorithm, vector.publicKey, vector.signature, data)
+              .then(function(is_verified) {
+                  assert_true(is_verified, "Signature verified");
+              }, function(err) {
+                  assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              });
+
+              data[0] = 255 - data[0];
+              return operation;
+          }, vector.name + " with altered data after call");
+      }, function(err) {
+          promise_test(function(test) {
+              assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+          }, "importVectorKeys step: " + vector.name + " with altered data after call");
+      });
+
+      all_promises.push(promise);
+  });
+
+  // Check for failures due to using privateKey to verify.
+  testVectors.forEach(function(vector) {
+      var promise = importVectorKeys(vector, ["verify"], ["sign"])
+      .then(function(vectors) {
+          var algorithm = {name: vector.algorithmName};
+          promise_test(function(test) {
+              return subtle.verify(algorithm, vector.privateKey, vector.signature, vector.data)
+              .then(function(data) {
+                  assert_unreached("Should have thrown error for using privateKey to verify in " + vector.name + ": " + err.message + "'");
+              }, function(err) {
+                  assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of '" + err.message + "'");
+              });
+          }, vector.name + " using privateKey to verify");
+
+      }, function(err) {
+          promise_test(function(test) {
+              assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+          }, "importVectorKeys step: " + vector.name + " using privateKey to verify");
+      });
+
+      all_promises.push(promise);
+  });
+
+  // Check for failures due to using publicKey to sign.
+  testVectors.forEach(function(vector) {
+      var promise = importVectorKeys(vector, ["verify"], ["sign"])
+      .then(function(vectors) {
+          var algorithm = {name: vector.algorithmName};
+          promise_test(function(test) {
+              return subtle.sign(algorithm, vector.publicKey, vector.data)
+              .then(function(signature) {
+                  assert_unreached("Should have thrown error for using publicKey to sign in " + vector.name + ": " + err.message + "'");
+              }, function(err) {
+                  assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of '" + err.message + "'");
+              });
+          }, vector.name + " using publicKey to sign");
+      }, function(err) {
+          promise_test(function(test) {
+              assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+          }, "importVectorKeys step: " + vector.name + " using publicKey to sign");
+      });
+
+      all_promises.push(promise);
+  });
+
+  // Check for failures due to no "verify" usage.
+  testVectors.forEach(function(originalVector) {
+      var vector = Object.assign({}, originalVector);
+
+      var promise = importVectorKeys(vector, [], ["sign"])
+      .then(function(vectors) {
+          var algorithm = {name: vector.algorithmName};
+          promise_test(function(test) {
+              return subtle.verify(algorithm, vector.publicKey, vector.signature, vector.data)
+              .then(function(data) {
+                  assert_unreached("Should have thrown error for no verify usage in " + vector.name + ": " + err.message + "'");
+              }, function(err) {
+                  assert_equals(err.name, "InvalidAccessError", "Should throw InvalidAccessError instead of '" + err.message + "'");
+              });
+          }, vector.name + " no verify usage");
+      }, function(err) {
+          promise_test(function(test) {
+              assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+          }, "importVectorKeys step: " + vector.name + " no verify usage");
+      });
+
+      all_promises.push(promise);
+  });
+
+  // Check for successful signing and verification.
+  testVectors.forEach(function(vector) {
+      var promise = importVectorKeys(vector, ["verify"], ["sign"])
+      .then(function(vectors) {
+          var algorithm = {name: vector.algorithmName};
+          promise_test(function(test) {
+              return subtle.sign(algorithm, vector.privateKey, vector.data)
+              .then(function(signature) {
+                  // Can we verify the signature?
+                  return subtle.verify(algorithm, vector.publicKey, signature, vector.data)
+                  .then(function(is_verified) {
+                      assert_true(is_verified, "Round trip verification works");
+                      return signature;
+                  }, function(err) {
+                      assert_unreached("verify error for test " + vector.name + ": " + err.message + "'");
+                  });
+              }, function(err) {
+                  assert_unreached("sign error for test " + vector.name + ": '" + err.message + "'");
+              });
+          }, vector.name + " round trip");
+
+      }, function(err) {
+          // We need a failed test if the importVectorKey operation fails, so
+          // we know we never tested signing or verifying
+          promise_test(function(test) {
+              assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+          }, "importVectorKeys step: " + vector.name + " round trip");
+      });
+
+      all_promises.push(promise);
+  });
+
+  // Test signing with the wrong algorithm
+  testVectors.forEach(function(vector) {
+      // Want to get the key for the wrong algorithm
+      var promise = subtle.generateKey({name: "HMAC", hash: "SHA-1"}, false, ["sign", "verify"])
+      .then(function(wrongKey) {
+          var algorithm = {name: vector.algorithmName};
+          return importVectorKeys(vector, ["verify"], ["sign"])
+          .then(function(vectors) {
+              promise_test(function(test) {
+                  var operation = subtle.sign(algorithm, wrongKey, vector.data)
+                  .then(function(signature) {
+                      assert_unreached("Signing should not have succeeded for " + vector.name);
+                  }, function(err) {
+                      assert_equals(err.name, "InvalidAccessError", "Should have thrown InvalidAccessError instead of '" + err.message + "'");
+                  });
+
+                  return operation;
+              }, vector.name + " signing with wrong algorithm name");
+
+          }, function(err) {
+              // We need a failed test if the importVectorKey operation fails, so
+              // we know we never tested verification.
+              promise_test(function(test) {
+                  assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+              }, "importVectorKeys step: " + vector.name + " signing with wrong algorithm name");
+          });
+      }, function(err) {
+          promise_test(function(test) {
+              assert_unreached("Generate wrong key for test " + vector.name + " failed: '" + err.message + "'");
+          }, "generate wrong key step: " + vector.name + " signing with wrong algorithm name");
+      });
+
+      all_promises.push(promise);
+  });
+
+  // Test verification with the wrong algorithm
+  testVectors.forEach(function(vector) {
+      // Want to get the key for the wrong algorithm
+      var promise = subtle.generateKey({name: "HMAC", hash: "SHA-1"}, false, ["sign", "verify"])
+      .then(function(wrongKey) {
+          return importVectorKeys(vector, ["verify"], ["sign"])
+          .then(function(vectors) {
+              var algorithm = {name: vector.algorithmName};
+              promise_test(function(test) {
+                  var operation = subtle.verify(algorithm, wrongKey, vector.signature, vector.data)
+                  .then(function(signature) {
+                      assert_unreached("Verifying should not have succeeded for " + vector.name);
+                  }, function(err) {
+                      assert_equals(err.name, "InvalidAccessError", "Should have thrown InvalidAccessError instead of '" + err.message + "'");
+                  });
+
+                  return operation;
+              }, vector.name + " verifying with wrong algorithm name");
+
+          }, function(err) {
+              // We need a failed test if the importVectorKey operation fails, so
+              // we know we never tested verification.
+              promise_test(function(test) {
+                  assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+              }, "importVectorKeys step: " + vector.name + " verifying with wrong algorithm name");
+          });
+      }, function(err) {
+          promise_test(function(test) {
+              assert_unreached("Generate wrong key for test " + vector.name + " failed: '" + err.message + "'");
+          }, "generate wrong key step: " + vector.name + " verifying with wrong algorithm name");
+      });
+
+      all_promises.push(promise);
+  });
+
+  // Test verification fails with wrong signature
+  testVectors.forEach(function(vector) {
+      var promise = importVectorKeys(vector, ["verify"], ["sign"])
+      .then(function(vectors) {
+          var algorithm = {name: vector.algorithmName};
+          var signature = copyBuffer(vector.signature);
+          signature[0] = 255 - signature[0];
+          promise_test(function(test) {
+              var operation = subtle.verify(algorithm, vector.publicKey, signature, vector.data)
+              .then(function(is_verified) {
+                  assert_false(is_verified, "Signature NOT verified");
+              }, function(err) {
+                  assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              });
+
+              return operation;
+          }, vector.name + " verification failure due to altered signature");
+
+      }, function(err) {
+          // We need a failed test if the importVectorKey operation fails, so
+          // we know we never tested verification.
+          promise_test(function(test) {
+              assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+          }, "importVectorKeys step: " + vector.name + " verification failure due to altered signature");
+      });
+
+      all_promises.push(promise);
+  });
+
+  // Test verification fails with short (odd length) signature
+  testVectors.forEach(function(vector) {
+      var promise = importVectorKeys(vector, ["verify"], ["sign"])
+      .then(function(vectors) {
+          var algorithm = {name: vector.algorithmName};
+          var signature = vector.signature.slice(1); // Skip the first byte
+          promise_test(function(test) {
+              var operation = subtle.verify(algorithm, vector.publicKey, signature, vector.data)
+              .then(function(is_verified) {
+                  assert_false(is_verified, "Signature NOT verified");
+              }, function(err) {
+                  assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              });
+
+              return operation;
+          }, vector.name + " verification failure due to shortened signature");
+
+      }, function(err) {
+          // We need a failed test if the importVectorKey operation fails, so
+          // we know we never tested verification.
+          promise_test(function(test) {
+              assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+          }, "importVectorKeys step: " + vector.name + " verification failure due to shortened signature");
+      });
+
+      all_promises.push(promise);
+  });
+
+  // Test verification fails with wrong data
+  testVectors.forEach(function(vector) {
+      var promise = importVectorKeys(vector, ["verify"], ["sign"])
+      .then(function(vectors) {
+          var algorithm = {name: vector.algorithmName};
+          var data = copyBuffer(vector.data);
+          data[0] = 255 - data[0];
+          promise_test(function(test) {
+              var operation = subtle.verify(algorithm, vector.publicKey, vector.signature, data)
+              .then(function(is_verified) {
+                  assert_false(is_verified, "Signature NOT verified");
+              }, function(err) {
+                  assert_unreached("Verification should not throw error " + vector.name + ": " + err.message + "'");
+              });
+
+              return operation;
+          }, vector.name + " verification failure due to altered data");
+
+      }, function(err) {
+          // We need a failed test if the importVectorKey operation fails, so
+          // we know we never tested verification.
+          promise_test(function(test) {
+              assert_unreached("importVectorKeys failed for " + vector.name + ". Message: ''" + err.message + "''");
+          }, "importVectorKeys step: " + vector.name + " verification failure due to altered data");
+      });
+
+      all_promises.push(promise);
+  });
+
+
+  promise_test(function() {
+      return Promise.all(all_promises)
+          .then(function() {done();})
+          .catch(function() {done();})
+  }, "setup");
+
+  // A test vector has all needed fields for signing and verifying, EXCEPT that the
+  // key field may be null. This function replaces that null with the Correct
+  // CryptoKey object.
+  //
+  // Returns a Promise that yields an updated vector on success.
+  function importVectorKeys(vector, publicKeyUsages, privateKeyUsages) {
+      var publicPromise, privatePromise;
+
+      if (vector.publicKey !== null) {
+          publicPromise = new Promise(function(resolve, reject) {
+              resolve(vector);
+          });
+      } else {
+          publicPromise = subtle.importKey(vector.publicKeyFormat, vector.publicKeyBuffer, {name: vector.algorithmName}, false, publicKeyUsages)
+          .then(function(key) {
+              vector.publicKey = key;
+              return vector;
+          });        // Returns a copy of the sourceBuffer it is sent.
+      }
+
+      if (vector.privateKey !== null) {
+          privatePromise = new Promise(function(resolve, reject) {
+              resolve(vector);
+          });
+      } else {
+          privatePromise = subtle.importKey(vector.privateKeyFormat, vector.privateKeyBuffer, {name: vector.algorithmName}, false, privateKeyUsages)
+          .then(function(key) {
+              vector.privateKey = key;
+              return vector;
+          });
+      }
+
+      return Promise.all([publicPromise, privatePromise]);
+  }
+
+  // Returns a copy of the sourceBuffer it is sent.
+  function copyBuffer(sourceBuffer) {
+      var source = new Uint8Array(sourceBuffer);
+      var copy = new Uint8Array(sourceBuffer.byteLength)
+
+      for (var i=0; i<source.byteLength; i++) {
+          copy[i] = source[i];
+      }
+
+      return copy;
+  }
+
+  function equalBuffers(a, b) {
+      if (a.byteLength !== b.byteLength) {
+          return false;
+      }
+
+      var aBytes = new Uint8Array(a);
+      var bBytes = new Uint8Array(b);
+
+      for (var i=0; i<a.byteLength; i++) {
+          if (aBytes[i] !== bBytes[i]) {
+              return false;
+          }
+      }
+
+      return true;
+  }
+
+  return;
+}

--- a/test/fixtures/wpt/WebCryptoAPI/sign_verify/eddsa_vectors.js
+++ b/test/fixtures/wpt/WebCryptoAPI/sign_verify/eddsa_vectors.js
@@ -1,0 +1,58 @@
+// eddsa_vectors.js
+
+// Data for testing Ed25519 and Ed448.
+
+// The following function returns an array of test vectors
+// for the subtleCrypto sign method.
+//
+// Each test vector has the following fields:
+//     name - a unique name for this vector
+//     publicKeyBuffer - an arrayBuffer with the key data
+//     publicKeyFormat - "spki" "jwk"
+//     publicKey - a CryptoKey object for the keyBuffer. INITIALLY null! You must fill this in first to use it!
+//     privateKeyBuffer - an arrayBuffer with the key data
+//     privateKeyFormat - "pkcs8" or "jwk"
+//     privateKey - a CryptoKey object for the keyBuffer. INITIALLY null! You must fill this in first to use it!
+//     algorithmName - the name of the AlgorithmIdentifier parameter to provide to sign
+//     data - the text to sign
+//     signature - the expected signature
+function getTestVectors() {
+  var pkcs8 = {
+      "Ed25519": new Uint8Array([48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32, 243, 200, 244, 196, 141, 248, 120, 20, 110, 140, 211, 191, 109, 244, 229, 14, 56, 155, 167, 7, 78, 21, 194, 53, 45, 205, 93, 48, 141, 76, 168, 31]),
+      "Ed448": new Uint8Array([48, 71, 2, 1, 0, 48, 5, 6, 3, 43, 101, 113, 4, 59, 4, 57, 14, 255, 3, 69, 140, 40, 224, 23, 156, 82, 29, 227, 18, 201, 105, 183, 131, 67, 72, 236, 171, 153, 26, 96, 227, 178, 233, 167, 158, 76, 217, 228, 128, 239, 41, 23, 18, 210, 200, 61, 4, 114, 114, 213, 201, 244, 40, 102, 79, 105, 109, 38, 112, 69, 143, 29, 46]),
+  };
+
+  var spki = {
+      "Ed25519": new Uint8Array([48, 42, 48, 5, 6, 3, 43, 101, 112, 3, 33, 0, 216, 225, 137, 99, 216, 9, 212, 135, 217, 84, 154, 204, 174, 198, 116, 46, 126, 235, 162, 77, 138, 13, 59, 20, 183, 227, 202, 234, 6, 137, 61, 204]),
+      "Ed448": new Uint8Array([48, 67, 48, 5, 6, 3, 43, 101, 113, 3, 58, 0, 171, 75, 184, 133, 253, 125, 44, 90, 242, 78, 131, 113, 12, 255, 160, 199, 74, 87, 226, 116, 128, 29, 178, 5, 123, 11, 220, 94, 160, 50, 182, 254, 107, 199, 139, 128, 69, 54, 90, 235, 38, 232, 110, 31, 20, 253, 52, 157, 7, 196, 132, 149, 245, 164, 106, 90, 128]),
+  };
+
+  // data
+  var data = new Uint8Array([43, 126, 208, 188, 119, 149, 105, 74, 180, 172, 211, 89, 3, 254, 140, 215, 216, 15, 106, 28, 134, 136, 166, 195, 65, 68, 9, 69, 117, 20, 161, 69, 120, 85, 187, 178, 25, 227, 10, 27, 238, 168, 254, 134, 144, 130, 217, 159, 200, 40, 47, 144, 80, 208, 36, 229, 158, 175, 7, 48, 186, 157, 183, 10]);
+
+  // For verification tests.
+  var signatures = {
+      "Ed25519": new Uint8Array([61, 144, 222, 94, 87, 67, 223, 194, 130, 37, 191, 173, 179, 65, 177, 22, 203, 248, 163, 241, 206, 237, 191, 74, 220, 53, 14, 245, 211, 71, 24, 67, 164, 24, 97, 77, 203, 110, 97, 72, 98, 97, 76, 247, 175, 20, 150, 249, 52, 11, 60, 132, 78, 164, 220, 234, 177, 211, 209, 85, 235, 126, 204, 0]),
+      "Ed448": new Uint8Array([118, 137, 126, 140, 80, 172, 107, 17, 50, 115, 92, 9, 197, 95, 80, 108, 1, 73, 210, 103, 124, 117, 102, 79, 139, 193, 11, 130, 111, 189, 157, 240, 160, 60, 217, 134, 188, 232, 51, 158, 100, 199, 209, 114, 14, 169, 54, 23, 132, 220, 115, 131, 119, 101, 172, 41, 128, 192, 218, 192, 129, 74, 139, 193, 135, 209, 201, 201, 7, 197, 220, 192, 121, 86, 248, 91, 112, 147, 15, 228, 45, 231, 100, 23, 114, 23, 203, 45, 82, 186, 183, 193, 222, 190, 12, 168, 156, 206, 203, 205, 99, 247, 2, 90, 42, 90, 87, 43, 157, 35, 176, 100, 47, 0]),
+  }
+
+  var vectors = [];
+  ["Ed25519", "Ed448"].forEach(function(algorithmName) {
+    var vector = {
+      name: "EdDSA " + algorithmName,
+      publicKeyBuffer: spki[algorithmName],
+      publicKeyFormat: "spki",
+      publicKey: null,
+      privateKeyBuffer: pkcs8[algorithmName],
+      privateKeyFormat: "pkcs8",
+      privateKey: null,
+      algorithmName: algorithmName,
+      data: data,
+      signature: signatures[algorithmName]
+    };
+
+    vectors.push(vector);
+  });
+
+  return vectors;
+}

--- a/test/fixtures/wpt/WebCryptoAPI/util/helpers.js
+++ b/test/fixtures/wpt/WebCryptoAPI/util/helpers.js
@@ -20,7 +20,11 @@ var registeredAlgorithmNames = [
     "SHA-384",
     "SHA-512",
     "HKDF-CTR",
-    "PBKDF2"
+    "PBKDF2",
+    "Ed25519",
+    "Ed448",
+    "X25519",
+    "X448"
 ];
 
 
@@ -177,6 +181,8 @@ function allAlgorithmSpecifiersFor(algorithmName) {
         curves.forEach(function(curveName) {
             results.push({name: algorithmName, namedCurve: curveName});
         });
+    } else if (algorithmName.toUpperCase().substring(0, 1) === "X" || algorithmName.toUpperCase().substring(0, 2) === "ED") {
+        results.push({ name: algorithmName });
     }
 
     return results;
@@ -216,6 +222,9 @@ function allValidUsages(validUsages, emptyIsValid, mandatoryUsages) {
     return okaySubsets;
 }
 
+function unique(names) {
+    return [...new Set(names)];
+}
 
 // Algorithm name specifiers are case-insensitive. Generate several
 // case variations of a given name.
@@ -227,5 +236,5 @@ function allNameVariants(name, slowTest) {
     // for slow tests effectively cut the amount of work in third by only
     // returning one variation
     if (slowTest) return [mixedCaseName];
-    return [upCaseName, lowCaseName, mixedCaseName];
+    return unique([upCaseName, lowCaseName, mixedCaseName]);
 }

--- a/test/fixtures/wpt/versions.json
+++ b/test/fixtures/wpt/versions.json
@@ -76,7 +76,7 @@
     "path": "wasm/webapi"
   },
   "WebCryptoAPI": {
-    "commit": "cdd0f03df41b222aed098fbbb11c6a3cc500a86b",
+    "commit": "edca84af42bd7e84da94e63b322fe343191842d2",
     "path": "WebCryptoAPI"
   },
   "webidl/ecmascript-binding/es-exceptions": {

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -450,3 +450,12 @@ assert.strictEqual(
     () => crypto.createHmac('sha7', 'key'),
     /Invalid digest/);
 }
+
+{
+  const buf = Buffer.alloc(0);
+  const keyObject = crypto.createSecretKey(Buffer.alloc(0));
+  assert.deepStrictEqual(
+    crypto.createHmac('sha256', buf).update('foo').digest(),
+    crypto.createHmac('sha256', keyObject).update('foo').digest(),
+  );
+}

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -34,18 +34,6 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
                                     'ascii');
 
 {
-  // Attempting to create an empty key should throw.
-  assert.throws(() => {
-    createSecretKey(Buffer.alloc(0));
-  }, {
-    name: 'RangeError',
-    code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "key.byteLength" is out of range. ' +
-             'It must be > 0. Received 0'
-  });
-}
-
-{
   // Attempting to create a key of a wrong type should throw
   const TYPE = 'wrong_type';
 

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -858,3 +858,13 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert(!first.privateKey.equals(second.privateKey));
   assert(!first.privateKey.equals(second.publicKey));
 }
+
+{
+  const first = createSecretKey(Buffer.alloc(0));
+  const second = createSecretKey(Buffer.alloc(0));
+  const third = createSecretKey(Buffer.alloc(1));
+  assert(first.equals(first));
+  assert(first.equals(second));
+  assert(!first.equals(third));
+  assert(!third.equals(first));
+}

--- a/test/parallel/test-webcrypto-derivebits-hkdf.js
+++ b/test/parallel/test-webcrypto-derivebits-hkdf.js
@@ -259,15 +259,18 @@ async function testDeriveBitsBadLengths(
   return Promise.all([
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], 0), {
-        message: /length cannot be zero/
+        message: /length cannot be zero/,
+        name: 'OperationError',
       }),
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], null), {
-        code: 'ERR_INVALID_ARG_TYPE'
+        message: 'length cannot be null',
+        name: 'OperationError',
       }),
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], 15), {
-        message: /length must be a multiple of 8/
+        message: /length must be a multiple of 8/,
+        name: 'OperationError',
       }),
   ]);
 }

--- a/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
@@ -119,7 +119,7 @@ async function testDecrypt({ keyBuffer, algorithm, result }) {
 
     decryptionFailing.forEach((vector) => {
       variations.push(assert.rejects(testDecrypt(vector), {
-        message: /bad decrypt/
+        name: 'OperationError'
       }));
     });
 

--- a/test/parallel/test-webcrypto-encrypt-decrypt-rsa.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt-rsa.js
@@ -127,7 +127,7 @@ async function testEncryptionLongPlaintext({ algorithm,
 
   return assert.rejects(
     subtle.encrypt(algorithm, publicKey, newplaintext), {
-      message: /data too large/
+      name: 'OperationError'
     });
 }
 

--- a/test/parallel/test-webcrypto-export-import.js
+++ b/test/parallel/test-webcrypto-export-import.js
@@ -46,15 +46,6 @@ const { subtle } = webcrypto;
       subtle.importKey('raw', keyData, {
         name: 'HMAC',
         hash: 'SHA-256',
-        length: 0
-      }, false, ['sign', 'verify']), {
-        name: 'DataError',
-        message: 'Zero-length key is not supported'
-      });
-    await assert.rejects(
-      subtle.importKey('raw', keyData, {
-        name: 'HMAC',
-        hash: 'SHA-256',
         length: 1
       }, false, ['sign', 'verify']), {
         name: 'DataError',

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -452,7 +452,7 @@ const vectors = {
     [1, true, {}, [], undefined, null].forEach(async (namedCurve) => {
       await assert.rejects(
         subtle.generateKey({ name, namedCurve }, true, privateUsages), {
-          code: 'ERR_INVALID_ARG_TYPE'
+          name: 'NotSupportedError',
         });
     });
   }
@@ -512,14 +512,14 @@ const vectors = {
     [1, 100, 257].forEach(async (length) => {
       await assert.rejects(
         subtle.generateKey({ name, length }, true, usages), {
-          code: 'ERR_INVALID_ARG_VALUE'
+          name: 'OperationError',
         });
     });
 
     ['', {}, [], false, null, undefined].forEach(async (length) => {
       await assert.rejects(
         subtle.generateKey({ name, length }, true, usages), {
-          code: 'ERR_INVALID_ARG_TYPE'
+          name: 'OperationError',
         });
     });
   }

--- a/test/pummel/test-webcrypto-derivebits-pbkdf2.js
+++ b/test/pummel/test-webcrypto-derivebits-pbkdf2.js
@@ -448,15 +448,18 @@ async function testDeriveBitsBadLengths(
   return Promise.all([
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], 0), {
-        message: /length cannot be zero/
+        name: 'OperationError',
+        message: /length cannot be zero/,
       }),
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], null), {
-        code: 'ERR_INVALID_ARG_TYPE'
+        name: 'OperationError',
+        message: 'length cannot be null',
       }),
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], 15), {
-        message: /length must be a multiple of 8/
+        name: 'OperationError',
+        message: /length must be a multiple of 8/,
       }),
   ]);
 }

--- a/test/wpt/status/WebCryptoAPI.json
+++ b/test/wpt/status/WebCryptoAPI.json
@@ -1,90 +1,11 @@
 {
-  "derive_bits_keys/ecdh_bits.https.any.js": {
-    "fail": "Derived correct bits expected true got false"
-  },
-  "derive_bits_keys/hkdf.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "derive_bits_keys/pbkdf2.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "digest/digest.https.any.js": {
-    "fail": "Expected NotSupportedError but got TypeError"
-  },
-  "encrypt_decrypt/aes_cbc.https.any.js": {
-    "fail": "Expected OperationError but got Error"
-  },
-  "encrypt_decrypt/rsa_oaep.https.any.js": {
-    "fail": "Expected OperationError but got Error"
-  },
-  "generateKey/failures_AES-CBC.https.any.js": {
-    "fail": "Expected OperationError but got TypeError"
-  },
-  "generateKey/failures_AES-CTR.https.any.js": {
-    "fail": "Expected OperationError but got TypeError"
-  },
-  "generateKey/failures_AES-GCM.https.any.js": {
-    "fail": "Expected OperationError but got TypeError"
-  },
-  "generateKey/failures_AES-KW.https.any.js": {
-    "fail": "Expected OperationError but got TypeError"
-  },
-  "generateKey/failures_ECDH.https.any.js": {
-    "fail": "Expected NotSupportedError but got TypeError"
-  },
-  "generateKey/failures_ECDSA.https.any.js": {
-    "fail": "Expected NotSupportedError but got TypeError"
-  },
-  "generateKey/failures_HMAC.https.any.js": {
-    "fail": "Operation succeeded, but should not have Reached unreachable code"
-  },
-  "generateKey/failures_RSA-OAEP.https.any.js": {
-    "fail": "Operation succeeded, but should not have Reached unreachable code"
-  },
-  "generateKey/failures_RSA-PSS.https.any.js": {
-    "fail": "Operation succeeded, but should not have Reached unreachable code"
-  },
-  "generateKey/failures_RSASSA-PKCS1-v1_5.https.any.js": {
-    "fail": "Operation succeeded, but should not have Reached unreachable code"
-  },
-  "generateKey/successes_AES-CBC.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "generateKey/successes_AES-CTR.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "generateKey/successes_AES-GCM.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "generateKey/successes_AES-KW.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "generateKey/successes_ECDH.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "generateKey/successes_ECDSA.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "generateKey/successes_HMAC.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "generateKey/successes_RSA-OAEP.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "generateKey/successes_RSA-PSS.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "generateKey/successes_RSASSA-PKCS1-v1_5.https.any.js": {
-    "fail": "location is not defined"
-  },
-  "getRandomValues.any.js": {
-    "fail": "The data argument must be an integer-type TypedArray"
+  "algorithm-discards-context.https.window.js": {
+    "skip": "Not relevant in Node.js context"
   },
   "historical.any.js": {
-    "fail": "expected (undefined) undefined but got..."
+    "skip": "Not relevant in Node.js context"
   },
   "idlharness.https.any.js": {
-    "fail": "Various non-IDL-compliant things"
+    "skip": "Various non-IDL-compliant things"
   }
 }
-

--- a/test/wpt/test-webcrypto.js
+++ b/test/wpt/test-webcrypto.js
@@ -11,4 +11,8 @@ const runner = new WPTRunner('WebCryptoAPI');
 // Set Node.js flags required for the tests.
 runner.setFlags(['--experimental-global-webcrypto']);
 
+runner.setInitScript(`
+  global.location = {};
+`);
+
 runner.runJsTests();

--- a/test/wpt/wpt.status
+++ b/test/wpt/wpt.status
@@ -7,7 +7,6 @@ prefix wpt
 [true] # This section applies to all platforms
 # https://github.com/nodejs/node/issues/40449
 test-user-timing: PASS,FLAKY
-test-webcrypto: SLOW
 
 [$system==win32]
 

--- a/test/wpt/wpt.status
+++ b/test/wpt/wpt.status
@@ -7,6 +7,7 @@ prefix wpt
 [true] # This section applies to all platforms
 # https://github.com/nodejs/node/issues/40449
 test-user-timing: PASS,FLAKY
+test-webcrypto: SLOW
 
 [$system==win32]
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -944,7 +944,7 @@ class Context(object):
 
   def GetTimeout(self, mode, section=''):
     timeout = self.timeout * TIMEOUT_SCALEFACTOR[ARCH_GUESS or 'ia32'][mode]
-    if section == 'pummel' or section == 'benchmark':
+    if section == 'pummel' or section == 'benchmark' or section == 'wpt':
       timeout = timeout * 6
     return timeout
 


### PR DESCRIPTION
I'm not expecting to land this PR as-is but i'm seeking feedback from @nodejs/crypto namely @tniessen and @jasnell on the end state which this currently reflects.

Overall the question is - is passing all relevant WebCryptoAPI WPT worth the ❗ items?

- update WebCryptoAPI WPT
- OperationError for generateKey() AES key length validation
- NotSupportedError for generateKey() and importKey() EC key namedCurve validation
- OperationError for HKDF deriveBits() length being null
- ❗ support for zero-length secret KeyObject
- OperationError for PBKDF2 deriveBits() iterations being 0
- OperationError for PBKDF2 deriveBits() length being null
- OperationError for when async crypto jobs fail for operation specific reasons
- ❗ workaround for openssl EVP_PKEY_derive HKDF not playing nice with zero-length IKM
- WPT global.location polyfill so that wpt/common/subset-tests.js execute

The C++ linter fails due to variable-length array use and I'd like suggestions for the C++ changes anyway.

I would still break this down into more individual commits. Or PRs if that's what the ask will be.