### PR TITLE
src: avoid copy when creating Blob

### DIFF
--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -71,11 +71,9 @@ bool Blob::HasInstance(Environment* env, v8::Local<v8::Value> object) {
   return GetConstructorTemplate(env)->HasInstance(object);
 }
 
-BaseObjectPtr<Blob> Blob::Create(
-    Environment* env,
-    const std::vector<BlobEntry> store,
-    size_t length) {
-
+BaseObjectPtr<Blob> Blob::Create(Environment* env,
+                                 const std::vector<BlobEntry>& store,
+                                 size_t length) {
   HandleScope scope(env->isolate());
 
   Local<Function> ctor;

--- a/src/node_blob.h
+++ b/src/node_blob.h
@@ -45,16 +45,13 @@ class Blob : public BaseObject {
   static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
       Environment* env);
 
-  static BaseObjectPtr<Blob> Create(
-      Environment* env,
-      const std::vector<BlobEntry> store,
-      size_t length);
+  static BaseObjectPtr<Blob> Create(Environment* env,
+                                    const std::vector<BlobEntry>& store,
+                                    size_t length);
 
   static bool HasInstance(Environment* env, v8::Local<v8::Value> object);
 
-  const std::vector<BlobEntry> entries() const {
-    return store_;
-  }
+  const std::vector<BlobEntry>& entries() const { return store_; }
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(Blob)


### PR DESCRIPTION
Cherry-picked and squashed two commits from @jasnell's #44325 in order to make the QUIC PR simpler to review (with his permission). This change makes sense even without the QUIC PR.

- [src: Avoid copy when creating a Blob](https://github.com/nodejs/node/pull/44325/commits/d5df5739d52f1a92cecc71154ff3b83f0f195439)
- [src: update blob constructor to support quic](https://github.com/nodejs/node/pull/44325/commits/f6b6cb7d2b0911d376d9dc6f7d499cf3d23899d5)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
