### PR TITLE
fs: remove chunk by chunk file read

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -44,7 +44,6 @@ const {
   constants: {
     kIoMaxLength,
     kMaxUserId,
-    kReadFileBufferLength,
     kReadFileUnknownBufferLength,
     kWriteFileMaxChunkSize,
   },
@@ -450,7 +449,7 @@ async function readFileHandle(filehandle, options) {
     } else {
       buffer = fullBuffer;
       offset = totalRead;
-      length = MathMin(size - totalRead, kReadFileBufferLength);
+      length = size - totalRead;
     }
 
     const bytesRead = (await binding.read(filehandle.fd, buffer, offset,

--- a/lib/internal/fs/read_file_context.js
+++ b/lib/internal/fs/read_file_context.js
@@ -2,13 +2,11 @@
 
 const {
   ArrayPrototypePush,
-  MathMin,
   ReflectApply,
 } = primordials;
 
 const {
   constants: {
-    kReadFileBufferLength,
     kReadFileUnknownBufferLength,
   }
 } = require('internal/fs/utils');
@@ -99,7 +97,7 @@ class ReadFileContext {
     } else {
       buffer = this.buffer;
       offset = this.pos;
-      length = MathMin(kReadFileBufferLength, this.size - this.pos);
+      length = this.size - this.pos;
     }
 
     const req = new FSReqCallback();

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -137,7 +137,6 @@ const kIoMaxLength = 2 ** 31 - 1;
 // Use up to 512kb per read otherwise to partition reading big files to prevent
 // blocking other threads in case the available threads are all in use.
 const kReadFileUnknownBufferLength = 64 * 1024;
-const kReadFileBufferLength = 512 * 1024;
 
 const kWriteFileMaxChunkSize = 512 * 1024;
 
@@ -924,7 +923,6 @@ module.exports = {
   constants: {
     kIoMaxLength,
     kMaxUserId,
-    kReadFileBufferLength,
     kReadFileUnknownBufferLength,
     kWriteFileMaxChunkSize,
   },


### PR DESCRIPTION
I'm still investigating why the performance is down by 20% for certain cases, but 68% performance looks like a good start.

I left the chunk-by-chunk implementation to support edge cases where the file size is unknown before reading it, where fstat returns 0.

```
fs/readfile-partitioned.js concurrent=1 len=1024 dur=1                        0.48 %       ±2.40% ±3.20% ±4.17%
fs/readfile-partitioned.js concurrent=1 len=16777216 dur=1           ***     19.44 %       ±4.43% ±5.91% ±7.74%
fs/readfile-partitioned.js concurrent=10 len=1024 dur=1                       1.24 %       ±2.71% ±3.60% ±4.69%
fs/readfile-partitioned.js concurrent=10 len=16777216 dur=1          ***    -68.32 %       ±1.90% ±2.55% ±3.37%
fs/readfile-promises.js concurrent=1 len=1024 duration=1                      2.00 %       ±2.88% ±3.84% ±5.00%
fs/readfile-promises.js concurrent=1 len=16777216 duration=1         ***     23.65 %       ±2.00% ±2.68% ±3.52%
fs/readfile-promises.js concurrent=10 len=1024 duration=1                    -0.51 %       ±0.55% ±0.74% ±0.96%
fs/readfile-promises.js concurrent=10 len=16777216 duration=1        ***    -16.45 %       ±3.41% ±4.53% ±5.90%
fs/readfile.js concurrent=1 len=1024 duration=1                              -2.52 %       ±3.28% ±4.37% ±5.69%
fs/readfile.js concurrent=1 len=16777216 duration=1                  ***     21.26 %       ±1.81% ±2.41% ±3.14%
fs/readfile.js concurrent=10 len=1024 duration=1                             -0.56 %       ±1.26% ±1.68% ±2.21%
fs/readfile.js concurrent=10 len=16777216 duration=1                 ***    -19.66 %       ±2.37% ±3.18% ±4.17%
```