### PR TITLE
doc: fix added version for readable.closed/destroyed properties

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1110,7 +1110,7 @@ Implementors should not override this method, but instead implement
 ##### `readable.closed`
 
 <!-- YAML
-added: v8.0.0
+added: v18.0.0
 -->
 
 * {boolean}
@@ -1120,7 +1120,7 @@ Is `true` after `'close'` has been emitted.
 ##### `readable.destroyed`
 
 <!-- YAML
-added: v18.0.0
+added: v8.0.0
 -->
 
 * {boolean}


### PR DESCRIPTION
PR reverses the added versions for `readable.closed` and `readable.destroyed`, as I believe that `closed` was added in v18 and `destroyed` was added in v8 (from looking at the v17 and earlier docs for this page which doesn't mention `closed` and puts `destroyed` as v8).