### PR TITLE
doc: clarify subprocess.stdout/in/err property

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1670,7 +1670,7 @@ in which the child process is launched.
 added: v0.1.90
 -->
 
-* {stream.Readable}
+* {stream.Readable|null|undefined}
 
 A `Readable Stream` that represents the child process's `stderr`.
 
@@ -1680,8 +1680,8 @@ then this will be `null`.
 `subprocess.stderr` is an alias for `subprocess.stdio[2]`. Both properties will
 refer to the same value.
 
-The `subprocess.stderr` property can be `null` if the child process could
-not be successfully spawned.
+The `subprocess.stderr` property can be `null` or `undefined`
+if the child process could not be successfully spawned.
 
 ### `subprocess.stdin`
 
@@ -1689,7 +1689,7 @@ not be successfully spawned.
 added: v0.1.90
 -->
 
-* {stream.Writable}
+* {stream.Writable|null|undefined}
 
 A `Writable Stream` that represents the child process's `stdin`.
 
@@ -1702,8 +1702,8 @@ then this will be `null`.
 `subprocess.stdin` is an alias for `subprocess.stdio[0]`. Both properties will
 refer to the same value.
 
-The `subprocess.stdin` property can be `undefined` if the child process could
-not be successfully spawned.
+The `subprocess.stdin` property can be `null` or `undefined`
+if the child process could not be successfully spawned.
 
 ### `subprocess.stdio`
 
@@ -1755,7 +1755,7 @@ not be successfully spawned.
 added: v0.1.90
 -->
 
-* {stream.Readable}
+* {stream.Readable|null|undefined}
 
 A `Readable Stream` that represents the child process's `stdout`.
 
@@ -1775,8 +1775,8 @@ subprocess.stdout.on('data', (data) => {
 });
 ```
 
-The `subprocess.stdout` property can be `null` if the child process could
-not be successfully spawned.
+The `subprocess.stdout` property can be `null` or `undefined`
+if the child process could not be successfully spawned.
 
 ### `subprocess.unref()`
 


### PR DESCRIPTION
Fix #43905

`subprocess.stdout/in/err` property can be `undefined` when `EMFILE` or `ENFILE` error happend.
https://github.com/nodejs/node/blob/389b7e138e89a339fabe4ad628bf09cd9748f957/test/sequential/test-child-process-emfile.js#L58-L65
And they can be `null` when the child process couldn't be successfully spawned.
https://github.com/nodejs/node/blob/389b7e138e89a339fabe4ad628bf09cd9748f957/lib/internal/child_process.js#L455-L460