### PR TITLE
build: go faster, drop -fno-omit-frame-pointer

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -204,15 +204,13 @@
             ],
           }],
           ['OS=="solaris"', {
+           'cflags': [ '-fno-omit-frame-pointer' ],
             # pull in V8's postmortem metadata
             'ldflags': [ '-Wl,-z,allextract' ]
           }],
           ['OS=="zos"', {
             # increase performance, number from experimentation
             'cflags': [ '-qINLINE=::150:100000' ]
-          }],
-          ['OS!="mac" and OS!="win" and OS!="zos"', {
-            'cflags': [ '-fno-omit-frame-pointer' ],
           }],
           ['OS=="linux"', {
             'conditions': [


### PR DESCRIPTION
This flag was added back in 2013 to support postmortem debugging on
Linux but it has a pretty bad impact on performance (up to 10%) and
I don't think it's actually necessary to get meaningful stack traces.
Maybe with mdb but gdb and lldb seem to manage just fine.

Even if the flag is necessary for postmortem debugging, I don't think
it's appropriate to make performance for all users suffer for the
benefit of a fringe group.

Signed, a member of said fringe group.