### PR TITLE
doc: emphasize that createCipher is never secure

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3013,6 +3013,10 @@ The `password` is used to derive the cipher key and initialization vector (IV).
 The value must be either a `'latin1'` encoded string, a [`Buffer`][], a
 `TypedArray`, or a `DataView`.
 
+<strong class="critical">This function is semantically insecure for all
+supported ciphers and fatally flawed for ciphers in counter mode (such as CTR,
+GCM, or CCM).</strong>
+
 The implementation of `crypto.createCipher()` derives keys using the OpenSSL
 function [`EVP_BytesToKey`][] with the digest algorithm set to MD5, one
 iteration, and no salt. The lack of salt allows dictionary attacks as the same
@@ -3135,6 +3139,10 @@ cipher in CCM or OCB mode (e.g. `'aes-128-ccm'`) is used. In that case, the
 `authTagLength` option is required and specifies the length of the
 authentication tag in bytes, see [CCM mode][].
 For `chacha20-poly1305`, the `authTagLength` option defaults to 16 bytes.
+
+<strong class="critical">This function is semantically insecure for all
+supported ciphers and fatally flawed for ciphers in counter mode (such as CTR,
+GCM, or CCM).</strong>
 
 The implementation of `crypto.createDecipher()` derives keys using the OpenSSL
 function [`EVP_BytesToKey`][] with the digest algorithm set to MD5, one

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2114,10 +2114,10 @@ changes:
 
 Type: Runtime
 
-Using [`crypto.createCipher()`][] and [`crypto.createDecipher()`][] should be
+Using [`crypto.createCipher()`][] and [`crypto.createDecipher()`][] must be
 avoided as they use a weak key derivation function (MD5 with no salt) and static
 initialization vectors. It is recommended to derive a key using
-[`crypto.pbkdf2()`][] or [`crypto.scrypt()`][] and to use
+[`crypto.pbkdf2()`][] or [`crypto.scrypt()`][] with random salts and to use
 [`crypto.createCipheriv()`][] and [`crypto.createDecipheriv()`][] to obtain the
 [`Cipher`][] and [`Decipher`][] objects respectively.
 


### PR DESCRIPTION
The current documentation clearly states that `createCipher()` and `createDecipher()` should not be used with ciphers in counter mode, but (1) this is an understatement, and (2) these functions are (semantically) insecure for ciphers in any other supported block cipher mode as well.

Semantic security requires IND-CPA, but a deterministic cipher with fixed key and IV, such as those generated by these functions, does not fulfill IND-CPA.

Are there justified use cases for `createCipher()` and `createDecipher()`? Yes and no. The only case in which these functions can be used in a semantically secure manner arises only when the `password` argument is not actually a password but rather a random or pseudo-random sequence that is unpredictable and that is never reused (e.g., securely derived from a password with a proper salt). Insofar, it is possible to use these APIs without immediately creating a vulnerability. However,

- any application that manages to fulfill this requirement should also be able to fulfill the similar requirements of `crypto.createCipheriv()` and those of `crypto.createDecipheriv()`, which give much more control over key and initialization vector, and
- the MD5-based key derivation step generally does not help and might even reduce the overall security due to its many weaknesses.

Refs: https://github.com/nodejs/node/pull/13821
Refs: https://github.com/nodejs/node/pull/19343
Refs: https://github.com/nodejs/node/pull/22089

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
