### PR TITLE
net, dns: Socket should handle its output as input

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1098,6 +1098,16 @@ Socket.prototype.connect = function(...args) {
   return this;
 };
 
+function socketToDnsFamily(family) {
+  switch (family) {
+    case 'IPv4':
+      return 4;
+    case 'IPv6':
+      return 6;
+  }
+
+  return family;
+}
 
 function lookupAndConnect(self, options) {
   const { localAddress, localPort } = options;
@@ -1140,7 +1150,7 @@ function lookupAndConnect(self, options) {
 
   if (dns === undefined) dns = require('dns');
   const dnsopts = {
-    family: options.family,
+    family: socketToDnsFamily(options.family),
     hints: options.hints || 0
   };
 

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -37,10 +37,6 @@ test-crypto-dh-stateless: SKIP
 test-crypto-keygen: SKIP
 
 [$system==solaris] # Also applies to SmartOS
-# https://github.com/nodejs/node/pull/43054
-test-net-socket-connect-without-cb: SKIP
-test-net-socket-ready-without-cb: SKIP
-test-tcp-wrap-listen: SKIP
 # https://github.com/nodejs/node/issues/43446
 test-net-connect-reset-until-connected: PASS, FLAKY
 # https://github.com/nodejs/node/issues/43457
@@ -64,12 +60,6 @@ test-fs-stat-bigint: PASS,FLAKY
 test-worker-message-port-message-before-close: PASS,FLAKY
 # https://github.com/nodejs/node/issues/43446
 test-net-connect-reset-until-connected: PASS, FLAKY
-
-[$system==aix]
-# https://github.com/nodejs/node/pull/43054
-test-net-socket-connect-without-cb: SKIP
-test-net-socket-ready-without-cb: SKIP
-test-tcp-wrap-listen: SKIP
 
 [$system==ibmi]
 # https://github.com/nodejs/node/pull/30819


### PR DESCRIPTION
As a consequence of https://github.com/nodejs/node/issues/43014 ,
server sockets and others, once connected, report string family
names. But when feeding these to Socket.connect(), it passes
these to host resolution with a string for family while a numeric
family is expected internally. This results wrong hints flags
to be set and resolution to fail.

As solution, is to add ability to handle both numeric and string
family names when doing lookup and connect.

Fixes: https://github.com/nodejs/node/issues/44003

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
