### PR TITLE
buffer: do not leak memory if buffer is too big

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -497,6 +497,7 @@ MaybeLocal<Object> New(Environment* env,
     if (length > kMaxLength) {
       Isolate* isolate(env->isolate());
       isolate->ThrowException(ERR_BUFFER_TOO_LARGE(isolate));
+      free(data);
       return Local<Object>();
     }
   }


### PR DESCRIPTION
A recent pull request changed this method to throw when the buffer was
too big, but this meant that the `free` finalizer would never get
called, leading to a memory leak.

Refs: https://github.com/nodejs/node/pull/40243