### PR TITLE
src: remove KeyObjectData::symmetric_key_len_

### DIFF
--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -839,20 +839,13 @@ ManagedEVPPKey ManagedEVPPKey::GetParsedKey(Environment* env,
   return ManagedEVPPKey(std::move(pkey));
 }
 
-KeyObjectData::KeyObjectData(
-    ByteSource symmetric_key)
+KeyObjectData::KeyObjectData(ByteSource symmetric_key)
     : key_type_(KeyType::kKeyTypeSecret),
       symmetric_key_(std::move(symmetric_key)),
-      symmetric_key_len_(symmetric_key_.size()),
       asymmetric_key_() {}
 
-KeyObjectData::KeyObjectData(
-    KeyType type,
-    const ManagedEVPPKey& pkey)
-    : key_type_(type),
-      symmetric_key_(),
-      symmetric_key_len_(0),
-      asymmetric_key_{pkey} {}
+KeyObjectData::KeyObjectData(KeyType type, const ManagedEVPPKey& pkey)
+    : key_type_(type), symmetric_key_(), asymmetric_key_{pkey} {}
 
 void KeyObjectData::MemoryInfo(MemoryTracker* tracker) const {
   switch (GetKeyType()) {
@@ -896,7 +889,7 @@ const char* KeyObjectData::GetSymmetricKey() const {
 
 size_t KeyObjectData::GetSymmetricKeySize() const {
   CHECK_EQ(key_type_, kKeyTypeSecret);
-  return symmetric_key_len_;
+  return symmetric_key_.size();
 }
 
 v8::Local<v8::Function> KeyObjectHandle::Initialize(Environment* env) {

--- a/src/crypto/crypto_keys.h
+++ b/src/crypto/crypto_keys.h
@@ -158,7 +158,6 @@ class KeyObjectData : public MemoryRetainer {
 
   const KeyType key_type_;
   const ByteSource symmetric_key_;
-  const unsigned int symmetric_key_len_;
   const ManagedEVPPKey asymmetric_key_;
 };
 


### PR DESCRIPTION
`symmetric_key_len_` is always equal to `symmetric_key_.size()`. Storing it separately is redundant and has no significant benefit.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
