### PR TITLE
test: mark test-gc-http-client-timeout as flaky on arm

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -32,6 +32,8 @@ test-tls-psk-client: PASS, FLAKY
 test-tls-securepair-client: PASS, FLAKY
 
 [$arch==arm]
+# https://github.com/nodejs/node/issues/43638
+test-gc-http-client-timeout: PASS,FLAKY
 
 [$arch==s390x]
 # https://github.com/nodejs/node/issues/41286


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

`sequential/test-gc-http-client-timeout` is failing on arm frequently. Mark it as flaky to unblock PRs to land.

Related: https://github.com/nodejs/reliability/issues/320
Related: https://github.com/nodejs/node/issues/43638