### PR TITLE
vm: include vm context in the embedded snapshot

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -555,50 +555,8 @@ Maybe<bool> InitializeContextRuntime(Local<Context> context) {
   Isolate* isolate = context->GetIsolate();
   HandleScope handle_scope(isolate);
 
-  // Delete `Intl.v8BreakIterator`
-  // https://github.com/nodejs/node/issues/14909
-  {
-    Local<String> intl_string =
-      FIXED_ONE_BYTE_STRING(isolate, "Intl");
-    Local<String> break_iter_string =
-      FIXED_ONE_BYTE_STRING(isolate, "v8BreakIterator");
-
-    Local<Value> intl_v;
-    if (!context->Global()
-        ->Get(context, intl_string)
-        .ToLocal(&intl_v)) {
-      return Nothing<bool>();
-    }
-
-    if (intl_v->IsObject() &&
-        intl_v.As<Object>()
-          ->Delete(context, break_iter_string)
-          .IsNothing()) {
-      return Nothing<bool>();
-    }
-  }
-
-  // Delete `Atomics.wake`
-  // https://github.com/nodejs/node/issues/21219
-  {
-    Local<String> atomics_string =
-      FIXED_ONE_BYTE_STRING(isolate, "Atomics");
-    Local<String> wake_string =
-      FIXED_ONE_BYTE_STRING(isolate, "wake");
-
-    Local<Value> atomics_v;
-    if (!context->Global()
-        ->Get(context, atomics_string)
-        .ToLocal(&atomics_v)) {
-      return Nothing<bool>();
-    }
-
-    if (atomics_v->IsObject() &&
-        atomics_v.As<Object>()
-          ->Delete(context, wake_string)
-          .IsNothing()) {
-      return Nothing<bool>();
-    }
+  if (per_process::cli_options->disable_proto == "") {
+    return Just(true);
   }
 
   // Remove __proto__
@@ -660,7 +618,32 @@ Maybe<bool> InitializeContextRuntime(Local<Context> context) {
   return Just(true);
 }
 
-Maybe<bool> InitializeContextForSnapshot(Local<Context> context) {
+Maybe<bool> InitializeBaseContextForSnapshot(Local<Context> context) {
+  Isolate* isolate = context->GetIsolate();
+  HandleScope handle_scope(isolate);
+
+  // Delete `Intl.v8BreakIterator`
+  // https://github.com/nodejs/node/issues/14909
+  {
+    Context::Scope context_scope(context);
+    Local<String> intl_string = FIXED_ONE_BYTE_STRING(isolate, "Intl");
+    Local<String> break_iter_string =
+        FIXED_ONE_BYTE_STRING(isolate, "v8BreakIterator");
+
+    Local<Value> intl_v;
+    if (!context->Global()->Get(context, intl_string).ToLocal(&intl_v)) {
+      return Nothing<bool>();
+    }
+
+    if (intl_v->IsObject() &&
+        intl_v.As<Object>()->Delete(context, break_iter_string).IsNothing()) {
+      return Nothing<bool>();
+    }
+  }
+  return Just(true);
+}
+
+Maybe<bool> InitializeMainContextForSnapshot(Local<Context> context) {
   Isolate* isolate = context->GetIsolate();
   HandleScope handle_scope(isolate);
 
@@ -670,6 +653,9 @@ Maybe<bool> InitializeContextForSnapshot(Local<Context> context) {
   context->SetEmbedderData(ContextEmbedderIndex::kAllowWasmCodeGeneration,
                            True(isolate));
 
+  if (InitializeBaseContextForSnapshot(context).IsNothing()) {
+    return Nothing<bool>();
+  }
   return InitializePrimordials(context);
 }
 
@@ -716,8 +702,9 @@ Maybe<bool> InitializePrimordials(Local<Context> context) {
   return Just(true);
 }
 
+// This initializes the main context (i.e. vm contexts are not included).
 Maybe<bool> InitializeContext(Local<Context> context) {
-  if (InitializeContextForSnapshot(context).IsNothing()) {
+  if (InitializeMainContextForSnapshot(context).IsNothing()) {
     return Nothing<bool>();
   }
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -6,6 +6,7 @@
 #include "memory_tracker-inl.h"
 #include "node_buffer.h"
 #include "node_context_data.h"
+#include "node_contextify.h"
 #include "node_errors.h"
 #include "node_internals.h"
 #include "node_options-inl.h"
@@ -444,6 +445,8 @@ void IsolateData::CreateProperties() {
 #undef V
 
   // TODO(legendecas): eagerly create per isolate templates.
+  set_contextify_global_template(
+      contextify::ContextifyContext::CreateGlobalTemplate(isolate_));
 }
 
 IsolateData::IsolateData(Isolate* isolate,
@@ -512,12 +515,18 @@ void TrackingTraceStateObserver::UpdateTraceCategoryState() {
 
 void Environment::AssignToContext(Local<v8::Context> context,
                                   const ContextInfo& info) {
-  ContextEmbedderTag::TagNodeContext(context);
   context->SetAlignedPointerInEmbedderData(ContextEmbedderIndex::kEnvironment,
                                            this);
   // Used to retrieve bindings
   context->SetAlignedPointerInEmbedderData(
       ContextEmbedderIndex::kBindingListIndex, &(this->bindings_));
+
+  // ContextifyContexts will update this to a pointer to the native object.
+  context->SetAlignedPointerInEmbedderData(
+      ContextEmbedderIndex::kContextifyContext, nullptr);
+
+  // This must not be done before other context fields are initialized.
+  ContextEmbedderTag::TagNodeContext(context);
 
 #if HAVE_INSPECTOR
   inspector_agent()->ContextCreated(context, info);
@@ -769,6 +778,8 @@ void Environment::InitializeMainContext(Local<Context> context,
                                         const EnvSerializeInfo* env_info) {
   context_.Reset(context->GetIsolate(), context);
   AssignToContext(context, ContextInfo(""));
+  context->SetAlignedPointerInEmbedderData(
+      ContextEmbedderIndex::kContextifyContext, nullptr);
   if (env_info != nullptr) {
     DeserializeProperties(env_info);
   } else {

--- a/src/env.cc
+++ b/src/env.cc
@@ -778,8 +778,6 @@ void Environment::InitializeMainContext(Local<Context> context,
                                         const EnvSerializeInfo* env_info) {
   context_.Reset(context->GetIsolate(), context);
   AssignToContext(context, ContextInfo(""));
-  context->SetAlignedPointerInEmbedderData(
-      ContextEmbedderIndex::kContextifyContext, nullptr);
   if (env_info != nullptr) {
     DeserializeProperties(env_info);
   } else {

--- a/src/env.h
+++ b/src/env.h
@@ -349,6 +349,7 @@ class NoArrayBufferZeroFillScope {
   V(nistcurve_string, "nistCurve")                                             \
   V(node_string, "node")                                                       \
   V(nsname_string, "nsname")                                                   \
+  V(object_string, "Object")                                                   \
   V(ocsp_request_string, "OCSPRequest")                                        \
   V(oncertcb_string, "oncertcb")                                               \
   V(onchange_string, "onchange")                                               \
@@ -477,6 +478,7 @@ class NoArrayBufferZeroFillScope {
   V(binding_data_ctor_template, v8::FunctionTemplate)                          \
   V(blob_constructor_template, v8::FunctionTemplate)                           \
   V(blocklist_constructor_template, v8::FunctionTemplate)                      \
+  V(contextify_global_template, v8::ObjectTemplate)                            \
   V(compiled_fn_entry_template, v8::ObjectTemplate)                            \
   V(dir_instance_template, v8::ObjectTemplate)                                 \
   V(fd_constructor_template, v8::ObjectTemplate)                               \
@@ -560,7 +562,6 @@ class NoArrayBufferZeroFillScope {
   V(primordials_safe_weak_set_prototype_object, v8::Object)                    \
   V(promise_hook_handler, v8::Function)                                        \
   V(promise_reject_callback, v8::Function)                                     \
-  V(script_data_constructor_function, v8::Function)                            \
   V(snapshot_serialize_callback, v8::Function)                                 \
   V(snapshot_deserialize_callback, v8::Function)                               \
   V(snapshot_deserialize_main, v8::Function)                                   \

--- a/src/env.h
+++ b/src/env.h
@@ -1002,7 +1002,8 @@ struct SnapshotData {
   enum class DataOwnership { kOwned, kNotOwned };
 
   static const uint32_t kMagic = 0x143da19;
-  static const SnapshotIndex kNodeBaseContextIndex = 0;
+  static const SnapshotIndex kNodeVMContextIndex = 0;
+  static const SnapshotIndex kNodeBaseContextIndex = kNodeVMContextIndex + 1;
   static const SnapshotIndex kNodeMainContextIndex = kNodeBaseContextIndex + 1;
 
   DataOwnership data_ownership = DataOwnership::kOwned;

--- a/src/node_context_data.h
+++ b/src/node_context_data.h
@@ -32,11 +32,15 @@ namespace node {
 #define NODE_CONTEXT_ALLOW_CODE_GENERATION_FROM_STRINGS_INDEX 36
 #endif
 
+#ifndef NODE_CONTEXT_CONTEXTIFY_CONTEXT_INDEX
+#define NODE_CONTEXT_CONTEXTIFY_CONTEXT_INDEX 37
+#endif
+
 // NODE_CONTEXT_TAG must be greater than any embedder indexes so that a single
 // check on the number of embedder data fields can assure the presence of all
 // embedder indexes.
 #ifndef NODE_CONTEXT_TAG
-#define NODE_CONTEXT_TAG 37
+#define NODE_CONTEXT_TAG 38
 #endif
 
 enum ContextEmbedderIndex {
@@ -46,6 +50,7 @@ enum ContextEmbedderIndex {
   kBindingListIndex = NODE_BINDING_LIST_INDEX,
   kAllowCodeGenerationFromStrings =
       NODE_CONTEXT_ALLOW_CODE_GENERATION_FROM_STRINGS_INDEX,
+  kContextifyContext = NODE_CONTEXT_CONTEXTIFY_CONTEXT_INDEX,
   kContextTag = NODE_CONTEXT_TAG,
 };
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -206,14 +206,16 @@ MaybeLocal<Context> ContextifyContext::CreateV8Context(
                        {},  // global object
                        {},  // deserialization callback
                        queue);
-    if (ctx.IsEmpty()) return MaybeLocal<Context>();
+    if (ctx.IsEmpty() || InitializeBaseContextForSnapshot(ctx).IsNothing()) {
+      return MaybeLocal<Context>();
+    }
   } else if (!Context::FromSnapshot(isolate,
-                             SnapshotData::kNodeVMContextIndex,
-                             {},       // deserialization callback
-                             nullptr,  // extensions
-                             {},       // global object
-                             queue)
-           .ToLocal(&ctx)) {
+                                    SnapshotData::kNodeVMContextIndex,
+                                    {},       // deserialization callback
+                                    nullptr,  // extensions
+                                    {},       // global object
+                                    queue)
+                  .ToLocal(&ctx)) {
     return MaybeLocal<Context>();
   }
   return scope.Escape(ctx);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -113,12 +113,26 @@ ContextifyContext::ContextifyContext(
     const ContextOptions& options)
   : env_(env),
     microtask_queue_wrap_(options.microtask_queue_wrap) {
-  MaybeLocal<Context> v8_context = CreateV8Context(env, sandbox_obj, options);
+  Local<ObjectTemplate> object_template = env->contextify_global_template();
+  if (object_template.IsEmpty()) {
+    object_template = CreateGlobalTemplate(env->isolate());
+    env->set_contextify_global_template(object_template);
+  }
 
-  // Allocation failure, maximum call stack size reached, termination, etc.
-  if (v8_context.IsEmpty()) return;
+  MicrotaskQueue* queue =
+      microtask_queue()
+          ? microtask_queue().get()
+          : env->isolate()->GetCurrentContext()->GetMicrotaskQueue();
 
-  context_.Reset(env->isolate(), v8_context.ToLocalChecked());
+  Local<Context> v8_context;
+  if (!(CreateV8Context(env->isolate(), object_template, queue)
+            .ToLocal(&v8_context)) ||
+      !InitializeContext(v8_context, env, sandbox_obj, options)) {
+    // Allocation failure, maximum call stack size reached, termination, etc.
+    return;
+  }
+
+  context_.Reset(env->isolate(), v8_context);
   context_.SetWeak(this, WeakCallback, WeakCallbackType::kParameter);
   env->AddCleanupHook(CleanupHook, this);
 }
@@ -140,40 +154,12 @@ void ContextifyContext::CleanupHook(void* arg) {
   delete self;
 }
 
-
-// This is an object that just keeps an internal pointer to this
-// ContextifyContext.  It's passed to the NamedPropertyHandler.  If we
-// pass the main JavaScript context object we're embedded in, then the
-// NamedPropertyHandler will store a reference to it forever and keep it
-// from getting gc'd.
-MaybeLocal<Object> ContextifyContext::CreateDataWrapper(Environment* env) {
-  Local<Object> wrapper;
-  if (!env->script_data_constructor_function()
-           ->NewInstance(env->context())
-           .ToLocal(&wrapper)) {
-    return MaybeLocal<Object>();
-  }
-
-  wrapper->SetAlignedPointerInInternalField(ContextifyContext::kSlot, this);
-  return wrapper;
-}
-
-MaybeLocal<Context> ContextifyContext::CreateV8Context(
-    Environment* env,
-    Local<Object> sandbox_obj,
-    const ContextOptions& options) {
-  EscapableHandleScope scope(env->isolate());
-  Local<FunctionTemplate> function_template =
-      FunctionTemplate::New(env->isolate());
-
-  function_template->SetClassName(sandbox_obj->GetConstructorName());
+Local<ObjectTemplate> ContextifyContext::CreateGlobalTemplate(
+    Isolate* isolate) {
+  Local<FunctionTemplate> function_template = FunctionTemplate::New(isolate);
 
   Local<ObjectTemplate> object_template =
       function_template->InstanceTemplate();
-
-  Local<Object> data_wrapper;
-  if (!CreateDataWrapper(env).ToLocal(&data_wrapper))
-    return MaybeLocal<Context>();
 
   NamedPropertyHandlerConfiguration config(
       PropertyGetterCallback,
@@ -182,7 +168,7 @@ MaybeLocal<Context> ContextifyContext::CreateV8Context(
       PropertyDeleterCallback,
       PropertyEnumeratorCallback,
       PropertyDefinerCallback,
-      data_wrapper,
+      {},
       PropertyHandlerFlags::kHasNoSideEffect);
 
   IndexedPropertyHandlerConfiguration indexed_config(
@@ -192,33 +178,48 @@ MaybeLocal<Context> ContextifyContext::CreateV8Context(
       IndexedPropertyDeleterCallback,
       PropertyEnumeratorCallback,
       IndexedPropertyDefinerCallback,
-      data_wrapper,
+      {},
       PropertyHandlerFlags::kHasNoSideEffect);
 
   object_template->SetHandler(config);
   object_template->SetHandler(indexed_config);
-  Local<Context> ctx = Context::New(
-      env->isolate(),
-      nullptr,  // extensions
-      object_template,
-      {},       // global object
-      {},       // deserialization callback
-      microtask_queue() ?
-          microtask_queue().get() :
-          env->isolate()->GetCurrentContext()->GetMicrotaskQueue());
+
+  return object_template;
+}
+
+MaybeLocal<Context> ContextifyContext::CreateV8Context(
+    Isolate* isolate,
+    Local<ObjectTemplate> object_template,
+    MicrotaskQueue* queue) {
+  EscapableHandleScope scope(isolate);
+
+  Local<Context> ctx = Context::New(isolate,
+                                    nullptr,  // extensions
+                                    object_template,
+                                    {},  // global object
+                                    {},  // deserialization callback
+                                    queue);
   if (ctx.IsEmpty()) return MaybeLocal<Context>();
-  // Only partially initialize the context - the primordials are left out
-  // and only initialized when necessary.
+
+  return scope.Escape(ctx);
+}
+
+bool ContextifyContext::InitializeContext(Local<Context> ctx,
+                                          Environment* env,
+                                          Local<Object> sandbox_obj,
+                                          const ContextOptions& options) {
+  HandleScope scope(env->isolate());
+
+  // This only initializes part of the context. The primordials are
+  // only initilaized when needed because even deserializing them slows
+  // things down significantly and they are only needed in rare occasions
+  // in the vm contexts.
   if (InitializeContextRuntime(ctx).IsNothing()) {
-    return MaybeLocal<Context>();
+    return false;
   }
 
-  if (ctx.IsEmpty()) {
-    return MaybeLocal<Context>();
-  }
-
-  Local<Context> context = env->context();
-  ctx->SetSecurityToken(context->GetSecurityToken());
+  Local<Context> main_context = env->context();
+  ctx->SetSecurityToken(main_context->GetSecurityToken());
 
   // We need to tie the lifetime of the sandbox object with the lifetime of
   // newly created context. We do this by making them hold references to each
@@ -227,11 +228,9 @@ MaybeLocal<Context> ContextifyContext::CreateV8Context(
   // directly in an Object, we instead hold onto the new context's global
   // object instead (which then has a reference to the context).
   ctx->SetEmbedderData(ContextEmbedderIndex::kSandboxObject, sandbox_obj);
-  sandbox_obj->SetPrivate(context,
-                          env->contextify_global_private_symbol(),
-                          ctx->Global());
+  sandbox_obj->SetPrivate(
+      main_context, env->contextify_global_private_symbol(), ctx->Global());
 
-  Utf8Value name_val(env->isolate(), options.name);
   // Delegate the code generation validation to
   // node::ModifyCodeGenerationFromStrings.
   ctx->AllowCodeGenerationFromStrings(false);
@@ -240,30 +239,39 @@ MaybeLocal<Context> ContextifyContext::CreateV8Context(
   ctx->SetEmbedderData(ContextEmbedderIndex::kAllowWasmCodeGeneration,
                        options.allow_code_gen_wasm);
 
+  Utf8Value name_val(env->isolate(), options.name);
   ContextInfo info(*name_val);
-
   if (!options.origin.IsEmpty()) {
     Utf8Value origin_val(env->isolate(), options.origin);
     info.origin = *origin_val;
   }
 
+  {
+    Context::Scope context_scope(ctx);
+    Local<String> ctor_name = sandbox_obj->GetConstructorName();
+    if (!ctor_name->Equals(ctx, env->object_string()).FromMaybe(false) &&
+        ctx->Global()
+            ->DefineOwnProperty(
+                ctx,
+                v8::Symbol::GetToStringTag(env->isolate()),
+                ctor_name,
+                static_cast<v8::PropertyAttribute>(v8::DontEnum))
+            .IsNothing()) {
+      return false;
+    }
+  }
+
   env->AssignToContext(ctx, info);
 
-  return scope.Escape(ctx);
+  // This should only be done after the initial initializations of the context
+  // global object is finished.
+  ctx->SetAlignedPointerInEmbedderData(ContextEmbedderIndex::kContextifyContext,
+                                       this);
+  return true;
 }
 
-
 void ContextifyContext::Init(Environment* env, Local<Object> target) {
-  Isolate* isolate = env->isolate();
   Local<Context> context = env->context();
-
-  Local<FunctionTemplate> function_template =
-      NewFunctionTemplate(isolate, nullptr);
-  function_template->InstanceTemplate()->SetInternalFieldCount(
-      ContextifyContext::kInternalFieldCount);
-  env->set_script_data_constructor_function(
-      function_template->GetFunction(env->context()).ToLocalChecked());
-
   SetMethod(context, target, "makeContext", MakeContext);
   SetMethod(context, target, "isContext", IsContext);
   SetMethod(context, target, "compileFunction", CompileFunction);
@@ -274,6 +282,17 @@ void ContextifyContext::RegisterExternalReferences(
   registry->Register(MakeContext);
   registry->Register(IsContext);
   registry->Register(CompileFunction);
+  registry->Register(PropertyGetterCallback);
+  registry->Register(PropertySetterCallback);
+  registry->Register(PropertyDescriptorCallback);
+  registry->Register(PropertyDeleterCallback);
+  registry->Register(PropertyEnumeratorCallback);
+  registry->Register(PropertyDefinerCallback);
+  registry->Register(IndexedPropertyGetterCallback);
+  registry->Register(IndexedPropertySetterCallback);
+  registry->Register(IndexedPropertyDescriptorCallback);
+  registry->Register(IndexedPropertyDeleterCallback);
+  registry->Register(IndexedPropertyDefinerCallback);
 }
 
 // makeContext(sandbox, name, origin, strings, wasm);
@@ -323,8 +342,8 @@ void ContextifyContext::MakeContext(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  if (context_ptr->context().IsEmpty())
-    return;
+  Local<Context> new_context = context_ptr->context();
+  if (new_context.IsEmpty()) return;
 
   sandbox->SetPrivate(
       env->context(),
@@ -371,10 +390,20 @@ ContextifyContext* ContextifyContext::ContextFromContextifiedSandbox(
 // static
 template <typename T>
 ContextifyContext* ContextifyContext::Get(const PropertyCallbackInfo<T>& args) {
-  Local<Value> data = args.Data();
+  Local<Context> context;
+  if (!args.This()->GetCreationContext().ToLocal(&context)) {
+    return nullptr;
+  }
+  if (!ContextEmbedderTag::IsNodeContext(context)) {
+    return nullptr;
+  }
   return static_cast<ContextifyContext*>(
-      data.As<Object>()->GetAlignedPointerFromInternalField(
-          ContextifyContext::kSlot));
+      context->GetAlignedPointerFromEmbedderData(
+          ContextEmbedderIndex::kContextifyContext));
+}
+
+bool ContextifyContext::IsStillInitializing(const ContextifyContext* ctx) {
+  return ctx == nullptr || ctx->context_.IsEmpty();
 }
 
 // static
@@ -384,8 +413,7 @@ void ContextifyContext::PropertyGetterCallback(
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
-  if (ctx->context_.IsEmpty())
-    return;
+  if (IsStillInitializing(ctx)) return;
 
   Local<Context> context = ctx->context();
   Local<Object> sandbox = ctx->sandbox();
@@ -413,8 +441,7 @@ void ContextifyContext::PropertySetterCallback(
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
-  if (ctx->context_.IsEmpty())
-    return;
+  if (IsStillInitializing(ctx)) return;
 
   Local<Context> context = ctx->context();
   PropertyAttribute attributes = PropertyAttribute::None;
@@ -466,8 +493,7 @@ void ContextifyContext::PropertyDescriptorCallback(
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
-  if (ctx->context_.IsEmpty())
-    return;
+  if (IsStillInitializing(ctx)) return;
 
   Local<Context> context = ctx->context();
 
@@ -489,8 +515,7 @@ void ContextifyContext::PropertyDefinerCallback(
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
-  if (ctx->context_.IsEmpty())
-    return;
+  if (IsStillInitializing(ctx)) return;
 
   Local<Context> context = ctx->context();
   Isolate* isolate = context->GetIsolate();
@@ -550,8 +575,7 @@ void ContextifyContext::PropertyDeleterCallback(
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
-  if (ctx->context_.IsEmpty())
-    return;
+  if (IsStillInitializing(ctx)) return;
 
   Maybe<bool> success = ctx->sandbox()->Delete(ctx->context(), property);
 
@@ -569,8 +593,7 @@ void ContextifyContext::PropertyEnumeratorCallback(
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
-  if (ctx->context_.IsEmpty())
-    return;
+  if (IsStillInitializing(ctx)) return;
 
   Local<Array> properties;
 
@@ -587,8 +610,7 @@ void ContextifyContext::IndexedPropertyGetterCallback(
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
-  if (ctx->context_.IsEmpty())
-    return;
+  if (IsStillInitializing(ctx)) return;
 
   ContextifyContext::PropertyGetterCallback(
       Uint32ToName(ctx->context(), index), args);
@@ -602,8 +624,7 @@ void ContextifyContext::IndexedPropertySetterCallback(
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
-  if (ctx->context_.IsEmpty())
-    return;
+  if (IsStillInitializing(ctx)) return;
 
   ContextifyContext::PropertySetterCallback(
       Uint32ToName(ctx->context(), index), value, args);
@@ -616,8 +637,7 @@ void ContextifyContext::IndexedPropertyDescriptorCallback(
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
-  if (ctx->context_.IsEmpty())
-    return;
+  if (IsStillInitializing(ctx)) return;
 
   ContextifyContext::PropertyDescriptorCallback(
       Uint32ToName(ctx->context(), index), args);
@@ -631,8 +651,7 @@ void ContextifyContext::IndexedPropertyDefinerCallback(
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
-  if (ctx->context_.IsEmpty())
-    return;
+  if (IsStillInitializing(ctx)) return;
 
   ContextifyContext::PropertyDefinerCallback(
       Uint32ToName(ctx->context(), index), desc, args);
@@ -645,8 +664,7 @@ void ContextifyContext::IndexedPropertyDeleterCallback(
   ContextifyContext* ctx = ContextifyContext::Get(args);
 
   // Still initializing
-  if (ctx->context_.IsEmpty())
-    return;
+  if (IsStillInitializing(ctx)) return;
 
   Maybe<bool> success = ctx->sandbox()->Delete(ctx->context(), index);
 
@@ -891,8 +909,8 @@ void ContextifyScript::RunInContext(const FunctionCallbackInfo<Value>& args) {
   bool break_on_first_line = args[4]->IsTrue();
 
   // Do the eval within the context
-  Context::Scope context_scope(context);
-  EvalMachine(env,
+  EvalMachine(context,
+              env,
               timeout,
               display_errors,
               break_on_sigint,
@@ -901,13 +919,16 @@ void ContextifyScript::RunInContext(const FunctionCallbackInfo<Value>& args) {
               args);
 }
 
-bool ContextifyScript::EvalMachine(Environment* env,
+bool ContextifyScript::EvalMachine(Local<Context> context,
+                                   Environment* env,
                                    const int64_t timeout,
                                    const bool display_errors,
                                    const bool break_on_sigint,
                                    const bool break_on_first_line,
                                    std::shared_ptr<MicrotaskQueue> mtask_queue,
                                    const FunctionCallbackInfo<Value>& args) {
+  Context::Scope context_scope(context);
+
   if (!env->can_call_into_js())
     return false;
   if (!ContextifyScript::InstanceOf(env, args.Holder())) {
@@ -916,6 +937,7 @@ bool ContextifyScript::EvalMachine(Environment* env,
         "Script methods can only be called on script instances.");
     return false;
   }
+
   TryCatchScope try_catch(env);
   Isolate::SafeForTerminationScope safe_for_termination(env->isolate());
   ContextifyScript* wrapped_script;
@@ -934,7 +956,7 @@ bool ContextifyScript::EvalMachine(Environment* env,
   bool timed_out = false;
   bool received_signal = false;
   auto run = [&]() {
-    MaybeLocal<Value> result = script->Run(env->context());
+    MaybeLocal<Value> result = script->Run(context);
     if (!result.IsEmpty() && mtask_queue)
       mtask_queue->PerformCheckpoint(env->isolate());
     return result;

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -52,6 +52,7 @@ class ContextifyContext {
   static v8::MaybeLocal<v8::Context> CreateV8Context(
       v8::Isolate* isolate,
       v8::Local<v8::ObjectTemplate> object_template,
+      const SnapshotData* snapshot_data,
       v8::MicrotaskQueue* queue);
   bool InitializeContext(v8::Local<v8::Context> ctx,
                          Environment* env,

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -30,7 +30,12 @@ class ExternalReferenceRegistry {
   V(v8::GenericNamedPropertyDeleterCallback)                                   \
   V(v8::GenericNamedPropertyEnumeratorCallback)                                \
   V(v8::GenericNamedPropertyQueryCallback)                                     \
-  V(v8::GenericNamedPropertySetterCallback)
+  V(v8::GenericNamedPropertySetterCallback)                                    \
+  V(v8::IndexedPropertySetterCallback)                                         \
+  V(v8::IndexedPropertyDefinerCallback)                                        \
+  V(v8::IndexedPropertyDeleterCallback)                                        \
+  V(v8::IndexedPropertyQueryCallback)                                          \
+  V(v8::IndexedPropertyDescriptorCallback)
 
 #define V(ExternalReferenceType)                                               \
   void Register(ExternalReferenceType addr) { RegisterT(addr); }

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -92,6 +92,8 @@ void SignalExit(int signal, siginfo_t* info, void* ucontext);
 std::string GetProcessTitle(const char* default_title);
 std::string GetHumanReadableProcessName();
 
+v8::Maybe<bool> InitializeBaseContextForSnapshot(
+    v8::Local<v8::Context> context);
 v8::Maybe<bool> InitializeContextRuntime(v8::Local<v8::Context> context);
 v8::Maybe<bool> InitializePrimordials(v8::Local<v8::Context> context);
 


### PR DESCRIPTION
The first commit comes from https://github.com/nodejs/node/pull/44258

### vm: make ContextifyContext template context-independent

Instead of creating an object template for every ContextifyContext,
we now create one object template that can be reused by all
contexts. The native pointer can be obtained through an embdder
pointer field in the creation context of the receiver in the
interceptors, because the interceptors are only meant to be invoked
on the global object of the contextified contexts. This makes
the ContextifyContext template context-independent and therefore
snapshotable.

### vm: include vm context in the embedded snapshot

Include a minimally initialized contextify context in the embedded
snapshot. This paves the way for user-land vm context snapshots.

### vm: avoid unnecessary property getter interceptor calls

Access to the global object from within a vm context is intercepted
so it's slow, therefore we should try to avoid unnecessary access
to it during the initialization of vm contexts.

- Remove the Atomics.wake deletion as V8 now does not install it
  anymore.
- Move the Intl.v8BreakIterator deletion into the snapshot.
- Do not query the Object prototype if --disable-proto is not set.

This should speed up the creation of vm contexts by about ~12%.

Refs: https://github.com/nodejs/node/issues/44014
Refs: https://github.com/nodejs/node/issues/37476

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
