### PR TITLE
src: extract common context embedder tag checks

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -177,16 +177,7 @@ inline Environment* Environment::GetCurrent(v8::Isolate* isolate) {
 }
 
 inline Environment* Environment::GetCurrent(v8::Local<v8::Context> context) {
-  if (UNLIKELY(context.IsEmpty())) {
-    return nullptr;
-  }
-  if (UNLIKELY(context->GetNumberOfEmbedderDataFields() <=
-               ContextEmbedderIndex::kContextTag)) {
-    return nullptr;
-  }
-  if (UNLIKELY(context->GetAlignedPointerFromEmbedderData(
-                   ContextEmbedderIndex::kContextTag) !=
-               Environment::kNodeContextTagPtr)) {
+  if (UNLIKELY(!ContextEmbedderTag::IsNodeContext(context))) {
     return nullptr;
   }
   return static_cast<Environment*>(

--- a/src/env.cc
+++ b/src/env.cc
@@ -61,9 +61,9 @@ using v8::WeakCallbackInfo;
 using v8::WeakCallbackType;
 using worker::Worker;
 
-int const Environment::kNodeContextTag = 0x6e6f64;
-void* const Environment::kNodeContextTagPtr = const_cast<void*>(
-    static_cast<const void*>(&Environment::kNodeContextTag));
+int const ContextEmbedderTag::kNodeContextTag = 0x6e6f64;
+void* const ContextEmbedderTag::kNodeContextTagPtr = const_cast<void*>(
+    static_cast<const void*>(&ContextEmbedderTag::kNodeContextTag));
 
 void AsyncHooks::SetJSPromiseHooks(Local<Function> init,
                                    Local<Function> before,
@@ -512,11 +512,9 @@ void TrackingTraceStateObserver::UpdateTraceCategoryState() {
 
 void Environment::AssignToContext(Local<v8::Context> context,
                                   const ContextInfo& info) {
+  ContextEmbedderTag::TagNodeContext(context);
   context->SetAlignedPointerInEmbedderData(ContextEmbedderIndex::kEnvironment,
                                            this);
-  // Used by Environment::GetCurrent to know that we are on a node context.
-  context->SetAlignedPointerInEmbedderData(ContextEmbedderIndex::kContextTag,
-                                           Environment::kNodeContextTagPtr);
   // Used to retrieve bindings
   context->SetAlignedPointerInEmbedderData(
       ContextEmbedderIndex::kBindingListIndex, &(this->bindings_));

--- a/src/env.h
+++ b/src/env.h
@@ -1573,9 +1573,6 @@ class Environment : public MemoryRetainer {
   uint64_t thread_id_;
   std::unordered_set<worker::Worker*> sub_worker_contexts_;
 
-  static void* const kNodeContextTagPtr;
-  static int const kNodeContextTag;
-
 #if HAVE_INSPECTOR
   std::unique_ptr<inspector::Agent> inspector_agent_;
   bool is_in_inspector_console_call_ = false;


### PR DESCRIPTION
Extract common context embedder tag checks to ContextEmbedderTag so
that verifying if a context is a node context doesn't need to access
private members of node::Environment.

Refs: https://github.com/nodejs/node/pull/44179
Refs: https://github.com/nodejs/node/pull/44252
