### PR TITLE
src: fix bug in GetErrorSource()

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -105,7 +105,7 @@ static std::string GetErrorSource(Isolate* isolate,
   if (has_source_map_url && env != nullptr && env->source_maps_enabled()) {
     std::string source = GetSourceMapErrorSource(
         isolate, context, message, added_exception_line);
-    return added_exception_line ? source : sourceline;
+    return *added_exception_line ? source : sourceline;
   }
 
   // Because of how node modules work, all scripts are wrapped with a


### PR DESCRIPTION
Reported by static analysis. I assume this was supposed to dereference the `bool*`.

There does not seem to be a test covering `(*added_exception_line) == false` and I'm not familiar enough with this part of the code base to come up with one quickly.

Refs: https://github.com/nodejs/node/pull/43875

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
