### PR TITLE
lib: do not add stack traces to `DOMException` instances

### DIFF
--- a/lib/internal/per_context/domexception.js
+++ b/lib/internal/per_context/domexception.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const {
-  ErrorCaptureStackTrace,
   ErrorPrototype,
   ObjectDefineProperties,
   ObjectDefineProperty,
@@ -50,7 +49,6 @@ const disusedNamesSet = new SafeSet()
 
 class DOMException {
   constructor(message = '', name = 'Error') {
-    ErrorCaptureStackTrace(this);
     internalsMap.set(this, {
       message: `${message}`,
       name: `${name}`

--- a/test/message/test-abort-error.js
+++ b/test/message/test-abort-error.js
@@ -1,0 +1,6 @@
+'use strict';
+require('../common');
+const { setImmediate } = require('node:timers/promises');
+
+Error.stackTraceLimit = 2;
+setImmediate(undefined, { signal: AbortSignal.abort() }).catch(console.error);

--- a/test/message/test-abort-error.out
+++ b/test/message/test-abort-error.out
@@ -1,0 +1,6 @@
+AbortError: The operation was aborted
+    at setImmediate (node:timers/promises:*:*)
+    at Object.<anonymous> (*) {
+  code: 'ABORT_ERR',
+  [cause]: [DOMException [AbortError]: This operation was aborted]
+}


### PR DESCRIPTION
To align with the web. (DOMException are usually created internally
anyway, making stack traces mostly irrelevant to end users).

Chromium and Firefox show no stack trace at all:

```
DOMException: The user aborted a request.
```

Safari shows only one line that says `(anonymous function)` (even though there's no anonymous function in user code):

```
AbortError: Fetch is aborted
(anonymous function)
```

I suppose a fix would be to ensure our `DOMException` implementation have no `stack` property to align with browsers.

_Originally posted by @aduh95 in https://github.com/nodejs/node/issues/44253#issuecomment-1218560544_

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
