### PR TITLE
lib,test: fix bug in InternalSocketAddress

### DIFF
--- a/lib/internal/socketaddress.js
+++ b/lib/internal/socketaddress.js
@@ -142,6 +142,12 @@ class InternalSocketAddress extends JSTransferable {
   constructor(handle) {
     super();
     this[kHandle] = handle;
+    this[kDetail] = this[kHandle]?.detail({
+      address: undefined,
+      port: undefined,
+      family: undefined,
+      flowlabel: undefined,
+    });
   }
 }
 


### PR DESCRIPTION
`InternalSocketAddress` must set `[kDetails]` in order for the inherited properties to function correctly.

Cherry-picked from @jasnell's #44325 in order to make the QUIC PR simpler to review (with his permission). This change makes sense even without the QUIC PR.

- [lib: fix bug in InternalSocketAddress](https://github.com/nodejs/node/pull/44325/commits/24ef1f8d38ccca1067397570644494c2de33f533)

I added a test case for `InternalSocketAddress` to `test-socketaddress.js`, which is not part of the original commit.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
