### PR TITLE
net: remove redundant connecting assignment

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1238,7 +1238,6 @@ function afterConnect(status, handle, req, readable, writable) {
       stopPerf(self, kPerfHooksNetConnectContext);
     }
   } else {
-    self.connecting = false;
     let details;
     if (req.localAddress && req.localPort) {
       details = req.localAddress + ':' + req.localPort;

--- a/test/sequential/test-net-connect-handle-econnrefused.js
+++ b/test/sequential/test-net-connect-handle-econnrefused.js
@@ -27,5 +27,6 @@ const assert = require('assert');
 const c = net.createConnection(common.PORT);
 c.on('connect', common.mustNotCall());
 c.on('error', common.mustCall((e) => {
+  assert.strictEqual(c.connecting, false);
   assert.strictEqual(e.code, 'ECONNREFUSED');
 }));


### PR DESCRIPTION
It's already assigned in a few lines before:

https://github.com/nodejs/node/blob/7d13f5e34f7a9e98b925d7fdf77ebfadb7ed17d8/lib/net.js#L1209

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
