### PR TITLE
deps: V8: backport 22698d267667

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.8',
+    'v8_embedder_string': '-node.9',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/builtins/builtins-async-module.cc
+++ b/deps/v8/src/builtins/builtins-async-module.cc
@@ -12,7 +12,15 @@ namespace internal {
 BUILTIN(CallAsyncModuleFulfilled) {
   HandleScope handle_scope(isolate);
   Handle<SourceTextModule> module(args.at<SourceTextModule>(0));
-  SourceTextModule::AsyncModuleExecutionFulfilled(isolate, module);
+  if (SourceTextModule::AsyncModuleExecutionFulfilled(isolate, module)
+          .IsNothing()) {
+    // The evaluation of async module can not throwing a JavaScript observable
+    // exception.
+    DCHECK(isolate->has_pending_exception());
+    DCHECK_EQ(isolate->pending_exception(),
+              ReadOnlyRoots(isolate).termination_exception());
+    return ReadOnlyRoots(isolate).exception();
+  }
   return ReadOnlyRoots(isolate).undefined_value();
 }
 

--- a/deps/v8/src/objects/source-text-module.cc
+++ b/deps/v8/src/objects/source-text-module.cc
@@ -749,14 +749,14 @@ MaybeHandle<Object> SourceTextModule::Evaluate(
   return capability;
 }
 
-void SourceTextModule::AsyncModuleExecutionFulfilled(
+Maybe<bool> SourceTextModule::AsyncModuleExecutionFulfilled(
     Isolate* isolate, Handle<SourceTextModule> module) {
   // 1. If module.[[Status]] is evaluated, then
   if (module->status() == kErrored) {
     // a. Assert: module.[[EvaluationError]] is not empty.
     DCHECK(!module->exception().IsTheHole(isolate));
     // b. Return.
-    return;
+    return Just(true);
   }
   // 3. Assert: module.[[AsyncEvaluating]] is true.
   DCHECK(module->IsAsyncEvaluating());
@@ -812,7 +812,9 @@ void SourceTextModule::AsyncModuleExecutionFulfilled(
     } else if (m->async()) {
       //  ii. Otherwise, if m.[[Async]] is *true*, then
       //   a. Perform ! ExecuteAsyncModule(m).
-      ExecuteAsyncModule(isolate, m);
+      // The execution may have been terminated and can not be resumed, so just
+      // raise the exception.
+      MAYBE_RETURN(ExecuteAsyncModule(isolate, m), Nothing<bool>());
     } else {
       //  iii. Otherwise,
       //   a. Let _result_ be m.ExecuteModule().
@@ -846,6 +848,7 @@ void SourceTextModule::AsyncModuleExecutionFulfilled(
   }
 
   // 10. Return undefined.
+  return Just(true);
 }
 
 void SourceTextModule::AsyncModuleExecutionRejected(
@@ -905,8 +908,9 @@ void SourceTextModule::AsyncModuleExecutionRejected(
   }
 }
 
-void SourceTextModule::ExecuteAsyncModule(Isolate* isolate,
-                                          Handle<SourceTextModule> module) {
+// static
+Maybe<bool> SourceTextModule::ExecuteAsyncModule(
+    Isolate* isolate, Handle<SourceTextModule> module) {
   // 1. Assert: module.[[Status]] is "evaluating" or "evaluated".
   CHECK(module->status() == kEvaluating || module->status() == kEvaluated);
 
@@ -956,9 +960,19 @@ void SourceTextModule::ExecuteAsyncModule(Isolate* isolate,
   // Note: In V8 we have broken module.ExecuteModule into
   // ExecuteModule for synchronous module execution and
   // InnerExecuteAsyncModule for asynchronous execution.
-  InnerExecuteAsyncModule(isolate, module, capability).ToHandleChecked();
+  MaybeHandle<Object> ret =
+      InnerExecuteAsyncModule(isolate, module, capability);
+  if (ret.is_null()) {
+    // The evaluation of async module can not throwing a JavaScript observable
+    // exception.
+    DCHECK(isolate->has_pending_exception());
+    DCHECK_EQ(isolate->pending_exception(),
+              ReadOnlyRoots(isolate).termination_exception());
+    return Nothing<bool>();
+  }
 
   // 13. Return.
+  return Just<bool>(true);
 }
 
 MaybeHandle<Object> SourceTextModule::InnerExecuteAsyncModule(
@@ -1145,8 +1159,11 @@ MaybeHandle<Object> SourceTextModule::InnerModuleEvaluation(
 
     // c. If module.[[PendingAsyncDependencies]] is 0,
     //    perform ! ExecuteAsyncModule(_module_).
+    // The execution may have been terminated and can not be resumed, so just
+    // raise the exception.
     if (!module->HasPendingAsyncDependencies()) {
-      SourceTextModule::ExecuteAsyncModule(isolate, module);
+      MAYBE_RETURN(SourceTextModule::ExecuteAsyncModule(isolate, module),
+                   MaybeHandle<Object>());
     }
   } else {
     // 15. Otherwise, perform ? module.ExecuteModule().

--- a/deps/v8/src/objects/source-text-module.h
+++ b/deps/v8/src/objects/source-text-module.h
@@ -54,9 +54,10 @@ class SourceTextModule
   static int ExportIndex(int cell_index);
 
   // Used by builtins to fulfill or reject the promise associated
-  // with async SourceTextModules.
-  static void AsyncModuleExecutionFulfilled(Isolate* isolate,
-                                            Handle<SourceTextModule> module);
+  // with async SourceTextModules. Return Nothing if the execution is
+  // terminated.
+  static Maybe<bool> AsyncModuleExecutionFulfilled(
+      Isolate* isolate, Handle<SourceTextModule> module);
   static void AsyncModuleExecutionRejected(Isolate* isolate,
                                            Handle<SourceTextModule> module,
                                            Handle<Object> exception);
@@ -201,9 +202,10 @@ class SourceTextModule
   static V8_WARN_UNUSED_RESULT MaybeHandle<Object> ExecuteModule(
       Isolate* isolate, Handle<SourceTextModule> module);
 
-  // Implementation of spec ExecuteAsyncModule.
-  static void ExecuteAsyncModule(Isolate* isolate,
-                                 Handle<SourceTextModule> module);
+  // Implementation of spec ExecuteAsyncModule. Return Nothing if the execution
+  // is been terminated.
+  static V8_WARN_UNUSED_RESULT Maybe<bool> ExecuteAsyncModule(
+      Isolate* isolate, Handle<SourceTextModule> module);
 
   static void Reset(Isolate* isolate, Handle<SourceTextModule> module);
 

--- a/test/parallel/test-worker-process-exit-async-module.js
+++ b/test/parallel/test-worker-process-exit-async-module.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Regression for https://github.com/nodejs/node/issues/43182.
+const w = new Worker(new URL('data:text/javascript,process.exit(1);await new Promise(()=>{ process.exit(2); })'));
+w.on('exit', common.mustCall((code) => {
+  assert.strictEqual(code, 1);
+}));


### PR DESCRIPTION
Comimts:

#### test: add test on worker process.exit in async modules

Fixes https://github.com/nodejs/node/issues/43182

#### deps: V8: backport 22698d267667

Original commit message:

    [module] Fix aborts in terminated async module evaluation

    SourceTextModule::ExecuteAsyncModule asserts the execution of
    the module's async function to succeed without exception. However,
    the problem is that TerminateExecution initiated by embedders is
    breaking that assumption. The execution can be terminated with an
    exception and the exception is not catchable by JavaScript.

    The uncatchable exceptions during the async module evaluation need
    to be raised to the embedder and not crash the process if possible.

    Refs: https://github.com/nodejs/node/issues/43182

    Change-Id: Ifc152428b95945b6b49a2f70ba35018cfc0ce40b
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3696493
    Reviewed-by: Camillo Bruni <cbruni@chromium.org>
    Commit-Queue: Chengzhong Wu <legendecas@gmail.com>
    Cr-Commit-Position: refs/heads/main@{[#81307](https://github.com/legendecas/node/issues/81307)}

Refs: https://github.com/v8/v8/commit/22698d267667ad36f8b1d2c1f5ec71f54fcea3eb


