### PR TITLE
src: remove unnecessary callback of uv_close

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -107,7 +107,7 @@ class WorkerThreadsTaskRunner::DelayedTaskScheduler {
       for (uv_timer_t* timer : timers)
         scheduler_->TakeTimerTask(timer);
       uv_close(reinterpret_cast<uv_handle_t*>(&scheduler_->flush_tasks_),
-               [](uv_handle_t* handle) {});
+               nullptr);
     }
 
    private:

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -587,7 +587,7 @@ void SyncProcessRunner::CloseKillTimer() {
 
     uv_handle_t* uv_timer_handle = reinterpret_cast<uv_handle_t*>(&uv_timer_);
     uv_ref(uv_timer_handle);
-    uv_close(uv_timer_handle, KillTimerCloseCallback);
+    uv_close(uv_timer_handle, nullptr);
 
     kill_timer_initialized_ = false;
   }
@@ -1095,11 +1095,6 @@ void SyncProcessRunner::ExitCallback(uv_process_t* handle,
 void SyncProcessRunner::KillTimerCallback(uv_timer_t* handle) {
   SyncProcessRunner* self = reinterpret_cast<SyncProcessRunner*>(handle->data);
   self->OnKillTimerTimeout();
-}
-
-
-void SyncProcessRunner::KillTimerCloseCallback(uv_handle_t* handle) {
-  // No-op.
 }
 
 }  // namespace node

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -195,7 +195,6 @@ class SyncProcessRunner {
                            int64_t exit_status,
                            int term_signal);
   static void KillTimerCallback(uv_timer_t* handle);
-  static void KillTimerCloseCallback(uv_handle_t* handle);
 
   double max_buffer_;
   uint64_t timeout_;


### PR DESCRIPTION
remove unnecessary callback of uv_close.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
