### PR TITLE
test: remove unnecessary .toString() calls in HTTP tests

### DIFF
--- a/test/parallel/test-http-missing-header-separator-cr.js
+++ b/test/parallel/test-http-missing-header-separator-cr.js
@@ -26,7 +26,7 @@ server.listen(0, common.mustSucceed(() => {
   let response = '';
 
   client.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
   }));
 
   client.setEncoding('utf8');

--- a/test/parallel/test-http-server-close-all.js
+++ b/test/parallel/test-http-server-close-all.js
@@ -31,8 +31,10 @@ server.listen(0, function() {
     const client2 = connect(port);
     let response = '';
 
+    client2.setEncoding('utf8');
+
     client2.on('data', common.mustCall((chunk) => {
-      response += chunk.toString('utf-8');
+      response += chunk;
 
       if (response.endsWith('0\r\n\r\n')) {
         assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));

--- a/test/parallel/test-http-server-close-idle.js
+++ b/test/parallel/test-http-server-close-idle.js
@@ -33,8 +33,10 @@ server.listen(0, function() {
     const client2 = connect(port);
     let response = '';
 
+    client2.setEncoding('utf8');
+
     client2.on('data', common.mustCall((chunk) => {
-      response += chunk.toString('utf-8');
+      response += chunk;
 
       if (response.endsWith('0\r\n\r\n')) {
         assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));

--- a/test/parallel/test-http-server-headers-timeout-delayed-headers.js
+++ b/test/parallel/test-http-server-headers-timeout-delayed-headers.js
@@ -33,8 +33,9 @@ server.listen(0, common.mustCall(() => {
   const client = connect(server.address().port);
   let response = '';
 
+  client.setEncoding('utf8');
   client.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
   }));
 
   const errOrEnd = common.mustSucceed(function(err) {

--- a/test/parallel/test-http-server-headers-timeout-interrupted-headers.js
+++ b/test/parallel/test-http-server-headers-timeout-interrupted-headers.js
@@ -33,8 +33,9 @@ server.listen(0, common.mustCall(() => {
   const client = connect(server.address().port);
   let response = '';
 
+  client.setEncoding('utf8');
   client.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
   }));
 
   const errOrEnd = common.mustSucceed(function(err) {

--- a/test/parallel/test-http-server-headers-timeout-keepalive.js
+++ b/test/parallel/test-http-server-headers-timeout-keepalive.js
@@ -47,8 +47,9 @@ server.listen(0, common.mustCall(() => {
   let second = false;
   let response = '';
 
+  client.setEncoding('utf8');
   client.on('data', common.mustCallAtLeast((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
 
     // First response has ended
     if (!second && response.endsWith('\r\n\r\n')) {

--- a/test/parallel/test-http-server-headers-timeout-pipelining.js
+++ b/test/parallel/test-http-server-headers-timeout-pipelining.js
@@ -33,8 +33,9 @@ server.listen(0, common.mustCall(() => {
   let second = false;
   let response = '';
 
+  client.setEncoding('utf8');
   client.on('data', common.mustCallAtLeast((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
 
     // First response has ended
     if (!second && response.endsWith('\r\n\r\n')) {

--- a/test/parallel/test-http-server-request-timeout-delayed-body.js
+++ b/test/parallel/test-http-server-request-timeout-delayed-body.js
@@ -40,8 +40,9 @@ server.listen(0, common.mustCall(() => {
   const client = connect(server.address().port);
   let response = '';
 
+  client.setEncoding('utf8');
   client.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
   }));
 
   client.resume();

--- a/test/parallel/test-http-server-request-timeout-delayed-headers.js
+++ b/test/parallel/test-http-server-request-timeout-delayed-headers.js
@@ -28,8 +28,9 @@ server.listen(0, common.mustCall(() => {
   const client = connect(server.address().port);
   let response = '';
 
+  client.setEncoding('utf8');
   client.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
   }));
 
   const errOrEnd = common.mustSucceed(function(err) {

--- a/test/parallel/test-http-server-request-timeout-interrupted-body.js
+++ b/test/parallel/test-http-server-request-timeout-interrupted-body.js
@@ -40,8 +40,9 @@ server.listen(0, common.mustCall(() => {
   const client = connect(server.address().port);
   let response = '';
 
+  client.setEncoding('utf8');
   client.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
   }));
 
   const errOrEnd = common.mustSucceed(function(err) {

--- a/test/parallel/test-http-server-request-timeout-interrupted-headers.js
+++ b/test/parallel/test-http-server-request-timeout-interrupted-headers.js
@@ -28,8 +28,9 @@ server.listen(0, common.mustCall(() => {
   const client = connect(server.address().port);
   let response = '';
 
+  client.setEncoding('utf8');
   client.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
   }));
 
   const errOrEnd = common.mustSucceed(function(err) {

--- a/test/parallel/test-http-server-request-timeout-keepalive.js
+++ b/test/parallel/test-http-server-request-timeout-keepalive.js
@@ -45,8 +45,9 @@ server.listen(0, common.mustCall(() => {
   let second = false;
   let response = '';
 
+  client.setEncoding('utf8');
   client.on('data', common.mustCallAtLeast((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
 
     // First response has ended
     if (!second && response.endsWith('\r\n\r\n')) {

--- a/test/parallel/test-http-server-request-timeout-pipelining.js
+++ b/test/parallel/test-http-server-request-timeout-pipelining.js
@@ -27,8 +27,9 @@ server.listen(0, common.mustCall(() => {
   let second = false;
   let response = '';
 
+  client.setEncoding('utf8');
   client.on('data', common.mustCallAtLeast((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
 
     // First response has ended
     if (!second && response.endsWith('\r\n\r\n')) {

--- a/test/parallel/test-http-server-request-timeout-upgrade.js
+++ b/test/parallel/test-http-server-request-timeout-upgrade.js
@@ -33,8 +33,9 @@ server.listen(0, common.mustCall(() => {
   const client = connect(server.address().port);
   let response = '';
 
+  client.setEncoding('utf8');
   client.on('data', common.mustCallAtLeast((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
   }, 1));
 
   client.on('end', common.mustCall(() => {

--- a/test/parallel/test-http-server-request-timeouts-mixed.js
+++ b/test/parallel/test-http-server-request-timeouts-mixed.js
@@ -43,8 +43,9 @@ function createClient(server) {
     completed: false
   };
 
+  request.client.setEncoding('utf8');
   request.client.on('data', common.mustCallAtLeast((chunk) => {
-    request.response += chunk.toString('utf-8');
+    request.response += chunk;
   }));
 
   request.client.on('end', common.mustCall(() => {

--- a/test/parallel/test-http-transfer-encoding-repeated-chunked.js
+++ b/test/parallel/test-http-transfer-encoding-repeated-chunked.js
@@ -34,7 +34,7 @@ server.listen(0, common.mustSucceed(() => {
   let response = '';
 
   client.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
   }));
 
   client.setEncoding('utf8');

--- a/test/parallel/test-http-transfer-encoding-smuggling.js
+++ b/test/parallel/test-http-transfer-encoding-smuggling.js
@@ -35,7 +35,7 @@ server.listen(0, common.mustSucceed(() => {
   // Verify that the server listener is never called
 
   client.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
+    response += chunk;
   }));
 
   client.setEncoding('utf8');

--- a/test/parallel/test-https-server-close-all.js
+++ b/test/parallel/test-https-server-close-all.js
@@ -42,8 +42,9 @@ server.listen(0, function() {
     const client2 = connect({ port, rejectUnauthorized: false });
     let response = '';
 
+    client2.setEncoding('utf8');
     client2.on('data', common.mustCall((chunk) => {
-      response += chunk.toString('utf-8');
+      response += chunk;
 
       if (response.endsWith('0\r\n\r\n')) {
         assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));

--- a/test/parallel/test-https-server-close-idle.js
+++ b/test/parallel/test-https-server-close-idle.js
@@ -44,8 +44,9 @@ server.listen(0, function() {
     const client2 = connect({ port, rejectUnauthorized: false });
     let response = '';
 
+    client2.setEncoding('utf8');
     client2.on('data', common.mustCall((chunk) => {
-      response += chunk.toString('utf-8');
+      response += chunk;
 
       if (response.endsWith('0\r\n\r\n')) {
         assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));


### PR DESCRIPTION
Let’s not have bad examples in our test suite and instead use the
proper way of converting stream data to UTF-8
(i.e. `stream.setEncoding('utf8')`) in all places.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
