### PR TITLE
[v16.x] src,doc,test: add --openssl-shared-config option

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -749,6 +749,21 @@ Load an OpenSSL configuration file on startup. Among other uses, this can be
 used to enable FIPS-compliant crypto if Node.js is built
 against FIPS-enabled OpenSSL.
 
+### `--openssl-shared-config`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable OpenSSL default configuration section, `openssl_conf` to be read from
+the OpenSSL configuration file. The default configuration file is named
+`openssl.cnf` but this can be changed using the environment variable
+`OPENSSL_CONF`, or by using the command line option `--openssl-config`.
+The location of the default OpenSSL configuration file depends on how OpenSSL
+is being linked to Node.js. Sharing the OpenSSL configuration may have unwanted
+implications and it is recommended to use a configuration section specific to
+Node.js which is `nodejs_conf` and is default when this option is not used.
+
 ### `--openssl-legacy-provider`
 
 <!-- YAML
@@ -1620,6 +1635,7 @@ Node.js options that are allowed are:
 * `--node-memory-debug`
 * `--openssl-config`
 * `--openssl-legacy-provider`
+* `--openssl-shared-config`
 * `--pending-deprecation`
 * `--policy-integrity`
 * `--preserve-symlinks-main`

--- a/src/node.cc
+++ b/src/node.cc
@@ -1096,6 +1096,12 @@ InitializationResult InitializeOncePerProcess(
     // instead only the section that matches the value of conf_section_name
     // will be read from the default configuration file.
     const char* conf_file = nullptr;
+    // To allow for using the previous default where the 'openssl_conf' appname
+    // was used, the command line option 'openssl-shared-config' can be used to
+    // force the old behavior.
+    if (per_process::cli_options->openssl_shared_config) {
+      conf_section_name = "openssl_conf";
+    }
     // Use OPENSSL_CONF environment variable is set.
     std::string env_openssl_conf;
     credentials::SafeGetenv("OPENSSL_CONF", &env_openssl_conf);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -824,13 +824,16 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             "minimum allocation size from the OpenSSL secure heap",
             &PerProcessOptions::secure_heap_min,
             kAllowedInEnvironment);
+  AddOption("--openssl-shared-config",
+            "enable OpenSSL shared configuration",
+            &PerProcessOptions::openssl_shared_config,
+            kAllowedInEnvironment);
 #endif  // HAVE_OPENSSL
 #if OPENSSL_VERSION_MAJOR >= 3
   AddOption("--openssl-legacy-provider",
             "enable OpenSSL 3.0 legacy provider",
             &PerProcessOptions::openssl_legacy_provider,
             kAllowedInEnvironment);
-
 #endif  // OPENSSL_VERSION_MAJOR
   AddOption("--use-largepages",
             "Map the Node.js static code to large pages. Options are "

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -247,6 +247,7 @@ class PerProcessOptions : public Options {
   std::string tls_cipher_list = DEFAULT_CIPHER_LIST_CORE;
   int64_t secure_heap = 0;
   int64_t secure_heap_min = 2;
+  bool openssl_shared_config = false;
 #ifdef NODE_OPENSSL_CERT_STORE
   bool ssl_openssl_cert_store = true;
 #else

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -55,6 +55,7 @@ const conditionalOpts = [
       return [
         '--openssl-config',
         common.hasOpenSSL3 ? '--openssl-legacy-provider' : '',
+        '--openssl-shared-config',
         '--tls-cipher-list',
         '--use-bundled-ca',
         '--use-openssl-ca',


### PR DESCRIPTION
This was forgotten in: https://github.com/nodejs/node/pull/43545/
Ref: https://github.com/nodejs/nodejs.org/pull/4713

This commit adds a new command line option named
'--openssl-shared-config' intended to allow reverting to the old OpenSSL
configuration behavior where Node.js would use the configuration section
name (called appname in OpenSSL) 'openssl_conf' which could potentially
be used my other applications..

PR-URL: https://github.com/nodejs/node/pull/43124
Refs: https://github.com/nodejs/node/issues/40366
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Rich Trott <rtrott@gmail.com>
Reviewed-By: Rafael Gonzaga <rafael.nunu@hotmail.com>
Reviewed-By: Beth Griggs <bgriggs@redhat.com>