### PR TITLE
fs: remove unused option in `fs.fstatSync()`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1535,11 +1535,10 @@ function hasNoEntryError(ctx) {
  * @param {number} fd
  * @param {{
  *   bigint?: boolean;
- *   throwIfNoEntry?: boolean;
  *   }} [options]
  * @returns {Stats}
  */
-function fstatSync(fd, options = { bigint: false, throwIfNoEntry: true }) {
+function fstatSync(fd, options = { bigint: false }) {
   fd = getValidatedFd(fd);
   const ctx = { fd };
   const stats = binding.fstat(fd, options.bigint, undefined, ctx);


### PR DESCRIPTION
[`fs.fstatSync(fd[, options])`](https://nodejs.org/api/fs.html#fsfstatsyncfd-options) works with file descriptors and therefore does not support `throwIfNoEntry` option.