### PR TITLE
src: remap invalid file descriptors using `dup2`

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -608,11 +608,32 @@ static void PlatformInit(ProcessInitializationFlags::Flags flags) {
     for (auto& s : stdio) {
       const int fd = &s - stdio;
       if (fstat(fd, &s.stat) == 0) continue;
+
       // Anything but EBADF means something is seriously wrong.  We don't
       // have to special-case EINTR, fstat() is not interruptible.
       if (errno != EBADF) ABORT();
-      if (fd != open("/dev/null", O_RDWR)) ABORT();
-      if (fstat(fd, &s.stat) != 0) ABORT();
+
+      // If EBADF (file descriptor doesn't exist), open /dev/null and duplicate
+      // its file descriptor to the invalid file descriptor.  Make sure *that*
+      // file descriptor is valid.  POSIX doesn't guarantee the next file
+      // descriptor open(2) gives us is the lowest available number anymore in
+      // POSIX.1-2017, which is why dup2(2) is needed.
+      int null_fd;
+
+      do {
+        null_fd = open("/dev/null", O_RDWR);
+      } while (null_fd < 0 && errno == EINTR);
+
+      if (null_fd != fd) {
+        int err;
+
+        do {
+          err = dup2(null_fd, fd);
+        } while (err < 0 && errno == EINTR);
+        CHECK_EQ(err, 0);
+      }
+
+      if (fstat(fd, &s.stat) < 0) ABORT();
     }
   }
 


### PR DESCRIPTION
When checking for the validity of the stdio file descriptors in `PlatformInit()`, this was the code previously used (as in #875):

```c++
// Make sure file descriptors 0-2 are valid before we start logging anything.
for (int fd = STDIN_FILENO; fd <= STDERR_FILENO; fd += 1) {
  struct stat ignored;
  if (fstat(fd, &ignored) == 0)
    continue;
  // Anything but EBADF means something is seriously wrong.  We don't
  // have to special-case EINTR, fstat() is not interruptible.
  if (errno != EBADF)
    abort();
  if (fd != open("/dev/null", O_RDWR))
    abort();
}
```

As I understand it, the intention behind this is to map file descriptors to `/dev/null` if they don't exist, by hoping the next file descriptor to be given will be the one which doesn't exist. This is imperfect as it is very platform dependent and breaks when `/dev/null` has already been given a different file descriptor in the same process, but e.g. `stdin` has disappeared in the meantime (as is the case with this issue on FreeBSD with the `daemon` tool when not passing `-f`: https://github.com/nodejs/help/issues/2411).

Instead, this patch uses the [`dup2(2)`](https://www.freebsd.org/cgi/man.cgi?query=dup2) syscall to properly remap the missing stdio file descriptor to what `/dev/null`'s file descriptor actually is.