### PR TITLE
doc: clarify part of onboarding guide regarding adding to teams

### DIFF
--- a/onboarding.md
+++ b/onboarding.md
@@ -19,8 +19,8 @@ onboarding session.
 
 * Prior to the onboarding session, add the new Collaborator to
   [the collaborators team](https://github.com/orgs/nodejs/teams/collaborators).
-* Ask them if they want to join any subsystem teams. See
-  [Who to CC in the issue tracker][who-to-cc].
+* Ask them if they want to join any [subsystem teams](https://github.com/orgs/nodejs/teams/core/teams)
+  and add them accordingly. See [Who to CC in the issue tracker][who-to-cc].
 
 ## Onboarding session
 


### PR DESCRIPTION
There are a number of teams (for example, the build team) which require
more than just showing interest as a prerequisite for being added, so
this change adds a link to the set of subsystem teams where new
Collaborators can be added directy.

Also, the doc didn't actually mention if the new Collaborator should be
added to the team. This change also clarifies that.

Refs: https://github.com/nodejs/build/issues/3003
Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
