### PR TITLE
src: print js call stack in blob sync API

### DIFF
--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -406,6 +406,7 @@ void FixedSizeBlobCopyJob::Run(const FunctionCallbackInfo<Value>& args) {
   if (job->mode() == FixedSizeBlobCopyJob::Mode::ASYNC)
     return job->ScheduleWork();
 
+  env->PrintSyncTrace();
   job->DoThreadPoolWork();
   args.GetReturnValue().Set(
       ArrayBuffer::New(env->isolate(), job->destination_));


### PR DESCRIPTION
print js call stack in blob sync API when `--trace-sync-io` is set.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
