### PR TITLE
src: fix `ssize_t` error from `nghttp2.h`

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -3,8 +3,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-// FIXME(joyeecheung): nghttp2.h needs stdint.h to compile on Windows
-#include <cstdint>
 // clang-format off
 #include "node.h"  // nghttp2.h needs ssize_t
 // clang-format on

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -5,6 +5,9 @@
 
 // FIXME(joyeecheung): nghttp2.h needs stdint.h to compile on Windows
 #include <cstdint>
+// clang-format off
+#include "node.h"  // nghttp2.h needs ssize_t
+// clang-format on
 #include "nghttp2/nghttp2.h"
 
 #include "env.h"


### PR DESCRIPTION
The "node_http2.h" include reordering enforced by clang-format (https://github.com/nodejs/node/commit/32446d8c8aaf293321cd712a7d63ea8f2b5fd712#diff-33f026e43570112875cf4c8eab6743496f3aa014329611128e348ec23d6f771cR1)
broke Electron's Node.js upgrade on Windows.

https://ci.appveyor.com/project/electron-bot/electron-x64-testing/builds/44562886/job/vf7dodmpnfn47y68
```sh
In file included from ../../third_party/electron_node/src/node_http2.cc:1:
In file included from ../../third_party/electron_node/src/node_http2.h:8:
../../third_party/electron_node/deps/nghttp2/lib/includes\nghttp2/nghttp2.h(930,9): error: unknown type name 'ssize_t'
typedef ssize_t (*nghttp2_data_source_read_callback)(
        ^
```

ssize_t is a part of the POSIX standard and it's not available on
Windows, so the fix for this is to include "node.h" which
typedefs it on Windows in
https://github.com/nodejs/node/blob/bb4dff783ddb3b20c67041f7ccef796c335c2407/src/node.h#L212-L220.

Refs: https://github.com/electron/electron/pull/35350#discussion_r954890551
Signed-off-by: Darshan Sen <raisinten@gmail.com>

cc @nodejs/cpp-reviewers 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
