### PR TITLE
module: exports & imports runtime deprecate invalid slashes

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3202,12 +3202,15 @@ The [`--trace-atomics-wait`][] flag is deprecated.
 <!-- YAML
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/44495
+    description: Runtime deprecation.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/44477
     description: Documentation-only deprecation
                  with `--pending-deprecation` support.
 -->
 
-Type: Documentation-only (supports [`--pending-deprecation`][])
+Type: Runtime
 
 Package imports and exports targets mapping into paths including a double slash
 (of _"/"_ or _"\\"_) are deprecated and will fail with a resolution validation

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -33,7 +33,6 @@ const {
   Stats,
 } = require('fs');
 const { getOptionValue } = require('internal/options');
-const pendingDeprecation = getOptionValue('--pending-deprecation');
 // Do not eagerly grab .manifest, it may be in TDZ
 const policy = getOptionValue('--experimental-policy') ?
   require('internal/process/policy') :
@@ -102,7 +101,6 @@ function emitTrailingSlashPatternDeprecation(match, pjsonUrl, base) {
 const doubleSlashRegEx = /[/\\][/\\]/;
 
 function emitInvalidSegmentDeprecation(target, request, match, pjsonUrl, base) {
-  if (!pendingDeprecation) { return; }
   const pjsonPath = fileURLToPath(pjsonUrl);
   const double = RegExpPrototypeExec(doubleSlashRegEx, target) !== null;
   process.emitWarning(


### PR DESCRIPTION
This is a follow-on to https://github.com/nodejs/node/pull/44477, making the deprecation a runtime deprecation.

Creating now since there may be time to make the runtime deprecation for version 19.

@nodejs/modules 