### PR TITLE
src: per-isolate eternal templates

### DIFF
--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -89,8 +89,7 @@ NodeMainInstance::NodeMainInstance(const SnapshotData* snapshot_data,
       event_loop,
       platform,
       array_buffer_allocator_.get(),
-      snapshot_data == nullptr ? nullptr
-                               : &(snapshot_data->isolate_data_indices));
+      snapshot_data == nullptr ? nullptr : &(snapshot_data->isolate_data_info));
   IsolateSettings s;
   SetIsolateMiscHandlers(isolate_, s);
   if (snapshot_data == nullptr) {

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -126,13 +126,10 @@ static const int v8_snapshot_blob_size = )"
   { v8_snapshot_blob_data, v8_snapshot_blob_size },
   // -- v8_snapshot_blob_data ends --
   // -- isolate_data_indices begins --
-  {
-)";
-  WriteVector(&ss,
-              data->isolate_data_indices.data(),
-              data->isolate_data_indices.size());
-  ss << R"(},
+)" << data->isolate_data_info
+     << R"(
   // -- isolate_data_indices ends --
+  ,
   // -- env_info begins --
 )" << data->env_info
      << R"(
@@ -222,9 +219,6 @@ int SnapshotBuilder::Generate(SnapshotData* out,
       }
     });
 
-    out->isolate_data_indices =
-        main_instance->isolate_data()->Serialize(&creator);
-
     // The default context with only things created by V8.
     Local<Context> default_context = Context::New(isolate);
 
@@ -285,6 +279,8 @@ int SnapshotBuilder::Generate(SnapshotData* out,
       }
 
       // Serialize the native states
+      out->isolate_data_info =
+          main_instance->isolate_data()->Serialize(&creator);
       out->env_info = env->Serialize(&creator);
 
 #ifdef NODE_USE_NODE_CODE_CACHE


### PR DESCRIPTION
`FunctionTemplate` and `ObjectTemplate` can be shared across realms. They should be per-isolate eternal handles and can not be modified.

As these templates are lazily initialized, their setters are still exposed with DCHECK on their value presence.

/cc @nodejs/startup 