### PR TITLE
doc: fix style of diagnostics_channel.md

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -434,6 +434,8 @@ Emitted when server receives a request.
 
 Emitted when server sends a response.
 
+#### Net
+
 `net.client.socket`
 
 * `socket` {net.Socket}
@@ -445,6 +447,8 @@ Emitted when a new TCP or pipe client socket is created.
 * `socket` {net.Socket}
 
 Emitted when a new TCP or pipe connection is received.
+
+#### UDP
 
 `udp.socket`
 


### PR DESCRIPTION
fix style of `diagnostics_channel.md`
See https://nodejs.org/dist/latest-v18.x/docs/api/diagnostics_channel.html#built-in-channels
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
