### PR TITLE
esm: treat `307` and `308` as redirects in HTTPS imports

### DIFF
--- a/lib/internal/modules/esm/fetch_module.js
+++ b/lib/internal/modules/esm/fetch_module.js
@@ -90,6 +90,18 @@ function createUnzip() {
 }
 
 /**
+ * Redirection status code as per section 6.4 of RFC 7231:
+ * https://datatracker.ietf.org/doc/html/rfc7231#section-6.4
+ * and RFC 7238:
+ * https://datatracker.ietf.org/doc/html/rfc7238
+ * @param {number} statusCode
+ * @returns {boolean}
+ */
+function isRedirect(statusCode) {
+  return [300, 301, 302, 303, 307, 308].includes(statusCode);
+}
+
+/**
  * @param {URL} parsed
  * @returns {Promise<CacheEntry> | CacheEntry}
  */
@@ -107,13 +119,8 @@ function fetchWithRedirects(parsed) {
     // `finally` on network error/timeout.
     const { 0: res } = await once(req, 'response');
     try {
-      const isRedirect = res.statusCode >= 300 && (
-        res.statusCode <= 303 ||
-        res.statusCode === 307 ||
-        res.statusCode === 308
-      );
       const hasLocation = ObjectPrototypeHasOwnProperty(res.headers, 'location');
-      if (isRedirect && hasLocation) {
+      if (isRedirect(res.statusCode) && hasLocation) {
         const location = new URL(res.headers.location, parsed);
         if (location.protocol !== 'http:' && location.protocol !== 'https:') {
           throw new ERR_NETWORK_IMPORT_DISALLOWED(
@@ -131,12 +138,8 @@ function fetchWithRedirects(parsed) {
         err.message = `Cannot find module '${parsed.href}', HTTP 404`;
         throw err;
       }
-      if (
-        (
-          res.statusCode > 303 &&
-          res.statusCode !== 307 &&
-          res.statusCode !== 308
-        ) || res.statusCode < 200) {
+      if ((res.statusCode > 303 && !isRedirect(res.statusCode)) ||
+          res.statusCode < 200) {
         throw new ERR_NETWORK_IMPORT_DISALLOWED(
           res.headers.location,
           parsed.href,

--- a/lib/internal/modules/esm/fetch_module.js
+++ b/lib/internal/modules/esm/fetch_module.js
@@ -107,7 +107,11 @@ function fetchWithRedirects(parsed) {
     // `finally` on network error/timeout.
     const { 0: res } = await once(req, 'response');
     try {
-      const isRedirect = res.statusCode >= 300 && res.statusCode <= 303;
+      const isRedirect = res.statusCode >= 300 && (
+        res.statusCode <= 303 ||
+        res.statusCode === 307 ||
+        res.statusCode === 308
+      );
       const hasLocation = ObjectPrototypeHasOwnProperty(res.headers, 'location');
       if (isRedirect && hasLocation) {
         const location = new URL(res.headers.location, parsed);
@@ -127,7 +131,12 @@ function fetchWithRedirects(parsed) {
         err.message = `Cannot find module '${parsed.href}', HTTP 404`;
         throw err;
       }
-      if (res.statusCode > 303 || res.statusCode < 200) {
+      if (
+        (
+          res.statusCode > 303 &&
+          res.statusCode !== 307 &&
+          res.statusCode !== 308
+        ) || res.statusCode < 200) {
         throw new ERR_NETWORK_IMPORT_DISALLOWED(
           res.headers.location,
           parsed.href,

--- a/lib/internal/modules/esm/fetch_module.js
+++ b/lib/internal/modules/esm/fetch_module.js
@@ -1,5 +1,6 @@
 'use strict';
 const {
+  ArrayPrototypeIncludes,
   ObjectPrototypeHasOwnProperty,
   PromisePrototypeThen,
   SafeMap,
@@ -98,7 +99,7 @@ function createUnzip() {
  * @returns {boolean}
  */
 function isRedirect(statusCode) {
-  return [300, 301, 302, 303, 307, 308].includes(statusCode);
+  return ArrayPrototypeIncludes([300, 301, 302, 303, 307, 308], statusCode);
 }
 
 /**
@@ -138,8 +139,7 @@ function fetchWithRedirects(parsed) {
         err.message = `Cannot find module '${parsed.href}', HTTP 404`;
         throw err;
       }
-      if ((res.statusCode > 303 && !isRedirect(res.statusCode)) ||
-          res.statusCode < 200) {
+      if (res.statusCode < 200 || res.statusCode >= 400) {
         throw new ERR_NETWORK_IMPORT_DISALLOWED(
           res.headers.location,
           parsed.href,

--- a/lib/internal/modules/esm/fetch_module.js
+++ b/lib/internal/modules/esm/fetch_module.js
@@ -1,6 +1,5 @@
 'use strict';
 const {
-  ArrayPrototypeIncludes,
   ObjectPrototypeHasOwnProperty,
   PromisePrototypeThen,
   SafeMap,
@@ -99,7 +98,17 @@ function createUnzip() {
  * @returns {boolean}
  */
 function isRedirect(statusCode) {
-  return ArrayPrototypeIncludes([300, 301, 302, 303, 307, 308], statusCode);
+  switch (statusCode) {
+    case 300: // Multiple Choices
+    case 301: // Moved Permanently
+    case 302: // Found
+    case 303: // See Other
+    case 307: // Temporary Redirect
+    case 308: // Permanent Redirect
+      return true;
+    default:
+      return false;
+  }
 }
 
 /**


### PR DESCRIPTION
Per RFC 7231 and 7238, HTTP `307` and `308` status code are also for
redirect responses.

Fixes: https://github.com/nodejs/node/issues/43679
Refs: https://datatracker.ietf.org/doc/html/rfc7231#section-6.4.7
Refs: https://datatracker.ietf.org/doc/html/rfc7238