### PR TITLE
test-runner: before and after each hooks

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -446,6 +446,120 @@ same as [`it([name], { skip: true }[, fn])`][it options].
 Shorthand for marking a test as `TODO`,
 same as [`it([name], { todo: true }[, fn])`][it options].
 
+### `before([, fn][, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function|AsyncFunction} The hook function.
+  If the hook uses callbacks,
+  the callback function is passed as the second argument. **Default:** A no-op
+  function.
+* `options` {Object} Configuration options for the hook. The following
+  properties are supported:
+  * `signal` {AbortSignal} Allows aborting an in-progress hook
+  * `timeout` {number} A number of milliseconds the hook will fail after.
+    If unspecified, subtests inherit this value from their parent.
+    **Default:** `Infinity`.
+
+This function is used to create a hook running before running a suite.
+
+```js
+describe('tests', async () => {
+  before(() => console.log('about to run some test'));
+  it('is a subtest', () => {
+    assert.ok('some relevant assertion here');
+  });
+});
+```
+
+### `after([, fn][, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function|AsyncFunction} The hook function.
+  If the hook uses callbacks,
+  the callback function is passed as the second argument. **Default:** A no-op
+  function.
+* `options` {Object} Configuration options for the hook. The following
+  properties are supported:
+  * `signal` {AbortSignal} Allows aborting an in-progress hook
+  * `timeout` {number} A number of milliseconds the hook will fail after.
+    If unspecified, subtests inherit this value from their parent.
+    **Default:** `Infinity`.
+
+This function is used to create a hook running after  running a suite.
+
+```js
+describe('tests', async () => {
+  after(() => console.log('finished running tests'));
+  it('is a subtest', () => {
+    assert.ok('some relevant assertion here');
+  });
+});
+```
+
+### `beforeEach([, fn][, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function|AsyncFunction} The hook function.
+  If the hook uses callbacks,
+  the callback function is passed as the second argument. **Default:** A no-op
+  function.
+* `options` {Object} Configuration options for the hook. The following
+  properties are supported:
+  * `signal` {AbortSignal} Allows aborting an in-progress hook
+  * `timeout` {number} A number of milliseconds the hook will fail after.
+    If unspecified, subtests inherit this value from their parent.
+    **Default:** `Infinity`.
+
+This function is used to create a hook running
+before each subtest of the current suite.
+
+```js
+describe('tests', async () => {
+  beforeEach(() => t.diagnostics('about to run a test'));
+  it('is a subtest', () => {
+    assert.ok('some relevant assertion here');
+  });
+});
+```
+
+### `afterEach([, fn][, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function|AsyncFunction} The hook function.
+  If the hook uses callbacks,
+  the callback function is passed as the second argument. **Default:** A no-op
+  function.
+* `options` {Object} Configuration options for the hook. The following
+  properties are supported:
+  * `signal` {AbortSignal} Allows aborting an in-progress hook
+  * `timeout` {number} A number of milliseconds the hook will fail after.
+    If unspecified, subtests inherit this value from their parent.
+    **Default:** `Infinity`.
+
+This function is used to create a hook running
+after each subtest of the current test.
+
+```js
+describe('tests', async () => {
+  afterEach(() => t.diagnostics('about to run a test'));
+  it('is a subtest', () => {
+    assert.ok('some relevant assertion here');
+  });
+});
+```
+
 ## Class: `TestContext`
 
 <!-- YAML
@@ -455,6 +569,70 @@ added: v18.0.0
 An instance of `TestContext` is passed to each test function in order to
 interact with the test runner. However, the `TestContext` constructor is not
 exposed as part of the API.
+
+### `context.beforeEach([, fn][, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function|AsyncFunction} The hook function. The first argument
+  to this function is a [`TestContext`][] object. If the hook uses callbacks,
+  the callback function is passed as the second argument. **Default:** A no-op
+  function.
+* `options` {Object} Configuration options for the hook. The following
+  properties are supported:
+  * `signal` {AbortSignal} Allows aborting an in-progress hook
+  * `timeout` {number} A number of milliseconds the hook will fail after.
+    If unspecified, subtests inherit this value from their parent.
+    **Default:** `Infinity`.
+
+This function is used to create a hook running
+before each subtest of the current test.
+
+```js
+test('top level test', async (t) => {
+  t.beforeEach((t) => t.diagnostics(`about to run ${t.name}`));
+  await t.test(
+    'This is a subtest',
+    (t) => {
+      assert.ok('some relevant assertion here');
+    }
+  );
+});
+```
+
+### `context.afterEach([, fn][, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function|AsyncFunction} The hook function. The first argument
+  to this function is a [`TestContext`][] object. If the hook uses callbacks,
+  the callback function is passed as the second argument. **Default:** A no-op
+  function.
+* `options` {Object} Configuration options for the hook. The following
+  properties are supported:
+  * `signal` {AbortSignal} Allows aborting an in-progress hook
+  * `timeout` {number} A number of milliseconds the hook will fail after.
+    If unspecified, subtests inherit this value from their parent.
+    **Default:** `Infinity`.
+
+This function is used to create a hook running
+after each subtest of the current test.
+
+```js
+test('top level test', async (t) => {
+  t.afterEach((t) => t.diagnostics(`finished running ${t.name}`));
+  await t.test(
+    'This is a subtest',
+    (t) => {
+      assert.ok('some relevant assertion here');
+    }
+  );
+});
+```
 
 ### `context.diagnostic(message)`
 
@@ -473,6 +651,14 @@ test('top level test', (t) => {
   t.diagnostic('A diagnostic message');
 });
 ```
+
+### `context.name`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The name of the test
 
 ### `context.runOnly(shouldRunOnlyTests)`
 
@@ -616,6 +802,14 @@ added: v18.7.0
 An instance of `SuiteContext` is passed to each suite function in order to
 interact with the test runner. However, the `SuiteContext` constructor is not
 exposed as part of the API.
+
+### `context.name`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The name of the suite
 
 ### `context.signal`
 

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -174,8 +174,19 @@ function runInParentContext(Factory) {
   return cb;
 }
 
+function hook(hook) {
+  return (fn, options) => {
+    const parent = testResources.get(executionAsyncId()) || setup(root);
+    parent.createHook(hook, fn, options);
+  };
+}
+
 module.exports = {
   test: FunctionPrototypeBind(test, root),
   describe: runInParentContext(Suite),
   it: runInParentContext(ItTest),
+  before: hook('before'),
+  after: hook('after'),
+  beforeEach: hook('beforeEach'),
+  afterEach: hook('afterEach'),
 };

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -1,11 +1,14 @@
 'use strict';
 const {
   ArrayPrototypePush,
+  ArrayPrototypeReduce,
   ArrayPrototypeShift,
+  ArrayPrototypeSlice,
   ArrayPrototypeUnshift,
   FunctionPrototype,
   MathMax,
   Number,
+  ObjectSeal,
   PromisePrototypeThen,
   PromiseResolve,
   ReflectApply,
@@ -22,12 +25,11 @@ const {
     ERR_INVALID_ARG_TYPE,
     ERR_TEST_FAILURE,
   },
-  kIsNodeError,
   AbortError,
 } = require('internal/errors');
 const { getOptionValue } = require('internal/options');
 const { TapStream } = require('internal/test_runner/tap_stream');
-const { createDeferredCallback } = require('internal/test_runner/utils');
+const { createDeferredCallback, isTestFailureError } = require('internal/test_runner/utils');
 const {
   createDeferredPromise,
   kEmptyObject,
@@ -36,6 +38,7 @@ const { isPromise } = require('internal/util/types');
 const {
   validateAbortSignal,
   validateNumber,
+  validateOneOf,
   validateUint32,
 } = require('internal/validators');
 const { setTimeout } = require('timers/promises');
@@ -48,6 +51,7 @@ const kParentAlreadyFinished = 'parentAlreadyFinished';
 const kSubtestsFailed = 'subtestsFailed';
 const kTestCodeFailure = 'testCodeFailure';
 const kTestTimeoutFailure = 'testTimeoutFailure';
+const kHookFailure = 'hookFailed';
 const kDefaultIndent = '    ';
 const kDefaultTimeout = null;
 const noop = FunctionPrototype;
@@ -56,6 +60,8 @@ const testOnlyFlag = !isTestRunner && getOptionValue('--test-only');
 // TODO(cjihrig): Use uv_available_parallelism() once it lands.
 const rootConcurrency = isTestRunner ? MathMax(cpus().length - 1, 1) : 1;
 const kShouldAbort = Symbol('kShouldAbort');
+const kRunHook = Symbol('kRunHook');
+const kHookNames = ObjectSeal(['before', 'after', 'beforeEach', 'afterEach']);
 
 
 function stopTest(timeout, signal) {
@@ -81,6 +87,10 @@ class TestContext {
     return this.#test.signal;
   }
 
+  get name() {
+    return this.#test.name;
+  }
+
   diagnostic(message) {
     this.#test.diagnostic(message);
   }
@@ -102,6 +112,14 @@ class TestContext {
     const subtest = this.#test.createSubtest(Test, name, options, fn);
 
     return subtest.start();
+  }
+
+  beforeEach(fn, options) {
+    this.#test.createHook('beforeEach', fn, options);
+  }
+
+  afterEach(fn, options) {
+    this.#test.createHook('afterEach', fn, options);
   }
 }
 
@@ -207,6 +225,12 @@ class Test extends AsyncResource {
     this.pendingSubtests = [];
     this.readySubtests = new SafeMap();
     this.subtests = [];
+    this.hooks = {
+      before: [],
+      after: [],
+      beforeEach: [],
+      afterEach: [],
+    };
     this.waitingOn = 0;
     this.finished = false;
   }
@@ -325,8 +349,17 @@ class Test extends AsyncResource {
         kCancelledByParent
       )
     );
+    this.startTime = this.startTime || this.endTime; // If a test was canceled before it was started, e.g inside a hook
     this.cancelled = true;
     this.#abortController.abort();
+  }
+
+  createHook(name, fn, options) {
+    validateOneOf(name, 'hook name', kHookNames);
+    // eslint-disable-next-line no-use-before-define
+    const hook = new TestHook(fn, options);
+    ArrayPrototypePush(this.hooks[name], hook);
+    return hook;
   }
 
   fail(err) {
@@ -392,8 +425,27 @@ class Test extends AsyncResource {
     return { ctx, args: [ctx] };
   }
 
+  async [kRunHook](hook, args) {
+    validateOneOf(hook, 'hook name', kHookNames);
+    try {
+      await ArrayPrototypeReduce(this.hooks[hook], async (prev, hook) => {
+        await prev;
+        await hook.run(args);
+        if (hook.error) {
+          throw hook.error;
+        }
+      }, PromiseResolve());
+    } catch (err) {
+      const error = new ERR_TEST_FAILURE(`failed running ${hook} hook`, kHookFailure);
+      error.cause = isTestFailureError(err) ? err.cause : err;
+      throw error;
+    }
+  }
+
   async run() {
-    this.parent.activeSubtests++;
+    if (this.parent !== null) {
+      this.parent.activeSubtests++;
+    }
     this.startTime = hrtime();
 
     if (this[kShouldAbort]()) {
@@ -402,16 +454,20 @@ class Test extends AsyncResource {
     }
 
     try {
-      const stopPromise = stopTest(this.timeout, this.signal);
       const { args, ctx } = this.getRunArgs();
-      ArrayPrototypeUnshift(args, this.fn, ctx); // Note that if it's not OK to mutate args, we need to first clone it.
+      if (this.parent?.hooks.beforeEach.length > 0) {
+        await this.parent[kRunHook]('beforeEach', { args, ctx });
+      }
+      const stopPromise = stopTest(this.timeout, this.signal);
+      const runArgs = ArrayPrototypeSlice(args);
+      ArrayPrototypeUnshift(runArgs, this.fn, ctx);
 
-      if (this.fn.length === args.length - 1) {
+      if (this.fn.length === runArgs.length - 1) {
         // This test is using legacy Node.js error first callbacks.
         const { promise, cb } = createDeferredCallback();
 
-        ArrayPrototypePush(args, cb);
-        const ret = ReflectApply(this.runInAsyncScope, this, args);
+        ArrayPrototypePush(runArgs, cb);
+        const ret = ReflectApply(this.runInAsyncScope, this, runArgs);
 
         if (isPromise(ret)) {
           this.fail(new ERR_TEST_FAILURE(
@@ -424,7 +480,7 @@ class Test extends AsyncResource {
         }
       } else {
         // This test is synchronous or using Promises.
-        const promise = ReflectApply(this.runInAsyncScope, this, args);
+        const promise = ReflectApply(this.runInAsyncScope, this, runArgs);
         await SafePromiseRace([PromiseResolve(promise), stopPromise]);
       }
 
@@ -433,9 +489,13 @@ class Test extends AsyncResource {
         return;
       }
 
+      if (this.parent?.hooks.afterEach.length > 0) {
+        await this.parent[kRunHook]('afterEach', { args, ctx });
+      }
+
       this.pass();
     } catch (err) {
-      if (err?.code === 'ERR_TEST_FAILURE' && kIsNodeError in err) {
+      if (isTestFailureError(err)) {
         if (err.failureType === kTestTimeoutFailure) {
           this.cancel(err);
         } else {
@@ -549,10 +609,28 @@ class Test extends AsyncResource {
   }
 }
 
+class TestHook extends Test {
+  #args;
+  constructor(fn, options) {
+    if (options === null || typeof options !== 'object') {
+      options = kEmptyObject;
+    }
+    const { timeout, signal } = options;
+    super({ __proto__: null, fn, timeout, signal });
+  }
+  run(args) {
+    this.#args = args;
+    return super.run();
+  }
+  getRunArgs() {
+    return this.#args;
+  }
+}
+
 class ItTest extends Test {
   constructor(opt) { super(opt); } // eslint-disable-line no-useless-constructor
   getRunArgs() {
-    return { ctx: { signal: this.signal }, args: [] };
+    return { ctx: { signal: this.signal, name: this.name }, args: [] };
   }
 }
 class Suite extends Test {
@@ -560,9 +638,9 @@ class Suite extends Test {
     super(options);
 
     try {
-      const context = { signal: this.signal };
+      const { ctx, args } = this.getRunArgs();
       this.buildSuite = PromisePrototypeThen(
-        PromiseResolve(this.runInAsyncScope(this.fn, context, [context])),
+        PromiseResolve(this.runInAsyncScope(this.fn, ctx, args)),
         undefined,
         (err) => {
           this.fail(new ERR_TEST_FAILURE(err, kTestCodeFailure));
@@ -574,23 +652,40 @@ class Suite extends Test {
     this.buildPhaseFinished = true;
   }
 
-  async run() {
-    this.parent.activeSubtests++;
-    await this.buildSuite;
-    this.startTime = hrtime();
+  getRunArgs() {
+    return { ctx: { signal: this.signal, name: this.name }, args: [] };
+  }
 
-    if (this[kShouldAbort]()) {
-      this.subtests = [];
-      this.postRun();
-      return;
+  async run() {
+    try {
+      this.parent.activeSubtests++;
+      await this.buildSuite;
+      this.startTime = hrtime();
+
+      if (this[kShouldAbort]()) {
+        this.subtests = [];
+        this.postRun();
+        return;
+      }
+
+
+      const hookArgs = this.getRunArgs();
+      await this[kRunHook]('before', hookArgs);
+      const stopPromise = stopTest(this.timeout, this.signal);
+      const subtests = this.skipped || this.error ? [] : this.subtests;
+      const promise = SafePromiseAll(subtests, (subtests) => subtests.start());
+
+      await SafePromiseRace([promise, stopPromise]);
+      await this[kRunHook]('after', hookArgs);
+      this.pass();
+    } catch (err) {
+      if (isTestFailureError(err)) {
+        this.fail(err);
+      } else {
+        this.fail(new ERR_TEST_FAILURE(err, kTestCodeFailure));
+      }
     }
 
-    const stopPromise = stopTest(this.timeout, this.signal);
-    const subtests = this.skipped || this.error ? [] : this.subtests;
-    const promise = SafePromiseAll(subtests, (subtests) => subtests.start());
-
-    await SafePromiseRace([promise, stopPromise]);
-    this.pass();
     this.postRun();
   }
 }

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -6,6 +6,7 @@ const {
   codes: {
     ERR_TEST_FAILURE,
   },
+  kIsNodeError,
 } = require('internal/errors');
 
 const kMultipleCallbackInvocations = 'multipleCallbackInvocations';
@@ -49,8 +50,13 @@ function createDeferredCallback() {
   return { promise, cb };
 }
 
+function isTestFailureError(err) {
+  return err?.code === 'ERR_TEST_FAILURE' && kIsNodeError in err;
+}
+
 module.exports = {
   createDeferredCallback,
   doesPathMatchFilter,
   isSupportedFileType,
+  isTestFailureError,
 };

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,5 +1,5 @@
 'use strict';
-const { test, describe, it } = require('internal/test_runner/harness');
+const { test, describe, it, before, after, beforeEach, afterEach } = require('internal/test_runner/harness');
 const { emitExperimentalWarning } = require('internal/util');
 
 emitExperimentalWarning('The test runner');
@@ -8,3 +8,7 @@ module.exports = test;
 module.exports.test = test;
 module.exports.describe = describe;
 module.exports.it = it;
+module.exports.before = before;
+module.exports.after = after;
+module.exports.beforeEach = beforeEach;
+module.exports.afterEach = afterEach;

--- a/test/message/test_runner_describe_it.js
+++ b/test/message/test_runner_describe_it.js
@@ -214,15 +214,15 @@ it('callback fail', (done) => {
 });
 
 it('sync t is this in test', function() {
-  assert.deepStrictEqual(this, { signal: this.signal });
+  assert.deepStrictEqual(this, { signal: this.signal, name: this.name });
 });
 
 it('async t is this in test', async function() {
-  assert.deepStrictEqual(this, { signal: this.signal });
+  assert.deepStrictEqual(this, { signal: this.signal, name: this.name });
 });
 
 it('callback t is this in test', function(done) {
-  assert.deepStrictEqual(this, { signal: this.signal });
+  assert.deepStrictEqual(this, { signal: this.signal, name: this.name });
   done();
 });
 

--- a/test/message/test_runner_hooks.js
+++ b/test/message/test_runner_hooks.js
@@ -1,0 +1,111 @@
+// Flags: --no-warnings
+'use strict';
+require('../common');
+const assert = require('assert');
+const { test, describe, it, before, after, beforeEach, afterEach } = require('node:test');
+
+describe('describe hooks', () => {
+  const testArr = [];
+  before(function() {
+    testArr.push('before ' + this.name);
+  });
+  after(function() {
+    testArr.push('after ' + this.name);
+    assert.deepStrictEqual(testArr, [
+      'before describe hooks',
+      'beforeEach 1', '1', 'afterEach 1',
+      'beforeEach 2', '2', 'afterEach 2',
+      'before nested',
+      'beforeEach nested 1', 'nested 1', 'afterEach nested 1',
+      'beforeEach nested 2', 'nested 2', 'afterEach nested 2',
+      'after nested',
+      'after describe hooks',
+    ]);
+  });
+  beforeEach(function() {
+    testArr.push('beforeEach ' + this.name);
+  });
+  afterEach(function() {
+    testArr.push('afterEach ' + this.name);
+  });
+
+  it('1', () => testArr.push('1'));
+  it('2', () => testArr.push('2'));
+
+  describe('nested', () => {
+    before(function() {
+      testArr.push('before ' + this.name);
+    });
+    after(function() {
+      testArr.push('after ' + this.name);
+    });
+    beforeEach(function() {
+      testArr.push('beforeEach ' + this.name);
+    });
+    afterEach(function() {
+      testArr.push('afterEach ' + this.name);
+    });
+    it('nested 1', () => testArr.push('nested 1'));
+    it('nested 2', () => testArr.push('nested 2'));
+  });
+});
+
+describe('before throws', () => {
+  before(() => { throw new Error('before'); });
+  it('1', () => {});
+  it('2', () => {});
+});
+
+describe('after throws', () => {
+  after(() => { throw new Error('after'); });
+  it('1', () => {});
+  it('2', () => {});
+});
+
+describe('beforeEach throws', () => {
+  beforeEach(() => { throw new Error('beforeEach'); });
+  it('1', () => {});
+  it('2', () => {});
+});
+
+describe('afterEach throws', () => {
+  afterEach(() => { throw new Error('afterEach'); });
+  it('1', () => {});
+  it('2', () => {});
+});
+
+test('test hooks', async (t) => {
+  const testArr = [];
+  t.beforeEach((t) => testArr.push('beforeEach ' + t.name));
+  t.afterEach((t) => testArr.push('afterEach ' + t.name));
+  await t.test('1', () => testArr.push('1'));
+  await t.test('2', () => testArr.push('2'));
+
+  await t.test('nested', async (t) => {
+    t.beforeEach((t) => testArr.push('nested beforeEach ' + t.name));
+    t.afterEach((t) => testArr.push('nested afterEach ' + t.name));
+    await t.test('nested 1', () => testArr.push('nested1'));
+    await t.test('nested 2', () => testArr.push('nested 2'));
+  });
+
+  assert.deepStrictEqual(testArr, [
+    'beforeEach 1', '1', 'afterEach 1',
+    'beforeEach 2', '2', 'afterEach 2',
+    'beforeEach nested',
+    'nested beforeEach nested 1', 'nested1', 'nested afterEach nested 1',
+    'nested beforeEach nested 2', 'nested 2', 'nested afterEach nested 2',
+    'afterEach nested',
+  ]);
+});
+
+test('t.beforeEach throws', async (t) => {
+  t.beforeEach(() => { throw new Error('beforeEach'); });
+  await t.test('1', () => {});
+  await t.test('2', () => {});
+});
+
+test('t.afterEach throws', async (t) => {
+  t.afterEach(() => { throw new Error('afterEach'); });
+  await t.test('1', () => {});
+  await t.test('2', () => {});
+});

--- a/test/message/test_runner_hooks.out
+++ b/test/message/test_runner_hooks.out
@@ -1,0 +1,229 @@
+TAP version 13
+# Subtest: describe hooks
+    # Subtest: 1
+    ok 1 - 1
+      ---
+      duration_ms: *
+      ...
+    # Subtest: 2
+    ok 2 - 2
+      ---
+      duration_ms: *
+      ...
+    # Subtest: nested
+        # Subtest: nested 1
+        ok 1 - nested 1
+          ---
+          duration_ms: *
+          ...
+        # Subtest: nested 2
+        ok 2 - nested 2
+          ---
+          duration_ms: *
+          ...
+        1..2
+    ok 3 - nested
+      ---
+      duration_ms: *
+      ...
+    1..3
+ok 1 - describe hooks
+  ---
+  duration_ms: *
+  ...
+# Subtest: before throws
+    # Subtest: 1
+    not ok 1 - 1
+      ---
+      duration_ms: *
+      failureType: 'cancelledByParent'
+      error: 'test did not finish before its parent and was cancelled'
+      code: 'ERR_TEST_FAILURE'
+      ...
+    # Subtest: 2
+    not ok 2 - 2
+      ---
+      duration_ms: *
+      failureType: 'cancelledByParent'
+      error: 'test did not finish before its parent and was cancelled'
+      code: 'ERR_TEST_FAILURE'
+      ...
+    1..2
+not ok 2 - before throws
+  ---
+  duration_ms: *
+  failureType: 'hookFailed'
+  error: 'failed running before hook'
+  code: 'ERR_TEST_FAILURE'
+  ...
+# Subtest: after throws
+    # Subtest: 1
+    ok 1 - 1
+      ---
+      duration_ms: *
+      ...
+    # Subtest: 2
+    ok 2 - 2
+      ---
+      duration_ms: *
+      ...
+    1..2
+not ok 3 - after throws
+  ---
+  duration_ms: *
+  failureType: 'hookFailed'
+  error: 'failed running after hook'
+  code: 'ERR_TEST_FAILURE'
+  ...
+# Subtest: beforeEach throws
+    # Subtest: 1
+    not ok 1 - 1
+      ---
+      duration_ms: *
+      failureType: 'hookFailed'
+      error: 'failed running beforeEach hook'
+      code: 'ERR_TEST_FAILURE'
+      stack: |-
+        *
+      ...
+    # Subtest: 2
+    not ok 2 - 2
+      ---
+      duration_ms: *
+      failureType: 'hookFailed'
+      error: 'failed running beforeEach hook'
+      code: 'ERR_TEST_FAILURE'
+      ...
+    1..2
+not ok 4 - beforeEach throws
+  ---
+  duration_ms: *
+  failureType: 'subtestsFailed'
+  error: '2 subtests failed'
+  code: 'ERR_TEST_FAILURE'
+  ...
+# Subtest: afterEach throws
+    # Subtest: 1
+    not ok 1 - 1
+      ---
+      duration_ms: *
+      failureType: 'hookFailed'
+      error: 'failed running afterEach hook'
+      code: 'ERR_TEST_FAILURE'
+      stack: |-
+        *
+      ...
+    # Subtest: 2
+    not ok 2 - 2
+      ---
+      duration_ms: *
+      failureType: 'hookFailed'
+      error: 'failed running afterEach hook'
+      code: 'ERR_TEST_FAILURE'
+      ...
+    1..2
+not ok 5 - afterEach throws
+  ---
+  duration_ms: *
+  failureType: 'subtestsFailed'
+  error: '2 subtests failed'
+  code: 'ERR_TEST_FAILURE'
+  ...
+# Subtest: test hooks
+    # Subtest: 1
+    ok 1 - 1
+      ---
+      duration_ms: *
+      ...
+    # Subtest: 2
+    ok 2 - 2
+      ---
+      duration_ms: *
+      ...
+    # Subtest: nested
+        # Subtest: nested 1
+        ok 1 - nested 1
+          ---
+          duration_ms: *
+          ...
+        # Subtest: nested 2
+        ok 2 - nested 2
+          ---
+          duration_ms: *
+          ...
+        1..2
+    ok 3 - nested
+      ---
+      duration_ms: *
+      ...
+    1..3
+ok 6 - test hooks
+  ---
+  duration_ms: *
+  ...
+# Subtest: t.beforeEach throws
+    # Subtest: 1
+    not ok 1 - 1
+      ---
+      duration_ms: *
+      failureType: 'hookFailed'
+      error: 'failed running beforeEach hook'
+      code: 'ERR_TEST_FAILURE'
+      stack: |-
+        *
+      ...
+    # Subtest: 2
+    not ok 2 - 2
+      ---
+      duration_ms: *
+      failureType: 'hookFailed'
+      error: 'failed running beforeEach hook'
+      code: 'ERR_TEST_FAILURE'
+      stack: |-
+        *
+      ...
+    1..2
+not ok 7 - t.beforeEach throws
+  ---
+  duration_ms: *
+  failureType: 'subtestsFailed'
+  error: '2 subtests failed'
+  code: 'ERR_TEST_FAILURE'
+  ...
+# Subtest: t.afterEach throws
+    # Subtest: 1
+    not ok 1 - 1
+      ---
+      duration_ms: *
+      failureType: 'hookFailed'
+      error: 'failed running afterEach hook'
+      code: 'ERR_TEST_FAILURE'
+      stack: |-
+        *
+      ...
+    # Subtest: 2
+    not ok 2 - 2
+      ---
+      duration_ms: *
+      failureType: 'hookFailed'
+      error: 'failed running afterEach hook'
+      code: 'ERR_TEST_FAILURE'
+      stack: |-
+        *
+      ...
+    1..2
+not ok 8 - t.afterEach throws
+  ---
+  duration_ms: *
+  failureType: 'subtestsFailed'
+  error: '2 subtests failed'
+  code: 'ERR_TEST_FAILURE'
+  ...
+1..8
+# tests 8
+# pass 2
+# fail 6
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms *


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/43403

todo:
- [x] do we need `before` and `after` hooks? maybe only inside `describe`?
- [x] docs
- [x] tests
- [x] wait for previous test runner prs to land
- [x] handle errors within hooks
- [x] depends on https://github.com/nodejs/node/pull/43998