### PR TITLE
test: update tap reporter version to 14

### DIFF
--- a/lib/internal/test_runner/tap_stream.js
+++ b/lib/internal/test_runner/tap_stream.js
@@ -89,7 +89,7 @@ class TapStream extends Readable {
   }
 
   version() {
-    this.#tryPush('TAP version 13\n');
+    this.#tryPush('TAP version 14\n');
   }
 
   #test(indent, testNumber, status, description, directive) {

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -488,6 +488,8 @@ class Test extends AsyncResource {
     // Output this test's results and update the parent's waiting counter.
     if (this.subtests.length > 0) {
       this.reporter.plan(this.subtests[0].indent, this.subtests.length);
+    } else {
+      this.reporter.subtest(this.indent, this.name);
     }
 
     this.report();

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -488,8 +488,6 @@ class Test extends AsyncResource {
     // Output this test's results and update the parent's waiting counter.
     if (this.subtests.length > 0) {
       this.reporter.plan(this.subtests[0].indent, this.subtests.length);
-    } else {
-      this.reporter.subtest(this.indent, this.name);
     }
 
     this.report();

--- a/test/message/test_runner_abort.out
+++ b/test/message/test_runner_abort.out
@@ -1,4 +1,4 @@
-TAP version 13
+TAP version 14
 # Subtest: promise timeout signal
     # Subtest: ok 1
     ok 1 - ok 1

--- a/test/message/test_runner_abort_suite.out
+++ b/test/message/test_runner_abort_suite.out
@@ -1,4 +1,4 @@
-TAP version 13
+TAP version 14
 # Subtest: describe timeout signal
     # Subtest: ok 1
     ok 1 - ok 1

--- a/test/message/test_runner_describe_it.out
+++ b/test/message/test_runner_describe_it.out
@@ -1,4 +1,4 @@
-TAP version 13
+TAP version 14
 # Subtest: sync pass todo
 ok 1 - sync pass todo # TODO
   ---
@@ -116,9 +116,9 @@ not ok 13 - async assertion fail
   failureType: 'testCodeFailure'
   error: |-
     Expected values to be strictly equal:
-    
+
     true !== false
-    
+
   code: 'ERR_ASSERTION'
   stack: |-
     *

--- a/test/message/test_runner_no_refs.out
+++ b/test/message/test_runner_no_refs.out
@@ -1,4 +1,4 @@
-TAP version 13
+TAP version 14
 # Subtest: does not keep event loop alive
     # Subtest: +does not keep event loop alive
     not ok 1 - +does not keep event loop alive

--- a/test/message/test_runner_only_tests.out
+++ b/test/message/test_runner_only_tests.out
@@ -1,4 +1,4 @@
-TAP version 13
+TAP version 14
 # Subtest: only = undefined
 ok 1 - only = undefined # SKIP 'only' option not set
   ---

--- a/test/message/test_runner_output.out
+++ b/test/message/test_runner_output.out
@@ -1,4 +1,4 @@
-TAP version 13
+TAP version 14
 # Subtest: sync pass todo
 ok 1 - sync pass todo # TODO
   ---

--- a/test/message/test_runner_unresolved_promise.out
+++ b/test/message/test_runner_unresolved_promise.out
@@ -1,4 +1,4 @@
-TAP version 13
+TAP version 14
 # Subtest: pass
 ok 1 - pass
   ---

--- a/tools/node_modules/eslint/lib/cli-engine/formatters/tap.js
+++ b/tools/node_modules/eslint/lib/cli-engine/formatters/tap.js
@@ -41,7 +41,7 @@ function outputDiagnostics(diagnostic) {
 //------------------------------------------------------------------------------
 
 module.exports = function(results) {
-    let output = `TAP version 13\n1..${results.length}\n`;
+    let output = `TAP version 14\n1..${results.length}\n`;
 
     results.forEach((result, id) => {
         const messages = result.messages;


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/44040 according to TAP specification available on http://testanything.org/tap-version-14-specification.html


Example test:

```javascript
const test = require('node:test');
const assert = require('node:assert');

test('top-level test 1', async (t) => {
  await t.test('level 1.1', () => {});
});

test('top-level test 2', () => {});
```

Produced output:

```
TAP version 14
# Subtest: top-level test 1
    ok 1 - level 1.1
      ---
      duration_ms: 0.001925209
      ...
    1..1
ok 1 - top-level test 1
  ---
  duration_ms: 0.002924375
  ...
ok 2 - top-level test 2
  ---
  duration_ms: 0.000044334
  ...
1..2
# tests 2
# pass 2
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 0.031293292
```