### PR TITLE
node-api: Memory leak fix for  RefBase::Delete(RefBase* reference)

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -561,6 +561,7 @@ void RefBase::Finalize(bool is_env_teardown) {
     napi_finalize fini = _finalize_callback;
     _finalize_callback = nullptr;
     _env->CallFinalizer(fini, _finalize_data, _finalize_hint);
+    _finalize_ran = true;
   }
 
   // this is safe because if a request to delete the reference

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -561,7 +561,7 @@ void RefBase::Finalize(bool is_env_teardown) {
     napi_finalize fini = _finalize_callback;
     _finalize_callback = nullptr;
     _env->CallFinalizer(fini, _finalize_data, _finalize_hint);
-    _finalize_ran = true; 
+    _finalize_ran = true;
   }
 
   // this is safe because if a request to delete the reference

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -561,7 +561,7 @@ void RefBase::Finalize(bool is_env_teardown) {
     napi_finalize fini = _finalize_callback;
     _finalize_callback = nullptr;
     _env->CallFinalizer(fini, _finalize_data, _finalize_hint);
-    _finalize_ran = true;
+    _finalize_ran = true; 
   }
 
   // this is safe because if a request to delete the reference


### PR DESCRIPTION
Memory leak fix: Added missing`_finalize_ran`.