### PR TITLE
uv: fix uv_err_name memory leak

### DIFF
--- a/src/uv.cc
+++ b/src/uv.cc
@@ -73,7 +73,8 @@ void ErrName(const FunctionCallbackInfo<Value>& args) {
   int err;
   if (!args[0]->Int32Value(env->context()).To(&err)) return;
   CHECK_LT(err, 0);
-  const char* name = uv_err_name(err);
+  char name[50];
+  uv_err_name_r(err, name, sizeof(name));
   args.GetReturnValue().Set(OneByteString(env->isolate(), name));
 }
 

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -12,6 +12,8 @@ const { internalBinding } = require('internal/test/binding');
 const uv = internalBinding('uv');
 const keys = Object.keys(uv);
 
+assert.strictEqual(uv.errname(-111111), 'Unknown system error -111111');
+
 keys.forEach((key) => {
   if (!key.startsWith('UV_'))
     return;


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/44401

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
