### PR TITLE
src: slim down env-inl.h

### DIFF
--- a/src/async_wrap-inl.h
+++ b/src/async_wrap-inl.h
@@ -80,13 +80,6 @@ inline v8::MaybeLocal<v8::Value> AsyncWrap::MakeCallback(
   return MakeCallback(cb_v.As<v8::Function>(), argc, argv);
 }
 
-
-// Defined here to avoid a circular dependency with env-inl.h.
-inline AsyncHooks::DefaultTriggerAsyncIdScope ::DefaultTriggerAsyncIdScope(
-    AsyncWrap* async_wrap)
-    : DefaultTriggerAsyncIdScope(async_wrap->env(),
-                                 async_wrap->get_async_id()) {}
-
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -44,8 +44,8 @@ class BaseObject : public MemoryRetainer {
 
   // Associates this object with `object`. It uses the 0th internal field for
   // that, and in particular aborts if there is no such field.
-  inline BaseObject(Environment* env, v8::Local<v8::Object> object);
-  inline ~BaseObject() override;
+  BaseObject(Environment* env, v8::Local<v8::Object> object);
+  ~BaseObject() override;
 
   BaseObject() = delete;
 
@@ -65,7 +65,7 @@ class BaseObject : public MemoryRetainer {
   // was also passed to the `BaseObject()` constructor initially.
   // This may return `nullptr` if the C++ object has not been constructed yet,
   // e.g. when the JS object used `MakeLazilyInitializedJSTemplate`.
-  static inline void LazilyInitializedJSTemplateConstructor(
+  static void LazilyInitializedJSTemplateConstructor(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static inline BaseObject* FromJSObject(v8::Local<v8::Value> object);
   template <typename T>
@@ -74,7 +74,7 @@ class BaseObject : public MemoryRetainer {
   // Make the `v8::Global` a weak reference and, `delete` this object once
   // the JS object has been garbage collected and there are no (strong)
   // BaseObjectPtr references to it.
-  inline void MakeWeak();
+  void MakeWeak();
 
   // Undo `MakeWeak()`, i.e. turn this into a strong reference that is a GC
   // root and will not be touched by the garbage collector.
@@ -88,7 +88,7 @@ class BaseObject : public MemoryRetainer {
   // Utility to create a FunctionTemplate with one internal field (used for
   // the `BaseObject*` pointer) and a constructor that initializes that field
   // to `nullptr`.
-  static inline v8::Local<v8::FunctionTemplate> MakeLazilyInitializedJSTemplate(
+  static v8::Local<v8::FunctionTemplate> MakeLazilyInitializedJSTemplate(
       Environment* env);
 
   // Setter/Getter pair for internal fields that can be passed to SetAccessor.
@@ -202,11 +202,11 @@ class BaseObject : public MemoryRetainer {
   inline bool has_pointer_data() const;
   // This creates a PointerData struct if none was associated with this
   // BaseObject before.
-  inline PointerData* pointer_data();
+  PointerData* pointer_data();
 
   // Functions that adjust the strong pointer count.
-  inline void decrease_refcount();
-  inline void increase_refcount();
+  void decrease_refcount();
+  void increase_refcount();
 
   Environment* env_;
   PointerData* pointer_data_ = nullptr;

--- a/src/env.h
+++ b/src/env.h
@@ -729,10 +729,10 @@ class AsyncHooks : public MemoryRetainer {
   // The `js_execution_async_resources` array contains the value in that case.
   inline v8::Local<v8::Object> native_execution_async_resource(size_t index);
 
-  inline void SetJSPromiseHooks(v8::Local<v8::Function> init,
-                                v8::Local<v8::Function> before,
-                                v8::Local<v8::Function> after,
-                                v8::Local<v8::Function> resolve);
+  void SetJSPromiseHooks(v8::Local<v8::Function> init,
+                         v8::Local<v8::Function> before,
+                         v8::Local<v8::Function> after,
+                         v8::Local<v8::Function> resolve);
 
   inline v8::Local<v8::String> provider_string(int idx);
 
@@ -742,13 +742,14 @@ class AsyncHooks : public MemoryRetainer {
   // NB: This call does not take (co-)ownership of `execution_async_resource`.
   // The lifetime of the `v8::Local<>` pointee must last until
   // `pop_async_context()` or `clear_async_id_stack()` are called.
-  inline void push_async_context(double async_id, double trigger_async_id,
-      v8::Local<v8::Object> execution_async_resource);
-  inline bool pop_async_context(double async_id);
-  inline void clear_async_id_stack();  // Used in fatal exceptions.
+  void push_async_context(double async_id,
+                          double trigger_async_id,
+                          v8::Local<v8::Object> execution_async_resource);
+  bool pop_async_context(double async_id);
+  void clear_async_id_stack();  // Used in fatal exceptions.
 
-  inline void AddContext(v8::Local<v8::Context> ctx);
-  inline void RemoveContext(v8::Local<v8::Context> ctx);
+  void AddContext(v8::Local<v8::Context> ctx);
+  void RemoveContext(v8::Local<v8::Context> ctx);
 
   AsyncHooks(const AsyncHooks&) = delete;
   AsyncHooks& operator=(const AsyncHooks&) = delete;
@@ -1128,17 +1129,15 @@ class Environment : public MemoryRetainer {
   template <typename T, typename OnCloseCallback>
   inline void CloseHandle(T* handle, OnCloseCallback callback);
 
-  inline void AssignToContext(v8::Local<v8::Context> context,
-                              const ContextInfo& info);
+  void AssignToContext(v8::Local<v8::Context> context, const ContextInfo& info);
 
   void StartProfilerIdleNotifier();
 
   inline v8::Isolate* isolate() const;
   inline uv_loop_t* event_loop() const;
-  inline void TryLoadAddon(
-      const char* filename,
-      int flags,
-      const std::function<bool(binding::DLib*)>& was_loaded);
+  void TryLoadAddon(const char* filename,
+                    int flags,
+                    const std::function<bool(binding::DLib*)>& was_loaded);
 
   static inline Environment* from_timer_handle(uv_timer_t* handle);
   inline uv_timer_t* timer_handle();
@@ -1228,7 +1227,7 @@ class Environment : public MemoryRetainer {
   // loop alive.
   // This is used by Workers to manage their own .ref()/.unref() implementation,
   // as Workers aren't directly associated with their own libuv handles.
-  inline void add_refs(int64_t diff);
+  void add_refs(int64_t diff);
 
   inline bool has_run_bootstrapping_code() const;
   inline void DoneBootstrapping();
@@ -1280,7 +1279,7 @@ class Environment : public MemoryRetainer {
                                const char* path = nullptr,
                                const char* dest = nullptr);
 
-  inline v8::Local<v8::FunctionTemplate> NewFunctionTemplate(
+  v8::Local<v8::FunctionTemplate> NewFunctionTemplate(
       v8::FunctionCallback callback,
       v8::Local<v8::Signature> signature = v8::Local<v8::Signature>(),
       v8::ConstructorBehavior behavior = v8::ConstructorBehavior::kAllow,
@@ -1288,48 +1287,47 @@ class Environment : public MemoryRetainer {
       const v8::CFunction* c_function = nullptr);
 
   // Convenience methods for NewFunctionTemplate().
-  inline void SetMethod(v8::Local<v8::Object> that,
-                        const char* name,
-                        v8::FunctionCallback callback);
+  void SetMethod(v8::Local<v8::Object> that,
+                 const char* name,
+                 v8::FunctionCallback callback);
 
-  inline void SetFastMethod(v8::Local<v8::Object> that,
-                            const char* name,
-                            v8::FunctionCallback slow_callback,
-                            const v8::CFunction* c_function);
+  void SetFastMethod(v8::Local<v8::Object> that,
+                     const char* name,
+                     v8::FunctionCallback slow_callback,
+                     const v8::CFunction* c_function);
 
-  inline void SetProtoMethod(v8::Local<v8::FunctionTemplate> that,
-                             const char* name,
-                             v8::FunctionCallback callback);
+  void SetProtoMethod(v8::Local<v8::FunctionTemplate> that,
+                      const char* name,
+                      v8::FunctionCallback callback);
 
-  inline void SetInstanceMethod(v8::Local<v8::FunctionTemplate> that,
-                                const char* name,
-                                v8::FunctionCallback callback);
-
+  void SetInstanceMethod(v8::Local<v8::FunctionTemplate> that,
+                         const char* name,
+                         v8::FunctionCallback callback);
 
   // Safe variants denote the function has no side effects.
-  inline void SetMethodNoSideEffect(v8::Local<v8::Object> that,
-                                    const char* name,
-                                    v8::FunctionCallback callback);
-  inline void SetProtoMethodNoSideEffect(v8::Local<v8::FunctionTemplate> that,
-                                         const char* name,
-                                         v8::FunctionCallback callback);
+  void SetMethodNoSideEffect(v8::Local<v8::Object> that,
+                             const char* name,
+                             v8::FunctionCallback callback);
+  void SetProtoMethodNoSideEffect(v8::Local<v8::FunctionTemplate> that,
+                                  const char* name,
+                                  v8::FunctionCallback callback);
 
   enum class SetConstructorFunctionFlag {
     NONE,
     SET_CLASS_NAME,
   };
 
-  inline void SetConstructorFunction(v8::Local<v8::Object> that,
-                          const char* name,
-                          v8::Local<v8::FunctionTemplate> tmpl,
-                          SetConstructorFunctionFlag flag =
-                              SetConstructorFunctionFlag::SET_CLASS_NAME);
+  void SetConstructorFunction(v8::Local<v8::Object> that,
+                              const char* name,
+                              v8::Local<v8::FunctionTemplate> tmpl,
+                              SetConstructorFunctionFlag flag =
+                                  SetConstructorFunctionFlag::SET_CLASS_NAME);
 
-  inline void SetConstructorFunction(v8::Local<v8::Object> that,
-                          v8::Local<v8::String> name,
-                          v8::Local<v8::FunctionTemplate> tmpl,
-                          SetConstructorFunctionFlag flag =
-                              SetConstructorFunctionFlag::SET_CLASS_NAME);
+  void SetConstructorFunction(v8::Local<v8::Object> that,
+                              v8::Local<v8::String> name,
+                              v8::Local<v8::FunctionTemplate> tmpl,
+                              SetConstructorFunctionFlag flag =
+                                  SetConstructorFunctionFlag::SET_CLASS_NAME);
 
   void AtExit(void (*cb)(void* arg), void* arg);
   void RunAtExitCallbacks();
@@ -1487,9 +1485,8 @@ class Environment : public MemoryRetainer {
   void RunAndClearNativeImmediates(bool only_refed = false);
   void RunAndClearInterrupts();
 
-  inline uv_buf_t allocate_managed_buffer(const size_t suggested_size);
-  inline std::unique_ptr<v8::BackingStore> release_managed_buffer(
-      const uv_buf_t& buf);
+  uv_buf_t allocate_managed_buffer(const size_t suggested_size);
+  std::unique_ptr<v8::BackingStore> release_managed_buffer(const uv_buf_t& buf);
 
   void AddUnmanagedFd(int fd);
   void RemoveUnmanagedFd(int fd);


### PR DESCRIPTION
Move big and/or infrequently used functions from env-inl.h to env.cc to
speed up build times and reduce binary bloat.

This commit also touches async_wrap-inl.h and base_object-inl.h because
those are closely interwined with env-inl.h.

Non-functional change.

Refs: https://github.com/nodejs/node/issues/43712

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
