### PR TITLE
doc: fix typo in packages.md

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -257,7 +257,7 @@ likely be a breaking change.**
 To make the introduction of [`"exports"`][] non-breaking, ensure that every
 previously supported entry point is exported. It is best to explicitly specify
 entry points so that the package's public API is well-defined. For example,
-a project that previous exported `main`, `lib`,
+a project that previously exported `main`, `lib`,
 `feature`, and the `package.json` could use the following `package.exports`:
 
 ```json


### PR DESCRIPTION
"previous" read like it should be "previously".