### PR TITLE
lib: add diagnostics channel to process and worker

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -428,6 +428,8 @@ Emitted when server receives a request.
 
 Emitted when server sends a response.
 
+#### NET
+
 `net.client.socket`
 
 * `socket` {net.Socket}
@@ -440,13 +442,40 @@ Emitted when a new TCP or pipe client socket is created.
 
 Emitted when a new TCP or pipe connection is received.
 
+#### UDP
+
 `udp.socket`
 
 * `socket` {dgram.Socket}
 
 Emitted when a new UDP socket is created.
 
+#### Process
+
+<!-- YAML
+added: REPLACEME
+-->
+
+`child_process`
+
+* `process` {ChildProcess}
+
+Emitted when a new process is created.
+
+#### Worker Thread
+
+<!-- YAML
+added: REPLACEME
+-->
+
+`worker_threads`
+
+* `worker` [`Worker`][]
+
+Emitted when a new thread is created.
+
 [`'uncaughtException'`]: process.md#event-uncaughtexception
+[`Worker`]: worker_threads.md#class-worker
 [`channel.subscribe(onMessage)`]: #channelsubscribeonmessage
 [`diagnostics_channel.channel(name)`]: #diagnostics_channelchannelname
 [`diagnostics_channel.subscribe(name, onMessage)`]: #diagnostics_channelsubscribename-onmessage

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -59,6 +59,8 @@ const { convertToValidSignal, deprecate } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 const spawn_sync = internalBinding('spawn_sync');
 const { kStateSymbol } = require('internal/dgram');
+const dc = require('diagnostics_channel');
+const childProcessChannel = dc.channel('child_process');
 
 const {
   UV_EACCES,
@@ -301,6 +303,11 @@ function ChildProcess() {
 
     maybeClose(this);
   };
+  if (childProcessChannel.hasSubscribers) {
+    childProcessChannel.publish({
+      process: this,
+    });
+  }
 }
 ObjectSetPrototypeOf(ChildProcess.prototype, EventEmitter.prototype);
 ObjectSetPrototypeOf(ChildProcess, EventEmitter);

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -89,6 +89,9 @@ let debug = require('internal/util/debuglog').debuglog('worker', (fn) => {
   debug = fn;
 });
 
+const dc = require('diagnostics_channel');
+const workerThreadsChannel = dc.channel('worker_threads');
+
 let cwdCounter;
 
 const environmentData = new SafeMap();
@@ -262,6 +265,11 @@ class Worker extends EventEmitter {
     this[kHandle].startThread();
 
     process.nextTick(() => process.emit('worker', this));
+    if (workerThreadsChannel.hasSubscribers) {
+      workerThreadsChannel.publish({
+        worker: this,
+      });
+    }
   }
 
   [kOnExit](code, customErr, customErrReason) {

--- a/test/parallel/test-diagnostics-channel-process.js
+++ b/test/parallel/test-diagnostics-channel-process.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const { ChildProcess } = require('child_process');
+const dc = require('diagnostics_channel');
+
+if (cluster.isPrimary) {
+  dc.subscribe('child_process', common.mustCall(({ process }) => {
+    assert.strictEqual(process instanceof ChildProcess, true);
+  }));
+  const worker = cluster.fork();
+  worker.on('online', common.mustCall(() => {
+    worker.send('disconnect');
+  }));
+} else {
+  process.on('message', common.mustCall((msg) => {
+    assert.strictEqual(msg, 'disconnect');
+    process.disconnect();
+  }));
+}

--- a/test/parallel/test-diagnostics-channel-worker-threads.js
+++ b/test/parallel/test-diagnostics-channel-worker-threads.js
@@ -1,0 +1,11 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+const dc = require('diagnostics_channel');
+
+dc.subscribe('worker_threads', common.mustCall(({ worker }) => {
+  assert.strictEqual(worker instanceof Worker, true);
+}));
+
+new Worker('const a = 1;', { eval: true });


### PR DESCRIPTION
Add diagnostics channel to process and worker, so we can collect the process or worker info. Such as execPath, code, pid, threadId, performance info of worker threads and snapshot of worker threads, and so on.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)