### PR TITLE
stream: improve view validation on `ReadableStreamBYOBRequest.respondWithNewView()`

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -2516,6 +2516,15 @@ function readableByteStreamControllerRespondWithNewView(controller, view) {
   const viewBuffer = ArrayBufferViewGetBuffer(view);
   const viewBufferByteLength = ArrayBufferGetByteLength(viewBuffer);
 
+  if (stream[kState].state === 'closed') {
+    if (viewByteLength !== 0)
+      throw new ERR_INVALID_STATE.TypeError('View is not zero-length');
+  } else {
+    assert(stream[kState].state === 'readable');
+    if (viewByteLength === 0)
+      throw new ERR_INVALID_STATE.TypeError('View is zero-length');
+  }
+
   const {
     byteOffset,
     byteLength,

--- a/test/wpt/status/streams.json
+++ b/test/wpt/status/streams.json
@@ -4,13 +4,5 @@
   },
   "transferable/deserialize-error.window.js": {
     "skip": "Browser-specific test"
-  },
-  "readable-byte-streams/bad-buffers-and-views.any.js": {
-    "fail": {
-      "note": "TODO: implement detached ArrayBuffer support",
-      "expected": [
-        "ReadableStream with byte source: respondWithNewView() throws if the supplied view's buffer is zero-length (in the readable state)"
-      ]
-    }
   }
 }


### PR DESCRIPTION
- This throws if the view is zero-length when there is an active reader when using `ReadableStreamBYOBRequest.respondWithNewView()`.

- By doing that, we can get all tests passed in `wpt/streams/readable-byte-streams/bad-buffers-and-views.any.js`.

Refs: https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-with-new-view

> 5. If state is "closed"
> 5.1. If view.[[ByteLength]] is not 0, throw a TypeError exception.
> 6. Otherwise,
> 6.1 Assert: state is "readable".
> 6.2 If view.[[ByteLength]] is 0, throw a TypeError exception.

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
