### PR TITLE
http: add drop request event for http server

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1406,6 +1406,20 @@ This event is guaranteed to be passed an instance of the {net.Socket} class,
 a subclass of {stream.Duplex}, unless the user specifies a socket
 type other than {net.Socket}.
 
+### Event: `'dropRequest'`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `request` {http.IncomingMessage} Arguments for the HTTP request, as it is in
+  the [`'request'`][] event
+* `socket` {stream.Duplex} Network socket between the server and client
+
+When the number of requests on a socket reaches the threshold of
+`server.maxRequestsPerSocket`, the server will drop new requests
+and emit `'dropRequest'` event instead, then send `503` to client.
+
 ### Event: `'request'`
 
 <!-- YAML

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -985,7 +985,7 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
     if (isRequestsLimitSet &&
       (server.maxRequestsPerSocket < state.requestsCount)) {
       handled = true;
-
+      server.emit('dropRequest', req, socket);
       res.writeHead(503);
       res.end();
     } else if (req.headers.expect !== undefined) {

--- a/test/parallel/test-http-keep-alive-drop-requests.js
+++ b/test/parallel/test-http-keep-alive-drop-requests.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const net = require('net');
+const assert = require('assert');
+
+function request(socket) {
+  socket.write('GET / HTTP/1.1\r\n');
+  socket.write('Connection: keep-alive\r\n');
+  socket.write('\r\n\r\n');
+}
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.end('ok');
+}));
+
+server.on('dropRequest', common.mustCall((request, socket) => {
+  assert.strictEqual(request instanceof http.IncomingMessage, true);
+  assert.strictEqual(socket instanceof net.Socket, true);
+  server.close();
+}));
+
+server.listen(0, common.mustCall(() => {
+  const socket = net.connect(server.address().port);
+  socket.on('connect', common.mustCall(() => {
+    request(socket);
+    request(socket);
+  }));
+  socket.on('data', common.mustCallAtLeast());
+  socket.on('close', common.mustCall());
+}));
+
+server.maxRequestsPerSocket = 1;

--- a/test/parallel/test-https-keep-alive-drop-requests.js
+++ b/test/parallel/test-https-keep-alive-drop-requests.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const https = require('https');
+const http = require('http');
+const net = require('net');
+const assert = require('assert');
+const tls = require('tls');
+const { readKey } = require('../common/fixtures');
+
+function request(socket) {
+  socket.write('GET / HTTP/1.1\r\nConnection: keep-alive\r\n\r\n\r\n');
+}
+
+// https options
+const httpsOptions = {
+  key: readKey('agent1-key.pem'),
+  cert: readKey('agent1-cert.pem')
+};
+
+const server = https.createServer(httpsOptions, common.mustCall((req, res) => {
+  res.end('ok');
+}));
+
+server.on('dropRequest', common.mustCall((request, socket) => {
+  assert.strictEqual(request instanceof http.IncomingMessage, true);
+  assert.strictEqual(socket instanceof net.Socket, true);
+  server.close();
+}));
+
+server.listen(0, common.mustCall(() => {
+  const socket = tls.connect(
+    server.address().port,
+    {
+      rejectUnauthorized: false
+    },
+    common.mustCall(() => {
+      request(socket);
+      request(socket);
+      socket.on('error', common.mustNotCall());
+      socket.on('data', common.mustCallAtLeast());
+      socket.on('close', common.mustCall());
+    })
+  );
+}));
+
+server.maxRequestsPerSocket = 1;


### PR DESCRIPTION
Add `dropRequest` event for http server to notify user when the number of requests on a socket reaches the threshold of
`server.maxRequestsPerSocket`.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Affected subsystem: http