### PR TITLE
worker: add function to get isolate address

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -232,6 +232,27 @@ buffers and external strings.
 }
 ```
 
+## `v8.isolateAddress`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* {string}
+
+The address of the V8 Isolate corresponding to the current [worker
+thread][worker threads]. You can add this to your application-level logs
+lines to correlate it with the `--trace_gc` log lines output by V8. The
+exact format of this identifier is platform-dependent.
+
+This identifier is stable while the current worker thread is executing.
+However the address may be reused by other threads after this worker
+thread stops. See [`require('node:worker_threads').threadId`][] for an
+identifier which is guaranteed not to be reused over the process's
+lifetime.
+
 ## `v8.setFlagsFromString(flags)`
 
 <!-- YAML
@@ -1028,6 +1049,7 @@ Returns true if the Node.js instance is run to build a snapshot.
 [`deserializer._readHostObject()`]: #deserializer_readhostobject
 [`deserializer.transferArrayBuffer()`]: #deserializertransferarraybufferid-arraybuffer
 [`init` callback]: #initpromise-parent
+[`require('node:worker_threads').threadId`]: worker_threads.md#workerthreadid
 [`serialize()`]: #v8serializevalue
 [`serializer._getSharedArrayBufferId()`]: #serializer_getsharedarraybufferidsharedarraybuffer
 [`serializer._writeHostObject()`]: #serializer_writehostobjectobject

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -25,6 +25,7 @@ const {
   Int16Array,
   Int32Array,
   Int8Array,
+  ObjectDefineProperties,
   ObjectPrototypeToString,
   Uint16Array,
   Uint32Array,
@@ -91,6 +92,7 @@ const binding = internalBinding('v8');
 
 const {
   cachedDataVersionTag,
+  getIsolateAddress,
   setFlagsFromString: _setFlagsFromString,
   updateHeapStatisticsBuffer,
   updateHeapSpaceStatisticsBuffer,
@@ -389,3 +391,12 @@ module.exports = {
   promiseHooks,
   startupSnapshot
 };
+
+ObjectDefineProperties(module.exports, {
+  isolateAddress: {
+    __proto__: null,
+    configurable: false,
+    enumerable: true,
+    get() { return getIsolateAddress(); }
+  }
+});

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -153,6 +153,15 @@ void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(result);
 }
 
+void GetIsolateAddress(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  char address[64];
+  // Use %p (even though it's platform dependent) because that's what V8 uses
+  // for --trace-gc, and we want to match it.
+  snprintf(address, sizeof(address), "%p", isolate);
+  args.GetReturnValue().Set(OneByteString(isolate, address));
+}
+
 void UpdateHeapStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
   BindingData* data = Environment::GetBindingData<BindingData>(args);
   HeapStatistics s;
@@ -190,7 +199,6 @@ void UpdateHeapCodeStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
 #undef V
 }
 
-
 void SetFlagsFromString(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());
   String::Utf8Value flags(args.GetIsolate(), args[0]);
@@ -208,6 +216,9 @@ void Initialize(Local<Object> target,
 
   env->SetMethodNoSideEffect(target, "cachedDataVersionTag",
                              CachedDataVersionTag);
+
+  env->SetMethodNoSideEffect(target, "getIsolateAddress", GetIsolateAddress);
+
   env->SetMethod(
       target, "updateHeapStatisticsBuffer", UpdateHeapStatisticsBuffer);
 
@@ -253,6 +264,7 @@ void Initialize(Local<Object> target,
 
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(CachedDataVersionTag);
+  registry->Register(GetIsolateAddress);
   registry->Register(UpdateHeapStatisticsBuffer);
   registry->Register(UpdateHeapCodeStatisticsBuffer);
   registry->Register(UpdateHeapSpaceStatisticsBuffer);

--- a/test/fixtures/gc.js
+++ b/test/fixtures/gc.js
@@ -1,3 +1,6 @@
+const { isolateAddress } = require('v8');
+console.log('my isolate address:', isolateAddress);
+
 let arr = new Array(300_000).fill('a');
 
 for (let index = 0; index < arr.length; index++) {


### PR DESCRIPTION
This change adds an experimental getter `v8.isolateAddress`, which
returns the address of the currently executing isolate. It is intended
to be used by application developers to correlate the output of
`--trace_gc` with application-level log lines.

Fixes: https://github.com/nodejs/node/issues/43810