### PR TITLE
doc: inspector.close undefined in worker threads

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -19,6 +19,8 @@ const inspector = require('node:inspector');
 
 Deactivate the inspector. Blocks until there are no active connections.
 
+This function is not available in [worker threads][].
+
 ## `inspector.console`
 
 * {Object} An object to send messages to the remote inspector console.
@@ -260,3 +262,4 @@ session.post('HeapProfiler.takeHeapSnapshot', null, (err, r) => {
 [`'Debugger.paused'`]: https://chromedevtools.github.io/devtools-protocol/v8/Debugger#event-paused
 [`session.connect()`]: #sessionconnect
 [security warning]: cli.md#warning-binding-inspector-to-a-public-ipport-combination-is-insecure
+[worker threads]: worker_threads.md


### PR DESCRIPTION
In the main thread, `inspector.close` is defined as `process._debugEnd`:
```bash
$ node -e 'console.log(require("inspector").close)'
[Function: _debugEnd]
```

It's not defined in worker threads:
```bash
$ node -e 'const {Worker} = require("worker_threads");new Worker("console.log(require(\"inspector\").close)", {eval: true})'
undefined
```

(As far as I can tell this is intentional and has existed for quite some
time.)