### PR TITLE
build: Add --libdir flag to configure

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -706,6 +706,14 @@ parser.add_argument('--shared',
     help='compile shared library for embedding node in another project. ' +
          '(This mode is not officially supported for regular applications)')
 
+parser.add_argument('--libdir',
+    action='store',
+    dest='libdir',
+    default='lib',
+    help='a directory to install the shared library into relative to the '
+         'prefix. This is a no-op if --shared is not specified. ' +
+         '(This mode is not officially supported for regular applications)')
+
 parser.add_argument('--without-v8-platform',
     action='store_true',
     dest='without_v8_platform',
@@ -1323,6 +1331,7 @@ def configure_node(o):
   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
 
   o['variables']['node_shared'] = b(options.shared)
+  o['variables']['libdir'] = options.libdir
   node_module_version = getmoduleversion.get_version()
 
   if options.dest_os == 'android':

--- a/tools/install.py
+++ b/tools/install.py
@@ -169,14 +169,14 @@ def files(action):
 
       # install libnode.version.so
       so_name = 'libnode.' + re.sub(r'\.x$', '.so', variables.get('shlib_suffix'))
-      action([output_prefix + so_name], 'lib/' + so_name)
+      action([output_prefix + so_name], variables.get('libdir') + '/' + output_lib)
 
       # create symlink of libnode.so -> libnode.version.so (C++ addons compat)
       link_path = abspath(install_path, 'lib/libnode.so')
       try_symlink(so_name, link_path)
     else:
       output_lib = 'libnode.' + variables.get('shlib_suffix')
-      action([output_prefix + output_lib], 'lib/' + output_lib)
+      action([output_prefix + output_lib], variables.get('libdir') + '/' + output_lib)
 
   action(['deps/v8/tools/gdbinit'], 'share/doc/node/')
   action(['deps/v8/tools/lldb_commands.py'], 'share/doc/node/')

--- a/tools/install.py
+++ b/tools/install.py
@@ -169,7 +169,7 @@ def files(action):
 
       # install libnode.version.so
       so_name = 'libnode.' + re.sub(r'\.x$', '.so', variables.get('shlib_suffix'))
-      action([output_prefix + so_name], variables.get('libdir') + '/' + output_lib)
+      action([output_prefix + so_name], variables.get('libdir') + '/' + so_name)
 
       # create symlink of libnode.so -> libnode.version.so (C++ addons compat)
       link_path = abspath(install_path, 'lib/libnode.so')


### PR DESCRIPTION
This will allow distribution packages to select an alternative location for the unofficial libnode.so. For example, on Fedora it will install into /usr/lib64 on 64-bit systems.

We've been carrying a [similar patch](https://src.fedoraproject.org/rpms/nodejs/blob/16/f/0002-Install-both-binaries-and-use-libdir.patch) in Fedora for years now, but as of the changes in https://github.com/nodejs/node/pull/42256 it looks like this is now upstreamable.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
