### PR TITLE
doc: fix default of duplex.allowHalfOpen

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2288,7 +2288,7 @@ added: v0.9.4
 
 If `false` then the stream will automatically end the writable side when the
 readable side ends. Set initially by the `allowHalfOpen` constructor option,
-which defaults to `false`.
+which defaults to `true`.
 
 This can be changed manually to change the half-open behavior of an existing
 `Duplex` stream instance, but must be changed before the `'end'` event is


### PR DESCRIPTION
To match the default value of `allowHalfOpen` in [`new stream.Duplex(options)`](https://nodejs.org/api/stream.html#new-streamduplexoptions).