### PR TITLE
dns: fix cares memory leak

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1428,6 +1428,7 @@ static void Query(const FunctionCallbackInfo<Value>& args) {
 
 
 void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
+  auto cleanup = OnScopeLeave([&]() { uv_freeaddrinfo(res); });
   std::unique_ptr<GetAddrInfoReqWrap> req_wrap {
       static_cast<GetAddrInfoReqWrap*>(req->data)};
   Environment* env = req_wrap->env();
@@ -1487,8 +1488,6 @@ void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
 
     argv[1] = results;
   }
-
-  uv_freeaddrinfo(res);
 
   TRACE_EVENT_NESTABLE_ASYNC_END2(
       TRACING_CATEGORY_NODE2(dns, native), "lookup", req_wrap.get(),


### PR DESCRIPTION
fix cares memory leak.

I have a question that the function `AfterGetAddrInfo` return directly when `IsNothing` is true , is it expected? this make the callback of `dns.lookup` never be called.

cc @addaleax
Refs: https://github.com/nodejs/node/pull/39735
 
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)