### PR TITLE
test: reduce loop times for preventing test from timeout

### DIFF
--- a/test/parallel/test-vm-break-on-sigint.js
+++ b/test/parallel/test-vm-break-on-sigint.js
@@ -16,7 +16,7 @@ if (!process.env.HAS_STARTED_WORKER) {
   }
 } else {
   const ctx = vm.createContext({});
-  for (let i = 0; i < 10000; i++) {
+  for (let i = 0; i < 100; i++) {
     vm.runInContext('console.log(1)', ctx, { breakOnSigint: true });
   }
 }


### PR DESCRIPTION
reduce loop times for preventing test from timeout.

fix: https://github.com/nodejs/node/pull/43780#issuecomment-1193855386
refs: https://github.com/nodejs/reliability/issues/331

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
