### PR TITLE
build: add long paths awareness on windows

### DIFF
--- a/src/res/node.exe.extra.manifest
+++ b/src/res/node.exe.extra.manifest
@@ -14,4 +14,9 @@
       <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
   </application>
   </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -43,4 +43,7 @@ console.log({
 
 fs.writeFile(fullPath, 'ok', common.mustSucceed(() => {
   fs.stat(fullPath, common.mustSucceed());
+
+  // Tests https://github.com/nodejs/node/issues/39721
+  fs.realpath.native(fullPath, common.mustSucceed());
 }));


### PR DESCRIPTION
On windows when using `fs.realpath.native`, `fs.realpathSync.native` and `fs.promises.realpath` on long path, ENOENT is thrown. On the other hand, long paths work well with `fs.realpath` and `fs.realpathSync`. On Linux, all of the mentioned `realpath` versions work as expected.

The problem with native realpath implementation on windows was, that by default applications aren't long path aware, unless specified otherwise by their manifest file, which was the case with node. The other way to enable working with long paths is to add a `\\?\` prefix to path prior to using it in windows API functions. This approach is used by all `fs` functions working with paths (they add prefix by calling `pathModule.toNamespacedPath(path)`), but this is not done in `fs.realpath.native` and `fs.realpathSync.native`. 

Although fix could have been made in `fs.js`, a change to node manifest file was chosen as a more comprehensive and broader solution to the long paths on windows problem in general.

An existing windows long path test is improved to cover the issue that is fixed by these changes.

Fixes: https://github.com/nodejs/node/issues/39721