### PR TITLE
test_runner: fix `duration_ms` to be milliseconds

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -615,8 +615,8 @@ class Test extends AsyncResource {
   }
 
   #duration() {
-    // Duration is recorded in BigInt nanoseconds. Convert to seconds.
-    return Number(this.endTime - this.startTime) / 1_000_000_000;
+    // Duration is recorded in BigInt nanoseconds. Convert to milliseconds.
+    return Number(this.endTime - this.startTime) / 1_000_000;
   }
 
   report() {


### PR DESCRIPTION
result of running `node -e "require('node:test').test((t, done)=>setTimeout(() => done(), 500))"`
before:
```console
TAP version 13
# Subtest: <anonymous>
ok 1 - <anonymous>
  ---
  duration_ms: 0.501664977
  ...
1..1
# tests 1
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 0.562913893
```
after:
```console
TAP version 13
# Subtest: <anonymous>
ok 1 - <anonymous>
  ---
  duration_ms: 501.590752
  ...
1..1
# tests 1
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 530.935436
```

not sure whether this was intended or not