### PR TITLE
src: fix incorrect comments in crypto

### DIFF
--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -493,7 +493,7 @@ void CipherBase::InitIv(const char* cipher_type,
 
   // Throw if an IV was passed which does not match the cipher's fixed IV length
   // static_cast<int> for the iv_buf.size() is safe because we've verified
-  // prior that the value is not larger than MAX_INT.
+  // prior that the value is not larger than INT_MAX.
   if (!is_authenticated_mode &&
       has_iv &&
       static_cast<int>(iv_buf.size()) != expected_iv_len) {

--- a/src/crypto/crypto_keygen.h
+++ b/src/crypto/crypto_keygen.h
@@ -200,8 +200,8 @@ struct KeyPairGenTraits final {
 };
 
 struct SecretKeyGenConfig final : public MemoryRetainer {
-  size_t length;  // Expressed a a number of bits
-  char* out = nullptr;  // Placeholder for the generated key bytes
+  size_t length;        // In bytes.
+  char* out = nullptr;  // Placeholder for the generated key bytes.
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(SecretKeyGenConfig)


### PR DESCRIPTION
Just two nits in comments in the crypto code.

Refs: https://github.com/nodejs/node/pull/44467#pullrequestreview-1092608747

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
