### PR TITLE
test: mark connection leak test flaky on IBM i

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -85,6 +85,7 @@ test-crypto-secure-heap: SKIP
 test-dgram-connect: PASS, FLAKY
 test-http-client-parse-error: PASS, FLAKY
 test-http-multi-line-headers: PASS, FLAKY
+test-http-pipeline-requests-connection-leak: PASS, FLAKY
 test-http-server-unconsume: PASS, FLAKY
 test-http-upgrade-advertise: PASS, FLAKY
 test-tls-client-mindhsize: PASS, FLAKY


### PR DESCRIPTION
Mark `test-http-pipeline-requests-connection-leak` flaky on IBM i.

Refs: https://github.com/nodejs/node/issues/43509
Refs: https://github.com/nodejs/node/issues/39683

---

There's an underlying issue on IBM i for which an OS patches (PTFs) are available but we've not been able to get them applied onto all of the IBM i machines we have in the CI.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
