### PR TITLE
lib,crypto: add optional cause to `DOMException`

### DIFF
--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -241,11 +241,10 @@ async function aesGenerateKey(algorithm, extractable, keyUsages) {
   }
 
   const key = await generateKey('aes', { length }).catch((err) => {
-    // TODO(@panva): add err as cause to DOMException
     throw lazyDOMException(
-      'The operation failed for an operation-specific reason' +
-      `[${err.message}]`,
-      'OperationError');
+      'The operation failed for an operation-specific reason',
+      'OperationError',
+      err);
   });
 
   return new InternalCryptoKey(

--- a/lib/internal/crypto/cfrg.js
+++ b/lib/internal/crypto/cfrg.js
@@ -150,10 +150,10 @@ async function cfrgGenerateKey(algorithm, extractable, keyUsages) {
   }
 
   const keyPair = await generateKeyPair(genKeyType).catch((err) => {
-    // TODO(@panva): add err as cause to DOMException
     throw lazyDOMException(
       'The operation failed for an operation-specific reason',
-      'OperationError');
+      'OperationError',
+      err);
   });
 
   let publicUsages;

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -112,10 +112,10 @@ async function ecGenerateKey(algorithm, extractable, keyUsages) {
   }
 
   const keypair = await generateKeyPair('ec', { namedCurve }).catch((err) => {
-    // TODO(@panva): add err as cause to DOMException
     throw lazyDOMException(
       'The operation failed for an operation-specific reason',
-      'OperationError');
+      'OperationError',
+      err);
   });
 
   let publicUsages;

--- a/lib/internal/crypto/mac.js
+++ b/lib/internal/crypto/mac.js
@@ -66,10 +66,10 @@ async function hmacGenerateKey(algorithm, extractable, keyUsages) {
   }
 
   const key = await generateKey('hmac', { length }).catch((err) => {
-    // TODO(@panva): add err as cause to DOMException
     throw lazyDOMException(
       'The operation failed for an operation-specific reason',
-      'OperationError');
+      'OperationError',
+      err);
   });
 
   return new InternalCryptoKey(

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -178,10 +178,10 @@ async function rsaKeyGenerate(
     modulusLength,
     publicExponent: publicExponentConverted,
   }).catch((err) => {
-    // TODO(@panva): add err as cause to DOMException
     throw lazyDOMException(
       'The operation failed for an operation-specific reason',
-      'OperationError');
+      'OperationError',
+      err);
   });
 
   const keyAlgorithm = {

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -279,10 +279,10 @@ const validateByteSource = hideStackFrames((val, name) => {
 
 function onDone(resolve, reject, err, result) {
   if (err) {
-    // TODO(@panva): add err as cause to DOMException
     return reject(lazyDOMException(
       'The operation failed for an operation-specific reason',
-      'OperationError'));
+      'OperationError',
+      err));
   }
   resolve(result);
 }

--- a/lib/internal/per_context/domexception.js
+++ b/lib/internal/per_context/domexception.js
@@ -49,12 +49,21 @@ const disusedNamesSet = new SafeSet()
   .add('ValidationError');
 
 class DOMException {
-  constructor(message = '', name = 'Error') {
+  constructor(message = '', name = 'Error', cause = undefined) {
     ErrorCaptureStackTrace(this);
     internalsMap.set(this, {
       message: `${message}`,
-      name: `${name}`
+      name: `${name}`,
+      cause
     });
+  }
+
+  get cause() {
+    const internals = internalsMap.get(this);
+    if (internals === undefined) {
+      throwInvalidThisError(TypeError, 'DOMException');
+    }
+    return internals.cause;
   }
 
   get name() {
@@ -93,6 +102,7 @@ ObjectDefineProperties(DOMException.prototype, {
   [SymbolToStringTag]: { __proto__: null, configurable: true, value: 'DOMException' },
   name: { __proto__: null, enumerable: true, configurable: true },
   message: { __proto__: null, enumerable: true, configurable: true },
+  cause: { __proto__: null, enumerable: true, configurable: true },
   code: { __proto__: null, enumerable: true, configurable: true }
 });
 

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -498,9 +498,9 @@ const lazyDOMExceptionClass = () => {
   return _DOMException;
 };
 
-const lazyDOMException = hideStackFrames((message, name) => {
+const lazyDOMException = hideStackFrames((message, name, cause) => {
   _DOMException ??= internalBinding('messaging').DOMException;
-  return new _DOMException(message, name);
+  return new _DOMException(message, name, cause);
 });
 
 const kEnumerableProperty = ObjectCreate(null);

--- a/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
@@ -118,8 +118,11 @@ async function testDecrypt({ keyBuffer, algorithm, result }) {
     });
 
     decryptionFailing.forEach((vector) => {
-      variations.push(assert.rejects(testDecrypt(vector), {
-        name: 'OperationError'
+      variations.push(assert.rejects(testDecrypt(vector), (err) => {
+        assert.strictEqual(err.name, 'OperationError');
+        assert.ok(err.cause instanceof Error);
+        assert.match(err.cause?.message, /bad decrypt/);
+        return true;
       }));
     });
 
@@ -157,8 +160,11 @@ async function testDecrypt({ keyBuffer, algorithm, result }) {
     });
 
     decryptionFailing.forEach((vector) => {
-      variations.push(assert.rejects(testDecrypt(vector), {
-        name: 'OperationError'
+      variations.push(assert.rejects(testDecrypt(vector), (err) => {
+        assert.strictEqual(err.name, 'OperationError');
+        assert.ok(err.cause instanceof Error);
+        assert.match(err.cause?.message, /foo/);
+        return true;
       }));
     });
 
@@ -194,8 +200,11 @@ async function testDecrypt({ keyBuffer, algorithm, result }) {
     });
 
     decryptionFailing.forEach((vector) => {
-      variations.push(assert.rejects(testDecrypt(vector), {
-        name: 'OperationError'
+      variations.push(assert.rejects(testDecrypt(vector), (err) => {
+        assert.strictEqual(err.name, 'OperationError');
+        assert.ok(err.cause instanceof Error);
+        assert.match(err.cause?.message, /foo/);
+        return true;
       }));
     });
 

--- a/test/parallel/test-webcrypto-encrypt-decrypt-rsa.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt-rsa.js
@@ -126,8 +126,11 @@ async function testEncryptionLongPlaintext({ algorithm,
   newplaintext[plaintext.byteLength] = 32;
 
   return assert.rejects(
-    subtle.encrypt(algorithm, publicKey, newplaintext), {
-      name: 'OperationError'
+    subtle.encrypt(algorithm, publicKey, newplaintext), (err) => {
+      assert.strictEqual(err.name, 'OperationError');
+      assert.ok(err.cause instanceof Error);
+      assert.match(err.cause?.message, /data too large for key size/);
+      return true;
     });
 }
 

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -377,8 +377,11 @@ const vectors = {
         modulusLength,
         publicExponent: new Uint8Array(publicExponent),
         hash
-      }, true, usages), {
-        name: 'OperationError',
+      }, true, usages), (err) => {
+        assert.strictEqual(err.name, 'OperationError');
+        assert.ok(err.cause instanceof Error);
+        assert.match(err.cause?.message, /pub exponent out of range/);
+        return true;
       });
     }));
   }


### PR DESCRIPTION
Adds an optional [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) to `DOMException`, put to use for operation specific WebCryptoAPI errors.