### PR TITLE
net,tls: pass a valid socket on the `tlsClientError` event

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -423,6 +423,10 @@ function onerror(err) {
   if (!owner._secureEstablished) {
     // When handshake fails control is not yet released,
     // so self._tlsError will return null instead of actual error
+
+    // Set closing the socket after emitting an event since the socket needs to
+    // be accessible when the `tlsClientError` event is emmited.
+    owner._closeAfterHandlingError = true;
     owner.destroy(err);
   } else if (owner._tlsOptions?.isServer &&
              owner._rejectUnauthorized &&

--- a/lib/net.js
+++ b/lib/net.js
@@ -102,6 +102,7 @@ const {
   uvExceptionWithHostPort,
 } = require('internal/errors');
 const { isUint8Array } = require('internal/util/types');
+const { queueMicrotask } = require('internal/process/task_queues');
 const {
   validateAbortSignal,
   validateFunction,
@@ -289,6 +290,19 @@ function initSocketHandle(self) {
   }
 }
 
+function closeSocketHandle(self, isException, isCleanupPending = false) {
+  if (self._handle) {
+    self._handle.close(() => {
+      debug('emit close');
+      self.emit('close', isException);
+      if (isCleanupPending) {
+        self._handle.onread = noop;
+        self._handle = null;
+        self._sockname = null;
+      }
+    });
+  }
+}
 
 const kBytesRead = Symbol('kBytesRead');
 const kBytesWritten = Symbol('kBytesWritten');
@@ -337,6 +351,7 @@ function Socket(options) {
   this[kBuffer] = null;
   this[kBufferCb] = null;
   this[kBufferGen] = null;
+  this._closeAfterHandlingError = false;
 
   if (typeof options === 'number')
     options = { fd: options }; // Legacy interface.
@@ -755,15 +770,19 @@ Socket.prototype._destroy = function(exception, cb) {
       });
       if (err)
         this.emit('error', errnoException(err, 'reset'));
+    } else if (this._closeAfterHandlingError) {
+      // Enqueue closing the socket as a microtask, so that the socket can be
+      // accessible when an `error` event is handled in the `next tick queue`.
+      queueMicrotask(() => closeSocketHandle(this, isException, true));
     } else {
-      this._handle.close(() => {
-        debug('emit close');
-        this.emit('close', isException);
-      });
+      closeSocketHandle(this, isException);
     }
-    this._handle.onread = noop;
-    this._handle = null;
-    this._sockname = null;
+
+    if (!this._closeAfterHandlingError) {
+      this._handle.onread = noop;
+      this._handle = null;
+      this._sockname = null;
+    }
     cb(exception);
   } else {
     cb(exception);

--- a/test/internet/test-https-issue-43963.js
+++ b/test/internet/test-https-issue-43963.js
@@ -1,0 +1,31 @@
+'use strict';
+const common = require('../common');
+const https = require('node:https');
+const assert = require('node:assert');
+
+const server = https.createServer();
+
+server.on(
+  'tlsClientError',
+  common.mustCall((exception, tlsSocket) => {
+    assert.strictEqual(exception !== undefined, true);
+    assert.strictEqual(Object.keys(tlsSocket.address()).length !== 0, true);
+    assert.strictEqual(tlsSocket.localAddress !== undefined, true);
+    assert.strictEqual(tlsSocket.localPort !== undefined, true);
+    assert.strictEqual(tlsSocket.remoteAddress !== undefined, true);
+    assert.strictEqual(tlsSocket.remoteFamily !== undefined, true);
+    assert.strictEqual(tlsSocket.remotePort !== undefined, true);
+  }),
+);
+
+server.listen(0, () => {
+  const req = https.request({
+    hostname: '127.0.0.1',
+    port: server.address().port,
+  });
+  req.on(
+    'error',
+    common.mustCall(() => server.close()),
+  );
+  req.end();
+});


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/43963

On the `tlsClientError` event, the `tls.TLSSocket` instance is passed as 'closed' status. 
Thus, users can't get information such as `remote address`, `remoteFamily`, and so on.

This adds a flag to close a socket after emitting the `tlsClientError` event.

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
