### PR TITLE
net: remove unused callback

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1034,7 +1034,7 @@ function internalConnect(
     req.address = address;
     req.oncomplete = afterConnect;
 
-    err = self._handle.connect(req, address, afterConnect);
+    err = self._handle.connect(req, address);
   }
 
   if (err) {


### PR DESCRIPTION
 remove unused callback, see `PipeWrap::Connect` in `pipe_wrap.cc`.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
