### PR TITLE
inspector: expose inspector.close on workers

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -19,8 +19,6 @@ const inspector = require('node:inspector');
 
 Deactivate the inspector. Blocks until there are no active connections.
 
-This function is not available in [worker threads][].
-
 ## `inspector.console`
 
 * {Object} An object to send messages to the remote inspector console.
@@ -262,4 +260,3 @@ session.post('HeapProfiler.takeHeapSnapshot', null, (err, r) => {
 [`'Debugger.paused'`]: https://chromedevtools.github.io/devtools-protocol/v8/Debugger#event-paused
 [`session.connect()`]: #sessionconnect
 [security warning]: cli.md#warning-binding-inspector-to-a-public-ipport-combination-is-insecure
-[worker threads]: worker_threads.md

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -32,6 +32,7 @@ const {
   validateString,
 } = require('internal/validators');
 const { isMainThread } = require('worker_threads');
+const { _debugEnd } = internalBinding('process_methods');
 
 const {
   Connection,
@@ -195,7 +196,7 @@ function inspectorWaitForDebugger() {
 
 module.exports = {
   open: inspectorOpen,
-  close: process._debugEnd,
+  close: _debugEnd,
   url,
   waitForDebugger: inspectorWaitForDebugger,
   console,

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -566,24 +566,24 @@ static void Initialize(Local<Object> target,
   // define various internal methods
   if (env->owns_process_state()) {
     SetMethod(context, target, "_debugProcess", DebugProcess);
-    SetMethod(context, target, "_debugEnd", DebugEnd);
     SetMethod(context, target, "abort", Abort);
     SetMethod(context, target, "causeSegfault", CauseSegfault);
     SetMethod(context, target, "chdir", Chdir);
   }
 
   SetMethod(context, target, "umask", Umask);
-  SetMethod(context, target, "_rawDebug", RawDebug);
   SetMethod(context, target, "memoryUsage", MemoryUsage);
   SetMethod(context, target, "rss", Rss);
   SetMethod(context, target, "cpuUsage", CPUUsage);
   SetMethod(context, target, "resourceUsage", ResourceUsage);
 
+  SetMethod(context, target, "_debugEnd", DebugEnd);
   SetMethod(context, target, "_getActiveRequestsInfo", GetActiveRequestsInfo);
   SetMethod(context, target, "_getActiveRequests", GetActiveRequests);
   SetMethod(context, target, "_getActiveHandles", GetActiveHandles);
   SetMethod(context, target, "_getActiveHandlesInfo", GetActiveHandlesInfo);
   SetMethod(context, target, "_kill", Kill);
+  SetMethod(context, target, "_rawDebug", RawDebug);
 
   SetMethodNoSideEffect(context, target, "cwd", Cwd);
   SetMethod(context, target, "dlopen", binding::DLOpen);

--- a/test/parallel/test-inspector-close-worker.js
+++ b/test/parallel/test-inspector-close-worker.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+const { isMainThread, Worker } = require('worker_threads');
+const assert = require('assert');
+const inspector = require('inspector');
+
+if (!isMainThread) {
+  // Verify the inspector api on the worker thread.
+  assert.strictEqual(inspector.url(), undefined);
+
+  inspector.open(0, undefined, false);
+  const wsUrl = inspector.url();
+  assert(wsUrl.startsWith('ws://'));
+  inspector.close();
+  assert.strictEqual(inspector.url(), undefined);
+  return;
+}
+
+// Open inspector on the main thread first.
+inspector.open(0, undefined, false);
+const wsUrl = inspector.url();
+assert(wsUrl.startsWith('ws://'));
+
+const worker = new Worker(__filename);
+worker.on('exit', common.mustCall((code) => {
+  assert.strictEqual(code, 0);
+
+  // Verify inspector on the main thread is still active.
+  assert.strictEqual(inspector.url(), wsUrl);
+  inspector.close();
+  assert.strictEqual(inspector.url(), undefined);
+}));


### PR DESCRIPTION
Workers can open their own inspector io thread with `inspector.open`.
They should be able to close their own inspector io thead too with
`inspector.close`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
