### PR TITLE
doc,inspector: document changes of inspector.close

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -17,6 +17,14 @@ const inspector = require('node:inspector');
 
 ## `inspector.close()`
 
+<!-- YAML
+added: v9.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/44489
+    description: The API is exposed in the worker threads.
+-->
+
 Deactivate the inspector. Blocks until there are no active connections.
 
 ## `inspector.console`


### PR DESCRIPTION
Retrospectively document the changes history of the `inspector.close`
API.

Refs: https://github.com/nodejs/node/pull/44489
Refs: https://github.com/nodejs/node/pull/13228