### PR TITLE
doc: list supported MODP groups explicitly

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1181,20 +1181,16 @@ const { createDiffieHellmanGroup } = require('node:crypto');
 const dh = createDiffieHellmanGroup('modp1');
 ```
 
-The name (e.g. `'modp1'`) is taken from [RFC 2412][] (modp1 and 2) and
-[RFC 3526][]:
+The following groups are supported:
 
-```console
-$ perl -ne 'print "$1\n" if /"(modp\d+)"/' src/node_crypto_groups.h
-modp1  #  768 bits
-modp2  # 1024 bits
-modp5  # 1536 bits
-modp14 # 2048 bits
-modp15 # etc.
-modp16
-modp17
-modp18
-```
+* `'modp1'` (768 bits, [RFC 2409][] Section 6.1)
+* `'modp2'` (1024 bits, [RFC 2409][] Section 6.2)
+* `'modp5'` (1536 bits, [RFC 3526][] Section 2)
+* `'modp14'` (2048 bits, [RFC 3526][] Section 3)
+* `'modp15'` (3072 bits, [RFC 3526][] Section 4)
+* `'modp16'` (4096 bits, [RFC 3526][] Section 5)
+* `'modp17'` (6144 bits, [RFC 3526][] Section 6)
+* `'modp18'` (8192 bits, [RFC 3526][] Section 7)
 
 ## Class: `ECDH`
 
@@ -6105,6 +6101,7 @@ See the [list of SSL OP Flags][] for details.
 [Nonce-Disrespecting Adversaries]: https://github.com/nonce-disrespect/nonce-disrespect
 [OpenSSL's SPKAC implementation]: https://www.openssl.org/docs/man1.1.0/apps/openssl-spkac.html
 [RFC 1421]: https://www.rfc-editor.org/rfc/rfc1421.txt
+[RFC 2409]: https://www.rfc-editor.org/rfc/rfc2409.txt
 [RFC 2412]: https://www.rfc-editor.org/rfc/rfc2412.txt
 [RFC 2818]: https://www.rfc-editor.org/rfc/rfc2818.txt
 [RFC 3526]: https://www.rfc-editor.org/rfc/rfc3526.txt


### PR DESCRIPTION
Instead of referring users to perl to find information about supported
MODP groups in crypto_groups.h, explicitly list the groups with their
respective strengths and with references to the defining RFC sections.

Refs: https://github.com/nodejs/node/pull/43896

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
