### PR TITLE
worker_threads: add options.timeout for worker_threads

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1001,6 +1001,10 @@ changes:
       used for generated code.
     * `stackSizeMb` {number} The default maximum stack size for the thread.
       Small values may lead to unusable Worker instances. **Default:** `4`.
+  * `timeout` {number} In milliseconds the maximum amount of time the worker
+    is allowed to run. **Default:** `undefined`.
+  * `signal` {AbortSignal} Allow closing the worker using an
+    AbortSignal.
 
 ### Event: `'error'`
 
@@ -1063,6 +1067,15 @@ added: v10.5.0
 
 The `'online'` event is emitted when the worker thread has started executing
 JavaScript code.
+
+### Event: `'timeout'`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The `'timeout'` event is emitted when the maximum amount of execution time
+reaches the threshold of `options.timeout`.
 
 ### `worker.getHeapSnapshot()`
 
@@ -1271,6 +1284,14 @@ added: v10.5.0
 Calling `unref()` on a worker allows the thread to exit if this is the only
 active handle in the event system. If the worker is already `unref()`ed calling
 `unref()` again has no effect.
+
+### `worker.clearTimer()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Cancel the timer created by `options.timeout`.
 
 ## Notes
 

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -58,7 +58,7 @@ const {
 const { deserializeError } = require('internal/error_serdes');
 const { fileURLToPath, isURLInstance, pathToFileURL } = require('internal/url');
 const { kEmptyObject } = require('internal/util');
-const { validateArray } = require('internal/validators');
+const { validateArray, validateAbortSignal } = require('internal/validators');
 
 const {
   ownsProcessState,
@@ -88,6 +88,8 @@ const SHARE_ENV = SymbolFor('nodejs.worker_threads.SHARE_ENV');
 let debug = require('internal/util/debuglog').debuglog('worker', (fn) => {
   debug = fn;
 });
+
+const { clearTimeout, setTimeout } = require('timers');
 
 let cwdCounter;
 
@@ -121,6 +123,7 @@ function assignEnvironmentData(data) {
 }
 
 class Worker extends EventEmitter {
+  #timer = null;
   constructor(filename, options = kEmptyObject) {
     super();
     debug(`[${threadId}] create new worker`, filename, options);
@@ -261,9 +264,42 @@ class Worker extends EventEmitter {
     // Actually start the new thread now that everything is in place.
     this[kHandle].startThread();
 
+    if (typeof options.timeout === 'number' && options.timeout > 0) {
+      this.#timer = setTimeout(() => {
+        if (this.#timer) {
+          this.#timer = null;
+          this.emit('timeout');
+          this.terminate();
+        }
+      }, options.timeout).unref();
+      this.once('exit', () => {
+        this.clearTimer();
+      });
+    }
+
+    if (options.signal) {
+      validateAbortSignal(options.signal, 'options.signal');
+      const signal = options.signal;
+      const onAbortListener = () => {
+        this.terminate();
+      };
+      if (signal.aborted) {
+        process.nextTick(onAbortListener);
+      } else {
+        signal.addEventListener('abort', onAbortListener, { once: true });
+        this.once('exit',
+                  () => signal.removeEventListener('abort', onAbortListener));
+      }
+    }
+
     process.nextTick(() => process.emit('worker', this));
   }
-
+  clearTimer() {
+    if (this.#timer) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+  }
   [kOnExit](code, customErr, customErrReason) {
     debug(`[${threadId}] hears end event for Worker ${this.threadId}`);
     drainMessagePort(this[kPublicPort]);

--- a/test/parallel/test-worker-abort.js
+++ b/test/parallel/test-worker-abort.js
@@ -1,0 +1,14 @@
+'use strict';
+const common = require('../common');
+const { Worker, isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+  const ac = new AbortController();
+  const w = new Worker(__filename, { signal: ac.signal });
+  w.on('online', common.mustCall(() => {
+    ac.abort();
+  }));
+  w.on('exit', common.mustCall());
+} else {
+  setInterval(() => {}, 1000);
+}

--- a/test/parallel/test-worker-timeout.js
+++ b/test/parallel/test-worker-timeout.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+const { Worker, isMainThread, workerData } = require('worker_threads');
+
+if (isMainThread) {
+
+  {
+    const w = new Worker(__filename, { workerData: { type: '1' }, timeout: 3000 });
+    w.on('timeout', common.mustCall());
+    w.on('exit', common.mustCall());
+  }
+  {
+    const w = new Worker(__filename, { workerData: { type: '2' }, timeout: 60 * 1000 });
+    w.on('timeout', common.mustNotCall());
+    w.on('exit', common.mustCall());
+  }
+  {
+    const w = new Worker(__filename, { workerData: { type: '3' } });
+    w.on('timeout', common.mustNotCall());
+    w.on('exit', common.mustCall());
+  }
+
+} else {
+  const { type } = workerData;
+  if (type === '1') {
+    setInterval(() => {}, 1000);
+  } else if (type === '2') {
+    // Nothing
+  } else if (type === '3') {
+    setTimeout(() => {}, 1000);
+  }
+}


### PR DESCRIPTION
add `options.timeout` and `options.signal` for `worker_threads`. Be consistent with the `child_process`.

Refs: `timeout` and `signal` of [child_process](https://nodejs.org/dist/latest-v18.x/docs/api/child_process.html#child_processexeccommand-options-callback)

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
