### PR TITLE
test: add check to test-fs-readfile-tostring-fail

### DIFF
--- a/test/pummel/test-fs-readfile-tostring-fail.js
+++ b/test/pummel/test-fs-readfile-tostring-fail.js
@@ -28,7 +28,7 @@ const a = Buffer.alloc(size, 'a');
 let expectedSize = 0;
 
 for (let i = 0; i < 201; i++) {
-  stream.write(a, (err) => { if (err) throw err; });
+  stream.write(a, (err) => { assert.ifError(err); });
   expectedSize += a.length;
 }
 

--- a/test/pummel/test-fs-readfile-tostring-fail.js
+++ b/test/pummel/test-fs-readfile-tostring-fail.js
@@ -25,13 +25,17 @@ stream.on('error', (err) => { throw err; });
 
 const size = kStringMaxLength / 200;
 const a = Buffer.alloc(size, 'a');
+let expectedSize = 0;
 
 for (let i = 0; i < 201; i++) {
-  stream.write(a);
+  stream.write(a, (err) => { if (err) throw err; });
+  expectedSize += a.length;
 }
 
 stream.end();
 stream.on('finish', common.mustCall(function() {
+  assert.strictEqual(stream.bytesWritten, expectedSize,
+                     `${stream.bytesWritten} bytes written (expected ${expectedSize} bytes).`);
   fs.readFile(file, 'utf8', common.mustCall(function(err, buf) {
     assert.ok(err instanceof Error);
     if (err.message !== 'Array buffer allocation failed') {


### PR DESCRIPTION
Check that all of the bytes were written to the temporary file before
reading it to catch the case where there is insufficient disk space.

Refs: https://github.com/nodejs/node/issues/43833

---

It feels like this extra check shouldn't be necessary but for some reason I can't get this test to emit any errors on the write stream cc @nodejs/streams @nodejs/fs.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
