### PR TITLE
deps: cherry-pick 00704f5a from V8 upstream

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.9',
+    'v8_embedder_string': '-node.10',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-array-buffer.h
+++ b/deps/v8/include/v8-array-buffer.h
@@ -256,6 +256,12 @@ class V8_EXPORT ArrayBuffer : public Object {
    */
   std::shared_ptr<BackingStore> GetBackingStore();
 
+  /**
+   * More efficient shortcut for GetBackingStore()->Data(). The returned pointer
+   * is valid as long as the ArrayBuffer is alive.
+   */
+  void* Data() const;
+
   V8_INLINE static ArrayBuffer* Cast(Value* value) {
 #ifdef V8_ENABLE_CHECKS
     CheckCast(value);
@@ -413,6 +419,12 @@ class V8_EXPORT SharedArrayBuffer : public Object {
    * should not attempt to manage lifetime of the storage through other means.
    */
   std::shared_ptr<BackingStore> GetBackingStore();
+
+  /**
+   * More efficient shortcut for GetBackingStore()->Data(). The returned pointer
+   * is valid as long as the ArrayBuffer is alive.
+   */
+  void* Data() const;
 
   V8_INLINE static SharedArrayBuffer* Cast(Value* value) {
 #ifdef V8_ENABLE_CHECKS

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -4038,6 +4038,11 @@ std::shared_ptr<v8::BackingStore> v8::ArrayBuffer::GetBackingStore() {
   return std::static_pointer_cast<v8::BackingStore>(bs_base);
 }
 
+void* v8::ArrayBuffer::Data() const {
+  i::Handle<i::JSArrayBuffer> self = Utils::OpenHandle(this);
+  return self->backing_store();
+}
+
 std::shared_ptr<v8::BackingStore> v8::SharedArrayBuffer::GetBackingStore() {
   i::Handle<i::JSArrayBuffer> self = Utils::OpenHandle(this);
   std::shared_ptr<i::BackingStore> backing_store = self->GetBackingStore();
@@ -4046,6 +4051,11 @@ std::shared_ptr<v8::BackingStore> v8::SharedArrayBuffer::GetBackingStore() {
   }
   std::shared_ptr<i::BackingStoreBase> bs_base = backing_store;
   return std::static_pointer_cast<v8::BackingStore>(bs_base);
+}
+
+void* v8::SharedArrayBuffer::Data() const {
+  i::Handle<i::JSArrayBuffer> self = Utils::OpenHandle(this);
+  return self->backing_store();
 }
 
 void v8::ArrayBuffer::CheckCast(Value* that) {

--- a/deps/v8/test/cctest/test-api-array-buffer.cc
+++ b/deps/v8/test/cctest/test-api-array-buffer.cc
@@ -366,6 +366,7 @@ THREADED_TEST(SkipArrayBufferBackingStoreDuringGC) {
 
   // Should not move the pointer
   CHECK_EQ(ab->GetBackingStore()->Data(), store_ptr);
+  CHECK_EQ(ab->Data(), store_ptr);
 
   CcTest::array_buffer_allocator()->Free(buffer, 100);
 }
@@ -394,8 +395,8 @@ THREADED_TEST(SkipArrayBufferDuringScavenge) {
   CcTest::CollectGarbage(i::NEW_SPACE);  // in survivor space now
   CcTest::CollectGarbage(i::NEW_SPACE);  // in old gen now
 
-  // Use `ab` to silence compiler warning
   CHECK_EQ(ab->GetBackingStore()->Data(), store_ptr);
+  CHECK_EQ(ab->Data(), store_ptr);
 }
 
 THREADED_TEST(Regress1006600) {
@@ -418,6 +419,7 @@ THREADED_TEST(ArrayBuffer_NewBackingStore) {
   CHECK(!backing_store->IsShared());
   Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(isolate, backing_store);
   CHECK_EQ(backing_store.get(), ab->GetBackingStore().get());
+  CHECK_EQ(backing_store->Data(), ab->Data());
 }
 
 THREADED_TEST(SharedArrayBuffer_NewBackingStore) {
@@ -430,6 +432,7 @@ THREADED_TEST(SharedArrayBuffer_NewBackingStore) {
   Local<v8::SharedArrayBuffer> ab =
       v8::SharedArrayBuffer::New(isolate, backing_store);
   CHECK_EQ(backing_store.get(), ab->GetBackingStore().get());
+  CHECK_EQ(backing_store->Data(), ab->Data());
 }
 
 static void* backing_store_custom_data = nullptr;


### PR DESCRIPTION
Original commit message:

    Add more efficient API for accesssing ArrayBuffer raw data

    Raw data access is already possible via GetBackingStore()->GetData().
    This API exposes a more efficient way for accessing
    JSArrayBuffer::backing_store (which, despite the confusing name, is no
    the BackingStore but its raw data pointer).

    Bug: v8:10343
    Change-Id: I695cea91e2c3de75ce6c86bac6e413ce6617958b
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3764341
    Reviewed-by: Camillo Bruni <cbruni@chromium.org>
    Commit-Queue: Marja Hölttä <marja@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#81745}

Refs: https://github.com/v8/v8/commit/00704f5a03d9db02c14c4f4c35188effc46e82ab
Refs: https://github.com/nodejs/node/issues/32226