### PR TITLE
test: update wpt url status

### DIFF
--- a/test/wpt/status/url.json
+++ b/test/wpt/status/url.json
@@ -10,7 +10,7 @@
     "requires": ["small-icu"]
   },
   "urlencoded-parser.any.js": {
-    "fail": "missing Request and Response"
+    "requires": ["small-icu"]
   },
   "url-constructor.any.js": {
     "requires": ["small-icu"]


### PR DESCRIPTION
`urlencoded-parser.any.js` is now passed thanks to https://github.com/nodejs/undici/pull/1563, which is released in [undici v5.8.1](https://github.com/nodejs/undici/releases/tag/v5.8.1)