### PR TITLE
crypto: use EVP_PKEY_CTX_set_dsa_paramgen_q_bits when available

### DIFF
--- a/src/crypto/crypto_dsa.cc
+++ b/src/crypto/crypto_dsa.cc
@@ -12,6 +12,17 @@
 
 #include <cstdio>
 
+// EVP_PKEY_CTX_set_dsa_paramgen_q_bits was added in OpenSSL 1.1.1e.
+#if OPENSSL_VERSION_NUMBER < 0x1010105fL
+#define EVP_PKEY_CTX_set_dsa_paramgen_q_bits(ctx, qbits)                       \
+  EVP_PKEY_CTX_ctrl((ctx),                                                     \
+                    EVP_PKEY_DSA,                                              \
+                    EVP_PKEY_OP_PARAMGEN,                                      \
+                    EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS,                         \
+                    (qbits),                                                   \
+                    nullptr)
+#endif
+
 namespace node {
 
 using v8::FunctionCallbackInfo;
@@ -39,13 +50,8 @@ EVPKeyCtxPointer DsaKeyGenTraits::Setup(DsaKeyPairGenConfig* params) {
   }
 
   if (params->params.divisor_bits != -1) {
-    if (EVP_PKEY_CTX_ctrl(
-            param_ctx.get(),
-            EVP_PKEY_DSA,
-            EVP_PKEY_OP_PARAMGEN,
-            EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS,
-            params->params.divisor_bits,
-            nullptr) <= 0) {
+    if (EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
+            param_ctx.get(), params->params.divisor_bits) <= 0) {
       return EVPKeyCtxPointer();
     }
   }


### PR DESCRIPTION
This matches the formulation described in the documentation: https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_CTX_set_dsa_paramgen_q_bits.html

It is also, starting OpenSSL 3.0, more type-safe because the wrapper macros were finally converted to real functions. In OpenSSL 3.0, it is also no longer quite a wrapper over EVP_PKEY_CTX_ctrl, so using this name saves some extra OSSL_PARAM <-> EVP_PKEY_CTRL conversions.

Alas, it was only backported to OpenSSL 1.1.1e, so I've left a temporary compatibility define until you all decide to drop pre-1.1.1e releases of 1.1.1.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
