### PR TITLE
doc: fix heading levels for test runner hooks

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -484,7 +484,7 @@ same as [`it([name], { skip: true }[, fn])`][it options].
 Shorthand for marking a test as `TODO`,
 same as [`it([name], { todo: true }[, fn])`][it options].
 
-### `before([, fn][, options])`
+## `before([, fn][, options])`
 
 <!-- YAML
 added: v18.8.0
@@ -512,7 +512,7 @@ describe('tests', async () => {
 });
 ```
 
-### `after([, fn][, options])`
+## `after([, fn][, options])`
 
 <!-- YAML
 added: v18.8.0
@@ -540,7 +540,7 @@ describe('tests', async () => {
 });
 ```
 
-### `beforeEach([, fn][, options])`
+## `beforeEach([, fn][, options])`
 
 <!-- YAML
 added: v18.8.0
@@ -569,7 +569,7 @@ describe('tests', async () => {
 });
 ```
 
-### `afterEach([, fn][, options])`
+## `afterEach([, fn][, options])`
 
 <!-- YAML
 added: v18.8.0


### PR DESCRIPTION
before/after/beforeEach/afterEach are exported directly from `node:test` and should not be indented under `it.todo`.