### PR TITLE
test_runner: verbose error when entire test tree is canceled

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -14,7 +14,7 @@ const {
   },
 } = require('internal/errors');
 const { getOptionValue } = require('internal/options');
-const { Test, ItTest, Suite } = require('internal/test_runner/test');
+const { kCancelledByParent, Test, ItTest, Suite } = require('internal/test_runner/test');
 
 const isTestRunner = getOptionValue('--test');
 const testResources = new SafeMap();
@@ -77,7 +77,9 @@ function setup(root) {
     createProcessEventHandler('unhandledRejection', root);
 
   const exitHandler = () => {
-    root.postRun();
+    root.postRun(new ERR_TEST_FAILURE(
+      'Promise resolution is still pending but the event loop has already resolved',
+      kCancelledByParent));
 
     let passCount = 0;
     let failCount = 0;

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -511,7 +511,7 @@ class Test extends AsyncResource {
     this.postRun();
   }
 
-  postRun() {
+  postRun(pendingSubtestsError) {
     let failedSubtests = 0;
 
     // If the test was failed before it even started, then the end time will
@@ -528,8 +528,8 @@ class Test extends AsyncResource {
       const subtest = this.subtests[i];
 
       if (!subtest.finished) {
-        subtest.cancel();
-        subtest.postRun();
+        subtest.cancel(pendingSubtestsError);
+        subtest.postRun(pendingSubtestsError);
       }
 
       if (!subtest.passed) {
@@ -691,4 +691,4 @@ class Suite extends Test {
   }
 }
 
-module.exports = { kDefaultIndent, kSubtestsFailed, kTestCodeFailure, Test, Suite, ItTest };
+module.exports = { kCancelledByParent, kDefaultIndent, kSubtestsFailed, kTestCodeFailure, Test, Suite, ItTest };

--- a/test/message/test_runner_no_refs.out
+++ b/test/message/test_runner_no_refs.out
@@ -5,7 +5,7 @@ TAP version 13
       ---
       duration_ms: *
       failureType: 'cancelledByParent'
-      error: 'test did not finish before its parent and was cancelled'
+      error: 'Promise resolution is still pending but the event loop has already resolved'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -15,7 +15,7 @@ not ok 1 - does not keep event loop alive
   ---
   duration_ms: *
   failureType: 'cancelledByParent'
-  error: 'test did not finish before its parent and was cancelled'
+  error: 'Promise resolution is still pending but the event loop has already resolved'
   code: 'ERR_TEST_FAILURE'
   stack: |-
     *

--- a/test/message/test_runner_unresolved_promise.out
+++ b/test/message/test_runner_unresolved_promise.out
@@ -9,7 +9,7 @@ not ok 2 - never resolving promise
   ---
   duration_ms: *
   failureType: 'cancelledByParent'
-  error: 'test did not finish before its parent and was cancelled'
+  error: 'Promise resolution is still pending but the event loop has already resolved'
   code: 'ERR_TEST_FAILURE'
   stack: |-
     *
@@ -19,7 +19,7 @@ not ok 3 - fail
   ---
   duration_ms: 0
   failureType: 'cancelledByParent'
-  error: 'test did not finish before its parent and was cancelled'
+  error: 'Promise resolution is still pending but the event loop has already resolved'
   code: 'ERR_TEST_FAILURE'
   stack: |-
     *


### PR DESCRIPTION
depends on https://github.com/nodejs/node/pull/44059
this is a very confusing behavior that was raised in comments/suggestions to my PR's, so I think a more verbose error can help make it less confusing.
I am not sure about the wording so any suggestions will be appreciated