### PR TITLE
stream: only cleanup error listener if not readable

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -32,8 +32,8 @@ const {
 
 const {
   isIterable,
-  isReadable,
   isReadableNodeStream,
+  isReadableFinished,
   isNodeStream,
 } = require('internal/streams/utils');
 const { AbortController } = require('internal/abort_controller');
@@ -41,7 +41,7 @@ const { AbortController } = require('internal/abort_controller');
 let PassThrough;
 let Readable;
 
-function destroyer(stream, reading, writing) {
+function destroyer(stream, reading, writing, isLast) {
   let finished = false;
   stream.on('close', () => {
     finished = true;
@@ -51,13 +51,15 @@ function destroyer(stream, reading, writing) {
     finished = !err;
   });
 
-  return {
-    destroy: (err) => {
-      if (finished) return;
-      finished = true;
-      destroyImpl.destroyer(stream, err || new ERR_STREAM_DESTROYED('pipe'));
-    },
-    cleanup
+  return (err) => {
+    if (isLast && isReadableFinished(stream) === false) {
+      cleanup();
+    }
+    if (finished) {
+      return;
+    }
+    finished = true;
+    destroyImpl.destroyer(stream, err || new ERR_STREAM_DESTROYED('pipe'));
   };
 }
 
@@ -164,10 +166,6 @@ function pipelineImpl(streams, callback, opts) {
   const signal = ac.signal;
   const outerSignal = opts?.signal;
 
-  // Need to cleanup event listeners if last stream is readable
-  // https://github.com/nodejs/node/issues/35452
-  const lastStreamCleanup = [];
-
   validateAbortSignal(outerSignal, 'options.signal');
 
   function abort() {
@@ -203,9 +201,6 @@ function pipelineImpl(streams, callback, opts) {
     ac.abort();
 
     if (final) {
-      if (!error) {
-        lastStreamCleanup.forEach((fn) => fn());
-      }
       process.nextTick(callback, error, value);
     }
   }
@@ -220,12 +215,7 @@ function pipelineImpl(streams, callback, opts) {
 
     if (isNodeStream(stream)) {
       if (end) {
-        const { destroy, cleanup } = destroyer(stream, reading, writing);
-        destroys.push(destroy);
-
-        if (isReadable(stream) && isLastStream) {
-          lastStreamCleanup.push(cleanup);
-        }
+        destroys.push(destroyer(stream, reading, writing, isLastStream));
       }
 
       // Catch stream errors that occur after pipe/pump has completed.
@@ -239,11 +229,6 @@ function pipelineImpl(streams, callback, opts) {
         }
       }
       stream.on('error', onError);
-      if (isReadable(stream) && isLastStream) {
-        lastStreamCleanup.push(() => {
-          stream.removeListener('error', onError);
-        });
-      }
     }
 
     if (i === 0) {
@@ -311,19 +296,12 @@ function pipelineImpl(streams, callback, opts) {
 
         ret = pt;
 
-        const { destroy, cleanup } = destroyer(ret, false, true);
-        destroys.push(destroy);
-        if (isLastStream) {
-          lastStreamCleanup.push(cleanup);
-        }
+        destroys.push(destroyer(ret, false, true));
       }
     } else if (isNodeStream(stream)) {
       if (isReadableNodeStream(ret)) {
         finishCount += 2;
-        const cleanup = pipe(ret, stream, finish, { end });
-        if (isReadable(stream) && isLastStream) {
-          lastStreamCleanup.push(cleanup);
-        }
+        pipe(ret, stream, finish, { end });
       } else if (isIterable(ret)) {
         finishCount++;
         pump(ret, stream, finish, { end });

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -177,6 +177,7 @@ function pipelineImpl(streams, callback, opts) {
   let error;
   let value;
   const destroys = [];
+  const cleanups = [];
 
   let finishCount = 0;
 
@@ -195,6 +196,10 @@ function pipelineImpl(streams, callback, opts) {
 
     while (destroys.length) {
       destroys.shift()(error);
+    }
+
+    for (const cleanup of cleanups) {
+      cleanup();
     }
 
     outerSignal?.removeEventListener('abort', abort);
@@ -229,6 +234,7 @@ function pipelineImpl(streams, callback, opts) {
         }
       }
       stream.on('error', onError);
+      cleanups.push(() => stream.off('error', onError));
     }
 
     if (i === 0) {
@@ -301,7 +307,8 @@ function pipelineImpl(streams, callback, opts) {
     } else if (isNodeStream(stream)) {
       if (isReadableNodeStream(ret)) {
         finishCount += 2;
-        pipe(ret, stream, finish, { end });
+        const cleanup = pipe(ret, stream, finish, { end });
+        cleanups.push(cleanup);
       } else if (isIterable(ret)) {
         finishCount++;
         pump(ret, stream, finish, { end });

--- a/test/parallel/test-stream-pipeline-listeners.js
+++ b/test/parallel/test-stream-pipeline-listeners.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 
 process.on('uncaughtException', common.mustCall((err) => {
   assert.strictEqual(err.message, 'no way');
-}, 2));
+}, 1));
 
 // Ensure that listeners is removed if last stream is readable
 // And other stream's listeners unchanged
@@ -29,30 +29,6 @@ pipeline(a, b, common.mustCall((error) => {
     b.destroy(new Error('no way'));
   }, 100);
 }));
-
-// Async generators
-const c = new PassThrough();
-c.end('foobar');
-const d = pipeline(
-  c,
-  async function* (source) {
-    for await (const chunk of source) {
-      yield String(chunk).toUpperCase();
-    }
-  },
-  common.mustCall((error) => {
-    if (error) {
-      assert.ifError(error);
-    }
-
-    assert(c.listenerCount('error') > 0);
-    assert.strictEqual(d.listenerCount('error'), 0);
-    setTimeout(() => {
-      assert.strictEqual(b.listenerCount('error'), 0);
-      d.destroy(new Error('no way'));
-    }, 100);
-  })
-);
 
 // If last stream is not readable, will not throw and remove listeners
 const e = new PassThrough();

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1556,3 +1556,44 @@ const tsp = require('timers/promises');
     })
   );
 }
+
+{
+  const r = new Readable({
+    read() {
+      this.push('asd');
+      this.push(null);
+    }
+  });
+  const s = new Duplex({
+    readable: false,
+    read() {},
+    write(chunk, encoding, callback) {
+      callback();
+    }
+  });
+  pipeline(r, s, common.mustCall((err) => {
+    assert(!err);
+    assert(s.listenerCount('error'), 1);
+  }));
+}
+
+{
+  const r = new Readable({
+    read() {
+      this.push('asd');
+      this.push(null);
+    }
+  });
+  const s = new Duplex({
+    read() {
+      this.push(null);
+    },
+    write(chunk, encoding, callback) {
+      callback();
+    }
+  });
+  pipeline(r, s, common.mustCall((err) => {
+    assert(!err);
+    assert(s.listenerCount('error'), 1);
+  }));
+}


### PR DESCRIPTION
Only cleanup the error listener if we know for sure that
the last stream is still readable after the pipeline has
completed.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
