### PR TITLE
lib: use private field in AbortController

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -292,34 +292,21 @@ function abortSignal(signal, reason) {
   signal.dispatchEvent(event);
 }
 
-// TODO(joyeecheung): use private fields and we'll get invalid access
-// validation from V8 instead of throwing ERR_INVALID_THIS ourselves.
-const kSignal = Symbol('signal');
-
-function validateAbortController(obj) {
-  if (obj?.[kSignal] === undefined)
-    throw new ERR_INVALID_THIS('AbortController');
-}
-
 class AbortController {
-  constructor() {
-    this[kSignal] = createAbortSignal();
-  }
+  #signal = createAbortSignal();
 
   /**
    * @type {AbortSignal}
    */
   get signal() {
-    validateAbortController(this);
-    return this[kSignal];
+    return this.#signal;
   }
 
   /**
    * @param {any} reason
    */
   abort(reason = new DOMException('This operation was aborted', 'AbortError')) {
-    validateAbortController(this);
-    abortSignal(this[kSignal], reason);
+    abortSignal(this.#signal, reason);
   }
 
   [customInspectSymbol](depth, options) {

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -108,11 +108,11 @@ const { setTimeout: sleep } = require('timers/promises');
   for (const badController of badAbortControllers) {
     throws(
       () => acSignalGet.call(badController),
-      { code: 'ERR_INVALID_THIS', name: 'TypeError' }
+      { name: 'TypeError' }
     );
     throws(
       () => acAbort.call(badController),
-      { code: 'ERR_INVALID_THIS', name: 'TypeError' }
+      { name: 'TypeError' }
     );
   }
 }
@@ -139,7 +139,7 @@ const { setTimeout: sleep } = require('timers/promises');
   for (const badSignal of badAbortSignals) {
     throws(
       () => signalAbortedGet.call(badSignal),
-      { code: 'ERR_INVALID_THIS', name: 'TypeError' }
+      { name: 'TypeError' }
     );
   }
 }


### PR DESCRIPTION
Instead of validating the receiver ourselves, let V8 handle
the validation using the semantics of private fields.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
