### PR TITLE
stream: fix setting abort reason in `ReadableStream.pipeTo()`

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -28,6 +28,7 @@ const {
 } = primordials;
 
 const {
+  AbortError,
   codes: {
     ERR_ILLEGAL_CONSTRUCTOR,
     ERR_INVALID_ARG_VALUE,
@@ -1303,8 +1304,14 @@ function readableStreamPipeTo(
   }
 
   function abortAlgorithm() {
-    // Cannot use the AbortError class here. It must be a DOMException
-    const error = new DOMException('The operation was aborted', 'AbortError');
+    let error;
+    if (signal.reason instanceof AbortError) {
+      // Cannot use the AbortError class here. It must be a DOMException.
+      error = new DOMException(signal.reason.message, 'AbortError');
+    } else {
+      error = signal.reason;
+    }
+
     const actions = [];
     if (!preventAbort) {
       ArrayPrototypePush(

--- a/test/parallel/test-webstream-readablestream-pipeto.js
+++ b/test/parallel/test-webstream-readablestream-pipeto.js
@@ -1,0 +1,24 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('node:assert');
+const { AbortError } = require('internal/errors');
+
+// Purpose: pass an AbortError instance, which isn't the DOMException, as an
+// abort reason.
+
+for (const message of [undefined, 'abc']) {
+  const rs = new ReadableStream();
+  const ws = new WritableStream();
+  const ac = new AbortController();
+  const reason = new AbortError(message);
+  ac.abort(reason);
+
+  assert.rejects(rs.pipeTo(ws, { signal: ac.signal }), (e) => {
+    assert(e instanceof DOMException);
+    assert.strictEqual(e.name, 'AbortError');
+    assert.strictEqual(e.message, reason.message);
+    return true;
+  });
+}

--- a/test/wpt/status/streams.json
+++ b/test/wpt/status/streams.json
@@ -2,15 +2,6 @@
   "piping/abort.any.js": {
     "fail": {
       "expected": [
-        "(reason: 'null') all the error objects should be the same object",
-        "(reason: 'undefined') all the error objects should be the same object",
-        "(reason: 'error1: error1') all the error objects should be the same object",
-        "(reason: 'null') abort should prevent further reads",
-        "(reason: 'undefined') abort should prevent further reads",
-        "(reason: 'error1: error1') abort should prevent further reads",
-        "(reason: 'null') all pending writes should complete on abort",
-        "(reason: 'undefined') all pending writes should complete on abort",
-        "(reason: 'error1: error1') all pending writes should complete on abort",
         "pipeTo on a teed readable byte stream should only be aborted when both branches are aborted"
       ]
     }


### PR DESCRIPTION
In 14.2 in the specification, `error` should be signal’s abort reason. The current behavior seems to assume that only an `AbortError` instance is given as signal’s abort reason.

> 14. If signal is not undefined,
>> 1. Let abortAlgorithm be the following steps:
>> 2. Let error be signal’s abort reason.  <--

Refs: https://streams.spec.whatwg.org/#readable-stream-pipe-to

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
