### PR TITLE
benchmark: fix benchmark compare output

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -261,6 +261,12 @@ class Benchmark {
       time: nanoSecondsToString(elapsed),
       type: 'report',
     });
+
+    // If, for any reason, the process is unable to self close within
+    // a second after completing, forcefully close it.
+    setTimeout(() => {
+      process.exit(0);
+    }, 5000).unref();
   }
 }
 
@@ -287,15 +293,9 @@ function formatResult(data) {
 }
 
 function sendResult(data) {
-  if (process.send && Object.hasOwn(process.env, 'NODE_RUN_BENCHMARK_FN')) {
+  if (process.send) {
     // If forked, report by process send
-    process.send(data, () => {
-      // If, for any reason, the process is unable to self close within
-      // a second after completing, forcefully close it.
-      setTimeout(() => {
-        process.exit(0);
-      }, 5000).unref();
-    });
+    process.send(data);
   } else {
     // Otherwise report by stdout
     process.stdout.write(formatResult(data));


### PR DESCRIPTION
The patch https://github.com/nodejs/node/pull/43601 makes `benchmark/compare.js` not work as expected as it outputs malformed CSV data.

Expected outputs:
```
$ node benchmark/compare.js --new ./node --old ./node --filter ok assert
"binary","filename","configuration","rate","time"
"old","assert/ok.js","n=100000",38415366.14645858,0.002603125
"new","assert/ok.js","n=100000",36958903.17802217,0.002705708
```

Outputs with the main branch:
```
$ node benchmark/compare.js --new ./node --old ./node --filter ok assert
"binary","filename","configuration","rate","time"
assert/ok.js n=100000: 40,438,760.551989086
assert/ok.js n=100000: 40,999,014.79367451
assert/ok.js n=100000: 36,593,175.372792974
assert/ok.js n=100000: 37,697,312.44550382
```

This patch moves the forced exit introduced in https://github.com/nodejs/node/commit/684e1079653f670f1a6f611365203a32ba0b49d5 to `Benchmark.report` which is only used in benchmarking processes.