### PR TITLE
fs: add encoding parameter to benchmarks

### DIFF
--- a/benchmark/fs/readfile-partitioned.js
+++ b/benchmark/fs/readfile-partitioned.js
@@ -17,12 +17,13 @@ const zlib = require('zlib');
 const assert = require('assert');
 
 const bench = common.createBenchmark(main, {
-  dur: [5],
+  duration: [5],
+  encoding: ['', 'utf-8'],
   len: [1024, 16 * 1024 * 1024],
   concurrent: [1, 10]
 });
 
-function main({ len, dur, concurrent }) {
+function main({ len, duration, concurrent, encoding }) {
   try {
     fs.unlinkSync(filename);
   } catch {
@@ -47,10 +48,10 @@ function main({ len, dur, concurrent }) {
     } catch {
       // Continue regardless of error.
     }
-  }, dur * 1000);
+  }, duration * 1000);
 
   function read() {
-    fs.readFile(filename, afterRead);
+    fs.readFile(filename, encoding, afterRead);
   }
 
   function afterRead(er, data) {

--- a/benchmark/fs/readfile-promises.js
+++ b/benchmark/fs/readfile-promises.js
@@ -15,11 +15,12 @@ const filename = path.resolve(tmpdir.path,
 
 const bench = common.createBenchmark(main, {
   duration: [5],
+  encoding: ['', 'utf-8'],
   len: [1024, 16 * 1024 * 1024],
   concurrent: [1, 10]
 });
 
-function main({ len, duration, concurrent }) {
+function main({ len, duration, concurrent, encoding }) {
   try {
     fs.unlinkSync(filename);
   } catch {
@@ -44,7 +45,7 @@ function main({ len, duration, concurrent }) {
   }, duration * 1000);
 
   function read() {
-    fs.promises.readFile(filename)
+    fs.promises.readFile(filename, encoding)
       .then((res) => afterRead(undefined, res))
       .catch((err) => afterRead(err));
   }

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -15,11 +15,12 @@ const filename = path.resolve(tmpdir.path,
 
 const bench = common.createBenchmark(main, {
   duration: [5],
+  encoding: ['', 'utf-8'],
   len: [1024, 16 * 1024 * 1024],
   concurrent: [1, 10]
 });
 
-function main({ len, duration, concurrent }) {
+function main({ len, duration, concurrent, encoding }) {
   try {
     fs.unlinkSync(filename);
   } catch {
@@ -44,7 +45,7 @@ function main({ len, duration, concurrent }) {
   }, duration * 1000);
 
   function read() {
-    fs.readFile(filename, afterRead);
+    fs.readFile(filename, encoding, afterRead);
   }
 
   function afterRead(er, data) {


### PR DESCRIPTION
Example output

```
fs/readfile.js concurrent=1 len=1024 encoding="undefined" duration=5: 40,590.2356841829
fs/readfile.js concurrent=10 len=1024 encoding="undefined" duration=5: 115,114.82816873376
fs/readfile.js concurrent=1 len=16777216 encoding="undefined" duration=5: 877.7391872447944
fs/readfile.js concurrent=10 len=16777216 encoding="undefined" duration=5: 942.8575813623352
fs/readfile.js concurrent=1 len=1024 encoding="utf-8" duration=5: 37,029.85724031153
fs/readfile.js concurrent=10 len=1024 encoding="utf-8" duration=5: 100,228.93646632427
fs/readfile.js concurrent=1 len=16777216 encoding="utf-8" duration=5: 278.740263620088
fs/readfile.js concurrent=10 len=16777216 encoding="utf-8" duration=5: 355.10858887408915
```