### PR TITLE
fix(api): fixed an entry of the process api that was non-conforming

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -3644,7 +3644,6 @@ changes:
     - v12.19.0
     pr-url: https://github.com/nodejs/node/pull/32499
     description: Calling `process.umask()` with no arguments is deprecated.
-
 -->
 
 > Stability: 0 - Deprecated. Calling `process.umask()` with no argument causes


### PR DESCRIPTION
This PR simply removes an empty-line which is non-conforming to our API docs schema. It was getting unnoticed by our build-tools. But it got noticed by `nodejs/nodejs.dev` `sync-api` tool, where the MDX parser was complaining regarding this non-escaped line.
