### PR TITLE
module: add support for `nodeEntryPointConfig.loaders` in `package.json`

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1315,10 +1315,36 @@ Package imports permit mapping to external packages.
 
 This field defines [subpath imports][] for the current package.
 
+### `nodeEntryPointConfig`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {Object}
+
+Additional configuration on how to start the Node.js processes inside a package
+(does not apply if the entry point is using `.mjs` or `.cjs` file extension).
+
+#### `nodeEntryPointConfig.loaders`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string\[]}
+
+Specify the `module` of a custom experimental [ECMAScript module loader][].
+`module` may be any string accepted as an [`import` specifier][] resolved
+relative to the `package.json` file.
+This field is ignored if the [`--experimental-loader`][] CLI flag is used.
+
+
 [Babel]: https://babeljs.io/
 [CommonJS]: modules.md
 [Conditional exports]: #conditional-exports
 [Corepack]: corepack.md
+[ECMAScript module loader]: esm.md#loaders
 [ES module]: esm.md
 [ES modules]: esm.md
 [Node.js documentation for this section]: https://github.com/nodejs/node/blob/HEAD/doc/api/packages.md#conditions-definitions
@@ -1329,9 +1355,11 @@ This field defines [subpath imports][] for the current package.
 [`"packageManager"`]: #packagemanager
 [`"type"`]: #type
 [`--conditions` / `-C` flag]: #resolving-user-conditions
+[`--experimental-loader`]: cli.md#--experimental-loadermodule
 [`--no-addons` flag]: cli.md#--no-addons
 [`ERR_PACKAGE_PATH_NOT_EXPORTED`]: errors.md#err_package_path_not_exported
 [`esm`]: https://github.com/standard-things/esm#readme
+[`import` specifier]: esm.md#import-specifiers
 [`package.json`]: #nodejs-packagejson-field-definitions
 [entry points]: #package-entry-points
 [folders as modules]: modules.md#folders-as-modules

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -314,10 +314,12 @@ function readPackage(requestPath) {
   try {
     const parsed = JSONParse(json);
     const filtered = {
+      __proto__: null,
       name: parsed.name,
       main: parsed.main,
       exports: parsed.exports,
       imports: parsed.imports,
+      nodeEntryPointConfig: parsed.nodeEntryPointConfig,
       type: parsed.type
     };
     packageJsonCache.set(jsonPath, filtered);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -1080,7 +1080,7 @@ function throwIfUnsupportedURLScheme(parsed, experimentalNetworkImports) {
   }
 }
 
-async function defaultResolve(specifier, context = {}) {
+function defaultResolve(specifier, context = {}) {
   let { parentURL, conditions } = context;
   if (parentURL && policy?.manifest) {
     const redirects = policy.manifest.getDependencyMapper(parentURL);
@@ -1226,11 +1226,11 @@ const {
 
 if (policy) {
   const $defaultResolve = defaultResolve;
-  module.exports.defaultResolve = async function defaultResolve(
+  module.exports.defaultResolve = function defaultResolve(
     specifier,
     context
   ) {
-    const ret = await $defaultResolve(specifier, context);
+    const ret = $defaultResolve(specifier, context);
     // This is a preflight check to avoid data exfiltration by query params etc.
     policy.manifest.mightAllow(ret.url, () =>
       new ERR_MANIFEST_DEPENDENCY_MISSING(

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -48,7 +48,7 @@ function shouldUseESMLoader(mainPath) {
   if (!mainPath || StringPrototypeEndsWith(mainPath, '.cjs'))
     return false;
   const pkg = readPackageScope(mainPath);
-  if (typeof pkg.data.nodeEntryPointConfig === 'object') {
+  if (typeof pkg.data?.nodeEntryPointConfig === 'object') {
     const { loaders } = pkg.data.nodeEntryPointConfig;
     if (loaders != null) {
       const { pathToFileURL } = require('internal/url');
@@ -58,7 +58,9 @@ function shouldUseESMLoader(mainPath) {
       } = require('internal/modules/esm/resolve');
       validateArray(loaders, 'nodeEntryPointConfig.loaders');
       const context = { parentURL: pathToFileURL(pkg.path).href + '/', conditions: DEFAULT_CONDITIONS };
-      ArrayPrototypePushApply(userLoaders, ArrayPrototypeMap(loaders, (loaderSpecifier) => defaultResolve(loaderSpecifier, context).url));
+      const resolvedLoaders =
+        ArrayPrototypeMap(loaders, (loaderSpecifier) => defaultResolve(loaderSpecifier, context).url);
+      ArrayPrototypePushApply(userLoaders, resolvedLoaders);
       return true;
     }
   }

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const {
+  ArrayPrototypeMap,
+  ArrayPrototypePushApply,
   ObjectCreate,
   StringPrototypeEndsWith,
 } = primordials;
@@ -11,6 +13,7 @@ const path = require('path');
 const {
   handleProcessExit,
 } = require('internal/modules/esm/handle_process_exit');
+const { validateArray } = require('internal/validators');
 
 function resolveMainPath(main) {
   // Note extension resolution for the main entry point can be deprecated in a
@@ -45,6 +48,20 @@ function shouldUseESMLoader(mainPath) {
   if (!mainPath || StringPrototypeEndsWith(mainPath, '.cjs'))
     return false;
   const pkg = readPackageScope(mainPath);
+  if (typeof pkg.data.nodeEntryPointConfig === 'object') {
+    const { loaders } = pkg.data.nodeEntryPointConfig;
+    if (loaders != null) {
+      const { pathToFileURL } = require('internal/url');
+      const {
+        defaultResolve,
+        DEFAULT_CONDITIONS,
+      } = require('internal/modules/esm/resolve');
+      validateArray(loaders, 'nodeEntryPointConfig.loaders');
+      const context = { parentURL: pathToFileURL(pkg.path).href + '/', conditions: DEFAULT_CONDITIONS };
+      ArrayPrototypePushApply(userLoaders, ArrayPrototypeMap(loaders, (loaderSpecifier) => defaultResolve(loaderSpecifier, context).url));
+      return true;
+    }
+  }
   return pkg && pkg.data.type === 'module';
 }
 

--- a/test/es-module/test-esm-loader-chaining.mjs
+++ b/test/es-module/test-esm-loader-chaining.mjs
@@ -431,3 +431,27 @@ const commonArgs = [
   assert.match(stderr, /'load' hook's nextLoad\(\) context/);
   assert.strictEqual(status, 1);
 }
+
+{
+  const { status } = spawnSync(
+    process.execPath,
+    [
+      fixtures.path('es-module-loaders', 'package.json-loader-relative-url', 'entryPoint'),
+    ],
+    { encoding: 'utf8' },
+  );
+
+  assert.strictEqual(status, 0);
+}
+
+{
+  const { status } = spawnSync(
+    process.execPath,
+    [
+      fixtures.path('es-module-loaders', 'package.json-loader-package-name', 'entryPoint'),
+    ],
+    { encoding: 'utf8' },
+  );
+
+  assert.strictEqual(status, 0);
+}

--- a/test/es-module/test-esm-loader-search.js
+++ b/test/es-module/test-esm-loader-search.js
@@ -10,8 +10,8 @@ const {
   defaultResolve: resolve
 } = require('internal/modules/esm/resolve');
 
-assert.rejects(
-  resolve('target'),
+assert.throws(
+  () => resolve('target'),
   {
     code: 'ERR_MODULE_NOT_FOUND',
     name: 'Error',

--- a/test/fixtures/es-module-loaders/package.json-loader-package-name/entryPoint
+++ b/test/fixtures/es-module-loaders/package.json-loader-package-name/entryPoint
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+export {};

--- a/test/fixtures/es-module-loaders/package.json-loader-package-name/node_modules/extensionless-loader/index.js
+++ b/test/fixtures/es-module-loaders/package.json-loader-package-name/node_modules/extensionless-loader/index.js
@@ -1,0 +1,9 @@
+const extensionlessPath = /\/[^.]+$/;
+
+export async function resolve(specifier, context, next) {
+  const n = await next(specifier.toString(), context);
+  if (n.format == null && extensionlessPath.test(n.url)) {
+    n.format = "module";
+  }
+  return n;
+}

--- a/test/fixtures/es-module-loaders/package.json-loader-package-name/node_modules/extensionless-loader/package.json
+++ b/test/fixtures/es-module-loaders/package.json-loader-package-name/node_modules/extensionless-loader/package.json
@@ -1,0 +1,5 @@
+{
+  "name":"extensioless-loader",
+  "type": "module",
+  "main": "./index.js"
+}

--- a/test/fixtures/es-module-loaders/package.json-loader-package-name/package.json
+++ b/test/fixtures/es-module-loaders/package.json-loader-package-name/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "somePackage",
+  "nodeEntryPointConfig": {
+    "loaders": ["extensionless-loader"]
+  }
+}

--- a/test/fixtures/es-module-loaders/package.json-loader-relative-url/entryPoint
+++ b/test/fixtures/es-module-loaders/package.json-loader-relative-url/entryPoint
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+export {};

--- a/test/fixtures/es-module-loaders/package.json-loader-relative-url/load-extensionless-as-esm.mjs
+++ b/test/fixtures/es-module-loaders/package.json-loader-relative-url/load-extensionless-as-esm.mjs
@@ -1,0 +1,9 @@
+const extensionlessPath = /\/[^.]+$/;
+
+export async function resolve(specifier, context, next) {
+  const n = await next(specifier.toString(), context);
+  if (n.format == null && extensionlessPath.test(n.url)) {
+    n.format = "module";
+  }
+  return n;
+}

--- a/test/fixtures/es-module-loaders/package.json-loader-relative-url/package.json
+++ b/test/fixtures/es-module-loaders/package.json-loader-relative-url/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "package.json-loader-relative-url",
+  "nodeEntryPointConfig": {
+    "loaders": ["./load-extensionless-as-esm.mjs"]
+  }
+}


### PR DESCRIPTION
Currently, starting a `.mjs` or `.cjs` file allow to skip the lookup and the parsing of a `package.json` file, I'm reluctant to change that but I'm curious what others think.

I had to make the default `resolve` function sync – but we don't use anything async inside anyway, I assume it's fine. If we move the loaders off-thread (or even to make the loading of loaders itself go through non-default loaders), we might need to think of an async way of resolving those loaders, not sure.

Opening as draft because it's just at the PoC stage, and I would like to get some feedback on the initial implementation before going further.

/cc @nodejs/loaders 
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
