### PR TITLE
stream: use null for the error argument

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -497,7 +497,7 @@ function afterWrite(stream, state, count, cb) {
 
   while (count-- > 0) {
     state.pendingcb--;
-    cb();
+    cb(null);
   }
 
   if (state.destroyed) {
@@ -640,8 +640,10 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   }
 
   if (typeof cb === 'function') {
-    if (err || state.finished) {
+    if (err) {
       process.nextTick(cb, err);
+    } else if (state.finished) {
+      process.nextTick(cb, null);
     } else {
       state[kOnFinished].push(cb);
     }
@@ -742,7 +744,7 @@ function finish(stream, state) {
 
   const onfinishCallbacks = state[kOnFinished].splice(0);
   for (let i = 0; i < onfinishCallbacks.length; i++) {
-    onfinishCallbacks[i]();
+    onfinishCallbacks[i](null);
   }
 
   stream.emit('finish');

--- a/test/parallel/test-stream-writable-end-cb-error.js
+++ b/test/parallel/test-stream-writable-end-cb-error.js
@@ -36,7 +36,7 @@ const stream = require('stream');
   let called = false;
   writable.end('asd', common.mustCall((err) => {
     called = true;
-    assert.strictEqual(err, undefined);
+    assert.strictEqual(err, null);
   }));
 
   writable.on('error', common.mustCall((err) => {

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -194,7 +194,8 @@ for (let i = 0; i < chunks.length; i++) {
 {
   // Verify write callbacks
   const callbacks = chunks.map(function(chunk, i) {
-    return [i, function() {
+    return [i, function(err) {
+      assert.strictEqual(err, null);
       callbacks._called[i] = chunk;
     }];
   }).reduce(function(set, x) {
@@ -225,7 +226,9 @@ for (let i = 0; i < chunks.length; i++) {
 {
   // Verify end() callback
   const tw = new TestWriter();
-  tw.end(common.mustCall());
+  tw.end(common.mustCall(function(err) {
+    assert.strictEqual(err, null);
+  }));
 }
 
 const helloWorldBuffer = Buffer.from('hello world');
@@ -233,7 +236,9 @@ const helloWorldBuffer = Buffer.from('hello world');
 {
   // Verify end() callback with chunk
   const tw = new TestWriter();
-  tw.end(helloWorldBuffer, common.mustCall());
+  tw.end(helloWorldBuffer, common.mustCall(function(err) {
+    assert.strictEqual(err, null);
+  }));
 }
 
 {


### PR DESCRIPTION
When no error occurs, use `null` instead of `undefined` for the `error`
argument of the `writable.write()` and `writable.end()` callbacks.

Fixes: https://github.com/nodejs/node/issues/44290

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
