### PR TITLE
esm,loader: make evaluation errors catchable

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -14,6 +14,7 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   PromiseAll,
+  PromisePrototypeCatch,
   RegExpPrototypeExec,
   SafeArrayIterator,
   SafeWeakMap,
@@ -525,9 +526,12 @@ class ESMLoader {
         .then(({ module }) => module.getNamespace());
     }
 
-    const namespaces = await PromiseAll(new SafeArrayIterator(jobs));
+    const namespaces = await PromisePrototypeCatch(
+      PromiseAll(new SafeArrayIterator(jobs)),
+      (err) => { throw err; }, // Make errors catchable in a custom loader.
+    );
 
-    if (!wasArr) { return namespaces[0]; } // We can skip the pairing below
+    if (!wasArr) { return namespaces[0]; } // We can skip the pairing below.
 
     for (let i = 0; i < count; i++) {
       const namespace = ObjectCreate(null);


### PR DESCRIPTION
Currently, an error thrown during module job evaluation is uncatchable. Such errors should be catchable in a custom loader.