### PR TITLE
doc: improved building doc for Android

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -659,7 +659,7 @@ Be sure you have downloaded and extracted
 a folder. Then run:
 
 ```console
-$ ./android-configure /path/to/your/android-ndk target_arch android_sdk_version
+$ source ./android-configure /path/to/your/android-ndk target_arch android_sdk_version
 $ make -j4
 ```
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -37,7 +37,7 @@ file a new issue.
       * [Option 1: Manual install](#option-1-manual-install)
       * [Option 2: Automated install with Boxstarter](#option-2-automated-install-with-boxstarter)
     * [Building Node.js](#building-nodejs-2)
-  * [Android/Android-based devices (e.g. Firefox OS)](#androidandroid-based-devices-eg-firefox-os)
+  * [Android](#android)
 * [`Intl` (ECMA-402) support](#intl-ecma-402-support)
   * [Build with full ICU support (all locales supported by ICU)](#build-with-full-icu-support-all-locales-supported-by-icu)
     * [Unix/macOS](#unixmacos)
@@ -647,7 +647,7 @@ To test if Node.js was built correctly:
 > Release\node -e "console.log('Hello from Node.js', process.version)"
 ```
 
-### Android/Android-based devices (e.g. Firefox OS)
+### Android
 
 Android is not a supported platform. Patches to improve the Android build are
 welcome. There is no testing on Android in the current continuous integration
@@ -655,13 +655,16 @@ environment. The participation of people dedicated and determined to improve
 Android building, testing, and support is encouraged.
 
 Be sure you have downloaded and extracted
-[Android NDK](https://developer.android.com/tools/sdk/ndk/index.html) before in
+[Android NDK](https://developer.android.com/ndk) before in
 a folder. Then run:
 
 ```console
-$ ./android-configure /path/to/your/android-ndk
-$ make
+$ ./android-configure /path/to/your/android-ndk target_arch android_sdk_version
+$ make -j4
 ```
+
+The Android SDK version should be at least 24 (Android 7.0) and the target
+architecture supports \[arm, arm64/aarch64, x86, x86\_64].
 
 ## `Intl` (ECMA-402) support
 


### PR DESCRIPTION
Improved building document for Android.
- Outdated toolchain (Android NDK) links replaced
- Optimized redundant platform names
- Added compilation requirements

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
