### PR TITLE
module: open stat/readPackage to mutations

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -162,6 +162,7 @@ function stat(filename) {
   }
   return result;
 }
+Module._stat = stat;
 
 function updateChildren(parent, child, scan) {
   const children = parent?.children;
@@ -334,6 +335,7 @@ function readPackage(requestPath) {
     throw e;
   }
 }
+Module._readPackage = readPackage;
 
 function readPackageScope(checkPath) {
   const rootSeparatorIndex = StringPrototypeIndexOf(checkPath, sep);
@@ -343,7 +345,7 @@ function readPackageScope(checkPath) {
     checkPath = StringPrototypeSlice(checkPath, 0, separatorIndex);
     if (StringPrototypeEndsWith(checkPath, sep + 'node_modules'))
       return false;
-    const pjson = readPackage(checkPath + sep);
+    const pjson = Module._readPackage(checkPath + sep);
     if (pjson) return {
       data: pjson,
       path: checkPath,
@@ -353,7 +355,7 @@ function readPackageScope(checkPath) {
 }
 
 function tryPackage(requestPath, exts, isMain, originalPath) {
-  const pkg = readPackage(requestPath)?.main;
+  const pkg = Module._readPackage(requestPath)?.main;
 
   if (!pkg) {
     return tryExtensions(path.resolve(requestPath, 'index'), exts, isMain);
@@ -399,7 +401,7 @@ const realpathCache = new SafeMap();
 // keep symlinks intact, otherwise resolve to the
 // absolute realpath.
 function tryFile(requestPath, isMain) {
-  const rc = stat(requestPath);
+  const rc = Module._stat(requestPath);
   if (rc !== 0) return;
   if (preserveSymlinks && !isMain) {
     return path.resolve(requestPath);
@@ -493,7 +495,7 @@ function resolveExports(nmPath, request) {
   if (!name)
     return;
   const pkgPath = path.resolve(nmPath, name);
-  const pkg = readPackage(pkgPath);
+  const pkg = Module._readPackage(pkgPath);
   if (pkg?.exports != null) {
     try {
       return finalizeEsmResolution(packageExportsResolve(
@@ -533,7 +535,7 @@ Module._findPath = function(request, paths, isMain) {
   for (let i = 0; i < paths.length; i++) {
     // Don't search further if path doesn't exist
     const curPath = paths[i];
-    if (curPath && stat(curPath) < 1) continue;
+    if (curPath && Module._stat(curPath) < 1) continue;
 
     if (!absoluteRequest) {
       const exportsResolved = resolveExports(curPath, request);
@@ -544,7 +546,7 @@ Module._findPath = function(request, paths, isMain) {
     const basePath = path.resolve(curPath, request);
     let filename;
 
-    const rc = stat(basePath);
+    const rc = Module._stat(basePath);
     if (!trailingSlash) {
       if (rc === 0) {  // File.
         if (!isMain) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -79,12 +79,17 @@ const {
   maybeCacheSourceMap,
 } = require('internal/source_map/source_map_cache');
 const { pathToFileURL, fileURLToPath, isURLInstance } = require('internal/url');
-const { deprecate, kEmptyObject, filterOwnProperties, setOwnProperty } = require('internal/util');
+const {
+  deprecate,
+  emitExperimentalWarning,
+  kEmptyObject,
+  filterOwnProperties,
+  setOwnProperty,
+} = require('internal/util');
 const vm = require('vm');
 const assert = require('internal/assert');
 const fs = require('fs');
 const internalFS = require('internal/fs/utils');
-const { emitExperimentalWarning } = require('internal/util');
 const path = require('path');
 const { sep } = path;
 const { internalModuleStat } = internalBinding('fs');

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -84,6 +84,7 @@ const vm = require('vm');
 const assert = require('internal/assert');
 const fs = require('fs');
 const internalFS = require('internal/fs/utils');
+const { emitExperimentalWarning } = require('internal/util');
 const path = require('path');
 const { sep } = path;
 const { internalModuleStat } = internalBinding('fs');
@@ -162,7 +163,18 @@ function stat(filename) {
   }
   return result;
 }
-Module._stat = stat;
+
+let _stat = stat;
+ObjectDefineProperty(Module, '_stat', {
+  __proto__: null,
+  get() { return _stat; },
+  set(stat) {
+    emitExperimentalWarning('Module._stat');
+    _stat = stat;
+    return true;
+  },
+  configurable: true,
+});
 
 function updateChildren(parent, child, scan) {
   const children = parent?.children;
@@ -335,7 +347,18 @@ function readPackage(requestPath) {
     throw e;
   }
 }
-Module._readPackage = readPackage;
+
+let _readPackage = readPackage;
+ObjectDefineProperty(Module, '_readPackage', {
+  __proto__: null,
+  get() { return _readPackage; },
+  set(readPackage) {
+    emitExperimentalWarning('Module._readPackage');
+    _readPackage = readPackage;
+    return true;
+  },
+  configurable: true,
+});
 
 function readPackageScope(checkPath) {
   const rootSeparatorIndex = StringPrototypeIndexOf(checkPath, sep);
@@ -345,7 +368,7 @@ function readPackageScope(checkPath) {
     checkPath = StringPrototypeSlice(checkPath, 0, separatorIndex);
     if (StringPrototypeEndsWith(checkPath, sep + 'node_modules'))
       return false;
-    const pjson = Module._readPackage(checkPath + sep);
+    const pjson = _readPackage(checkPath + sep);
     if (pjson) return {
       data: pjson,
       path: checkPath,
@@ -355,7 +378,7 @@ function readPackageScope(checkPath) {
 }
 
 function tryPackage(requestPath, exts, isMain, originalPath) {
-  const pkg = Module._readPackage(requestPath)?.main;
+  const pkg = _readPackage(requestPath)?.main;
 
   if (!pkg) {
     return tryExtensions(path.resolve(requestPath, 'index'), exts, isMain);
@@ -401,7 +424,7 @@ const realpathCache = new SafeMap();
 // keep symlinks intact, otherwise resolve to the
 // absolute realpath.
 function tryFile(requestPath, isMain) {
-  const rc = Module._stat(requestPath);
+  const rc = _stat(requestPath);
   if (rc !== 0) return;
   if (preserveSymlinks && !isMain) {
     return path.resolve(requestPath);
@@ -495,7 +518,7 @@ function resolveExports(nmPath, request) {
   if (!name)
     return;
   const pkgPath = path.resolve(nmPath, name);
-  const pkg = Module._readPackage(pkgPath);
+  const pkg = _readPackage(pkgPath);
   if (pkg?.exports != null) {
     try {
       return finalizeEsmResolution(packageExportsResolve(
@@ -535,7 +558,7 @@ Module._findPath = function(request, paths, isMain) {
   for (let i = 0; i < paths.length; i++) {
     // Don't search further if path doesn't exist
     const curPath = paths[i];
-    if (curPath && Module._stat(curPath) < 1) continue;
+    if (curPath && _stat(curPath) < 1) continue;
 
     if (!absoluteRequest) {
       const exportsResolved = resolveExports(curPath, request);
@@ -546,7 +569,7 @@ Module._findPath = function(request, paths, isMain) {
     const basePath = path.resolve(curPath, request);
     let filename;
 
-    const rc = Module._stat(basePath);
+    const rc = _stat(basePath);
     if (!trailingSlash) {
       if (rc === 0) {  // File.
         if (!isMain) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

While the CJS loader uses the `fs` module to perform most filesystem I/O, it uses two hidden internal primitives for speed: `internalModuleStat`, and `packageJsonReader`. Because `internalModuleStat` is destructured, it cannot be replaced. As a result, tools that experiment with virtual filesystem layers have to reimplement the whole CJS resolution stack. This is problematic because we want to experiment writing VFS with https://github.com/nodejs/single-executable.

This diff aims to provide a way for advanced tooling authors to avoid having to hijack the full resolution (which is much more invasive and dangerous than what this diff allows), while still respecting the wish for speed from Node (ie we're not suggesting to stop using the special internal primitives, but just to expose them the same way we already expose `Module._findPaths` or `Module._resolveFilename`).