### PR TITLE
v8: add benchmarks to serialize/deserialize and improve if statements

### DIFF
--- a/benchmark/v8/deserialize.js
+++ b/benchmark/v8/deserialize.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const common = require('../common.js');
+const v8 = require('v8');
+
+const bench = common.createBenchmark(main, {
+  n: [1e6]
+});
+
+function main({ n }) {
+  const serialized = v8.serialize({ a: 1 });
+  bench.start();
+  for (let i = 0; i < n; i++)
+    v8.deserialize(serialized);
+  bench.end(n);
+}

--- a/benchmark/v8/serialize.js
+++ b/benchmark/v8/serialize.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const common = require('../common.js');
+const v8 = require('v8');
+
+const bench = common.createBenchmark(main, {
+  n: [1e6]
+});
+
+function main({ n }) {
+  bench.start();
+  for (let i = 0; i < n; i++)
+    v8.serialize({ a: 1 });
+  bench.end(n);
+}

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -247,38 +247,40 @@ Deserializer.prototype.readRawBytes = function readRawBytes(length) {
 
 function arrayBufferViewTypeToIndex(abView) {
   const type = ObjectPrototypeToString(abView);
-  if (type === '[object Int8Array]') return 0;
-  if (type === '[object Uint8Array]') return 1;
-  if (type === '[object Uint8ClampedArray]') return 2;
-  if (type === '[object Int16Array]') return 3;
-  if (type === '[object Uint16Array]') return 4;
-  if (type === '[object Int32Array]') return 5;
-  if (type === '[object Uint32Array]') return 6;
-  if (type === '[object Float32Array]') return 7;
-  if (type === '[object Float64Array]') return 8;
-  if (type === '[object DataView]') return 9;
-  // Index 10 is FastBuffer.
-  if (type === '[object BigInt64Array]') return 11;
-  if (type === '[object BigUint64Array]') return 12;
-  return -1;
+
+  switch (type) {
+    case '[object Int8Array]': return 0;
+    case '[object Uint8Array]': return 1;
+    case '[object Uint8ClampedArray]': return 2;
+    case '[object Int16Array]': return 3;
+    case '[object Uint16Array]': return 4;
+    case '[object Int32Array]': return 5;
+    case '[object Uint32Array]': return 6;
+    case '[object Float32Array]': return 7;
+    case '[object Float64Array]': return 8;
+    case '[object DataView]': return 9;
+      // Index 10 is FastBuffer.
+    case '[object BigInt64Array]': return 11;
+    case '[object BigUint64Array]': return 12;
+    default: return -1;
+  }
 }
 
-function arrayBufferViewIndexToType(index) {
-  if (index === 0) return Int8Array;
-  if (index === 1) return Uint8Array;
-  if (index === 2) return Uint8ClampedArray;
-  if (index === 3) return Int16Array;
-  if (index === 4) return Uint16Array;
-  if (index === 5) return Int32Array;
-  if (index === 6) return Uint32Array;
-  if (index === 7) return Float32Array;
-  if (index === 8) return Float64Array;
-  if (index === 9) return DataView;
-  if (index === 10) return FastBuffer;
-  if (index === 11) return BigInt64Array;
-  if (index === 12) return BigUint64Array;
-  return undefined;
-}
+const arrayBufferTypes = [
+  Int8Array,
+  Uint8Array,
+  Uint8ClampedArray,
+  Int16Array,
+  Uint16Array,
+  Int32Array,
+  Uint32Array,
+  Float32Array,
+  Float64Array,
+  DataView,
+  FastBuffer,
+  BigInt64Array,
+  BigUint64Array,
+];
 
 class DefaultSerializer extends Serializer {
   constructor() {
@@ -325,7 +327,7 @@ class DefaultDeserializer extends Deserializer {
    */
   _readHostObject() {
     const typeIndex = this.readUint32();
-    const ctor = arrayBufferViewIndexToType(typeIndex);
+    const ctor = arrayBufferTypes[typeIndex];
     const byteLength = this.readUint32();
     const byteOffset = this._readRawBytes(byteLength);
     const BYTES_PER_ELEMENT = ctor.BYTES_PER_ELEMENT || 1;


### PR DESCRIPTION
I added 2 benchmarks to serialize and deserialize method in order to understand the performance impact of replacing a really big if statement with a switch statement. Here are my findings:

## Serialize

### Before

```
➜  node git:(perf/v8-deserialize-serialize) ./node-master benchmark/v8/serialize.js
v8/serialize.js n=1000000: 699,777.9223973043
➜  node git:(perf/v8-deserialize-serialize) ./node-master benchmark/v8/serialize.js
v8/serialize.js n=1000000: 696,074.8630130064
➜  node git:(perf/v8-deserialize-serialize) ./node-master benchmark/v8/serialize.js
v8/serialize.js n=1000000: 704,981.8835623765
```

### After

```
➜  node git:(perf/v8-deserialize-serialize) ./node-debug benchmark/v8/serialize.js
v8/serialize.js n=1000000: 702,113.8598850783
➜  node git:(perf/v8-deserialize-serialize) ./node-debug benchmark/v8/serialize.js
v8/serialize.js n=1000000: 705,363.8894045315
➜  node git:(perf/v8-deserialize-serialize) ./node-debug benchmark/v8/serialize.js
v8/serialize.js n=1000000: 703,806.1453469822
```

## Deserialize

### Before

```
➜  node git:(perf/v8-deserialize-serialize) ./node-master benchmark/v8/deserialize.js
v8/deserialize.js n=1000000: 1,571,634.7166923403
➜  node git:(perf/v8-deserialize-serialize) ./node-master benchmark/v8/deserialize.js
v8/deserialize.js n=1000000: 1,567,321.4530283604
➜  node git:(perf/v8-deserialize-serialize) ./node-master benchmark/v8/deserialize.js
v8/deserialize.js n=1000000: 1,572,912.0436487873
```

### After

```
➜  node git:(perf/v8-deserialize-serialize) ./node-debug benchmark/v8/deserialize.js
v8/deserialize.js n=1000000: 1,575,016.1488374511
➜  node git:(perf/v8-deserialize-serialize) ./node-debug benchmark/v8/deserialize.js
v8/deserialize.js n=1000000: 1,573,957.404044289
➜  node git:(perf/v8-deserialize-serialize) ./node-debug benchmark/v8/deserialize.js
v8/deserialize.js n=1000000: 1,579,010.319407197
```