### PR TITLE
bootstrap: clean up inspector console methods during serialization

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -28,6 +28,7 @@ const {
   SafeArrayIterator,
   SafeMap,
   SafeWeakMap,
+  SafeSet,
   StringPrototypeIncludes,
   StringPrototypePadStart,
   StringPrototypeRepeat,
@@ -687,6 +688,32 @@ Console.prototype.groupCollapsed = Console.prototype.group;
 function initializeGlobalConsole(globalConsole) {
   globalConsole[kBindStreamsLazy](process);
   globalConsole[kBindProperties](true, 'auto');
+
+  const {
+    addSerializeCallback,
+    isBuildingSnapshot,
+  } = require('v8').startupSnapshot;
+
+  if (!internalBinding('config').hasInspector || !isBuildingSnapshot()) {
+    return;
+  }
+  const { console: consoleFromVM } = internalBinding('inspector');
+  const nodeConsoleKeys = ObjectKeys(Console.prototype);
+  const vmConsoleKeys = ObjectKeys(consoleFromVM);
+  const originalKeys = new SafeSet(vmConsoleKeys.concat(nodeConsoleKeys));
+  const inspectorConsoleKeys = new SafeSet();
+  for (const key of ObjectKeys(globalConsole)) {
+    if (!originalKeys.has(key)) {
+      inspectorConsoleKeys.add(key);
+    }
+  }
+  // During deserialization these should be reinstalled to console by
+  // V8 when the inspector client is created.
+  addSerializeCallback(() => {
+    for (const key of inspectorConsoleKeys) {
+      globalConsole[key] = undefined;
+    }
+  });
 }
 
 module.exports = {

--- a/test/fixtures/snapshot/console.js
+++ b/test/fixtures/snapshot/console.js
@@ -1,0 +1,9 @@
+const {
+  setDeserializeMainFunction,
+} = require('v8').startupSnapshot;
+
+console.log(JSON.stringify(Object.keys(console), null, 2));
+
+setDeserializeMainFunction(() => {
+  console.log(JSON.stringify(Object.keys(console), null, 2));
+});

--- a/test/parallel/test-snapshot-console.js
+++ b/test/parallel/test-snapshot-console.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// TODO(joyeecheung): remove the flag when it is turned on by default in V8.
+// Flags: --experimental-async-stack-tagging-api
+// This tests the console works in the deserialized snapshot.
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const path = require('path');
+const fs = require('fs');
+
+tmpdir.refresh();
+const blobPath = path.join(tmpdir.path, 'snapshot.blob');
+const entry = fixtures.path('snapshot', 'console.js');
+
+{
+  const child = spawnSync(process.execPath, [
+    '--experimental-async-stack-tagging-api',
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot',
+    entry,
+  ], {
+    cwd: tmpdir.path
+  });
+  const stdout = child.stdout.toString();
+  if (child.status !== 0) {
+    console.log(stdout);
+    console.log(child.stderr.toString());
+    assert.strictEqual(child.status, 0);
+  }
+  assert.deepStrictEqual(Object.keys(console), JSON.parse(stdout));
+  const stats = fs.statSync(path.join(tmpdir.path, 'snapshot.blob'));
+  assert(stats.isFile());
+}
+
+{
+  const child = spawnSync(process.execPath, [
+    '--experimental-async-stack-tagging-api',
+    '--snapshot-blob',
+    blobPath,
+  ], {
+    cwd: tmpdir.path,
+    env: {
+      ...process.env,
+    }
+  });
+
+  const stdout = child.stdout.toString();
+  if (child.status !== 0) {
+    console.log(stdout);
+    console.log(child.stderr.toString());
+    assert.strictEqual(child.status, 0);
+  }
+  assert.deepStrictEqual(Object.keys(console), JSON.parse(stdout));
+  assert.strictEqual(child.status, 0);
+}


### PR DESCRIPTION
Some console methods are created by the V8 inspector after
an inspector client is created, reset them to undefined during
sereialization to avoid holding on to invalid references in
the snapshot. V8 will take care of the re-initialization when
another inspector client is created during deserialization.

Fixes: https://github.com/nodejs/node-v8/issues/237

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
