### PR TITLE
test: tune down parallelism for some flaky tests

### DIFF
--- a/test/parallel/test-worker-fshandles-error-on-termination.js
+++ b/test/parallel/test-worker-fshandles-error-on-termination.js
@@ -6,8 +6,8 @@ const fs = require('fs/promises');
 const { scheduler } = require('timers/promises');
 const { parentPort, Worker } = require('worker_threads');
 
-const MAX_ITERATIONS = 20;
-const MAX_THREADS = 10;
+const MAX_ITERATIONS = 5;
+const MAX_THREADS = 6;
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-fshandles-open-close-on-termination.js
+++ b/test/parallel/test-worker-fshandles-open-close-on-termination.js
@@ -6,8 +6,8 @@ const fs = require('fs/promises');
 const { scheduler } = require('timers/promises');
 const { parentPort, Worker } = require('worker_threads');
 
-const MAX_ITERATIONS = 20;
-const MAX_THREADS = 10;
+const MAX_ITERATIONS = 5;
+const MAX_THREADS = 6;
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-worker-http2-stream-terminate.js
+++ b/test/parallel/test-worker-http2-stream-terminate.js
@@ -11,8 +11,8 @@ const { Worker, parentPort } = require('worker_threads');
 // stream activity is ongoing, in particular the C++ function
 // ReportWritesToJSStreamListener::OnStreamAfterReqFinished.
 
-const MAX_ITERATIONS = 20;
-const MAX_THREADS = 10;
+const MAX_ITERATIONS = 5;
+const MAX_THREADS = 6;
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {


### PR DESCRIPTION
These tests seem to timeout quite often. I don't know why, but one
possible reason is that they are starting a lot of threads. It seems
that tests in `test/parallel` are assumed to only start one thread each,
so having 11 threads running at a time feels like a lot.

It also seems that these tests fail in a correlated fashion: take a look
at [this reliability report][]. The failures all occur on the same build
machines on the same PRs. This suggests to me some sort of CPU
contention.

[this reliability report]: https://github.com/nodejs/reliability/issues/334

On my Linux machine decreasing the parallelism & iterations here reduce
the `user` time from ~11.5 seconds to ~2 seconds, depending on the test.
I have seen these tests take 30-60 seconds on CI (Alpine in particular).

I went back to the diffs that introduced that introduced these changes
and verified that they failed at least 90% of the time with the reduced
iteration count, which feels sufficient.

Refs: https://github.com/nodejs/node/issues/43499
Refs: https://github.com/nodejs/node/issues/43084

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
