### PR TITLE
test: improve api/encoding.cc coverage

### DIFF
--- a/src/api/encoding.cc
+++ b/src/api/encoding.cc
@@ -15,7 +15,11 @@ enum encoding ParseEncoding(const char* encoding,
   switch (encoding[0]) {
     case 'u':
     case 'U':
-      // utf8, utf16le
+      // Note: the two first conditions are needed for performance reasons
+      // as "utf8"/"utf-8" is a common case.
+      // (same for other cases below)
+
+      // utf, utf16le
       if (encoding[1] == 't' && encoding[2] == 'f') {
         // Skip `-`
         const size_t skip = encoding[3] == '-' ? 4 : 3;

--- a/src/api/encoding.cc
+++ b/src/api/encoding.cc
@@ -19,7 +19,7 @@ enum encoding ParseEncoding(const char* encoding,
       // as "utf8"/"utf-8" is a common case.
       // (same for other cases below)
 
-      // utf, utf16le
+      // utf8, utf16le
       if (encoding[1] == 't' && encoding[2] == 'f') {
         // Skip `-`
         const size_t skip = encoding[3] == '-' ? 4 : 3;

--- a/test/addons/parse-encoding/test.js
+++ b/test/addons/parse-encoding/test.js
@@ -4,14 +4,18 @@ const common = require('../../common');
 const assert = require('assert');
 const { parseEncoding } = require(`./build/${common.buildType}/binding`);
 
-assert.strictEqual(parseEncoding(''), 'UNKNOWN');
-
 assert.strictEqual(parseEncoding('ascii'), 'ASCII');
+assert.strictEqual(parseEncoding('ASCII'), 'ASCII');
 assert.strictEqual(parseEncoding('base64'), 'BASE64');
+assert.strictEqual(parseEncoding('BASE64'), 'BASE64');
 assert.strictEqual(parseEncoding('base64url'), 'BASE64URL');
+assert.strictEqual(parseEncoding('BASE64URL'), 'BASE64URL');
 assert.strictEqual(parseEncoding('binary'), 'LATIN1');
+assert.strictEqual(parseEncoding('BINARY'), 'LATIN1');
 assert.strictEqual(parseEncoding('buffer'), 'BUFFER');
+assert.strictEqual(parseEncoding('BUFFER'), 'BUFFER');
 assert.strictEqual(parseEncoding('hex'), 'HEX');
+assert.strictEqual(parseEncoding('HEX'), 'HEX');
 assert.strictEqual(parseEncoding('latin1'), 'LATIN1');
 assert.strictEqual(parseEncoding('LATIN1'), 'LATIN1');
 
@@ -34,6 +38,7 @@ assert.strictEqual(parseEncoding('UTF16LE'), 'UCS2');
 assert.strictEqual(parseEncoding('UTF-16LE'), 'UCS2');
 
 // unknown cases
+assert.strictEqual(parseEncoding(''), 'UNKNOWN');
 assert.strictEqual(parseEncoding('utf-buffer'), 'UNKNOWN');
 assert.strictEqual(parseEncoding('utf-16leNOT'), 'UNKNOWN');
 assert.strictEqual(parseEncoding('linary'), 'UNKNOWN');

--- a/test/addons/parse-encoding/test.js
+++ b/test/addons/parse-encoding/test.js
@@ -4,6 +4,7 @@ const common = require('../../common');
 const assert = require('assert');
 const { parseEncoding } = require(`./build/${common.buildType}/binding`);
 
+
 assert.strictEqual(parseEncoding('ascii'), 'ASCII');
 assert.strictEqual(parseEncoding('ASCII'), 'ASCII');
 assert.strictEqual(parseEncoding('base64'), 'BASE64');
@@ -39,6 +40,8 @@ assert.strictEqual(parseEncoding('UTF-16LE'), 'UCS2');
 
 // unknown cases
 assert.strictEqual(parseEncoding(''), 'UNKNOWN');
+assert.strictEqual(parseEncoding('asCOO'), 'UNKNOWN');
+assert.strictEqual(parseEncoding('hux'), 'UNKNOWN');
 assert.strictEqual(parseEncoding('utf-buffer'), 'UNKNOWN');
 assert.strictEqual(parseEncoding('utf-16leNOT'), 'UNKNOWN');
 assert.strictEqual(parseEncoding('linary'), 'UNKNOWN');

--- a/test/addons/parse-encoding/test.js
+++ b/test/addons/parse-encoding/test.js
@@ -13,6 +13,7 @@ assert.strictEqual(parseEncoding('binary'), 'LATIN1');
 assert.strictEqual(parseEncoding('buffer'), 'BUFFER');
 assert.strictEqual(parseEncoding('hex'), 'HEX');
 assert.strictEqual(parseEncoding('latin1'), 'LATIN1');
+assert.strictEqual(parseEncoding('LATIN1'), 'LATIN1');
 
 // ucs2 variations
 assert.strictEqual(parseEncoding('ucs2'), 'UCS2');

--- a/test/addons/parse-encoding/test.js
+++ b/test/addons/parse-encoding/test.js
@@ -13,11 +13,27 @@ assert.strictEqual(parseEncoding('binary'), 'LATIN1');
 assert.strictEqual(parseEncoding('buffer'), 'BUFFER');
 assert.strictEqual(parseEncoding('hex'), 'HEX');
 assert.strictEqual(parseEncoding('latin1'), 'LATIN1');
+
+// ucs2 variations
 assert.strictEqual(parseEncoding('ucs2'), 'UCS2');
+assert.strictEqual(parseEncoding('ucs-2'), 'UCS2');
+assert.strictEqual(parseEncoding('UCS2'), 'UCS2');
+assert.strictEqual(parseEncoding('UCS-2'), 'UCS2');
+
+// utf8 variations
 assert.strictEqual(parseEncoding('utf8'), 'UTF8');
-assert.strictEqual(parseEncoding('utf-16LE'), 'UCS2');
+assert.strictEqual(parseEncoding('utf-8'), 'UTF8');
+assert.strictEqual(parseEncoding('UTF8'), 'UTF8');
+assert.strictEqual(parseEncoding('UTF-8'), 'UTF8');
+
+// utf16le variations
+assert.strictEqual(parseEncoding('utf16le'), 'UCS2');
+assert.strictEqual(parseEncoding('utf-16le'), 'UCS2');
+assert.strictEqual(parseEncoding('UTF16LE'), 'UCS2');
+assert.strictEqual(parseEncoding('UTF-16LE'), 'UCS2');
+
+// unknown cases
 assert.strictEqual(parseEncoding('utf-buffer'), 'UNKNOWN');
 assert.strictEqual(parseEncoding('utf-16leNOT'), 'UNKNOWN');
-
 assert.strictEqual(parseEncoding('linary'), 'UNKNOWN');
 assert.strictEqual(parseEncoding('luffer'), 'UNKNOWN');


### PR DESCRIPTION
Hi, Node fam' 👋 

## Context

I intend to improve the coverage of [this file](https://coverage.nodejs.org/coverage-7900f6540ea8ffd3/cxxcoverage.api_encoding.cc.html).

As I'm not familiar with the code base, I didn't update the whole file, I prefer to collect feedback first 👍 

## Gains 

| Before | After |
| -------| -----|
| https://coverage.nodejs.org/coverage-7900f6540ea8ffd3/cxxcoverage.api_encoding.cc.html | https://app.codecov.io/gh/nodejs/node/blob/9294affe152c64104baf35ac4f7d0d61ca174a38/src/api/encoding.cc |