### PR TITLE
src: restore context default IsCodeGenerationFromStringsAllowed value

### DIFF
--- a/test/parallel/test-eval-disallow-code-generation-from-strings.js
+++ b/test/parallel/test-eval-disallow-code-generation-from-strings.js
@@ -1,0 +1,9 @@
+// Flags: --disallow-code-generation-from-strings
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// Verify that v8 option --disallow-code-generation-from-strings is still
+// respected
+assert.throws(() => eval('"eval"'), EvalError);

--- a/test/parallel/test-eval.js
+++ b/test/parallel/test-eval.js
@@ -1,0 +1,7 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// Verify that eval is allowed by default.
+assert.strictEqual(eval('"eval"'), 'eval');


### PR DESCRIPTION
Context's default IsCodeGenerationFromStringsAllowed value can be
changed by v8 flag `--disallow-code-generation-from-strings`. Restore
the value at runtime when delegating the code generation validation to
`node::ModifyCodeGenerationFromStrings`.

The context's settings are serialized in the snapshot. Reset the setting
values to its default values before the serialization so that it can be
correctly re-initialized after deserialization at runtime.

Fixes: https://github.com/nodejs/node/issues/44287