### PR TITLE
cluster: fix cluster rr distribute error when `accept` fails.

### DIFF
--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -98,6 +98,10 @@ RoundRobinHandle.prototype.remove = function(worker) {
 };
 
 RoundRobinHandle.prototype.distribute = function(err, handle) {
+  // If `accept` fails just skip it (handle is undefined)
+  if (err) {
+    return;
+  }
   append(this.handles, handle);
   // eslint-disable-next-line node-core/no-array-destructuring
   const [ workerEntry ] = this.free; // this.free is a SafeMap

--- a/test/parallel/test-cluster-accept-fail.js
+++ b/test/parallel/test-cluster-accept-fail.js
@@ -1,0 +1,30 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const cluster = require('cluster');
+const rr = require('internal/cluster/round_robin_handle');
+
+if (cluster.isPrimary) {
+  const distribute = rr.prototype.distribute;
+  rr.prototype.distribute = function(err, handle) {
+    assert.strictEqual(err, 0);
+    handle.close();
+    distribute.call(this, -1, undefined);
+  };
+  cluster.schedulingPolicy = cluster.SCHED_RR;
+  cluster.fork();
+} else {
+  const server = net.createServer(common.mustNotCall());
+  server.listen(0, common.mustCall(() => {
+
+    const socket = net.connect(server.address().port);
+
+    socket.on('close', common.mustCall(() => {
+      server.close(common.mustCall(() => {
+        process.disconnect();
+      }));
+    }));
+  }));
+}


### PR DESCRIPTION
 fix cluster rr distribute error when `accept` fails.

```
node:internal/linkedlist:31
  if (item._idleNext || item._idlePrev) {
           ^

TypeError: Cannot read properties of undefined (reading '_idleNext')
    at append (node:internal/linkedlist:31:12)
    at RoundRobinHandle.distribute (node:internal/cluster/round_robin_handle:105:3)
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
