### PR TITLE
lib: implement safe alternatives to `Promise` static methods

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -2,7 +2,6 @@
 
 const {
   ArrayPrototypeJoin,
-  ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypeSome,
   FunctionPrototype,
@@ -111,8 +110,7 @@ class ModuleJob {
       }
       jobsInGraph.add(moduleJob);
       const dependencyJobs = await moduleJob.linked;
-      return SafePromiseAll(
-        ArrayPrototypeMap(dependencyJobs, addJobsToDependencyGraph));
+      return SafePromiseAll(dependencyJobs, addJobsToDependencyGraph);
     };
     await addJobsToDependencyGraph(this);
 

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -8,13 +8,12 @@ const {
   FunctionPrototype,
   ObjectCreate,
   ObjectSetPrototypeOf,
-  PromiseAll,
   PromiseResolve,
   PromisePrototypeCatch,
   ReflectApply,
   RegExpPrototypeExec,
   RegExpPrototypeSymbolReplace,
-  SafeArrayIterator,
+  SafePromiseAll,
   SafeSet,
   StringPrototypeIncludes,
   StringPrototypeSplit,
@@ -82,9 +81,9 @@ class ModuleJob {
       });
 
       if (promises !== undefined)
-        await PromiseAll(new SafeArrayIterator(promises));
+        await SafePromiseAll(promises);
 
-      return PromiseAll(new SafeArrayIterator(dependencyJobs));
+      return SafePromiseAll(dependencyJobs);
     };
     // Promise for the list of all dependencyJobs.
     this.linked = link();
@@ -112,8 +111,8 @@ class ModuleJob {
       }
       jobsInGraph.add(moduleJob);
       const dependencyJobs = await moduleJob.linked;
-      return PromiseAll(new SafeArrayIterator(
-        ArrayPrototypeMap(dependencyJobs, addJobsToDependencyGraph)));
+      return SafePromiseAll(
+        ArrayPrototypeMap(dependencyJobs, addJobsToDependencyGraph));
     };
     await addJobsToDependencyGraph(this);
 

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -262,6 +262,7 @@ function copyPrototype(src, dest, prefix) {
 
 const {
   ArrayPrototypeForEach,
+  ArrayPrototypeMap,
   FinalizationRegistry,
   FunctionPrototypeCall,
   Map,
@@ -433,6 +434,60 @@ primordials.AsyncIteratorPrototype =
   primordials.ReflectGetPrototypeOf(
     primordials.ReflectGetPrototypeOf(
       async function* () {}).prototype);
+
+const arrayToSafePromiseIterable = (promises) =>
+  new primordials.SafeArrayIterator(
+    ArrayPrototypeMap(
+      promises,
+      (promise) =>
+        new SafePromise((a, b) => PromisePrototypeThen(promise, a, b))
+    )
+  );
+
+/**
+ * @param {Promise<any>[]} promises
+ * @returns {Promise<any[]>}
+ */
+primordials.SafePromiseAll = (promises) =>
+  // Wrapping on a new Promise is necessary to not expose the SafePromise
+  // prototype to user-land.
+  new Promise((a, b) =>
+    SafePromise.all(arrayToSafePromiseIterable(promises)).then(a, b)
+  );
+
+/**
+ * @param {Promise<any>[]} promises
+ * @returns {Promise<object>}
+ */
+primordials.SafePromiseAllSettled = (promises) =>
+  // Wrapping on a new Promise is necessary to not expose the SafePromise
+  // prototype to user-land.
+  new Promise((a, b) =>
+    SafePromise.allSettled(arrayToSafePromiseIterable(promises)).then(a, b)
+  );
+
+/**
+ * @param {Promise<any>[]} promises
+ * @returns {Promise<any>}
+ */
+primordials.SafePromiseAny = (promises) =>
+  // Wrapping on a new Promise is necessary to not expose the SafePromise
+  // prototype to user-land.
+  new Promise((a, b) =>
+    SafePromise.any(arrayToSafePromiseIterable(promises)).then(a, b)
+  );
+
+/**
+ * @param {Promise<any>[]} promises
+ * @returns {Promise<any>}
+ */
+primordials.SafePromiseRace = (promises) =>
+  // Wrapping on a new Promise is necessary to not expose the SafePromise
+  // prototype to user-land.
+  new Promise((a, b) =>
+    SafePromise.race(arrayToSafePromiseIterable(promises)).then(a, b)
+  );
+
 
 ObjectSetPrototypeOf(primordials, null);
 ObjectFreeze(primordials);

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -435,57 +435,61 @@ primordials.AsyncIteratorPrototype =
     primordials.ReflectGetPrototypeOf(
       async function* () {}).prototype);
 
-const arrayToSafePromiseIterable = (promises) =>
+const arrayToSafePromiseIterable = (promises, mapFn) =>
   new primordials.SafeArrayIterator(
     ArrayPrototypeMap(
       promises,
-      (promise) =>
-        new SafePromise((a, b) => PromisePrototypeThen(promise, a, b))
+      (promise, i) =>
+        new SafePromise((a, b) => PromisePrototypeThen(mapFn == null ? promise : mapFn(promise, i), a, b))
     )
   );
 
 /**
  * @param {Promise<any>[]} promises
+ * @param {(v: Promise<any>, k: number) => Promise<any>} [mapFn]
  * @returns {Promise<any[]>}
  */
-primordials.SafePromiseAll = (promises) =>
+primordials.SafePromiseAll = (promises, mapFn) =>
   // Wrapping on a new Promise is necessary to not expose the SafePromise
   // prototype to user-land.
   new Promise((a, b) =>
-    SafePromise.all(arrayToSafePromiseIterable(promises)).then(a, b)
+    SafePromise.all(arrayToSafePromiseIterable(promises, mapFn)).then(a, b)
   );
 
 /**
  * @param {Promise<any>[]} promises
- * @returns {Promise<object>}
+ * @param {(v: Promise<any>, k: number) => Promise<any>} [mapFn]
+ * @returns {Promise<PromiseSettledResult<any>[]>}
  */
-primordials.SafePromiseAllSettled = (promises) =>
+primordials.SafePromiseAllSettled = (promises, mapFn) =>
   // Wrapping on a new Promise is necessary to not expose the SafePromise
   // prototype to user-land.
   new Promise((a, b) =>
-    SafePromise.allSettled(arrayToSafePromiseIterable(promises)).then(a, b)
+    SafePromise.allSettled(arrayToSafePromiseIterable(promises, mapFn)).then(a, b)
   );
 
 /**
  * @param {Promise<any>[]} promises
+ * @param {(v: Promise<any>, k: number) => Promise<any>} [mapFn]
  * @returns {Promise<any>}
  */
-primordials.SafePromiseAny = (promises) =>
+primordials.SafePromiseAny = (promises, mapFn) =>
   // Wrapping on a new Promise is necessary to not expose the SafePromise
   // prototype to user-land.
   new Promise((a, b) =>
-    SafePromise.any(arrayToSafePromiseIterable(promises)).then(a, b)
+    SafePromise.any(arrayToSafePromiseIterable(promises, mapFn)).then(a, b)
   );
 
 /**
  * @param {Promise<any>[]} promises
+ * @param {(v: Promise<any>, k: number) => Promise<any>} [mapFn]
  * @returns {Promise<any>}
  */
-primordials.SafePromiseRace = (promises) =>
+primordials.SafePromiseRace = (promises, mapFn) =>
   // Wrapping on a new Promise is necessary to not expose the SafePromise
   // prototype to user-land.
   new Promise((a, b) =>
-    SafePromise.race(arrayToSafePromiseIterable(promises)).then(a, b)
+    SafePromise.race(arrayToSafePromiseIterable(promises, mapFn)).then(a, b)
   );
 
 

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -10,8 +10,8 @@ const {
   ObjectDefineProperty,
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
-  PromiseAll,
   ReflectApply,
+  SafePromiseAll,
   SafeWeakMap,
   Symbol,
   SymbolToStringTag,
@@ -330,7 +330,7 @@ class SourceTextModule extends Module {
 
       try {
         if (promises !== undefined) {
-          await PromiseAll(promises);
+          await SafePromiseAll(promises);
         }
       } catch (e) {
         this.#error = e;

--- a/test/parallel/test-primordials-promise.js
+++ b/test/parallel/test-primordials-promise.js
@@ -7,9 +7,18 @@ const assert = require('assert');
 const {
   PromisePrototypeCatch,
   PromisePrototypeThen,
+  SafePromiseAll,
+  SafePromiseAllSettled,
+  SafePromiseAny,
   SafePromisePrototypeFinally,
+  SafePromiseRace,
 } = require('internal/test/binding').primordials;
 
+Array.prototype[Symbol.iterator] = common.mustNotCall();
+Promise.all = common.mustNotCall();
+Promise.allSettled = common.mustNotCall();
+Promise.any = common.mustNotCall();
+Promise.race = common.mustNotCall();
 Promise.prototype.catch = common.mustNotCall();
 Promise.prototype.finally = common.mustNotCall();
 Promise.prototype.then = common.mustNotCall();
@@ -17,6 +26,11 @@ Promise.prototype.then = common.mustNotCall();
 assertIsPromise(PromisePrototypeCatch(Promise.reject(), common.mustCall()));
 assertIsPromise(PromisePrototypeThen(test(), common.mustCall()));
 assertIsPromise(SafePromisePrototypeFinally(test(), common.mustCall()));
+
+assertIsPromise(SafePromiseAll([test()]));
+assertIsPromise(SafePromiseAllSettled([test()]));
+assertIsPromise(SafePromiseAny([test()]));
+assertIsPromise(SafePromiseRace([test()]));
 
 async function test() {
   const catchFn = common.mustCall();


### PR DESCRIPTION
Alternative to https://github.com/nodejs/node/pull/38843, but restricted to the changes related to the ESM implementation since it's easier to get consensus regarding whether we want tamperproofness on that part of the code base. /cc @nodejs/modules @nodejs/loaders 

Promise static methods that iterate over the provided argument (`%Promise.all%`, `%Promise.any%`, ...) look up the `then` property over each promise to support promise subclassing. This PR is introducing `SafePromiseAll`, `SafePromiseAny`, etc. that take an array, safely iterate over it, and wrap each promise in a `SafePromise` (whose prototype is not accessible from userland) and wrap the resulting `SafePromise` in a classic `Promise` to make the operation transparent from userland.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
