### PR TITLE
build: fixed building configuration for Android

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -21,8 +21,6 @@ if [ $ANDROID_SDK_VERSION -lt 24 ]; then
   echo "$ANDROID_SDK_VERSION should equal or later than 24 (Android 7.0)"
 fi
 
-CC_VER="4.9"
-
 case $ARCH in
     arm)
         DEST_CPU="arm"

--- a/android-configure
+++ b/android-configure
@@ -17,8 +17,8 @@ NDK_PATH=$1
 ARCH="$2"
 ANDROID_SDK_VERSION=$3
 
-if [ $ANDROID_SDK_VERSION -lt 23 ]; then
-  echo "$ANDROID_SDK_VERSION should equal or later than 23(Android 6.0)"
+if [ $ANDROID_SDK_VERSION -lt 24 ]; then
+  echo "$ANDROID_SDK_VERSION should equal or later than 24 (Android 7.0)"
 fi
 
 CC_VER="4.9"
@@ -26,7 +26,7 @@ CC_VER="4.9"
 case $ARCH in
     arm)
         DEST_CPU="arm"
-        TOOLCHAIN_NAME="armv7-linux-androideabi"
+        TOOLCHAIN_NAME="armv7a-linux-androideabi"
         ;;
     x86)
         DEST_CPU="ia32"


### PR DESCRIPTION
Fixed architecture configuration and modified minimum Android SDK version.

In newer versions of the Android NDK, if the Android API version is lower than 24 (Android 7.0), compilation will not work because of API changes (in fact, Android API versions of 24 and below are no longer common), and the Android device architecture now only exists for ‘armv7a’, not ‘armv7’, which can also lead to compilation errors.
 
Reference:
https://developer.android.com/studio/releases/platforms
https://developer.android.com/ndk/guides/abis

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
