### PR TITLE
test: fix incorrect DNS cancel tests

### DIFF
--- a/test/parallel/test-dns-channel-cancel-promise.js
+++ b/test/parallel/test-dns-channel-cancel-promise.js
@@ -7,23 +7,15 @@ const dgram = require('dgram');
 const server = dgram.createSocket('udp4');
 const resolver = new dnsPromises.Resolver();
 
-const addMessageListener = () => {
-  server.removeAllListeners('message');
-
-  server.once('message', () => {
-    server.once('message', common.mustNotCall);
-
-    resolver.cancel();
-  });
-};
-
 server.bind(0, common.mustCall(async () => {
   resolver.setServers([`127.0.0.1:${server.address().port}`]);
 
-  addMessageListener();
-
   // Single promise
   {
+    server.once('message', () => {
+      resolver.cancel();
+    });
+
     const hostname = 'example0.org';
 
     await assert.rejects(
@@ -36,10 +28,12 @@ server.bind(0, common.mustCall(async () => {
     );
   }
 
-  addMessageListener();
-
   // Multiple promises
   {
+    server.once('message', () => {
+      resolver.cancel();
+    });
+
     const assertions = [];
     const assertionCount = 10;
 

--- a/test/parallel/test-dns-channel-cancel.js
+++ b/test/parallel/test-dns-channel-cancel.js
@@ -10,16 +10,6 @@ const resolver = new Resolver();
 const desiredQueries = 11;
 let finishedQueries = 0;
 
-const addMessageListener = () => {
-  server.removeAllListeners('message');
-
-  server.once('message', () => {
-    server.once('message', common.mustNotCall);
-
-    resolver.cancel();
-  });
-};
-
 server.bind(0, common.mustCall(async () => {
   resolver.setServers([`127.0.0.1:${server.address().port}`]);
 
@@ -37,7 +27,9 @@ server.bind(0, common.mustCall(async () => {
   const next = (...args) => {
     callback(...args);
 
-    addMessageListener();
+    server.once('message', () => {
+      resolver.cancel();
+    });
 
     // Multiple queries
     for (let i = 1; i < desiredQueries; i++) {
@@ -45,7 +37,10 @@ server.bind(0, common.mustCall(async () => {
     }
   };
 
+  server.once('message', () => {
+    resolver.cancel();
+  });
+
   // Single query
-  addMessageListener();
   resolver.resolve4('example0.org', next);
 }));


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/44428

Followup to #44022

Not sure what was I thinking at that moment, but calling `resolve4` 11 times sends out 11 datagrams as expected, so `mustNotCall` was actually wrong.