### PR TITLE
src: remove base64_select_table and base64_table

### DIFF
--- a/src/base64-inl.h
+++ b/src/base64-inl.h
@@ -9,6 +9,10 @@
 
 namespace node {
 
+static constexpr char base64_table_url[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                           "abcdefghijklmnopqrstuvwxyz"
+                                           "0123456789-_";
+
 extern const int8_t unbase64_table[256];
 
 
@@ -144,7 +148,7 @@ inline size_t base64_encode(const char* src,
   unsigned k;
   unsigned n;
 
-  const char* table = base64_select_table(mode);
+  const char* table = base64_table_url;
 
   i = 0;
   k = 0;

--- a/src/base64.h
+++ b/src/base64.h
@@ -17,22 +17,6 @@ enum class Base64Mode {
   URL
 };
 
-static constexpr char base64_table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                       "abcdefghijklmnopqrstuvwxyz"
-                                       "0123456789+/";
-
-static constexpr char base64_table_url[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                           "abcdefghijklmnopqrstuvwxyz"
-                                           "0123456789-_";
-
-static inline const char* base64_select_table(Base64Mode mode) {
-  switch (mode) {
-    case Base64Mode::NORMAL: return base64_table;
-    case Base64Mode::URL: return base64_table_url;
-    default: UNREACHABLE();
-  }
-}
-
 static inline constexpr size_t base64_encoded_size(
     size_t size,
     Base64Mode mode = Base64Mode::NORMAL) {


### PR DESCRIPTION
`node::base64_encode()` uses `::base64_encode()` when the mode is `Base64Mode::NORMAL`, so `base64_select_table` is only ever called for `Base64Mode::URL` and thus only ever returns `base64_table_url`, but never `base64_table`.

Also move `base64_table_url` into `base64-inl.h`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
