### PR TITLE
module: Allow searching system paths

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1254,7 +1254,11 @@ Module._initPaths = function() {
     path.resolve(process.execPath, '..') :
     path.resolve(process.execPath, '..', '..');
 
-  const paths = [path.resolve(prefixDir, 'lib', 'node')];
+  const paths = [
+    path.resolve(prefixDir, 'local', 'lib', 'node_modules'),
+    path.resolve(prefixDir, 'lib', 'node_modules'),
+    path.resolve(prefixDir, 'lib', 'node'),
+  ];
 
   if (homeDir) {
     ArrayPrototypeUnshift(paths, path.resolve(homeDir, '.node_libraries'));


### PR DESCRIPTION
Add $prefix/local/lib/node_modules and $prefix/lib/node_modules as
locations to search for globally-installed packages.

The search priority order is:

1. node_modules/ in the current directory hierarchy
2. .node_modules/ and .node_libraries/ in the user's home directory
3. $prefix/local/lib/node_modules/
4. $prefix/lib/node_modules/
5. $prefix/lib/node/

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
