### PR TITLE
buffer: add from(`ArrayBufferView`) support

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1207,10 +1207,14 @@ console.log(buf);
 
 <!-- YAML
 added: v5.10.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/43863
+    description: The `buffer` parameter can now be an any `ArrayBufferView`.
 -->
 
-* `buffer` {Buffer|Uint8Array} An existing `Buffer` or [`Uint8Array`][] from
-  which to copy data.
+* `buffer` {Buffer|ArrayBufferView} An existing `Buffer`, [`TypedArray`][],
+  or [`DataView`][] from which to copy data.
 
 Copies the passed `buffer` data onto a new `Buffer` instance.
 
@@ -1242,8 +1246,8 @@ console.log(buf2.toString());
 // Prints: buffer
 ```
 
-A `TypeError` will be thrown if `buffer` is not a `Buffer` or another type
-appropriate for `Buffer.from()` variants.
+A `TypeError` will be thrown if `buffer` is not an `ArrayBufferView`
+or another type appropriate for `Buffer.from()` variants.
 
 ### Static method: `Buffer.from(object[, offsetOrEncoding[, length]])`
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -83,7 +83,8 @@ const {
 const {
   isAnyArrayBuffer,
   isArrayBufferView,
-  isUint8Array
+  isTypedArray,
+  isUint8Array,
 } = require('internal/util/types');
 const {
   inspect: utilInspect
@@ -305,6 +306,15 @@ Buffer.from = function from(value, encodingOrOffset, length) {
   if (typeof value === 'object' && value !== null) {
     if (isAnyArrayBuffer(value))
       return fromArrayBuffer(value, encodingOrOffset, length);
+
+    if (isArrayBufferView(value) && !isUint8Array(value)) {
+      if (!isTypedArray(value)) {
+        // DataView is not a TypedArray
+        return fromArrayBuffer(value.buffer.slice(value.byteOffset,
+                                                  value.byteOffset + value.byteLength));
+      }
+      return fromArrayBuffer(value.slice().buffer);
+    }
 
     const valueOf = value.valueOf && value.valueOf();
     if (valueOf != null &&

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -3,8 +3,11 @@ const common = require('../common');
 
 const assert = require('assert');
 const vm = require('vm');
+const os = require('os');
 
 const SlowBuffer = require('buffer').SlowBuffer;
+
+const isBigEnd = os.endianness() === 'BE';
 
 // Verify the maximum Uint8Array size. There is no concrete limit by spec. The
 // internal limits should be updated if this fails.
@@ -62,7 +65,12 @@ assert.strictEqual(d.length, 0);
 {
   const ui32 = new Uint32Array(4).fill(42);
   const e = Buffer.from(ui32);
-  assert.deepStrictEqual(e, Buffer.from([
+  assert.deepStrictEqual(e, Buffer.from(isBigEnd ? [
+    0, 0, 0, 42,
+    0, 0, 0, 42,
+    0, 0, 0, 42,
+    0, 0, 0, 42,
+  ] : [
     42, 0, 0, 0,
     42, 0, 0, 0,
     42, 0, 0, 0,
@@ -73,7 +81,12 @@ assert.strictEqual(d.length, 0);
 {
   const ui32 = new Uint32Array(4).fill(42);
   const e = Buffer(ui32);
-  assert.deepStrictEqual(e, Buffer.from([
+  assert.deepStrictEqual(e, Buffer.from(isBigEnd ? [
+    0, 0, 0, 42,
+    0, 0, 0, 42,
+    0, 0, 0, 42,
+    0, 0, 0, 42,
+  ] : [
     42, 0, 0, 0,
     42, 0, 0, 0,
     42, 0, 0, 0,
@@ -85,7 +98,12 @@ assert.strictEqual(d.length, 0);
 {
   const bui64 = new BigUint64Array(4).fill(42n);
   const e = Buffer.from(bui64);
-  assert.deepStrictEqual(e, Buffer.from([
+  assert.deepStrictEqual(e, Buffer.from(isBigEnd ? [
+    0, 0, 0, 0, 0, 0, 0, 42,
+    0, 0, 0, 0, 0, 0, 0, 42,
+    0, 0, 0, 0, 0, 0, 0, 42,
+    0, 0, 0, 0, 0, 0, 0, 42,
+  ] : [
     42, 0, 0, 0, 0, 0, 0, 0,
     42, 0, 0, 0, 0, 0, 0, 0,
     42, 0, 0, 0, 0, 0, 0, 0,
@@ -96,7 +114,12 @@ assert.strictEqual(d.length, 0);
 {
   const bui64 = new BigUint64Array(4).fill(42n);
   const e = Buffer(bui64);
-  assert.deepStrictEqual(e, Buffer.from([
+  assert.deepStrictEqual(e, Buffer.from(isBigEnd ? [
+    0, 0, 0, 0, 0, 0, 0, 42,
+    0, 0, 0, 0, 0, 0, 0, 42,
+    0, 0, 0, 0, 0, 0, 0, 42,
+    0, 0, 0, 0, 0, 0, 0, 42,
+  ] : [
     42, 0, 0, 0, 0, 0, 0, 0,
     42, 0, 0, 0, 0, 0, 0, 0,
     42, 0, 0, 0, 0, 0, 0, 0,
@@ -108,7 +131,12 @@ assert.strictEqual(d.length, 0);
 {
   const f64 = new Float64Array(4).fill(42);
   const e = Buffer.from(f64);
-  assert.deepStrictEqual(e, Buffer.from([
+  assert.deepStrictEqual(e, Buffer.from(isBigEnd ? [
+    64, 69, 0, 0, 0, 0, 0, 0,
+    64, 69, 0, 0, 0, 0, 0, 0,
+    64, 69, 0, 0, 0, 0, 0, 0,
+    64, 69, 0, 0, 0, 0, 0, 0,
+  ] : [
     0, 0, 0, 0, 0, 0, 69, 64,
     0, 0, 0, 0, 0, 0, 69, 64,
     0, 0, 0, 0, 0, 0, 69, 64,
@@ -119,7 +147,12 @@ assert.strictEqual(d.length, 0);
 {
   const f64 = new Float64Array(4).fill(42);
   const e = Buffer(f64);
-  assert.deepStrictEqual(e, Buffer.from([
+  assert.deepStrictEqual(e, Buffer.from(isBigEnd ? [
+    64, 69, 0, 0, 0, 0, 0, 0,
+    64, 69, 0, 0, 0, 0, 0, 0,
+    64, 69, 0, 0, 0, 0, 0, 0,
+    64, 69, 0, 0, 0, 0, 0, 0,
+  ] : [
     0, 0, 0, 0, 0, 0, 69, 64,
     0, 0, 0, 0, 0, 0, 69, 64,
     0, 0, 0, 0, 0, 0, 69, 64,

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -59,22 +59,72 @@ assert.strictEqual(d.length, 0);
 }
 
 // Test creating a Buffer from a Uint32Array
-// Note: it is implicitly interpreted as Array of integers modulo 256
 {
   const ui32 = new Uint32Array(4).fill(42);
   const e = Buffer.from(ui32);
-  for (const [index, value] of e.entries()) {
-    assert.strictEqual(value, ui32[index]);
-  }
+  assert.deepStrictEqual(e, Buffer.from([
+    42, 0, 0, 0,
+    42, 0, 0, 0,
+    42, 0, 0, 0,
+    42, 0, 0, 0,
+  ]));
 }
 // Test creating a Buffer from a Uint32Array (old constructor)
-// Note: it is implicitly interpreted as Array of integers modulo 256
 {
   const ui32 = new Uint32Array(4).fill(42);
   const e = Buffer(ui32);
-  for (const [key, value] of e.entries()) {
-    assert.strictEqual(value, ui32[key]);
-  }
+  assert.deepStrictEqual(e, Buffer.from([
+    42, 0, 0, 0,
+    42, 0, 0, 0,
+    42, 0, 0, 0,
+    42, 0, 0, 0,
+  ]));
+}
+
+// Test creating a Buffer from a BigUint64Array
+{
+  const bui64 = new BigUint64Array(4).fill(42n);
+  const e = Buffer.from(bui64);
+  assert.deepStrictEqual(e, Buffer.from([
+    42, 0, 0, 0, 0, 0, 0, 0,
+    42, 0, 0, 0, 0, 0, 0, 0,
+    42, 0, 0, 0, 0, 0, 0, 0,
+    42, 0, 0, 0, 0, 0, 0, 0,
+  ]));
+}
+// Test creating a Buffer from a BigUint64Array (old constructor)
+{
+  const bui64 = new BigUint64Array(4).fill(42n);
+  const e = Buffer(bui64);
+  assert.deepStrictEqual(e, Buffer.from([
+    42, 0, 0, 0, 0, 0, 0, 0,
+    42, 0, 0, 0, 0, 0, 0, 0,
+    42, 0, 0, 0, 0, 0, 0, 0,
+    42, 0, 0, 0, 0, 0, 0, 0,
+  ]));
+}
+
+// Test creating a Buffer from a Float64Array
+{
+  const f64 = new Float64Array(4).fill(42);
+  const e = Buffer.from(f64);
+  assert.deepStrictEqual(e, Buffer.from([
+    0, 0, 0, 0, 0, 0, 69, 64,
+    0, 0, 0, 0, 0, 0, 69, 64,
+    0, 0, 0, 0, 0, 0, 69, 64,
+    0, 0, 0, 0, 0, 0, 69, 64,
+  ]));
+}
+// Test creating a Buffer from a Float64Array (old constructor)
+{
+  const f64 = new Float64Array(4).fill(42);
+  const e = Buffer(f64);
+  assert.deepStrictEqual(e, Buffer.from([
+    0, 0, 0, 0, 0, 0, 69, 64,
+    0, 0, 0, 0, 0, 0, 69, 64,
+    0, 0, 0, 0, 0, 0, 69, 64,
+    0, 0, 0, 0, 0, 0, 69, 64,
+  ]));
 }
 
 // Test invalid encoding for Buffer.toString

--- a/test/parallel/test-buffer-from-arraybufferview.js
+++ b/test/parallel/test-buffer-from-arraybufferview.js
@@ -1,0 +1,72 @@
+'use strict';
+const common = require('../common');
+
+// Test Buffer.from(ArrayBufferView)
+
+const assert = require('assert');
+
+// The buffer contains numbers from 27 * 0 to 27 * 127, modulo 256
+const full = Uint8Array.from({ length: 128 }, (_, i) => 27 * i);
+
+{
+  const expected = Buffer.from(full.buffer);
+
+  assert.deepStrictEqual(
+    Buffer.from(Buffer.from(full.buffer)),
+    expected);
+
+  for (const abv of common.getArrayBufferViews(full)) {
+    assert.deepStrictEqual(
+      Buffer.from(abv),
+      expected);
+  }
+}
+
+{
+  const expected = Buffer.from(full.buffer.slice(48, 96));
+
+  assert.deepStrictEqual(
+    Buffer.from(Buffer.from(full.buffer, 48, 48)),
+    expected);
+
+  assert.deepStrictEqual(
+    Buffer.from(new Int8Array(full.buffer, 48, 48)),
+    expected);
+  assert.deepStrictEqual(
+    Buffer.from(new Uint8Array(full.buffer, 48, 48)),
+    expected);
+  assert.deepStrictEqual(
+    Buffer.from(new Uint8ClampedArray(full.buffer, 48, 48)),
+    expected);
+
+  assert.deepStrictEqual(
+    Buffer.from(new Int16Array(full.buffer, 48, 24)),
+    expected);
+  assert.deepStrictEqual(
+    Buffer.from(new Uint16Array(full.buffer, 48, 24)),
+    expected);
+
+  assert.deepStrictEqual(
+    Buffer.from(new Int32Array(full.buffer, 48, 12)),
+    expected);
+  assert.deepStrictEqual(
+    Buffer.from(new Uint32Array(full.buffer, 48, 12)),
+    expected);
+  assert.deepStrictEqual(
+    Buffer.from(new Float32Array(full.buffer, 48, 12)),
+    expected);
+
+  assert.deepStrictEqual(
+    Buffer.from(new Float64Array(full.buffer, 48, 6)),
+    expected);
+  assert.deepStrictEqual(
+    Buffer.from(new BigInt64Array(full.buffer, 48, 6)),
+    expected);
+  assert.deepStrictEqual(
+    Buffer.from(new BigUint64Array(full.buffer, 48, 6)),
+    expected);
+
+  assert.deepStrictEqual(
+    Buffer.from(new DataView(full.buffer, 48, 48)),
+    expected);
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/43862

CITGM with `Buffer.from` throwing `SyntaxError` when `isArrayBufferView(value) && !(value instanceof Uint8Array)`: https://ci.nodejs.org/job/citgm-smoker/2970/