### PR TITLE
perf_hooks: fix gc elapsed time

### DIFF
--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -71,6 +71,7 @@ class PerformanceState {
   AliasedUint32Array observers;
 
   uint64_t performance_last_gc_start_mark = 0;
+  uint16_t current_gc_type = 0;
 
   void Mark(enum PerformanceMilestone milestone,
             uint64_t ts = PERFORMANCE_NOW());


### PR DESCRIPTION
fix gc elapsed time
Refs: https://github.com/nodejs/node/issues/44046
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Affected subsystem: perf_hooks