### PR TITLE
util: use string width in util `formatPrimitive()`string length line check

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1529,15 +1529,17 @@ function formatPrimitive(fn, value, ctx) {
       value = value.slice(0, ctx.maxStringLength);
       trailer = `... ${remaining} more character${remaining > 1 ? 's' : ''}`;
     }
-    if (ctx.compact !== true &&
-        // TODO(BridgeAR): Add unicode support. Use the readline getStringWidth
-        // function.
-        value.length > kMinLineLength &&
-        value.length > ctx.breakLength - ctx.indentationLvl - 4) {
-      return value
-        .split(/(?<=\n)/)
-        .map((line) => fn(strEscape(line), 'string'))
-        .join(` +\n${' '.repeat(ctx.indentationLvl + 2)}`) + trailer;
+    if (ctx.compact !== true) {
+      const valueStringWidth = getStringWidth(value, ctx.colors);
+      if (
+        valueStringWidth > kMinLineLength &&
+        valueStringWidth > ctx.breakLength - ctx.indentationLvl - 4
+      ) {
+        return value
+          .split(/(?<=\n)/)
+          .map((line) => fn(strEscape(line), 'string'))
+          .join(` +\n${' '.repeat(ctx.indentationLvl + 2)}`) + trailer;
+      }
     }
     return fn(strEscape(value), 'string') + trailer;
   }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2637,6 +2637,14 @@ assert.strictEqual(
 
   assert.strictEqual(out, expected);
 
+  // Unicode character width support.
+  out = util.inspect(
+    `${('あ').repeat(5)}\n${('あ').repeat(5)}`,
+    { compact: 3, breakLength: 15 }
+  );
+  expected = "'あああああ\\n' +\n  'あああああ'";
+  assert.strictEqual(out, expected);
+
   // Array grouping should prevent lining up outer elements on a single line.
   obj = [[[1, 2, 3, 4, 5, 6, 7, 8, 9]]];
 


### PR DESCRIPTION
Improves support for `util.inspect` formatting strings with unicode characters by updating to look at the printed string width instead of the string length.

Characters like `あ` have a width of 2 and length 1.