### PR TITLE
tools: fix duration_ms to be milliseconds

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -69,7 +69,7 @@ else:
 
 from io import open
 from os.path import join, dirname, abspath, basename, isdir, exists
-from datetime import datetime
+from datetime import datetime, timedelta
 try:
     from queue import Queue, Empty  # Python 3
 except ImportError:
@@ -400,16 +400,8 @@ class TapProgressIndicator(SimpleProgressIndicator):
 
 
     duration = output.test.duration
-
-    # total_seconds() was added in 2.7
-    total_seconds = (duration.microseconds +
-      (duration.seconds + duration.days * 24 * 3600) * 10**6) / 10**6
-
-    # duration_ms is measured in seconds and is read as such by TAP parsers.
-    # It should read as "duration including ms" rather than "duration in ms"
     logger.info('  ---')
-    logger.info('  duration_ms: %d.%d' %
-      (total_seconds, duration.microseconds / 1000))
+    logger.info('  duration_ms: %.5f' % (duration  / timedelta(milliseconds=1)))
     if self.severity != 'ok' or self.traceback != '':
       if output.HasTimedOut():
         self.traceback = 'timeout\n' + output.output.stdout + output.output.stderr


### PR DESCRIPTION
I figured if we land https://github.com/nodejs/node/pull/44450 (merged) it will be best to also fix it here.
this fix depends on https://github.com/nodejs/tap2junit/pull/38 (merged)