### PR TITLE
report: expose report public native apis

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -993,6 +993,7 @@
         'test/cctest/test_node_api.cc',
         'test/cctest/test_per_process.cc',
         'test/cctest/test_platform.cc',
+        'test/cctest/test_report.cc',
         'test/cctest/test_json_utils.cc',
         'test/cctest/test_sockaddr.cc',
         'test/cctest/test_traced_value.cc',

--- a/src/node.h
+++ b/src/node.h
@@ -75,8 +75,9 @@
 #include "v8-platform.h"  // NOLINT(build/include_order)
 #include "node_version.h"  // NODE_MODULE_VERSION
 
-#include <memory>
 #include <functional>
+#include <memory>
+#include <ostream>
 
 // We cannot use __POSIX__ in this header because that's only defined when
 // building Node.js.
@@ -616,6 +617,33 @@ NODE_EXTERN v8::MaybeLocal<v8::Value> PrepareStackTraceCallback(
     v8::Local<v8::Context> context,
     v8::Local<v8::Value> exception,
     v8::Local<v8::Array> trace);
+
+// Writes a diagnostic report to a file. If filename is not provided, the
+// default filename includes the date, time, PID, and a sequence number.
+// The report's JavaScript stack trace is taken from err, if present.
+// If isolate is nullptr, no information about the JavaScript environment
+// is included in the report.
+// Returns the filename of the written report.
+NODE_EXTERN std::string TriggerNodeReport(v8::Isolate* isolate,
+                                          const char* message,
+                                          const char* trigger,
+                                          const std::string& filename,
+                                          v8::Local<v8::Value> error);
+NODE_EXTERN std::string TriggerNodeReport(Environment* env,
+                                          const char* message,
+                                          const char* trigger,
+                                          const std::string& filename,
+                                          v8::Local<v8::Value> error);
+NODE_EXTERN void GetNodeReport(v8::Isolate* isolate,
+                               const char* message,
+                               const char* trigger,
+                               v8::Local<v8::Value> error,
+                               std::ostream& out);
+NODE_EXTERN void GetNodeReport(Environment* env,
+                               const char* message,
+                               const char* trigger,
+                               v8::Local<v8::Value> error,
+                               std::ostream& out);
 
 // This returns the MultiIsolatePlatform used for an Environment or IsolateData
 // instance, if one exists.

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -449,8 +449,7 @@ static void ReportFatalException(Environment* env,
   }
 
   if (env->isolate_data()->options()->report_uncaught_exception) {
-    report::TriggerNodeReport(
-        isolate, env, report_message.c_str(), "Exception", "", error);
+    TriggerNodeReport(env, report_message.c_str(), "Exception", "", error);
   }
 
   if (env->options()->trace_uncaught) {
@@ -482,10 +481,6 @@ void OnFatalError(const char* location, const char* message) {
   }
 
   Isolate* isolate = Isolate::TryGetCurrent();
-  Environment* env = nullptr;
-  if (isolate != nullptr) {
-    env = Environment::GetCurrent(isolate);
-  }
   bool report_on_fatalerror;
   {
     Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
@@ -493,8 +488,7 @@ void OnFatalError(const char* location, const char* message) {
   }
 
   if (report_on_fatalerror) {
-    report::TriggerNodeReport(
-        isolate, env, message, "FatalError", "", Local<Object>());
+    TriggerNodeReport(isolate, message, "FatalError", "", Local<Object>());
   }
 
   fflush(stderr);
@@ -512,10 +506,6 @@ void OOMErrorHandler(const char* location, bool is_heap_oom) {
   }
 
   Isolate* isolate = Isolate::TryGetCurrent();
-  Environment* env = nullptr;
-  if (isolate != nullptr) {
-    env = Environment::GetCurrent(isolate);
-  }
   bool report_on_fatalerror;
   {
     Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
@@ -523,8 +513,7 @@ void OOMErrorHandler(const char* location, bool is_heap_oom) {
   }
 
   if (report_on_fatalerror) {
-    report::TriggerNodeReport(
-        isolate, env, message, "OOMError", "", Local<Object>());
+    TriggerNodeReport(isolate, message, "OOMError", "", Local<Object>());
   }
 
   fflush(stderr);

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -14,24 +14,10 @@
 #endif
 
 #include <iomanip>
+#include <sstream>
 
 namespace node {
 namespace report {
-
-// Function declarations - functions in src/node_report.cc
-std::string TriggerNodeReport(v8::Isolate* isolate,
-                              Environment* env,
-                              const char* message,
-                              const char* trigger,
-                              const std::string& name,
-                              v8::Local<v8::Value> error);
-void GetNodeReport(v8::Isolate* isolate,
-                   Environment* env,
-                   const char* message,
-                   const char* trigger,
-                   v8::Local<v8::Value> error,
-                   std::ostream& out);
-
 // Function declarations - utility functions in src/node_report_utils.cc
 void WalkHandle(uv_handle_t* h, void* arg);
 

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -44,8 +44,7 @@ void WriteReport(const FunctionCallbackInfo<Value>& info) {
   else
     error = Local<Value>();
 
-  filename = TriggerNodeReport(
-      isolate, env, *message, *trigger, filename, error);
+  filename = TriggerNodeReport(env, *message, *trigger, filename, error);
   // Return value is the report filename
   info.GetReturnValue().Set(
       String::NewFromUtf8(isolate, filename.c_str()).ToLocalChecked());
@@ -65,8 +64,7 @@ void GetReport(const FunctionCallbackInfo<Value>& info) {
   else
     error = Local<Object>();
 
-  GetNodeReport(
-      isolate, env, "JavaScript API", __func__, error, out);
+  GetNodeReport(env, "JavaScript API", __func__, error, out);
 
   // Return value is the contents of a report as a string.
   info.GetReturnValue().Set(

--- a/test/addons/report-api/binding.cc
+++ b/test/addons/report-api/binding.cc
@@ -1,0 +1,53 @@
+#include <node.h>
+#include <v8.h>
+
+using v8::FunctionCallbackInfo;
+using v8::Isolate;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+
+void TriggerReport(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+
+  node::TriggerNodeReport(
+      isolate, "FooMessage", "BarTrigger", std::string(), Local<Value>());
+}
+
+void TriggerReportNoIsolate(const FunctionCallbackInfo<Value>& args) {
+  node::TriggerNodeReport(static_cast<Isolate*>(nullptr),
+                          "FooMessage",
+                          "BarTrigger",
+                          std::string(),
+                          Local<Value>());
+}
+
+void TriggerReportEnv(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+
+  node::TriggerNodeReport(
+      node::GetCurrentEnvironment(isolate->GetCurrentContext()),
+      "FooMessage",
+      "BarTrigger",
+      std::string(),
+      Local<Value>());
+}
+
+void TriggerReportNoEnv(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+
+  node::TriggerNodeReport(static_cast<node::Environment*>(nullptr),
+                          "FooMessage",
+                          "BarTrigger",
+                          std::string(),
+                          Local<Value>());
+}
+
+void init(Local<Object> exports) {
+  NODE_SET_METHOD(exports, "triggerReport", TriggerReport);
+  NODE_SET_METHOD(exports, "triggerReportNoIsolate", TriggerReportNoIsolate);
+  NODE_SET_METHOD(exports, "triggerReportEnv", TriggerReportEnv);
+  NODE_SET_METHOD(exports, "triggerReportNoEnv", TriggerReportNoEnv);
+}
+
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/report-api/binding.gyp
+++ b/test/addons/report-api/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'includes': ['../common.gypi'],
+    }
+  ]
+}

--- a/test/addons/report-api/test.js
+++ b/test/addons/report-api/test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const path = require('path');
+const helper = require('../../common/report.js');
+const tmpdir = require('../../common/tmpdir');
+
+const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
+const addon = require(binding);
+
+function myAddonMain(method, hasJavaScriptFrames) {
+  tmpdir.refresh();
+  process.report.directory = tmpdir.path;
+
+  addon[method]();
+
+  const reports = helper.findReports(process.pid, tmpdir.path);
+  assert.strictEqual(reports.length, 1);
+
+  const report = reports[0];
+  helper.validate(report);
+
+  const content = require(report);
+  assert.strictEqual(content.header.event, 'FooMessage');
+  assert.strictEqual(content.header.trigger, 'BarTrigger');
+
+  // Check that the javascript stack is present.
+  if (hasJavaScriptFrames) {
+    assert.strictEqual(content.javascriptStack.stack.findIndex((frame) => frame.match('myAddonMain')), 0);
+  } else {
+    assert.strictEqual(content.javascriptStack, undefined);
+  }
+}
+
+const methods = [
+  ['triggerReport', true],
+  ['triggerReportNoIsolate', false],
+  ['triggerReportEnv', true],
+  ['triggerReportNoEnv', false],
+];
+for (const [method, hasJavaScriptFrames] of methods) {
+  myAddonMain(method, hasJavaScriptFrames);
+}

--- a/test/cctest/test_report.cc
+++ b/test/cctest/test_report.cc
@@ -1,0 +1,125 @@
+#include "node.h"
+
+#include <string>
+#include "gtest/gtest.h"
+#include "node_test_fixture.h"
+
+using node::Environment;
+using v8::Context;
+using v8::Function;
+using v8::FunctionCallbackInfo;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Local;
+using v8::SealHandleScope;
+using v8::String;
+using v8::Value;
+
+bool report_callback_called = false;
+
+class ReportTest : public EnvironmentTestFixture {
+ private:
+  void TearDown() override {
+    NodeTestFixture::TearDown();
+    report_callback_called = false;
+  }
+};
+
+TEST_F(ReportTest, ReportWithNoIsolate) {
+  SealHandleScope handle_scope(isolate_);
+
+  std::ostringstream oss;
+  node::GetNodeReport(static_cast<Isolate*>(nullptr),
+                      "FooMessage",
+                      "BarTrigger",
+                      Local<Value>(),
+                      oss);
+
+  // Simple checks on the output string contains the message and trigger.
+  std::string actual = oss.str();
+  EXPECT_NE(actual.find("FooMessage"), std::string::npos);
+  EXPECT_NE(actual.find("BarTrigger"), std::string::npos);
+}
+
+TEST_F(ReportTest, ReportWithNoEnv) {
+  SealHandleScope handle_scope(isolate_);
+
+  std::ostringstream oss;
+  node::GetNodeReport(static_cast<Environment*>(nullptr),
+                      "FooMessage",
+                      "BarTrigger",
+                      Local<Value>(),
+                      oss);
+
+  // Simple checks on the output string contains the message and trigger.
+  std::string actual = oss.str();
+  EXPECT_NE(actual.find("FooMessage"), std::string::npos);
+  EXPECT_NE(actual.find("BarTrigger"), std::string::npos);
+}
+
+TEST_F(ReportTest, ReportWithIsolate) {
+  const HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env{handle_scope, argv};
+
+  Local<Context> context = isolate_->GetCurrentContext();
+  Local<Function> fn =
+      Function::New(context, [](const FunctionCallbackInfo<Value>& args) {
+        Isolate* isolate = args.GetIsolate();
+        HandleScope scope(isolate);
+
+        std::ostringstream oss;
+        node::GetNodeReport(isolate, "FooMessage", "BarTrigger", args[0], oss);
+
+        // Simple checks on the output string contains the message and trigger.
+        std::string actual = oss.str();
+        EXPECT_NE(actual.find("FooMessage"), std::string::npos);
+        EXPECT_NE(actual.find("BarTrigger"), std::string::npos);
+
+        report_callback_called = true;
+      }).ToLocalChecked();
+
+  context->Global()
+      ->Set(context, String::NewFromUtf8(isolate_, "foo").ToLocalChecked(), fn)
+      .FromJust();
+
+  node::LoadEnvironment(*env, "foo()").ToLocalChecked();
+
+  EXPECT_TRUE(report_callback_called);
+}
+
+TEST_F(ReportTest, ReportWithEnv) {
+  const HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env{handle_scope, argv};
+
+  Local<Context> context = isolate_->GetCurrentContext();
+  Local<Function> fn =
+      Function::New(context, [](const FunctionCallbackInfo<Value>& args) {
+        Isolate* isolate = args.GetIsolate();
+        HandleScope scope(isolate);
+
+        std::ostringstream oss;
+        node::GetNodeReport(
+            node::GetCurrentEnvironment(isolate->GetCurrentContext()),
+            "FooMessage",
+            "BarTrigger",
+            args[0],
+            oss);
+
+        // Simple checks on the output string contains the message and trigger.
+        std::string actual = oss.str();
+        EXPECT_NE(actual.find("FooMessage"), std::string::npos);
+        EXPECT_NE(actual.find("BarTrigger"), std::string::npos);
+
+        report_callback_called = true;
+      }).ToLocalChecked();
+
+  context->Global()
+      ->Set(context, String::NewFromUtf8(isolate_, "foo").ToLocalChecked(), fn)
+      .FromJust();
+
+  node::LoadEnvironment(*env, "foo()").ToLocalChecked();
+
+  EXPECT_TRUE(report_callback_called);
+}


### PR DESCRIPTION
Allows APM vendors to generate a diagnostic report without calling into
JavaScript. Like, from their own message channels interrupting the
isolate and generating a report on demand.