### PR TITLE
doc: remove node-report from support tiers

### DIFF
--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -126,7 +126,6 @@ The tools are currently assigned to Tiers as follows:
 
 | Tool Type | Tool/API Name             | Regular Testing in Node.js CI | Integrated with Node.js | Target Tier |
 | --------- | ------------------------- | ----------------------------- | ----------------------- | ----------- |
-| FFDC      | node-report               | No                            | No                      | 1           |
 | Memory    | V8 heap profiler          | No                            | Yes                     | 1           |
 | Memory    | V8 sampling heap profiler | No                            | Yes                     | 1           |
 | AsyncFlow | Async Hooks (API)         | ?                             | Yes                     | 1           |


### PR DESCRIPTION
https://www.npmjs.com/package/node-report

> This module has been superseded by the diagnostics report feature of Node.js core. It is now unmaintained.