### PR TITLE
report: skip report if uncaught exception is handled

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1145,8 +1145,8 @@ changes:
                  `--report-uncaught-exception`.
 -->
 
-Enables report to be generated when the process is exiting for uncaught
-exceptions. Useful when inspecting the JavaScript stack in conjunction with
+Enables report to be generated when the process exits due to an uncaught
+exception. Useful when inspecting the JavaScript stack in conjunction with
 native stack and other runtime environment data.
 
 ### `--secure-heap=n`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1131,6 +1131,9 @@ Default signal is `SIGUSR2`.
 <!-- YAML
 added: v11.8.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/44208
+    description: Report is not generated if the uncaught exception is handled.
   - version:
      - v13.12.0
      - v12.17.0
@@ -1142,9 +1145,9 @@ changes:
                  `--report-uncaught-exception`.
 -->
 
-Enables report to be generated on uncaught exceptions. Useful when inspecting
-the JavaScript stack in conjunction with native stack and other runtime
-environment data.
+Enables report to be generated when the process is exiting for uncaught
+exceptions. Useful when inspecting the JavaScript stack in conjunction with
+native stack and other runtime environment data.
 
 ### `--secure-heap=n`
 

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -151,27 +151,6 @@ function createOnGlobalUncaughtException() {
     // call that threw and was never cleared. So clear it now.
     clearDefaultTriggerAsyncId();
 
-    // If diagnostic reporting is enabled, call into its handler to see
-    // whether it is interested in handling the situation.
-    // Ignore if the error is scoped inside a domain.
-    // use == in the checks as we want to allow for null and undefined
-    if (er == null || er.domain == null) {
-      try {
-        const report = internalBinding('report');
-        if (report != null && report.shouldReportOnUncaughtException()) {
-          report.writeReport(
-            typeof er?.message === 'string' ?
-              er.message :
-              'Exception',
-            'Exception',
-            null,
-            er ?? {});
-        }
-      } catch {
-        // Ignore the exception. Diagnostic reporting is unavailable.
-      }
-    }
-
     const type = fromPromise ? 'unhandledRejection' : 'uncaughtException';
     process.emit('uncaughtExceptionMonitor', er, type);
     if (exceptionHandlerState.captureFn !== null) {

--- a/test/report/test-report-uncaught-exception-compat.js
+++ b/test/report/test-report-uncaught-exception-compat.js
@@ -1,5 +1,33 @@
-// Flags: --experimental-report --report-uncaught-exception --report-compact
 'use strict';
-// Test producing a compact report on uncaught exception.
-require('../common');
-require('./test-report-uncaught-exception.js');
+// Test producing a report on uncaught exception.
+const common = require('../common');
+const assert = require('assert');
+const childProcess = require('child_process');
+const helper = require('../common/report');
+const tmpdir = require('../common/tmpdir');
+
+if (process.argv[2] === 'child') {
+  process.report.directory = process.argv[3];
+
+  throw new Error('test error');
+}
+
+tmpdir.refresh();
+const child = childProcess.spawn(process.execPath, [
+  '--report-uncaught-exception',
+  '--report-compact',
+  __filename,
+  'child',
+  tmpdir.path,
+]);
+child.on('exit', common.mustCall((code) => {
+  assert.strictEqual(code, 1);
+  const reports = helper.findReports(child.pid, tmpdir.path);
+  assert.strictEqual(reports.length, 1);
+
+  helper.validate(reports[0], [
+    ['header.event', 'Exception'],
+    ['header.trigger', 'Exception'],
+    ['javascriptStack.message', 'Error: test error'],
+  ]);
+}));

--- a/test/report/test-report-uncaught-exception-compat.js
+++ b/test/report/test-report-uncaught-exception-compat.js
@@ -7,8 +7,6 @@ const helper = require('../common/report');
 const tmpdir = require('../common/tmpdir');
 
 if (process.argv[2] === 'child') {
-  process.report.directory = process.argv[3];
-
   throw new Error('test error');
 }
 
@@ -18,8 +16,9 @@ const child = childProcess.spawn(process.execPath, [
   '--report-compact',
   __filename,
   'child',
-  tmpdir.path,
-]);
+], {
+  cwd: tmpdir.path
+});
 child.on('exit', common.mustCall((code) => {
   assert.strictEqual(code, 1);
   const reports = helper.findReports(child.pid, tmpdir.path);

--- a/test/report/test-report-uncaught-exception-handled.js
+++ b/test/report/test-report-uncaught-exception-handled.js
@@ -10,9 +10,8 @@ const error = new Error('test error');
 tmpdir.refresh();
 process.report.directory = tmpdir.path;
 
-// First, install an uncaught exception hook.
-process.setUncaughtExceptionCaptureCallback(common.mustCall());
-// Do not install process uncaughtException handler.
+// Make sure the uncaughtException listener is called.
+process.on('uncaughtException', common.mustCall());
 
 process.on('exit', (code) => {
   assert.strictEqual(code, 0);

--- a/test/report/test-report-uncaught-exception-primitives.js
+++ b/test/report/test-report-uncaught-exception-primitives.js
@@ -1,25 +1,33 @@
-// Flags: --report-uncaught-exception
 'use strict';
 // Test producing a report on uncaught exception.
 const common = require('../common');
 const assert = require('assert');
+const childProcess = require('child_process');
 const helper = require('../common/report');
 const tmpdir = require('../common/tmpdir');
 
-const exception = 1;
+if (process.argv[2] === 'child') {
+  process.report.directory = process.argv[3];
+
+  // eslint-disable-next-line no-throw-literal
+  throw 1;
+}
 
 tmpdir.refresh();
-process.report.directory = tmpdir.path;
-
-process.on('uncaughtException', common.mustCall((err) => {
-  assert.strictEqual(err, exception);
-  const reports = helper.findReports(process.pid, tmpdir.path);
+const child = childProcess.spawn(process.execPath, [
+  '--report-uncaught-exception',
+  __filename,
+  'child',
+  tmpdir.path,
+]);
+child.on('exit', common.mustCall((code) => {
+  assert.strictEqual(code, 1);
+  const reports = helper.findReports(child.pid, tmpdir.path);
   assert.strictEqual(reports.length, 1);
 
   helper.validate(reports[0], [
     ['header.event', 'Exception'],
-    ['javascriptStack.message', `${exception}`],
+    ['header.trigger', 'Exception'],
+    ['javascriptStack.message', '1'],
   ]);
 }));
-
-throw exception;

--- a/test/report/test-report-uncaught-exception-primitives.js
+++ b/test/report/test-report-uncaught-exception-primitives.js
@@ -7,8 +7,6 @@ const helper = require('../common/report');
 const tmpdir = require('../common/tmpdir');
 
 if (process.argv[2] === 'child') {
-  process.report.directory = process.argv[3];
-
   // eslint-disable-next-line no-throw-literal
   throw 1;
 }
@@ -18,8 +16,9 @@ const child = childProcess.spawn(process.execPath, [
   '--report-uncaught-exception',
   __filename,
   'child',
-  tmpdir.path,
-]);
+], {
+  cwd: tmpdir.path,
+});
 child.on('exit', common.mustCall((code) => {
   assert.strictEqual(code, 1);
   const reports = helper.findReports(child.pid, tmpdir.path);

--- a/test/report/test-report-uncaught-exception-symbols.js
+++ b/test/report/test-report-uncaught-exception-symbols.js
@@ -7,8 +7,6 @@ const helper = require('../common/report');
 const tmpdir = require('../common/tmpdir');
 
 if (process.argv[2] === 'child') {
-  process.report.directory = process.argv[3];
-
   throw Symbol('foobar');
 }
 
@@ -17,8 +15,9 @@ const child = childProcess.spawn(process.execPath, [
   '--report-uncaught-exception',
   __filename,
   'child',
-  tmpdir.path,
-]);
+], {
+  cwd: tmpdir.path,
+});
 child.on('exit', common.mustCall((code) => {
   assert.strictEqual(code, 1);
   const reports = helper.findReports(child.pid, tmpdir.path);

--- a/test/report/test-report-uncaught-exception-symbols.js
+++ b/test/report/test-report-uncaught-exception-symbols.js
@@ -1,25 +1,32 @@
-// Flags: --report-uncaught-exception
 'use strict';
 // Test producing a report on uncaught exception.
 const common = require('../common');
 const assert = require('assert');
+const childProcess = require('child_process');
 const helper = require('../common/report');
 const tmpdir = require('../common/tmpdir');
 
-const exception = Symbol('foobar');
+if (process.argv[2] === 'child') {
+  process.report.directory = process.argv[3];
+
+  throw Symbol('foobar');
+}
 
 tmpdir.refresh();
-process.report.directory = tmpdir.path;
-
-process.on('uncaughtException', common.mustCall((err) => {
-  assert.strictEqual(err, exception);
-  const reports = helper.findReports(process.pid, tmpdir.path);
+const child = childProcess.spawn(process.execPath, [
+  '--report-uncaught-exception',
+  __filename,
+  'child',
+  tmpdir.path,
+]);
+child.on('exit', common.mustCall((code) => {
+  assert.strictEqual(code, 1);
+  const reports = helper.findReports(child.pid, tmpdir.path);
   assert.strictEqual(reports.length, 1);
 
   helper.validate(reports[0], [
     ['header.event', 'Exception'],
+    ['header.trigger', 'Exception'],
     ['javascriptStack.message', 'Symbol(foobar)'],
   ]);
 }));
-
-throw exception;

--- a/test/report/test-report-uncaught-exception.js
+++ b/test/report/test-report-uncaught-exception.js
@@ -7,8 +7,6 @@ const helper = require('../common/report');
 const tmpdir = require('../common/tmpdir');
 
 if (process.argv[2] === 'child') {
-  process.report.directory = process.argv[3];
-
   throw new Error('test error');
 }
 
@@ -17,8 +15,9 @@ const child = childProcess.spawn(process.execPath, [
   '--report-uncaught-exception',
   __filename,
   'child',
-  tmpdir.path,
-]);
+], {
+  cwd: tmpdir.path,
+});
 child.on('exit', common.mustCall((code) => {
   assert.strictEqual(code, 1);
   const reports = helper.findReports(child.pid, tmpdir.path);

--- a/test/report/test-report-uncaught-exception.js
+++ b/test/report/test-report-uncaught-exception.js
@@ -1,20 +1,32 @@
-// Flags: --report-uncaught-exception
 'use strict';
 // Test producing a report on uncaught exception.
 const common = require('../common');
 const assert = require('assert');
+const childProcess = require('child_process');
 const helper = require('../common/report');
 const tmpdir = require('../common/tmpdir');
-const error = new Error('test error');
+
+if (process.argv[2] === 'child') {
+  process.report.directory = process.argv[3];
+
+  throw new Error('test error');
+}
 
 tmpdir.refresh();
-process.report.directory = tmpdir.path;
-
-process.on('uncaughtException', common.mustCall((err) => {
-  assert.strictEqual(err, error);
-  const reports = helper.findReports(process.pid, tmpdir.path);
+const child = childProcess.spawn(process.execPath, [
+  '--report-uncaught-exception',
+  __filename,
+  'child',
+  tmpdir.path,
+]);
+child.on('exit', common.mustCall((code) => {
+  assert.strictEqual(code, 1);
+  const reports = helper.findReports(child.pid, tmpdir.path);
   assert.strictEqual(reports.length, 1);
-  helper.validate(reports[0]);
-}));
 
-throw error;
+  helper.validate(reports[0], [
+    ['header.event', 'Exception'],
+    ['header.trigger', 'Exception'],
+    ['javascriptStack.message', 'Error: test error'],
+  ]);
+}));


### PR DESCRIPTION
If the exception is handled by the userland
process#uncaughtException handler, reports should not be generated
repetitively as the process may continue to run.
