### PR TITLE
test: fix `test/internet/test-inspector-help-page`

### DIFF
--- a/test/internet/test-inspector-help-page.js
+++ b/test/internet/test-inspector-help-page.js
@@ -14,7 +14,7 @@ const stderr = child.stderr.toString();
 const helpUrl = stderr.match(/For help, see: (.+)/)[1];
 
 function check(url, cb) {
-  https.get(url, common.mustCall((res) => {
+  https.get(url, { agent: new https.Agent() }, common.mustCall((res) => {
     assert(res.statusCode >= 200 && res.statusCode < 400);
 
     if (res.statusCode >= 300)


### PR DESCRIPTION
This fixes the test to use its own `https.agent` instead of the default one.

It seems to be related to the default options change of the global agent.

Refs: https://github.com/nodejs/node/pull/43522
Refs: https://github.com/nodejs/node/actions/workflows/test-internet.yml

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
