### PR TITLE
test: make the vm timeout escape tests more lenient

### DIFF
--- a/test/parallel/test-vm-timeout-escape-promise-2.js
+++ b/test/parallel/test-vm-timeout-escape-promise-2.js
@@ -16,7 +16,7 @@ function loop() {
   while (1) {
     const current = hrtime();
     const span = (current - start) / NS_PER_MS;
-    if (span >= 100n) {
+    if (span >= 2000n) {
       throw new Error(
         `escaped timeout at ${span} milliseconds!`);
     }

--- a/test/parallel/test-vm-timeout-escape-promise-module.js
+++ b/test/parallel/test-vm-timeout-escape-promise-module.js
@@ -18,7 +18,7 @@ function loop() {
   while (1) {
     const current = hrtime();
     const span = (current - start) / NS_PER_MS;
-    if (span >= 100n) {
+    if (span >= 2000n) {
       throw new Error(
         `escaped timeout at ${span} milliseconds!`);
     }

--- a/test/parallel/test-vm-timeout-escape-promise.js
+++ b/test/parallel/test-vm-timeout-escape-promise.js
@@ -17,7 +17,7 @@ function loop() {
   while (1) {
     const current = hrtime();
     const span = (current - start) / NS_PER_MS;
-    if (span >= 100n) {
+    if (span >= 2000n) {
       throw new Error(
         `escaped timeout at ${span} milliseconds!`);
     }


### PR DESCRIPTION
Previously the tests required that Node.js finish the initialization
of the watchdog thread and fires the timeout within 100ms, which
can be difficult on certain systems under load. This patch
relaxes the requirement to 2000ms. If there is a bug and the
timeout can actually be escaped, raising the timeout to 2000ms
would not make a difference anyway.

Refs: https://github.com/nodejs/reliability/issues/333
Refs: https://github.com/nodejs/reliability/issues/361

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
