### PR TITLE
assert: add `includes` api

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1419,6 +1419,59 @@ let err;
 //     at errorFrame
 ```
 
+## `assert.includes(string, substring[, message])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental.
+
+* `string` {string}
+* `substring` {string}
+* `message` {string|Error}
+
+Expects the `substring` input to be included in the `string` input.
+
+```mjs
+import assert from 'node:assert/strict';
+
+assert.includes('I will fail', 'pass');
+// AssertionError [ERR_ASSERTION]: The substring was not located inside the target string.
+
+assert.includes(123, 'pass');
+// AssertionError [ERR_ASSERTION]: The "string" argument must be of type string.
+
+assert.includes('I will fail', /pass/);
+// AssertionError [ERR_ASSERTION]: The "substring" argument must be of type string.
+
+assert.includes('I will pass', 'pass');
+// OK
+```
+
+```cjs
+const assert = require('node:assert/strict');
+
+assert.includes('I will fail', 'pass');
+// AssertionError [ERR_ASSERTION]: The substring was not located inside the target string.
+
+assert.includes(123, 'pass');
+// AssertionError [ERR_ASSERTION]: The "string" argument must be of type string.
+
+assert.includes('I will fail', /pass/);
+// AssertionError [ERR_ASSERTION]: The "substring" argument must be of type string.
+
+assert.includes('I will pass', 'pass');
+// OK
+```
+
+If the `substring` argument is not part of the `string` argument, or if `string` is
+of another type than `string`, or if `substring` is of another type than `string`, an
+[`AssertionError`][] is thrown with a `message` property set equal to the value of the
+`message` parameter. If the `message` parameter is undefined, a default error message
+is assigned. If the `message` parameter is an instance of an [`Error`][] then it will
+be thrown instead of the [`AssertionError`][].
+
 ## `assert.match(string, regexp[, message])`
 
 <!-- YAML

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1046,14 +1046,14 @@ assert.includes = function includes(string, substring, message = '') {
     }
 
     if (!message) {
-      if (stringDoesNotIncludeSubstring) {
-        message += 'The substring was not located inside the target string.\n'
-      }
       if (stringIsNotString) {
-        message += `The "string" argument must be of type string. Received type ${typeof string} (${inspect(string)})\n`;
+        message += `The "string" argument must be of type string. Received type ${typeof string} (${inspect(string)})`;
       }
       if (substringIsNotString) {
-        message += `The "substring" argument must be of type string. Received type ${typeof substring} (${inspect(substring)})`;
+        message += `${stringIsNotString ? ' ' : ''}The "substring" argument must be of type string. Received type ${typeof substring} (${inspect(substring)})`;
+      }
+      if (!message && stringDoesNotIncludeSubstring) {
+        message += 'The substring was not located inside the target string'
       }
     }
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1037,7 +1037,7 @@ function internalMatch(string, regexp, message, fn) {
  */
 assert.includes = function includes(string, substring, message = '') {
   const stringIsNotString = typeof string !== 'string';
-  const substringIsNotString = typeof substring !== 'string'
+  const substringIsNotString = typeof substring !== 'string';
   const stringDoesNotIncludeSubstring = !StringPrototypeIncludes(string, substring);
 
   if (stringIsNotString || substringIsNotString || stringDoesNotIncludeSubstring) {
@@ -1053,7 +1053,7 @@ assert.includes = function includes(string, substring, message = '') {
         message += `${stringIsNotString ? ' ' : ''}The "substring" argument must be of type string. Received type ${typeof substring} (${inspect(substring)})`;
       }
       if (!message && stringDoesNotIncludeSubstring) {
-        message += 'The substring was not located inside the target string'
+        message += 'The substring was not located inside the target string';
       }
     }
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1029,6 +1029,45 @@ function internalMatch(string, regexp, message, fn) {
 }
 
 /**
+ * Expects the `substring` input to be included in the `string` input.
+ * @param {string} string
+ * @param {string} substring
+ * @param {string | Error} [message]
+ * @returns {void}
+ */
+assert.includes = function includes(string, substring, message = '') {
+  const stringIsNotString = typeof string !== 'string';
+  const substringIsNotString = typeof substring !== 'string'
+  const stringDoesNotIncludeSubstring = !StringPrototypeIncludes(string, substring);
+
+  if (stringIsNotString || substringIsNotString || stringDoesNotIncludeSubstring) {
+    if (message instanceof Error) {
+      throw message;
+    }
+
+    if (!message) {
+      if (stringDoesNotIncludeSubstring) {
+        message += 'The substring was not located inside the target string.\n'
+      }
+      if (stringIsNotString) {
+        message += `The "string" argument must be of type string. Received type ${typeof string} (${inspect(string)})\n`;
+      }
+      if (substringIsNotString) {
+        message += `The "substring" argument must be of type string. Received type ${typeof substring} (${inspect(substring)})`;
+      }
+    }
+
+    throw new AssertionError({
+      actual: string,
+      expected: substring,
+      operator: includes.name,
+      message,
+      stackStartFn: includes
+    });
+  }
+};
+
+/**
  * Expects the `string` input to match the regular expression.
  * @param {string} string
  * @param {RegExp} regexp

--- a/test/parallel/test-assert-includes.js
+++ b/test/parallel/test-assert-includes.js
@@ -1,0 +1,12 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// Test that assert.includes works as expected
+
+assert.doesNotThrow(() => assert.includes('I will pass', 'pass'));
+assert.throws(() => assert.includes('I will fail', 'pass'));
+assert.throws(() => assert.includes('fail', 'I will fail'));
+assert.throws(() => assert.includes('I will fail', /fail/));
+assert.throws(() => assert.includes(123, 'I will fail'));


### PR DESCRIPTION
very simple proxy to `StringPrototypeIncludes`

inspired by https://github.com/nodejs/node/pull/43784#discussion_r932089979