### PR TITLE
src: remove usages on ScriptCompiler::CompileFunctionInContext

### DIFF
--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -243,9 +243,9 @@ MaybeLocal<Function> BuiltinLoader::LookupAndCompileInternal(
   ScriptCompiler::CachedData* cached_data = nullptr;
   {
     // Note: The lock here should not extend into the
-    // `CompileFunctionInContext()` call below, because this function may
-    // recurse if there is a syntax error during bootstrap (because the fatal
-    // exception handler is invoked, which may load built-in modules).
+    // `CompileFunction()` call below, because this function may recurse if
+    // there is a syntax error during bootstrap (because the fatal exception
+    // handler is invoked, which may load built-in modules).
     Mutex::ScopedLock lock(code_cache_mutex_);
     auto cache_it = code_cache_.find(id);
     if (cache_it != code_cache_.end()) {
@@ -267,20 +267,20 @@ MaybeLocal<Function> BuiltinLoader::LookupAndCompileInternal(
                      has_cache ? "with" : "without");
 
   MaybeLocal<Function> maybe_fun =
-      ScriptCompiler::CompileFunctionInContext(context,
-                                               &script_source,
-                                               parameters->size(),
-                                               parameters->data(),
-                                               0,
-                                               nullptr,
-                                               options);
+      ScriptCompiler::CompileFunction(context,
+                                      &script_source,
+                                      parameters->size(),
+                                      parameters->data(),
+                                      0,
+                                      nullptr,
+                                      options);
 
   // This could fail when there are early errors in the built-in modules,
   // e.g. the syntax errors
   Local<Function> fun;
   if (!maybe_fun.ToLocal(&fun)) {
     // In the case of early errors, v8 is already capable of
-    // decorating the stack for us - note that we use CompileFunctionInContext
+    // decorating the stack for us - note that we use CompileFunction
     // so there is no need to worry about wrappers.
     return MaybeLocal<Function>();
   }

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -174,14 +174,14 @@ class CompiledFnEntry final : public BaseObject {
   CompiledFnEntry(Environment* env,
                   v8::Local<v8::Object> object,
                   uint32_t id,
-                  v8::Local<v8::ScriptOrModule> script);
+                  v8::Local<v8::Function> fn);
   ~CompiledFnEntry();
 
   bool IsNotIndicativeOfMemoryLeakAtExit() const override { return true; }
 
  private:
   uint32_t id_;
-  v8::Global<v8::ScriptOrModule> script_;
+  v8::Global<v8::Function> fn_;
 
   static void WeakCallback(const v8::WeakCallbackInfo<CompiledFnEntry>& data);
 };

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1329,13 +1329,13 @@ void CompileSerializeMain(const FunctionCallbackInfo<Value>& args) {
   };
   ScriptCompiler::Source script_source(source, origin);
   Local<Function> fn;
-  if (ScriptCompiler::CompileFunctionInContext(context,
-                                               &script_source,
-                                               parameters.size(),
-                                               parameters.data(),
-                                               0,
-                                               nullptr,
-                                               ScriptCompiler::kEagerCompile)
+  if (ScriptCompiler::CompileFunction(context,
+                                      &script_source,
+                                      parameters.size(),
+                                      parameters.data(),
+                                      0,
+                                      nullptr,
+                                      ScriptCompiler::kEagerCompile)
           .ToLocal(&fn)) {
     args.GetReturnValue().Set(fn);
   }


### PR DESCRIPTION
V8 APIs like HostImportModuleDynamicallyCallback and
ScriptCompiler::CompileFunction are moving away from ScriptOrModule.

Replaces ScriptCompiler::CompileFunctionInContext with
ScriptCompiler::CompileFunction to remove the usages on the optional
out param ScriptOrModule.

Fixes: https://github.com/nodejs/node-v8/issues/214