### PR TITLE
doc: use serial comma in stream docs

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -594,7 +594,7 @@ added: v11.4.0
 * {boolean}
 
 Is `true` if it is safe to call [`writable.write()`][stream-write], which means
-the stream has not been destroyed, errored or ended.
+the stream has not been destroyed, errored, or ended.
 
 ##### `writable.writableAborted`
 
@@ -1547,7 +1547,7 @@ changes:
 
 * `chunk` {Buffer|Uint8Array|string|null|any} Chunk of data to unshift onto the
   read queue. For streams not operating in object mode, `chunk` must be a
-  string, `Buffer`, `Uint8Array` or `null`. For object mode streams, `chunk`
+  string, `Buffer`, `Uint8Array`, or `null`. For object mode streams, `chunk`
   may be any JavaScript value.
 * `encoding` {string} Encoding of string chunks. Must be a valid
   `Buffer` encoding, such as `'utf8'` or `'ascii'`.
@@ -3135,7 +3135,7 @@ added: v1.2.0
 
 For many simple cases, it is possible to create a stream without relying on
 inheritance. This can be accomplished by directly creating instances of the
-`stream.Writable`, `stream.Readable`, `stream.Duplex` or `stream.Transform`
+`stream.Writable`, `stream.Readable`, `stream.Duplex`, or `stream.Transform`
 objects and passing appropriate methods as constructor options.
 
 ```js
@@ -3763,7 +3763,7 @@ changes:
 * Returns: {boolean} `true` if additional chunks of data may continue to be
   pushed; `false` otherwise.
 
-When `chunk` is a `Buffer`, `Uint8Array` or `string`, the `chunk` of data will
+When `chunk` is a `Buffer`, `Uint8Array`, or `string`, the `chunk` of data will
 be added to the internal queue for users of the stream to consume.
 Passing `chunk` as `null` signals the end of the stream (EOF), after which no
 more data can be written.
@@ -4438,7 +4438,7 @@ situations within Node.js where this is done, particularly in the
 
 Use of `readable.push('')` is not recommended.
 
-Pushing a zero-byte string, `Buffer` or `Uint8Array` to a stream that is not in
+Pushing a zero-byte string, `Buffer`, or `Uint8Array` to a stream that is not in
 object mode has an interesting side effect. Because it _is_ a call to
 [`readable.push()`][stream-push], the call will end the reading process.
 However, because the argument is an empty string, no data is added to the


### PR DESCRIPTION
This aligns `doc/api/stream.md` with the following guide.

https://github.com/nodejs/node/blob/047cd618593372f91dada42f29cc9a8e35cda22c/doc/README.md?plain=1#L21

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
