### PR TITLE
src: deduplicate SetALPN implementations

### DIFF
--- a/src/crypto/crypto_common.cc
+++ b/src/crypto/crypto_common.cc
@@ -26,7 +26,6 @@ namespace node {
 
 using v8::Array;
 using v8::ArrayBuffer;
-using v8::ArrayBufferView;
 using v8::BackingStore;
 using v8::Context;
 using v8::EscapableHandleScope;
@@ -87,18 +86,10 @@ void LogSecret(
   keylog_cb(ssl.get(), line.c_str());
 }
 
-bool SetALPN(const SSLPointer& ssl, const std::string& alpn) {
-  return SSL_set_alpn_protos(
-      ssl.get(),
-      reinterpret_cast<const uint8_t*>(alpn.c_str()),
-      alpn.length()) == 0;
-}
-
-bool SetALPN(const SSLPointer& ssl, Local<Value> alpn) {
-  if (!alpn->IsArrayBufferView())
-    return false;
-  ArrayBufferViewContents<unsigned char> protos(alpn.As<ArrayBufferView>());
-  return SSL_set_alpn_protos(ssl.get(), protos.data(), protos.length()) == 0;
+bool SetALPN(const SSLPointer& ssl, std::string_view alpn) {
+  return SSL_set_alpn_protos(ssl.get(),
+                             reinterpret_cast<const uint8_t*>(alpn.data()),
+                             alpn.length()) == 0;
 }
 
 MaybeLocal<Value> GetSSLOCSPResponse(

--- a/src/crypto/crypto_common.h
+++ b/src/crypto/crypto_common.h
@@ -33,9 +33,8 @@ void LogSecret(
     const unsigned char* secret,
     size_t secretlen);
 
-bool SetALPN(const SSLPointer& ssl, const std::string& alpn);
-
-bool SetALPN(const SSLPointer& ssl, v8::Local<v8::Value> alpn);
+// TODO(tniessen): use std::u8string_view when we switch to C++20.
+bool SetALPN(const SSLPointer& ssl, std::string_view alpn);
 
 v8::MaybeLocal<v8::Value> GetSSLOCSPResponse(
     Environment* env,

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -1530,7 +1530,8 @@ void TLSWrap::SetALPNProtocols(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowTypeError("Must give a Buffer as first argument");
 
   if (w->is_client()) {
-    CHECK(SetALPN(w->ssl_, args[0]));
+    ArrayBufferViewContents<char> protos(args[0].As<ArrayBufferView>());
+    CHECK(SetALPN(w->ssl_, {protos.data(), protos.length()}));
   } else {
     CHECK(
         w->object()->SetPrivate(


### PR DESCRIPTION
Instead of accepting either a `std::string` or a mysterious `Local<Value>`, accept any `std::string_view`, which can trivially be constructed from both strings and `ArrayBufferView`s.

This also removes the need to check `IsArrayBufferView()` inside of `SetALPN`, which was dead code anyway.

cc @nodejs/cpp-reviewers

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
