### PR TITLE
src: improve SPKAC::ExportChallenge()

### DIFF
--- a/src/crypto/crypto_spkac.cc
+++ b/src/crypto/crypto_spkac.cc
@@ -99,12 +99,9 @@ ByteSource ExportChallenge(const ArrayBufferOrViewContents<char>& input) {
   if (!sp)
     return ByteSource();
 
-  char* buf = nullptr;
-  ASN1_STRING_to_UTF8(
-    reinterpret_cast<unsigned char**>(&buf),
-    sp->spkac->challenge);
-
-  return ByteSource::Allocated(buf, strlen(buf));
+  unsigned char* buf = nullptr;
+  int buf_size = ASN1_STRING_to_UTF8(&buf, sp->spkac->challenge);
+  return (buf_size >= 0) ? ByteSource::Allocated(buf, buf_size) : ByteSource();
 }
 
 void ExportChallenge(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
Declare `buf` as an `unsigned char*` to get rid of the `reinterpret_cast` and do not ignore the return value of `ASN1_STRING_TO_UTF8()`. This also removes the need to call `strlen()` on the result.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
