### PR TITLE
lib: fix TypeError when converting a detached buffer source

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -412,7 +412,13 @@ function makeTextDecoderICU() {
     decode(input = empty, options = kEmptyObject) {
       validateDecoder(this);
       if (isAnyArrayBuffer(input)) {
-        input = lazyBuffer().from(input);
+        try {
+          input = lazyBuffer().from(input);
+        } catch {
+          // If the buffer is detached,
+          // use an empty Uint8Array to avoid TypeError
+          input = empty;
+        }
       } else if (!isArrayBufferView(input)) {
         throw new ERR_INVALID_ARG_TYPE('input',
                                        ['ArrayBuffer', 'ArrayBufferView'],

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -491,10 +491,18 @@ function makeTextDecoderJS() {
     decode(input = empty, options = kEmptyObject) {
       validateDecoder(this);
       if (isAnyArrayBuffer(input)) {
-        input = lazyBuffer().from(input);
+        try {
+          input = lazyBuffer().from(input);
+        } catch {
+          input = empty;
+        }
       } else if (isArrayBufferView(input)) {
-        input = lazyBuffer().from(input.buffer, input.byteOffset,
-                                  input.byteLength);
+        try {
+          input = lazyBuffer().from(input.buffer, input.byteOffset,
+                                    input.byteLength);
+        } catch {
+          input = empty;
+        }
       } else {
         throw new ERR_INVALID_ARG_TYPE('input',
                                        ['ArrayBuffer', 'ArrayBufferView'],

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -211,3 +211,10 @@ if (common.hasIntl) {
     assert.strictEqual(e.code, 'ERR_ENCODING_NOT_SUPPORTED');
   }
 }
+
+{
+  const buffer = new ArrayBuffer(1);
+  new MessageChannel().port1.postMessage(buffer, [buffer]); // buffer is detached
+  const decoder = new TextDecoder();
+  assert.strictEqual(decoder.decode(buffer), '');
+}

--- a/test/wpt/status/encoding.json
+++ b/test/wpt/status/encoding.json
@@ -61,12 +61,7 @@
     "requires": ["small-icu"]
   },
   "streams/decode-utf8.any.js": {
-    "requires": ["small-icu"],
-    "fail": {
-      "expected": [
-        "decoding a transferred ArrayBuffer chunk should give no output"
-      ]
-    }
+    "requires": ["small-icu"]
   },
   "streams/decode-bad-chunks.any.js": {
     "fail": {


### PR DESCRIPTION
Currently `TextDecoder.decode` will throw TypeError when a detached buffer is given since it will try to convert a detached buffer into new buffer. This PR fixed TypeError by checking if a buffer is detached.

```js
const buffer = new ArrayBuffer(1);
new MessageChannel().port1.postMessage(buffer, [buffer]); // buffer is detached
const decoder = new TextDecoder();
decoder.decode(buffer);
// node: TypeError: Cannot perform Construct on a detached ArrayBuffer
// chrome/safari/deno: ""
```