### PR TITLE
test: deflake gc-http-client tests by restricting number of requests per cpu

### DIFF
--- a/test/sequential/test-gc-http-client-timeout.js
+++ b/test/sequential/test-gc-http-client-timeout.js
@@ -17,16 +17,20 @@ function serverHandler(req, res) {
 }
 
 const cpus = os.cpus().length;
+const numRequests = 36;
 let createClients = true;
 let done = 0;
 let count = 0;
 let countGC = 0;
 
 const server = http.createServer(serverHandler);
-server.listen(0, common.mustCall(getAll));
+server.listen(0, common.mustCall(() => getAll(numRequests)));
 
-function getAll() {
+function getAll(requestsRemaining) {
   if (!createClients)
+    return;
+
+  if (requestsRemaining <= 0)
     return;
 
   const req = http.get({
@@ -40,11 +44,11 @@ function getAll() {
   count++;
   onGC(req, { ongc });
 
-  setImmediate(getAll);
+  setImmediate(getAll, requestsRemaining - 1);
 }
 
 for (let i = 0; i < cpus; i++)
-  getAll();
+  getAll(numRequests);
 
 function cb(res) {
   res.resume();

--- a/test/sequential/test-gc-http-client.js
+++ b/test/sequential/test-gc-http-client.js
@@ -13,6 +13,7 @@ function serverHandler(req, res) {
 }
 
 const http = require('http');
+const numRequests = 36;
 let createClients = true;
 let done = 0;
 let count = 0;
@@ -21,11 +22,14 @@ let countGC = 0;
 const server = http.createServer(serverHandler);
 server.listen(0, common.mustCall(() => {
   for (let i = 0; i < cpus; i++)
-    getAll();
+    getAll(numRequests);
 }));
 
-function getAll() {
+function getAll(requestsRemaining) {
   if (!createClients)
+    return;
+
+  if (requestsRemaining <= 0)
     return;
 
   const req = http.get({
@@ -37,7 +41,7 @@ function getAll() {
   count++;
   onGC(req, { ongc });
 
-  setImmediate(getAll);
+  setImmediate(getAll, requestsRemaining - 1);
 }
 
 function cb(res) {


### PR DESCRIPTION
test-gc-http-client-* tests are failing on some systems due to too many concurrent connections being created, as the number of requests called per test is non-deterministic. 

This change limits the number of calls of `getAll()` (the function responsible for creating the request) to 36 per CPU. 

I chose this number arbitrarily as it completed the full set of requests on my machine, without any errors - perhaps there might be a better number for this setting (or a better approach entirely...). I also didn't want to change the semantics of the test by restricting to an absolute number of requests.

It's my first PR on this project, so please let me know if I'm way off the mark!

Fixes: https://github.com/nodejs/node/issues/43638