### PR TITLE
cluster: fix closing dgram sockets in cluster workers throws errors

### DIFF
--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -111,6 +111,10 @@ cluster._getServer = function(obj, options, cb) {
   });
 
   obj.once('listening', () => {
+    // short-lived sockets might have been closed
+    if (!indexes.has(indexesKey)) {
+      return;
+    }
     cluster.worker.state = 'listening';
     const address = obj.address();
     message.act = 'listening';

--- a/test/parallel/test-dgram-cluster-close-in-listening.js
+++ b/test/parallel/test-dgram-cluster-close-in-listening.js
@@ -1,0 +1,29 @@
+'use strict';
+// Ensure that closing dgram sockets in 'listening' callbacks of cluster workers
+// won't throw errors.
+
+const common = require('../common');
+const dgram = require('dgram');
+const cluster = require('cluster');
+if (common.isWindows)
+  common.skip('dgram clustering is currently not supported on windows.');
+
+if (cluster.isPrimary) {
+  for (let i = 0; i < 3; i += 1) {
+    cluster.fork();
+  }
+} else {
+  const socket = dgram.createSocket('udp4');
+
+  socket.on('error', common.mustNotCall());
+
+  socket.on('listening', common.mustCall(() => {
+    socket.close();
+  }));
+
+  socket.on('close', common.mustCall(() => {
+    cluster.worker.disconnect();
+  }));
+
+  socket.bind(0);
+}


### PR DESCRIPTION
This fixes closing dgram sockets right after binding in cluster workers
will throws `ERR_SOCKET_DGRAM_NOT_RUNNING` errors.

Before this, the code snippet below will throw:
```js
const dgram = require('dgram')
const cluster = require('cluster')

if (cluster.isMaster || cluster.isPrimary) {
  cluster.fork()
} else {
  const socket = dgram.createSocket('udp4');
  socket.bind(0, () => {
    socket.close();
  });
}
```

While running in primary processes won't throw:
```js
const dgram = require('dgram')

const socket = dgram.createSocket('udp4');
socket.bind(0, () => {
  socket.close();
});
```

Fixes: https://github.com/nodejs/node/issues/40671

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
