### PR TITLE
events: replace NodeCustomEvent with CustomEvent

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -408,15 +408,6 @@ ObjectDefineProperties(CustomEvent.prototype, {
   detail: kEnumerableProperty,
 });
 
-class NodeCustomEvent extends Event {
-  constructor(type, options) {
-    super(type, options);
-    if (options?.detail) {
-      this.detail = options.detail;
-    }
-  }
-}
-
 // Weak listener cleanup
 // This has to be lazy for snapshots to work
 let weakListenersState = null;
@@ -837,7 +828,7 @@ class EventTarget {
   }
 
   [kCreateEvent](nodeValue, type) {
-    return new NodeCustomEvent(type, { detail: nodeValue });
+    return new CustomEvent(type, { detail: nodeValue });
   }
   [customInspectSymbol](depth, options) {
     if (!isEventTarget(this))


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

`CustomEvent` is implemented at https://github.com/nodejs/node/pull/43514, `NodeCustomEvent` is the same as `CustomEvent`, so I replace `NodeCustomEvent` with `CustomEvent` in favor of web API. cc @daeyeon 


Refs: https://github.com/nodejs/node/pull/43514#issuecomment-1161220074