### PR TITLE
[v16.x] build: add windows-2022 to v16.x actions

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -32,7 +32,11 @@ permissions:
 jobs:
   build-windows:
     if: github.event.pull_request.draft == false
-    runs-on: windows-2019
+    strategy:
+      matrix:
+        windows: [windows-2019, windows-2022]
+      fail-fast: false
+    runs-on: ${{ matrix.windows }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   coverage-windows:
     if: github.event.pull_request.draft == false
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Closes #42560

This was reverted in the commit mentioned below due to a compiler bug. The bug got resolved in MSVC 14.33, which is part of the GitHub Actions 20220821.1 image for windows-2022.

Note that I'm not adding this to the `main` branch yet as there's a separate issue there: https://github.com/nodejs/node/issues/43092

Ref: https://github.com/nodejs/node/commit/79e2ab2a6793bf4235cf67f31d640f8de5519d44
Ref: https://github.com/nodejs/node/issues/42560
Ref: https://developercommunity.visualstudio.com/t/Failed-to-compile-nodejs-16140-with-la/1682115?space=62&q=nodejs
Ref: https://github.com/actions/runner-images/blob/releases/win22/20220821/images/win/Windows2022-Readme.md

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
