### PR TITLE
src: add --max-semi-space-size to the options allowed in NODE_OPTIONS

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1936,6 +1936,7 @@ V8 options that are allowed are:
 * `--interpreted-frames-native-stack`
 * `--jitless`
 * `--max-old-space-size`
+* `--max-semi-space-size`
 * `--perf-basic-prof-only-functions`
 * `--perf-basic-prof`
 * `--perf-prof-unwinding-info`

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -709,6 +709,7 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             V8Option{},
             kAllowedInEnvvar);
   AddOption("--max-old-space-size", "", V8Option{}, kAllowedInEnvvar);
+  AddOption("--max-semi-space-size", "", V8Option{}, kAllowedInEnvvar);
   AddOption("--perf-basic-prof", "", V8Option{}, kAllowedInEnvvar);
   AddOption(
       "--perf-basic-prof-only-functions", "", V8Option{}, kAllowedInEnvvar);

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -72,6 +72,7 @@ expect('--disallow-code-generation-from-strings', 'B\n');
 expect('--huge-max-old-generation-size', 'B\n');
 expect('--jitless', 'B\n');
 expect('--max-old-space-size=0', 'B\n');
+expect('--max-semi-space-size=0', 'B\n');
 expect('--stack-trace-limit=100',
        /(\s*at f \(\[(eval|worker eval)\]:1:\d*\)\r?\n)/,
        '(function f() { f(); })();',


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

[--max-semi-space-size](https://nodejs.org/docs/latest/api/cli.html#--max-semi-space-sizesize-in-megabytes) was added to the Useful V8 options in https://github.com/nodejs/node/pull/42575, but if you pass it in the NODE_OPTIONS environment variable, you still get `node: --max-semi-space-size= is not allowed in NODE_OPTIONS`.

Since the option is explicitly documented as being useful and since `NODE_OPTIONS` appears to be the supported way of passing parameters to the node process from npm, I think it should be included in the options passed through by `NODE_OPTIONS`.

It appears that this issue was not contemplated in the original request, although there is a comment asking for it: https://github.com/nodejs/node/issues/42511#issuecomment-1156238669