### PR TITLE
doc: fix description of named exports detection

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -126,7 +126,7 @@ There is the ECMAScript module loader:
 * It accepts only `.js`, `.mjs`, and `.cjs` extensions for JavaScript text
   files.
 * It can be used to load JavaScript CommonJS modules. Such modules
-  are passed through the `es-module-lexer` to try to identify named exports,
+  are passed through the [cjs-module-lexer][] to try to identify named exports,
   which are available if they can be determined through static analysis.
   Imported CommonJS modules have their URLs converted to absolute
   paths and are then loaded via the CommonJS module loader.
@@ -1345,3 +1345,6 @@ This field defines [subpath imports][] for the current package.
 [supported package managers]: corepack.md#supported-package-managers
 [the dual CommonJS/ES module packages section]: #dual-commonjses-module-packages
 [the full specifier path]: esm.md#mandatory-file-extensions
+[cjs-module-lexer]: https://github.com/nodejs/cjs-module-lexer/tree/1.2.2
+
+<!-- Note: The cjs-module-lexer link should be kept in-sync with the deps version -->


### PR DESCRIPTION
The tool used to do named exports detection should be `cjs-module-lexer`, not `esm-module-lexer`.
Reference: https://github.com/nodejs/node/blob/5e57d24d325f0aea74394f78ebdc06857cca77b1/doc/api/esm.md

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
