### PR TITLE
events: improve performance by ~120%

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -58,6 +58,9 @@ const {
   identicalSequenceRange,
 } = require('internal/util/inspect');
 
+function NullObject() {}
+NullObject.prototype = ObjectCreate(null);
+
 let spliceOne;
 
 const {
@@ -338,7 +341,7 @@ EventEmitter.init = function(opts) {
 
   if (this._events === undefined ||
       this._events === ObjectGetPrototypeOf(this)._events) {
-    this._events = ObjectCreate(null);
+    this._events = new NullObject();
     this._eventsCount = 0;
   }
 
@@ -547,7 +550,7 @@ function _addListener(target, type, listener, prepend) {
 
   events = target._events;
   if (events === undefined) {
-    events = target._events = ObjectCreate(null);
+    events = target._events = new NullObject();
     target._eventsCount = 0;
   } else {
     // To avoid recursion in the case that type === "newListener"! Before
@@ -685,7 +688,7 @@ EventEmitter.prototype.removeListener =
 
       if (list === listener || list.listener === listener) {
         if (--this._eventsCount === 0)
-          this._events = ObjectCreate(null);
+          this._events = new NullObject();
         else {
           delete events[type];
           if (events.removeListener)
@@ -740,11 +743,11 @@ EventEmitter.prototype.removeAllListeners =
       // Not listening for removeListener, no need to emit
       if (events.removeListener === undefined) {
         if (arguments.length === 0) {
-          this._events = ObjectCreate(null);
+          this._events = new NullObject();
           this._eventsCount = 0;
         } else if (events[type] !== undefined) {
           if (--this._eventsCount === 0)
-            this._events = ObjectCreate(null);
+            this._events = new NullObject();
           else
             delete events[type];
         }
@@ -758,7 +761,7 @@ EventEmitter.prototype.removeAllListeners =
           this.removeAllListeners(key);
         }
         this.removeAllListeners('removeListener');
-        this._events = ObjectCreate(null);
+        this._events = new NullObject();
         this._eventsCount = 0;
         return this;
       }


### PR DESCRIPTION
`Object.create(null)` is 20x slower on Node 14, and 10x slower on Node 18. This is mainly related to the bug I've opened: https://bugs.chromium.org/p/v8/issues/detail?id=13273#c2

V8 is super optimized for `new Cls()`, but not for `Object.create(null)`

```
events/ee-add-remove.js n=1000000 removeListener=0 newListener=0        ***     18.89 %       ±0.88% ±1.17% ±1.52%
events/ee-add-remove.js n=1000000 removeListener=0 newListener=1        ***     13.76 %       ±1.23% ±1.64% ±2.15%
events/ee-add-remove.js n=1000000 removeListener=1 newListener=0        ***     13.46 %       ±1.08% ±1.44% ±1.89%
events/ee-add-remove.js n=1000000 removeListener=1 newListener=1        ***      3.88 %       ±1.05% ±1.40% ±1.84%
events/ee-emit.js listeners=1 argc=0 n=2000000                          ***    116.87 %       ±2.80% ±3.77% ±4.98%
events/ee-emit.js listeners=1 argc=10 n=2000000                         ***    114.85 %       ±5.35% ±7.20% ±9.56%
events/ee-emit.js listeners=1 argc=2 n=2000000                          ***    114.53 %       ±3.65% ±4.92% ±6.52%
events/ee-emit.js listeners=1 argc=4 n=2000000                          ***    119.26 %       ±1.67% ±2.23% ±2.93%
events/ee-emit.js listeners=10 argc=0 n=2000000                         ***      9.36 %       ±1.44% ±1.91% ±2.49%
events/ee-emit.js listeners=10 argc=10 n=2000000                        ***      8.07 %       ±1.19% ±1.59% ±2.07%
events/ee-emit.js listeners=10 argc=2 n=2000000                         ***      9.76 %       ±1.08% ±1.45% ±1.90%
events/ee-emit.js listeners=10 argc=4 n=2000000                         ***      8.57 %       ±1.16% ±1.55% ±2.01%
events/ee-emit.js listeners=5 argc=0 n=2000000                          ***     14.15 %       ±1.51% ±2.02% ±2.63%
events/ee-emit.js listeners=5 argc=10 n=2000000                         ***     12.37 %       ±1.34% ±1.78% ±2.32%
events/ee-emit.js listeners=5 argc=2 n=2000000                          ***     13.79 %       ±1.42% ±1.89% ±2.47%
events/ee-emit.js listeners=5 argc=4 n=2000000                          ***     11.68 %       ±3.91% ±5.25% ±6.93%
events/ee-listener-count-on-prototype.js n=50000000                     ***     -9.40 %       ±1.30% ±1.75% ±2.32%
events/ee-listeners.js raw='false' listeners=5 n=5000000                ***     -5.34 %       ±2.32% ±3.12% ±4.12%
events/ee-listeners.js raw='false' listeners=50 n=5000000                 *      1.49 %       ±1.16% ±1.55% ±2.03%
events/ee-listeners.js raw='true' listeners=5 n=5000000                 ***     -7.73 %       ±1.63% ±2.19% ±2.89%
events/ee-listeners.js raw='true' listeners=50 n=5000000                ***     -5.43 %       ±0.91% ±1.21% ±1.59%
events/ee-once.js argc=0 n=20000000                                     ***     16.98 %       ±1.47% ±1.95% ±2.55%
events/ee-once.js argc=1 n=20000000                                     ***     16.58 %       ±1.34% ±1.79% ±2.34%
events/ee-once.js argc=4 n=20000000                                     ***     15.86 %       ±1.17% ±1.57% ±2.06%
events/ee-once.js argc=5 n=20000000                                     ***     15.28 %       ±1.63% ±2.17% ±2.84%
events/eventtarget.js listeners=1 n=1000000                                     -0.15 %       ±0.46% ±0.62% ±0.80%
events/eventtarget.js listeners=10 n=1000000                                     0.01 %       ±0.50% ±0.66% ±0.87%
events/eventtarget.js listeners=5 n=1000000                                     -0.45 %       ±0.54% ±0.73% ±0.95%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 28 comparisons, you can thus expect the following amount of false-positive results:
  1.40 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.28 false positives, when considering a   1% risk acceptance (**, ***),
  0.03 false positives, when considering a 0.1% risk acceptance (***)
```