### PR TITLE
build: shim for invoking node w/o .exe from WSL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ deps/npm/bin/npm text eol=lf
 deps/npm/bin/npx text eol=lf
 deps/corepack/shims/corepack text eol=lf
 tools/msvs/find_python.cmd text eol=crlf
+tools/msvs/node text eol=lf

--- a/tools/msvs/node
+++ b/tools/msvs/node
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Shim for invoking node without .exe from WSL
+basedir=$(dirname "$0")
+"$basedir/node.exe" "$@"

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -440,6 +440,8 @@ mkdir %TARGET_NAME%\node_modules > nul 2>nul
 
 copy /Y node.exe %TARGET_NAME%\ > nul
 if errorlevel 1 echo Cannot copy node.exe && goto package_error
+copy /Y ..\tools\msvs\node %TARGET_NAME%\ > nul
+if errorlevel 1 echo Cannot copy node && goto package_error
 copy /Y ..\LICENSE %TARGET_NAME%\ > nul
 if errorlevel 1 echo Cannot copy LICENSE && goto package_error
 copy /Y ..\README.md %TARGET_NAME%\ > nul


### PR DESCRIPTION
This issue has been described in -
https://github.com/nodejs/node/issues/43861

Reason for using build subsystem -
Shims will be just copied in the stage_package label of vcbuild.bat

Fixes: https://github.com/nodejs/node/issues/43861

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
