### PR TITLE
test: ensure NODE_EXTRA_CA_CERTS not set before tests

### DIFF
--- a/test/parallel/test-tls-env-extra-ca-file-load.js
+++ b/test/parallel/test-tls-env-extra-ca-file-load.js
@@ -20,7 +20,7 @@ if (process.argv[2] !== 'child') {
   const NODE_EXTRA_CA_CERTS = fixtures.path('keys', 'ca1-cert.pem');
   const extendsEnv = (obj) => ({ ...process.env, ...obj });
 
-  // Clean the starting state
+  // Remove any pre-existing extra CA certs.
   delete process.env.NODE_EXTRA_CA_CERTS;
   [
     extendsEnv({ CHILD_USE_EXTRA_CA_CERTS: 'yes', NODE_EXTRA_CA_CERTS }),

--- a/test/parallel/test-tls-env-extra-ca-file-load.js
+++ b/test/parallel/test-tls-env-extra-ca-file-load.js
@@ -20,6 +20,8 @@ if (process.argv[2] !== 'child') {
   const NODE_EXTRA_CA_CERTS = fixtures.path('keys', 'ca1-cert.pem');
   const extendsEnv = (obj) => ({ ...process.env, ...obj });
 
+  // Clean the starting state
+  delete process.env.NODE_EXTRA_CA_CERTS;
   [
     extendsEnv({ CHILD_USE_EXTRA_CA_CERTS: 'yes', NODE_EXTRA_CA_CERTS }),
     extendsEnv({ CHILD_USE_EXTRA_CA_CERTS: 'no' }),


### PR DESCRIPTION
The 'test-tls-env-extra-ca-file-load.js' test assumes that
NODE_EXTRA_CA_CERTS is not set. If the build environment
happens to have it set, this test will fail. This change
deletes that env var before running the test.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
