### PR TITLE
child_process: skip count length when maxBuffer is Infinity

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -437,6 +437,11 @@ function execFile(file, args = [], options, callback) {
       child.stdout.setEncoding(encoding);
 
     child.stdout.on('data', function onChildStdout(chunk) {
+      // Do not need to count the length
+      if (options.maxBuffer === Infinity) {
+        ArrayPrototypePush(_stdout, chunk);
+        return;
+      }
       const encoding = child.stdout.readableEncoding;
       const length = encoding ?
         Buffer.byteLength(chunk, encoding) :
@@ -462,6 +467,11 @@ function execFile(file, args = [], options, callback) {
       child.stderr.setEncoding(encoding);
 
     child.stderr.on('data', function onChildStderr(chunk) {
+      // Do not need to count the length
+      if (options.maxBuffer === Infinity) {
+        ArrayPrototypePush(_stderr, chunk);
+        return;
+      }
       const encoding = child.stderr.readableEncoding;
       const length = encoding ?
         Buffer.byteLength(chunk, encoding) :
@@ -476,7 +486,7 @@ function execFile(file, args = [], options, callback) {
         ex = new ERR_CHILD_PROCESS_STDIO_MAXBUFFER('stderr');
         kill();
       } else {
-        _stderr.push(chunk);
+        ArrayPrototypePush(_stderr, chunk);
       }
     });
   }


### PR DESCRIPTION
Do not count length when `maxBuffer` is `Infinity` because `xxxLen > options.maxBuffer` is always `false`.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Affected subsystem: child_process