### PR TITLE
doc,worker: deprecate `--trace-atomics-wait`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1244,7 +1244,10 @@ for TLSv1.2, which is not as secure as TLSv1.3.
 
 <!-- YAML
 added: v14.3.0
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated
 
 Print short summaries of calls to [`Atomics.wait()`][] to stderr.
 The output could look like this:

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3177,6 +3177,19 @@ Type: Documentation-only
 `code` values other than `undefined`, `null`, integer numbers and integer
 strings (e.g., '1') are deprecated as parameter in [`process.exit()`][].
 
+### DEP0165: `--trace-atomics-wait`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/44093
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+The [`--trace-atomics-wait`][] flag is deprecated.
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
@@ -3184,6 +3197,7 @@ strings (e.g., '1') are deprecated as parameter in [`process.exit()`][].
 [`"exports"` or `"main"` entry]: packages.md#main-entry-point-export
 [`--pending-deprecation`]: cli.md#--pending-deprecation
 [`--throw-deprecation`]: cli.md#--throw-deprecation
+[`--trace-atomics-wait`]: cli.md#--trace-atomics-wait
 [`--unhandled-rejections`]: cli.md#--unhandled-rejectionsmode
 [`Buffer.allocUnsafeSlow(size)`]: buffer.md#static-method-bufferallocunsafeslowsize
 [`Buffer.from(array)`]: buffer.md#static-method-bufferfromarray

--- a/doc/node.1
+++ b/doc/node.1
@@ -435,6 +435,7 @@ favour of TLSv1.3, which is more secure.
 Print short summaries of calls to
 .Sy Atomics.wait() .
 .
+This flag is deprecated.
 .It Fl -trace-deprecation
 Print stack traces for deprecations.
 .

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -540,7 +540,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::throw_deprecation,
             kAllowedInEnvironment);
   AddOption("--trace-atomics-wait",
-            "trace Atomics.wait() operations",
+            "(deprecated) trace Atomics.wait() operations",
             &EnvironmentOptions::trace_atomics_wait,
             kAllowedInEnvironment);
   AddOption("--trace-deprecation",


### PR DESCRIPTION
V8 has asked if it possible to remove the functionality underlying
`--trace-atomics-wait`. Let's start with a documentation-only
deprecation.

Refs: https://github.com/nodejs/node/issues/42982