### PR TITLE
debugger: various fixes to the debugger and the debugger tests

### DIFF
--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -64,7 +64,10 @@ async function portIsFree(host, port, timeout = 3000) {
     const error = await new Promise((resolve) => {
       const socket = net.connect(port, host);
       socket.on('error', resolve);
-      socket.on('connect', resolve);
+      socket.on('connect', () => {
+        socket.end();
+        resolve();
+      });
     });
     if (error?.code === 'ECONNREFUSED') {
       return;

--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -45,7 +45,7 @@ const debuglog = util.debuglog('inspect');
 
 const { ERR_DEBUGGER_STARTUP_ERROR } = require('internal/errors').codes;
 
-async function portIsFree(host, port, timeout = 9999) {
+async function portIsFree(host, port, timeout = 3000) {
   if (port === 0) return; // Binding to a random port.
 
   const retryDelay = 150;

--- a/test/common/debugger.js
+++ b/test/common/debugger.js
@@ -7,7 +7,13 @@ const BREAK_MESSAGE = new RegExp('(?:' + [
   'exception', 'other', 'promiseRejection',
 ].join('|') + ') in', 'i');
 
-const TIMEOUT = common.platformTimeout(5000);
+let TIMEOUT = common.platformTimeout(5000);
+if (common.isWindows) {
+  // Some of the windows machines in the CI need more time to receive
+  // the outputs from the client.
+  // https://github.com/nodejs/build/issues/3014
+  TIMEOUT = common.platformTimeout(15000);
+}
 
 function isPreBreak(output) {
   return /Break on start/.test(output) && /1 \(function \(exports/.test(output);


### PR DESCRIPTION
Another attempt to alleviate https://github.com/nodejs/build/issues/3014

### debugger: decrease timeout used to wait for the port to be free

By default, the debugger would query the specified inspector
sever port to see if it's available before starting the server,
and it would keep retrying until a timeout (previously 9999 ms)
is reached. This timeout seems to be longer than necessary. This
patch decreases the timeout to 3 seconds.

### debugger: end connections used to check availability of the port

The debugger check the availability of the specified inspector server
port by trying to connect to it, and retry if the connection can be
established (which means the port is not yet free), but it never ends
those connections. This patch adds code to end the connections after
they are established to avoid taking up more resources than necessary.

### test: increase timeout in the debugger tests on Windows

On certain Windows machines it may take longer for the testing
processes to receive outputs from the debugger process. Increasing
the timeout to 15 seconds to avoid failing the tests in those
cases.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
