### PR TITLE
build: enable GitPod prebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 !.github
 !.gitignore
 !.gitkeep
+!.gitpod.yml
 !.mailmap
 !.nycrc
 !.yamllint.yaml

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+# Ref: https://github.com/gitpod-io/gitpod/issues/6283#issuecomment-1001043454
+tasks:
+  - init: ./configure && timeout 50m make -j16 || true
+
+# Ref: https://www.gitpod.io/docs/prebuilds#github-specific-configuration
+github:
+  prebuilds:
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to true)
+    addComment: false


### PR DESCRIPTION
The goal here is to make it easier to get started contributing to Node.js. Ongoing contributors will find something like this useful too, although there are limitations (such as it won't be useful for compiling Windows executables for testing).

Experience it now by going to https://gitpod.io/#https://github.com/Trott/io.js (which is this PR up and running on my fork of this repository). If you have a GitPod account, you will get (in a matter of seconds) a development environment with a compiled version of the Node.js binary and artifacts in place so that recompiling small changes won't take much time either. People wishing to get started developing in Node.js core (and people wishing to not have to recompile after every V8 update, etc.) won't need to install the compilation tool chain and so on.

This will be very useful to have installed (even if only temporarily) for [Grace Hopper Open Source Day](https://github.com/nodejs/TSC/issues/1238).

This will probably require installing [the GitPod app](https://github.com/apps/gitpod-io) to this repository, so /ping @nodejs/tsc. 