### PR TITLE
esm: do not bind loader hook functions

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -8,7 +8,6 @@ const {
   ArrayIsArray,
   ArrayPrototypeJoin,
   ArrayPrototypePush,
-  FunctionPrototypeBind,
   FunctionPrototypeCall,
   ObjectAssign,
   ObjectCreate,
@@ -314,16 +313,14 @@ class ESMLoader {
       'DeprecationWarning',
     );
 
-    // Use .bind() to avoid giving access to the Loader instance when called.
     if (globalPreload) {
-      acceptedHooks.globalPreloader =
-        FunctionPrototypeBind(globalPreload, null);
+      acceptedHooks.globalPreloader = globalPreload;
     }
     if (resolve) {
-      acceptedHooks.resolver = FunctionPrototypeBind(resolve, null);
+      acceptedHooks.resolver = resolve;
     }
     if (load) {
-      acceptedHooks.loader = FunctionPrototypeBind(load, null);
+      acceptedHooks.loader = load;
     }
 
     return acceptedHooks;
@@ -354,7 +351,7 @@ class ESMLoader {
         ArrayPrototypePush(
           this.#globalPreloaders,
           {
-            fn: FunctionPrototypeBind(globalPreloader), // [1]
+            fn: globalPreloader,
             url,
           },
         );
@@ -363,7 +360,7 @@ class ESMLoader {
         ArrayPrototypePush(
           this.#resolvers,
           {
-            fn: FunctionPrototypeBind(resolver), // [1]
+            fn: resolver,
             url,
           },
         );
@@ -372,14 +369,12 @@ class ESMLoader {
         ArrayPrototypePush(
           this.#loaders,
           {
-            fn: FunctionPrototypeBind(loader), // [1]
+            fn: loader,
             url,
           },
         );
       }
     }
-
-    // [1] ensure hook function is not bound to ESMLoader instance
 
     this.preload();
   }

--- a/test/fixtures/es-module-loaders/loader-this-value-inside-hook-functions.mjs
+++ b/test/fixtures/es-module-loaders/loader-this-value-inside-hook-functions.mjs
@@ -1,0 +1,14 @@
+export function resolve(url, _, next) {
+  if (this != null) throw new Error('hook function must not be bound to ESMLoader instance');
+  return next(url);
+}
+
+export function load(url, _, next) {
+  if (this != null) throw new Error('hook function must not be bound to ESMLoader instance');
+  return next(url);
+}
+
+export function globalPreload() {
+  if (this != null) throw new Error('hook function must not be bound to ESMLoader instance');
+  return "";
+}

--- a/test/parallel/test-loaders-this-value-inside-hook-functions.mjs
+++ b/test/parallel/test-loaders-this-value-inside-hook-functions.mjs
@@ -1,0 +1,4 @@
+// Flags: --experimental-loader ./test/fixtures/es-module-loaders/loader-this-value-inside-hook-functions.mjs
+import '../common/index.mjs';
+
+// Actual test is inside the loader module.


### PR DESCRIPTION
Previous code was binding function hooks twice, but there's no need for binding given how the code is written. Adding a test  to ensure it stays this way.

/cc @nodejs/loaders 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
