### PR TITLE
dns: improve lookup performance by ~3%

### DIFF
--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -34,6 +34,8 @@ const {
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_IP_ADDRESS,
 } = errors.codes;
+function NullObject() {}
+NullObject.prototype = ObjectCreate(null);
 
 function validateTimeout(options) {
   const { timeout = -1 } = { ...options };
@@ -221,7 +223,7 @@ function setDefaultResultOrder(value) {
 }
 
 function createResolverClass(resolver) {
-  const resolveMap = ObjectCreate(null);
+  const resolveMap = new NullObject();
 
   class Resolver extends ResolverBase {}
 


### PR DESCRIPTION
This change improves dns lookup performance by roughly 3%.

Referencing: https://github.com/nodejs/node/pull/44627

```
                                                              confidence improvement accuracy (*)   (**)   (***)
dns/lookup-promises.js n=5000000 all='false' name='::1'                      -0.03 %       ±2.42% ±3.23%  ±4.22%
dns/lookup-promises.js n=5000000 all='false' name='127.0.0.1'                 0.01 %       ±2.77% ±3.69%  ±4.80%
dns/lookup-promises.js n=5000000 all='true' name='::1'                        0.29 %       ±1.67% ±2.23%  ±2.90%
dns/lookup-promises.js n=5000000 all='true' name='127.0.0.1'                  2.99 %       ±5.73% ±7.70% ±10.16%
dns/lookup.js n=5000000 all='false' name='::1'                                0.37 %       ±0.86% ±1.14%  ±1.49%
dns/lookup.js n=5000000 all='false' name='127.0.0.1'                         -0.21 %       ±0.79% ±1.05%  ±1.37%
dns/lookup.js n=5000000 all='true' name='::1'                                 0.51 %       ±0.93% ±1.24%  ±1.61%
dns/lookup.js n=5000000 all='true' name='127.0.0.1'                          -0.50 %       ±0.89% ±1.18%  ±1.55%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 8 comparisons, you can thus expect the following amount of false-positive results:
  0.40 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.08 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
`