### PR TITLE
src: use named struct instead of typedef

### DIFF
--- a/src/crypto/crypto_groups.h
+++ b/src/crypto/crypto_groups.h
@@ -390,12 +390,12 @@ static const unsigned char group_modp18[] = {
   0x80, 0xdd, 0x98, 0xed, 0xd3, 0xdf, 0xff, 0xff, 0xff, 0xff,
   0xff, 0xff, 0xff, 0xff };
 
-typedef struct {
+struct modp_group {
   const char* name;
   const char* prime;
   unsigned int prime_size;
   unsigned int gen;
-} modp_group;
+};
 
 static const modp_group modp_groups[] = {
 #define V(var) reinterpret_cast<const char*>(var)


### PR DESCRIPTION
There is no reason to use `typedef` with an unnamed `struct` here, and using a named `struct` is consistent with the rest of the codebase.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
