### PR TITLE
http: make idle http parser count configurable

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3633,6 +3633,16 @@ try {
 }
 ```
 
+## `http.setMaxIdleHTTPParsers`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+Set the maximum number of idle HTTP parsers. **Default:** `1000`.
+
 [RFC 8187]: https://www.rfc-editor.org/rfc/rfc8187.txt
 [`'checkContinue'`]: #event-checkcontinue
 [`'finish'`]: #event-finish

--- a/lib/http.js
+++ b/lib/http.js
@@ -27,9 +27,10 @@ const {
   ObjectDefineProperty,
 } = primordials;
 
+const { validateInteger } = require('internal/validators');
 const httpAgent = require('_http_agent');
 const { ClientRequest } = require('_http_client');
-const { methods } = require('_http_common');
+const { methods, parsers } = require('_http_common');
 const { IncomingMessage } = require('_http_incoming');
 const {
   validateHeaderName,
@@ -123,7 +124,11 @@ module.exports = {
   validateHeaderName,
   validateHeaderValue,
   get,
-  request
+  request,
+  setMaxIdleHTTPParsers(max) {
+    validateInteger(max, 'max', 1);
+    parsers.max = max;
+  }
 };
 
 ObjectDefineProperty(module.exports, 'maxHeaderSize', {

--- a/test/parallel/test-http-set-max-idle-http-parser.js
+++ b/test/parallel/test-http-set-max-idle-http-parser.js
@@ -1,0 +1,19 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const httpCommon = require('_http_common');
+const http = require('http');
+
+[Symbol(), {}, [], () => {}, 1n, true, '1', null, undefined].forEach((value) => {
+  assert.throws(() => http.setMaxIdleHTTPParsers(value), { code: 'ERR_INVALID_ARG_TYPE' });
+});
+
+[-1, -Infinity, NaN, 0, 1.1].forEach((value) => {
+  assert.throws(() => http.setMaxIdleHTTPParsers(value), { code: 'ERR_OUT_OF_RANGE' });
+});
+
+[1, Number.MAX_SAFE_INTEGER].forEach((value) => {
+  assert.notStrictEqual(httpCommon.parsers.max, value);
+  http.setMaxIdleHTTPParsers(value);
+  assert.strictEqual(httpCommon.parsers.max, value);
+});


### PR DESCRIPTION
make the maximum number of idle HTTP parser configurable.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)