### PR TITLE
stream: fix `writableStream.abort()`

### DIFF
--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -637,8 +637,11 @@ function writableStreamAbort(stream, reason) {
   if (state === 'closed' || state === 'errored')
     return PromiseResolve();
 
+  // TODO(daeyeon): Remove `controller[kState].abortReason` and use
+  // `controller[kState].abortController.signal.reason` for the
+  // `WritableStreamDefaultController.prototype.abortReason` getter.
   controller[kState].abortReason = reason;
-  controller[kState].abortController.abort();
+  controller[kState].abortController.abort(reason);
 
   if (stream[kState].pendingAbortRequest.abort.promise !== undefined)
     return stream[kState].pendingAbortRequest.abort.promise;

--- a/test/wpt/status/streams.json
+++ b/test/wpt/status/streams.json
@@ -106,10 +106,5 @@
   },
   "transferable/transfer-with-messageport.window.js": {
     "skip": "Browser-specific test"
-  },
-  "writable-streams/aborting.any.js": {
-    "fail": {
-      "expected": ["WritableStreamDefaultController.signal"]
-    }
   }
 }


### PR DESCRIPTION
This includes:
- Fixing the following step in `writableStream.abort(reason)`. Passing the `reason` was missing.

> WritableStreamAbort(stream, reason) performs the following steps:
>> 2. Signal abort on stream.[[controller]].[[signal]] with reason.

- Leaving a TODO to remove the internal `abortReason` property of `WritableStreamDefaultController` in a follow-up.

<br/>

Refs: https://streams.spec.whatwg.org/#writable-stream-abort

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
