### PR TITLE
stream: fix `isDetachedBuffer` validations in `ReadableStream`

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -910,11 +910,6 @@ class ReadableStreamBYOBReader {
       );
     }
 
-    if (isDetachedBuffer(viewBuffer)) {
-      return PromiseReject(
-        new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached'),
-      );
-    }
     // Supposed to assert here that the view's buffer is not
     // detached, but there's no API available to use to check that.
     if (this[kState].stream === undefined) {

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -102,7 +102,6 @@ const {
   extractSizeAlgorithm,
   lazyTransfer,
   isDetachedBuffer,
-  isViewedArrayBufferDetached,
   isBrandCheck,
   resetQueue,
   setPromiseHandled,
@@ -684,7 +683,7 @@ class ReadableStreamBYOBRequest {
         'This BYOB request has been invalidated');
     }
 
-    if (isViewedArrayBufferDetached(view)) {
+    if (isDetachedBuffer(ArrayBufferViewGetBuffer(view))) {
       throw new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached');
     }
 

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -684,6 +684,14 @@ class ReadableStreamBYOBRequest {
         'This BYOB request has been invalidated');
     }
 
+    if (!isArrayBufferView(view)) {
+      throw new ERR_INVALID_ARG_TYPE(
+        'view',
+        ['Buffer', 'TypedArray', 'DataView'],
+        view,
+      );
+    }
+
     if (isViewedArrayBufferDetached(view)) {
       throw new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached');
     }
@@ -2507,16 +2515,6 @@ function readableByteStreamControllerRespondWithNewView(controller, view) {
   const desc = pendingPullIntos[0];
   assert(stream[kState].state !== 'errored');
 
-  if (!isArrayBufferView(view)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'view',
-      [
-        'Buffer',
-        'TypedArray',
-        'DataView',
-      ],
-      view);
-  }
   const viewByteLength = ArrayBufferViewGetByteLength(view);
   const viewByteOffset = ArrayBufferViewGetByteOffset(view);
   const viewBuffer = ArrayBufferViewGetBuffer(view);

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -905,7 +905,7 @@ class ReadableStreamBYOBReader {
     if (viewByteLength === 0 || viewBufferByteLength === 0) {
       return PromiseReject(
         new ERR_INVALID_STATE.TypeError(
-          'View or Viewed ArrayBuffer is zero-length',
+          'View or Viewed ArrayBuffer is zero-length or detached',
         ),
       );
     }

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -101,6 +101,7 @@ const {
   extractHighWaterMark,
   extractSizeAlgorithm,
   lazyTransfer,
+  isDetachedBuffer,
   isViewedArrayBufferDetached,
   isBrandCheck,
   resetQueue,
@@ -654,13 +655,8 @@ class ReadableStreamBYOBRequest {
         'This BYOB request has been invalidated');
     }
 
-    const viewByteLength = ArrayBufferViewGetByteLength(view);
-    const viewBuffer = ArrayBufferViewGetBuffer(view);
-    const viewBufferByteLength = ArrayBufferGetByteLength(viewBuffer);
-
-    if (viewByteLength === 0 || viewBufferByteLength === 0) {
-      throw new ERR_INVALID_STATE.TypeError(
-        'View ArrayBuffer is zero-length or detached');
+    if (isViewedArrayBufferDetached(view)) {
+      throw new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached');
     }
 
     readableByteStreamControllerRespond(controller, bytesWritten);
@@ -894,14 +890,9 @@ class ReadableStreamBYOBReader {
           ],
           view));
     }
-    const viewByteLength = ArrayBufferViewGetByteLength(view);
-    const viewBuffer = ArrayBufferViewGetBuffer(view);
-    const viewBufferByteLength = ArrayBufferGetByteLength(viewBuffer);
 
-    if (viewByteLength === 0 || viewBufferByteLength === 0) {
-      return PromiseReject(
-        new ERR_INVALID_STATE.TypeError(
-          'View ArrayBuffer is zero-length or detached'));
+    if (isViewedArrayBufferDetached(view)) {
+      throw new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached');
     }
     // Supposed to assert here that the view's buffer is not
     // detached, but there's no API available to use to check that.
@@ -2298,11 +2289,10 @@ function readableByteStreamControllerEnqueue(
   if (pendingPullIntos.length) {
     const firstPendingPullInto = pendingPullIntos[0];
 
-    const pendingBufferByteLength =
-      ArrayBufferGetByteLength(firstPendingPullInto.buffer);
-    if (pendingBufferByteLength === 0) {
+    if (isDetachedBuffer(firstPendingPullInto.buffer)) {
       throw new ERR_INVALID_STATE.TypeError(
-        'Destination ArrayBuffer is zero-length or detached');
+        'Destination ArrayBuffer is detached',
+      );
     }
 
     firstPendingPullInto.buffer =

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -59,6 +59,7 @@ const {
 } = require('v8');
 
 const {
+  validateBuffer,
   validateObject,
 } = require('internal/validators');
 
@@ -684,13 +685,7 @@ class ReadableStreamBYOBRequest {
         'This BYOB request has been invalidated');
     }
 
-    if (!isArrayBufferView(view)) {
-      throw new ERR_INVALID_ARG_TYPE(
-        'view',
-        ['Buffer', 'TypedArray', 'DataView'],
-        view,
-      );
-    }
+    validateBuffer(view, 'view');
 
     if (isViewedArrayBufferDetached(view)) {
       throw new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached');

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -102,6 +102,7 @@ const {
   extractSizeAlgorithm,
   lazyTransfer,
   isDetachedBuffer,
+  isViewedArrayBufferDetached,
   isBrandCheck,
   resetQueue,
   setPromiseHandled,
@@ -683,7 +684,7 @@ class ReadableStreamBYOBRequest {
         'This BYOB request has been invalidated');
     }
 
-    if (isDetachedBuffer(ArrayBufferViewGetBuffer(view))) {
+    if (isViewedArrayBufferDetached(view)) {
       throw new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached');
     }
 

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -655,9 +655,16 @@ class ReadableStreamBYOBRequest {
         'This BYOB request has been invalidated');
     }
 
-    if (isViewedArrayBufferDetached(view)) {
+    const viewByteLength = ArrayBufferViewGetByteLength(view);
+    const viewBuffer = ArrayBufferViewGetBuffer(view);
+    const viewBufferByteLength = ArrayBufferGetByteLength(viewBuffer);
+
+    if (isDetachedBuffer(viewBuffer)) {
       throw new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached');
     }
+
+    assert(viewByteLength > 0);
+    assert(viewBufferByteLength > 0);
 
     readableByteStreamControllerRespond(controller, bytesWritten);
   }
@@ -891,8 +898,22 @@ class ReadableStreamBYOBReader {
           view));
     }
 
-    if (isViewedArrayBufferDetached(view)) {
-      throw new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached');
+    const viewByteLength = ArrayBufferViewGetByteLength(view);
+    const viewBuffer = ArrayBufferViewGetBuffer(view);
+    const viewBufferByteLength = ArrayBufferGetByteLength(viewBuffer);
+
+    if (viewByteLength === 0 || viewBufferByteLength === 0) {
+      return PromiseReject(
+        new ERR_INVALID_STATE.TypeError(
+          'View or Viewed ArrayBuffer is zero-length',
+        ),
+      );
+    }
+
+    if (isDetachedBuffer(viewBuffer)) {
+      return PromiseReject(
+        new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached'),
+      );
     }
     // Supposed to assert here that the view's buffer is not
     // detached, but there's no API available to use to check that.

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -130,21 +130,12 @@ function transferArrayBuffer(buffer) {
 }
 
 function isDetachedBuffer(buffer) {
-  if (ArrayBufferGetByteLength(buffer) === 0) {
-    try {
-      new Uint8Array(buffer);
-    } catch {
-      return true;
-    }
+  try {
+    new Uint8Array(buffer);
+  } catch {
+    return true;
   }
   return false;
-}
-
-function isViewedArrayBufferDetached(view) {
-  return (
-    ArrayBufferViewGetByteLength(view) === 0 &&
-    isDetachedBuffer(ArrayBufferViewGetBuffer(view))
-  );
 }
 
 function dequeueValue(controller) {
@@ -245,7 +236,6 @@ module.exports = {
   isBrandCheck,
   isDetachedBuffer,
   isPromisePending,
-  isViewedArrayBufferDetached,
   peekQueueValue,
   resetQueue,
   setPromiseHandled,

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -129,7 +129,7 @@ function transferArrayBuffer(buffer) {
   return res;
 }
 
-function isArrayBufferDetached(buffer) {
+function isDetachedBuffer(buffer) {
   if (ArrayBufferGetByteLength(buffer) === 0) {
     try {
       new Uint8Array(buffer);
@@ -143,7 +143,7 @@ function isArrayBufferDetached(buffer) {
 function isViewedArrayBufferDetached(view) {
   return (
     ArrayBufferViewGetByteLength(view) === 0 &&
-    isArrayBufferDetached(ArrayBufferViewGetBuffer(view))
+    isDetachedBuffer(ArrayBufferViewGetBuffer(view))
   );
 }
 
@@ -243,6 +243,7 @@ module.exports = {
   extractSizeAlgorithm,
   lazyTransfer,
   isBrandCheck,
+  isDetachedBuffer,
   isPromisePending,
   isViewedArrayBufferDetached,
   peekQueueValue,

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -132,8 +132,7 @@ function transferArrayBuffer(buffer) {
 }
 
 function isDetachedBuffer(buffer) {
-  if (!isArrayBuffer(buffer))
-    throw new ERR_INVALID_ARG_TYPE('buffer', 'ArrayBuffer', buffer);
+  assert(isArrayBuffer(buffer));
   if (ArrayBufferGetByteLength(buffer) === 0) {
     // TODO(daeyeon): Consider using C++ builtin to improve performance.
     try {
@@ -147,13 +146,7 @@ function isDetachedBuffer(buffer) {
 }
 
 function isViewedArrayBufferDetached(view) {
-  if (!isArrayBufferView(view)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'view',
-      ['Buffer', 'TypedArray', 'DataView'],
-      view,
-    );
-  }
+  assert(isArrayBufferView(view));
   return (
     ArrayBufferViewGetByteLength(view) === 0 &&
     isDetachedBuffer(ArrayBufferViewGetBuffer(view))

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -31,8 +31,6 @@ const {
 } = internalBinding('buffer');
 
 const {
-  isArrayBuffer,
-  isArrayBufferView,
   isPromise,
 } = require('internal/util/types');
 
@@ -132,7 +130,6 @@ function transferArrayBuffer(buffer) {
 }
 
 function isDetachedBuffer(buffer) {
-  assert(isArrayBuffer(buffer));
   if (ArrayBufferGetByteLength(buffer) === 0) {
     // TODO(daeyeon): Consider using C++ builtin to improve performance.
     try {
@@ -146,7 +143,6 @@ function isDetachedBuffer(buffer) {
 }
 
 function isViewedArrayBufferDetached(view) {
-  assert(isArrayBufferView(view));
   return (
     ArrayBufferViewGetByteLength(view) === 0 &&
     isDetachedBuffer(ArrayBufferViewGetBuffer(view))

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -130,12 +130,21 @@ function transferArrayBuffer(buffer) {
 }
 
 function isDetachedBuffer(buffer) {
-  try {
-    new Uint8Array(buffer);
-  } catch {
-    return true;
+  if (ArrayBufferGetByteLength(buffer) === 0) {
+    try {
+      new Uint8Array(buffer);
+    } catch {
+      return true;
+    }
   }
   return false;
+}
+
+function isViewedArrayBufferDetached(view) {
+  return (
+    ArrayBufferViewGetByteLength(view) === 0 &&
+    isDetachedBuffer(ArrayBufferViewGetBuffer(view))
+  );
 }
 
 function dequeueValue(controller) {
@@ -236,6 +245,7 @@ module.exports = {
   isBrandCheck,
   isDetachedBuffer,
   isPromisePending,
+  isViewedArrayBufferDetached,
   peekQueueValue,
   resetQueue,
   setPromiseHandled,

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -31,6 +31,8 @@ const {
 } = internalBinding('buffer');
 
 const {
+  isArrayBuffer,
+  isArrayBufferView,
   isPromise,
 } = require('internal/util/types');
 
@@ -130,10 +132,14 @@ function transferArrayBuffer(buffer) {
 }
 
 function isDetachedBuffer(buffer) {
+  if (!isArrayBuffer(buffer))
+    throw new ERR_INVALID_ARG_TYPE('buffer', 'ArrayBuffer', buffer);
   if (ArrayBufferGetByteLength(buffer) === 0) {
+    // TODO(daeyeon): Consider using C++ builtin to improve performance.
     try {
       new Uint8Array(buffer);
-    } catch {
+    } catch (error) {
+      assert(error.name === 'TypeError');
       return true;
     }
   }
@@ -141,6 +147,13 @@ function isDetachedBuffer(buffer) {
 }
 
 function isViewedArrayBufferDetached(view) {
+  if (!isArrayBufferView(view)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'view',
+      ['Buffer', 'TypedArray', 'DataView'],
+      view,
+    );
+  }
   return (
     ArrayBufferViewGetByteLength(view) === 0 &&
     isDetachedBuffer(ArrayBufferViewGetBuffer(view))

--- a/test/parallel/test-whatwg-readablebytestream-bad-buffers-and-views.js
+++ b/test/parallel/test-whatwg-readablebytestream-bad-buffers-and-views.js
@@ -51,4 +51,48 @@ let pass = 0;
   reader.read(new Uint8Array([4, 5, 6]));
 }
 
+{
+  const stream = new ReadableStream({
+    start(c) {
+      c.enqueue(new Uint8Array([1, 2, 3]));
+    },
+    type: 'bytes',
+  });
+  const reader = stream.getReader({ mode: 'byob' });
+  const view = new Uint8Array();
+  reader
+    .read(view)
+    .then(common.mustNotCall())
+    .catch(
+      common.mustCall(
+        common.expectsError({
+          code: 'ERR_INVALID_STATE',
+          name: 'TypeError',
+        }),
+      ),
+    );
+}
+
+{
+  const stream = new ReadableStream({
+    start(c) {
+      c.enqueue(new Uint8Array([1, 2, 3]));
+    },
+    type: 'bytes',
+  });
+  const reader = stream.getReader({ mode: 'byob' });
+  const view = new Uint8Array(new ArrayBuffer(10), 0, 0);
+  reader
+    .read(view)
+    .then(common.mustNotCall())
+    .catch(
+      common.mustCall(
+        common.expectsError({
+          code: 'ERR_INVALID_STATE',
+          name: 'TypeError',
+        }),
+      ),
+    );
+}
+
 process.on('exit', () => assert.strictEqual(pass, 2));

--- a/test/parallel/test-whatwg-readablebytestream-bad-buffers-and-views.js
+++ b/test/parallel/test-whatwg-readablebytestream-bad-buffers-and-views.js
@@ -60,17 +60,12 @@ let pass = 0;
   });
   const reader = stream.getReader({ mode: 'byob' });
   const view = new Uint8Array();
-  reader
-    .read(view)
-    .then(common.mustNotCall())
-    .catch(
-      common.mustCall(
-        common.expectsError({
-          code: 'ERR_INVALID_STATE',
-          name: 'TypeError',
-        }),
-      ),
-    );
+  assert
+    .rejects(reader.read(view), {
+      code: 'ERR_INVALID_STATE',
+      name: 'TypeError',
+    })
+    .then(common.mustCall());
 }
 
 {
@@ -82,17 +77,12 @@ let pass = 0;
   });
   const reader = stream.getReader({ mode: 'byob' });
   const view = new Uint8Array(new ArrayBuffer(10), 0, 0);
-  reader
-    .read(view)
-    .then(common.mustNotCall())
-    .catch(
-      common.mustCall(
-        common.expectsError({
-          code: 'ERR_INVALID_STATE',
-          name: 'TypeError',
-        }),
-      ),
-    );
+  assert
+    .rejects(reader.read(view), {
+      code: 'ERR_INVALID_STATE',
+      name: 'TypeError',
+    })
+    .then(common.mustCall());
 }
 
 process.on('exit', () => assert.strictEqual(pass, 2));


### PR DESCRIPTION
This fixes validations below related to `isDetachedBuffer` using a function introduced in https://github.com/nodejs/node/pull/43866.

https://streams.spec.whatwg.org/#rs-byob-request-respond
> The respond(bytesWritten) method steps are:
>> If this.[[controller]] is undefined, throw a TypeError exception.
>> If ! IsDetachedBuffer(this.[[view]].[[ArrayBuffer]]) is true, throw a TypeError exception.

https://streams.spec.whatwg.org/#byob-reader-read
> The read(view) method steps are:
>> If view.[[ByteLength]] is 0, return a promise rejected with a TypeError exception.
>> If view.[[ViewedArrayBuffer]].[[ArrayBufferByteLength]] is 0, return a promise rejected with a TypeError exception.
>> If ! IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is true, return a promise rejected with a TypeError exception.

https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue
> 8. If controller.[[pendingPullIntos]] is not empty,
> > 8.1 Let firstPendingPullInto be controller.[[pendingPullIntos]][0].
> > 8.2 If ! IsDetachedBuffer(firstPendingPullInto’s buffer) is true, throw a TypeError exception.

Refs: https://github.com/nodejs/node/pull/43866#pullrequestreview-1047386968

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
