### PR TITLE
test: fix WPT runner result

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -474,7 +474,6 @@ class WPTRunner {
     }
 
     process.on('exit', () => {
-      const total = this.specMap.size;
       if (this.inProgress.size > 0) {
         for (const filename of this.inProgress) {
           this.fail(filename, { name: 'Unknown' }, kIncomplete);
@@ -506,7 +505,9 @@ class WPTRunner {
       }
 
       const unexpectedPasses = [];
-      for (const [key, specMap] of this.specMap) {
+      for (const specMap of queue) {
+        const key = specMap.filename;
+
         // File has no expected failures
         if (!specMap.failedTests.length) {
           continue;
@@ -529,7 +530,8 @@ class WPTRunner {
         }
       }
 
-      const ran = total - skipped;
+      const ran = queue.length;
+      const total = ran + skipped;
       const passed = ran - expectedFailures - failures.length;
       console.log(`Ran ${ran}/${total} tests, ${skipped} skipped,`,
                   `${passed} passed, ${expectedFailures} expected failures,`,


### PR DESCRIPTION
This doesn't include the other tests in the result when running a specific test in WPT.

The following is a result tested with https://github.com/nodejs/node/pull/44234.

### To-Be
```console
$ node test/wpt/test-streams.js readable-byte-streams/bad-buffers-and-views.any.js

[PASS] ReadableStream with byte source: reading into a zero-length view on a non-zero-length buffer rejects
{
  "readable-byte-streams/bad-buffers-and-views.any.js": {
    "fail": {
      "expected": [
        "ReadableStream with byte source: respondWithNewView() throws if the supplied view's buffer is zero-length (in the readable state)"
      ]
    }
  }
}
Ran 1/1 tests, 0 skipped, 0 passed, 1 expected failures, 0 unexpected failures, 0 unexpected passes
```

### As-Is
```console
$ node test/wpt/test-streams.js readable-byte-streams/bad-buffers-and-views.any.js

[PASS] ReadableStream with byte source: reading into a zero-length view on a non-zero-length buffer rejects
{
  "readable-byte-streams/bad-buffers-and-views.any.js": {
    "fail": {
      "expected": [
        "ReadableStream with byte source: respondWithNewView() throws if the supplied view's buffer is zero-length (in the readable state)"
      ]
    }
  }
}
Ran 64/64 tests, 0 skipped, 63 passed, 1 expected failures, 0 unexpected failures, 7 unexpected passes
/home/daeyeon/code/daeyeon.node/test/common/wpt.js:546
        throw new Error(
        ^

Error: Found 7 unexpected passes. Consider updating test/wpt/status/streams.json for these files:
piping/abort.any.js
queuing-strategies.any.js
readable-byte-streams/general.any.js
readable-byte-streams/tee.any.js
readable-streams/default-reader.any.js
readable-streams/templated.any.js
writable-streams/aborting.any.js
    at process.<anonymous> (/home/daeyeon/code/daeyeon.node/test/common/wpt.js:546:15)
    at process.emit (node:events:525:35)
```

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
