### PR TITLE
doc: remove ebpf from supported tooling list

### DIFF
--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -133,7 +133,6 @@ The tools are currently assigned to Tiers as follows:
 | Debugger  | [Command line Debug Client][]             | ?                             | Yes                     | 1           |
 | Tracing   | [trace\_events (API)][trace_events (API)] | No                            | Yes                     | 1           |
 | Tracing   | trace\_gc                                 | No                            | Yes                     | 1           |
-| M/T       | eBPF tracing tool                         | No                            | No                      | ?           |
 
 [0x]: https://github.com/davidmarkclements/0x
 [Async Hooks (API)]: https://nodejs.org/api/async_hooks.html


### PR DESCRIPTION
Fixes: https://github.com/nodejs/diagnostics/issues/535. eBPF and DTrace support were removed on https://github.com/nodejs/node/pull/43652.

FWIW I'll open a new issue regarding that support any time soon. However, this PR should still be valid once that document should reflect the current state of the support.