### PR TITLE
stream: finish pipeline if dst closes before src

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -20,6 +20,7 @@ const {
     ERR_INVALID_RETURN_VALUE,
     ERR_MISSING_ARGS,
     ERR_STREAM_DESTROYED,
+    ERR_STREAM_PREMATURE_CLOSE,
   },
   AbortError,
 } = require('internal/errors');
@@ -344,13 +345,24 @@ function pipelineImpl(streams, callback, opts) {
 }
 
 function pipe(src, dst, finish, { end }) {
+  let ended = false
+  dst.on('close', () => {
+    if (!ended) {
+      // Finish if the destination closes before the source has completed.
+      finish(new ERR_STREAM_PREMATURE_CLOSE());
+    }
+  })
+
   src.pipe(dst, { end });
 
   if (end) {
     // Compat. Before node v10.12.0 stdio used to throw an error so
     // pipe() did/does not end() stdio destinations.
     // Now they allow it but "secretly" don't close the underlying fd.
-    src.once('end', () => dst.end());
+    src.once('end', () => {
+      ended = true
+      dst.end()
+    });
   } else {
     finish();
   }

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -345,13 +345,13 @@ function pipelineImpl(streams, callback, opts) {
 }
 
 function pipe(src, dst, finish, { end }) {
-  let ended = false
+  let ended = false;
   dst.on('close', () => {
     if (!ended) {
       // Finish if the destination closes before the source has completed.
       finish(new ERR_STREAM_PREMATURE_CLOSE());
     }
-  })
+  });
 
   src.pipe(dst, { end });
 
@@ -360,8 +360,8 @@ function pipe(src, dst, finish, { end }) {
     // pipe() did/does not end() stdio destinations.
     // Now they allow it but "secretly" don't close the underlying fd.
     src.once('end', () => {
-      ended = true
-      dst.end()
+      ended = true;
+      dst.end();
     });
   } else {
     finish();

--- a/test/parallel/test-stream-pipeline-duplex.js
+++ b/test/parallel/test-stream-pipeline-duplex.js
@@ -6,14 +6,14 @@ const assert = require('assert');
 
 const remote = new PassThrough();
 const local = new Duplex({
-  read () {},
-  write (chunk, enc, callback) {
-    callback()
+  read() {},
+  write(chunk, enc, callback) {
+    callback();
   }
 });
 
 pipeline(remote, local, remote, common.mustCall((err) => {
-  assert.equal(err.code, 'ERR_STREAM_PREMATURE_CLOSE')
+  assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
 }));
 
 setImmediate(() => {

--- a/test/parallel/test-stream-pipeline-duplex.js
+++ b/test/parallel/test-stream-pipeline-duplex.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const { pipeline, Duplex, PassThrough } = require('stream');
+const assert = require('assert');
+
+const remote = new PassThrough();
+const local = new Duplex({
+  read () {},
+  write (chunk, enc, callback) {
+    callback()
+  }
+});
+
+pipeline(remote, local, remote, common.mustCall((err) => {
+  assert.equal(err.code, 'ERR_STREAM_PREMATURE_CLOSE')
+}));
+
+setImmediate(() => {
+  remote.end();
+});


### PR DESCRIPTION
If the destination stream is closed before the source has completed
the pipeline should finnish with premature close.

Fixes: https://github.com/nodejs/node/issues/43682

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
