### PR TITLE
deps: V8: fix debug build

### DIFF
--- a/deps/v8/src/codegen/register.h
+++ b/deps/v8/src/codegen/register.h
@@ -26,7 +26,8 @@ template <typename... RegTypes,
               std::conjunction_v<std::is_same<Register, RegTypes>...> ||
               std::conjunction_v<std::is_same<DoubleRegister, RegTypes>...>>>
 inline constexpr bool AreAliased(RegTypes... regs) {
-  int num_different_regs = RegListBase{regs...}.Count();
+  using FirstRegType = std::tuple_element_t<0, std::tuple<RegTypes...>>;
+  int num_different_regs = RegListBase<FirstRegType>{regs...}.Count();
   int num_given_regs = (... + (regs.is_valid() ? 1 : 0));
   return num_different_regs < num_given_regs;
 }


### PR DESCRIPTION
This is a (very) partial cherry-pick of upstream change v8/v8@f8fddd6b13
that fixes the following debug mode build error with clang:

    ../deps/v8/src/codegen/register.h:29:48: error: member reference
    base type 'RegListBase' is not a structure or union
      int num_different_regs = RegListBase{regs...}.Count();

Fixes: https://github.com/nodejs/node/issues/44371