### PR TITLE
report: add request info to report

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -37,7 +37,7 @@ is provided below for reference.
       "/home/nodeuser/project/node/test/report/test-exception.js",
       "child"
     ],
-    "nodejsVersion": "v12.0.0-pre",
+    "nodejsVersion": "v19.0.0-pre",
     "glibcVersionRuntime": "2.17",
     "glibcVersionCompiler": "2.17",
     "wordSize": "64 bit",
@@ -395,6 +395,21 @@ is provided below for reference.
     "/lib64/libpthread.so.0",
     "/lib64/libc.so.6",
     "/lib64/ld-linux-x86-64.so.2"
+  ],
+  "requests": [
+    {
+      "type": "FSReqCallback"
+    },
+    {
+      "type": "GetAddrInfoReqWrap",
+      "family": 0,
+      "hostname": "localhost"
+    },
+    {
+      "type": "ConnectWrap",
+      "address": "127.0.0.1",
+      "port": 9999
+    }
   ]
 }
 ```

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -59,7 +59,7 @@ function _validateContent(report, fields = []) {
 
   // Verify that all sections are present as own properties of the report.
   const sections = ['header', 'nativeStack', 'libuv', 'environmentVariables',
-                    'sharedObjects', 'resourceUsage', 'workers'];
+                    'sharedObjects', 'resourceUsage', 'workers', 'requests'];
   if (!isWindows)
     sections.push('userLimits');
 
@@ -310,6 +310,11 @@ function _validateContent(report, fields = []) {
   // Verify the format of the workers section.
   assert(Array.isArray(report.workers));
   report.workers.forEach((worker) => _validateContent(worker));
+
+  assert(Array.isArray(report.requests));
+  report.requests.forEach(({ type }) => {
+    assert.strictEqual(typeof type, 'string');
+  });
 }
 
 function checkForUnknownFields(actual, expected) {

--- a/test/report/test-report-getreport.js
+++ b/test/report/test-report-getreport.js
@@ -2,7 +2,7 @@
 require('../common');
 const assert = require('assert');
 const helper = require('../common/report');
-
+const fs = require('fs');
 {
   // Test with no arguments.
   helper.validateContent(process.report.getReport());
@@ -28,6 +28,13 @@ const helper = require('../common/report');
   error.foo = 'goo';
   helper.validateContent(process.report.getReport(error),
                          [['javascriptStack.errorProperties.foo', 'goo']]);
+}
+
+{
+  fs.readFile(__filename, () => {});
+  const report = process.report.getReport();
+  helper.validateContent(report, []);
+  assert(report.requests.length > 0);
 }
 
 // Test with an invalid error argument.


### PR DESCRIPTION
add request info to report.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
