### PR TITLE
src: nest namespace report in namespace node

### DIFF
--- a/src/node_report.h
+++ b/src/node_report.h
@@ -1,4 +1,7 @@
-#pragma once
+#ifndef SRC_NODE_REPORT_H_
+#define SRC_NODE_REPORT_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
 #include "node_buffer.h"
@@ -12,17 +15,18 @@
 
 #include <iomanip>
 
+namespace node {
 namespace report {
 
 // Function declarations - functions in src/node_report.cc
 std::string TriggerNodeReport(v8::Isolate* isolate,
-                              node::Environment* env,
+                              Environment* env,
                               const char* message,
                               const char* trigger,
                               const std::string& name,
                               v8::Local<v8::Value> error);
 void GetNodeReport(v8::Isolate* isolate,
-                   node::Environment* env,
+                   Environment* env,
                    const char* message,
                    const char* trigger,
                    v8::Local<v8::Value> error,
@@ -45,3 +49,8 @@ void WriteReport(const v8::FunctionCallbackInfo<v8::Value>& info);
 void GetReport(const v8::FunctionCallbackInfo<v8::Value>& info);
 
 }  // namespace report
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_NODE_REPORT_H_

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -15,11 +15,8 @@
 #include <atomic>
 #include <sstream>
 
+namespace node {
 namespace report {
-using node::Environment;
-using node::Mutex;
-using node::SetMethod;
-using node::Utf8Value;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
@@ -77,48 +74,48 @@ void GetReport(const FunctionCallbackInfo<Value>& info) {
 }
 
 static void GetCompact(const FunctionCallbackInfo<Value>& info) {
-  node::Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
-  info.GetReturnValue().Set(node::per_process::cli_options->report_compact);
+  Mutex::ScopedLock lock(per_process::cli_options_mutex);
+  info.GetReturnValue().Set(per_process::cli_options->report_compact);
 }
 
 static void SetCompact(const FunctionCallbackInfo<Value>& info) {
-  node::Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
+  Mutex::ScopedLock lock(per_process::cli_options_mutex);
   Environment* env = Environment::GetCurrent(info);
   Isolate* isolate = env->isolate();
   bool compact = info[0]->ToBoolean(isolate)->Value();
-  node::per_process::cli_options->report_compact = compact;
+  per_process::cli_options->report_compact = compact;
 }
 
 static void GetDirectory(const FunctionCallbackInfo<Value>& info) {
-  node::Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
+  Mutex::ScopedLock lock(per_process::cli_options_mutex);
   Environment* env = Environment::GetCurrent(info);
-  std::string directory = node::per_process::cli_options->report_directory;
+  std::string directory = per_process::cli_options->report_directory;
   auto result = String::NewFromUtf8(env->isolate(), directory.c_str());
   info.GetReturnValue().Set(result.ToLocalChecked());
 }
 
 static void SetDirectory(const FunctionCallbackInfo<Value>& info) {
-  node::Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
+  Mutex::ScopedLock lock(per_process::cli_options_mutex);
   Environment* env = Environment::GetCurrent(info);
   CHECK(info[0]->IsString());
   Utf8Value dir(env->isolate(), info[0].As<String>());
-  node::per_process::cli_options->report_directory = *dir;
+  per_process::cli_options->report_directory = *dir;
 }
 
 static void GetFilename(const FunctionCallbackInfo<Value>& info) {
-  node::Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
+  Mutex::ScopedLock lock(per_process::cli_options_mutex);
   Environment* env = Environment::GetCurrent(info);
-  std::string filename = node::per_process::cli_options->report_filename;
+  std::string filename = per_process::cli_options->report_filename;
   auto result = String::NewFromUtf8(env->isolate(), filename.c_str());
   info.GetReturnValue().Set(result.ToLocalChecked());
 }
 
 static void SetFilename(const FunctionCallbackInfo<Value>& info) {
-  node::Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
+  Mutex::ScopedLock lock(per_process::cli_options_mutex);
   Environment* env = Environment::GetCurrent(info);
   CHECK(info[0]->IsString());
   Utf8Value name(env->isolate(), info[0].As<String>());
-  node::per_process::cli_options->report_filename = *name;
+  per_process::cli_options->report_filename = *name;
 }
 
 static void GetSignal(const FunctionCallbackInfo<Value>& info) {
@@ -136,15 +133,14 @@ static void SetSignal(const FunctionCallbackInfo<Value>& info) {
 }
 
 static void ShouldReportOnFatalError(const FunctionCallbackInfo<Value>& info) {
-  Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
-  info.GetReturnValue().Set(
-      node::per_process::cli_options->report_on_fatalerror);
+  Mutex::ScopedLock lock(per_process::cli_options_mutex);
+  info.GetReturnValue().Set(per_process::cli_options->report_on_fatalerror);
 }
 
 static void SetReportOnFatalError(const FunctionCallbackInfo<Value>& info) {
   CHECK(info[0]->IsBoolean());
-  Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
-  node::per_process::cli_options->report_on_fatalerror = info[0]->IsTrue();
+  Mutex::ScopedLock lock(per_process::cli_options_mutex);
+  per_process::cli_options->report_on_fatalerror = info[0]->IsTrue();
 }
 
 static void ShouldReportOnSignal(const FunctionCallbackInfo<Value>& info) {
@@ -201,7 +197,7 @@ static void Initialize(Local<Object> exports,
             SetReportOnUncaughtException);
 }
 
-void RegisterExternalReferences(node::ExternalReferenceRegistry* registry) {
+void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(WriteReport);
   registry->Register(GetReport);
   registry->Register(GetCompact);
@@ -221,6 +217,7 @@ void RegisterExternalReferences(node::ExternalReferenceRegistry* registry) {
 }
 
 }  // namespace report
+}  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(report, report::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(report, report::RegisterExternalReferences)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(report, node::report::Initialize)
+NODE_MODULE_EXTERNAL_REFERENCE(report, node::report::RegisterExternalReferences)

--- a/src/node_report_utils.cc
+++ b/src/node_report_utils.cc
@@ -3,10 +3,8 @@
 #include "node_report.h"
 #include "util-inl.h"
 
+namespace node {
 namespace report {
-
-using node::JSONWriter;
-using node::MallocedBuffer;
 
 static constexpr auto null = JSONWriter::Null{};
 
@@ -210,8 +208,7 @@ void WalkHandle(uv_handle_t* h, void* arg) {
       // SIGWINCH is used by libuv so always appears.
       // See http://docs.libuv.org/en/v1.x/signal.html
       writer->json_keyvalue("signum", handle->signal.signum);
-      writer->json_keyvalue("signal",
-                            node::signo_string(handle->signal.signum));
+      writer->json_keyvalue("signal", signo_string(handle->signal.signum));
       break;
     default:
       break;
@@ -269,3 +266,4 @@ void WalkHandle(uv_handle_t* h, void* arg) {
 }
 
 }  // namespace report
+}  // namespace node


### PR DESCRIPTION
Nest namespace `report` in the commonly defined top-level namespace `node` so that most of the aliases can be removed. Also, this shows a clearer indication that the symbols in the namespace `report` are part of Node.js core when debugging the native codes.