### PR TITLE
test: use --port=0 in debugger tests that do not have to work on 9229

### DIFF
--- a/test/sequential/test-debugger-auto-resume.js
+++ b/test/sequential/test-debugger-auto-resume.js
@@ -20,7 +20,7 @@ addLibraryPath(process.env);
   const env = { ...process.env };
   env.NODE_INSPECT_RESUME_ON_START = '1';
 
-  const cli = startCLI([script], [], { env });
+  const cli = startCLI(['--port=0', script], [], { env });
 
   cli.waitForInitialBreak()
     .then(() => {

--- a/test/sequential/test-debugger-backtrace.js
+++ b/test/sequential/test-debugger-backtrace.js
@@ -13,7 +13,7 @@ const path = require('path');
 {
   const scriptFullPath = fixtures.path('debugger', 'backtrace.js');
   const script = path.relative(process.cwd(), scriptFullPath);
-  const cli = startCLI([script]);
+  const cli = startCLI(['--port=0', script]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-break.js
+++ b/test/sequential/test-debugger-break.js
@@ -13,7 +13,7 @@ const path = require('path');
 {
   const scriptFullPath = fixtures.path('debugger', 'break.js');
   const script = path.relative(process.cwd(), scriptFullPath);
-  const cli = startCLI([script]);
+  const cli = startCLI(['--port=0', script]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-breakpoint-exists.js
+++ b/test/sequential/test-debugger-breakpoint-exists.js
@@ -10,7 +10,7 @@ const startCLI = require('../common/debugger');
 // Test for "Breakpoint at specified location already exists" error.
 {
   const script = fixtures.path('debugger', 'three-lines.js');
-  const cli = startCLI([script]);
+  const cli = startCLI(['--port=0', script]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-clear-breakpoints.js
+++ b/test/sequential/test-debugger-clear-breakpoints.js
@@ -13,7 +13,7 @@ const path = require('path');
 {
   const scriptFullPath = fixtures.path('debugger', 'break.js');
   const script = path.relative(process.cwd(), scriptFullPath);
-  const cli = startCLI([script]);
+  const cli = startCLI(['--port=0', script]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-exceptions.js
+++ b/test/sequential/test-debugger-exceptions.js
@@ -13,7 +13,7 @@ const path = require('path');
 {
   const scriptFullPath = fixtures.path('debugger', 'exceptions.js');
   const script = path.relative(process.cwd(), scriptFullPath);
-  const cli = startCLI([script]);
+  const cli = startCLI(['--port=0', script]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-exec-scope.js
+++ b/test/sequential/test-debugger-exec-scope.js
@@ -10,7 +10,7 @@ const assert = require('assert');
 
 // exec .scope
 {
-  const cli = startCLI([fixtures.path('debugger/backtrace.js')]);
+  const cli = startCLI(['--port=0', fixtures.path('debugger/backtrace.js')]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-exec.js
+++ b/test/sequential/test-debugger-exec.js
@@ -10,7 +10,7 @@ const assert = require('assert');
 
 {
 
-  const cli = startCLI([fixtures.path('debugger/alive.js')]);
+  const cli = startCLI(['--port=0', fixtures.path('debugger/alive.js')]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-heap-profiler.js
+++ b/test/sequential/test-debugger-heap-profiler.js
@@ -17,7 +17,7 @@ const filename = path.join(tmpdir.path, 'node.heapsnapshot');
 // Heap profiler take snapshot.
 {
   const opts = { cwd: tmpdir.path };
-  const cli = startCLI([fixtures.path('debugger/empty.js')], [], opts);
+  const cli = startCLI(['--port=0', fixtures.path('debugger/empty.js')], [], opts);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-help.js
+++ b/test/sequential/test-debugger-help.js
@@ -9,7 +9,7 @@ const startCLI = require('../common/debugger');
 const assert = require('assert');
 
 {
-  const cli = startCLI([fixtures.path('debugger/empty.js')]);
+  const cli = startCLI(['--port=0', fixtures.path('debugger/empty.js')]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-list.js
+++ b/test/sequential/test-debugger-list.js
@@ -8,7 +8,7 @@ const startCLI = require('../common/debugger');
 
 const assert = require('assert');
 
-const cli = startCLI([fixtures.path('debugger/three-lines.js')]);
+const cli = startCLI(['--port=0', fixtures.path('debugger/three-lines.js')]);
 
 (async () => {
   await cli.waitForInitialBreak();

--- a/test/sequential/test-debugger-low-level.js
+++ b/test/sequential/test-debugger-low-level.js
@@ -9,7 +9,7 @@ const assert = require('assert');
 
 // Debugger agent direct access.
 {
-  const cli = startCLI([fixtures.path('debugger/three-lines.js')]);
+  const cli = startCLI(['--port=0', fixtures.path('debugger/three-lines.js')]);
   const scriptPattern = /^\* (\d+): \S+debugger(?:\/|\\)three-lines\.js/m;
 
   function onFatal(error) {

--- a/test/sequential/test-debugger-object-type-remote-object.js
+++ b/test/sequential/test-debugger-object-type-remote-object.js
@@ -8,7 +8,7 @@ const startCLI = require('../common/debugger');
 
 const assert = require('assert');
 
-const cli = startCLI([fixtures.path('debugger/empty.js')]);
+const cli = startCLI(['--port=0', fixtures.path('debugger/empty.js')]);
 
 (async () => {
   await cli.waitForInitialBreak();

--- a/test/sequential/test-debugger-preserve-breaks.js
+++ b/test/sequential/test-debugger-preserve-breaks.js
@@ -13,7 +13,7 @@ const path = require('path');
 {
   const scriptFullPath = fixtures.path('debugger', 'three-lines.js');
   const script = path.relative(process.cwd(), scriptFullPath);
-  const cli = startCLI([script]);
+  const cli = startCLI(['--port=0', script]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-profile-command.js
+++ b/test/sequential/test-debugger-profile-command.js
@@ -10,7 +10,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const cli = startCLI([fixtures.path('debugger/empty.js')]);
+const cli = startCLI(['--port=0', fixtures.path('debugger/empty.js')]);
 
 const rootDir = path.resolve(__dirname, '..', '..');
 

--- a/test/sequential/test-debugger-profile.js
+++ b/test/sequential/test-debugger-profile.js
@@ -14,7 +14,7 @@ function delay(ms) {
 
 // Profiles.
 {
-  const cli = startCLI([fixtures.path('debugger/empty.js')]);
+  const cli = startCLI(['--port=0', fixtures.path('debugger/empty.js')]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-restart-message.js
+++ b/test/sequential/test-debugger-restart-message.js
@@ -14,7 +14,7 @@ const startCLI = require('../common/debugger');
 // Using `restart` should result in only one "Connect/For help" message.
 {
   const script = fixtures.path('debugger', 'three-lines.js');
-  const cli = startCLI([script]);
+  const cli = startCLI(['--port=0', script]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-run-after-quit-restart.js
+++ b/test/sequential/test-debugger-run-after-quit-restart.js
@@ -13,7 +13,7 @@ const path = require('path');
 {
   const scriptFullPath = fixtures.path('debugger', 'three-lines.js');
   const script = path.relative(process.cwd(), scriptFullPath);
-  const cli = startCLI([script]);
+  const cli = startCLI(['--port=0', script]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-sb-before-load.js
+++ b/test/sequential/test-debugger-sb-before-load.js
@@ -17,7 +17,7 @@ const path = require('path');
   const otherScriptFullPath = fixtures.path('debugger', 'cjs', 'other.js');
   const otherScript = path.relative(process.cwd(), otherScriptFullPath);
 
-  const cli = startCLI([script]);
+  const cli = startCLI(['--port=0', script]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-scripts.js
+++ b/test/sequential/test-debugger-scripts.js
@@ -11,7 +11,7 @@ const assert = require('assert');
 // List scripts.
 {
   const script = fixtures.path('debugger', 'three-lines.js');
-  const cli = startCLI([script]);
+  const cli = startCLI(['--port=0', script]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-use-strict.js
+++ b/test/sequential/test-debugger-use-strict.js
@@ -11,7 +11,7 @@ const assert = require('assert');
 // Test for files that start with strict directive.
 {
   const script = fixtures.path('debugger', 'use-strict.js');
-  const cli = startCLI([script]);
+  const cli = startCLI(['--port=0', script]);
 
   function onFatal(error) {
     cli.quit();

--- a/test/sequential/test-debugger-watchers.js
+++ b/test/sequential/test-debugger-watchers.js
@@ -10,7 +10,7 @@ const assert = require('assert');
 
 // Stepping through breakpoints.
 {
-  const cli = startCLI([fixtures.path('debugger/break.js')]);
+  const cli = startCLI(['--port=0', fixtures.path('debugger/break.js')]);
 
   function onFatal(error) {
     cli.quit();


### PR DESCRIPTION
To avoid failures when there is another running process occupying
the port 9229 which may happen if there is a stale process, use the
--port argument of node-inspect to use a random port in tests that
don't have to work on port 9229.

The following tests are not touched:

- test-debugger-launch: specifically needs to test port 9229
- test-debugger-pid: needs modifications to node-inspect
- test-debugger-random-port-with-inspect-port: same as -pid test

Refs: https://github.com/nodejs/build/issues/3014
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
