### PR TITLE
test: fix test http upload timeout

### DIFF
--- a/test/pummel/test-http-upload-timeout.js
+++ b/test/pummel/test-http-upload-timeout.js
@@ -23,19 +23,20 @@
 // This tests setTimeout() by having multiple clients connecting and sending
 // data in random intervals. Clients are also randomly disconnecting until there
 // are no more clients left. If no false timeout occurs, this test has passed.
-require('../common');
+const common = require('../common');
 const http = require('http');
 const server = http.createServer();
 let connections = 0;
 
+const ontimeout = common.mustNotCall('Unexpected timeout');
+
 server.on('request', function(req, res) {
   req.socket.setTimeout(1000);
-  req.socket.on('timeout', function() {
-    throw new Error('Unexpected timeout');
-  });
+  req.socket.on('timeout', ontimeout);
   req.on('end', function() {
     connections--;
     res.writeHead(200);
+    req.socket.off('timeout', ontimeout);
     res.end('done\n');
     if (connections === 0) {
       server.close();
@@ -47,7 +48,7 @@ server.on('request', function(req, res) {
 server.listen(0, function() {
   for (let i = 0; i < 10; i++) {
     connections++;
-
+    let count = 0;
     setTimeout(function() {
       const request = http.request({
         port: server.address().port,
@@ -56,13 +57,12 @@ server.listen(0, function() {
       });
 
       function ping() {
-        const nextPing = (Math.random() * 900).toFixed();
-        if (nextPing > 600) {
+        if (++count === 10) {
           request.end();
           return;
         }
         request.write('ping');
-        setTimeout(ping, nextPing);
+        setTimeout(ping, 300);
       }
       ping();
     }, i * 50);


### PR DESCRIPTION
fix test http upload timeout which often fail in CI.

```
/home/iojs/build/workspace/node-test-commit-linux-containered/test/pummel/test-http-upload-timeout.js:34
    throw new Error('Unexpected timeout');
    ^

Error: Unexpected timeout
    at Socket.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/pummel/test-http-upload-timeout.js:34:11)
    at Socket.emit (node:events:525:35)
    at Socket._onTimeout (node:net:522:8)
    at listOnTimeout (node:internal/timers:564:17)
    at process.processTimers (node:internal/timers:507:7)
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)