### PR TITLE
node-api: Add API to check safety of calling JS

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -6295,6 +6295,24 @@ node_api_get_module_file_name(napi_env env, const char** result);
 `result` may be an empty string if the add-on loading process fails to establish
 the add-on's file name during loading.
 
+#### `napi_can_call_into_js`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+```c
+NAPI_EXTERN napi_status napi_can_call_into_js(napi_env env);
+```
+
+* `[in] env`: The environment that the API is invoked under.
+
+Returns `napi_ok` if the API succeeded.
+
+This API is used to check if it is safe to call into JavaScript.
+
 [ABI Stability]: https://nodejs.org/en/docs/guides/abi-stability/
 [AppVeyor]: https://www.appveyor.com
 [C++ Addons]: addons.md

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -566,6 +566,11 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_object_seal(napi_env env,
                                                     napi_value object);
 #endif  // NAPI_VERSION >= 8
 
+#ifdef NAPI_EXPERIMENTAL
+NAPI_EXTERN napi_status NAPI_CDECL napi_can_call_into_js(napi_env env,
+                                                         bool* result);
+#endif
+
 EXTERN_C_END
 
 #endif  // SRC_JS_NATIVE_API_H_

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -3252,3 +3252,10 @@ napi_status NAPI_CDECL napi_is_detached_arraybuffer(napi_env env,
 
   return napi_clear_last_error(env);
 }
+
+napi_status NAPI_CDECL napi_can_call_into_js(napi_env env, bool* result) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, result);
+  *result = (env)->can_call_into_js();
+  return napi_clear_last_error(env);
+}


### PR DESCRIPTION
This PR seeks to resolve an race condition issue while shutting down node with neon bindings.  Due to the race, it is possible to call into JavaScript during shutdown while it is not allowed.  The added API cal exposes the can_call_into_js so that we are able to check and catch the condition where we are no longer allowed to call into JavaScript.

https://github.com/neon-bindings/neon/pull/913