### PR TITLE
crypto: handle invalid prepareAsymmetricKey JWK inputs

### DIFF
--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -31,7 +31,6 @@ const {
   SecretKeyObject,
   parsePublicKeyEncoding,
   parsePrivateKeyEncoding,
-  isJwk
 } = require('internal/crypto/keys');
 
 const {
@@ -65,6 +64,10 @@ const {
 const { isArrayBufferView } = require('internal/util/types');
 
 const { getOptionValue } = require('internal/options');
+
+function isJwk(obj) {
+  return obj != null && obj.kty !== undefined;
+}
 
 function wrapKey(key, ctor) {
   if (typeof key === 'string' ||

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -525,14 +525,18 @@ function prepareAsymmetricKey(key, ctx) {
     return { format: kKeyFormatPEM, data: getArrayBufferOrView(key, 'key') };
   } else if (typeof key === 'object') {
     const { key: data, encoding, format } = key;
+
     // The 'key' property can be a KeyObject as well to allow specifying
     // additional options such as padding along with the key.
     if (isKeyObject(data))
       return { data: getKeyObjectHandle(data, ctx) };
     else if (isCryptoKey(data))
       return { data: getKeyObjectHandle(data[kKeyObject], ctx) };
-    else if (isJwk(data) && format === 'jwk')
+    else if (format === 'jwk') {
+      validateObject(data, 'key.key');
       return { data: getKeyObjectHandleFromJwk(data, ctx), format: 'jwk' };
+    }
+
     // Either PEM or DER using PKCS#1 or SPKI.
     if (!isStringOrBuffer(data)) {
       throw new ERR_INVALID_ARG_TYPE(
@@ -720,10 +724,6 @@ function isCryptoKey(obj) {
   return obj != null && obj[kKeyObject] !== undefined;
 }
 
-function isJwk(obj) {
-  return obj != null && obj.kty !== undefined;
-}
-
 module.exports = {
   // Public API.
   createSecretKey,
@@ -745,5 +745,4 @@ module.exports = {
   PrivateKeyObject,
   isKeyObject,
   isCryptoKey,
-  isJwk,
 };

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -868,3 +868,15 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert(!first.equals(third));
   assert(!third.equals(first));
 }
+
+{
+  // This should not cause a crash: https://github.com/nodejs/node/issues/44471
+  for (const key of ['', 'foo', null, undefined, true, Boolean]) {
+    assert.throws(() => {
+      createPublicKey({ key, format: 'jwk' });
+    }, { code: 'ERR_INVALID_ARG_TYPE', message: /The "key\.key" property must be of type object/ });
+    assert.throws(() => {
+      createPrivateKey({ key, format: 'jwk' });
+    }, { code: 'ERR_INVALID_ARG_TYPE', message: /The "key\.key" property must be of type object/ });
+  }
+}

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -756,3 +756,21 @@ assert.throws(
     message: /digest too big for rsa key/
   });
 }
+
+{
+  // This should not cause a crash: https://github.com/nodejs/node/issues/44471
+  for (const key of ['', 'foo', null, undefined, true, Boolean]) {
+    assert.throws(() => {
+      crypto.verify('sha256', 'foo', { key, format: 'jwk' }, Buffer.alloc(0));
+    }, { code: 'ERR_INVALID_ARG_TYPE', message: /The "key\.key" property must be of type object/ });
+    assert.throws(() => {
+      crypto.createVerify('sha256').verify({ key, format: 'jwk' }, Buffer.alloc(0));
+    }, { code: 'ERR_INVALID_ARG_TYPE', message: /The "key\.key" property must be of type object/ });
+    assert.throws(() => {
+      crypto.sign('sha256', 'foo', { key, format: 'jwk' });
+    }, { code: 'ERR_INVALID_ARG_TYPE', message: /The "key\.key" property must be of type object/ });
+    assert.throws(() => {
+      crypto.createSign('sha256').sign({ key, format: 'jwk' });
+    }, { code: 'ERR_INVALID_ARG_TYPE', message: /The "key\.key" property must be of type object/ });
+  }
+}


### PR DESCRIPTION
Fixes a crash in prepareAsymmetricKey #44471

```
node[88386]: ../src/crypto/crypto_keys.cc:68:void node::crypto::(anonymous namespace)::GetKeyFormatAndTypeFromJs(node::crypto::AsymmetricKeyEncodingConfig *, const FunctionCallbackInfo<v8::Value> &, unsigned int *, node::crypto::KeyEncodingContext): Assertion `(context == kKeyContextInput && config->format_ == kKeyFormatPEM) || (context == kKeyContextGenerate && config->format_ == kKeyFormatJWK)' failed.
 1: 0x103037252 node::Abort() [/opt/local/bin/node]
 2: 0x103037085 node::AppendExceptionLine(node::Environment*, v8::Local<v8::Value>, v8::Local<v8::Message>, node::ErrorHandlingMode) [/opt/local/bin/node]
 3: 0x103138e07 node::crypto::(anonymous namespace)::GetKeyFormatAndTypeFromJs(node::crypto::AsymmetricKeyEncodingConfig*, v8::FunctionCallbackInfo<v8::Value> const&, unsigned int*, node::crypto::KeyEncodingContext) [/opt/local/bin/node]
 4: 0x103138693 node::crypto::ManagedEVPPKey::GetPrivateKeyEncodingFromJs(v8::FunctionCallbackInfo<v8::Value> const&, unsigned int*, node::crypto::KeyEncodingContext) [/opt/local/bin/node]
 5: 0x103139575 node::crypto::ManagedEVPPKey::GetPublicOrPrivateKeyFromJs(v8::FunctionCallbackInfo<v8::Value> const&, unsigned int*) [/opt/local/bin/node]
 6: 0x10313a3ba node::crypto::KeyObjectHandle::Init(v8::FunctionCallbackInfo<v8::Value> const&) [/opt/local/bin/node]
 7: 0x1031b491b v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) [/opt/local/bin/node]
 8: 0x1031b44ab v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) [/opt/local/bin/node]
 9: 0x1031b3c28 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [/opt/local/bin/node]
10: 0x1038710f9 Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit [/opt/local/bin/node]
```