### PR TITLE
child_process: fix setSimultaneousAccepts

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -691,9 +691,10 @@ function setupChannel(target, channel, serializationMode) {
 
     const obj = handleConversion[message.type];
 
-    // Update simultaneous accepts on Windows
-    if (process.platform === 'win32') {
-      handle.setSimultaneousAccepts(false);
+    // Call setSimultaneousAccepts if it is a function
+    // currently, it is only defined in tcp_wrap.cc and on win32
+    if (obj.simultaneousAccepts && typeof handle.setSimultaneousAccepts === 'function') {
+      handle.setSimultaneousAccepts(true);
     }
 
     // Convert handle object
@@ -816,8 +817,11 @@ function setupChannel(target, channel, serializationMode) {
       if (!handle)
         message = message.msg;
 
-      // Update simultaneous accepts on Windows
-      if (obj.simultaneousAccepts && process.platform === 'win32') {
+      // Call setSimultaneousAccepts if it is a function
+      // currently, it is only defined in tcp_wrap.cc and on win32
+      if (handle &&
+          obj.simultaneousAccepts &&
+          typeof handle.setSimultaneousAccepts === 'function') {
         handle.setSimultaneousAccepts(true);
       }
     } else if (this._handleQueue &&

--- a/lib/net.js
+++ b/lib/net.js
@@ -1890,7 +1890,8 @@ if (isWindows) {
                              process.env.NODE_MANY_ACCEPTS !== '0');
     }
 
-    if (handle._simultaneousAccepts !== simultaneousAccepts) {
+    if (handle._simultaneousAccepts !== simultaneousAccepts &&
+      typeof handle.setSimultaneousAccepts === 'function') {
       handle.setSimultaneousAccepts(!!simultaneousAccepts);
       handle._simultaneousAccepts = simultaneousAccepts;
     }

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -207,6 +207,9 @@ void TCPWrap::SetSimultaneousAccepts(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
+  if (wrap->provider_type() != ProviderType::PROVIDER_TCPSERVERWRAP) {
+    return;
+  }
   bool enable = args[0]->IsTrue();
   int err = uv_tcp_simultaneous_accepts(&wrap->handle_, enable);
   args.GetReturnValue().Set(err);

--- a/test/parallel/test-setsimultaneousaccepts.js
+++ b/test/parallel/test-setsimultaneousaccepts.js
@@ -1,0 +1,54 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const child_process = require('child_process');
+
+const CODE = `
+  const net = require('net');
+  process.on('message', (message, handle) => {
+    // net.Socket or net.Server
+    handle instanceof net.Socket ? handle.destroy() : handle.close();
+    process.send('accepted');
+  })
+`;
+
+const child = child_process.fork(process.execPath, { execArgv: ['-e', CODE ] });
+
+let tcpServer;
+const sockets = [];
+let accepted = 0;
+
+child.on('message', (message) => {
+  assert.strictEqual(message, 'accepted');
+  if (++accepted === 2) {
+    child.kill();
+    tcpServer.close();
+    sockets.forEach((socket) => {
+      socket.destroy();
+    });
+  }
+});
+
+tcpServer = net.createServer(common.mustCall((socket) => {
+  const setSimultaneousAccepts = socket._handle.setSimultaneousAccepts;
+  if (typeof setSimultaneousAccepts === 'function') {
+    socket._handle.setSimultaneousAccepts = common.mustCall((...args) => {
+      const ret = setSimultaneousAccepts.call(socket._handle, ...args);
+      assert.strictEqual(ret, undefined);
+    });
+  }
+  child.send(null, socket._handle);
+  sockets.push(socket);
+}));
+tcpServer.listen(0, common.mustCall(() => {
+  net.connect(tcpServer.address().port);
+  const setSimultaneousAccepts = tcpServer._handle.setSimultaneousAccepts;
+  if (typeof setSimultaneousAccepts === 'function') {
+    tcpServer._handle.setSimultaneousAccepts = common.mustCall((...args) => {
+      const ret = setSimultaneousAccepts.call(tcpServer._handle, ...args);
+      assert.strictEqual(ret, 0);
+    });
+  }
+  child.send(null, tcpServer);
+}));


### PR DESCRIPTION
The error from CI is as follows. When pass the pipe handle by IPC on win32, the bug will be triggered because `setSimultaneousAccepts ` is only defined on tcp handle. In addition, `setSimultaneousAccepts` should only be valid on tcp server.
```
error Message
fail (1)
Stacktrace
node:internal/child_process:821
        handle.setSimultaneousAccepts(true);
               ^

TypeError: handle.setSimultaneousAccepts is not a function
    at target._send (node:internal/child_process:821:16)
    at target.send (node:internal/child_process:738:19)
    at sendHelper (node:internal/cluster/utils:28:15)
    at RoundRobinHandle.handoff (node:internal/cluster/round_robin_handle:128:3)
    at RoundRobinHandle.distribute (node:internal/cluster/round_robin_handle:108:10)
    at handle.onconnection (node:internal/cluster/round_robin_handle:45:54)
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)