### PR TITLE
test: return frozen function from common.must[Not]Call

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -454,7 +454,7 @@ function _mustCallInner(fn, criteria = 1, field) {
       configurable: true,
     },
   });
-  return _return;
+  return Object.freeze(_return);
 }
 
 function hasMultiLocalhost() {
@@ -510,13 +510,13 @@ function getCallSite(top) {
 
 function mustNotCall(msg) {
   const callSite = getCallSite(mustNotCall);
-  return function mustNotCall(...args) {
+  return Object.freeze(function mustNotCall(...args) {
     const argsInfo = args.length > 0 ?
       `\ncalled with arguments: ${args.map((arg) => inspect(arg)).join(', ')}` : '';
     assert.fail(
       `${msg || 'function should not have been called'} at ${callSite}` +
       argsInfo);
-  };
+  });
 }
 
 const _mustNotMutateObjectDeepProxies = new WeakMap();


### PR DESCRIPTION
I wonder if it would make sense to return frozen functions from `mustCall()`, `mustCallAtLeast()`, `mustNotCall()` and `mustSucceed()`.

Pros: implicit check that functions are never mutated, with no code cost.

Cons: impossible to monkey-patch them in tests.