### PR TITLE
src: collect sync api call stack

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1439,6 +1439,14 @@ added: v2.1.0
 Prints a stack trace whenever synchronous I/O is detected after the first turn
 of the event loop.
 
+### `--trace-sync-io-file-name`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Write the call stack to file when `--trace-sync-io` is set.
+
 ### `--trace-tls`
 
 <!-- YAML
@@ -1869,6 +1877,7 @@ Node.js options that are allowed are:
 * `--trace-events-enabled`
 * `--trace-exit`
 * `--trace-sigint`
+* `--trace-sync-io-file-name`
 * `--trace-sync-io`
 * `--trace-tls`
 * `--trace-uncaught`

--- a/src/env.h
+++ b/src/env.h
@@ -1194,7 +1194,7 @@ class Environment : public MemoryRetainer {
   inline bool printed_error() const;
   inline void set_printed_error(bool value);
 
-  void PrintSyncTrace() const;
+  void PrintSyncTrace();
   inline void set_trace_sync_io(bool value);
 
   inline void set_force_context_aware(bool value);
@@ -1511,6 +1511,7 @@ class Environment : public MemoryRetainer {
   std::shared_ptr<KVStore> env_vars_;
   bool printed_error_ = false;
   bool trace_sync_io_ = false;
+  FILE* sync_io_fp_ = nullptr;
   bool emit_env_nonstring_warning_ = true;
   bool emit_err_name_warning_ = true;
   bool emit_filehandle_warning_ = true;

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -556,6 +556,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "first tick",
             &EnvironmentOptions::trace_sync_io,
             kAllowedInEnvironment);
+  AddOption("--trace-sync-io-file-name",
+            "write the call stack to file when --trace-sync-io is set",
+            &EnvironmentOptions::trace_sync_io_file_name,
+            kAllowedInEnvironment);
   AddOption("--trace-tls",
             "prints TLS packet trace information to stderr",
             &EnvironmentOptions::trace_tls,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -159,6 +159,7 @@ class EnvironmentOptions : public Options {
   bool trace_deprecation = false;
   bool trace_exit = false;
   bool trace_sync_io = false;
+  std::string trace_sync_io_file_name;
   bool trace_tls = false;
   bool trace_uncaught = false;
   bool trace_warnings = false;

--- a/test/parallel/test-sync-io-option-with-filename.js
+++ b/test/parallel/test-sync-io-option-with-filename.js
@@ -1,0 +1,81 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+if (process.env.isChild === '1') {
+  setImmediate(() => {
+    if (process.env.mode === 'eval') {
+      eval('require("fs").statSync(__filename);');
+    } else {
+      require('fs').statSync(__filename);
+    }
+  });
+  return;
+}
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+{
+  const FILE_NAME = path.join(tmpdir.path, 'sync_io_file_eval.log');
+  cp.spawnSync(process.execPath,
+               [
+                 '--trace-sync-io',
+                 '--trace-sync-io-file-name=sync_io_file_eval.log',
+                 __filename,
+               ],
+               {
+                 cwd: tmpdir.path,
+                 env: {
+                   ...process.env,
+                   isChild: '1',
+                   mode: 'eval'
+                 }
+               });
+
+  console.log(fs.readFileSync(FILE_NAME, 'utf-8'));
+  assert(fs.existsSync(FILE_NAME));
+}
+
+{
+  const FILE_NAME = path.join(tmpdir.path, 'sync_io_file.log');
+  cp.spawnSync(process.execPath,
+               [
+                 '--trace-sync-io',
+                 '--trace-sync-io-file-name=sync_io_file.log',
+                 __filename,
+               ],
+               {
+                 cwd: tmpdir.path,
+                 env: {
+                   ...process.env,
+                   isChild: '1',
+                 }
+               });
+
+  console.log(fs.readFileSync(FILE_NAME, 'utf-8'));
+  assert(fs.existsSync(FILE_NAME));
+}
+
+{
+  const FILE_NAME = path.join(tmpdir.path, 'sync_io_file_env_variable.log');
+  cp.spawnSync(process.execPath,
+               [
+                 '--trace-sync-io',
+                 __filename,
+               ],
+               {
+                 cwd: tmpdir.path,
+                 env: {
+                   ...process.env,
+                   isChild: '1',
+                   NODE_OPTIONS: '--trace-sync-io-file-name=sync_io_file_env_variable.log'
+                 }
+               });
+
+  console.log(fs.readFileSync(FILE_NAME, 'utf-8'));
+  assert(fs.existsSync(FILE_NAME));
+}


### PR DESCRIPTION
Adds an option to support writing call stack of sync api to file. The format is as follows.
```
a -> b -> c
d -> e -> f
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
