### PR TITLE
src: make Endianness an enum class

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -751,26 +751,23 @@ inline v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
         .Check();                                                              \
   } while (0)
 
-enum Endianness {
-  kLittleEndian,  // _Not_ LITTLE_ENDIAN, clashes with endian.h.
-  kBigEndian
-};
+enum class Endianness { LITTLE, BIG };
 
-inline enum Endianness GetEndianness() {
+inline Endianness GetEndianness() {
   // Constant-folded by the compiler.
   const union {
     uint8_t u8[2];
     uint16_t u16;
   } u = {{1, 0}};
-  return u.u16 == 1 ? kLittleEndian : kBigEndian;
+  return u.u16 == 1 ? Endianness::LITTLE : Endianness::BIG;
 }
 
 inline bool IsLittleEndian() {
-  return GetEndianness() == kLittleEndian;
+  return GetEndianness() == Endianness::LITTLE;
 }
 
 inline bool IsBigEndian() {
-  return GetEndianness() == kBigEndian;
+  return GetEndianness() == Endianness::BIG;
 }
 
 // Round up a to the next highest multiple of b.


### PR DESCRIPTION
~Remove `GetEndianness()` and the `enum Endianness` because neither is used except from within `IsLittleEndian()` and `IsBigEndian()`.~

~Make `IsLittleEndian()` and `IsBigEndian()` `constexpr`s so that they are guaranteed to be computable at compile time.~

I haven't found a way to implement this is a `constexpr` that is accepted by clang, so just make `Endianness` an `enum class` for now until we can use c++20.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
