### PR TITLE
test: deflake test-diagnostics-channel-net

### DIFF
--- a/test/parallel/test-diagnostics-channel-net.js
+++ b/test/parallel/test-diagnostics-channel-net.js
@@ -4,16 +4,13 @@ const assert = require('assert');
 const net = require('net');
 const dc = require('diagnostics_channel');
 
-const netClientSocketChannel = dc.channel('net.client.socket');
-const netServerSocketChannel = dc.channel('net.server.socket');
-
 const isNetSocket = (socket) => socket instanceof net.Socket;
 
-netClientSocketChannel.subscribe(common.mustCall(({ socket }) => {
+dc.subscribe('net.client.socket', common.mustCall(({ socket }) => {
   assert.strictEqual(isNetSocket(socket), true);
 }));
 
-netServerSocketChannel.subscribe(common.mustCall(({ socket }) => {
+dc.subscribe('net.server.socket', common.mustCall(({ socket }) => {
   assert.strictEqual(isNetSocket(socket), true);
 }));
 


### PR DESCRIPTION
This test uses the deprecated methods in `diagnostics_channel` (see the
reference), which are deprecated because the channels can be GC'd while
in use, leading to lost messages.

Change to use the non-deprecated APIs, which should work. I wasn't able
to reproduce this locally; I assume it's memory dependent.

Refs: https://github.com/nodejs/node/pull/42714
Fixes: https://github.com/nodejs/node/issues/44143