### PR TITLE
doc: fix release guide example consistency

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -737,7 +737,7 @@ haven't pushed your tag first, then build promotion won't work properly.
 Push the tag using the following command:
 
 ```console
-$ git push <remote> <vx.y.z>
+$ git push upstream v1.2.3
 ```
 
 _Note_: Please do not push the tag unless you are ready to complete the


### PR DESCRIPTION
This changeset fixes two consistency issues in this single example that
guides releasers on how to push the tag to the remote repo.

The first issue is that the remote git reference is consistently
referred to as `upstream` elsewhere in the guide.

The second issue being that the version example used in the rest of the
guide should be a fictional `v1.2.3` as stated in the **How to create a
release** section notes:

>  * Examples will use the fictional release version `1.2.3`.

cc @nodejs/releasers 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
