### PR TITLE
stream: fix 0 transform hwm backpressure

### DIFF
--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -87,11 +87,11 @@ function Transform(options) {
   // TODO (ronag): This should preferably always be
   // applied but would be semver-major. Or even better
   // Make transform a Readable with the Writable interface.
-  if (options && options.highWaterMark === 0) {
+  const readableHighWaterMark = options ? getHighWaterMark(this, options, 'readableHighWaterMark', true) : null;
+  if (readableHighWaterMark === 0) {
     // A Duplex will buffer both on the writable and readable side while
     // a Transform just wants to buffer hwm number of elements. To avoid
     // buffering twice we disable buffering on the writable side.
-    const readableHighWaterMark = getHighWaterMark(this, options, 'readableHighWaterMark', true);
     options = {
       ...options,
       highWaterMark: null,

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -66,7 +66,6 @@
 const {
   ObjectSetPrototypeOf,
   Symbol,
-  MathMax
 } = primordials;
 
 module.exports = Transform;

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -85,7 +85,8 @@ function Transform(options) {
     return new Transform(options);
 
   // TODO (ronag): This should preferably always be
-  // applied but would be semver-major.
+  // applied but would be semver-major. Or even better
+  // Make transform a Readable with the Writable interface.
   if (options && options.highWaterMark === 0) {
     // A Duplex will buffer both on the writable and readable side while
     // a Transform just wants to buffer hwm number of elements. To avoid

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -88,7 +88,7 @@ function Transform(options) {
     options = {
       ...options,
       highWaterMark: null,
-      readableHighWaterMark: Math.max(1, options.readableHighWaterMark || options.highWaterMark),
+      readableHighWaterMark: Math.max(1, options.readableHighWaterMark || options.highWaterMark || 1),
       // TODO (ronag) This should preferably be 0, but we have
       // a "bug" where we check needDrain before calling _write and not after.
       writableHighWaterMark: options.writableHighWaterMark || 1

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -82,6 +82,15 @@ function Transform(options) {
   if (!(this instanceof Transform))
     return new Transform(options);
 
+  if (options && options.highWaterMark != null) {
+    options = {
+      ...options,
+      highWaterMark: null,
+      readableHighWaterMark: Math.max(1, options.highWaterMark),
+      writableHighWaterMark: 0
+    }
+  }
+
   Duplex.call(this, options);
 
   // We have implemented the _read method, and done the other things
@@ -164,9 +173,7 @@ Transform.prototype._write = function(chunk, encoding, callback) {
     if (
       wState.ended || // Backwards compat.
       length === rState.length || // Backwards compat.
-      rState.length < rState.highWaterMark ||
-      rState.highWaterMark === 0 ||
-      rState.length === 0
+      rState.length < rState.highWaterMark
     ) {
       callback();
     } else {

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -85,8 +85,8 @@ function Transform(options) {
     return new Transform(options);
 
   // TODO (ronag): This should preferably always be
-  // applied but would be semver-major. Or even better
-  // Make transform a Readable with the Writable interface.
+  // applied but would be semver-major. Or even better;
+  // make Transform a Readable with the Writable interface.
   const readableHighWaterMark = options ? getHighWaterMark(this, options, 'readableHighWaterMark', true) : null;
   if (readableHighWaterMark === 0) {
     // A Duplex will buffer both on the writable and readable side while
@@ -95,7 +95,7 @@ function Transform(options) {
     options = {
       ...options,
       highWaterMark: null,
-      readableHighWaterMark: MathMax(1, readableHighWaterMark),
+      readableHighWaterMark,
       // TODO (ronag) This is not optimal since we have
       // a "bug" where we check needDrain before calling _write and not after.
       // Refs: https://github.com/nodejs/node/pull/32887

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -65,7 +65,8 @@
 
 const {
   ObjectSetPrototypeOf,
-  Symbol
+  Symbol,
+  MathMax
 } = primordials;
 
 module.exports = Transform;
@@ -89,17 +90,17 @@ function Transform(options) {
     // A Duplex will buffer both on the writable and readable side while
     // a Transform just wants to buffer hwm number of elements. To avoid
     // buffering twice we disable buffering on the writable side.
-    const readableHighWaterMark = getHighWaterMark(this, options, 'readableHighWaterMark', true)
+    const readableHighWaterMark = getHighWaterMark(this, options, 'readableHighWaterMark', true);
     options = {
       ...options,
       highWaterMark: null,
-      readableHighWaterMark: Math.max(1, readableHighWaterMark),
+      readableHighWaterMark: MathMax(1, readableHighWaterMark),
       // TODO (ronag) This is not optimal since we have
       // a "bug" where we check needDrain before calling _write and not after.
       // Refs: https://github.com/nodejs/node/pull/32887
       // Refs: https://github.com/nodejs/node/pull/35941
       writableHighWaterMark: 0
-    }
+    };
   }
 
   Duplex.call(this, options);

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -95,11 +95,11 @@ function Transform(options) {
       ...options,
       highWaterMark: null,
       readableHighWaterMark,
-      // TODO (ronag) This is not optimal since we have
+      // TODO (ronag): 0 is not optimal since we have
       // a "bug" where we check needDrain before calling _write and not after.
       // Refs: https://github.com/nodejs/node/pull/32887
       // Refs: https://github.com/nodejs/node/pull/35941
-      writableHighWaterMark: 0
+      writableHighWaterMark: options.writableHighWaterMark || 0
     };
   }
 

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -85,6 +85,9 @@ function Transform(options) {
   // TODO (ronag): This should preferably always be
   // applied but would be semver-major.
   if (options && options.highWaterMark === 0) {
+    // A Duplex will buffer both on the writable and readable side while
+    // a Transform just wants to buffer hwm number of elements. To avoid
+    // buffering twice we disable buffering on the writable side.
     options = {
       ...options,
       highWaterMark: null,

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -94,6 +94,8 @@ function Transform(options) {
       readableHighWaterMark: Math.max(1, options.readableHighWaterMark || options.highWaterMark || 1),
       // TODO (ronag) This should preferably be 0, but we have
       // a "bug" where we check needDrain before calling _write and not after.
+      // Refs: https://github.com/nodejs/node/pull/32887
+      // Refs: https://github.com/nodejs/node/pull/35941
       writableHighWaterMark: options.writableHighWaterMark || 1
     }
   }

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -82,12 +82,16 @@ function Transform(options) {
   if (!(this instanceof Transform))
     return new Transform(options);
 
-  if (options && options.highWaterMark != null) {
+  // TODO (ronag): This should preferably always be
+  // applied but would be semver-major.
+  if (options && options.highWaterMark === 0) {
     options = {
       ...options,
       highWaterMark: null,
-      readableHighWaterMark: Math.max(1, options.highWaterMark),
-      writableHighWaterMark: 0
+      readableHighWaterMark: Math.max(1, options.readableHighWaterMark || options.highWaterMark),
+      // TODO (ronag) This should preferably be 0, but we have
+      // a "bug" where we check needDrain before calling _write and not after.
+      writableHighWaterMark: options.writableHighWaterMark || 1
     }
   }
 

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -94,11 +94,11 @@ function Transform(options) {
       ...options,
       highWaterMark: null,
       readableHighWaterMark: Math.max(1, readableHighWaterMark),
-      // TODO (ronag) This should be 0, but we have
+      // TODO (ronag) This is not optimal since we have
       // a "bug" where we check needDrain before calling _write and not after.
       // Refs: https://github.com/nodejs/node/pull/32887
       // Refs: https://github.com/nodejs/node/pull/35941
-      writableHighWaterMark: options.writableHighWaterMark || 1
+      writableHighWaterMark: 0
     }
   }
 

--- a/lib/internal/streams/transform.js
+++ b/lib/internal/streams/transform.js
@@ -73,6 +73,7 @@ const {
   ERR_METHOD_NOT_IMPLEMENTED
 } = require('internal/errors').codes;
 const Duplex = require('internal/streams/duplex');
+const { getHighWaterMark } = require('internal/streams/state');
 ObjectSetPrototypeOf(Transform.prototype, Duplex.prototype);
 ObjectSetPrototypeOf(Transform, Duplex);
 
@@ -88,11 +89,12 @@ function Transform(options) {
     // A Duplex will buffer both on the writable and readable side while
     // a Transform just wants to buffer hwm number of elements. To avoid
     // buffering twice we disable buffering on the writable side.
+    const readableHighWaterMark = getHighWaterMark(this, options, 'readableHighWaterMark', true)
     options = {
       ...options,
       highWaterMark: null,
-      readableHighWaterMark: Math.max(1, options.readableHighWaterMark || options.highWaterMark || 1),
-      // TODO (ronag) This should preferably be 0, but we have
+      readableHighWaterMark: Math.max(1, readableHighWaterMark),
+      // TODO (ronag) This should be 0, but we have
       // a "bug" where we check needDrain before calling _write and not after.
       // Refs: https://github.com/nodejs/node/pull/32887
       // Refs: https://github.com/nodejs/node/pull/35941

--- a/test/parallel/test-stream-passthrough-drain.js
+++ b/test/parallel/test-stream-passthrough-drain.js
@@ -1,8 +1,9 @@
 'use strict';
 const common = require('../common');
+const assert = require('assert')
 const { PassThrough } = require('stream');
 
 const pt = new PassThrough({ highWaterMark: 0 });
 pt.on('drain', common.mustCall());
-pt.write('hello');
+assert(!pt.write('hello1'));
 pt.read();

--- a/test/parallel/test-stream-passthrough-drain.js
+++ b/test/parallel/test-stream-passthrough-drain.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert')
+const assert = require('assert');
 const { PassThrough } = require('stream');
 
 const pt = new PassThrough({ highWaterMark: 0 });

--- a/test/parallel/test-stream-passthrough-drain.js
+++ b/test/parallel/test-stream-passthrough-drain.js
@@ -7,3 +7,4 @@ const pt = new PassThrough({ highWaterMark: 0 });
 pt.on('drain', common.mustCall());
 assert(!pt.write('hello1'));
 pt.read();
+pt.read();

--- a/test/parallel/test-stream-transform-hwm0.js
+++ b/test/parallel/test-stream-transform-hwm0.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Transform } = require('stream');
+
+const t = new Transform({
+  objectMode: true, highWaterMark: 0,
+  transform(chunk, enc, callback) {
+    process.nextTick(() => callback(null, chunk, enc));
+  }
+});
+
+assert.strictEqual(t.write(1), false);
+t.on('drain', common.mustCall(() => {
+  assert.strictEqual(t.write(2), false);
+  t.end();
+}));
+
+t.once('readable', common.mustCall(() => {
+  assert.strictEqual(t.read(), 1);
+  setImmediate(common.mustCall(() => {
+    assert.strictEqual(t.read(), null);
+    t.once('readable', common.mustCall(() => {
+      assert.strictEqual(t.read(), 2);
+    }));
+  }));
+}));

--- a/test/parallel/test-stream-transform-hwm0.js
+++ b/test/parallel/test-stream-transform-hwm0.js
@@ -19,10 +19,8 @@ t.on('drain', common.mustCall(() => {
 
 t.once('readable', common.mustCall(() => {
   assert.strictEqual(t.read(), 1);
-  setImmediate(common.mustCall(() => {
-    assert.strictEqual(t.read(), null);
-    t.once('readable', common.mustCall(() => {
-      assert.strictEqual(t.read(), 2);
-    }));
+  assert.strictEqual(t.read(), null);
+  t.once('readable', common.mustCall(() => {
+    assert.strictEqual(t.read(), 2);
   }));
 }));

--- a/test/parallel/test-stream-transform-hwm0.js
+++ b/test/parallel/test-stream-transform-hwm0.js
@@ -1,28 +1,28 @@
 'use strict';
 
- const common = require('../common');
- const assert = require('assert');
- const { Transform } = require('stream');
+const common = require('../common');
+const assert = require('assert');
+const { Transform } = require('stream');
 
- const t = new Transform({
-   objectMode: true, highWaterMark: 0,
-   transform(chunk, enc, callback) {
-     process.nextTick(() => callback(null, chunk, enc));
-   }
- });
+const t = new Transform({
+  objectMode: true, highWaterMark: 0,
+  transform(chunk, enc, callback) {
+    process.nextTick(() => callback(null, chunk, enc));
+  }
+});
 
- assert.strictEqual(t.write(1), false);
- t.on('drain', common.mustCall(() => {
-   assert.strictEqual(t.write(2), false);
-   t.end();
- }));
+assert.strictEqual(t.write(1), false);
+t.on('drain', common.mustCall(() => {
+  assert.strictEqual(t.write(2), false);
+  t.end();
+}));
 
- t.once('readable', common.mustCall(() => {
-   assert.strictEqual(t.read(), 1);
-   setImmediate(common.mustCall(() => {
-     assert.strictEqual(t.read(), null);
-     t.once('readable', common.mustCall(() => {
-       assert.strictEqual(t.read(), 2);
-     }));
-   }));
- }));
+t.once('readable', common.mustCall(() => {
+  assert.strictEqual(t.read(), 1);
+  setImmediate(common.mustCall(() => {
+    assert.strictEqual(t.read(), null);
+    t.once('readable', common.mustCall(() => {
+      assert.strictEqual(t.read(), 2);
+    }));
+  }));
+}));

--- a/test/parallel/test-stream-transform-hwm0.js
+++ b/test/parallel/test-stream-transform-hwm0.js
@@ -1,26 +1,28 @@
 'use strict';
 
-const common = require('../common');
-const assert = require('assert');
-const { Transform } = require('stream');
+ const common = require('../common');
+ const assert = require('assert');
+ const { Transform } = require('stream');
 
-const t = new Transform({
-  objectMode: true, highWaterMark: 0,
-  transform(chunk, enc, callback) {
-    process.nextTick(() => callback(null, chunk, enc));
-  }
-});
+ const t = new Transform({
+   objectMode: true, highWaterMark: 0,
+   transform(chunk, enc, callback) {
+     process.nextTick(() => callback(null, chunk, enc));
+   }
+ });
 
-assert.strictEqual(t.write(1), false);
-t.on('drain', common.mustCall(() => {
-  assert.strictEqual(t.write(2), false);
-  t.end();
-}));
+ assert.strictEqual(t.write(1), false);
+ t.on('drain', common.mustCall(() => {
+   assert.strictEqual(t.write(2), false);
+   t.end();
+ }));
 
-t.once('readable', common.mustCall(() => {
-  assert.strictEqual(t.read(), 1);
-  assert.strictEqual(t.read(), null);
-  t.once('readable', common.mustCall(() => {
-    assert.strictEqual(t.read(), 2);
-  }));
-}));
+ t.once('readable', common.mustCall(() => {
+   assert.strictEqual(t.read(), 1);
+   setImmediate(common.mustCall(() => {
+     assert.strictEqual(t.read(), null);
+     t.once('readable', common.mustCall(() => {
+       assert.strictEqual(t.read(), 2);
+     }));
+   }));
+ }));

--- a/test/parallel/test-stream-transform-split-highwatermark.js
+++ b/test/parallel/test-stream-transform-split-highwatermark.js
@@ -39,21 +39,6 @@ testTransform(555, 555, {
   writableHighWaterMark: 777,
 });
 
-// Test highWaterMark = 0 overriding
-testTransform(0, 0, {
-  highWaterMark: 0,
-  readableHighWaterMark: 666,
-});
-testTransform(0, 0, {
-  highWaterMark: 0,
-  writableHighWaterMark: 777,
-});
-testTransform(0, 0, {
-  highWaterMark: 0,
-  readableHighWaterMark: 666,
-  writableHighWaterMark: 777,
-});
-
 // Test undefined, null
 [undefined, null].forEach((v) => {
   testTransform(DEFAULT, DEFAULT, { readableHighWaterMark: v });

--- a/test/parallel/test-stream-transform-split-highwatermark.js
+++ b/test/parallel/test-stream-transform-split-highwatermark.js
@@ -20,10 +20,6 @@ testTransform(666, 777, {
   writableHighWaterMark: 777,
 });
 
-// test 0 overriding defaultHwm
-testTransform(0, DEFAULT, { readableHighWaterMark: 0 });
-testTransform(DEFAULT, 0, { writableHighWaterMark: 0 });
-
 // Test highWaterMark overriding
 testTransform(555, 555, {
   highWaterMark: 555,


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/42457
Refs: https://github.com/nodejs/node/pull/43648/files

This also fixes a long standing issue where setting a hwm on a transform stream actually causes twice as much buffering as expected.