### PR TITLE
test_runner: fix test runner hooks failure stack

### DIFF
--- a/lib/internal/test_runner/tap_stream.js
+++ b/lib/internal/test_runner/tap_stream.js
@@ -167,7 +167,7 @@ function jsToYaml(indent, name, value) {
   }
 
   if (isErrorObj) {
-    const { kTestCodeFailure } = lazyLoadTest();
+    const { kTestCodeFailure, kHookFailure } = lazyLoadTest();
     const {
       cause,
       code,
@@ -181,10 +181,12 @@ function jsToYaml(indent, name, value) {
 
     // If the ERR_TEST_FAILURE came from an error provided by user code,
     // then try to unwrap the original error message and stack.
-    if (code === 'ERR_TEST_FAILURE' && failureType === kTestCodeFailure) {
-      errMsg = cause?.message ?? errMsg;
+    if (code === 'ERR_TEST_FAILURE' && (failureType === kTestCodeFailure || failureType === kHookFailure)) {
       errStack = cause?.stack ?? errStack;
       errCode = cause?.code ?? errCode;
+      if (failureType === kTestCodeFailure) {
+        errMsg = cause?.message ?? errMsg;
+      }
     }
 
     result += jsToYaml(indent, 'error', errMsg);

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -691,4 +691,13 @@ class Suite extends Test {
   }
 }
 
-module.exports = { kCancelledByParent, kDefaultIndent, kSubtestsFailed, kTestCodeFailure, Test, Suite, ItTest };
+module.exports = {
+  ItTest,
+  kCancelledByParent,
+  kDefaultIndent,
+  kHookFailure,
+  kSubtestsFailed,
+  kTestCodeFailure,
+  Suite,
+  Test,
+};

--- a/test/message/test_runner_hooks.out
+++ b/test/message/test_runner_hooks.out
@@ -55,6 +55,16 @@ not ok 2 - before throws
   failureType: 'hookFailed'
   error: 'failed running before hook'
   code: 'ERR_TEST_FAILURE'
+  stack: |-
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+    *
   ...
 # Subtest: after throws
     # Subtest: 1
@@ -74,6 +84,16 @@ not ok 3 - after throws
   failureType: 'hookFailed'
   error: 'failed running after hook'
   code: 'ERR_TEST_FAILURE'
+  stack: |-
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+    *
   ...
 # Subtest: beforeEach throws
     # Subtest: 1
@@ -85,6 +105,15 @@ not ok 3 - after throws
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
       ...
     # Subtest: 2
     not ok 2 - 2
@@ -93,6 +122,17 @@ not ok 3 - after throws
       failureType: 'hookFailed'
       error: 'failed running beforeEach hook'
       code: 'ERR_TEST_FAILURE'
+      stack: |-
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
       ...
     1..2
 not ok 4 - beforeEach throws
@@ -112,6 +152,15 @@ not ok 4 - beforeEach throws
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
       ...
     # Subtest: 2
     not ok 2 - 2
@@ -120,6 +169,17 @@ not ok 4 - beforeEach throws
       failureType: 'hookFailed'
       error: 'failed running afterEach hook'
       code: 'ERR_TEST_FAILURE'
+      stack: |-
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
       ...
     1..2
 not ok 5 - afterEach throws
@@ -171,6 +231,15 @@ ok 6 - test hooks
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
       ...
     # Subtest: 2
     not ok 2 - 2
@@ -180,6 +249,15 @@ ok 6 - test hooks
       error: 'failed running beforeEach hook'
       code: 'ERR_TEST_FAILURE'
       stack: |-
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
         *
       ...
     1..2
@@ -200,6 +278,15 @@ not ok 7 - t.beforeEach throws
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
       ...
     # Subtest: 2
     not ok 2 - 2
@@ -209,6 +296,15 @@ not ok 7 - t.beforeEach throws
       error: 'failed running afterEach hook'
       code: 'ERR_TEST_FAILURE'
       stack: |-
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
+        *
         *
       ...
     1..2


### PR DESCRIPTION
before the fix a hook failure (i.e `beforeEach(() => { throw new Error(''); })`) resulted in:

```js
  duration_ms: 0.000442797
  failureType: 'hookFailed'
  error: 'failed running before hook'
  code: 'ERR_TEST_FAILURE'
```

after the fix:
```js
  duration_ms: 0.000439342
  failureType: 'hookFailed'
  error: 'failed running before hook'
  code: 'ERR_TEST_FAILURE'
  stack: |-
    Object.<anonymous> (/Users/mosheatlow/repos/node/test/message/test_runner_hooks.js:54:24)
    TestHook.runInAsyncScope (node:async_hooks:203:9)
    TestHook.run (node:internal/test_runner/test:483:25)
    TestHook.run (node:internal/test_runner/test:624:18)
    node:internal/test_runner/test:433:20
    process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    async [kRunHook] (node:internal/test_runner/test:431:7)
    async Suite.run (node:internal/test_runner/test:674:7)
    async Test.processPendingSubtests (node:internal/test_runner/test:249:7)
```