### PR TITLE
doc: add missing imports in events sample code

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1487,9 +1487,9 @@ require manual async tracking. Specifically, all events emitted by instances
 of `events.EventEmitterAsyncResource` will run within its [async context][].
 
 ```mjs
-import { EventEmitterAsyncResource } from 'node:events';
+import { EventEmitterAsyncResource, EventEmitter } from 'node:events';
 import { notStrictEqual, strictEqual } from 'node:assert';
-import { executionAsyncId } from 'node:async_hooks';
+import { executionAsyncId, triggerAsyncId } from 'node:async_hooks';
 
 // Async tracking tooling will identify this as 'Q'.
 const ee1 = new EventEmitterAsyncResource({ name: 'Q' });
@@ -1516,9 +1516,9 @@ Promise.resolve().then(() => {
 ```
 
 ```cjs
-const { EventEmitterAsyncResource } = require('node:events');
+const { EventEmitterAsyncResource, EventEmitter } = require('node:events');
 const { notStrictEqual, strictEqual } = require('node:assert');
-const { executionAsyncId } = require('node:async_hooks');
+const { executionAsyncId, triggerAsyncId } = require('node:async_hooks');
 
 // Async tracking tooling will identify this as 'Q'.
 const ee1 = new EventEmitterAsyncResource({ name: 'Q' });


### PR DESCRIPTION
There were missing imports in the events documentation example for using `EventEmitterAsyncResource`, so I added them in both ESM and CJS.

---

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

