### PR TITLE
doc: apply scroll-margin-top to h2, h3 elements

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -40,15 +40,11 @@
   --color-text-secondary: var(--green2);
 }
 
+h2 :target,
+h3 :target,
 h4 :target,
 h5 :target {
   scroll-margin-top: 55px;
-}
-
-@supports not (content-visibility: auto) {
-  h3 :target {
-    scroll-margin-top: 55px;
-  }
 }
 
 .dark-mode {


### PR DESCRIPTION
#42739 added a `scroll-margin-top` rule to `h4`, `h5` headings so they wouldn't be obscured by the fixed header.

However, other heading elements (`h2`, `h3`) currently lack this style.

For example, visit https://nodejs.org/api/process.html#processmemoryusagerss. The expected behavior is that the `h3` heading "process.memoryUsage.rss()" should not be obscured by the header. An example of an `h2` heading is https://nodejs.org/api/process.html#process.

This PR applies the `scroll-margin-top` rule to `h2` and `h3` elements containing `:target` anchors. Per this [feedback](https://github.com/nodejs/node/pull/44414#issuecomment-1229968025), it also removes the `@supports` rule, which is no longer necessary.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
