### PR TITLE
test: change misleading variable name

### DIFF
--- a/test/pummel/test-crypto-dh-hash.js
+++ b/test/pummel/test-crypto-dh-hash.js
@@ -50,10 +50,10 @@ const hashes = {
 
 for (const name in hashes) {
   const group = crypto.getDiffieHellman(name);
-  const private_key = group.getPrime('hex');
+  const prime = group.getPrime('hex');
   const hash1 = hashes[name];
   const hash2 = crypto.createHash('sha1')
-                    .update(private_key.toUpperCase()).digest('hex');
+                    .update(prime.toUpperCase()).digest('hex');
   assert.strictEqual(hash1, hash2);
   assert.strictEqual(group.getGenerator('hex'), '02');
 }


### PR DESCRIPTION
The return value of `getPrime()` is not a private key in any way.

Refs: https://github.com/nodejs/node-v0.x-archive/pull/2638

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
