### PR TITLE
test: fix multiple incorrect mustNotCall() uses

### DIFF
--- a/test/parallel/test-console-log-stdio-broken-dest.js
+++ b/test/parallel/test-console-log-stdio-broken-dest.js
@@ -15,7 +15,7 @@ const stream = new Writable({
 });
 const myConsole = new Console(stream, stream);
 
-process.on('warning', common.mustNotCall);
+process.on('warning', common.mustNotCall());
 
 stream.cork();
 for (let i = 0; i < EventEmitter.defaultMaxListeners + 1; i++) {

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -141,7 +141,7 @@ function onSession(session, next) {
 
     function testNoTls() {
       // HTTP/1.1 client
-      get(Object.assign(parse(origin), clientOptions), common.mustNotCall)
+      get(Object.assign(parse(origin), clientOptions), common.mustNotCall())
         .on('error', common.mustCall(cleanup))
         .on('error', common.mustCall(testWrongALPN))
         .end();

--- a/test/parallel/test-stream-readable-reading-readingMore.js
+++ b/test/parallel/test-stream-readable-reading-readingMore.js
@@ -124,7 +124,7 @@ const Readable = require('stream').Readable;
   assert.strictEqual(state.reading, false);
   assert.strictEqual(state.readingMore, false);
 
-  const onReadable = common.mustNotCall;
+  const onReadable = common.mustNotCall();
 
   readable.on('readable', onReadable);
 

--- a/test/parallel/test-zlib-invalid-input.js
+++ b/test/parallel/test-zlib-invalid-input.js
@@ -53,7 +53,7 @@ nonStringInputs.forEach(common.mustCall((input) => {
 
 unzips.forEach(common.mustCall((uz, i) => {
   uz.on('error', common.mustCall());
-  uz.on('end', common.mustNotCall);
+  uz.on('end', common.mustNotCall());
 
   // This will trigger error event
   uz.write('this is not valid compressed data.');

--- a/test/parallel/test-zlib-sync-no-event.js
+++ b/test/parallel/test-zlib-sync-no-event.js
@@ -7,12 +7,12 @@ const message = 'Come on, Fhqwhgads.';
 const buffer = Buffer.from(message);
 
 const zipper = new zlib.Gzip();
-zipper.on('close', common.mustNotCall);
+zipper.on('close', common.mustNotCall());
 
 const zipped = zipper._processChunk(buffer, zlib.constants.Z_FINISH);
 
 const unzipper = new zlib.Gunzip();
-unzipper.on('close', common.mustNotCall);
+unzipper.on('close', common.mustNotCall());
 
 const unzipped = unzipper._processChunk(zipped, zlib.constants.Z_FINISH);
 assert.notStrictEqual(zipped.toString(), message);


### PR DESCRIPTION
This does not fix occurrences in `test/parallel/test-dns-*` because those tests contain unrelated pre-existing bugs that would cause the tests to fail with this fix. This unrelated bug in those tests should be fixed separately before the use of `mustNotCall()` can be fixed in those files (see https://github.com/nodejs/node/issues/44428).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
