### PR TITLE
build: add .gitattributes for npm and other shims

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 test/fixtures/* -text
 vcbuild.bat text eol=crlf
+deps/npm/bin/npm text eol=lf
+deps/npm/bin/npx text eol=lf
+deps/corepack/shims/corepack text eol=lf
 tools/msvs/find_python.cmd text eol=crlf


### PR DESCRIPTION
This issue has been described in -
https://github.com/nodejs/node/issues/43860

On Windows system, git clone or git checkout on the repo turns LF line
endings to CRLF in the worktree.
This can happen due to many reasons like -
- git config --system core.autocrlf (set to true)
- git config --global core.autocrlf (set to true)
- git config --local core.autocrlf (set to true)
- git clone --config core.autocrlf=true ...

Adding gitattributes for the shims will not convert them to CRLF line
endings.

Also, there is a note[1] in test/README.md which says -
For the tests to run on Windows, be sure to clone Node.js source code
with the `autocrlf` git config flag set to true.

Reason for using build subsystem -
These shims are just copied in stage_package label of vcbuild.bat

Fixes: https://github.com/nodejs/node/issues/43860
[1]: https://github.com/nodejs/node/commit/3654cd4cdaf2ab84d0e6a190c3b9e89e86726a88

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
