### PR TITLE
[WIP] src: fix integration of Atomics.waitAsync()

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -253,7 +253,9 @@ void PerIsolatePlatformData::PostTask(std::unique_ptr<Task> task) {
 }
 
 void PerIsolatePlatformData::PostDelayedTask(
-    std::unique_ptr<Task> task, double delay_in_seconds) {
+    std::unique_ptr<Task> task,
+    double delay_in_seconds,
+    DelayedTask::Nestability nestability) {
   if (flush_tasks_ == nullptr) {
     // V8 may post tasks during Isolate disposal. In that case, the only
     // sensible path forward is to discard the task.
@@ -263,8 +265,15 @@ void PerIsolatePlatformData::PostDelayedTask(
   delayed->task = std::move(task);
   delayed->platform_data = shared_from_this();
   delayed->timeout = delay_in_seconds;
+  delayed->nestability = nestability;
   foreground_delayed_tasks_.Push(std::move(delayed));
   uv_async_send(flush_tasks_);
+}
+
+void PerIsolatePlatformData::PostDelayedTask(std::unique_ptr<Task> task,
+                                             double delay_in_seconds) {
+  PostDelayedTask(
+      std::move(task), delay_in_seconds, DelayedTask::Nestability::kNestable);
 }
 
 void PerIsolatePlatformData::PostNonNestableTask(std::unique_ptr<Task> task) {
@@ -274,7 +283,9 @@ void PerIsolatePlatformData::PostNonNestableTask(std::unique_ptr<Task> task) {
 void PerIsolatePlatformData::PostNonNestableDelayedTask(
     std::unique_ptr<Task> task,
     double delay_in_seconds) {
-  PostDelayedTask(std::move(task), delay_in_seconds);
+  PostDelayedTask(std::move(task),
+                  delay_in_seconds,
+                  DelayedTask::Nestability::kNonNestable);
 }
 
 PerIsolatePlatformData::~PerIsolatePlatformData() {
@@ -460,7 +471,12 @@ bool PerIsolatePlatformData::FlushForegroundTasksInternal() {
     // Timers may not guarantee queue ordering of events with the same delay if
     // the delay is non-zero. This should not be a problem in practice.
     uv_timer_start(&delayed->timer, RunForegroundTask, delay_millis, 0);
-    uv_unref(reinterpret_cast<uv_handle_t*>(&delayed->timer));
+    // Do not unref non-nestable tasks which can run call into JS.
+    // For the moment all nestable tasks are from GC or logging so it's
+    // okay to unref the timer for them.
+    if (delayed->nestability == DelayedTask::Nestability::kNestable) {
+      uv_unref(reinterpret_cast<uv_handle_t*>(&delayed->timer));
+    }
     uv_handle_count_++;
 
     scheduled_delayed_tasks_.emplace_back(delayed.release(),

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -43,10 +43,12 @@ class TaskQueue {
 };
 
 struct DelayedTask {
+  enum class Nestability { kNestable, kNonNestable };
   std::unique_ptr<v8::Task> task;
   uv_timer_t timer;
   double timeout;
   std::shared_ptr<PerIsolatePlatformData> platform_data;
+  Nestability nestability;
 };
 
 // This acts as the foreground task runner for a given Isolate.
@@ -86,6 +88,9 @@ class PerIsolatePlatformData :
   void DeleteFromScheduledTasks(DelayedTask* task);
   void DecreaseHandleCount();
 
+  void PostDelayedTask(std::unique_ptr<v8::Task> task,
+                       double delay_in_seconds,
+                       DelayedTask::Nestability nestability);
   static void FlushTasks(uv_async_t* handle);
   void RunForegroundTask(std::unique_ptr<v8::Task> task);
   static void RunForegroundTask(uv_timer_t* timer);

--- a/test/fixtures/atomics-wait-async-timeout.js
+++ b/test/fixtures/atomics-wait-async-timeout.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const sab = new SharedArrayBuffer(16);
+const i32a = new Int32Array(sab);
+const result = Atomics.waitAsync(i32a, 0, 0, 1000);
+result.value.then((val) => console.log(val));

--- a/test/parallel/test-atomics-wait-async-timeout-main-2.js
+++ b/test/parallel/test-atomics-wait-async-timeout-main-2.js
@@ -1,0 +1,24 @@
+'use strict';
+
+require('../common');
+
+if (process.argv[2] === 'child') {
+  const sab = new SharedArrayBuffer(16);
+  const i32a = new Int32Array(sab);
+  const result = Atomics.waitAsync(i32a, 0, 0, 1000 * 1000);
+  result.value.then((val) => console.log(val));
+  return;
+}
+
+const { spawnSync } = require('child_process');
+const assert = require('assert');
+
+const child = spawnSync(process.execPath, [
+  __filename, 'child',
+], { timeout: 1000 });
+
+if (!child.error) {
+  console.log(child.stderr.toString());
+  console.log(child.stdout.toString());
+}
+assert.strictEqual(child.error.code, 'ETIMEDOUT');

--- a/test/parallel/test-atomics-wait-async-timeout-main.js
+++ b/test/parallel/test-atomics-wait-async-timeout-main.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('../common');
+
+if (process.argv[2] === 'child') {
+  const sab = new SharedArrayBuffer(16);
+  const i32a = new Int32Array(sab);
+  const result = Atomics.waitAsync(i32a, 0, 0, 1000);
+  result.value.then((val) => console.log(val));
+  return;
+}
+
+const { spawnSync } = require('child_process');
+const assert = require('assert');
+
+const child = spawnSync(process.execPath, [__filename, 'child']);
+assert.strictEqual(child.stdout.toString().trim(), 'timed-out');
+assert.strictEqual(child.stderr.toString().trim(), '');
+assert.strictEqual(child.status, 0);

--- a/test/parallel/test-atomics-wait-async-timeout-worker-2.js
+++ b/test/parallel/test-atomics-wait-async-timeout-worker-2.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const { Worker, workerData } = require('worker_threads');
+const assert = require('assert');
+
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+  const sab = new SharedArrayBuffer(16);
+  const i32a = new Int32Array(sab);
+  const w = new Worker(__filename, {
+    workerData: i32a
+  });
+  const chunks = [];
+  w.stdout.on('data', (chunk) => chunks.push(chunk));
+  w.on('exit', common.mustCall((code) => {
+    assert.strictEqual(Buffer.concat(chunks).toString().trim(), '');
+    assert.strictEqual(code, 1);
+  }));
+  setTimeout(() => {
+    w.terminate();
+  }, 1000);
+} else {
+  const i32a = workerData;
+  const result = Atomics.waitAsync(i32a, 0, 0, 1000 * 1000);
+  result.value.then((val) => console.log(val));
+}

--- a/test/parallel/test-atomics-wait-async-timeout-worker.js
+++ b/test/parallel/test-atomics-wait-async-timeout-worker.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const { Worker, workerData } = require('worker_threads');
+const assert = require('assert');
+
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+  const sab = new SharedArrayBuffer(16);
+  const i32a = new Int32Array(sab);
+  const w = new Worker(__filename, { workerData: i32a });
+  const chunks = [];
+  w.stdout.on('data', (chunk) => chunks.push(chunk));
+  w.on('exit', common.mustCall((code) => {
+    assert.strictEqual(Buffer.concat(chunks).toString().trim(), 'timed-out');
+    assert.strictEqual(code, 0);
+  }));
+} else {
+  const i32a = workerData;
+  const result = Atomics.waitAsync(i32a, 0, 0, 1000);
+  result.value.then((val) => console.log(val));
+}


### PR DESCRIPTION
Previously we unref the timers scheduled by `PostDelayedTask()` and
`PostNonNestableDelayedTask()`, which had been fine because they
were only ever scheduled by GC or logging so it didn't hurt to
stop the event loop early and ignore them. But now that
`Atomics.waitAsync()` uses `PostNonNestableDelayedTask()` to
resolve a promise, we should keep the event loop open for it.

From offline discussion with @syg, what happens with a `Atomics.waitAsync()` with a timeout on an atomics that does not get notified in time is host-defined. For a host like Node.js, it makes sense to keep running until the returned promise resolves with a `timed-out` value i.e. makes it similar to how `setTimeout()` would behave.

This fix is not yet ready though, pending issues:

- When the Atomics are notified in time, V8 doesn't notify the platform that the delayed task posted for the `Atomics.waitAsync()` timeout is cancelled. From what I can tell, V8 only internally marks that task as cancelled, and when the platform runs the task through `task->Run()`, V8's `Run()` implementation of that task sees that it's internally cancelled and skips it. Without knowing that the task is already canceled, the embedder would keep the isolate alive for longer than necessary.
- Is `PostNonNestableDelayedTask()` supposed to be thread-safe for this use case (at least for the foreground task runner)? IIUC the V8 header does not specify thread safety for the TaskRunner methods, though the default V8 platform has been implemented with thread safety in mind. Currently this method of the foreground task runner is not thread-safe in Node.js because of the access to the main loop.
- V8's documentation is not quite clear about whether the isolate must be kept alive when there is a delayed task. Historically delayed tasks are scheduled for GC and other disposable tasks, so Node.js has not been keeping the isolate alive for them, leading to this issue. Should V8 provide more information in the task posted so that the embedder can count on something more reliable than nestability to decide whether the isolate should stay alive for it?

Opened https://bugs.chromium.org/p/v8/issues/detail?id=13238 for the issues above

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
