### PR TITLE
src: make minor improvements to SecureBuffer

### DIFF
--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -673,22 +673,21 @@ CryptoJobMode GetCryptoJobMode(v8::Local<v8::Value> args) {
 }
 
 namespace {
-// SecureBuffer uses openssl to allocate a Uint8Array using
-// OPENSSL_secure_malloc. Because we do not yet actually
-// make use of secure heap, this has the same semantics as
+// SecureBuffer uses OPENSSL_secure_malloc to allocate a Uint8Array.
+// Without --secure-heap, OpenSSL's secure heap is disabled,
+// in which case this has the same semantics as
 // using OPENSSL_malloc. However, if the secure heap is
 // initialized, SecureBuffer will automatically use it.
 void SecureBuffer(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsUint32());
   Environment* env = Environment::GetCurrent(args);
   uint32_t len = args[0].As<Uint32>()->Value();
-  char* data = static_cast<char*>(OPENSSL_secure_malloc(len));
+  void* data = OPENSSL_secure_zalloc(len);
   if (data == nullptr) {
     // There's no memory available for the allocation.
     // Return nothing.
     return;
   }
-  memset(data, 0, len);
   std::shared_ptr<BackingStore> store =
       ArrayBuffer::NewBackingStore(
           data,


### PR DESCRIPTION
- Remove an unnecessary `static_cast<char*>()`.
- Use `OPENSSL_secure_zalloc()` instead of `OPENSSL_secure_malloc()` + `memset()`.
- Update the comment describing the function which predates support for OpenSSL's secure heap.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
