### PR TITLE
doc: revert anachronistic 'node:' prefixed module require()s in API history notes

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -832,7 +832,7 @@ added: v10.6.0
 changes:
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/32953
-    description: Exposed as `require('node:dns/promises')`.
+    description: Exposed as `require('dns/promises')`.
   - version:
     - v11.14.0
     - v10.17.0

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -128,7 +128,7 @@ added: v10.0.0
 changes:
   - version: v14.0.0
     pr-url: https://github.com/nodejs/node/pull/31553
-    description: Exposed as `require('node:fs/promises')`.
+    description: Exposed as `require('fs/promises')`.
   - version:
     - v11.14.0
     - v10.17.0
@@ -136,7 +136,7 @@ changes:
     description: This API is no longer experimental.
   - version: v10.1.0
     pr-url: https://github.com/nodejs/node/pull/20504
-    description: The API is accessible via `require('node:fs').promises` only.
+    description: The API is accessible via `require('fs').promises` only.
 -->
 
 The `fs/promises` API provides asynchronous file system methods that return

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -447,7 +447,7 @@ added: v0.11.15
 changes:
   - version: v15.3.0
     pr-url: https://github.com/nodejs/node/pull/34962
-    description: Exposed as `require('node:path/posix')`.
+    description: Exposed as `require('path/posix')`.
 -->
 
 * {Object}
@@ -592,7 +592,7 @@ added: v0.11.15
 changes:
   - version: v15.3.0
     pr-url: https://github.com/nodejs/node/pull/34962
-    description: Exposed as `require('node:path/win32')`.
+    description: Exposed as `require('path/win32')`.
 -->
 
 * {Object}

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1477,7 +1477,7 @@ added: v10.0.0
 changes:
   - version: v15.3.0
     pr-url: https://github.com/nodejs/node/pull/34055
-    description: Exposed as `require('node:util/types')`.
+    description: Exposed as `require('util/types')`.
 -->
 
 `util.types` provides type checks for different kinds of built-in objects.


### PR DESCRIPTION
Support for the 'node:' prefixed builtin module namespace was introduced
for `require()` expressions in Node v16.0.0, and backported to v14.18.0.
This was never supported in Node v15.x or chronologically older.

All of the current API history notes in the docs using 'node:' prefixed
module `require()`s happen to be documenting changes in Node versions
from before the time when support was first introduced.

This commit reverts those `require()`s in the history notes to be
un-prefixed. (They were incorrect as written; The prefixed `require()`s
would not work for those older Node versions.)

This change prevents the API history notes from inaccurately implying
'node:' prefixed builtin modules were introduced many Node versions ago,
or were `require()`-able with the 'node:' prefix in those Node versions.

Refs: https://github.com/nodejs/node/pull/35387
Refs: https://github.com/nodejs/node/pull/37246
Refs: https://github.com/nodejs/node/pull/42752

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
