### PR TITLE
crypto: restrict PBKDF2 args to signed int

### DIFF
--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -15,6 +15,7 @@ const {
 
 const {
   validateFunction,
+  validateInt32,
   validateInteger,
   validateString,
   validateUint32,
@@ -91,8 +92,10 @@ function check(password, salt, iterations, keylen, digest) {
 
   password = getArrayBufferOrView(password, 'password');
   salt = getArrayBufferOrView(salt, 'salt');
-  validateUint32(iterations, 'iterations', true);
-  validateUint32(keylen, 'keylen');
+  // OpenSSL uses a signed int to represent these values, so we are restricted
+  // to the 31-bit range here (which is plenty).
+  validateInt32(iterations, 'iterations', 1);
+  validateInt32(keylen, 'keylen', 0);
 
   return { password, salt, iterations, keylen, digest };
 }

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -63,7 +63,7 @@ assert.throws(
   }
 );
 
-for (const iterations of [-1, 0]) {
+for (const iterations of [-1, 0, 2147483648]) {
   assert.throws(
     () => crypto.pbkdf2Sync('password', 'salt', iterations, 20, 'sha1'),
     {
@@ -98,7 +98,7 @@ for (const iterations of [-1, 0]) {
     });
 });
 
-[-1, 4294967297].forEach((input) => {
+[-1, 2147483648, 4294967296].forEach((input) => {
   assert.throws(
     () => {
       crypto.pbkdf2('password', 'salt', 1, input, 'sha256',


### PR DESCRIPTION
OpenSSL internally represents the output length and the iteration count as signed integers, which is why node's C++ implementation expects these arguments to fit into signed integers as well. The JavaScript validation logic, however, only requires the arguments to be unsigned 32-bit integers, which is a superset of non-negative (signed) 32-bit integers.

Change the JavaScript validation to match the expectation within C++.

Fixes: https://github.com/nodejs/node/issues/44570

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
