### PR TITLE
src,node-api: fix `napi_check_object_type_tag()`

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -2457,9 +2457,9 @@ napi_status NAPI_CDECL napi_check_object_type_tag(napi_env env,
         *result =
             (tag.lower == type_tag->lower && tag.upper == type_tag->upper);
       } else if (size == 1) {
-        *result = (tag.lower == type_tag->lower);
+        *result = (tag.lower == type_tag->lower && 0 == type_tag->upper);
       } else if (size == 0) {
-        *result = (type_tag->lower == 0 && type_tag->upper == 0);
+        *result = (0 == type_tag->lower && 0 == type_tag->upper);
       }
     }
   }

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -2452,8 +2452,16 @@ napi_status NAPI_CDECL napi_check_object_type_tag(napi_env env,
     napi_type_tag tag;
     val.As<v8::BigInt>()->ToWordsArray(
         &sign, &size, reinterpret_cast<uint64_t*>(&tag));
-    if (size == 2 && sign == 0)
-      *result = (tag.lower == type_tag->lower && tag.upper == type_tag->upper);
+    if (sign == 0) {
+      if (size == 2) {
+        *result =
+            (tag.lower == type_tag->lower && tag.upper == type_tag->upper);
+      } else if (size == 1) {
+        *result = (tag.lower == type_tag->lower);
+      } else if (size == 0) {
+        *result = (type_tag->lower == 0 && type_tag->upper == 0);
+      }
+    }
   }
 
   return GET_RETURN_STATUS(env);

--- a/test/js-native-api/test_object/test.js
+++ b/test/js-native-api/test_object/test.js
@@ -163,10 +163,14 @@ assert.strictEqual(newObject.test_string, 'test string');
   // Verify that objects can be type-tagged and type-tag-checked.
   const obj1 = test_object.TypeTaggedInstance(0);
   const obj2 = test_object.TypeTaggedInstance(1);
+  const obj3 = test_object.TypeTaggedInstance(2);
+  const obj4 = test_object.TypeTaggedInstance(3);
 
   // Verify that type tags are correctly accepted.
   assert.strictEqual(test_object.CheckTypeTag(0, obj1), true);
   assert.strictEqual(test_object.CheckTypeTag(1, obj2), true);
+  assert.strictEqual(test_object.CheckTypeTag(2, obj3), true);
+  assert.strictEqual(test_object.CheckTypeTag(3, obj4), true);
 
   // Verify that wrongly tagged objects are rejected.
   assert.strictEqual(test_object.CheckTypeTag(0, obj2), false);

--- a/test/js-native-api/test_object/test.js
+++ b/test/js-native-api/test_object/test.js
@@ -175,6 +175,11 @@ assert.strictEqual(newObject.test_string, 'test string');
   // Verify that wrongly tagged objects are rejected.
   assert.strictEqual(test_object.CheckTypeTag(0, obj2), false);
   assert.strictEqual(test_object.CheckTypeTag(1, obj1), false);
+  assert.strictEqual(test_object.CheckTypeTag(0, obj3), false);
+  assert.strictEqual(test_object.CheckTypeTag(1, obj4), false);
+  assert.strictEqual(test_object.CheckTypeTag(2, obj4), false);
+  assert.strictEqual(test_object.CheckTypeTag(3, obj3), false);
+  assert.strictEqual(test_object.CheckTypeTag(4, obj3), false);
 
   // Verify that untagged objects are rejected.
   assert.strictEqual(test_object.CheckTypeTag(0, {}), false);

--- a/test/js-native-api/test_object/test_object.c
+++ b/test/js-native-api/test_object/test_object.c
@@ -605,11 +605,12 @@ static napi_value TestSeal(napi_env env,
 }
 
 // We create two type tags. They are basically 128-bit UUIDs.
-static const napi_type_tag type_tags[4] = {
+static const napi_type_tag type_tags[5] = {
   { 0xdaf987b3cc62481a, 0xb745b0497f299531 },
   { 0xbb7936c374084d9b, 0xa9548d0762eeedb9 },
   { 0xa5ed9ce2e4c00c38, 0 },
   { 0, 0 },
+  { 0xa5ed9ce2e4c00c38, 0xdaf987b3cc62481a },
 };
 
 static napi_value

--- a/test/js-native-api/test_object/test_object.c
+++ b/test/js-native-api/test_object/test_object.c
@@ -605,9 +605,11 @@ static napi_value TestSeal(napi_env env,
 }
 
 // We create two type tags. They are basically 128-bit UUIDs.
-static const napi_type_tag type_tags[2] = {
+static const napi_type_tag type_tags[4] = {
   { 0xdaf987b3cc62481a, 0xb745b0497f299531 },
-  { 0xbb7936c374084d9b, 0xa9548d0762eeedb9 }
+  { 0xbb7936c374084d9b, 0xa9548d0762eeedb9 },
+  { 0xa5ed9ce2e4c00c38, 0 },
+  { 0, 0 },
 };
 
 static napi_value


### PR DESCRIPTION
Fixes: #43786 

This fixes a comparison failure occurring when the upper value of 
a type tag is 0, or a type tag value is 0.

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
