### PR TITLE
tls,http2: send fatal alert on ALPN mismatch

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2275,6 +2275,11 @@ a given number of milliseconds set using `http2secureServer.setTimeout()`.
 
 <!-- YAML
 added: v8.4.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/44031
+    description: This event will only be emitted if the client did not transmit
+                 an ALPN extension during the TLS handshake.
 -->
 
 * `socket` {stream.Duplex}
@@ -2284,6 +2289,15 @@ negotiate an allowed protocol (i.e. HTTP/2 or HTTP/1.1). The event handler
 receives the socket for handling. If no listener is registered for this event,
 the connection is terminated. A timeout may be specified using the
 `'unknownProtocolTimeout'` option passed to [`http2.createSecureServer()`][].
+
+In earlier versions of Node.js, this event would be emitted if `allowHTTP1` is
+`false` and, during the TLS handshake, the client either does not send an ALPN
+extension or sends an ALPN extension that does not include HTTP/2 (`h2`). Newer
+versions of Node.js only emit this event if `allowHTTP1` is `false` and the
+client does not send an ALPN extension. If the client sends an ALPN extension
+that does not include HTTP/2 (or HTTP/1.1 if `allowHTTP1` is `true`), the TLS
+handshake will fail and no secure connection will be established.
+
 See the [Compatibility API][].
 
 #### `server.close([callback])`

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -683,8 +683,8 @@ is set to describe how authorization failed. Depending on the settings
 of the TLS server, unauthorized connections may still be accepted.
 
 The `tlsSocket.alpnProtocol` property is a string that contains the selected
-ALPN protocol. When ALPN has no selected protocol, `tlsSocket.alpnProtocol`
-equals `false`.
+ALPN protocol. When ALPN has no selected protocol because the client or the
+server did not send an ALPN extension, `tlsSocket.alpnProtocol` equals `false`.
 
 The `tlsSocket.servername` property is a string containing the server name
 requested via SNI.
@@ -2012,6 +2012,11 @@ where `secureSocket` has the same API as `pair.cleartext`.
 <!-- YAML
 added: v0.3.2
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/44031
+    description: If `ALPNProtocols` is set, incoming connections that send an
+                 ALPN extension with no supported protocols are terminated with
+                 a fatal `no_application_protocol` alert.
   - version: v12.3.0
     pr-url: https://github.com/nodejs/node/pull/27665
     description: The `options` parameter now supports `net.createServer()`

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3055,7 +3055,7 @@ function connectionListener(socket) {
       // going on in a format that they *might* understand.
       socket.end('HTTP/1.0 403 Forbidden\r\n' +
                  'Content-Type: text/plain\r\n\r\n' +
-                 'Unknown ALPN Protocol, expected `h2` to be available.\n' +
+                 'Missing ALPN Protocol, expected `h2` to be available.\n' +
                  'If this is a HTTP request: The server was not ' +
                  'configured with the `allowHTTP1` option or a ' +
                  'listener for the `unknownProtocol` event.\n');

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -5,6 +5,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
+const { spawn } = require('child_process');
 const tls = require('tls');
 const fixtures = require('../common/fixtures');
 
@@ -68,7 +69,7 @@ function Test1() {
   }, {
     ALPNProtocols: ['c', 'b', 'e'],
   }, {
-    ALPNProtocols: ['first-priority-unsupported', 'x', 'y'],
+    ALPNProtocols: ['x', 'y', 'c'],
   }];
 
   runTest(clientsOptions, serverOptions, function(results) {
@@ -82,8 +83,8 @@ function Test1() {
                    client: { ALPN: 'b' } });
     // Nothing is selected by ALPN
     checkResults(results[2],
-                 { server: { ALPN: false },
-                   client: { ALPN: false } });
+                 { server: { ALPN: 'c' },
+                   client: { ALPN: 'c' } });
     // execute next test
     Test2();
   });
@@ -161,6 +162,50 @@ function Test4() {
                  { server: { ALPN: false },
                    client: { ALPN: false } });
   });
+
+  TestFatalAlert();
+}
+
+function TestFatalAlert() {
+  const server = tls.createServer({
+    ALPNProtocols: ['foo'],
+    key: loadPEM('agent2-key'),
+    cert: loadPEM('agent2-cert')
+  }, common.mustNotCall());
+
+  server.listen(0, serverIP, common.mustCall(() => {
+    const { port } = server.address();
+
+    // The Node.js client will just report ECONNRESET because the connection
+    // is severed before the TLS handshake completes.
+    tls.connect({
+      host: serverIP,
+      port,
+      rejectUnauthorized: false,
+      ALPNProtocols: ['bar']
+    }, common.mustNotCall()).on('error', common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ECONNRESET');
+
+      // OpenSSL's s_client should output the TLS alert number, which is 120
+      // for the 'no_application_protocol' alert.
+      const { opensslCli } = common;
+      if (opensslCli) {
+        const addr = `${serverIP}:${port}`;
+        let stderr = '';
+        spawn(opensslCli, ['s_client', '--alpn', 'bar', addr], {
+          stdio: ['ignore', 'ignore', 'pipe']
+        }).stderr
+          .setEncoding('utf8')
+          .on('data', (chunk) => stderr += chunk)
+          .on('close', common.mustCall(() => {
+            assert.match(stderr, /SSL alert number 120/);
+            server.close();
+          }));
+      } else {
+        server.close();
+      }
+    }));
+  }));
 }
 
 Test1();


### PR DESCRIPTION
To comply with RFC 7301, make TLS servers send a fatal alert during the TLS handshake if both the client and the server are configured to use ALPN and if the server does not support any of the protocols advertised by the client.

> It is expected that a server will have a list of protocols that it supports, in preference order, and will only select a protocol if the client supports it.  In that case, the server SHOULD select the most highly preferred protocol that it supports and that is also advertised by the client.  In the event that the server supports no protocols that the client advertises, then the server SHALL respond with a fatal "no_application_protocol" alert.
>
> ```asn1
> enum {
>     no_application_protocol(120),
>     (255)
> } AlertDescription;
> ```

This affects HTTP/2 servers. Until now, applications could intercept the `'unknownProtocol'` event when the client either did not advertise any protocols or if the list of protocols advertised by the client did not include HTTP/2 (or HTTP/1.1 if `allowHTTP1` was `true`). With this change, only the first case can be handled, and the `'unknownProtocol'` event will not be emitted in the second case because the TLS handshake fails and no secure connection is established.

---

I am marking this as semver-major because it changes existing behavior in a potentially breaking way.

@nodejs/http2 It seems that the HTTP/2 server implementation has a few tricks up its sleeve for when ALPN does not match (switching to HTTP/1.1, sending an informational HTTP/1.0 message, destroying the connection...). Please review these changes carefully.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
