### PR TITLE
util: refactor to use validateObject

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -104,9 +104,6 @@ const {
 } = require('internal/util');
 
 const {
-  codes: {
-    ERR_INVALID_ARG_TYPE
-  },
   isStackOverflowError
 } = require('internal/errors');
 
@@ -2101,10 +2098,7 @@ function format(...args) {
 }
 
 function formatWithOptions(inspectOptions, ...args) {
-  if (typeof inspectOptions !== 'object' || inspectOptions === null) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'inspectOptions', 'object', inspectOptions);
-  }
+  validateObject(inspectOptions, 'inspectOptions', { allowArray: true });
   return formatWithOptionsInternal(inspectOptions, args);
 }
 


### PR DESCRIPTION
This PR refactored `util.formatWithOptions` to use `validateObject` to validate the first argument instead of the custom validator. 