### PR TITLE
inspector: prevent integer overflow in open()

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -25,7 +25,9 @@ if (!hasInspector)
 const EventEmitter = require('events');
 const { queueMicrotask } = require('internal/process/task_queues');
 const {
+  isUint32,
   validateFunction,
+  validateInt32,
   validateObject,
   validateString,
 } = require('internal/validators');
@@ -167,6 +169,13 @@ class Session extends EventEmitter {
 function inspectorOpen(port, host, wait) {
   if (isEnabled()) {
     throw new ERR_INSPECTOR_ALREADY_ACTIVATED();
+  }
+  // inspectorOpen() currently does not typecheck its arguments and adding
+  // such checks would be a potentially breaking change. However, the native
+  // open() function requires the port to fit into a 16-bit unsigned integer,
+  // causing an integer overflow otherwise, so we at least need to prevent that.
+  if (isUint32(port)) {
+    validateInt32(port, 'port', 0, 65535);
   }
   open(port, host);
   if (wait)

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -281,6 +281,7 @@ void Open(const FunctionCallbackInfo<Value>& args) {
 
   if (args.Length() > 0 && args[0]->IsUint32()) {
     uint32_t port = args[0].As<Uint32>()->Value();
+    CHECK_LE(port, std::numeric_limits<uint16_t>::max());
     ExclusiveAccess<HostPort>::Scoped host_port(agent->host_port());
     host_port->set_port(static_cast<int>(port));
   }

--- a/test/parallel/test-inspector-open-port-integer-overflow.js
+++ b/test/parallel/test-inspector-open-port-integer-overflow.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// Regression test for an integer overflow in inspector.open() when the port
+// exceeds the range of an unsigned 16-bit integer.
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+common.skipIfWorker();
+
+const assert = require('assert');
+const inspector = require('inspector');
+
+assert.throws(() => inspector.open(99999), {
+  name: 'RangeError',
+  code: 'ERR_OUT_OF_RANGE',
+  message: 'The value of "port" is out of range. It must be >= 0 && <= 65535. Received 99999'
+});


### PR DESCRIPTION
When the `port` exceeds the unsigned 16-bit range, an integer overflow occurs and an attempt is made to open the inspector on `port % (2 ** 16)` instead, which may or may not succeed.

Prevent this by verifying that `port` is an unsigned 16-bit integer if it is an unsigned 32-bit integer. (Any stricter test would be an unnecessary breaking change and non-`uint32` values will not cause an overflow.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
