### PR TITLE
doc,report: document special filenames

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1064,6 +1064,9 @@ changes:
 
 Name of the file to which the report will be written.
 
+If the filename is set to `'stdout'` or `'stderr'`, the report is written to
+the stdout or stderr of the process respectively.
+
 ### `--report-on-fatalerror`
 
 <!-- YAML

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2825,6 +2825,9 @@ Filename where the report is written. If set to the empty string, the output
 filename will be comprised of a timestamp, PID, and sequence number. The default
 value is the empty string.
 
+If the value of `process.report.filename` is set to `'stdout'` or `'stderr'`,
+the report is written to the stdout or stderr of the process respectively.
+
 ```mjs
 import { report } from 'node:process';
 
@@ -3019,6 +3022,9 @@ changes:
 Writes a diagnostic report to a file. If `filename` is not provided, the default
 filename includes the date, time, PID, and a sequence number. The report's
 JavaScript stack trace is taken from `err`, if present.
+
+If the value of `filename` is set to `'stdout'` or `'stderr'`, the report is
+written to the stdout or stderr of the process respectively.
 
 ```mjs
 import { report } from 'node:process';


### PR DESCRIPTION
Filenames `stdout` and `stderr` have special meanings when writing
the report.
