### PR TITLE
tools: don't use f-strings in test.py

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -227,7 +227,7 @@ class ProgressIndicator(object):
           if self.measure_flakiness:
             outputs = [case.Run() for _ in range(self.measure_flakiness)]
             # +1s are there because the test already failed once at this point.
-            print(f" failed {len([i for i in outputs if i.UnexpectedOutput()]) + 1} out of {self.measure_flakiness + 1}")
+            print(" failed %d out of %d" % (len([i for i in outputs if i.UnexpectedOutput()]) + 1, self.measure_flakiness + 1))
       else:
         self.succeeded += 1
       self.remaining -= 1


### PR DESCRIPTION
PR #43954 introduced the use of f-strings to `test.py` making the script
only work with python versions >= 3.6. Remove that use to make it
compatible again with older python versions.

I don't know whether the change was intentional, but [looking at the code in `test.py`](https://github.com/nodejs/node/blob/main/tools/test.py#L48-L65) it seems it's supposed to support older python versions.