### PR TITLE
lib: codify findSourceMap return value when not found

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -162,7 +162,8 @@ added:
 -->
 
 * `path` {string}
-* Returns: {module.SourceMap}
+* Returns: {module.SourceMap|undefined} Returns `module.SourceMap` if a source
+  map is found, `undefined` otherwise.
 
 `path` is the resolved path for the file for which a corresponding source map
 should be fetched.

--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -195,7 +195,7 @@ function getOriginalSource(payload, originalSourcePath) {
 
 function getSourceMapErrorSource(fileName, lineNumber, columnNumber) {
   const sm = findSourceMap(fileName);
-  if (sm === null) {
+  if (sm === undefined) {
     return;
   }
   const {

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -297,7 +297,7 @@ function findSourceMap(sourceURL) {
   if (sourceMap && sourceMap.data) {
     return new SourceMap(sourceMap.data);
   }
-  return null;
+  return undefined;
 }
 
 module.exports = {

--- a/test/parallel/test-source-map-api.js
+++ b/test/parallel/test-source-map-api.js
@@ -21,6 +21,19 @@ const { readFileSync } = require('fs');
   );
 }
 
+// `findSourceMap()` should return undefined when no source map is found.
+{
+  const files = [
+    __filename,
+    '',
+    'invalid-file',
+  ];
+  for (const file of files) {
+    const sourceMap = findSourceMap(file);
+    assert.strictEqual(sourceMap, undefined);
+  }
+}
+
 // findSourceMap() can lookup source-maps based on URIs, in the
 // non-exceptional case.
 {


### PR DESCRIPTION
Return `undefined` when no source map is found for the given filename on
`findSourceMap`.

Fixes: https://github.com/nodejs/node/issues/44391