### PR TITLE
src: fix to use replacement character for unassigned codepoint

### DIFF
--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -425,7 +425,11 @@ void ConverterObject::Create(const FunctionCallbackInfo<Value>& args) {
                         nullptr, nullptr, nullptr, &status);
   }
 
-  new ConverterObject(env, obj, conv, flags);
+  auto converter = new ConverterObject(env, obj, conv, flags);
+  size_t sublen = ucnv_getMinCharSize(conv);
+  std::string sub(sublen, '?');
+  converter->set_subst_chars(sub.c_str());
+
   args.GetReturnValue().Set(obj);
 }
 

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -200,7 +200,7 @@ if (common.hasIntl) {
   assert.strictEqual(str, 'foo\ufffd');
 }
 
-{
+if (common.hasIntl) {
   const decoder = new TextDecoder('Shift_JIS');
   const chunk = new Uint8Array([-1]);
   const str = decoder.decode(chunk);

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -199,3 +199,10 @@ if (common.hasIntl) {
   const str = decoder.decode(chunk);
   assert.strictEqual(str, 'foo\ufffd');
 }
+
+{
+  const decoder = new TextDecoder('Shift_JIS');
+  const chunk = new Uint8Array([-1]);
+  const str = decoder.decode(chunk);
+  assert.strictEqual(str, '\ufffd');
+}


### PR DESCRIPTION
According to [WHATWG spec](https://encoding.spec.whatwg.org/#:~:text=the%0A%20%20associated%20steps%3A-,%22replacement%22,-Push%20U%2BFFFD), any decoder should use `�(U+FFFD)` when an unassigned codepoint is found during decoding.

Fixes: https://github.com/nodejs/node/issues/43962