### PR TITLE
crypto: add digest name to INVALID_DIGEST errors

### DIFF
--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -58,7 +58,7 @@ Maybe<bool> HKDFTraits::AdditionalConfig(
   Utf8Value hash(env->isolate(), args[offset]);
   params->digest = EVP_get_digestbyname(*hash);
   if (params->digest == nullptr) {
-    THROW_ERR_CRYPTO_INVALID_DIGEST(env);
+    THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *hash);
     return Nothing<bool>();
   }
 

--- a/src/crypto/crypto_hmac.cc
+++ b/src/crypto/crypto_hmac.cc
@@ -72,7 +72,8 @@ void Hmac::HmacInit(const char* hash_type, const char* key, int key_len) {
 
   const EVP_MD* md = EVP_get_digestbyname(hash_type);
   if (md == nullptr)
-    return THROW_ERR_CRYPTO_INVALID_DIGEST(env());
+    return THROW_ERR_CRYPTO_INVALID_DIGEST(
+        env(), "Invalid digest: %s", hash_type);
   if (key_len == 0) {
     key = "";
   }
@@ -189,7 +190,7 @@ Maybe<bool> HmacTraits::AdditionalConfig(
   Utf8Value digest(env->isolate(), args[offset + 1]);
   params->digest = EVP_get_digestbyname(*digest);
   if (params->digest == nullptr) {
-    THROW_ERR_CRYPTO_INVALID_DIGEST(env);
+    THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
     return Nothing<bool>();
   }
 

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -328,7 +328,7 @@ Maybe<bool> RSACipherTraits::AdditionalConfig(
 
       params->digest = EVP_get_digestbyname(*digest);
       if (params->digest == nullptr) {
-        THROW_ERR_CRYPTO_INVALID_DIGEST(env);
+        THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
         return Nothing<bool>();
       }
 

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -647,7 +647,7 @@ Maybe<bool> SignTraits::AdditionalConfig(
     Utf8Value digest(env->isolate(), args[offset + 6]);
     params->digest = EVP_get_digestbyname(*digest);
     if (params->digest == nullptr) {
-      THROW_ERR_CRYPTO_INVALID_DIGEST(env);
+      THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
       return Nothing<bool>();
     }
   }


### PR DESCRIPTION
We already do this in some places. This adds the digest name to remaining uses of `ERR_CRYPTO_INVALID_DIGEST` except for one occurrence in `crypto_sig.cc` that would require significant refactoring due to the unusual error handling there.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
