### PR TITLE
src: remove usages of GetBackingStore in WASI

### DIFF
--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -73,7 +73,6 @@ inline void Debug(WASI* wasi, Args&&... args) {
   } while (0)
 
 using v8::Array;
-using v8::BackingStore;
 using v8::BigInt;
 using v8::Context;
 using v8::Exception;
@@ -1654,10 +1653,9 @@ void WASI::_SetMemory(const FunctionCallbackInfo<Value>& args) {
 
 uvwasi_errno_t WASI::backingStore(char** store, size_t* byte_length) {
   Local<WasmMemoryObject> memory = PersistentToLocal::Strong(this->memory_);
-  std::shared_ptr<BackingStore> backing_store =
-      memory->Buffer()->GetBackingStore();
-  *byte_length = backing_store->ByteLength();
-  *store = static_cast<char*>(backing_store->Data());
+  Local<v8::ArrayBuffer> ab = memory->Buffer();
+  *byte_length = ab->ByteLength();
+  *store = static_cast<char*>(ab->Data());
   CHECK_NOT_NULL(*store);
   return UVWASI_ESUCCESS;
 }

--- a/src/node_wasm_web_api.cc
+++ b/src/node_wasm_web_api.cc
@@ -105,12 +105,12 @@ void WasmStreamingObject::Push(const FunctionCallbackInfo<Value>& args) {
 
   if (LIKELY(chunk->IsArrayBufferView())) {
     Local<ArrayBufferView> view = chunk.As<ArrayBufferView>();
-    bytes = view->Buffer()->GetBackingStore()->Data();
+    bytes = view->Buffer()->Data();
     offset = view->ByteOffset();
     size = view->ByteLength();
   } else if (LIKELY(chunk->IsArrayBuffer())) {
     Local<ArrayBuffer> buffer = chunk.As<ArrayBuffer>();
-    bytes = buffer->GetBackingStore()->Data();
+    bytes = buffer->Data();
     offset = 0;
     size = buffer->ByteLength();
   } else {


### PR DESCRIPTION
This removes all usages of GetBackingStore in WASI. See the linked issue
for an explanation.

Refs: https://github.com/nodejs/node/issues/32226
Refs: https://github.com/nodejs/node/pull/43921