### PR TITLE
esm: throw on any non-2xx response

### DIFF
--- a/lib/internal/modules/esm/fetch_module.js
+++ b/lib/internal/modules/esm/fetch_module.js
@@ -148,7 +148,9 @@ function fetchWithRedirects(parsed) {
         err.message = `Cannot find module '${parsed.href}', HTTP 404`;
         throw err;
       }
-      if (res.statusCode < 200 || res.statusCode >= 400) {
+      // This condition catches all unsupported status codes, including
+      // 3xx redirection codes without `Location` HTTP header.
+      if (res.statusCode < 200 || res.statusCode >= 300) {
         throw new ERR_NETWORK_IMPORT_DISALLOWED(
           res.headers.location,
           parsed.href,


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/43689

Restrict accepting responses with `3xx` status code as to-be-imported code and proceeding.
There are three categories in 3xx codes:

- Redirects (300, 301, 302, 303, 307, 308). If a redirecting response has `Location` header, it is already handled by code above. If it doesn't, we can't follow it and should throw. We shouldn't attempt to read the response body (usually, there will be human-readable redirect, e.g. text or html).
- Known non-redirects (304, 305, 306). Any of these should be treated as error here.
- Unknown codes (e.g. future RFC). If it's something that we'll want to handle, it should be implemented explicitly. By default all unknown non-`2xx` responses are errors.

Arguably, we can move further and restrict all `2xx` responses other than `200` and maybe `204`. I think, formally it would contradict with the purpose of 2xx codes.

---

/cc @GeoffreyBooth @JakobJingleheimer

I expect to see other follow-ups from https://github.com/nodejs/node/pull/43689. Depending on them, this PR might be made obsolete by a better alternative, applied separately, or improved.