### PR TITLE
test: s390x z15 accelerated zlib fixes

### DIFF
--- a/test/parallel/test-zlib-dictionary-fail.js
+++ b/test/parallel/test-zlib-dictionary-fail.js
@@ -53,7 +53,7 @@ const input = Buffer.from([0x78, 0xBB, 0x04, 0x09, 0x01, 0xA5]);
   stream.on('error', common.mustCall(function(err) {
     // It's not possible to separate invalid dict and invalid data when using
     // the raw format
-    assert.match(err.message, /invalid/);
+    assert.match(err.message, /(invalid|Operation-Ending-Supplemental Code is 0x12)/);
   }));
 
   stream.write(input);

--- a/test/parallel/test-zlib-flush-drain-longblock.js
+++ b/test/parallel/test-zlib-flush-drain-longblock.js
@@ -16,7 +16,7 @@ zipper.write('A'.repeat(17000));
 zipper.flush();
 
 let received = 0;
-unzipper.on('data', common.mustCall((d) => {
+unzipper.on('data', common.mustCallAtLeast((d) => {
   received += d.length;
 }, 2));
 

--- a/test/parallel/test-zlib-from-string.js
+++ b/test/parallel/test-zlib-from-string.js
@@ -55,7 +55,9 @@ const expectedBase64Gzip = 'H4sIAAAAAAAAA11RS05DMQy8yhzg6d2BPSAkJPZu4laWkjiN4' +
                            'sHnHNzRtagj5AQAA';
 
 zlib.deflate(inputString, common.mustCall((err, buffer) => {
-  assert.strictEqual(buffer.toString('base64'), expectedBase64Deflate);
+  zlib.inflate(buffer, common.mustCall((err, inflated) => {
+    assert.strictEqual(inflated.toString(), inputString);
+  }));
 }));
 
 zlib.gzip(inputString, common.mustCall((err, buffer) => {


### PR DESCRIPTION
Modern s390x x15 has accelerated zlib operations on the CPU. Many
distros currently have patches to take advantage of this feature. One
side-effect of these patches is that compression routine is no longer
deterministic as with software. Interruption to input produces
different compressed results. Invalid input can result in processor
fault.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
