### PR TITLE
src: use V8 entropy source if RAND_bytes() != 1

### DIFF
--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -134,7 +134,7 @@ struct MarkPopErrorOnReturn {
 void CheckEntropy();
 
 // Generate length bytes of random data. If this returns false, the data
-// may not be truly random but it's still generally good enough.
+// might not be random at all and should not be used.
 bool EntropySource(unsigned char* buffer, size_t length);
 
 int PasswordCallback(char* buf, int size, int rwflag, void* u);

--- a/src/node.cc
+++ b/src/node.cc
@@ -980,8 +980,10 @@ std::unique_ptr<InitializationResult> InitializeOncePerProcess(
       return result;
     }
 
-    // V8 on Windows doesn't have a good source of entropy. Seed it from
-    // OpenSSL's pool.
+    // Seed V8's PRNG from OpenSSL's pool. This is recommended by V8 and a
+    // potentially better source of randomness than what V8 uses by default, but
+    // it does not guarantee that pseudo-random values produced by V8 will be
+    // cryptograhically secure.
     V8::SetEntropySource(crypto::EntropySource);
 #endif  // HAVE_OPENSSL && !defined(OPENSSL_IS_BORINGSSL)
   }


### PR DESCRIPTION
`RAND_bytes()` may return `0` to indicate an error, in which case the buffer might not have been filled with random data at all. Instead of ignoring this case, let V8 use its own entropy source. Historically, this used to be a weak source of entropy, but V8 now implements a proper source even on Windows.

And even if V8's own entropy source turns out to be weak, it does not matter much: V8's PRNG itself is not cryptographically secure, so even if it is seeded from a cryptographically secure entropy source, it does not produce cryptographically secure random numbers.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
