### PR TITLE
src: remove UncheckedMalloc(0) workaround

### DIFF
--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -361,14 +361,12 @@ T* UncheckedRealloc(T* pointer, size_t n) {
 // As per spec realloc behaves like malloc if passed nullptr.
 template <typename T>
 inline T* UncheckedMalloc(size_t n) {
-  if (n == 0) n = 1;
   return UncheckedRealloc<T>(nullptr, n);
 }
 
 template <typename T>
 inline T* UncheckedCalloc(size_t n) {
-  if (n == 0) n = 1;
-  MultiplyWithOverflowCheck(sizeof(T), n);
+  if (MultiplyWithOverflowCheck(sizeof(T), n) == 0) return nullptr;
   return static_cast<T*>(calloc(n, sizeof(T)));
 }
 

--- a/test/cctest/test_util.cc
+++ b/test/cctest/test_util.cc
@@ -97,39 +97,39 @@ TEST(UtilTest, ToLower) {
   EXPECT_EQ('a', ToLower('A'));
 }
 
-#define TEST_AND_FREE(expression)                                             \
-  do {                                                                        \
-    auto pointer = expression;                                                \
-    EXPECT_NE(nullptr, pointer);                                              \
-    free(pointer);                                                            \
+#define TEST_AND_FREE(expression, size)                                        \
+  do {                                                                         \
+    auto pointer = expression(size);                                           \
+    EXPECT_EQ(pointer == nullptr, size == 0);                                  \
+    free(pointer);                                                             \
   } while (0)
 
 TEST(UtilTest, Malloc) {
-  TEST_AND_FREE(Malloc<char>(0));
-  TEST_AND_FREE(Malloc<char>(1));
-  TEST_AND_FREE(Malloc(0));
-  TEST_AND_FREE(Malloc(1));
+  TEST_AND_FREE(Malloc<char>, 0);
+  TEST_AND_FREE(Malloc<char>, 1);
+  TEST_AND_FREE(Malloc, 0);
+  TEST_AND_FREE(Malloc, 1);
 }
 
 TEST(UtilTest, Calloc) {
-  TEST_AND_FREE(Calloc<char>(0));
-  TEST_AND_FREE(Calloc<char>(1));
-  TEST_AND_FREE(Calloc(0));
-  TEST_AND_FREE(Calloc(1));
+  TEST_AND_FREE(Calloc<char>, 0);
+  TEST_AND_FREE(Calloc<char>, 1);
+  TEST_AND_FREE(Calloc, 0);
+  TEST_AND_FREE(Calloc, 1);
 }
 
 TEST(UtilTest, UncheckedMalloc) {
-  TEST_AND_FREE(UncheckedMalloc<char>(0));
-  TEST_AND_FREE(UncheckedMalloc<char>(1));
-  TEST_AND_FREE(UncheckedMalloc(0));
-  TEST_AND_FREE(UncheckedMalloc(1));
+  TEST_AND_FREE(UncheckedMalloc<char>, 0);
+  TEST_AND_FREE(UncheckedMalloc<char>, 1);
+  TEST_AND_FREE(UncheckedMalloc, 0);
+  TEST_AND_FREE(UncheckedMalloc, 1);
 }
 
 TEST(UtilTest, UncheckedCalloc) {
-  TEST_AND_FREE(UncheckedCalloc<char>(0));
-  TEST_AND_FREE(UncheckedCalloc<char>(1));
-  TEST_AND_FREE(UncheckedCalloc(0));
-  TEST_AND_FREE(UncheckedCalloc(1));
+  TEST_AND_FREE(UncheckedCalloc<char>, 0);
+  TEST_AND_FREE(UncheckedCalloc<char>, 1);
+  TEST_AND_FREE(UncheckedCalloc, 0);
+  TEST_AND_FREE(UncheckedCalloc, 1);
 }
 
 template <typename T>


### PR DESCRIPTION
Unlike `UncheckedRealloc(p, 0)`, which returns a `nullptr`, both `UncheckedMalloc(0)` and `UncheckedCalloc(0)` currently perform fake allocations to return a non-`nullptr`.

Assuming that `UncheckedMalloc(0)` returns a non-`nullptr` is non-standard and we use other allocators as well (e.g., OPENSSL_malloc) that do not guarantee this behavior. It is the caller's responsibility to check that `size != 0` implies `UncheckedMalloc(size) != nullptr`, and that's exactly what the checked variants (`Malloc` etc.) already do.

The current behavior is also inconsistent with `UncheckedRealloc()`, which always returns a `nullptr` when the size is `0`, and with the documentation in `src/README.md` as well as with multiple comments in the source code.

https://github.com/nodejs/node/blob/0917626b96c2229ace91b55f72bc3faf152e74e9/src/README.md?plain=1#L954-L955

https://github.com/nodejs/node/blob/e62f6ce630c3ea9d9484d14bb892cb6836b250d4/src/util.h#L69-L78

https://github.com/nodejs/node/blob/e62f6ce630c3ea9d9484d14bb892cb6836b250d4/src/util-inl.h#L334-L340

---

This changes `UncheckedMalloc()`, `UncheckedCalloc()`, and `UncheckedRealloc()` to always return a `nullptr` when the size is `0` instead of doing fake allocations in `UncheckedMalloc()` and `UncheckedCalloc()` while returning a `nullptr` from `UncheckedRealloc()`. This is consistent with existing documentation and comments.

---

Refs: https://github.com/nodejs/node/issues/8571
Refs: https://github.com/nodejs/node/pull/8572

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
