### PR TITLE
http: wait for pending responses in closeIdleConnections

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -490,6 +490,10 @@ Server.prototype.closeIdleConnections = function() {
   const connections = this[kConnections].idle();
 
   for (let i = 0, l = connections.length; i < l; i++) {
+    if (connections[i].socket._httpMessage && !connections[i].socket._httpMessage.finished) {
+      continue;
+    }
+
     connections[i].socket.destroy();
   }
 };

--- a/test/parallel/test-http-server-close-idle-wait-response.js
+++ b/test/parallel/test-http-server-close-idle-wait-response.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+
+const { createServer, get } = require('http');
+
+const server = createServer(common.mustCall(function(req, res) {
+  req.resume();
+
+  setTimeout(common.mustCall(() => {
+    res.writeHead(204, { 'Connection': 'keep-alive', 'Keep-Alive': 'timeout=1' });
+    res.end();
+  }), common.platformTimeout(1000));
+}));
+
+server.listen(0, function() {
+  const port = server.address().port;
+
+  get(`http://localhost:${port}`, common.mustCall((res) => {
+    server.close();
+  })).on('finish', common.mustCall(() => {
+    setTimeout(common.mustCall(() => {
+      server.closeIdleConnections();
+    }), common.platformTimeout(500));
+  }));
+});


### PR DESCRIPTION
This PR fixes a problem in `closeIdleConnections` which, as the documentation states, should not consider a connection idle if the request has been sent but the socket is awaiting the response.

See: https://github.com/fastify/fastify/issues/4098
Fixes: #43771