### PR TITLE
path: add dot for path.format if absent in ext

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -206,6 +206,10 @@ A [`TypeError`][] is thrown if `path` is not a string.
 
 <!-- YAML
 added: v0.11.15
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/44349
+    description: The dot will be added if it is not specified in `ext`.
 -->
 
 * `pathObject` {Object} Any JavaScript object having the following properties:
@@ -253,6 +257,14 @@ path.format({
   root: '/',
   name: 'file',
   ext: '.txt'
+});
+// Returns: '/file.txt'
+
+// The dot will be added if it is not specified in `ext`.
+path.format({
+  root: '/',
+  name: 'file',
+  ext: 'txt'
 });
 // Returns: '/file.txt'
 ```

--- a/lib/path.js
+++ b/lib/path.js
@@ -127,6 +127,10 @@ function normalizeString(path, allowAboveRoot, separator, isPathSeparator) {
   return res;
 }
 
+function formatExt(ext) {
+  return ext ? `${ext[0] === '.' ? '' : '.'}${ext}` : '';
+}
+
 /**
  * @param {string} sep
  * @param {{
@@ -142,7 +146,7 @@ function _format(sep, pathObject) {
   validateObject(pathObject, 'pathObject');
   const dir = pathObject.dir || pathObject.root;
   const base = pathObject.base ||
-    `${pathObject.name || ''}${pathObject.ext || ''}`;
+    `${pathObject.name || ''}${formatExt(pathObject.ext)}`;
   if (!dir) {
     return base;
   }

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -224,3 +224,7 @@ function checkFormat(path, testCases) {
     });
   });
 }
+
+// See https://github.com/nodejs/node/issues/44343
+assert.strictEqual(path.format({ name: 'x', ext: 'png' }), 'x.png');
+assert.strictEqual(path.format({ name: 'x', ext: '.png' }), 'x.png');


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/44343

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
