### PR TITLE
feat(esm): leverage loaders when resolving subsequent loaders

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -701,8 +701,9 @@ changes:
 To customize the default module resolution, loader hooks can optionally be
 provided via a `--experimental-loader ./loader-name.mjs` argument to Node.js.
 
-When hooks are used they apply to the entry point and all `import` calls. They
-won't apply to `require` calls; those still follow [CommonJS][] rules.
+When hooks are used they apply to each subsequent loader, the entry point, and
+all `import` calls. They won't apply to `require` calls; those still follow
+[CommonJS][] rules.
 
 Loaders follow the pattern of `--require`:
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -310,7 +310,7 @@ class ESMLoader {
 
   /**
    * Collect custom/user-defined hook(s). After all hooks have been collected,
-   * calls global preload hook(s).
+   * the global preload hook(s) must be called.
    * @param {KeyedExports} customLoaders
    *  A list of exports from user-defined loaders (as returned by
    *  ESMLoader.import()).
@@ -357,8 +357,6 @@ class ESMLoader {
         );
       }
     }
-
-    this.preload();
   }
 
   async eval(

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -2,7 +2,7 @@
 
 const {
   ArrayIsArray,
-  ObjectCreate,
+  ArrayPrototypePushApply,
 } = primordials;
 
 const { ESMLoader } = require('internal/modules/esm/loader');
@@ -10,6 +10,7 @@ const {
   hasUncaughtExceptionCaptureCallback,
 } = require('internal/process/execution');
 const { pathToFileURL } = require('internal/url');
+const { kEmptyObject } = require('internal/util');
 
 const esmLoader = new ESMLoader();
 exports.esmLoader = esmLoader;
@@ -29,41 +30,61 @@ async function initializeLoader() {
   const { getOptionValue } = require('internal/options');
   const customLoaders = getOptionValue('--experimental-loader');
   const preloadModules = getOptionValue('--import');
-  const loaders = await loadModulesInIsolation(customLoaders);
-
-  // Hooks must then be added to external/public loader
-  // (so they're triggered in userland)
-  esmLoader.addCustomLoaders(loaders);
-
-  // Preload after loaders are added so they can be used
-  if (preloadModules?.length) {
-    await loadModulesInIsolation(preloadModules, loaders);
-  }
-
-  isESMInitialized = true;
-}
-
-function loadModulesInIsolation(specifiers, loaders = []) {
-  if (!ArrayIsArray(specifiers) || specifiers.length === 0) { return; }
 
   let cwd;
   try {
     cwd = process.cwd() + '/';
   } catch {
-    cwd = 'file:///';
+    cwd = '/';
   }
+
+  const internalEsmLoader = new ESMLoader();
+  const allLoaders = [];
+
+  const parentURL = pathToFileURL(cwd).href;
+
+  for (let i = 0; i < customLoaders.length; i++) {
+    const customLoader = customLoaders[i];
+
+    // Importation must be handled by internal loader to avoid polluting user-land
+    const keyedExportsSublist = await internalEsmLoader.import(
+      [customLoader],
+      parentURL,
+      kEmptyObject,
+    );
+
+    internalEsmLoader.addCustomLoaders(keyedExportsSublist);
+    ArrayPrototypePushApply(allLoaders, keyedExportsSublist);
+  }
+
+  // Hooks must then be added to external/public loader
+  // (so they're triggered in userland)
+  esmLoader.addCustomLoaders(allLoaders);
+  esmLoader.preload();
+
+  // Preload after loaders are added so they can be used
+  if (preloadModules?.length) {
+    await loadModulesInIsolation(parentURL, preloadModules, allLoaders);
+  }
+
+  isESMInitialized = true;
+}
+
+function loadModulesInIsolation(parentURL, specifiers, loaders = []) {
+  if (!ArrayIsArray(specifiers) || specifiers.length === 0) { return; }
 
   // A separate loader instance is necessary to avoid cross-contamination
   // between internal Node.js and userland. For example, a module with internal
   // state (such as a counter) should be independent.
   const internalEsmLoader = new ESMLoader();
   internalEsmLoader.addCustomLoaders(loaders);
+  internalEsmLoader.preload();
 
   // Importation must be handled by internal loader to avoid poluting userland
   return internalEsmLoader.import(
     specifiers,
-    pathToFileURL(cwd).href,
-    ObjectCreate(null),
+    parentURL,
+    kEmptyObject,
   );
 }
 

--- a/test/es-module/test-esm-loader-chaining.mjs
+++ b/test/es-module/test-esm-loader-chaining.mjs
@@ -4,7 +4,6 @@ import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
-
 const setupArgs = [
   '--no-warnings',
   '--input-type=module',
@@ -250,6 +249,23 @@ describe('ESM: loader chaining', { concurrency: true }, () => {
 
     assert.strictEqual(stderr, '');
     assert.match(stdout, /421/);
+    assert.strictEqual(code, 0);
+  });
+
+  it('should allow loaders to influence subsequent loader resolutions', async () => {
+    const { code, stderr } = await spawnPromisified(
+      execPath,
+      [
+        '--loader',
+        fixtures.fileURL('es-module-loaders', 'loader-resolve-strip-xxx.mjs'),
+        '--loader',
+        'xxx/loader-resolve-strip-yyy.mjs',
+        ...commonArgs,
+      ],
+      { encoding: 'utf8', cwd: fixtures.path('es-module-loaders') },
+    );
+
+    assert.strictEqual(stderr, '');
     assert.strictEqual(code, 0);
   });
 

--- a/test/fixtures/es-module-loaders/loader-load-foo-or-42.mjs
+++ b/test/fixtures/es-module-loaders/loader-load-foo-or-42.mjs
@@ -1,4 +1,12 @@
-export async function load(url) {
+export async function load(url, context, next) {
+  // This check is needed to make sure that we don't prevent the
+  // resolution from follow-up loaders. It wouldn't be a problem
+  // in real life because loaders aren't supposed to break the
+  // resolution, but the ones used in our tests do, for convenience.
+  if (url.includes('loader')) {
+    return next(url);
+  }
+
   const val = url.includes('42')
     ? '42'
     : '"foo"';

--- a/test/fixtures/es-module-loaders/loader-load-incomplete.mjs
+++ b/test/fixtures/es-module-loaders/loader-load-incomplete.mjs
@@ -1,4 +1,12 @@
-export async function load() {
+export async function load(url, context, next) {
+  // This check is needed to make sure that we don't prevent the
+  // resolution from follow-up loaders. It wouldn't be a problem
+  // in real life because loaders aren't supposed to break the
+  // resolution, but the ones used in our tests do, for convenience.
+  if (url.includes('loader')) {
+    return next(url);
+  }
+
   return {
     format: 'module',
     source: 'export default 42',

--- a/test/fixtures/es-module-loaders/loader-load-passthru.mjs
+++ b/test/fixtures/es-module-loaders/loader-load-passthru.mjs
@@ -1,4 +1,12 @@
 export async function load(url, context, next) {
+  // This check is needed to make sure that we don't prevent the
+  // resolution from follow-up loaders. It wouldn't be a problem
+  // in real life because loaders aren't supposed to break the
+  // resolution, but the ones used in our tests do, for convenience.
+  if (url.includes('loader')) {
+    return next(url);
+  }
+
   console.log('load passthru'); // This log is deliberate
   return next(url);
 }

--- a/test/fixtures/es-module-loaders/loader-resolve-42.mjs
+++ b/test/fixtures/es-module-loaders/loader-resolve-42.mjs
@@ -1,4 +1,12 @@
 export async function resolve(specifier, context, next) {
+  // This check is needed to make sure that we don't prevent the
+  // resolution from follow-up loaders. It wouldn't be a problem
+  // in real life because loaders aren't supposed to break the
+  // resolution, but the ones used in our tests do, for convenience.
+  if (specifier.includes('loader')) {
+    return next(specifier);
+  }
+
   console.log('resolve 42'); // This log is deliberate
   console.log('next<HookName>:', next.name); // This log is deliberate
 

--- a/test/fixtures/es-module-loaders/loader-resolve-foo.mjs
+++ b/test/fixtures/es-module-loaders/loader-resolve-foo.mjs
@@ -1,4 +1,12 @@
 export async function resolve(specifier, context, next) {
+  // This check is needed to make sure that we don't prevent the
+  // resolution from follow-up loaders. It wouldn't be a problem
+  // in real life because loaders aren't supposed to break the
+  // resolution, but the ones used in our tests do, for convenience.
+  if (specifier.includes('loader')) {
+    return next(specifier);
+  }
+
   console.log('resolve foo'); // This log is deliberate
   return next('file:///foo.mjs');
 }

--- a/test/fixtures/es-module-loaders/loader-resolve-incomplete.mjs
+++ b/test/fixtures/es-module-loaders/loader-resolve-incomplete.mjs
@@ -1,4 +1,12 @@
-export async function resolve() {
+export async function resolve(specifier, context, next) {
+  // This check is needed to make sure that we don't prevent the
+  // resolution from follow-up loaders. It wouldn't be a problem
+  // in real life because loaders aren't supposed to break the
+  // resolution, but the ones used in our tests do, for convenience.
+  if (specifier.includes('loader')) {
+    return next(specifier);
+  }
+
   return {
     url: 'file:///incomplete-resolve-chain.js',
   };

--- a/test/fixtures/es-module-loaders/loader-resolve-next-modified.mjs
+++ b/test/fixtures/es-module-loaders/loader-resolve-next-modified.mjs
@@ -1,4 +1,12 @@
 export async function resolve(url, context, next) {
+  // This check is needed to make sure that we don't prevent the
+  // resolution from follow-up loaders. It wouldn't be a problem
+  // in real life because loaders aren't supposed to break the
+  // resolution, but the ones used in our tests do, for convenience.
+  if (url.includes('loader')) {
+    return next(url);
+  }
+
   const {
     format,
     url: nextUrl,

--- a/test/fixtures/es-module-loaders/loader-resolve-passthru.mjs
+++ b/test/fixtures/es-module-loaders/loader-resolve-passthru.mjs
@@ -1,4 +1,12 @@
 export async function resolve(specifier, context, next) {
+  // This check is needed to make sure that we don't prevent the
+  // resolution from follow-up loaders. It wouldn't be a problem
+  // in real life because loaders aren't supposed to break the
+  // resolution, but the ones used in our tests do, for convenience.
+  if (specifier.includes('loader')) {
+    return next(specifier);
+  }
+
   console.log('resolve passthru'); // This log is deliberate
   return next(specifier);
 }

--- a/test/fixtures/es-module-loaders/loader-resolve-shortcircuit.mjs
+++ b/test/fixtures/es-module-loaders/loader-resolve-shortcircuit.mjs
@@ -1,4 +1,12 @@
-export async function resolve(specifier) {
+export async function resolve(specifier, context, next) {
+  // This check is needed to make sure that we don't prevent the
+  // resolution from follow-up loaders. It wouldn't be a problem
+  // in real life because loaders aren't supposed to break the
+  // resolution, but the ones used in our tests do, for convenience.
+  if (specifier.includes('loader')) {
+    return next(specifier);
+  }
+
   return {
     shortCircuit: true,
     url: specifier,

--- a/test/fixtures/es-module-loaders/loader-resolve-strip-xxx.mjs
+++ b/test/fixtures/es-module-loaders/loader-resolve-strip-xxx.mjs
@@ -1,0 +1,4 @@
+export async function resolve(specifier, context, nextResolve) {
+  console.log(`loader-a`, {specifier});
+  return nextResolve(specifier.replace(/^xxx\//, `./`));
+}

--- a/test/fixtures/es-module-loaders/loader-resolve-strip-yyy.mjs
+++ b/test/fixtures/es-module-loaders/loader-resolve-strip-yyy.mjs
@@ -1,0 +1,4 @@
+export async function resolve(specifier, context, nextResolve) {
+  console.log(`loader-b`, {specifier});
+  return nextResolve(specifier.replace(/^yyy\//, `./`));
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR is a follow-up to the [Ambient Loaders proposal](https://github.com/nodejs/loaders/blob/main/doc/design/proposal-ambient-loaders.md). Since in the last meetings we weren't too sure whether "ambient loaders" shouldn't just be the default loaders behaviour, I implemented it this way (but can change it later if needed).

I left a few assets to quickly try the system; without this PR, the second `--loader` would fail because `xxx/*` wouldn't be resolvable:

```
cd dev_fixtures_do_not_merge
../node --loader ./loader-a.mjs --loader xxx/loader-b.mjs ./index.mjs
```

cc @nodejs/loaders @cspotcode
