### PR TITLE
win: fix fs.realpath.native for long paths

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2612,7 +2612,7 @@ realpathSync.native = (path, options) => {
   options = getOptions(options);
   path = getValidatedPath(path);
   const ctx = { path };
-  const result = binding.realpath(path, options.encoding, undefined, ctx);
+  const result = binding.realpath(pathModule.toNamespacedPath(path), options.encoding, undefined, ctx);
   handleErrorFromBinding(ctx);
   return result;
 };
@@ -2772,7 +2772,7 @@ realpath.native = (path, options, callback) => {
   path = getValidatedPath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  return binding.realpath(path, options.encoding, req);
+  return binding.realpath(pathModule.toNamespacedPath(path), options.encoding, req);
 };
 
 /**

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -43,4 +43,7 @@ console.log({
 
 fs.writeFile(fullPath, 'ok', common.mustSucceed(() => {
   fs.stat(fullPath, common.mustSucceed());
+
+  // Tests https://github.com/nodejs/node/issues/39721
+  fs.realpath.native(fullPath, common.mustSucceed());
 }));


### PR DESCRIPTION
On windows when using `fs.realpath.native`, `fs.realpathSync.native` and `fs.promises.realpath` on long path, ENOENT is thrown. On the other hand, long paths work well with `fs.realpath` and `fs.realpathSync`. On Linux, all of the mentioned `realpath` versions work as expected.

The problem is that windows API functions do not work with paths longer then 260 characters by default. There is a way to enable long path support via application manifest file, but it only works starting from Windows 10 version 1607 and it relies on registry key `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled` being set. Since that is not necessarily always the case with machines running node, this approach wouldn't work. The other way to enable working with long paths is to add a `\\?\` prefix to the path prior to using it in windows API functions. This approach is used by all `fs` functions working with paths, with the exception of `fs.realpath.native` and `fs.realpathSync.native`. 

Fix is made in `fs.js` implementation of `fs.realpath.native`, `fs.realpathSync.native`, so their path preprocessing matches to the other functions.

An existing windows long path test is improved to cover the issue that is fixed by these changes.

Fixes: https://github.com/nodejs/node/issues/39721