### PR TITLE
bootstrap: fixup Error.stackTraceLimit for user-land snapshot

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -191,6 +191,12 @@ function lazyBuffer() {
 }
 
 function isErrorStackTraceLimitWritable() {
+  // Do no touch Error.stackTraceLimit as V8 would attempt to install
+  // it again during deserialization.
+  if (require('v8').startupSnapshot.isBuildingSnapshot()) {
+    return false;
+  }
+
   const desc = ObjectGetOwnPropertyDescriptor(Error, 'stackTraceLimit');
   if (desc === undefined) {
     return ObjectIsExtensible(Error);

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -3,7 +3,10 @@
 const {
   Error,
   SafeSet,
-  SafeArrayIterator
+  SafeArrayIterator,
+  ObjectPrototypeHasOwnProperty,
+  ObjectGetOwnPropertyDescriptor,
+  ObjectDefineProperty
 } = primordials;
 
 const binding = internalBinding('mksnapshot');
@@ -125,7 +128,21 @@ function main() {
   const source = readFileSync(file, 'utf-8');
   const serializeMainFunction = compileSerializeMain(filename, source);
 
-  require('internal/v8/startup_snapshot').initializeCallbacks();
+  const {
+    initializeCallbacks,
+    namespace: {
+      addSerializeCallback,
+      addDeserializeCallback,
+    },
+  } = require('internal/v8/startup_snapshot');
+  initializeCallbacks();
+
+  let stackTraceLimitDesc;
+  addDeserializeCallback(() => {
+    if (stackTraceLimitDesc !== undefined) {
+      ObjectDefineProperty(Error, 'stackTraceLimit', stackTraceLimitDesc);
+    }
+  });
 
   if (getOptionValue('--inspect-brk')) {
     internalBinding('inspector').callAndPauseOnStart(
@@ -134,6 +151,16 @@ function main() {
   } else {
     serializeMainFunction(requireForUserSnapshot, filename, dirname);
   }
+
+  addSerializeCallback(() => {
+    if (ObjectPrototypeHasOwnProperty(Error, 'stackTraceLimit')) {
+      stackTraceLimitDesc =
+          ObjectGetOwnPropertyDescriptor(Error, 'stackTraceLimit');
+      process._rawDebug('Deleting Error.stackTraceLimit from the snapshot. ' +
+                        'It will be re-installed after deserialization');
+      delete Error.stackTraceLimit;
+    }
+  });
 }
 
 main();

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -153,9 +153,10 @@ function main() {
   }
 
   addSerializeCallback(() => {
-    if (ObjectPrototypeHasOwnProperty(Error, 'stackTraceLimit')) {
-      stackTraceLimitDesc =
-          ObjectGetOwnPropertyDescriptor(Error, 'stackTraceLimit');
+    stackTraceLimitDesc = ObjectGetOwnPropertyDescriptor(Error, 'stackTraceLimit');
+
+    if (stackTraceLimitDesc !== undefined) {
+      ObjectSetPrototypeOf(stackTraceLimitDesc, null);
       process._rawDebug('Deleting Error.stackTraceLimit from the snapshot. ' +
                         'It will be re-installed after deserialization');
       delete Error.stackTraceLimit;

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -2,11 +2,11 @@
 
 const {
   Error,
-  SafeSet,
-  SafeArrayIterator,
-  ObjectGetOwnPropertyDescriptor,
   ObjectDefineProperty,
-  ObjectSetPrototypeOf
+  ObjectGetOwnPropertyDescriptor,
+  ObjectSetPrototypeOf,
+  SafeArrayIterator,
+  SafeSet,
 } = primordials;
 
 const binding = internalBinding('mksnapshot');
@@ -156,6 +156,8 @@ function main() {
     stackTraceLimitDesc = ObjectGetOwnPropertyDescriptor(Error, 'stackTraceLimit');
 
     if (stackTraceLimitDesc !== undefined) {
+      // We want to use null-prototype objects to not rely on globally mutable
+      // %Object.prototype%.
       ObjectSetPrototypeOf(stackTraceLimitDesc, null);
       process._rawDebug('Deleting Error.stackTraceLimit from the snapshot. ' +
                         'It will be re-installed after deserialization');

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -4,9 +4,9 @@ const {
   Error,
   SafeSet,
   SafeArrayIterator,
-  ObjectPrototypeHasOwnProperty,
   ObjectGetOwnPropertyDescriptor,
-  ObjectDefineProperty
+  ObjectDefineProperty,
+  ObjectSetPrototypeOf
 } = primordials;
 
 const binding = internalBinding('mksnapshot');

--- a/lib/internal/v8/startup_snapshot.js
+++ b/lib/internal/v8/startup_snapshot.js
@@ -54,8 +54,6 @@ function runSerializeCallbacks() {
     const { 0: callback, 1: data } = serializeCallbacks.shift();
     callback(data);
   }
-  // Remove the hooks from the snapshot.
-  require('v8').startupSnapshot = undefined;
 }
 
 function addSerializeCallback(callback, data) {

--- a/test/parallel/test-snapshot-api.js
+++ b/test/parallel/test-snapshot-api.js
@@ -10,6 +10,12 @@ const fixtures = require('../common/fixtures');
 const path = require('path');
 const fs = require('fs');
 
+const v8 = require('v8');
+
+// By default it should be false. We'll test that it's true in snapshot
+// building mode in the fixture.
+assert(!v8.startupSnapshot.isBuildingSnapshot());
+
 tmpdir.refresh();
 const blobPath = path.join(tmpdir.path, 'snapshot.blob');
 const entry = fixtures.path('snapshot', 'v8-startup-snapshot-api.js');

--- a/test/parallel/test-snapshot-typescript.js
+++ b/test/parallel/test-snapshot-typescript.js
@@ -2,12 +2,7 @@
 
 // This tests the TypeScript compiler in the snapshot.
 
-const common = require('../common');
-
-if (process.features.debug) {
-  common.skip('V8 snapshot does not work with mutated globals yet: ' +
-              'https://bugs.chromium.org/p/v8/issues/detail?id=12772');
-}
+require('../common');
 
 const assert = require('assert');
 const { spawnSync } = require('child_process');

--- a/test/parallel/test-snapshot-warning.js
+++ b/test/parallel/test-snapshot-warning.js
@@ -4,12 +4,7 @@
 // during snapshot serialization and installed again during
 // deserialization.
 
-const common = require('../common');
-
-if (process.features.debug) {
-  common.skip('V8 snapshot does not work with mutated globals yet: ' +
-              'https://bugs.chromium.org/p/v8/issues/detail?id=12772');
-}
+require('../common');
 
 const assert = require('assert');
 const { spawnSync } = require('child_process');


### PR DESCRIPTION
It's difficult for V8 to handle Error.stackTraceLimit in the snapshot,
so delete it from the Error constructor if it's present before
snapshot serialization, and re-install it after deserialization.
In addition try not to touch it from our internals during snapshot
building in the first place by updating
isErrorStackTraceLimitWritable().

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
