### PR TITLE
net: add local family

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -294,6 +294,7 @@ TCP server, the argument is as follows, otherwise the argument is `undefined`.
 * `data` {Object} The argument passed to event listener.
   * `localAddress` {string}  Local address.
   * `localPort` {number} Local port.
+  * `localFamily` {string} Local family.
   * `remoteAddress` {string} Remote address.
   * `remotePort` {number} Remote port.
   * `remoteFamily` {string} Remote IP family. `'IPv4'` or `'IPv6'`.
@@ -1046,6 +1047,16 @@ added: v0.9.6
 * {integer}
 
 The numeric representation of the local port. For example, `80` or `21`.
+
+### `socket.localFamily`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string}
+
+The string representation of the local IP family. `'IPv4'` or `'IPv6'`.
 
 ### `socket.pause()`
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -834,6 +834,9 @@ protoGetter('localPort', function localPort() {
   return this._getsockname().port;
 });
 
+protoGetter('localFamily', function localFamily() {
+  return this._getsockname().family;
+});
 
 Socket.prototype[kAfterAsyncWrite] = function() {
   this[kLastWriteQueueSize] = 0;
@@ -1668,6 +1671,7 @@ function onconnection(err, clientHandle) {
         clientHandle.getsockname(localInfo);
         data.localAddress = localInfo.address;
         data.localPort = localInfo.port;
+        data.localFamily = localInfo.family;
       }
       if (clientHandle.getpeername) {
         const remoteInfo = ObjectCreate(null);

--- a/test/parallel/test-net-local-address-port.js
+++ b/test/parallel/test-net-local-address-port.js
@@ -27,6 +27,7 @@ const net = require('net');
 const server = net.createServer(common.mustCall(function(socket) {
   assert.strictEqual(socket.localAddress, common.localhostIPv4);
   assert.strictEqual(socket.localPort, this.address().port);
+  assert.strictEqual(socket.localFamily, this.address().family);
   socket.on('end', function() {
     server.close();
   });


### PR DESCRIPTION
add local family

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)