### PR TITLE
test: use mustSucceed instead of mustCall with assert.ifError

### DIFF
--- a/test/sequential/test-inspector-open.js
+++ b/test/sequential/test-inspector-open.js
@@ -32,13 +32,12 @@ let firstPort;
 function firstOpen(msg) {
   assert.strictEqual(msg.cmd, 'url');
   const port = url.parse(msg.url).port;
-  ping(port, (err) => {
-    assert.ifError(err);
+  ping(port, common.mustSucceed(() => {
     // Inspector is already open, and won't be reopened, so args don't matter.
     child.send({ cmd: 'open', args: [kOpenWhileOpen] });
     child.once('message', common.mustCall(tryToOpenWhenOpen));
     firstPort = port;
-  });
+  }));
 }
 
 function tryToOpenWhenOpen(msg) {
@@ -46,11 +45,10 @@ function tryToOpenWhenOpen(msg) {
   const port = url.parse(msg.url).port;
   // Reopen didn't do anything, the port was already open, and has not changed.
   assert.strictEqual(port, firstPort);
-  ping(port, (err) => {
-    assert.ifError(err);
+  ping(port, common.mustSucceed(() => {
     child.send({ cmd: 'close' });
     child.once('message', common.mustCall(closeWhenOpen));
-  });
+  }));
 }
 
 function closeWhenOpen(msg) {
@@ -73,10 +71,9 @@ function tryToCloseWhenClosed(msg) {
 function reopenAfterClose(msg) {
   assert.strictEqual(msg.cmd, 'url');
   const port = url.parse(msg.url).port;
-  ping(port, (err) => {
-    assert.ifError(err);
+  ping(port, common.mustSucceed(() => {
     process.exit();
-  });
+  }));
 }
 
 function ping(port, callback) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Use mustSucceed instead of mustCall + ifError.