### PR TITLE
dgram: add dgram send queue info

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -461,6 +461,23 @@ added: v8.7.0
 
 This method throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 
+### `socket.getSendQueueSize()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {number} Number of bytes queued for sending.
+
+### `socket.getSendQueueCount()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {number} Number of send requests currently in the queue awaiting
+  to be processed.
+
 ### `socket.ref()`
 
 <!-- YAML

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -976,6 +976,13 @@ Socket.prototype.getSendBufferSize = function() {
   return bufferSize(this, 0, SEND_BUFFER);
 };
 
+Socket.prototype.getSendQueueSize = function() {
+  return this[kStateSymbol].handle.getSendQueueSize();
+};
+
+Socket.prototype.getSendQueueCount = function() {
+  return this[kStateSymbol].handle.getSendQueueCount();
+};
 
 // Deprecated private APIs.
 ObjectDefineProperty(Socket.prototype, '_handle', {

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -182,6 +182,9 @@ void UDPWrap::Initialize(Local<Object> target,
   SetProtoMethod(isolate, t, "setBroadcast", SetBroadcast);
   SetProtoMethod(isolate, t, "setTTL", SetTTL);
   SetProtoMethod(isolate, t, "bufferSize", BufferSize);
+  SetProtoMethodNoSideEffect(isolate, t, "getSendQueueSize", GetSendQueueSize);
+  SetProtoMethodNoSideEffect(
+      isolate, t, "getSendQueueCount", GetSendQueueCount);
 
   t->Inherit(HandleWrap::GetConstructorTemplate(env));
 
@@ -783,6 +786,23 @@ MaybeLocal<Object> UDPWrap::Instantiate(Environment* env,
   return env->udp_constructor_function()->NewInstance(env->context());
 }
 
+void UDPWrap::GetSendQueueSize(const FunctionCallbackInfo<Value>& args) {
+  UDPWrap* wrap;
+  ASSIGN_OR_RETURN_UNWRAP(
+      &wrap, args.Holder(), args.GetReturnValue().Set(UV_EBADF));
+
+  size_t size = uv_udp_get_send_queue_size(&wrap->handle_);
+  args.GetReturnValue().Set(static_cast<double>(size));
+}
+
+void UDPWrap::GetSendQueueCount(const FunctionCallbackInfo<Value>& args) {
+  UDPWrap* wrap;
+  ASSIGN_OR_RETURN_UNWRAP(
+      &wrap, args.Holder(), args.GetReturnValue().Set(UV_EBADF));
+
+  size_t count = uv_udp_get_send_queue_count(&wrap->handle_);
+  args.GetReturnValue().Set(static_cast<double>(count));
+}
 
 }  // namespace node
 

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -150,6 +150,9 @@ class UDPWrap final : public HandleWrap,
   static void SetBroadcast(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetTTL(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void BufferSize(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetSendQueueSize(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetSendQueueCount(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
 
   // UDPListener implementation
   uv_buf_t OnAlloc(size_t suggested_size) override;

--- a/test/parallel/test-dgram-send-queue-info.js
+++ b/test/parallel/test-dgram-send-queue-info.js
@@ -1,0 +1,27 @@
+// Flags: --test-udp-no-try-send
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+
+const socket = dgram.createSocket('udp4');
+assert.strictEqual(socket.getSendQueueSize(), 0);
+assert.strictEqual(socket.getSendQueueCount(), 0);
+socket.close();
+
+const server = dgram.createSocket('udp4');
+const client = dgram.createSocket('udp4');
+
+server.bind(0, common.mustCall(() => {
+  client.connect(server.address().port, common.mustCall(() => {
+    const data = 'hello';
+    client.send(data);
+    client.send(data);
+    // See uv__send in win/udp.c
+    assert.strictEqual(client.getSendQueueSize(),
+                       common.isWindows ? 0 : data.length * 2);
+    assert.strictEqual(client.getSendQueueCount(), 2);
+    client.close();
+    server.close();
+  }));
+}));


### PR DESCRIPTION
Add `getSendQueueSize` and `getSendQueueCount` for `dgram`.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
