### PR TITLE
lib: refactor PriorityQueue to use private field

### DIFF
--- a/lib/internal/priority_queue.js
+++ b/lib/internal/priority_queue.js
@@ -1,14 +1,6 @@
 'use strict';
 
-const {
-  Array,
-  Symbol,
-} = primordials;
-
-const kCompare = Symbol('compare');
-const kHeap = Symbol('heap');
-const kSetPosition = Symbol('setPosition');
-const kSize = Symbol('size');
+const { Array } = primordials;
 
 // The PriorityQueue is a basic implementation of a binary heap that accepts
 // a custom sorting function via its constructor. This function is passed
@@ -17,23 +9,21 @@ const kSize = Symbol('size');
 // just a single criteria.
 
 module.exports = class PriorityQueue {
+  #compare = (a, b) => a - b;
+  #heap = new Array(64);
+  #setPosition;
+  #size = 0;
+
   constructor(comparator, setPosition) {
     if (comparator !== undefined)
-      this[kCompare] = comparator;
+      this.#compare = comparator;
     if (setPosition !== undefined)
-      this[kSetPosition] = setPosition;
-
-    this[kHeap] = new Array(64);
-    this[kSize] = 0;
-  }
-
-  [kCompare](a, b) {
-    return a - b;
+      this.#setPosition = setPosition;
   }
 
   insert(value) {
-    const heap = this[kHeap];
-    const pos = ++this[kSize];
+    const heap = this.#heap;
+    const pos = ++this.#size;
     heap[pos] = value;
 
     if (heap.length === pos)
@@ -43,14 +33,14 @@ module.exports = class PriorityQueue {
   }
 
   peek() {
-    return this[kHeap][1];
+    return this.#heap[1];
   }
 
   percolateDown(pos) {
-    const compare = this[kCompare];
-    const setPosition = this[kSetPosition];
-    const heap = this[kHeap];
-    const size = this[kSize];
+    const compare = this.#compare;
+    const setPosition = this.#setPosition;
+    const heap = this.#heap;
+    const size = this.#size;
     const item = heap[pos];
 
     while (pos * 2 <= size) {
@@ -71,9 +61,9 @@ module.exports = class PriorityQueue {
   }
 
   percolateUp(pos) {
-    const heap = this[kHeap];
-    const compare = this[kCompare];
-    const setPosition = this[kSetPosition];
+    const heap = this.#heap;
+    const compare = this.#compare;
+    const setPosition = this.#setPosition;
     const item = heap[pos];
 
     while (pos > 1) {
@@ -91,13 +81,13 @@ module.exports = class PriorityQueue {
   }
 
   removeAt(pos) {
-    const heap = this[kHeap];
-    const size = --this[kSize];
+    const heap = this.#heap;
+    const size = --this.#size;
     heap[pos] = heap[size + 1];
     heap[size + 1] = undefined;
 
     if (size > 0 && pos <= size) {
-      if (pos > 1 && this[kCompare](heap[pos / 2 | 0], heap[pos]) > 0)
+      if (pos > 1 && this.#compare(heap[pos / 2 | 0], heap[pos]) > 0)
         this.percolateUp(pos);
       else
         this.percolateDown(pos);
@@ -105,7 +95,7 @@ module.exports = class PriorityQueue {
   }
 
   shift() {
-    const heap = this[kHeap];
+    const heap = this.#heap;
     const value = heap[1];
     if (value === undefined)
       return;

--- a/lib/internal/priority_queue.js
+++ b/lib/internal/priority_queue.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const { Array } = primordials;
+const {
+  Array,
+} = primordials;
 
 // The PriorityQueue is a basic implementation of a binary heap that accepts
 // a custom sorting function via its constructor. This function is passed


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Today I am reading the code of PriorityQueue, I found use symbol to achieve private fields is not easy to read. so I refactor to use private field to improve readability.