### PR TITLE
test: do not race server.close with timeout

### DIFF
--- a/test/parallel/test-http-client-response-timeout.js
+++ b/test/parallel/test-http-client-response-timeout.js
@@ -9,6 +9,6 @@ server.listen(common.mustCall(() => {
     http.get({ port: server.address().port }, common.mustCall((res) => {
       res.on('timeout', common.mustCall(() => req.destroy()));
       res.setTimeout(1);
-      server.close();
+      setTimeout(common.mustCall(() => server.close()), 2);
     }));
 }));


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/43680

This fails when `server.close()` manages to close the connection before the timeout has fired.
Here is the original issue: https://github.com/nodejs/node/issues/33734
It is not about the behaviour when racing `server.close()` with the timeout - it is about the timeout not firing at all. I am removing the race condition as I don't think there should be any guarantees on which callback should fire first.