### PR TITLE
[v18.x backport] lib: reset `RegExp` statics before running user code

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -37,7 +37,6 @@ const {
   ObjectDefineProperty,
   Promise,
   ReflectApply,
-  RegExpPrototypeExec,
   SafeMap,
   SafeSet,
   String,
@@ -90,6 +89,7 @@ const {
   promisify: {
     custom: kCustomPromisifiedSymbol,
   },
+  SideEffectFreeRegExpPrototypeExec,
 } = require('internal/util');
 const {
   constants: {
@@ -2424,7 +2424,7 @@ if (isWindows) {
   // slash.
   const splitRootRe = /^(?:[a-zA-Z]:|[\\/]{2}[^\\/]+[\\/][^\\/]+)?[\\/]*/;
   splitRoot = function splitRoot(str) {
-    return RegExpPrototypeExec(splitRootRe, str)[0];
+    return SideEffectFreeRegExpPrototypeExec(splitRootRe, str)[0];
   };
 } else {
   splitRoot = function splitRoot(str) {

--- a/lib/internal/main/run_main_module.js
+++ b/lib/internal/main/run_main_module.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { RegExpPrototypeExec } = primordials;
+
 const {
   prepareMainThreadExecution,
   markBootstrapComplete
@@ -8,6 +10,9 @@ const {
 prepareMainThreadExecution(true);
 
 markBootstrapComplete();
+
+// Necessary to reset RegExp statics before user code runs.
+RegExpPrototypeExec(/^/, '');
 
 // Note: this loads the module through the ESM loader if the module is
 // determined to be an ES module. This hangs from the CJS module loader

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -9,6 +9,7 @@ const {
   ArrayPrototypeSplice,
   ObjectDefineProperty,
   PromisePrototypeThen,
+  RegExpPrototypeExec,
   globalThis: { Atomics },
 } = primordials;
 
@@ -266,5 +267,8 @@ function workerOnGlobalUncaughtException(error, fromPromise) {
 process._fatalException = workerOnGlobalUncaughtException;
 
 markBootstrapComplete();
+
+// Necessary to reset RegExp statics before user code runs.
+RegExpPrototypeExec(/^/, '');
 
 port.start();

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -11,7 +11,7 @@ const {
   SafeArrayIterator,
   SafeMap,
   SafeSet,
-  StringPrototypeReplace,
+  StringPrototypeReplaceAll,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
   SyntaxErrorPrototype,
@@ -144,14 +144,13 @@ function enrichCJSError(err, content, filename) {
 
 // Strategy for loading a node-style CommonJS module
 const isWindows = process.platform === 'win32';
-const winSepRegEx = /\//g;
 translators.set('commonjs', async function commonjsStrategy(url, source,
                                                             isMain) {
   debug(`Translating CJSModule ${url}`);
 
   let filename = internalURLModule.fileURLToPath(new URL(url));
   if (isWindows)
-    filename = StringPrototypeReplace(filename, winSepRegEx, '\\');
+    filename = StringPrototypeReplaceAll(filename, '/', '\\');
 
   if (!cjsParse) await initCJSParse();
   const { module, exportNames } = cjsPreparseModuleExports(filename);
@@ -274,7 +273,7 @@ translators.set('json', async function jsonStrategy(url, source) {
   let module;
   if (pathname) {
     modulePath = isWindows ?
-      StringPrototypeReplace(pathname, winSepRegEx, '\\') : pathname;
+      StringPrototypeReplaceAll(pathname, '/', '\\') : pathname;
     module = CJSModule._cache[modulePath];
     if (module && module.loaded) {
       const exports = module.exports;

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  RegExpPrototypeExec,
   globalThis,
 } = primordials;
 
@@ -45,6 +46,7 @@ function evalModule(source, print) {
   }
   const { loadESM } = require('internal/process/esm_loader');
   const { handleMainPromise } = require('internal/modules/run_main');
+  RegExpPrototypeExec(/^/, ''); // Necessary to reset RegExp statics before user code runs.
   return handleMainPromise(loadESM((loader) => loader.eval(source)));
 }
 
@@ -72,6 +74,7 @@ function evalScript(name, body, breakFirstLine, print) {
     return (main) => main();
   `;
   globalThis.__filename = name;
+  RegExpPrototypeExec(/^/, ''); // Necessary to reset RegExp statics before user code runs.
   const result = module._compile(script, `${name}-wrapper`)(() =>
     require('vm').runInThisContext(body, {
       filename: name,

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -23,6 +23,7 @@ const {
   StringPrototypeCharCodeAt,
   StringPrototypeIncludes,
   StringPrototypeReplace,
+  StringPrototypeReplaceAll,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -1424,8 +1425,6 @@ function urlToHttpOptions(url) {
   return options;
 }
 
-const forwardSlashRegEx = /\//g;
-
 function getPathFromURLWin32(url) {
   const hostname = url.hostname;
   let pathname = url.pathname;
@@ -1440,7 +1439,7 @@ function getPathFromURLWin32(url) {
       }
     }
   }
-  pathname = pathname.replace(forwardSlashRegEx, '\\');
+  pathname = StringPrototypeReplaceAll(pathname, '/', '\\');
   pathname = decodeURIComponent(pathname);
   if (hostname !== '') {
     // If hostname is set, then we have a UNC path

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -7,6 +7,7 @@ const {
   ArrayPrototypeSlice,
   ArrayPrototypeSort,
   Error,
+  FunctionPrototypeCall,
   ObjectCreate,
   ObjectDefineProperties,
   ObjectDefineProperty,
@@ -543,6 +544,21 @@ function setOwnProperty(obj, key, value) {
   });
 }
 
+let internalGlobal;
+function getInternalGlobal() {
+  if (internalGlobal == null) {
+    // Lazy-load to avoid a circular dependency.
+    const { runInNewContext } = require('vm');
+    internalGlobal = runInNewContext('this', undefined, { contextName: 'internal' });
+  }
+  return internalGlobal;
+}
+
+function SideEffectFreeRegExpPrototypeExec(regex, string) {
+  const { RegExp: RegExpFromAnotherRealm } = getInternalGlobal();
+  return FunctionPrototypeCall(RegExpFromAnotherRealm.prototype.exec, regex, string);
+}
+
 module.exports = {
   assertCrypto,
   cachedResult,
@@ -557,6 +573,7 @@ module.exports = {
   filterDuplicateStrings,
   filterOwnProperties,
   getConstructorOf,
+  getInternalGlobal,
   getSystemErrorMap,
   getSystemErrorName,
   isError,
@@ -567,6 +584,7 @@ module.exports = {
   normalizeEncoding,
   once,
   promisify,
+  SideEffectFreeRegExpPrototypeExec,
   sleep,
   spliceOne,
   toUSVString,

--- a/test/parallel/test-startup-empty-regexp-statics.js
+++ b/test/parallel/test-startup-empty-regexp-statics.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('node:assert');
+const { spawnSync, spawn } = require('node:child_process');
+
+assert.strictEqual(RegExp.$_, '');
+assert.strictEqual(RegExp.$0, undefined);
+assert.strictEqual(RegExp.$1, '');
+assert.strictEqual(RegExp.$2, '');
+assert.strictEqual(RegExp.$3, '');
+assert.strictEqual(RegExp.$4, '');
+assert.strictEqual(RegExp.$5, '');
+assert.strictEqual(RegExp.$6, '');
+assert.strictEqual(RegExp.$7, '');
+assert.strictEqual(RegExp.$8, '');
+assert.strictEqual(RegExp.$9, '');
+assert.strictEqual(RegExp.input, '');
+assert.strictEqual(RegExp.lastMatch, '');
+assert.strictEqual(RegExp.lastParen, '');
+assert.strictEqual(RegExp.leftContext, '');
+assert.strictEqual(RegExp.rightContext, '');
+assert.strictEqual(RegExp['$&'], '');
+assert.strictEqual(RegExp['$`'], '');
+assert.strictEqual(RegExp['$+'], '');
+assert.strictEqual(RegExp["$'"], '');
+
+const allRegExpStatics =
+    'RegExp.$_ + RegExp["$&"] + RegExp["$`"] + RegExp["$+"] + RegExp["$\'"] + ' +
+    'RegExp.input + RegExp.lastMatch + RegExp.lastParen + ' +
+    'RegExp.leftContext + RegExp.rightContext + ' +
+    Array.from({ length: 10 }, (_, i) => `RegExp.$${i}`).join(' + ');
+
+{
+  const child = spawnSync(process.execPath,
+                          [ '-p', allRegExpStatics ],
+                          { stdio: ['inherit', 'pipe', 'inherit'] });
+  assert.match(child.stdout.toString(), /^undefined\r?\n$/);
+  assert.strictEqual(child.status, 0);
+  assert.strictEqual(child.signal, null);
+}
+
+{
+  const child = spawnSync(process.execPath,
+                          [ '-e', `console.log(${allRegExpStatics})`, '--input-type=module' ],
+                          { stdio: ['inherit', 'pipe', 'inherit'] });
+  assert.match(child.stdout.toString(), /^undefined\r?\n$/);
+  assert.strictEqual(child.status, 0);
+  assert.strictEqual(child.signal, null);
+}
+
+{
+  const child = spawn(process.execPath, [], { stdio: ['pipe', 'pipe', 'inherit'], encoding: 'utf8' });
+
+  let stdout = '';
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+  });
+
+  child.on('exit', common.mustCall((status, signal) => {
+    assert.match(stdout, /^undefined\r?\n$/);
+    assert.strictEqual(status, 0);
+    assert.strictEqual(signal, null);
+  }));
+  child.on('error', common.mustNotCall());
+
+  child.stdin.end(`console.log(${allRegExpStatics});\n`);
+}

--- a/test/parallel/test-startup-empty-regexp-statics.mjs
+++ b/test/parallel/test-startup-empty-regexp-statics.mjs
@@ -1,0 +1,26 @@
+// We must load the CJS version here because the ESM wrapper call `hasIPv6`
+// which compiles a RegEx.
+// eslint-disable-next-line node-core/require-common-first
+import '../common/index.js';
+import assert from 'node:assert';
+
+assert.strictEqual(RegExp.$_, '');
+assert.strictEqual(RegExp.$0, undefined);
+assert.strictEqual(RegExp.$1, '');
+assert.strictEqual(RegExp.$2, '');
+assert.strictEqual(RegExp.$3, '');
+assert.strictEqual(RegExp.$4, '');
+assert.strictEqual(RegExp.$5, '');
+assert.strictEqual(RegExp.$6, '');
+assert.strictEqual(RegExp.$7, '');
+assert.strictEqual(RegExp.$8, '');
+assert.strictEqual(RegExp.$9, '');
+assert.strictEqual(RegExp.input, '');
+assert.strictEqual(RegExp.lastMatch, '');
+assert.strictEqual(RegExp.lastParen, '');
+assert.strictEqual(RegExp.leftContext, '');
+assert.strictEqual(RegExp.rightContext, '');
+assert.strictEqual(RegExp['$&'], '');
+assert.strictEqual(RegExp['$`'], '');
+assert.strictEqual(RegExp['$+'], '');
+assert.strictEqual(RegExp["$'"], '');

--- a/test/parallel/test-vm-measure-memory-multi-context.js
+++ b/test/parallel/test-vm-measure-memory-multi-context.js
@@ -23,6 +23,6 @@ expectExperimentalWarning();
       // We must hold on to the contexts here so that they
       // don't get GC'ed until the measurement is complete
       assert.strictEqual(arr.length, count);
-      assertDetailedShape(result, count);
+      assertDetailedShape(result, count + common.isWindows);
     }));
 }

--- a/test/parallel/test-vm-measure-memory.js
+++ b/test/parallel/test-vm-measure-memory.js
@@ -15,8 +15,10 @@ expectExperimentalWarning();
   vm.measureMemory({ execution: 'eager' })
     .then(common.mustCall(assertSummaryShape));
 
-  vm.measureMemory({ mode: 'detailed', execution: 'eager' })
-    .then(common.mustCall(assertSingleDetailedShape));
+  if (!common.isWindows) {
+    vm.measureMemory({ mode: 'detailed', execution: 'eager' })
+      .then(common.mustCall(assertSingleDetailedShape));
+  }
 
   vm.measureMemory({ mode: 'summary', execution: 'eager' })
     .then(common.mustCall(assertSummaryShape));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/43740

PR-URL: https://github.com/nodejs/node/pull/43741
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>
Reviewed-By: Geoffrey Booth <webadmin@geoffreybooth.com>
Reviewed-By: Matteo Collina <matteo.collina@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
