### PR TITLE
stream: fix `ReadableStreamReader.releaseLock()`

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -809,11 +809,7 @@ class ReadableStreamDefaultReader {
       throw new ERR_INVALID_THIS('ReadableStreamDefaultReader');
     if (this[kState].stream === undefined)
       return;
-    if (this[kState].readRequests.length) {
-      throw new ERR_INVALID_STATE.TypeError(
-        'Cannot release with pending read requests');
-    }
-    readableStreamReaderGenericRelease(this);
+    readableStreamDefaultReaderRelease(this);
   }
 
   /**
@@ -930,11 +926,7 @@ class ReadableStreamBYOBReader {
       throw new ERR_INVALID_THIS('ReadableStreamBYOBReader');
     if (this[kState].stream === undefined)
       return;
-    if (this[kState].readIntoRequests.length) {
-      throw new ERR_INVALID_STATE.TypeError(
-        'Cannot release with pending read requests');
-    }
-    readableStreamReaderGenericRelease(this);
+    readableStreamBYOBReaderRelease(this);
   }
 
   /**
@@ -1728,6 +1720,36 @@ function readableStreamReaderGenericInitialize(reader, stream) {
       setPromiseHandled(reader[kState].close.promise);
       break;
   }
+}
+
+function readableStreamDefaultReaderRelease(reader) {
+  readableStreamReaderGenericRelease(reader);
+  readableStreamDefaultReaderErrorReadRequests(
+    reader,
+    new ERR_INVALID_STATE.TypeError('Releasing reader')
+  );
+}
+
+function readableStreamDefaultReaderErrorReadRequests(reader, e) {
+  for (let n = 0; n < reader[kState].readRequests.length; ++n) {
+    reader[kState].readRequests[n][kError](e);
+  }
+  reader[kState].readRequests = [];
+}
+
+function readableStreamBYOBReaderRelease(reader) {
+  readableStreamReaderGenericRelease(reader);
+  readableStreamBYOBReaderErrorReadIntoRequests(
+    reader,
+    new ERR_INVALID_STATE.TypeError('Releasing reader')
+  );
+}
+
+function readableStreamBYOBReaderErrorReadIntoRequests(reader, e) {
+  for (let n = 0; n < reader[kState].readIntoRequests.length; ++n) {
+    reader[kState].readIntoRequests[n][kError](e);
+  }
+  reader[kState].readIntoRequests = [];
 }
 
 function readableStreamReaderGenericRelease(reader) {

--- a/test/parallel/test-whatwg-readablestream.js
+++ b/test/parallel/test-whatwg-readablestream.js
@@ -329,16 +329,10 @@ assert.throws(() => {
   const read2 = reader.read();
 
   // The stream is empty so the read will never settle.
-  read1.then(
-    common.mustNotCall(),
-    common.mustNotCall()
-  );
+  read1.then(common.mustNotCall(), common.mustCall());
 
   // The stream is empty so the read will never settle.
-  read2.then(
-    common.mustNotCall(),
-    common.mustNotCall()
-  );
+  read2.then(common.mustNotCall(), common.mustCall());
 
   assert.notStrictEqual(read1, read2);
 
@@ -346,10 +340,9 @@ assert.throws(() => {
 
   delay().then(common.mustCall());
 
-  assert.throws(() => reader.releaseLock(), {
-    code: 'ERR_INVALID_STATE',
-  });
   assert(stream.locked);
+  reader.releaseLock();
+  assert(!stream.locked);
 }
 
 {

--- a/test/parallel/test-whatwg-readablestream.js
+++ b/test/parallel/test-whatwg-readablestream.js
@@ -328,10 +328,7 @@ assert.throws(() => {
   const read1 = reader.read();
   const read2 = reader.read();
 
-  // The stream is empty so the read will never settle.
   read1.then(common.mustNotCall(), common.mustCall());
-
-  // The stream is empty so the read will never settle.
   read2.then(common.mustNotCall(), common.mustCall());
 
   assert.notStrictEqual(read1, read2);

--- a/test/wpt/status/streams.json
+++ b/test/wpt/status/streams.json
@@ -31,9 +31,6 @@
   "readable-byte-streams/general.any.js": {
     "fail": {
       "expected": [
-        "ReadableStream with byte source: releaseLock() on ReadableStreamDefaultReader must reject pending read()",
-        "ReadableStream with byte source: releaseLock() on ReadableStreamBYOBReader must reject pending read()",
-        "pull() resolving should not resolve read()",
         "ReadableStream with byte source: enqueue() discards auto-allocated BYOB request",
         "ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, respond()",
         "ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 1 element Uint16Array, respond(1)",
@@ -86,20 +83,6 @@
   },
   "readable-streams/cross-realm-crash.window.js": {
     "skip": "Browser-specific test"
-  },
-  "readable-streams/default-reader.any.js": {
-    "fail": {
-      "expected": [
-        "Second reader can read chunks after first reader was released with pending read requests"
-      ]
-    }
-  },
-  "readable-streams/templated.any.js": {
-    "fail": {
-      "expected": [
-        "ReadableStream (empty) reader: releasing the lock should reject all pending read requests"
-      ]
-    }
   },
   "transferable/deserialize-error.window.js": {
     "skip": "Browser-specific test"


### PR DESCRIPTION
This updates `ReadableStreamReader.releaseLock()` behavior to meet the latest web streams compatibility.

The notable change seems the following:

Attempting to `releaseLock()` when a reader has pending read requests leads :
- **Old version**:  `releaseLock()` will throw a `TypeError`.
- **Latest version**: Not throw a `TypeError`. Instead, promises returned by reader's `ReadableStreamDefaultReader.read()` are immediately rejected with a `TypeError`.


**Old version**
> releaseLock() method steps are:
>
>  1. If ! IsReadableStreamDefaultReader(*this*) is *false*, throw a *TypeError* exception.
>  2. If *this*.[[ownerReadableStream]] is *undefined*, return.
>  3. If *this*.[[readRequests]] is not empty, throw a *TypeError* exception. <----
>  4. Perform ! ReadableStreamReaderGenericRelease(*this*).

**Latest version**
> The releaseLock() method steps are:
>
> 1. If this.[[stream]] is undefined, return.
> 2. Perform ! ReadableStreamDefaultReaderRelease(this).

Refs: https://streams.spec.whatwg.org/#default-reader-release-lock
Refs: https://streams.spec.whatwg.org/#byob-reader-release-lock
Refs: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader/releaseLock

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
