### PR TITLE
Revert "build: go faster, drop -fno-omit-frame-pointer"

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -204,13 +204,18 @@
             ],
           }],
           ['OS=="solaris"', {
-           'cflags': [ '-fno-omit-frame-pointer' ],
             # pull in V8's postmortem metadata
             'ldflags': [ '-Wl,-z,allextract' ]
           }],
           ['OS=="zos"', {
             # increase performance, number from experimentation
             'cflags': [ '-qINLINE=::150:100000' ]
+          }],
+          ['OS!="mac" and OS!="win" and OS!="zos"', {
+            # -fno-omit-frame-pointer is necessary for the --perf_basic_prof
+            # flag to work correctly. perf(1) gets confused about JS stack
+            # frames otherwise, even with --call-graph dwarf.
+            'cflags': [ '-fno-omit-frame-pointer' ],
           }],
           ['OS=="linux"', {
             'conditions': [


### PR DESCRIPTION
This reverts commit d0f73d383d5e1ed58c96a272036744d4bed22b8f.

The lack of frame pointers unfortunately breaks the --perf_basic_prof flag because perf(1) then no longer understands C++ <-> JS stack frame transitions.

<hr>

Profiling with perf is probably common enough that (unlike postmortem debugging) people will notice when it's broken so revert it is.