### PR TITLE
src: use a typed array internally for `process._exiting`

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -71,17 +71,21 @@ setupGlobalProxy();
 setupBuffer();
 
 process.domain = null;
-ObjectDefineProperty(process, '_exiting', {
-  __proto__: null,
-  get() {
-    return getHiddenValue(process, exiting_aliased_Uint32Array)[0] === 1;
-  },
-  set(value) {
-    getHiddenValue(process, exiting_aliased_Uint32Array)[0] = value ? 1 : 0;
-  },
-  enumerable: true,
-  configurable: true,
-});
+{
+  const existingAliasedUint32Array =
+    getHiddenValue(process, exiting_aliased_Uint32Array);
+  ObjectDefineProperty(process, '_exiting', {
+    __proto__: null,
+    get() {
+      return existingAliasedUint32Array[0] === 1;
+    },
+    set(value) {
+      existingAliasedUint32Array[0] = value ? 1 : 0;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+}
 process._exiting = false;
 
 // process.config is serialized config.gypi

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -72,15 +72,15 @@ setupBuffer();
 
 process.domain = null;
 {
-  const existingAliasedUint32Array =
+  const exitingAliasedUint32Array =
     getHiddenValue(process, exiting_aliased_Uint32Array);
   ObjectDefineProperty(process, '_exiting', {
     __proto__: null,
     get() {
-      return existingAliasedUint32Array[0] === 1;
+      return exitingAliasedUint32Array[0] === 1;
     },
     set(value) {
-      existingAliasedUint32Array[0] = value ? 1 : 0;
+      exitingAliasedUint32Array[0] = value ? 1 : 0;
     },
     enumerable: true,
     configurable: true,

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -67,6 +67,17 @@ setupGlobalProxy();
 setupBuffer();
 
 process.domain = null;
+ObjectDefineProperty(process, '_exiting', {
+  __proto__: null,
+  get() {
+    return process._exitingAliasedUint32Array[0] === 1;
+  },
+  set(value) {
+    process._exitingAliasedUint32Array[0] = value ? 1 : 0;
+  },
+  enumerable: true,
+  configurable: true,
+});
 process._exiting = false;
 
 // process.config is serialized config.gypi

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -60,6 +60,10 @@ const {
   deprecate,
   exposeInterface,
 } = require('internal/util');
+const {
+  exiting_aliased_Uint32Array,
+  getHiddenValue,
+} = internalBinding('util');
 
 setupProcessObject();
 
@@ -70,10 +74,10 @@ process.domain = null;
 ObjectDefineProperty(process, '_exiting', {
   __proto__: null,
   get() {
-    return process._exitingAliasedUint32Array[0] === 1;
+    return getHiddenValue(process, exiting_aliased_Uint32Array)[0] === 1;
   },
   set(value) {
-    process._exitingAliasedUint32Array[0] = value ? 1 : 0;
+    getHiddenValue(process, exiting_aliased_Uint32Array)[0] = value ? 1 : 0;
   },
   enumerable: true,
   configurable: true,

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -65,14 +65,11 @@ Maybe<int> EmitProcessExit(Environment* env) {
   Context::Scope context_scope(context);
   Local<Object> process_object = env->process_object();
 
-  // TODO(addaleax): It might be nice to share process._exiting and
-  // process.exitCode via getter/setter pairs that pass data directly to the
-  // native side, so that we don't manually have to read and write JS properties
-  // here. These getters could use e.g. a typed array for performance.
-  if (process_object
-      ->Set(context,
-            FIXED_ONE_BYTE_STRING(isolate, "_exiting"),
-            True(isolate)).IsNothing()) return Nothing<int>();
+  // TODO(addaleax): It might be nice to share process.exitCode via
+  // getter/setter pairs that pass data directly to the native side, so that we
+  // don't manually have to read and write JS properties here. These getters
+  // could use e.g. a typed array for performance.
+  env->set_exiting(true);
 
   Local<String> exit_code = env->exit_code_string();
   Local<Value> code_v;

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -371,6 +371,14 @@ inline bool Environment::force_context_aware() const {
   return options_->force_context_aware;
 }
 
+inline void Environment::set_exiting(bool value) {
+  exiting_[0] = value ? 1 : 0;
+}
+
+inline AliasedUint32Array& Environment::exiting() {
+  return exiting_;
+}
+
 inline void Environment::set_abort_on_uncaught_exception(bool value) {
   options_->abort_on_uncaught_exception = value;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -736,6 +736,7 @@ Environment::Environment(IsolateData* isolate_data,
       exec_argv_(exec_args),
       argv_(args),
       exec_path_(GetExecPath(args)),
+      exiting_(isolate_, 1, MAYBE_FIELD_PTR(env_info, exiting)),
       should_abort_on_uncaught_toggle_(
           isolate_,
           1,
@@ -842,6 +843,9 @@ void Environment::InitializeMainContext(Local<Context> context,
 
   // By default, always abort when --abort-on-uncaught-exception was passed.
   should_abort_on_uncaught_toggle_[0] = 1;
+
+  // The process is not exiting by default.
+  set_exiting(false);
 
   performance_state_->Mark(performance::NODE_PERFORMANCE_MILESTONE_ENVIRONMENT,
                            time_origin_);
@@ -1744,6 +1748,7 @@ EnvSerializeInfo Environment::Serialize(SnapshotCreator* creator) {
   info.immediate_info = immediate_info_.Serialize(ctx, creator);
   info.tick_info = tick_info_.Serialize(ctx, creator);
   info.performance_state = performance_state_->Serialize(ctx, creator);
+  info.exiting = exiting_.Serialize(ctx, creator);
   info.stream_base_state = stream_base_state_.Serialize(ctx, creator);
   info.should_abort_on_uncaught_toggle =
       should_abort_on_uncaught_toggle_.Serialize(ctx, creator);
@@ -1815,6 +1820,7 @@ std::ostream& operator<<(std::ostream& output, const EnvSerializeInfo& i) {
          << "// -- performance_state begins --\n"
          << i.performance_state << ",\n"
          << "// -- performance_state ends --\n"
+         << i.exiting << ",  // exiting\n"
          << i.stream_base_state << ",  // stream_base_state\n"
          << i.should_abort_on_uncaught_toggle
          << ",  // should_abort_on_uncaught_toggle\n"
@@ -1861,6 +1867,7 @@ void Environment::DeserializeProperties(const EnvSerializeInfo* info) {
   immediate_info_.Deserialize(ctx);
   tick_info_.Deserialize(ctx);
   performance_state_->Deserialize(ctx);
+  exiting_.Deserialize(ctx);
   stream_base_state_.Deserialize(ctx);
   should_abort_on_uncaught_toggle_.Deserialize(ctx);
 
@@ -2091,6 +2098,7 @@ void Environment::MemoryInfo(MemoryTracker* tracker) const {
                       native_modules_without_cache);
   tracker->TrackField("destroy_async_id_list", destroy_async_id_list_);
   tracker->TrackField("exec_argv", exec_argv_);
+  tracker->TrackField("exiting", exiting_);
   tracker->TrackField("should_abort_on_uncaught_toggle",
                       should_abort_on_uncaught_toggle_);
   tracker->TrackField("stream_base_state", stream_base_state_);

--- a/src/env.h
+++ b/src/env.h
@@ -173,6 +173,7 @@ class NoArrayBufferZeroFillScope {
   V(napi_type_tag, "node:napi:type_tag")                                      \
   V(napi_wrapper, "node:napi:wrapper")                                        \
   V(untransferable_object_private_symbol, "node:untransferableObject")        \
+  V(exiting_aliased_Uint32Array, "node:exiting_aliased_Uint32Array")
 
 // Symbols are per-isolate primitives but Environment proxies them
 // for the sake of convenience.

--- a/src/env.h
+++ b/src/env.h
@@ -164,15 +164,15 @@ class NoArrayBufferZeroFillScope {
 // Private symbols are per-isolate primitives but Environment proxies them
 // for the sake of convenience.  Strings should be ASCII-only and have a
 // "node:" prefix to avoid name clashes with third-party code.
-#define PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)                              \
-  V(alpn_buffer_private_symbol, "node:alpnBuffer")                            \
-  V(arrow_message_private_symbol, "node:arrowMessage")                        \
-  V(contextify_context_private_symbol, "node:contextify:context")             \
-  V(contextify_global_private_symbol, "node:contextify:global")               \
-  V(decorated_private_symbol, "node:decorated")                               \
-  V(napi_type_tag, "node:napi:type_tag")                                      \
-  V(napi_wrapper, "node:napi:wrapper")                                        \
-  V(untransferable_object_private_symbol, "node:untransferableObject")        \
+#define PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)                               \
+  V(alpn_buffer_private_symbol, "node:alpnBuffer")                             \
+  V(arrow_message_private_symbol, "node:arrowMessage")                         \
+  V(contextify_context_private_symbol, "node:contextify:context")              \
+  V(contextify_global_private_symbol, "node:contextify:global")                \
+  V(decorated_private_symbol, "node:decorated")                                \
+  V(napi_type_tag, "node:napi:type_tag")                                       \
+  V(napi_wrapper, "node:napi:wrapper")                                         \
+  V(untransferable_object_private_symbol, "node:untransferableObject")         \
   V(exiting_aliased_Uint32Array, "node:exiting_aliased_Uint32Array")
 
 // Symbols are per-isolate primitives but Environment proxies them

--- a/src/env.h
+++ b/src/env.h
@@ -952,6 +952,7 @@ struct EnvSerializeInfo {
   TickInfo::SerializeInfo tick_info;
   ImmediateInfo::SerializeInfo immediate_info;
   performance::PerformanceState::SerializeInfo performance_state;
+  AliasedBufferIndex exiting;
   AliasedBufferIndex stream_base_state;
   AliasedBufferIndex should_abort_on_uncaught_toggle;
 
@@ -1152,6 +1153,11 @@ class Environment : public MemoryRetainer {
 
   inline void set_force_context_aware(bool value);
   inline bool force_context_aware() const;
+
+  // This is a pseudo-boolean that keeps track of whether the process is
+  // exiting.
+  inline void set_exiting(bool value);
+  inline AliasedUint32Array& exiting();
 
   // This stores whether the --abort-on-uncaught-exception flag was passed
   // to Node.
@@ -1549,6 +1555,8 @@ class Environment : public MemoryRetainer {
   uint32_t module_id_counter_ = 0;
   uint32_t script_id_counter_ = 0;
   uint32_t function_id_counter_ = 0;
+
+  AliasedUint32Array exiting_;
 
   AliasedUint32Array should_abort_on_uncaught_toggle_;
   int should_not_abort_scope_counter_ = 0;

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -91,10 +91,11 @@ MaybeLocal<Object> CreateProcessObject(Environment* env) {
     return MaybeLocal<Object>();
   }
 
-  // process._exitingAliasedUint32Array
-  Local<String> exiting_string =
-      FIXED_ONE_BYTE_STRING(env->isolate(), "_exitingAliasedUint32Array");
-  if (process->Set(context, exiting_string, env->exiting().GetJSArray())
+  // process[exiting_aliased_Uint32Array]
+  if (process
+          ->SetPrivate(context,
+                       env->exiting_aliased_Uint32Array(),
+                       env->exiting().GetJSArray())
           .IsNothing()) {
     return {};
   }

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -94,7 +94,9 @@ MaybeLocal<Object> CreateProcessObject(Environment* env) {
   // process._exitingAliasedUint32Array
   Local<String> exiting_string =
       FIXED_ONE_BYTE_STRING(env->isolate(), "_exitingAliasedUint32Array");
-  process->Set(context, exiting_string, env->exiting().GetJSArray()).FromJust();
+  if (process->Set(context, exiting_string, env->exiting().GetJSArray()).IsNothing()) {
+    return {};
+  }
 
   // process.version
   READONLY_PROPERTY(process,

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -94,7 +94,8 @@ MaybeLocal<Object> CreateProcessObject(Environment* env) {
   // process._exitingAliasedUint32Array
   Local<String> exiting_string =
       FIXED_ONE_BYTE_STRING(env->isolate(), "_exitingAliasedUint32Array");
-  if (process->Set(context, exiting_string, env->exiting().GetJSArray()).IsNothing()) {
+  if (process->Set(context, exiting_string, env->exiting().GetJSArray())
+          .IsNothing()) {
     return {};
   }
 

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -91,6 +91,11 @@ MaybeLocal<Object> CreateProcessObject(Environment* env) {
     return MaybeLocal<Object>();
   }
 
+  // process._exitingAliasedUint32Array
+  Local<String> exiting_string =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "_exitingAliasedUint32Array");
+  process->Set(context, exiting_string, env->exiting().GetJSArray()).FromJust();
+
   // process.version
   READONLY_PROPERTY(process,
                     "version",

--- a/typings/internalBinding/util.d.ts
+++ b/typings/internalBinding/util.d.ts
@@ -17,6 +17,7 @@ declare function InternalBinding(binding: 'util'): {
   napi_type_tag: 5;
   napi_wrapper: 6;
   untransferable_object_private_symbol: 7;
+  exiting_aliased_Uint32Array: 8;
 
   kPending: 0;
   kFulfilled: 1;


### PR DESCRIPTION
This would prevent manual writes to the `_exiting` JS property on the
`process` object by passing the data directly via a typed array for
performance.

This change partially addresses this TODO:
https://github.com/nodejs/node/blob/3d575a4f1bd197c3ce669758a2a3c763462a883a/src/api/hooks.cc#L68-L71

Signed-off-by: Darshan Sen <raisinten@gmail.com>

cc @addaleax @nodejs/cpp-reviewers 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
