### PR TITLE
[v14.x] src,doc,test: add --openssl-shared-config option

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -635,6 +635,21 @@ Load an OpenSSL configuration file on startup. Among other uses, this can be
 used to enable FIPS-compliant crypto if Node.js is built
 against FIPS-enabled OpenSSL.
 
+### `--openssl-shared-config`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable OpenSSL default configuration section, `openssl_conf` to be read from
+the OpenSSL configuration file. The default configuration file is named
+`openssl.cnf` but this can be changed using the environment variable
+`OPENSSL_CONF`, or by using the command line option `--openssl-config`.
+The location of the default OpenSSL configuration file depends on how OpenSSL
+is being linked to Node.js. Sharing the OpenSSL configuration may have unwanted
+implications and it is recommended to use a configuration section specific to
+Node.js which is `nodejs_conf` and is default when this option is not used.
+
 ### `--pending-deprecation`
 <!-- YAML
 added: v8.0.0
@@ -1372,6 +1387,7 @@ Node.js options that are allowed are:
 * `--no-warnings`
 * `--node-memory-debug`
 * `--openssl-config`
+* `--openssl-shared-config`
 * `--pending-deprecation`
 * `--policy-integrity`
 * `--preserve-symlinks-main`

--- a/src/node.cc
+++ b/src/node.cc
@@ -1053,6 +1053,12 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
   const char* conf_file = nullptr;
   // Use OPENSSL_CONF environment variable is set.
   std::string env_openssl_conf;
+  // To allow for using the previous default where the 'openssl_conf' appname
+  // was used, the command line option 'openssl-shared-config' can be used to
+  // force the old behavior.
+  if (per_process::cli_options->openssl_shared_config) {
+    conf_section_name = "openssl_conf";
+  }
   credentials::SafeGetenv("OPENSSL_CONF", &env_openssl_conf);
   if (!env_openssl_conf.empty()) {
     conf_file = env_openssl_conf.c_str();

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -779,6 +779,10 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             "force FIPS crypto (cannot be disabled)",
             &PerProcessOptions::force_fips_crypto,
             kAllowedInEnvironment);
+  AddOption("--openssl-shared-config",
+            "enable OpenSSL shared configuration",
+            &PerProcessOptions::openssl_shared_config,
+            kAllowedInEnvironment);
 #endif
   AddOption("--use-largepages",
             "Map the Node.js static code to large pages. Options are "

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -238,6 +238,7 @@ class PerProcessOptions : public Options {
   // or are used once during process initialization.
 #if HAVE_OPENSSL
   std::string openssl_config;
+  bool openssl_shared_config = false;
   std::string tls_cipher_list = DEFAULT_CIPHER_LIST_CORE;
 #ifdef NODE_OPENSSL_CERT_STORE
   bool ssl_openssl_cert_store = true;

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -47,6 +47,7 @@ const conditionalOpts = [
     filter: (opt) => {
       return [
         '--openssl-config',
+        '--openssl-shared-config',
         '--tls-cipher-list',
         '--use-bundled-ca',
         '--use-openssl-ca',


### PR DESCRIPTION
This was forgotten in: https://github.com/nodejs/node/pull/43586
Ref: https://github.com/nodejs/nodejs.org/pull/4713

This commit adds a new command line option named
'--openssl-shared-config' intended to allow reverting to the old OpenSSL
configuration behavior where Node.js would use the configuration section
name (called appname in OpenSSL) 'openssl_conf' which could potentially
be used my other applications..

PR-URL: https://github.com/nodejs/node/pull/43124
Refs: https://github.com/nodejs/node/issues/40366
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Rich Trott <rtrott@gmail.com>
Reviewed-By: Rafael Gonzaga <rafael.nunu@hotmail.com>
Reviewed-By: Beth Griggs <bgriggs@redhat.com>