### PR TITLE
src: dump isolate stats when process exits

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -778,7 +778,7 @@ ThreadId AllocateEnvironmentThreadId() {
 void DefaultProcessExitHandler(Environment* env, int exit_code) {
   env->set_can_call_into_js(false);
   env->stop_sub_worker_contexts();
-  v8::Isolate::GetCurrent()->DumpAndResetStats();
+  env->isolate()->DumpAndResetStats();
   DisposePlatform();
   uv_library_shutdown();
   exit(exit_code);

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -778,6 +778,7 @@ ThreadId AllocateEnvironmentThreadId() {
 void DefaultProcessExitHandler(Environment* env, int exit_code) {
   env->set_can_call_into_js(false);
   env->stop_sub_worker_contexts();
+  v8::Isolate::GetCurrent()->DumpAndResetStats();
   DisposePlatform();
   uv_library_shutdown();
   exit(exit_code);


### PR DESCRIPTION
When process exits, dump v8 isolate's internal stats for performance
evaluation and debugging.
It fixed the incorrect profiling log output when running V8's builtin
PGO profiling for node.js service type application, which exits by user
pressing CTRL+C etc. keys.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
