### PR TITLE
util: avoid inline access to Symbol.iterator

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -859,7 +859,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
   // Iterators and the rest are split to reduce checks.
   // We have to check all values in case the constructor is set to null.
   // Otherwise it would not possible to identify all types properly.
-  if (value[SymbolIterator] || constructor === null) {
+  if (SymbolIterator in value || constructor === null) {
     noIterator = false;
     if (ArrayIsArray(value)) {
       // Only set the constructor for non ordinary ("Array [...]") arrays.

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -3240,3 +3240,12 @@ assert.strictEqual(
     '-123_456_789.123_456_78'
   );
 }
+
+// Regression test for https://github.com/nodejs/node/issues/41244
+{
+  assert.strictEqual(util.inspect({
+    get [Symbol.iterator]() {
+      throw new Error();
+    }
+  }), '{ [Symbol(Symbol.iterator)]: [Getter] }');
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->



Currently `util.inspect` has the inline access to `Symbol.iterator` to check if the value to be inspected is an iterator, but it could throw when the value of `[Symbol.iterator]` throws(has) an error. 
This PR replaced the inline access with `in` operator to be able to inspect correctly.