### PR TITLE
doc: fix typo in diagnostics_channel

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -226,7 +226,7 @@ added:
 -->
 
 The class `Channel` represents an individual named channel within the data
-pipeline. It is use to track subscribers and to publish messages when there
+pipeline. It is used to track subscribers and to publish messages when there
 are subscribers present. It exists as a separate object to avoid channel
 lookups at publish time, enabling very fast publish speeds and allowing
 for heavy use while incurring very minimal cost. Channels are created with


### PR DESCRIPTION
The diagnostic_channel Channel class description had
a typo.
