### PR TITLE
doc: update (more) links to MDN page about dynamic imports

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -6158,7 +6158,7 @@ See the [list of SSL OP Flags][] for details.
 [`hash.update()`]: #hashupdatedata-inputencoding
 [`hmac.digest()`]: #hmacdigestencoding
 [`hmac.update()`]: #hmacupdatedata-inputencoding
-[`import()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports
+[`import()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import
 [`keyObject.export()`]: #keyobjectexportoptions
 [`postMessage()`]: worker_threads.md#portpostmessagevalue-transferlist
 [`sign.sign()`]: #signsignprivatekey-outputencoding

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -4162,7 +4162,7 @@ you need to implement any fall-back behavior yourself.
 [`http2.createServer()`]: #http2createserveroptions-onrequesthandler
 [`http2session.close()`]: #http2sessionclosecallback
 [`http2stream.pushStream()`]: #http2streampushstreamheaders-options-callback
-[`import()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports
+[`import()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import
 [`net.Server.close()`]: net.md#serverclosecallback
 [`net.Socket.bufferSize`]: net.md#socketbuffersize
 [`net.Socket.prototype.ref()`]: net.md#socketref

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -550,7 +550,7 @@ headers: max-age=0; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; p
 [`http.request()`]: http.md#httprequestoptions-callback
 [`https.Agent`]: #class-httpsagent
 [`https.request()`]: #httpsrequestoptions-callback
-[`import()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports
+[`import()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import
 [`net.Server`]: net.md#class-netserver
 [`new URL()`]: url.md#new-urlinput-base
 [`server.close()`]: http.md#serverclosecallback

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -1093,7 +1093,7 @@ This section was moved to
 [`MODULE_NOT_FOUND`]: errors.md#module_not_found
 [`__dirname`]: #__dirname
 [`__filename`]: #__filename
-[`import()`]: https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Imports
+[`import()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import
 [`module.builtinModules`]: module.md#modulebuiltinmodules
 [`module.children`]: #modulechildren
 [`module.id`]: #moduleid

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -2242,7 +2242,7 @@ added: v11.4.0
 [`SSL_export_keying_material`]: https://www.openssl.org/docs/man1.1.1/man3/SSL_export_keying_material.html
 [`SSL_get_version`]: https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html
 [`crypto.getCurves()`]: crypto.md#cryptogetcurves
-[`import()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports
+[`import()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import
 [`net.Server.address()`]: net.md#serveraddress
 [`net.Server`]: net.md#class-netserver
 [`net.Socket`]: net.md#class-netsocket


### PR DESCRIPTION
This is a follow-up on #43530.

> [The MDN page on `import`] was split into a separate page [specifically about dynamic `import()`] 2 days ago: https://github.com/mdn/content/commit/d2b50123d485c68c5321339446cf77a4bb16dd82