### PR TITLE
test: simplify test-tls-set-secure-context

### DIFF
--- a/test/parallel/test-tls-set-secure-context.js
+++ b/test/parallel/test-tls-set-secure-context.js
@@ -9,7 +9,9 @@ if (!common.hasCrypto)
 // secure context is changed.
 
 const assert = require('assert');
+const events = require('events');
 const https = require('https');
+const timers = require('timers/promises');
 const fixtures = require('../common/fixtures');
 const credentialOptions = [
   {
@@ -43,10 +45,10 @@ server.listen(0, common.mustCall(() => {
   const { port } = server.address();
   const firstRequest = makeRequest(port, 1);
 
-  async function makeRemainingRequests() {
+  (async function makeRemainingRequests() {
     // Wait until the first request is guaranteed to have been handled.
-    if (!firstResponse) {
-      return setImmediate(makeRemainingRequests);
+    while (!firstResponse) {
+      await timers.setImmediate();
     }
 
     assert.strictEqual(await makeRequest(port, 2), 'success');
@@ -56,54 +58,38 @@ server.listen(0, common.mustCall(() => {
     const errorMessageRegex = common.hasOpenSSL3 ?
       /^Error: self-signed certificate$/ :
       /^Error: self signed certificate$/;
-    await assert.rejects(async () => {
-      await makeRequest(port, 3);
-    }, errorMessageRegex);
+    await assert.rejects(makeRequest(port, 3), errorMessageRegex);
 
     server.setSecureContext(credentialOptions[0]);
     assert.strictEqual(await makeRequest(port, 4), 'success');
 
     server.setSecureContext(credentialOptions[1]);
     firstResponse.end('fun!');
-    await assert.rejects(async () => {
-      await makeRequest(port, 5);
-    }, errorMessageRegex);
+    await assert.rejects(makeRequest(port, 5), errorMessageRegex);
 
     assert.strictEqual(await firstRequest, 'multi-request-success-fun!');
     server.close();
-  }
-
-  makeRemainingRequests();
+  })().then(common.mustCall());
 }));
 
-function makeRequest(port, id) {
-  return new Promise((resolve, reject) => {
-    const options = {
-      rejectUnauthorized: true,
-      ca: credentialOptions[0].ca,
-      servername: 'agent1',
-      headers: { id },
-      agent: new https.Agent()
-    };
+async function makeRequest(port, id) {
+  const options = {
+    rejectUnauthorized: true,
+    ca: credentialOptions[0].ca,
+    servername: 'agent1',
+    headers: { id },
+    agent: new https.Agent()
+  };
 
-    let errored = false;
-    https.get(`https://localhost:${port}`, options, (res) => {
-      let response = '';
+  const req = https.get(`https://localhost:${port}`, options);
 
-      res.setEncoding('utf8');
+  let errored = false;
+  req.on('error', () => errored = true);
+  req.on('finish', () => assert.strictEqual(errored, false));
 
-      res.on('data', (chunk) => {
-        response += chunk;
-      });
-
-      res.on('end', common.mustCall(() => {
-        resolve(response);
-      }));
-    }).on('error', (err) => {
-      errored = true;
-      reject(err);
-    }).on('finish', () => {
-      assert.strictEqual(errored, false);
-    });
-  });
+  const [res] = await events.once(req, 'response');
+  res.setEncoding('utf8');
+  let response = '';
+  for await (const chunk of res) response += chunk;
+  return response;
 }


### PR DESCRIPTION
- Instead of recursively scheduling `makeRemainingRequests` and ignoring its outcome, safely loop within the async function.
- Avoid unncessary async lambda functions passed to `assert.rejects`.
- Use `events.once()` to simplify control flow in `makeRequest`, instead of manually constructing a `Promise`.

(Consider hiding whitespace changes for review.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
