### PR TITLE
readline: remove `question` method from `InterfaceConstructor`

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -303,61 +303,6 @@ paused.
 If the `InterfaceConstructor` was created with `output` set to `null` or
 `undefined` the prompt is not written.
 
-### `rl.question(query[, options], callback)`
-
-<!-- YAML
-added: v0.3.3
--->
-
-* `query` {string} A statement or query to write to `output`, prepended to the
-  prompt.
-* `options` {Object}
-  * `signal` {AbortSignal} Optionally allows the `question()` to be canceled
-    using an `AbortController`.
-* `callback` {Function} A callback function that is invoked with the user's
-  input in response to the `query`.
-
-The `rl.question()` method displays the `query` by writing it to the `output`,
-waits for user input to be provided on `input`, then invokes the `callback`
-function passing the provided input as the first argument.
-
-When called, `rl.question()` will resume the `input` stream if it has been
-paused.
-
-If the `InterfaceConstructor` was created with `output` set to `null` or
-`undefined` the `query` is not written.
-
-The `callback` function passed to `rl.question()` does not follow the typical
-pattern of accepting an `Error` object or `null` as the first argument.
-The `callback` is called with the provided answer as the only argument.
-
-An error will be thrown if calling `rl.question()` after `rl.close()`.
-
-Example usage:
-
-```js
-rl.question('What is your favorite food? ', (answer) => {
-  console.log(`Oh, so your favorite food is ${answer}`);
-});
-```
-
-Using an `AbortController` to cancel a question.
-
-```js
-const ac = new AbortController();
-const signal = ac.signal;
-
-rl.question('What is your favorite food? ', { signal }, (answer) => {
-  console.log(`Oh, so your favorite food is ${answer}`);
-});
-
-signal.addEventListener('abort', () => {
-  console.log('The food question timed out');
-}, { once: true });
-
-setTimeout(() => ac.abort(), 10000);
-```
-
 ### `rl.resume()`
 
 <!-- YAML

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -81,6 +81,7 @@ const lineEnding = /\r?\n|\r(?!\n)/;
 
 const kLineObjectStream = Symbol('line object stream');
 const kQuestionCancel = Symbol('kQuestionCancel');
+const kQuestion = Symbol('kQuestion');
 
 // GNU readline library - keyseq-timeout is 500ms (default)
 const ESCAPE_CODE_TIMEOUT = 500;
@@ -401,7 +402,7 @@ class Interface extends InterfaceConstructor {
     }
   }
 
-  question(query, cb) {
+  [kQuestion](query, cb) {
     if (this.closed) {
       throw new ERR_USE_AFTER_CLOSE('readline');
     }
@@ -1405,6 +1406,7 @@ module.exports = {
   kOnLine,
   kPreviousKey,
   kPrompt,
+  kQuestion,
   kQuestionCallback,
   kQuestionCancel,
   kRefreshLine,

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -81,6 +81,7 @@ const {
   kOnLine,
   kPreviousKey,
   kPrompt,
+  kQuestion,
   kQuestionCallback,
   kQuestionCancel,
   kRefreshLine,
@@ -120,8 +121,6 @@ function Interface(input, output, completer, terminal) {
 ObjectSetPrototypeOf(Interface.prototype, _Interface.prototype);
 ObjectSetPrototypeOf(Interface, _Interface);
 
-const superQuestion = _Interface.prototype.question;
-
 /**
  * Displays `query` by writing it to the `output`.
  * @param {string} query
@@ -129,7 +128,7 @@ const superQuestion = _Interface.prototype.question;
  * @param {Function} cb
  * @returns {void}
  */
-Interface.prototype.question = function(query, options, cb) {
+Interface.prototype.question = function question(query, options, cb) {
   cb = typeof options === 'function' ? options : cb;
   if (options === null || typeof options !== 'object') {
     options = kEmptyObject;
@@ -156,7 +155,7 @@ Interface.prototype.question = function(query, options, cb) {
   }
 
   if (typeof cb === 'function') {
-    FunctionPrototypeCall(superQuestion, this, query, cb);
+    this[kQuestion](query, cb);
   }
 };
 Interface.prototype.question[promisify.custom] = function question(query, options) {

--- a/lib/readline/promises.js
+++ b/lib/readline/promises.js
@@ -10,6 +10,7 @@ const {
 
 const {
   Interface: _Interface,
+  kQuestion,
   kQuestionCancel,
 } = require('internal/readline/interface');
 
@@ -49,7 +50,7 @@ class Interface extends _Interface {
         };
       }
 
-      super.question(query, cb);
+      this[kQuestion](query, cb);
     });
   }
 }


### PR DESCRIPTION
That method is overwritten in both `require('node:readline').Interface.prototype` and `require('node:readline/promises').Interface.prototype`, and is very much not useful outside of interacting with TTY, removing it from the parent class could enable the use of `InterfaceConstructor` in other contexts (such as interacting with files).

I don't think a deprecation cycle is granted here because that method is never directly exposed. Marking it as https://github.com/nodejs/node/labels/semver-major though, to be safe.

Refs: https://github.com/nodejs/node/pull/42590#issuecomment-1139923268

/cc @tniessen 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
