### PR TITLE
esm: fix loader hooks accepting too many arguments

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -148,7 +148,7 @@ function nextHookFactory(chain, meta, { validateArgs, validateOutput }) {
   }
 
   return ObjectDefineProperty(
-    async (arg0, context) => {
+    async (arg0 = undefined, context) => {
       // Update only when hook is invoked to avoid fingering the wrong filePath
       meta.hookErrIdentifier = `${hookFilePath} '${hookName}'`;
 
@@ -162,12 +162,10 @@ function nextHookFactory(chain, meta, { validateArgs, validateOutput }) {
       const argsToApply = [arg0];
 
       if (context) { // `context` has already been validated, so no fancy check needed.
-        argsToApply[1] = context;
         ObjectAssign(meta.context, context);
-      } else {
-        argsToApply[1] = meta.context;
       }
 
+      argsToApply[1] = meta.context;
       argsToApply[2] = nextNextHook;
 
       const output = await ReflectApply(hook, undefined, argsToApply);

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -15,7 +15,6 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   PromiseAll,
-  ReflectApply,
   RegExpPrototypeExec,
   SafeArrayIterator,
   SafeWeakMap,
@@ -159,16 +158,11 @@ function nextHookFactory(chain, meta, { validateArgs, validateOutput }) {
       // Set when next<HookName> is actually called, not just generated.
       if (generatedHookIndex === 0) { meta.chainFinished = true; }
 
-      const argsToApply = [arg0];
-
       if (context) { // `context` has already been validated, so no fancy check needed.
         ObjectAssign(meta.context, context);
       }
 
-      argsToApply[1] = meta.context;
-      argsToApply[2] = nextNextHook;
-
-      const output = await ReflectApply(hook, undefined, argsToApply);
+      const output = await hook(arg0, context, nextNextHook);
 
       validateOutput(outputErrIdentifier, output);
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -162,7 +162,7 @@ function nextHookFactory(chain, meta, { validateArgs, validateOutput }) {
         ObjectAssign(meta.context, context);
       }
 
-      const output = await hook(arg0, context, nextNextHook);
+      const output = await hook(arg0, meta.context, nextNextHook);
 
       validateOutput(outputErrIdentifier, output);
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -152,7 +152,7 @@ function nextHookFactory(chain, meta, { validateArgs, validateOutput }) {
       // Update only when hook is invoked to avoid fingering the wrong filePath
       meta.hookErrIdentifier = `${hookFilePath} '${hookName}'`;
 
-      validateArgs(`${meta.hookErrIdentifier} hook's ${nextHookName}()`, [arg0, context]);
+      validateArgs(`${meta.hookErrIdentifier} hook's ${nextHookName}()`, arg0, context);
 
       const outputErrIdentifier = `${chain[generatedHookIndex].url} '${hookName}' hook's ${nextHookName}()`;
 
@@ -573,7 +573,7 @@ class ESMLoader {
       shortCircuited: false,
     };
 
-    const validateArgs = (hookErrIdentifier, { 0: nextUrl, 1: ctx }) => {
+    const validateArgs = (hookErrIdentifier, nextUrl, ctx) => {
       if (typeof nextUrl !== 'string') {
         // non-strings can be coerced to a url string
         // validateString() throws a less-specific error
@@ -827,7 +827,7 @@ class ESMLoader {
       shortCircuited: false,
     };
 
-    const validateArgs = (hookErrIdentifier, { 0: suppliedSpecifier, 1: ctx }) => {
+    const validateArgs = (hookErrIdentifier, suppliedSpecifier, ctx) => {
       validateString(
         suppliedSpecifier,
         `${hookErrIdentifier} specifier`,

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -148,26 +148,28 @@ function nextHookFactory(chain, meta, { validateArgs, validateOutput }) {
   }
 
   return ObjectDefineProperty(
-    async (...args) => {
+    async (arg0, context) => {
       // Update only when hook is invoked to avoid fingering the wrong filePath
       meta.hookErrIdentifier = `${hookFilePath} '${hookName}'`;
 
-      validateArgs(`${meta.hookErrIdentifier} hook's ${nextHookName}()`, args);
+      validateArgs(`${meta.hookErrIdentifier} hook's ${nextHookName}()`, [arg0, context]);
 
       const outputErrIdentifier = `${chain[generatedHookIndex].url} '${hookName}' hook's ${nextHookName}()`;
 
       // Set when next<HookName> is actually called, not just generated.
       if (generatedHookIndex === 0) { meta.chainFinished = true; }
 
-      const argsToApply = [args[0], args[1]];
+      const argsToApply = [arg0];
 
-      if (argsToApply[1] == null) {
-        argsToApply[1] = meta.context;
+      if (context) { // `context` has already been validated, so no fancy check needed.
+        argsToApply[1] = context;
+        ObjectAssign(meta.context, context);
       } else {
-        ObjectAssign(meta.context, args[1]);
+        argsToApply[1] = meta.context;
       }
 
       argsToApply[2] = nextNextHook;
+
       const output = await ReflectApply(hook, undefined, argsToApply);
 
       validateOutput(outputErrIdentifier, output);

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -159,18 +159,16 @@ function nextHookFactory(chain, meta, { validateArgs, validateOutput }) {
       // Set when next<HookName> is actually called, not just generated.
       if (generatedHookIndex === 0) { meta.chainFinished = true; }
 
-      // `context` is an optional argument that only needs to be passed when changed
-      switch (args.length) {
-        case 1: // It was omitted, so supply the cached value
-          ArrayPrototypePush(args, meta.context);
-          break;
-        case 2: // Overrides were supplied, so update cached value
-          ObjectAssign(meta.context, args[1]);
-          break;
+      const argsToApply = [args[0], args[1]];
+
+      if (argsToApply[1] == null) {
+        argsToApply[1] = meta.context;
+      } else {
+        ObjectAssign(meta.context, args[1]);
       }
 
-      ArrayPrototypePush(args, nextNextHook);
-      const output = await ReflectApply(hook, undefined, args);
+      argsToApply[2] = nextNextHook;
+      const output = await ReflectApply(hook, undefined, argsToApply);
 
       validateOutput(outputErrIdentifier, output);
 

--- a/test/es-module/test-esm-loader-chaining.mjs
+++ b/test/es-module/test-esm-loader-chaining.mjs
@@ -114,11 +114,11 @@ describe('ESM: loader chaining', { concurrency: true }, () => {
       { encoding: 'utf8' },
     );
 
-    assert.match(stdout, /resolve arg count: 3/);
+    assert.match(stdout, /^resolve arg count: 3$/m);
     assert.match(stdout, /specifier: 'node:fs'/);
     assert.match(stdout, /next: \[AsyncFunction: nextResolve\]/);
 
-    assert.match(stdout, /load arg count: 3/);
+    assert.match(stdout, /^load arg count: 3$/m);
     assert.match(stdout, /url: 'node:fs'/);
     assert.match(stdout, /next: \[AsyncFunction: nextLoad\]/);
   });

--- a/test/es-module/test-esm-loader-chaining.mjs
+++ b/test/es-module/test-esm-loader-chaining.mjs
@@ -101,6 +101,28 @@ describe('ESM: loader chaining', { concurrency: true }, () => {
     assert.strictEqual(code, 0);
   });
 
+  it('should accept only the correct arguments', async () => {
+    const { stdout } = await spawnPromisified(
+      execPath,
+      [
+        '--loader',
+        fixtures.fileURL('es-module-loaders', 'loader-log-args.mjs'),
+        '--loader',
+        fixtures.fileURL('es-module-loaders', 'loader-with-too-many-args.mjs'),
+        ...commonArgs,
+      ],
+      { encoding: 'utf8' },
+    );
+
+    assert.match(stdout, /resolve arg count: 3/);
+    assert.match(stdout, /specifier: 'node:fs'/);
+    assert.match(stdout, /next: \[AsyncFunction: nextResolve\]/);
+
+    assert.match(stdout, /load arg count: 3/);
+    assert.match(stdout, /url: 'node:fs'/);
+    assert.match(stdout, /next: \[AsyncFunction: nextLoad\]/);
+  });
+
   it('should result in proper output from multiple changes in resolve hooks', async () => {
     const { code, stderr, stdout } = await spawnPromisified(
       execPath,

--- a/test/fixtures/es-module-loaders/loader-log-args.mjs
+++ b/test/fixtures/es-module-loaders/loader-log-args.mjs
@@ -1,0 +1,28 @@
+export async function resolve(...args) {
+  console.log(`resolve arg count: ${args.length}`);
+  console.log({
+    specifier: args[0],
+    context: args[1],
+    next: args[2],
+  });
+
+  return {
+    shortCircuit: true,
+    url: args[0],
+  };
+}
+
+export async function load(...args) {
+  console.log(`load arg count: ${args.length}`);
+  console.log({
+    url: args[0],
+    context: args[1],
+    next: args[2],
+  });
+
+  return {
+    format: 'module',
+    source: '',
+    shortCircuit: true,
+  };
+}

--- a/test/fixtures/es-module-loaders/loader-with-too-many-args.mjs
+++ b/test/fixtures/es-module-loaders/loader-with-too-many-args.mjs
@@ -1,0 +1,7 @@
+export async function resolve(specifier, context, next) {
+  return next(specifier, context, 'resolve-extra-arg');
+}
+
+export async function load(url, context, next) {
+  return next(url, context, 'load-extra-arg');
+}


### PR DESCRIPTION
When a user supplies too many arguments, those beyond the 2nd arg are currently blindly passed to the `next<HookName>` function. Now, those extra args are ignored. It assumes both `resolve` and `load` share the same number of args—which they currently do; if that changes, this will need to be updated.

Fixes https://github.com/nodejs/node/issues/44108