### PR TITLE
src: add option to set cpu affinity of mainthread

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -908,6 +908,13 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             &PerProcessOptions::trace_sigint,
             kAllowedInEnvironment);
 
+  AddOption("--set-mainthread-cpu-affinity",
+            "enable setting mainthread's cpu affinity to the currently "
+            "running cpu before entering event loop, implemented on "
+            "Linux OS only",
+            &PerProcessOptions::set_mainthread_cpu_affinity,
+            kAllowedInEnvironment);
+
   Insert(iop, &PerProcessOptions::get_per_isolate_options);
 
   AddOption("--node-memory-debug",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -283,6 +283,7 @@ class PerProcessOptions : public Options {
   // TODO(addaleax): Some of these could probably be per-Environment.
   std::string use_largepages = "off";
   bool trace_sigint = false;
+  bool set_mainthread_cpu_affinity = false;
   std::vector<std::string> cmdline;
 
   inline PerIsolateOptions* get_per_isolate_options();


### PR DESCRIPTION
Add runtime option '--set-mainthread-cpu-affinity' to pin the
mainthread to the current running cpu before entering event loop.
This feature is implemented on Linux OS currently.

Enabling this option will benefit node.js applications running on
heavy-workload system and can increase performance for several
node.js benchmarks, ex., several cases in benchmark/vm/ improved
by 40%.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
