### PR TITLE
src: expose environment RequestInterrupt

### DIFF
--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -166,6 +166,16 @@ void RemoveEnvironmentCleanupHookInternal(
   handle->info->env->RemoveCleanupHook(RunAsyncCleanupHook, handle->info.get());
 }
 
+void RequestInterrupt(Environment* env, void (*fun)(void* arg), void* arg) {
+  env->RequestInterrupt([fun, arg](Environment* env) {
+    // Disallow JavaScript execution during interrupt.
+    Isolate::DisallowJavascriptExecutionScope scope(
+        env->isolate(),
+        Isolate::DisallowJavascriptExecutionScope::CRASH_ON_FAILURE);
+    fun(arg);
+  });
+}
+
 async_id AsyncHooksGetExecutionAsyncId(Isolate* isolate) {
   Environment* env = Environment::GetCurrent(isolate);
   if (env == nullptr) return -1;

--- a/src/node.h
+++ b/src/node.h
@@ -1116,6 +1116,15 @@ inline void RemoveEnvironmentCleanupHook(AsyncCleanupHookHandle holder) {
   RemoveEnvironmentCleanupHookInternal(holder.get());
 }
 
+// This behaves like V8's Isolate::RequestInterrupt(), but also wakes up
+// the event loop if it is currently idle. Interrupt requests are drained
+// in `FreeEnvironment()`. The passed callback can not call back into
+// JavaScript.
+// This function can be called from any thread.
+NODE_EXTERN void RequestInterrupt(Environment* env,
+                                  void (*fun)(void* arg),
+                                  void* arg);
+
 /* Returns the id of the current execution context. If the return value is
  * zero then no execution has been set. This will happen if the user handles
  * I/O from native code. */

--- a/test/addons/request-interrupt/binding.cc
+++ b/test/addons/request-interrupt/binding.cc
@@ -1,0 +1,72 @@
+#include <node.h>
+#include <v8.h>
+#include <thread>  // NOLINT(build/c++11)
+
+using node::Environment;
+using v8::Context;
+using v8::FunctionCallbackInfo;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Local;
+using v8::Maybe;
+using v8::Object;
+using v8::String;
+using v8::Value;
+
+static std::thread interrupt_thread;
+
+void ScheduleInterrupt(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  HandleScope handle_scope(isolate);
+  Environment* env = node::GetCurrentEnvironment(isolate->GetCurrentContext());
+
+  interrupt_thread = std::thread([=]() {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    node::RequestInterrupt(
+        env,
+        [](void* data) {
+          // Interrupt is called from JS thread.
+          interrupt_thread.join();
+          exit(0);
+        },
+        nullptr);
+  });
+}
+
+void ScheduleInterruptWithJS(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  HandleScope handle_scope(isolate);
+  Environment* env = node::GetCurrentEnvironment(isolate->GetCurrentContext());
+
+  interrupt_thread = std::thread([=]() {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    node::RequestInterrupt(
+        env,
+        [](void* data) {
+          // Interrupt is called from JS thread.
+          interrupt_thread.join();
+          Isolate* isolate = static_cast<Isolate*>(data);
+          HandleScope handle_scope(isolate);
+          Local<Context> ctx = isolate->GetCurrentContext();
+          Local<String> str =
+              String::NewFromUtf8(isolate, "interrupt").ToLocalChecked();
+          // Calling into JS should abort immediately.
+          Maybe<bool> result = ctx->Global()->Set(ctx, str, str);
+          // Should not reach here.
+          if (!result.IsNothing()) {
+            // Called into JavaScript.
+            exit(2);
+          }
+          // Maybe exception thrown.
+          exit(1);
+        },
+        isolate);
+  });
+}
+
+void init(Local<Object> exports) {
+  NODE_SET_METHOD(exports, "scheduleInterrupt", ScheduleInterrupt);
+  NODE_SET_METHOD(exports, "ScheduleInterruptWithJS", ScheduleInterruptWithJS);
+}
+
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/request-interrupt/binding.gyp
+++ b/test/addons/request-interrupt/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'includes': ['../common.gypi'],
+    }
+  ]
+}

--- a/test/addons/request-interrupt/test.js
+++ b/test/addons/request-interrupt/test.js
@@ -45,10 +45,6 @@ for (const type of ['busyloop', 'idle']) {
 
   {
     const child = spawnSync(process.execPath, [ __filename, `child-${type}`, 'ScheduleInterruptWithJS' ]);
-    if (process.platform === 'win32') {
-      assert.notStrictEqual(child.status, 0, `${type} should not exit with code 0`);
-    } else {
-      assert.strictEqual(child.signal, 'SIGTRAP', `${type} should be interrupted with SIGTRAP`);
-    }
+    assert(common.nodeProcessAborted(child.status, child.signal));
   }
 }

--- a/test/addons/request-interrupt/test.js
+++ b/test/addons/request-interrupt/test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const path = require('path');
+const spawnSync = require('child_process').spawnSync;
+
+const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
+
+Object.defineProperty(globalThis, 'interrupt', {
+  get: () => {
+    return null;
+  },
+  set: () => {
+    throw new Error('should not calling into js');
+  },
+});
+
+if (process.argv[2] === 'child-busyloop') {
+  (function childMain() {
+    const addon = require(binding);
+    addon[process.argv[3]]();
+    while (true) {
+      /** wait for interrupt */
+    }
+  })();
+  return;
+}
+
+if (process.argv[2] === 'child-idle') {
+  (function childMain() {
+    const addon = require(binding);
+    addon[process.argv[3]]();
+    // wait for interrupt
+    setTimeout(() => {}, 10_000_000);
+  })();
+  return;
+}
+
+for (const type of ['busyloop', 'idle']) {
+  {
+    const child = spawnSync(process.execPath, [ __filename, `child-${type}`, 'scheduleInterrupt' ]);
+    assert.strictEqual(child.status, 0, `${type} should exit with code 0`);
+  }
+
+  {
+    const child = spawnSync(process.execPath, [ __filename, `child-${type}`, 'ScheduleInterruptWithJS' ]);
+    if (process.platform === 'win32') {
+      assert.notStrictEqual(child.status, 0, `${type} should not exit with code 0`);
+    } else {
+      assert.strictEqual(child.signal, 'SIGTRAP', `${type} should be interrupted with SIGTRAP`);
+    }
+  }
+}


### PR DESCRIPTION
Allow add-ons to interrupt JavaScript execution, and wake up loop if it
is currently idle.

Refs: https://github.com/nodejs/node/pull/44255#pullrequestreview-1076410060