### PR TITLE
perf_hooks: validate maxSize in setResourceTimingBufferSize

### DIFF
--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -51,6 +51,7 @@ const {
 const {
   validateFunction,
   validateObject,
+  validateInteger,
 } = require('internal/validators');
 
 const {
@@ -431,6 +432,7 @@ function bufferResourceTiming(entry) {
 
 // https://w3c.github.io/resource-timing/#dom-performance-setresourcetimingbuffersize
 function setResourceTimingBufferSize(maxSize) {
+  validateInteger(maxSize, 'maxSize', 0);
   // If the maxSize parameter is less than resource timing buffer current
   // size, no PerformanceResourceTiming objects are to be removed from the
   // performance entry buffer.

--- a/test/parallel/test-performance-resourcetimingbuffersize.js
+++ b/test/parallel/test-performance-resourcetimingbuffersize.js
@@ -30,6 +30,11 @@ const initiatorType = '';
 const cacheMode = '';
 
 async function main() {
+  const invalidValues = [ null, undefined, true, false, -1, 1.1, Infinity, NaN, '', 'foo', {}, [], () => {} ];
+  for (const value of invalidValues) {
+    assert.throws(() => performance.setResourceTimingBufferSize(value), `${value} should throw`);
+  }
+
   performance.setResourceTimingBufferSize(1);
   performance.markResourceTiming(timingInfo, requestedUrl, initiatorType, globalThis, cacheMode);
   // Trigger a resourcetimingbufferfull event.


### PR DESCRIPTION
This should be verified by IDL harness. However, we don't have an IDL harness setup for WebPerf interfaces yet. I'm still working on getting the IDL test green on WebPerf interfaces but that requires a lot of changes to interfaces without any behavioral updates, e.g. enumerability and own properties. I'll submit the IDL harness with a follow-up PR and get this fix landed first.

/cc @nodejs/diagnostics 