### PR TITLE
node-api: cleanup redundant static modifiers

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -61,7 +61,7 @@ namespace v8impl {
 
 namespace {
 
-inline static napi_status V8NameFromPropertyDescriptor(
+inline napi_status V8NameFromPropertyDescriptor(
     napi_env env,
     const napi_property_descriptor* p,
     v8::Local<v8::Name>* result) {
@@ -79,7 +79,7 @@ inline static napi_status V8NameFromPropertyDescriptor(
 }
 
 // convert from n-api property attributes to v8::PropertyAttribute
-inline static v8::PropertyAttribute V8PropertyAttributesFromDescriptor(
+inline v8::PropertyAttribute V8PropertyAttributesFromDescriptor(
     const napi_property_descriptor* descriptor) {
   unsigned int attribute_flags = v8::PropertyAttribute::None;
 
@@ -100,12 +100,12 @@ inline static v8::PropertyAttribute V8PropertyAttributesFromDescriptor(
   return static_cast<v8::PropertyAttribute>(attribute_flags);
 }
 
-inline static napi_deferred JsDeferredFromNodePersistent(
+inline napi_deferred JsDeferredFromNodePersistent(
     v8impl::Persistent<v8::Value>* local) {
   return reinterpret_cast<napi_deferred>(local);
 }
 
-inline static v8impl::Persistent<v8::Value>* NodePersistentFromJsDeferred(
+inline v8impl::Persistent<v8::Value>* NodePersistentFromJsDeferred(
     napi_deferred local) {
   return reinterpret_cast<v8impl::Persistent<v8::Value>*>(local);
 }
@@ -139,32 +139,30 @@ class EscapableHandleScopeWrapper {
   bool escape_called_;
 };
 
-inline static napi_handle_scope JsHandleScopeFromV8HandleScope(
-    HandleScopeWrapper* s) {
+inline napi_handle_scope JsHandleScopeFromV8HandleScope(HandleScopeWrapper* s) {
   return reinterpret_cast<napi_handle_scope>(s);
 }
 
-inline static HandleScopeWrapper* V8HandleScopeFromJsHandleScope(
-    napi_handle_scope s) {
+inline HandleScopeWrapper* V8HandleScopeFromJsHandleScope(napi_handle_scope s) {
   return reinterpret_cast<HandleScopeWrapper*>(s);
 }
 
-inline static napi_escapable_handle_scope
+inline napi_escapable_handle_scope
 JsEscapableHandleScopeFromV8EscapableHandleScope(
     EscapableHandleScopeWrapper* s) {
   return reinterpret_cast<napi_escapable_handle_scope>(s);
 }
 
-inline static EscapableHandleScopeWrapper*
+inline EscapableHandleScopeWrapper*
 V8EscapableHandleScopeFromJsEscapableHandleScope(
     napi_escapable_handle_scope s) {
   return reinterpret_cast<EscapableHandleScopeWrapper*>(s);
 }
 
-inline static napi_status ConcludeDeferred(napi_env env,
-                                           napi_deferred deferred,
-                                           napi_value result,
-                                           bool is_resolved) {
+inline napi_status ConcludeDeferred(napi_env env,
+                                    napi_deferred deferred,
+                                    napi_value result,
+                                    bool is_resolved) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -191,10 +189,10 @@ inline static napi_status ConcludeDeferred(napi_env env,
 
 enum UnwrapAction { KeepWrap, RemoveWrap };
 
-inline static napi_status Unwrap(napi_env env,
-                                 napi_value js_object,
-                                 void** result,
-                                 UnwrapAction action) {
+inline napi_status Unwrap(napi_env env,
+                          napi_value js_object,
+                          void** result,
+                          UnwrapAction action) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, js_object);
   if (action == KeepWrap) {

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -1,8 +1,6 @@
 #ifndef SRC_JS_NATIVE_API_V8_H_
 #define SRC_JS_NATIVE_API_V8_H_
 
-// This file needs to be compatible with C compilers.
-#include <string.h>  // NOLINT(modernize-deprecated-headers)
 #include "js_native_api_types.h"
 #include "js_native_api_v8_internals.h"
 
@@ -152,7 +150,7 @@ class EnvRefHolder {
   napi_env _env;
 };
 
-static inline napi_status napi_clear_last_error(napi_env env) {
+inline napi_status napi_clear_last_error(napi_env env) {
   env->last_error.error_code = napi_ok;
 
   // TODO(boingoing): Should this be a callback?
@@ -162,10 +160,10 @@ static inline napi_status napi_clear_last_error(napi_env env) {
   return napi_ok;
 }
 
-static inline napi_status napi_set_last_error(napi_env env,
-                                              napi_status error_code,
-                                              uint32_t engine_error_code = 0,
-                                              void* engine_reserved = nullptr) {
+inline napi_status napi_set_last_error(napi_env env,
+                                       napi_status error_code,
+                                       uint32_t engine_error_code = 0,
+                                       void* engine_reserved = nullptr) {
   env->last_error.error_code = error_code;
   env->last_error.engine_error_code = engine_error_code;
   env->last_error.engine_reserved = engine_reserved;
@@ -274,6 +272,12 @@ static inline napi_status napi_set_last_error(napi_env env,
 
 #define CHECK_MAYBE_EMPTY_WITH_PREAMBLE(env, maybe, status)                    \
   RETURN_STATUS_IF_FALSE_WITH_PREAMBLE((env), !((maybe).IsEmpty()), (status))
+
+#define STATUS_CALL(call)                                                      \
+  do {                                                                         \
+    napi_status status = (call);                                               \
+    if (status != napi_ok) return status;                                      \
+  } while (0)
 
 namespace v8impl {
 
@@ -430,11 +434,5 @@ class Reference : public RefBase {
 };
 
 }  // end of namespace v8impl
-
-#define STATUS_CALL(call)                                                      \
-  do {                                                                         \
-    napi_status status = (call);                                               \
-    if (status != napi_ok) return status;                                      \
-  } while (0)
 
 #endif  // SRC_JS_NATIVE_API_V8_H_

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -16,6 +16,7 @@
 #include "util-inl.h"
 
 #include <atomic>
+#include <cstring>
 #include <memory>
 
 node_napi_env__::node_napi_env__(v8::Local<v8::Context> context,
@@ -124,8 +125,8 @@ class BufferFinalizer : private Finalizer {
   };
 };
 
-static inline napi_env NewEnv(v8::Local<v8::Context> context,
-                              const std::string& module_filename) {
+inline napi_env NewEnv(v8::Local<v8::Context> context,
+                       const std::string& module_filename) {
   node_napi_env result;
 
   result = new node_napi_env__(context, module_filename);


### PR DESCRIPTION
Functions declared in anonymous namespaces are not necessarily to be
marked as static.

Refs: https://github.com/nodejs/node/pull/44141#discussion_r949670829