### PR TITLE
stream: remove `abortReason` from `WritableStreamDefaultController`

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -974,10 +974,6 @@ changes:
 The `WritableStreamDefaultController` manage's the {WritableStream}'s
 internal state.
 
-#### `writableStreamDefaultController.abortReason`
-
-* Type: {any} The `reason` value passed to `writableStream.abort()`.
-
 #### `writableStreamDefaultController.error(error)`
 
 <!-- YAML

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -509,15 +509,6 @@ class WritableStreamDefaultController {
   }
 
   /**
-   * @type {any}
-   */
-  get abortReason() {
-    if (!isWritableStreamDefaultController(this))
-      throw new ERR_INVALID_THIS('WritableStreamDefaultController');
-    return this[kState].abortReason;
-  }
-
-  /**
    * @type {AbortSignal}
    */
   get signal() {
@@ -545,7 +536,6 @@ class WritableStreamDefaultController {
 }
 
 ObjectDefineProperties(WritableStreamDefaultController.prototype, {
-  abortReason: kEnumerableProperty,
   signal: kEnumerableProperty,
   error: kEnumerableProperty,
 });
@@ -637,10 +627,6 @@ function writableStreamAbort(stream, reason) {
   if (state === 'closed' || state === 'errored')
     return PromiseResolve();
 
-  // TODO(daeyeon): Remove `controller[kState].abortReason` and use
-  // `controller[kState].abortController.signal.reason` for the
-  // `WritableStreamDefaultController.prototype.abortReason` getter.
-  controller[kState].abortReason = reason;
   controller[kState].abortController.abort(reason);
 
   if (stream[kState].pendingAbortRequest.abort.promise !== undefined)
@@ -1253,7 +1239,6 @@ function setupWritableStreamDefaultController(
   assert(stream[kState].controller === undefined);
   controller[kState] = {
     abortAlgorithm,
-    abortReason: undefined,
     closeAlgorithm,
     highWaterMark,
     queue: [],

--- a/test/parallel/test-whatwg-writablestream.js
+++ b/test/parallel/test-whatwg-writablestream.js
@@ -199,12 +199,6 @@ class Sink {
   });
 
   assert.throws(() => {
-    Reflect.get(WritableStreamDefaultController.prototype, 'abortReason', {});
-  }, {
-    code: 'ERR_INVALID_THIS',
-  });
-
-  assert.throws(() => {
     Reflect.get(WritableStreamDefaultController.prototype, 'signal', {});
   }, {
     code: 'ERR_INVALID_THIS',


### PR DESCRIPTION
The `abortReason` property has been removed from the spec since we can get
the abort reason via `writableStreamDefaultController.signal.reason`.

```webidl
[Exposed=*]
interface WritableStreamDefaultController {
  readonly attribute AbortSignal signal;
  undefined error(optional any e);
};
```

This reflects the change and removes a TODO left as a follow-up of https://github.com/nodejs/node/pull/44327.

Refs: https://streams.spec.whatwg.org/#ws-default-controller-class-definition

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
