### PR TITLE
src: prevent copying ArrayBufferViewContents

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -498,6 +498,9 @@ class ArrayBufferViewContents {
  public:
   ArrayBufferViewContents() = default;
 
+  ArrayBufferViewContents(const ArrayBufferViewContents&) = delete;
+  void operator=(const ArrayBufferViewContents&) = delete;
+
   explicit inline ArrayBufferViewContents(v8::Local<v8::Value> value);
   explicit inline ArrayBufferViewContents(v8::Local<v8::Object> value);
   explicit inline ArrayBufferViewContents(v8::Local<v8::ArrayBufferView> abv);
@@ -507,6 +510,13 @@ class ArrayBufferViewContents {
   inline size_t length() const { return length_; }
 
  private:
+  // Declaring operator new and delete as deleted is not spec compliant.
+  // Therefore declare them private instead to disable dynamic alloc
+  void* operator new(size_t size);
+  void* operator new[](size_t size);
+  void operator delete(void*, size_t);
+  void operator delete[](void*, size_t);
+
   T stack_storage_[kStackStorageSize];
   T* data_ = nullptr;
   size_t length_ = 0;

--- a/src/util.h
+++ b/src/util.h
@@ -511,7 +511,7 @@ class ArrayBufferViewContents {
 
  private:
   // Declaring operator new and delete as deleted is not spec compliant.
-  // Therefore declare them private instead to disable dynamic alloc
+  // Therefore, declare them private instead to disable dynamic alloc.
   void* operator new(size_t size);
   void* operator new[](size_t size);
   void operator delete(void*, size_t);


### PR DESCRIPTION
It is error-prone to copy or heap-allocate `ArrayBufferViewContents`,
because you might accidentally cause it to exceed the lifetime of its
argument. Let's make it impossible to do so. Fortunately we were not
doing so anywhere already, so this diff is purely defensive.

Refs: https://github.com/nodejs/node/pull/44079#discussion_r934376046