### PR TITLE
doc: deprecate coercion to integer in `process.exit()`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3163,6 +3163,20 @@ Use [`diagnostics_channel.subscribe(name, onMessage)`][] or
 [`diagnostics_channel.unsubscribe(name, onMessage)`][] which does the same
 thing instead.
 
+### DEP0164: `process.exit([code])` coercion to integer
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43738
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+Implicit coercion of a non-integer `code` parameter in [`process.exit()`][] is
+deprecated. Please use an integer value.
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
@@ -3241,6 +3255,7 @@ thing instead.
 [`os.networkInterfaces()`]: os.md#osnetworkinterfaces
 [`os.tmpdir()`]: os.md#ostmpdir
 [`process.env`]: process.md#processenv
+[`process.exit()`]: process.md#processexitcode
 [`process.getActiveResourcesInfo()`]: process.md#processgetactiveresourcesinfo
 [`process.mainModule`]: process.md#processmainmodule
 [`punycode`]: punycode.md

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3174,8 +3174,8 @@ changes:
 
 Type: Documentation-only
 
-Implicit coercion of a non-integer `code` parameter in [`process.exit()`][] is
-deprecated. Please use an integer value.
+`code` values other than `undefined`, `null`, integer numbers and integer
+strings (e.g., '1') are deprecated as parameter in [`process.exit()`][].
 
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/43716

This warns of invalid uses of `process.exit([code])` (such as in [the comment](https://github.com/nodejs/node/pull/43716#pullrequestreview-1032408092)) 
and recommends the correct practice.

The `code` passed as the first argument to `process.reallyExit()` is 
converted to an integer. This behavior has been unofficially supported so far.

https://github.com/nodejs/node/blob/adef64ce633f22b92feca3aa6a61ff7fb88bbd05/src/node_process_methods.cc#L442-L447

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
