### PR TITLE
doc: add Retry CI in collaborator guide

### DIFF
--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -253,7 +253,7 @@ current job but re-run everything else. Start a fresh CI if more than seven days
 have elapsed since the original failing CI as the compiled binaries for the
 Windows and ARM platforms are only kept for seven days.
 
-If new changes are made on the pull request branch after latest Jenkins CI run,
+If new commits are pushed to the pull request branch after the latest Jenkins CI run,
 a fresh CI run is required. It can be started by pressing "Retry" on the left
 sidebar, or by adding `request-ci` label to the pull request.
 

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -253,9 +253,9 @@ current job but re-run everything else. Start a fresh CI if more than seven days
 have elapsed since the original failing CI as the compiled binaries for the
 Windows and ARM platforms are only kept for seven days.
 
-If new commits are pushed to the pull request branch after the latest Jenkins CI run,
-a fresh CI run is required. It can be started by pressing "Retry" on the left
-sidebar, or by adding the `request-ci` label to the pull request.
+If new commits are pushed to the pull request branch after the latest Jenkins
+CI run, a fresh CI run is required. It can be started by pressing "Retry" on
+the left sidebar, or by adding the `request-ci` label to the pull request.
 
 #### Useful Jenkins CI jobs
 

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -253,6 +253,10 @@ current job but re-run everything else. Start a fresh CI if more than seven days
 have elapsed since the original failing CI as the compiled binaries for the
 Windows and ARM platforms are only kept for seven days.
 
+If new changes are made on the pull request branch after latest Jenkins CI run,
+a fresh CI run is required. It can be started by pressing "Retry" on the left
+sidebar, or by adding `request-ci` label to the pull request.
+
 #### Useful Jenkins CI jobs
 
 * [`node-test-pull-request`](https://ci.nodejs.org/job/node-test-pull-request/)

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -255,7 +255,7 @@ Windows and ARM platforms are only kept for seven days.
 
 If new commits are pushed to the pull request branch after the latest Jenkins CI run,
 a fresh CI run is required. It can be started by pressing "Retry" on the left
-sidebar, or by adding `request-ci` label to the pull request.
+sidebar, or by adding the `request-ci` label to the pull request.
 
 #### Useful Jenkins CI jobs
 


### PR DESCRIPTION
This is to prevent assumption that `Resume build` might be correct choice. Also to make it explicit that green/yellow CI is needed to be achieved on the last commit and intermediate success doesn't count.

Refs: https://github.com/nodejs/node/pull/43714#issuecomment-1186946040