### PR TITLE
build: add support for native Windows ARM64 MSVC

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -253,6 +253,14 @@ if %target_arch%==x86 if %msvs_host_arch%==x86 set vcvarsall_arg=x86
 :vs-set-2022
 if defined target_env if "%target_env%" NEQ "vs2022" goto vs-set-2019
 echo Looking for Visual Studio 2022
+@rem Visual Studio 2022 17.4 added support for native host tools on ARM64
+@rem https://devblogs.microsoft.com/visualstudio/arm64-visual-studio/
+if _%PROCESSOR_ARCHITECTURE%_==_ARM64_ set msvs_host_arch=arm64
+if _%PROCESSOR_ARCHITEW6432%_==_ARM64_ set msvs_host_arch=arm64
+set vcvarsall_arg=%msvs_host_arch%_%target_arch%
+if %target_arch%==x64 if %msvs_host_arch%==amd64 set vcvarsall_arg=amd64
+if %target_arch%==x86 if %msvs_host_arch%==x86 set vcvarsall_arg=x86
+if %target_arch%==arm64 if %msvs_host_arch%==arm64 set vcvarsall_arg=arm64
 @rem VCINSTALLDIR may be set if run from a VS Command Prompt and needs to be
 @rem cleared first as vswhere_usability_wrapper.cmd doesn't when it fails to
 @rem detect the version searched for


### PR DESCRIPTION
Visual Studio 2022 17.4 introduces native ARM64 support, including host tools for MSVC. As this won't be supported on VS2019, this commit only adds the detection logic for native ARM64 tools to vs-set-2022.

Refs: https://github.com/nodejs/build/issues/2540
Refs: https://devblogs.microsoft.com/visualstudio/arm64-visual-studio/

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
