### PR TITLE
src: avoid crash using `uv.errname()` binding

### DIFF
--- a/src/uv.cc
+++ b/src/uv.cc
@@ -70,9 +70,10 @@ void ErrName(const FunctionCallbackInfo<Value>& args) {
         "DEP0119").IsNothing())
     return;
   }
-  int err;
-  if (!args[0]->Int32Value(env->context()).To(&err)) return;
-  CHECK_LT(err, 0);
+  if (args[0]->IsNullOrUndefined()) {
+    return args.GetReturnValue().SetUndefined();
+  }
+  const int err = args[0].As<v8::Int32>()->Value();
   const char* name = uv_err_name(err);
   args.GetReturnValue().Set(OneByteString(env->isolate(), name));
 }

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -47,7 +47,21 @@ function runTest(fn) {
                  `Received ${err}`
       });
   });
+
+}
+
+function errNameTest(fn) {
+  // uv.errname should not cause crash with invalid args
+  [0, 1, 2, NaN, {}, false].forEach((err) => {
+    assert.match(fn(err), /Unknown system error/);
+  });
+
+  // uv.errname should return undefined with null or undefined args
+  [null, undefined].forEach((err) => {
+    assert.strictEqual(fn(err), undefined);
+  });
 }
 
 runTest(_errnoException);
 runTest(getSystemErrorName);
+errNameTest(uv.errname);


### PR DESCRIPTION
Return undefined from uv binding when no args are provided and do the libuv
call with any arg (if provided) to the binding.

Fixes: https://github.com/nodejs/node/issues/44400

This crash is being provoked by [this assertion](https://github.com/nodejs/node/blob/main/src/uv.cc#L75), using the binding directly is not guarantee that it will be invoked with the expected signature.