### PR TITLE
lib: improve hideStackFrames intellisense

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -392,8 +392,9 @@ function makeNodeErrorWithCode(Base, key) {
 
 /**
  * This function removes unnecessary frames from Node.js core errors.
- * @template {(...args: any[]) => any} T
- * @type {(fn: T) => T}
+ * @template {(...args: unknown[]) => unknown} T
+ * @param {T} fn
+ * @returns {T}
  */
 function hideStackFrames(fn) {
   // We rename the functions that will be hidden to cut off the stacktrace

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -266,10 +266,9 @@ const validateArray = hideStackFrames((value, name, minLength = 0) => {
     const reason = `must be longer than ${minLength}`;
     throw new ERR_INVALID_ARG_VALUE(name, value, reason);
   }
-
-  return true;
 });
 
+// eslint-disable-next-line jsdoc/require-returns-check
 /**
  * @param {*} signal
  * @param {string} [name='signal']
@@ -286,8 +285,6 @@ function validateSignalName(signal, name = 'signal') {
 
     throw new ERR_UNKNOWN_SIGNAL(signal);
   }
-
-  return true;
 }
 
 /**

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -209,7 +209,7 @@ function getOwnPropertyValueOrDefault(options, key, defaultValue) {
  * @param {{allowArray: boolean=, allowFunction: boolean=, nullable: boolean=}} [options]
  */
 const validateObject = hideStackFrames(
-  (value, name, options) => {
+  (value, name, options = null) => {
     const allowArray = getOwnPropertyValueOrDefault(options, 'allowArray', false);
     const allowFunction = getOwnPropertyValueOrDefault(options, 'allowFunction', false);
     const nullable = getOwnPropertyValueOrDefault(options, 'nullable', false);

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -34,10 +34,20 @@ const {
 } = require('internal/util/types');
 const { signals } = internalBinding('constants').os;
 
+/**
+ * @callback isInt32
+ * @param {number} value
+ * @returns {boolean}
+ */
 function isInt32(value) {
   return value === (value | 0);
 }
 
+/**
+ * @callback isUint32
+ * @param {number} value
+ * @returns {boolean}
+ */
 function isUint32(value) {
   return value === (value >>> 0);
 }
@@ -71,13 +81,15 @@ function parseFileMode(value, name, def) {
 }
 
 /**
- * @function validateInteger
+ * @callback validateInteger
  * @param {*} value
  * @param {string} name
  * @param {number} [min]
  * @param {number} [max]
  * @returns {asserts value is number}
  */
+
+/** @type {validateInteger} */
 const validateInteger = hideStackFrames(
   (value, name, min = NumberMIN_SAFE_INTEGER, max = NumberMAX_SAFE_INTEGER) => {
     if (typeof value !== 'number')
@@ -90,13 +102,15 @@ const validateInteger = hideStackFrames(
 );
 
 /**
- * @function validateInt32
+ * @callback validateInt32
  * @param {*} value
  * @param {string} name
  * @param {number} [min]
  * @param {number} [max]
  * @returns {asserts value is number}
  */
+
+/** @type {validateInt32} */
 const validateInt32 = hideStackFrames(
   (value, name, min = -2147483648, max = 2147483647) => {
     // The defaults for min and max correspond to the limits of 32-bit integers.
@@ -113,13 +127,15 @@ const validateInt32 = hideStackFrames(
 );
 
 /**
- * @function validateUint32
+ * @callback validateUint32
  * @param {*} value
  * @param {string} name
  * @param {number} [min]
  * @param {number} [max]
  * @returns {asserts value is number}
  */
+
+/** @type {validateUint32} */
 const validateUint32 = hideStackFrames((value, name, positive = false) => {
   if (typeof value !== 'number') {
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
@@ -136,48 +152,50 @@ const validateUint32 = hideStackFrames((value, name, positive = false) => {
 });
 
 /**
- * @function validateString
+ * @callback validateString
  * @param {*} value
  * @param {string} name
  * @returns {asserts value is string}
  */
+
+/** @type {validateString} */
 function validateString(value, name) {
   if (typeof value !== 'string')
     throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
-
-  return true;
 }
 
 /**
- * @function validateNumber
+ * @callback validateNumber
  * @param {*} value
  * @param {string} name
  * @param {number} [min]
  * @param {number} [max]
  * @returns {asserts value is number}
  */
+
+/** @type {validateNumber} */
 function validateNumber(value, name, min = undefined, max) {
   if (typeof value !== 'number')
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
 
   if ((min != null && value < min) || (max != null && value > max) ||
-      ((min != null || max != null) && NumberIsNaN(value))) {
+    ((min != null || max != null) && NumberIsNaN(value))) {
     throw new ERR_OUT_OF_RANGE(
       name,
       `${min != null ? `>= ${min}` : ''}${min != null && max != null ? ' && ' : ''}${max != null ? `<= ${max}` : ''}`,
       value);
   }
-
-  return true;
 }
 
 /**
- * @function validateOneOf
+ * @callback validateOneOf
  * @template T
  * @param {T} value
  * @param {string} name
  * @param {T[]} oneOf
  */
+
+/** @type {validateOneOf} */
 const validateOneOf = hideStackFrames((value, name, oneOf) => {
   if (!ArrayPrototypeIncludes(oneOf, value)) {
     const allowed = ArrayPrototypeJoin(
@@ -190,16 +208,16 @@ const validateOneOf = hideStackFrames((value, name, oneOf) => {
 });
 
 /**
- * @function validateBoolean
+ * @callback validateBoolean
  * @param {*} value
  * @param {string} name
  * @returns {asserts value is boolean}
  */
+
+/** @type {validateBoolean} */
 function validateBoolean(value, name) {
   if (typeof value !== 'boolean')
     throw new ERR_INVALID_ARG_TYPE(name, 'boolean', value);
-
-  return true;
 }
 
 function getOwnPropertyValueOrDefault(options, key, defaultValue) {
@@ -209,32 +227,36 @@ function getOwnPropertyValueOrDefault(options, key, defaultValue) {
 }
 
 /**
- * @function validateObject
+ * @callback validateObject
  * @param {*} value
  * @param {string} name
  * @param {{allowArray: boolean=, allowFunction: boolean=, nullable: boolean=}} [options]
  */
+
+/** @type {validateObject} */
 const validateObject = hideStackFrames(
   (value, name, options = null) => {
     const allowArray = getOwnPropertyValueOrDefault(options, 'allowArray', false);
     const allowFunction = getOwnPropertyValueOrDefault(options, 'allowFunction', false);
     const nullable = getOwnPropertyValueOrDefault(options, 'nullable', false);
     if ((!nullable && value === null) ||
-        (!allowArray && ArrayIsArray(value)) ||
-        (typeof value !== 'object' && (
-          !allowFunction || typeof value !== 'function'
-        ))) {
+      (!allowArray && ArrayIsArray(value)) ||
+      (typeof value !== 'object' && (
+        !allowFunction || typeof value !== 'function'
+      ))) {
       throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
     }
   });
 
 /**
- * @function validateArray
+ * @callback validateArray
  * @param {*} value
  * @param {string} name
  * @param {number} [minLength]
  * @returns {asserts value is unknown[]}
  */
+
+/** @type {validateArray} */
 const validateArray = hideStackFrames((value, name, minLength = 0) => {
   if (!ArrayIsArray(value)) {
     throw new ERR_INVALID_ARG_TYPE(name, 'Array', value);
@@ -248,121 +270,137 @@ const validateArray = hideStackFrames((value, name, minLength = 0) => {
 });
 
 /**
- * @function validateSignalName
+ * @callback validateSignalName
  * @param {*} signal
  * @param {string} name
  * @returns {asserts signal is keyof signals}
  */
+
+/** @type {validateSignalName} */
 function validateSignalName(signal, name = 'signal') {
   validateString(signal, name);
 
   if (signals[signal] === undefined) {
     if (signals[StringPrototypeToUpperCase(signal)] !== undefined) {
       throw new ERR_UNKNOWN_SIGNAL(signal +
-                                   ' (signals must use all capital letters)');
+        ' (signals must use all capital letters)');
     }
 
     throw new ERR_UNKNOWN_SIGNAL(signal);
   }
-
-  return true;
 }
 
 /**
- * @function validateBuffer
+ * @callback validateBuffer
  * @param {*} buffer
  * @param {string} [name='buffer']
  */
+
+/** @type {validateBuffer} */
 const validateBuffer = hideStackFrames((buffer, name = 'buffer') => {
   if (!isArrayBufferView(buffer)) {
-    throw new ERR_INVALID_ARG_TYPE(name,
-                                   ['Buffer', 'TypedArray', 'DataView'],
-                                   buffer);
+    throw new ERR_INVALID_ARG_TYPE(name, ['Buffer', 'TypedArray', 'DataView'], buffer);
   }
 });
 
 /**
- * @function validateEncoding
+ * @callback validateEncoding
  * @param {string} data
  * @param {string} encoding
  */
+
+/** @type {validateEncoding} */
 function validateEncoding(data, encoding) {
   const normalizedEncoding = normalizeEncoding(encoding);
   const length = data.length;
 
   if (normalizedEncoding === 'hex' && length % 2 !== 0) {
-    throw new ERR_INVALID_ARG_VALUE('encoding', encoding,
-                                    `is invalid for data of length ${length}`);
+    throw new ERR_INVALID_ARG_VALUE('encoding', encoding, `is invalid for data of length ${length}`);
   }
 }
 
-// Check that the port number is not NaN when coerced to a number,
-// is an integer and that it falls within the legal range of port numbers.
+/**
+ * @callback validatePort
+ * @description Check that the port number is not NaN when coerced to a number,
+ * is an integer and that it falls within the legal range of port numbers.
+ * @param {*} port
+ * @param {string} [name='Port']
+ * @param {boolean} [allowZero=true]
+ * @returns {number}
+ */
 function validatePort(port, name = 'Port', allowZero = true) {
   if ((typeof port !== 'number' && typeof port !== 'string') ||
-      (typeof port === 'string' && StringPrototypeTrim(port).length === 0) ||
-      +port !== (+port >>> 0) ||
-      port > 0xFFFF ||
-      (port === 0 && !allowZero)) {
+    (typeof port === 'string' && StringPrototypeTrim(port).length === 0) ||
+    +port !== (+port >>> 0) ||
+    port > 0xFFFF ||
+    (port === 0 && !allowZero)) {
     throw new ERR_SOCKET_BAD_PORT(name, port, allowZero);
   }
   return port | 0;
 }
 
 /**
- * @function validateAbortSignal
+ * @callback validateAbortSignal
  * @param {string} signal
  * @param {string} name
  */
 const validateAbortSignal = hideStackFrames((signal, name) => {
   if (signal !== undefined &&
-      (signal === null ||
-       typeof signal !== 'object' ||
-       !('aborted' in signal))) {
+    (signal === null ||
+      typeof signal !== 'object' ||
+      !('aborted' in signal))) {
     throw new ERR_INVALID_ARG_TYPE(name, 'AbortSignal', signal);
   }
 });
 
 /**
- * @function validateFunction
+ * @callback validateFunction
  * @param {*} value
  * @param {string} name
  * @returns {asserts value is Function}
  */
+
+/** @type {validateFunction} */
 const validateFunction = hideStackFrames((value, name) => {
   if (typeof value !== 'function')
     throw new ERR_INVALID_ARG_TYPE(name, 'Function', value);
 });
 
 /**
- * @function validatePlainFunction
+ * @callback validatePlainFunction
  * @param {*} value
  * @param {string} name
  * @returns {asserts value is Function}
  */
+
+/** @type {validatePlainFunction} */
 const validatePlainFunction = hideStackFrames((value, name) => {
   if (typeof value !== 'function' || isAsyncFunction(value))
     throw new ERR_INVALID_ARG_TYPE(name, 'Function', value);
 });
 
 /**
- * @function validateUndefined
+ * @callback validateUndefined
  * @param {*} value
  * @param {string} name
  * @returns {asserts value is undefined}
  */
+
+/** @type {validateUndefined} */
 const validateUndefined = hideStackFrames((value, name) => {
   if (value !== undefined)
     throw new ERR_INVALID_ARG_TYPE(name, 'undefined', value);
 });
 
 /**
- * @function validateUnion
+ * @callback validateUnion
  * @template T
  * @param {T} value
  * @param {string} name
  * @param {T[]} union
  */
+
+/** @type {validateUnion} */
 function validateUnion(value, name, union) {
   if (!ArrayPrototypeIncludes(union, value)) {
     throw new ERR_INVALID_ARG_TYPE(name, `('${ArrayPrototypeJoin(union, '|')}')`, value);

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -273,7 +273,7 @@ const validateArray = hideStackFrames((value, name, minLength = 0) => {
 
 /**
  * @param {*} signal
- * @param {string} name
+ * @param {string} [name='signal']
  * @returns {asserts signal is keyof signals}
  */
 function validateSignalName(signal, name = 'signal') {
@@ -341,7 +341,7 @@ function validatePort(port, name = 'Port', allowZero = true) {
 
 /**
  * @callback validateAbortSignal
- * @param {string=} signal
+ * @param {*} signal
  * @param {string} name
  */
 

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -144,6 +144,8 @@ const validateUint32 = hideStackFrames((value, name, positive = false) => {
 function validateString(value, name) {
   if (typeof value !== 'string')
     throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
+
+  return true;
 }
 
 /**
@@ -165,6 +167,8 @@ function validateNumber(value, name, min = undefined, max) {
       `${min != null ? `>= ${min}` : ''}${min != null && max != null ? ' && ' : ''}${max != null ? `<= ${max}` : ''}`,
       value);
   }
+
+  return true;
 }
 
 /**
@@ -194,6 +198,8 @@ const validateOneOf = hideStackFrames((value, name, oneOf) => {
 function validateBoolean(value, name) {
   if (typeof value !== 'boolean')
     throw new ERR_INVALID_ARG_TYPE(name, 'boolean', value);
+
+  return true;
 }
 
 function getOwnPropertyValueOrDefault(options, key, defaultValue) {
@@ -237,6 +243,8 @@ const validateArray = hideStackFrames((value, name, minLength = 0) => {
     const reason = `must be longer than ${minLength}`;
     throw new ERR_INVALID_ARG_VALUE(name, value, reason);
   }
+
+  return true;
 });
 
 /**
@@ -256,6 +264,8 @@ function validateSignalName(signal, name = 'signal') {
 
     throw new ERR_UNKNOWN_SIGNAL(signal);
   }
+
+  return true;
 }
 
 /**

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -70,6 +70,9 @@ function parseFileMode(value, name, def) {
   return value;
 }
 
+/**
+ * @type {(function(unknown, string, number=, number=): void)}
+ */
 const validateInteger = hideStackFrames(
   (value, name, min = NumberMIN_SAFE_INTEGER, max = NumberMAX_SAFE_INTEGER) => {
     if (typeof value !== 'number')
@@ -81,6 +84,9 @@ const validateInteger = hideStackFrames(
   }
 );
 
+/**
+ * @type {(function(unknown, string, number=, number=): void)}
+ */
 const validateInt32 = hideStackFrames(
   (value, name, min = -2147483648, max = 2147483647) => {
     // The defaults for min and max correspond to the limits of 32-bit integers.
@@ -96,7 +102,10 @@ const validateInt32 = hideStackFrames(
   }
 );
 
-const validateUint32 = hideStackFrames((value, name, positive) => {
+/**
+ * @type {(function(unknown, string, boolean=): void)}
+ */
+const validateUint32 = hideStackFrames((value, name, positive = false) => {
   if (typeof value !== 'number') {
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
   }
@@ -129,6 +138,9 @@ function validateNumber(value, name, min = undefined, max) {
   }
 }
 
+/**
+ * @type {(function(unknown, string, unknown[]): void)}
+ */
 const validateOneOf = hideStackFrames((value, name, oneOf) => {
   if (!ArrayPrototypeIncludes(oneOf, value)) {
     const allowed = ArrayPrototypeJoin(
@@ -152,13 +164,11 @@ function getOwnPropertyValueOrDefault(options, key, defaultValue) {
 }
 
 /**
- * @param {unknown} value
- * @param {string} name
- * @param {{
+ * @type {(function(unknown, string, {
  *   allowArray?: boolean,
  *   allowFunction?: boolean,
  *   nullable?: boolean
- * }} [options]
+ * }): void)}
  */
 const validateObject = hideStackFrames(
   (value, name, options) => {
@@ -174,6 +184,9 @@ const validateObject = hideStackFrames(
     }
   });
 
+/**
+ * @type {(function(unknown, string, number=): void)}
+ */
 const validateArray = hideStackFrames((value, name, minLength = 0) => {
   if (!ArrayIsArray(value)) {
     throw new ERR_INVALID_ARG_TYPE(name, 'Array', value);
@@ -197,6 +210,9 @@ function validateSignalName(signal, name = 'signal') {
   }
 }
 
+/**
+ * @type {(function(unknown, string=): void)}
+ */
 const validateBuffer = hideStackFrames((buffer, name = 'buffer') => {
   if (!isArrayBufferView(buffer)) {
     throw new ERR_INVALID_ARG_TYPE(name,
@@ -228,6 +244,9 @@ function validatePort(port, name = 'Port', allowZero = true) {
   return port | 0;
 }
 
+/**
+ * @type {(function(unknown, string): void)}
+ */
 const validateAbortSignal = hideStackFrames((signal, name) => {
   if (signal !== undefined &&
       (signal === null ||
@@ -237,16 +256,25 @@ const validateAbortSignal = hideStackFrames((signal, name) => {
   }
 });
 
+/**
+ * @type {(function(unknown, string): void)}
+ */
 const validateFunction = hideStackFrames((value, name) => {
   if (typeof value !== 'function')
     throw new ERR_INVALID_ARG_TYPE(name, 'Function', value);
 });
 
+/**
+ * @type {(function(unknown, string): void)}
+ */
 const validatePlainFunction = hideStackFrames((value, name) => {
   if (typeof value !== 'function' || isAsyncFunction(value))
     throw new ERR_INVALID_ARG_TYPE(name, 'Function', value);
 });
 
+/**
+ * @type {(function(unknown, string): void)}
+ */
 const validateUndefined = hideStackFrames((value, name) => {
   if (value !== undefined)
     throw new ERR_INVALID_ARG_TYPE(name, 'undefined', value);

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -35,7 +35,7 @@ const {
 const { signals } = internalBinding('constants').os;
 
 /**
- * @param {number} value
+ * @param {*} value
  * @returns {boolean}
  */
 function isInt32(value) {
@@ -43,7 +43,7 @@ function isInt32(value) {
 }
 
 /**
- * @param {number} value
+ * @param {*} value
  * @returns {boolean}
  */
 function isUint32(value) {

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -35,7 +35,6 @@ const {
 const { signals } = internalBinding('constants').os;
 
 /**
- * @callback isInt32
  * @param {number} value
  * @returns {boolean}
  */
@@ -44,7 +43,6 @@ function isInt32(value) {
 }
 
 /**
- * @callback isUint32
  * @param {number} value
  * @returns {boolean}
  */
@@ -179,7 +177,7 @@ function validateNumber(value, name, min = undefined, max) {
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
 
   if ((min != null && value < min) || (max != null && value > max) ||
-    ((min != null || max != null) && NumberIsNaN(value))) {
+      ((min != null || max != null) && NumberIsNaN(value))) {
     throw new ERR_OUT_OF_RANGE(
       name,
       `${min != null ? `>= ${min}` : ''}${min != null && max != null ? ' && ' : ''}${max != null ? `<= ${max}` : ''}`,
@@ -230,7 +228,11 @@ function getOwnPropertyValueOrDefault(options, key, defaultValue) {
  * @callback validateObject
  * @param {*} value
  * @param {string} name
- * @param {{allowArray: boolean=, allowFunction: boolean=, nullable: boolean=}} [options]
+ * @param {{
+ *   allowArray?: boolean,
+ *   allowFunction?: boolean,
+ *   nullable?: boolean
+ * }} [options]
  */
 
 /** @type {validateObject} */
@@ -240,10 +242,10 @@ const validateObject = hideStackFrames(
     const allowFunction = getOwnPropertyValueOrDefault(options, 'allowFunction', false);
     const nullable = getOwnPropertyValueOrDefault(options, 'nullable', false);
     if ((!nullable && value === null) ||
-      (!allowArray && ArrayIsArray(value)) ||
-      (typeof value !== 'object' && (
-        !allowFunction || typeof value !== 'function'
-      ))) {
+        (!allowArray && ArrayIsArray(value)) ||
+        (typeof value !== 'object' && (
+          !allowFunction || typeof value !== 'function'
+        ))) {
       throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
     }
   });
@@ -253,7 +255,7 @@ const validateObject = hideStackFrames(
  * @param {*} value
  * @param {string} name
  * @param {number} [minLength]
- * @returns {asserts value is unknown[]}
+ * @returns {asserts value is any[]}
  */
 
 /** @type {validateArray} */
@@ -270,24 +272,23 @@ const validateArray = hideStackFrames((value, name, minLength = 0) => {
 });
 
 /**
- * @callback validateSignalName
  * @param {*} signal
  * @param {string} name
  * @returns {asserts signal is keyof signals}
  */
-
-/** @type {validateSignalName} */
 function validateSignalName(signal, name = 'signal') {
   validateString(signal, name);
 
   if (signals[signal] === undefined) {
     if (signals[StringPrototypeToUpperCase(signal)] !== undefined) {
       throw new ERR_UNKNOWN_SIGNAL(signal +
-        ' (signals must use all capital letters)');
+                                   ' (signals must use all capital letters)');
     }
 
     throw new ERR_UNKNOWN_SIGNAL(signal);
   }
+
+  return true;
 }
 
 /**
@@ -299,29 +300,28 @@ function validateSignalName(signal, name = 'signal') {
 /** @type {validateBuffer} */
 const validateBuffer = hideStackFrames((buffer, name = 'buffer') => {
   if (!isArrayBufferView(buffer)) {
-    throw new ERR_INVALID_ARG_TYPE(name, ['Buffer', 'TypedArray', 'DataView'], buffer);
+    throw new ERR_INVALID_ARG_TYPE(name,
+                                   ['Buffer', 'TypedArray', 'DataView'],
+                                   buffer);
   }
 });
 
 /**
- * @callback validateEncoding
  * @param {string} data
  * @param {string} encoding
  */
-
-/** @type {validateEncoding} */
 function validateEncoding(data, encoding) {
   const normalizedEncoding = normalizeEncoding(encoding);
   const length = data.length;
 
   if (normalizedEncoding === 'hex' && length % 2 !== 0) {
-    throw new ERR_INVALID_ARG_VALUE('encoding', encoding, `is invalid for data of length ${length}`);
+    throw new ERR_INVALID_ARG_VALUE('encoding', encoding,
+                                    `is invalid for data of length ${length}`);
   }
 }
 
 /**
- * @callback validatePort
- * @description Check that the port number is not NaN when coerced to a number,
+ * Check that the port number is not NaN when coerced to a number,
  * is an integer and that it falls within the legal range of port numbers.
  * @param {*} port
  * @param {string} [name='Port']
@@ -330,10 +330,10 @@ function validateEncoding(data, encoding) {
  */
 function validatePort(port, name = 'Port', allowZero = true) {
   if ((typeof port !== 'number' && typeof port !== 'string') ||
-    (typeof port === 'string' && StringPrototypeTrim(port).length === 0) ||
-    +port !== (+port >>> 0) ||
-    port > 0xFFFF ||
-    (port === 0 && !allowZero)) {
+      (typeof port === 'string' && StringPrototypeTrim(port).length === 0) ||
+      +port !== (+port >>> 0) ||
+      port > 0xFFFF ||
+      (port === 0 && !allowZero)) {
     throw new ERR_SOCKET_BAD_PORT(name, port, allowZero);
   }
   return port | 0;
@@ -341,14 +341,16 @@ function validatePort(port, name = 'Port', allowZero = true) {
 
 /**
  * @callback validateAbortSignal
- * @param {string} signal
+ * @param {string=} signal
  * @param {string} name
  */
+
+/** @type {validateAbortSignal} */
 const validateAbortSignal = hideStackFrames((signal, name) => {
   if (signal !== undefined &&
-    (signal === null ||
-      typeof signal !== 'object' ||
-      !('aborted' in signal))) {
+      (signal === null ||
+       typeof signal !== 'object' ||
+       !('aborted' in signal))) {
     throw new ERR_INVALID_ARG_TYPE(name, 'AbortSignal', signal);
   }
 });
@@ -393,14 +395,11 @@ const validateUndefined = hideStackFrames((value, name) => {
 });
 
 /**
- * @callback validateUnion
  * @template T
  * @param {T} value
  * @param {string} name
  * @param {T[]} union
  */
-
-/** @type {validateUnion} */
 function validateUnion(value, name, union) {
   if (!ArrayPrototypeIncludes(union, value)) {
     throw new ERR_INVALID_ARG_TYPE(name, `('${ArrayPrototypeJoin(union, '|')}')`, value);

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -128,8 +128,7 @@ const validateInt32 = hideStackFrames(
  * @callback validateUint32
  * @param {*} value
  * @param {string} name
- * @param {number} [min]
- * @param {number} [max]
+ * @param {number|boolean} [positive=false]
  * @returns {asserts value is number}
  */
 

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -71,7 +71,12 @@ function parseFileMode(value, name, def) {
 }
 
 /**
- * @type {(function(unknown, string, number=, number=): void)}
+ * @function validateInteger
+ * @param {*} value
+ * @param {string} name
+ * @param {number} [min]
+ * @param {number} [max]
+ * @returns {asserts value is number}
  */
 const validateInteger = hideStackFrames(
   (value, name, min = NumberMIN_SAFE_INTEGER, max = NumberMAX_SAFE_INTEGER) => {
@@ -85,7 +90,12 @@ const validateInteger = hideStackFrames(
 );
 
 /**
- * @type {(function(unknown, string, number=, number=): void)}
+ * @function validateInt32
+ * @param {*} value
+ * @param {string} name
+ * @param {number} [min]
+ * @param {number} [max]
+ * @returns {asserts value is number}
  */
 const validateInt32 = hideStackFrames(
   (value, name, min = -2147483648, max = 2147483647) => {
@@ -103,7 +113,12 @@ const validateInt32 = hideStackFrames(
 );
 
 /**
- * @type {(function(unknown, string, boolean=): void)}
+ * @function validateUint32
+ * @param {*} value
+ * @param {string} name
+ * @param {number} [min]
+ * @param {number} [max]
+ * @returns {asserts value is number}
  */
 const validateUint32 = hideStackFrames((value, name, positive = false) => {
   if (typeof value !== 'number') {
@@ -120,11 +135,25 @@ const validateUint32 = hideStackFrames((value, name, positive = false) => {
   }
 });
 
+/**
+ * @function validateString
+ * @param {*} value
+ * @param {string} name
+ * @returns {asserts value is string}
+ */
 function validateString(value, name) {
   if (typeof value !== 'string')
     throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
 }
 
+/**
+ * @function validateNumber
+ * @param {*} value
+ * @param {string} name
+ * @param {number} [min]
+ * @param {number} [max]
+ * @returns {asserts value is number}
+ */
 function validateNumber(value, name, min = undefined, max) {
   if (typeof value !== 'number')
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
@@ -139,7 +168,11 @@ function validateNumber(value, name, min = undefined, max) {
 }
 
 /**
- * @type {(function(unknown, string, unknown[]): void)}
+ * @function validateOneOf
+ * @template T
+ * @param {T} value
+ * @param {string} name
+ * @param {T[]} oneOf
  */
 const validateOneOf = hideStackFrames((value, name, oneOf) => {
   if (!ArrayPrototypeIncludes(oneOf, value)) {
@@ -152,6 +185,12 @@ const validateOneOf = hideStackFrames((value, name, oneOf) => {
   }
 });
 
+/**
+ * @function validateBoolean
+ * @param {*} value
+ * @param {string} name
+ * @returns {asserts value is boolean}
+ */
 function validateBoolean(value, name) {
   if (typeof value !== 'boolean')
     throw new ERR_INVALID_ARG_TYPE(name, 'boolean', value);
@@ -164,11 +203,10 @@ function getOwnPropertyValueOrDefault(options, key, defaultValue) {
 }
 
 /**
- * @type {(function(unknown, string, {
- *   allowArray?: boolean,
- *   allowFunction?: boolean,
- *   nullable?: boolean
- * }): void)}
+ * @function validateObject
+ * @param {*} value
+ * @param {string} name
+ * @param {{allowArray: boolean=, allowFunction: boolean=, nullable: boolean=}} [options]
  */
 const validateObject = hideStackFrames(
   (value, name, options) => {
@@ -185,7 +223,11 @@ const validateObject = hideStackFrames(
   });
 
 /**
- * @type {(function(unknown, string, number=): void)}
+ * @function validateArray
+ * @param {*} value
+ * @param {string} name
+ * @param {number} [minLength]
+ * @returns {asserts value is unknown[]}
  */
 const validateArray = hideStackFrames((value, name, minLength = 0) => {
   if (!ArrayIsArray(value)) {
@@ -197,6 +239,12 @@ const validateArray = hideStackFrames((value, name, minLength = 0) => {
   }
 });
 
+/**
+ * @function validateSignalName
+ * @param {*} signal
+ * @param {string} name
+ * @returns {asserts signal is keyof signals}
+ */
 function validateSignalName(signal, name = 'signal') {
   validateString(signal, name);
 
@@ -211,7 +259,9 @@ function validateSignalName(signal, name = 'signal') {
 }
 
 /**
- * @type {(function(unknown, string=): void)}
+ * @function validateBuffer
+ * @param {*} buffer
+ * @param {string} [name='buffer']
  */
 const validateBuffer = hideStackFrames((buffer, name = 'buffer') => {
   if (!isArrayBufferView(buffer)) {
@@ -221,6 +271,11 @@ const validateBuffer = hideStackFrames((buffer, name = 'buffer') => {
   }
 });
 
+/**
+ * @function validateEncoding
+ * @param {string} data
+ * @param {string} encoding
+ */
 function validateEncoding(data, encoding) {
   const normalizedEncoding = normalizeEncoding(encoding);
   const length = data.length;
@@ -245,7 +300,9 @@ function validatePort(port, name = 'Port', allowZero = true) {
 }
 
 /**
- * @type {(function(unknown, string): void)}
+ * @function validateAbortSignal
+ * @param {string} signal
+ * @param {string} name
  */
 const validateAbortSignal = hideStackFrames((signal, name) => {
   if (signal !== undefined &&
@@ -257,7 +314,10 @@ const validateAbortSignal = hideStackFrames((signal, name) => {
 });
 
 /**
- * @type {(function(unknown, string): void)}
+ * @function validateFunction
+ * @param {*} value
+ * @param {string} name
+ * @returns {asserts value is Function}
  */
 const validateFunction = hideStackFrames((value, name) => {
   if (typeof value !== 'function')
@@ -265,7 +325,10 @@ const validateFunction = hideStackFrames((value, name) => {
 });
 
 /**
- * @type {(function(unknown, string): void)}
+ * @function validatePlainFunction
+ * @param {*} value
+ * @param {string} name
+ * @returns {asserts value is Function}
  */
 const validatePlainFunction = hideStackFrames((value, name) => {
   if (typeof value !== 'function' || isAsyncFunction(value))
@@ -273,13 +336,23 @@ const validatePlainFunction = hideStackFrames((value, name) => {
 });
 
 /**
- * @type {(function(unknown, string): void)}
+ * @function validateUndefined
+ * @param {*} value
+ * @param {string} name
+ * @returns {asserts value is undefined}
  */
 const validateUndefined = hideStackFrames((value, name) => {
   if (value !== undefined)
     throw new ERR_INVALID_ARG_TYPE(name, 'undefined', value);
 });
 
+/**
+ * @function validateUnion
+ * @template T
+ * @param {T} value
+ * @param {string} name
+ * @param {T[]} union
+ */
 function validateUnion(value, name, union) {
   if (!ArrayPrototypeIncludes(union, value)) {
     throw new ERR_INVALID_ARG_TYPE(name, `('${ArrayPrototypeJoin(union, '|')}')`, value);

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -291,6 +291,7 @@ function validateSignalName(signal, name = 'signal') {
  * @callback validateBuffer
  * @param {*} buffer
  * @param {string} [name='buffer']
+ * @returns {asserts buffer is ArrayBufferView}
  */
 
 /** @type {validateBuffer} */


### PR DESCRIPTION
This is a draft pull request to improve the developer experience by fixing internal function's JSDoc declarations. I wanted to receive some feedback before investing time on this.

Previously, all functions that uses hideStackFrames was invalidly typed and was shown as a warning in IDEs (On WebStorm and Sublime).

I wanted to introduce `T is boolean` kind of type guards into the functions but could not find a solution for functions that does not return any boolean, but throws an error. 