### PR TITLE
src: rename misleading arg in ClientHelloParser

### DIFF
--- a/src/crypto/crypto_clienthello-inl.h
+++ b/src/crypto/crypto_clienthello-inl.h
@@ -51,7 +51,7 @@ inline void ClientHelloParser::Reset() {
 
 inline void ClientHelloParser::Start(ClientHelloParser::OnHelloCb onhello_cb,
                                      ClientHelloParser::OnEndCb onend_cb,
-                                     void* onend_arg) {
+                                     void* cb_arg) {
   if (!IsEnded())
     return;
   Reset();
@@ -61,7 +61,7 @@ inline void ClientHelloParser::Start(ClientHelloParser::OnHelloCb onhello_cb,
   state_ = kWaiting;
   onhello_cb_ = onhello_cb;
   onend_cb_ = onend_cb;
-  cb_arg_ = onend_arg;
+  cb_arg_ = cb_arg;
 }
 
 inline void ClientHelloParser::End() {

--- a/src/crypto/crypto_clienthello.h
+++ b/src/crypto/crypto_clienthello.h
@@ -66,7 +66,7 @@ class ClientHelloParser {
   void Parse(const uint8_t* data, size_t avail);
 
   inline void Reset();
-  inline void Start(OnHelloCb onhello_cb, OnEndCb onend_cb, void* onend_arg);
+  inline void Start(OnHelloCb onhello_cb, OnEndCb onend_cb, void* cb_arg);
   inline void End();
   inline bool IsPaused() const;
   inline bool IsEnded() const;


### PR DESCRIPTION
Despite being named `onend_arg`, the pointer is passed both to the `onend_cb` and to the `onhello_cb`. Rename it to `cb_arg`, which matches the name of the class field `cb_arg_`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
