### PR TITLE
report: print javascript stack on fatal error

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -240,6 +240,7 @@ void SetIsolateErrorHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
   auto* fatal_error_cb = s.fatal_error_callback ?
       s.fatal_error_callback : OnFatalError;
   isolate->SetFatalErrorHandler(fatal_error_cb);
+  isolate->SetOOMErrorHandler(OOMErrorHandler);
 
   if ((s.flags & SHOULD_NOT_SET_PREPARE_STACK_TRACE_CALLBACK) == 0) {
     auto* prepare_stack_trace_cb = s.prepare_stack_trace_callback ?

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -493,6 +493,36 @@ void OnFatalError(const char* location, const char* message) {
   ABORT();
 }
 
+void OOMErrorHandler(const char* location, bool is_heap_oom) {
+  const char* message =
+      is_heap_oom ? "Allocation failed - JavaScript heap out of memory"
+                  : "Allocation failed - process out of memory";
+  if (location) {
+    FPrintF(stderr, "FATAL ERROR: %s %s\n", location, message);
+  } else {
+    FPrintF(stderr, "FATAL ERROR: %s\n", message);
+  }
+
+  Isolate* isolate = Isolate::TryGetCurrent();
+  Environment* env = nullptr;
+  if (isolate != nullptr) {
+    env = Environment::GetCurrent(isolate);
+  }
+  bool report_on_fatalerror;
+  {
+    Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
+    report_on_fatalerror = per_process::cli_options->report_on_fatalerror;
+  }
+
+  if (report_on_fatalerror) {
+    report::TriggerNodeReport(
+        isolate, env, message, "OOMError", "", Local<Object>());
+  }
+
+  fflush(stderr);
+  ABORT();
+}
+
 v8::ModifyCodeGenerationFromStringsResult ModifyCodeGenerationFromStrings(
     v8::Local<v8::Context> context,
     v8::Local<v8::Value> source,

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -21,6 +21,7 @@ void AppendExceptionLine(Environment* env,
 
 [[noreturn]] void FatalError(const char* location, const char* message);
 void OnFatalError(const char* location, const char* message);
+void OOMErrorHandler(const char* location, bool is_heap_oom);
 
 // Helpers to construct errors similar to the ones provided by
 // lib/internal/errors.js.

--- a/test/addons/report-fatalerror/binding.cc
+++ b/test/addons/report-fatalerror/binding.cc
@@ -1,0 +1,23 @@
+#include <node.h>
+#include <v8.h>
+
+using v8::FunctionCallbackInfo;
+using v8::Isolate;
+using v8::Local;
+using v8::MaybeLocal;
+using v8::Object;
+using v8::Value;
+
+void TriggerFatalError(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+
+  // Trigger a v8 ApiCheck failure.
+  MaybeLocal<Value> value;
+  value.ToLocalChecked();
+}
+
+void init(Local<Object> exports) {
+  NODE_SET_METHOD(exports, "triggerFatalError", TriggerFatalError);
+}
+
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/report-fatalerror/binding.gyp
+++ b/test/addons/report-fatalerror/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'includes': ['../common.gypi'],
+    }
+  ]
+}

--- a/test/addons/report-fatalerror/test.js
+++ b/test/addons/report-fatalerror/test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const path = require('path');
+const spawnSync = require('child_process').spawnSync;
+const helper = require('../../common/report.js');
+const tmpdir = require('../../common/tmpdir');
+
+const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
+
+if (process.argv[2] === 'child') {
+  (function childMain() {
+    const addon = require(binding);
+    addon.triggerFatalError();
+  })();
+  return;
+}
+
+const ARGS = [
+  __filename,
+  'child',
+];
+
+{
+  // Verify that --report-on-fatalerror is respected when set.
+  tmpdir.refresh();
+  const args = ['--report-on-fatalerror', ...ARGS];
+  const child = spawnSync(process.execPath, args, { cwd: tmpdir.path });
+  assert.notStrictEqual(child.status, 0, 'Process exited unexpectedly');
+
+  const reports = helper.findReports(child.pid, tmpdir.path);
+  assert.strictEqual(reports.length, 1);
+
+  const report = reports[0];
+  helper.validate(report);
+
+  const content = require(report);
+  assert.strictEqual(content.header.trigger, 'FatalError');
+
+  // Check that the javascript stack is present.
+  assert.strictEqual(content.javascriptStack.stack.findIndex((frame) => frame.match('childMain')), 0);
+}
+
+{
+  // Verify that --report-on-fatalerror is respected when not set.
+  const args = ARGS;
+  const child = spawnSync(process.execPath, args, { cwd: tmpdir.path });
+  assert.notStrictEqual(child.status, 0, 'Process exited unexpectedly');
+  const reports = helper.findReports(child.pid, tmpdir.path);
+  assert.strictEqual(reports.length, 0);
+}

--- a/test/report/test-report-fatalerror-oomerror.js
+++ b/test/report/test-report-fatalerror-oomerror.js
@@ -44,10 +44,12 @@ const ARGS = [
   const report = reports[0];
   helper.validate(report);
 
+  const content = require(report);
   // Errors occur in a context where env is not available, so thread ID is
   // unknown. Assert this, to verify that the underlying env-less situation is
   // actually reached.
-  assert.strictEqual(require(report).header.threadId, null);
+  assert.strictEqual(content.header.threadId, null);
+  assert.strictEqual(content.header.trigger, 'OOMError');
 }
 
 {


### PR DESCRIPTION
Try to print JavaScript stack on fatal error. OOMError needs to be
distinguished from fatal error since no new handle can be created at
that time.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
