### PR TITLE
doc: move policy docs to the permissions scope

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3577,7 +3577,7 @@ The native call from `process.cpuUsage` could not be processed.
 [domains]: domain.md
 [event emitter-based]: events.md#class-eventemitter
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
-[policy]: policy.md
+[policy]: permissions.md#policies
 [self-reference a package using its name]: packages.md#self-referencing-a-package-using-its-name
 [stream-based]: stream.md
 [syscall]: https://man7.org/linux/man-pages/man2/syscalls.2.html

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -45,7 +45,7 @@
 * [OS](os.md)
 * [Path](path.md)
 * [Performance hooks](perf_hooks.md)
-* [Policies](policy.md)
+* [Permissions](permissions.md)
 * [Process](process.md)
 * [Punycode](punycode.md)
 * [Query strings](querystring.md)

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -15,7 +15,7 @@ If you find a potential security vulnerability, please refer to our
 
 ## Module-based permissions
 
-## Policies
+### Policies
 
 <!--introduced_in=v11.8.0-->
 
@@ -39,7 +39,7 @@ by the running Node.js application in any way. A typical setup would be to
 create the policy file as a different user id than the one running Node.js
 and granting read permissions to the user id running Node.js.
 
-### Enabling
+#### Enabling
 
 <!-- type=misc -->
 
@@ -65,9 +65,9 @@ even if the file is changed on disk.
 node --experimental-policy=policy.json --policy-integrity="sha384-SggXRQHwCG8g+DktYYzxkXRIkTiEYWBHqev0xnpCxYlqMBufKZHAHQM3/boDaI/0" app.js
 ```
 
-### Features
+#### Features
 
-#### Error behavior
+##### Error behavior
 
 When a policy check fails, Node.js by default will throw an error.
 It is possible to change the error behavior to one of a few possibilities
@@ -91,7 +91,7 @@ available to change the behavior:
 }
 ```
 
-#### Integrity checks
+##### Integrity checks
 
 Policy files must use integrity checks with Subresource Integrity strings
 compatible with the browser
@@ -133,7 +133,7 @@ body for the resource which can be useful for local development. It is not
 recommended in production since it would allow unexpected alteration of
 resources to be considered valid.
 
-#### Dependency redirection
+##### Dependency redirection
 
 An application may need to ship patched versions of modules or to prevent
 modules from allowing all modules access to all other modules. Redirection
@@ -218,7 +218,7 @@ can be used to ensure some kinds of dynamic access are explicitly prevented.
 Unknown values for the resolved module location cause failures but are
 not guaranteed to be forward compatible.
 
-#### Example: Patched dependency
+##### Example: Patched dependency
 
 Redirected dependencies can provide attenuated or modified functionality as fits
 the application. For example, log data about timing of function durations by
@@ -238,7 +238,7 @@ module.exports = function fn(...args) {
 };
 ```
 
-### Scopes
+#### Scopes
 
 Use the `"scopes"` field of a manifest to set configuration for many resources
 at once. The `"scopes"` field works by matching resources by their segments.
@@ -259,7 +259,7 @@ origin of `blob:https://nodejs.org`; URLs starting with
 thus `https:` for its protocol scope. For opaque origin `blob:` URLs they will
 have `blob:` for their protocol scope since they do not adopt origins.
 
-#### Example
+##### Example
 
 ```json
 {
@@ -314,7 +314,7 @@ in the `"scopes"` of the policy.
 This determines the policy for all resources. It would not be used for
 `file:///C:/app/bin/main.js` unless `"file:"` is set to cascade.
 
-#### Integrity using scopes
+##### Integrity using scopes
 
 Setting an integrity to `true` on a scope will set the integrity for any
 resource not found in the manifest to `true`.
@@ -339,7 +339,7 @@ The following example allows loading any file:
 }
 ```
 
-#### Dependency redirection using scopes
+##### Dependency redirection using scopes
 
 The following example, would allow access to `fs` for all resources within
 `./app/`:
@@ -382,7 +382,7 @@ The following example, would allow access to `fs` for all `data:` resources:
 }
 ```
 
-#### Example: [import maps][] emulation
+##### Example: [import maps][] emulation
 
 Given an import map:
 

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -1,4 +1,28 @@
-# Policies
+# Permissions
+
+This section exposes security features available to be adopted in a
+Node.js application. The available scopes are:
+
+* [Resource-based permissions](#resource-based-permissions)
+* [Process-based permissions](#process-based-permissions)
+
+Resource-based permissions stands for the managment of modules using
+policies. A policy can guarantee which module/resource is available
+during the application execution.
+
+Process-based permissions stands for the management of resources such
+as _File System_ or _Network_. A permission can be configured to restrict
+access to specific resources, for instance, one can restrict access to
+all the _File System_ write.
+
+Both permissions can be used together to provide a safer environment.
+
+**Note**: if you find a potential security vulnerability on Node.js,
+refer to our [Security Policy][].
+
+## Resource-based permissions
+
+## Policies
 
 <!--introduced_in=v11.8.0-->
 
@@ -22,7 +46,7 @@ by the running Node.js application in any way. A typical setup would be to
 create the policy file as a different user id than the one running Node.js
 and granting read permissions to the user id running Node.js.
 
-## Enabling
+### Enabling
 
 <!-- type=misc -->
 
@@ -48,9 +72,9 @@ even if the file is changed on disk.
 node --experimental-policy=policy.json --policy-integrity="sha384-SggXRQHwCG8g+DktYYzxkXRIkTiEYWBHqev0xnpCxYlqMBufKZHAHQM3/boDaI/0" app.js
 ```
 
-## Features
+### Features
 
-### Error behavior
+#### Error behavior
 
 When a policy check fails, Node.js by default will throw an error.
 It is possible to change the error behavior to one of a few possibilities
@@ -74,7 +98,7 @@ available to change the behavior:
 }
 ```
 
-### Integrity checks
+#### Integrity checks
 
 Policy files must use integrity checks with Subresource Integrity strings
 compatible with the browser
@@ -116,7 +140,7 @@ body for the resource which can be useful for local development. It is not
 recommended in production since it would allow unexpected alteration of
 resources to be considered valid.
 
-### Dependency redirection
+#### Dependency redirection
 
 An application may need to ship patched versions of modules or to prevent
 modules from allowing all modules access to all other modules. Redirection
@@ -423,6 +447,9 @@ not adopt the origin of the `blob:` URL.
 Additionally, import maps only work on `import` so it may be desirable to add a
 `"import"` condition to all dependency mappings.
 
+## Process-based permissions
+
 [import maps]: https://url.spec.whatwg.org/#relative-url-with-fragment-string
 [relative-url string]: https://url.spec.whatwg.org/#relative-url-with-fragment-string
 [special schemes]: https://url.spec.whatwg.org/#special-scheme
+[Security Policy]: https://github.com/nodejs/node/blob/main/SECURITY.md

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -1,26 +1,19 @@
 # Permissions
 
-This section exposes security features available to be adopted in a
-Node.js application. The available scopes are:
+Permissions can be used to control what system resources the
+Node.js process has access to or what actions the process can take
+with those resources. Permissions can also control what modules can
+be accessed by other modules.
 
-* [Resource-based permissions](#resource-based-permissions)
-* [Process-based permissions](#process-based-permissions)
+* [Module-based permissions](#module-based-permissions) control which files
+  or URLs are available to other modules during application execution.
+  This can be used to control what modules can be accessed by third-party
+  dependencies, for example.
 
-Resource-based permissions stands for the managment of modules using
-policies. A policy can guarantee which module/resource is available
-during the application execution.
+If you find a potential security vulnerability, please refer to our
+[Security Policy][].
 
-Process-based permissions stands for the management of resources such
-as _File System_ or _Network_. A permission can be configured to restrict
-access to specific resources, for instance, one can restrict access to
-all the _File System_ write.
-
-Both permissions can be used together to provide a safer environment.
-
-**Note**: if you find a potential security vulnerability on Node.js,
-refer to our [Security Policy][].
-
-## Resource-based permissions
+## Module-based permissions
 
 ## Policies
 
@@ -447,9 +440,7 @@ not adopt the origin of the `blob:` URL.
 Additionally, import maps only work on `import` so it may be desirable to add a
 `"import"` condition to all dependency mappings.
 
-## Process-based permissions
-
+[Security Policy]: https://github.com/nodejs/node/blob/main/SECURITY.md
 [import maps]: https://url.spec.whatwg.org/#relative-url-with-fragment-string
 [relative-url string]: https://url.spec.whatwg.org/#relative-url-with-fragment-string
 [special schemes]: https://url.spec.whatwg.org/#special-scheme
-[Security Policy]: https://github.com/nodejs/node/blob/main/SECURITY.md

--- a/doc/api/policy.md
+++ b/doc/api/policy.md
@@ -1,0 +1,11 @@
+# Policies
+
+<!--introduced_in=v11.8.0-->
+
+<!-- type=misc -->
+
+> Stability: 1 - Experimental
+
+The former Policies documentation is now at [Permissions documentation][]
+
+[Permissions documentation]: permissions.md#policies

--- a/test/doctool/test-make-doc.mjs
+++ b/test/doctool/test-make-doc.mjs
@@ -45,6 +45,7 @@ const linkedHtmls = [...new Set(links)].map((link) => link.match(re)[1])
 const expectedJsons = linkedHtmls
                        .map((name) => name.replace('.html', '.json'));
 const expectedDocs = linkedHtmls.concat(expectedJsons);
+const renamedDocs = ['policy.json', 'policy.html'];
 
 // Test that all the relative links in the TOC match to the actual documents.
 for (const expectedDoc of expectedDocs) {
@@ -54,6 +55,11 @@ for (const expectedDoc of expectedDocs) {
 // Test that all the actual documents match to the relative links in the TOC
 // and that they are not empty files.
 for (const actualDoc of actualDocs) {
+  // When renaming the documentation, the old url is lost
+  // Unless the old file is still available pointing to the correct location
+  // 301 redirects are not yet automated. So keeping the old URL is a
+  // reasonable workaround.
+  if (renamedDocs.includes(actualDoc)) continue;
   assert.ok(
     expectedDocs.includes(actualDoc), `${actualDoc} does not match TOC`);
 


### PR DESCRIPTION
During the journey of the _Permission System_, we've felt the necessity to expand the `policy` documentation to include the permissions (#44004). The principal idea is to avoid confusion between `policy` and `permissions`.

**Note:** I've included the _Process-based permission_ just to simulate how it gonna work along with the _Permission System_. Once it's approved, I'll remove and keep just the _Resource-based permission_. 

Reference: https://github.com/nodejs/security-wg/issues/791#issuecomment-1212681390