### PR TITLE
src: use `if constexpr` where appropriate

### DIFF
--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -115,7 +115,7 @@ bool BaseObject::has_pointer_data() const {
 template <typename T, bool kIsWeak>
 BaseObject::PointerData*
 BaseObjectPtrImpl<T, kIsWeak>::pointer_data() const {
-  if (kIsWeak) {
+  if constexpr (kIsWeak) {
     return data_.pointer_data;
   }
   if (get_base_object() == nullptr) {
@@ -126,7 +126,7 @@ BaseObjectPtrImpl<T, kIsWeak>::pointer_data() const {
 
 template <typename T, bool kIsWeak>
 BaseObject* BaseObjectPtrImpl<T, kIsWeak>::get_base_object() const {
-  if (kIsWeak) {
+  if constexpr (kIsWeak) {
     if (pointer_data() == nullptr) {
       return nullptr;
     }
@@ -137,7 +137,7 @@ BaseObject* BaseObjectPtrImpl<T, kIsWeak>::get_base_object() const {
 
 template <typename T, bool kIsWeak>
 BaseObjectPtrImpl<T, kIsWeak>::~BaseObjectPtrImpl() {
-  if (kIsWeak) {
+  if constexpr (kIsWeak) {
     if (pointer_data() != nullptr &&
         --pointer_data()->weak_ptr_count == 0 &&
         pointer_data()->self == nullptr) {
@@ -157,7 +157,7 @@ template <typename T, bool kIsWeak>
 BaseObjectPtrImpl<T, kIsWeak>::BaseObjectPtrImpl(T* target)
   : BaseObjectPtrImpl() {
   if (target == nullptr) return;
-  if (kIsWeak) {
+  if constexpr (kIsWeak) {
     data_.pointer_data = target->pointer_data();
     CHECK_NOT_NULL(pointer_data());
     pointer_data()->weak_ptr_count++;
@@ -198,7 +198,7 @@ BaseObjectPtrImpl<T, kIsWeak>& BaseObjectPtrImpl<T, kIsWeak>::operator=(
 template <typename T, bool kIsWeak>
 BaseObjectPtrImpl<T, kIsWeak>::BaseObjectPtrImpl(BaseObjectPtrImpl&& other)
   : data_(other.data_) {
-  if (kIsWeak)
+  if constexpr (kIsWeak)
     other.data_.target = nullptr;
   else
     other.data_.pointer_data = nullptr;

--- a/src/json_utils.h
+++ b/src/json_utils.h
@@ -128,7 +128,7 @@ class JSONWriter {
             typename test_for_number = typename std::
                 enable_if<std::numeric_limits<T>::is_specialized, bool>::type>
   inline void write_value(T number) {
-    if (std::is_same<T, bool>::value)
+    if constexpr (std::is_same<T, bool>::value)
       out_ << (number ? "true" : "false");
     else
       out_ << number;

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -674,7 +674,7 @@ class Parser : public AsyncWrap, public StreamListener {
     // Should always be called from the same context.
     CHECK_EQ(env, parser->env());
 
-    if (should_pause) {
+    if constexpr (should_pause) {
       llhttp_pause(&parser->parser_);
     } else {
       llhttp_resume(&parser->parser_);

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -361,7 +361,7 @@ class CompressionStream : public AsyncWrap, public ThreadPoolWork {
     ctx_.SetBuffers(in, in_len, out, out_len);
     ctx_.SetFlush(flush);
 
-    if (!async) {
+    if constexpr (!async) {
       // sync version
       AsyncWrap::env()->PrintSyncTrace();
       DoThreadPoolWork();


### PR DESCRIPTION
Doesn't change much but communicates to readers that these
are compile-time conditionals.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
