### PR TITLE
bootstrap: check more metadata when loading the snapshot

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1198,6 +1198,15 @@ in the current working directory.
 When used without `--build-snapshot`, `--snapshot-blob` specifies the
 path to the blob that will be used to restore the application state.
 
+When loading a snapshot, Node.js checks that:
+
+1. The version, architecture and platform of the running Node.js binary
+   are exactly the same as that of the binary that generates the snapshot.
+2. The V8 flags and CPU features are compatible with that of the binary
+   that generates the snapshot.
+
+If they don't match, Node.js would refuse to load the snapshot and exit with 1.
+
 ### `--test`
 
 <!-- YAML

--- a/src/env.cc
+++ b/src/env.cc
@@ -261,6 +261,21 @@ std::ostream& operator<<(std::ostream& output,
   return output;
 }
 
+std::ostream& operator<<(std::ostream& output, const SnapshotMetadata& i) {
+  output << "{\n"
+         << "  "
+         << (i.type == SnapshotMetadata::Type::kDefault
+                 ? "SnapshotMetadata::Type::kDefault"
+                 : "SnapshotMetadata::Type::kFullyCustomized")
+         << ", // type\n"
+         << "  \"" << i.node_version << "\", // node_version\n"
+         << "  \"" << i.node_arch << "\", // node_arch\n"
+         << "  \"" << i.node_platform << "\", // node_platform\n"
+         << "  " << i.v8_cache_version_tag << ", // v8_cache_version_tag\n"
+         << "}";
+  return output;
+}
+
 IsolateDataSerializeInfo IsolateData::Serialize(SnapshotCreator* creator) {
   Isolate* isolate = creator->GetIsolate();
   IsolateDataSerializeInfo info;

--- a/src/env.h
+++ b/src/env.h
@@ -984,6 +984,19 @@ struct EnvSerializeInfo {
   friend std::ostream& operator<<(std::ostream& o, const EnvSerializeInfo& i);
 };
 
+struct SnapshotMetadata {
+  // For now kFullyCustomized is only built with the --build-snapshot CLI flag.
+  // We might want to add more types of snapshots in the future.
+  enum class Type : uint8_t { kDefault, kFullyCustomized };
+
+  Type type;
+  std::string node_version;
+  std::string node_arch;
+  std::string node_platform;
+  // Result of v8::ScriptCompiler::CachedDataVersionTag().
+  uint32_t v8_cache_version_tag;
+};
+
 struct SnapshotData {
   enum class DataOwnership { kOwned, kNotOwned };
 
@@ -992,6 +1005,8 @@ struct SnapshotData {
   static const SnapshotIndex kNodeMainContextIndex = kNodeBaseContextIndex + 1;
 
   DataOwnership data_ownership = DataOwnership::kOwned;
+
+  SnapshotMetadata metadata;
 
   // The result of v8::SnapshotCreator::CreateBlob() during the snapshot
   // building process.
@@ -1009,7 +1024,10 @@ struct SnapshotData {
   std::vector<builtins::CodeCacheInfo> code_cache;
 
   void ToBlob(FILE* out) const;
-  static void FromBlob(SnapshotData* out, FILE* in);
+  // If returns false, the metadata doesn't match the current Node.js binary,
+  // and the caller should not consume the snapshot data.
+  bool Check() const;
+  static bool FromBlob(SnapshotData* out, FILE* in);
 
   ~SnapshotData();
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1256,8 +1256,8 @@ int LoadSnapshotDataAndRun(const SnapshotData** snapshot_data_ptr,
     std::unique_ptr<SnapshotData> read_data = std::make_unique<SnapshotData>();
     if (!SnapshotData::FromBlob(read_data.get(), fp)) {
       // If we fail to read the customized snapshot, simply exit with 1.
-      result->exit_code = 1;
-      return result->exit_code;
+      exit_code = 1;
+      return exit_code;
     }
     *snapshot_data_ptr = read_data.release();
     fclose(fp);

--- a/src/node.cc
+++ b/src/node.cc
@@ -1266,7 +1266,7 @@ int LoadSnapshotDataAndRun(const SnapshotData** snapshot_data_ptr,
     // snapshot, but we will skip it if --no-node-snapshot is specified.
     const node::SnapshotData* read_data =
         SnapshotBuilder::GetEmbeddedSnapshotData();
-    if (read_data->Check()) {
+    if (read_data != nullptr && read_data->Check()) {
       // If we fail to read the embedded snapshot, treat it as if Node.js
       // was built without one.
       *snapshot_data_ptr = read_data;

--- a/src/node.cc
+++ b/src/node.cc
@@ -1254,13 +1254,23 @@ int LoadSnapshotDataAndRun(const SnapshotData** snapshot_data_ptr,
       return exit_code;
     }
     std::unique_ptr<SnapshotData> read_data = std::make_unique<SnapshotData>();
-    SnapshotData::FromBlob(read_data.get(), fp);
+    if (!SnapshotData::FromBlob(read_data.get(), fp)) {
+      // If we fail to read the customized snapshot, simply exit with 1.
+      result->exit_code = 1;
+      return result->exit_code;
+    }
     *snapshot_data_ptr = read_data.release();
     fclose(fp);
   } else if (per_process::cli_options->node_snapshot) {
     // If --snapshot-blob is not specified, we are reading the embedded
     // snapshot, but we will skip it if --no-node-snapshot is specified.
-    *snapshot_data_ptr = SnapshotBuilder::GetEmbeddedSnapshotData();
+    const node::SnapshotData* read_data =
+        SnapshotBuilder::GetEmbeddedSnapshotData();
+    if (read_data->Check()) {
+      // If we fail to read the embedded snapshot, treat it as if Node.js
+      // was built without one.
+      *snapshot_data_ptr = read_data;
+    }
   }
 
   if ((*snapshot_data_ptr) != nullptr) {

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -414,6 +414,7 @@ std::ostream& operator<<(std::ostream& output,
                          const TickInfo::SerializeInfo& d);
 std::ostream& operator<<(std::ostream& output,
                          const AsyncHooks::SerializeInfo& d);
+std::ostream& operator<<(std::ostream& output, const SnapshotMetadata& d);
 
 namespace performance {
 std::ostream& operator<<(std::ostream& output,

--- a/test/parallel/test-snapshot-incompatible.js
+++ b/test/parallel/test-snapshot-incompatible.js
@@ -1,0 +1,76 @@
+'use strict';
+
+// This tests that Node.js refuses to load snapshots built with incompatible
+// V8 configurations.
+
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const path = require('path');
+const fs = require('fs');
+
+tmpdir.refresh();
+const blobPath = path.join(tmpdir.path, 'snapshot.blob');
+const entry = fixtures.path('empty.js');
+
+// The flag used can be any flag that makes a difference in
+// v8::ScriptCompiler::CachedDataVersionTag(). --harmony
+// is chosen here because it's stable enough and makes a difference.
+{
+  // Build a snapshot with --harmony.
+  const child = spawnSync(process.execPath, [
+    '--harmony',
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot',
+    entry,
+  ], {
+    cwd: tmpdir.path
+  });
+  if (child.status !== 0) {
+    console.log(child.stderr.toString());
+    console.log(child.stdout.toString());
+    assert.strictEqual(child.status, 0);
+  }
+  const stats = fs.statSync(path.join(tmpdir.path, 'snapshot.blob'));
+  assert(stats.isFile());
+}
+
+{
+  // Now load the snapshot without --harmony, which should fail.
+  const child = spawnSync(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+  ], {
+    cwd: tmpdir.path,
+    env: {
+      ...process.env,
+    }
+  });
+
+  const stderr = child.stderr.toString().trim();
+  assert.match(stderr, /Failed to load the startup snapshot/);
+  assert.strictEqual(child.status, 1);
+}
+
+{
+  // Load it again with --harmony and it should work.
+  const child = spawnSync(process.execPath, [
+    '--harmony',
+    '--snapshot-blob',
+    blobPath,
+  ], {
+    cwd: tmpdir.path,
+    env: {
+      ...process.env,
+    }
+  });
+
+  if (child.status !== 0) {
+    console.log(child.stderr.toString());
+    console.log(child.stdout.toString());
+    assert.strictEqual(child.status, 0);
+  }
+}


### PR DESCRIPTION
This patch stores the metadata about the Node.js binary
into the SnapshotData and adds fields denoting how the
snapshot was generated, on what platform it was
generated as well as the V8 cached data version flag.
Instead of simply crashing when the metadata doesn't
match, Node.js now prints an error message and exit with
1 for the customized snapshot, or ignore the snapshot
and start from scratch if it's the default one.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
