### PR TITLE
src: optimized the Base64 encoding by AVX512VL instructions

### DIFF
--- a/src/base64-inl.h
+++ b/src/base64-inl.h
@@ -183,8 +183,10 @@ inline size_t base64_encode_scalar(
   return dlen;
 }
 
+// Only work for GCC for now
 #if (defined(__x86_64) || defined(__x86_64__)) &&                              \
-    (defined(__GNUC__) || defined(__GNUC))
+    defined(__GNUC__) && !defined(__llvm__) &&                                 \
+    !defined(__INTEL_COMPILER)
 #pragma GCC target("avx512vl", "avx512vbmi")
 /* Core logic is from https://github.com/WojciechMula/base64-avx512
  * Copyright 2019 Daniel Lemire, Wojciech Muła

--- a/src/base64-inl.h
+++ b/src/base64-inl.h
@@ -184,9 +184,8 @@ inline size_t base64_encode_scalar(
 }
 
 // Only work for GCC for now
-#if (defined(__x86_64) || defined(__x86_64__)) &&                              \
-    defined(__GNUC__) && !defined(__llvm__) &&                                 \
-    !defined(__INTEL_COMPILER)
+#if (defined(__x86_64) || defined(__x86_64__)) && defined(__GNUC__) &&         \
+    !defined(__llvm__) && !defined(__INTEL_COMPILER)
 #pragma GCC target("avx512vl", "avx512vbmi")
 /* Core logic is from https://github.com/WojciechMula/base64-avx512
  * Copyright 2019 Daniel Lemire, Wojciech Muła

--- a/src/base64-inl.h
+++ b/src/base64-inl.h
@@ -1,32 +1,3 @@
-/*
- * Copyright 2019 Daniel Lemire, Wojciech Muła
-
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- * may be used to endorse or promote products derived from this software without
- * specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 #ifndef SRC_BASE64_INL_H_
 #define SRC_BASE64_INL_H_
 
@@ -34,6 +5,11 @@
 
 #include "base64.h"
 #include "util.h"
+
+#if (defined(__x86_64) || defined(__x86_64__)) &&                              \
+    (defined(__GNUC__) || defined(__GNUC))
+#include <immintrin.h>
+#endif
 
 namespace node {
 
@@ -148,12 +124,8 @@ size_t base64_decode(char* const dst, const size_t dstlen,
   return base64_decode_fast(dst, dstlen, src, srclen, decoded_size);
 }
 
-
-inline size_t base64_encode_scalar(const char* src,
-                            size_t slen,
-                            char* dst,
-                            size_t dlen,
-                            Base64Mode mode) {
+inline size_t base64_encode_scalar(
+    const char* src, size_t slen, char* dst, size_t dlen, Base64Mode mode) {
   // We know how much we'll write, just make sure that there's space.
   CHECK(dlen >= base64_encoded_size(slen, mode) &&
         "not enough space provided for base64 encode");
@@ -211,16 +183,15 @@ inline size_t base64_encode_scalar(const char* src,
   return dlen;
 }
 
-
-#if (defined(__x86_64) || defined(__x86_64__)) && \
+#if (defined(__x86_64) || defined(__x86_64__)) &&                              \
     (defined(__GNUC__) || defined(__GNUC))
 #pragma GCC target("avx512vl", "avx512vbmi")
-#include <immintrin.h>
-inline size_t base64_encode_avx512vl(const char* src,
-                                     size_t slen,
-                                     char* dst,
-                                     size_t dlen,
-                                     Base64Mode mode) {
+/* Core logic is from https://github.com/WojciechMula/base64-avx512
+ * Copyright 2019 Daniel Lemire, Wojciech Muła
+ * under BSD-3-Clause license
+ */
+inline size_t base64_encode_avx512vl(
+    const char* src, size_t slen, char* dst, size_t dlen, Base64Mode mode) {
   // Do the exact check as scalar algorithm.
   CHECK(dlen >= base64_encoded_size(slen, mode) &&
         "not enough space provided for base64 encode");
@@ -233,15 +204,26 @@ inline size_t base64_encode_avx512vl(const char* src,
   // [b3 b2 b1 b0 c5 c4 c3 c2|c1 c0 d5 d4 d3 d2 d1 d0|
   //  a5 a4 a3 a2 a1 a0 b5 b4|b3 b2 b1 b0 c3 c2 c1 c0]
 
-  const __m512i shuffle_input = _mm512_setr_epi32(
-      0x01020001, 0x04050304, 0x07080607, 0x0a0b090a,
-      0x0d0e0c0d, 0x10110f10, 0x13141213, 0x16171516,
-      0x191a1819, 0x1c1d1b1c, 0x1f201e1f, 0x22232122,
-      0x25262425, 0x28292728, 0x2b2c2a2b, 0x2e2f2d2e);
-  const __m512i lookup = _mm512_loadu_si512((const __m512i*)(lookup_tbl));
+  const __m512i shuffle_input = _mm512_setr_epi32(0x01020001,
+                                                  0x04050304,
+                                                  0x07080607,
+                                                  0x0a0b090a,
+                                                  0x0d0e0c0d,
+                                                  0x10110f10,
+                                                  0x13141213,
+                                                  0x16171516,
+                                                  0x191a1819,
+                                                  0x1c1d1b1c,
+                                                  0x1f201e1f,
+                                                  0x22232122,
+                                                  0x25262425,
+                                                  0x28292728,
+                                                  0x2b2c2a2b,
+                                                  0x2e2f2d2e);
+  const __m512i lookup = _mm512_loadu_si512(lookup_tbl);
 
   while (slen >= 64) {
-    const __m512i v = _mm512_loadu_si512((const __m512i*)src);
+    const __m512i v = _mm512_loadu_si512(src);
 
     // Reorder bytes
     // [b3 b2 b1 b0 c5 c4 c3 c2|c1 c0 d5 d4 d3 d2 d1 d0|
@@ -254,7 +236,7 @@ inline size_t base64_encode_avx512vl(const char* src,
     // (a = [10:17], b = [4:11], c = [22:27], d = [16:21])
 
     // 48, 54, 36, 42, 16, 22, 4, 10
-    const __m512i shifts  = _mm512_set1_epi64(0x3036242a1016040alu);
+    const __m512i shifts = _mm512_set1_epi64(0x3036242a1016040alu);
     const __m512i indices = _mm512_multishift_epi64_epi8(shifts, in);
 
     // Note: the two higher bits of each indices' byte have garbage
@@ -271,19 +253,14 @@ inline size_t base64_encode_avx512vl(const char* src,
     slen -= 48;
   }
 
-  if (slen > 0)
-      base64_encode_scalar(src, slen, dst, dlen_remain, mode);
+  if (slen > 0) base64_encode_scalar(src, slen, dst, dlen_remain, mode);
 
   return dlen;
 }
 
-
-inline size_t base64_encode(const char* src,
-                            size_t slen,
-                            char* dst,
-                            size_t dlen,
-                            Base64Mode mode) {
-  if (__builtin_cpu_supports("avx512vl") && \
+inline size_t base64_encode(
+    const char* src, size_t slen, char* dst, size_t dlen, Base64Mode mode) {
+  if (__builtin_cpu_supports("avx512vl") &&
       __builtin_cpu_supports("avx512vbmi")) {
     return base64_encode_avx512vl(src, slen, dst, dlen, mode);
   } else {
@@ -292,11 +269,8 @@ inline size_t base64_encode(const char* src,
 }
 #pragma GCC reset_options
 #else
-inline size_t base64_encode(const char* src,
-                            size_t slen,
-                            char* dst,
-                            size_t dlen,
-                            Base64Mode mode) {
+inline size_t base64_encode(
+    const char* src, size_t slen, char* dst, size_t dlen, Base64Mode mode) {
   return base64_encode_scalar(src, slen, dst, dlen, mode);
 }
 #endif


### PR DESCRIPTION
This optimization only applies to Linux X86_64 at present.
The considerations is that AVX512VL is not a very new technology after
2018 and the main computing intensive AWS EC2 instances have been based
on Icelake. The users care about the performance gain of Base64 encoding
may mainly work on new arch machine and have specific requirements of
top performance. The purpose of this optimization is to provide the
known fastest solution for base64 encoding with no change to Node.js
building. It uses GCC pragma to enable this optimization according to
the building platform and uses GCC runtime definitions to enable on
supported platforms(new arch running Linux). The code is based on
WojciechMula's AVX512VL Base64 project as the known fastest solution,
which is faster than AVX512F/AVX512VBMI.The measurement of this patch
shows 2.4X performance (+140% gain) using benchmark/buffers/buffer-
base64-encoding micro bench on AWS EC2 m6i.large instances.wq

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
