### PR TITLE
doc: deprecate modp1, modp2, and modp5 groups

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1185,14 +1185,19 @@ const dh = createDiffieHellmanGroup('modp16');
 
 The following groups are supported:
 
-* `'modp1'` (768 bits, [RFC 2409][] Section 6.1)
-* `'modp2'` (1024 bits, [RFC 2409][] Section 6.2)
-* `'modp5'` (1536 bits, [RFC 3526][] Section 2)
 * `'modp14'` (2048 bits, [RFC 3526][] Section 3)
 * `'modp15'` (3072 bits, [RFC 3526][] Section 4)
 * `'modp16'` (4096 bits, [RFC 3526][] Section 5)
 * `'modp17'` (6144 bits, [RFC 3526][] Section 6)
 * `'modp18'` (8192 bits, [RFC 3526][] Section 7)
+
+The following groups are still supported but deprecated (see [Caveats][]):
+
+* `'modp1'` (768 bits, [RFC 2409][] Section 6.1) <span class="deprecated-inline"></span>
+* `'modp2'` (1024 bits, [RFC 2409][] Section 6.2) <span class="deprecated-inline"></span>
+* `'modp5'` (1536 bits, [RFC 3526][] Section 2) <span class="deprecated-inline"></span>
+
+These deprecated groups might be removed in future versions of Node.js.
 
 ## Class: `ECDH`
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3214,9 +3214,28 @@ Package imports and exports targets mapping into paths including a double slash
 error in a future release. This same deprecation also applies to pattern matches
 starting or ending in a slash.
 
+### DEP0167: Weak `DiffieHellmanGroup` instances (`modp1`, `modp2`, `modp5`)
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/44588
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+The well-known MODP groups `modp1`, `modp2`, and `modp5` are deprecated because
+they are not secure against practical attacks. See [RFC 8247 Section 2.4][] for
+details.
+
+These groups might be removed in future versions of Node.js. Applications that
+rely on these groups should evaluate using stronger MODP groups instead.
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
+[RFC 8247 Section 2.4]: https://www.rfc-editor.org/rfc/rfc8247#section-2.4
 [WHATWG URL API]: url.md#the-whatwg-url-api
 [`"exports"` or `"main"` entry]: packages.md#main-entry-point-export
 [`--pending-deprecation`]: cli.md#--pending-deprecation

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -598,7 +598,8 @@ hr {
   padding-left: 5rem;
 }
 
-#toc .stability_0::after {
+#toc .stability_0::after,
+.deprecated-inline::after {
   background-color: var(--red2);
   color: var(--white);
   content: "deprecated";


### PR DESCRIPTION
These MODP groups should not be used by new applications, and existing applications should attempt to migrate to stronger groups (or different key exchange mechanisms).

Some applications still rely on these particular groups, so Node.js will likely maintain support, directly or indirectly, for the foreseeable future.

Refs: https://github.com/nodejs/node/issues/44539

---

Effect of the added CSS selector:

<details>
<summary>Light mode</summary>

![screenshot of the new `deprecated-inline` CSS class](https://user-images.githubusercontent.com/3109072/189545628-4cbf082b-9376-458e-9320-9d0b349632ef.png)

</details>

<details>
<summary>Dark mode</summary>

![screenshot of the new `deprecated-inline` CSS class in dark mode](https://user-images.githubusercontent.com/3109072/189545398-b5f6f5ce-980a-49dd-81ae-cb7cca06e3f3.png)

</details>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
