### PR TITLE
dns: support dns module in the snapshot

### DIFF
--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -39,7 +39,7 @@ const {
 const {
   addSerializeCallback,
   addDeserializeCallback,
-  isBuildingSnapshot
+  isBuildingSnapshot,
 } = require('v8').startupSnapshot;
 
 function validateTimeout(options) {
@@ -212,9 +212,7 @@ function initializeDns() {
   }
 
   addSerializeCallback(() => {
-    if (defaultResolver !== undefined) {
-      defaultResolver[kSerializeResolver]();
-    }
+    defaultResolver?.[kSerializeResolver]();
   });
 }
 

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -10,6 +10,7 @@ const {
   RegExpPrototypeExec,
   RegExpPrototypeSymbolReplace,
   ObjectCreate,
+  Symbol,
 } = primordials;
 
 const errors = require('internal/errors');
@@ -35,6 +36,12 @@ const {
   ERR_INVALID_IP_ADDRESS,
 } = errors.codes;
 
+const {
+  addSerializeCallback,
+  addDeserializeCallback,
+  isBuildingSnapshot
+} = require('v8').startupSnapshot;
+
 function validateTimeout(options) {
   const { timeout = -1 } = { ...options };
   validateInt32(timeout, 'options.timeout', -1);
@@ -47,12 +54,27 @@ function validateTries(options) {
   return tries;
 }
 
+const kSerializeResolver = Symbol('dns:resolver:serialize');
+const kDeserializeResolver = Symbol('dns:resolver:deserialize');
+const kSnapshotStates = Symbol('dns:resolver:config');
+const kInitializeHandle = Symbol('dns:resolver:initializeHandle');
+const kSetServersInteral = Symbol('dns:resolver:setServers');
+
 // Resolver instances correspond 1:1 to c-ares channels.
 
 class ResolverBase {
   constructor(options = undefined) {
     const timeout = validateTimeout(options);
     const tries = validateTries(options);
+    // If we are building snapshot, save the states of the resolver along
+    // the way.
+    if (isBuildingSnapshot()) {
+      this[kSnapshotStates] = { timeout, tries };
+    }
+    this[kInitializeHandle](timeout, tries);
+  }
+
+  [kInitializeHandle](timeout, tries) {
     const { ChannelWrap } = lazyBinding();
     this._handle = new ChannelWrap(timeout, tries);
   }
@@ -77,9 +99,7 @@ class ResolverBase {
     // Cache the original servers because in the event of an error while
     // setting the servers, c-ares won't have any servers available for
     // resolution.
-    const orig = this._handle.getServers() || [];
     const newSet = [];
-
     ArrayPrototypeForEach(servers, (serv, index) => {
       validateString(serv, `servers[${index}]`);
       let ipVersion = isIP(serv);
@@ -118,6 +138,11 @@ class ResolverBase {
       throw new ERR_INVALID_IP_ADDRESS(serv);
     });
 
+    this[kSetServersInteral](newSet, servers);
+  }
+
+  [kSetServersInteral](newSet, servers) {
+    const orig = this._handle.getServers() || [];
     const errorNumber = this._handle.setServers(newSet);
 
     if (errorNumber !== 0) {
@@ -127,7 +152,12 @@ class ResolverBase {
       const err = strerror(errorNumber);
       throw new ERR_DNS_SET_SERVERS_FAILED(err, servers);
     }
+
+    if (isBuildingSnapshot()) {
+      this[kSnapshotStates].servers = newSet;
+    }
   }
+
 
   setLocalAddress(ipv4, ipv6) {
     validateString(ipv4, 'ipv4');
@@ -137,6 +167,31 @@ class ResolverBase {
     }
 
     this._handle.setLocalAddress(ipv4, ipv6);
+
+    if (isBuildingSnapshot()) {
+      this[kSnapshotStates].localAddress = { ipv4, ipv6 };
+    }
+  }
+
+  // TODO(joyeecheung): consider exposing this if custom DNS resolvers
+  // end up being useful for snapshot users.
+  [kSerializeResolver]() {
+    this._handle = null;  // We'll restore it during deserialization.
+    addDeserializeCallback(function deserializeResolver(resolver) {
+      resolver[kDeserializeResolver]();
+    }, this);
+  }
+
+  [kDeserializeResolver]() {
+    const { timeout, tries, localAddress, servers } = this[kSnapshotStates];
+    this[kInitializeHandle](timeout, tries);
+    if (localAddress) {
+      const { ipv4, ipv6 } = localAddress;
+      this._handle.setLocalAddress(ipv4, ipv6);
+    }
+    if (servers) {
+      this[kSetServersInteral](servers, servers);
+    }
   }
 }
 
@@ -151,6 +206,16 @@ function initializeDns() {
     // Allow the deserialized application to override order from CLI.
     dnsOrder = orderFromCLI;
   }
+
+  if (!isBuildingSnapshot()) {
+    return;
+  }
+
+  addSerializeCallback(() => {
+    if (defaultResolver !== undefined) {
+      defaultResolver[kSerializeResolver]();
+    }
+  });
 }
 
 const resolverKeys = [

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -49,7 +49,7 @@ const supportedModules = new SafeSet(new SafeArrayIterator([
   'crypto',
   // 'dgram',
   'diagnostics_channel',
-  // 'dns',
+  'dns',
   // 'dns/promises',
   // 'domain',
   'events',

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -19,18 +19,19 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "async_wrap-inl.h"
-#include "base_object-inl.h"
-#include "base64-inl.h"
 #include "cares_wrap.h"
+#include "async_wrap-inl.h"
+#include "base64-inl.h"
+#include "base_object-inl.h"
 #include "env-inl.h"
 #include "memory_tracker-inl.h"
 #include "node.h"
 #include "node_errors.h"
+#include "node_external_reference.h"
 #include "req_wrap-inl.h"
 #include "util-inl.h"
-#include "v8.h"
 #include "uv.h"
+#include "v8.h"
 
 #include <cerrno>
 #include <cstring>
@@ -1955,7 +1956,36 @@ void Initialize(Local<Object> target,
   SetConstructorFunction(context, target, "ChannelWrap", channel_wrap);
 }
 
+void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  registry->Register(GetAddrInfo);
+  registry->Register(GetNameInfo);
+  registry->Register(CanonicalizeIP);
+  registry->Register(StrError);
+  registry->Register(ChannelWrap::New);
+
+  registry->Register(Query<QueryAnyWrap>);
+  registry->Register(Query<QueryAWrap>);
+  registry->Register(Query<QueryAaaaWrap>);
+  registry->Register(Query<QueryCaaWrap>);
+  registry->Register(Query<QueryCnameWrap>);
+  registry->Register(Query<QueryMxWrap>);
+  registry->Register(Query<QueryNsWrap>);
+  registry->Register(Query<QueryTxtWrap>);
+  registry->Register(Query<QuerySrvWrap>);
+  registry->Register(Query<QueryPtrWrap>);
+  registry->Register(Query<QueryNaptrWrap>);
+  registry->Register(Query<QuerySoaWrap>);
+  registry->Register(Query<GetHostByAddrWrap>);
+
+  registry->Register(GetServers);
+  registry->Register(SetServers);
+  registry->Register(SetLocalAddress);
+  registry->Register(Cancel);
+}
+
 }  // namespace cares_wrap
 }  // namespace node
 
 NODE_MODULE_CONTEXT_AWARE_INTERNAL(cares_wrap, node::cares_wrap::Initialize)
+NODE_MODULE_EXTERNAL_REFERENCE(cares_wrap,
+                               node::cares_wrap::RegisterExternalReferences)

--- a/src/cares_wrap.h
+++ b/src/cares_wrap.h
@@ -9,8 +9,9 @@
 #include "base_object.h"
 #include "env.h"
 #include "memory_tracker.h"
-#include "util.h"
 #include "node.h"
+#include "node_internals.h"
+#include "util.h"
 
 #include "ares.h"
 #include "v8.h"

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -62,6 +62,7 @@ class ExternalReferenceRegistry {
   V(blob)                                                                      \
   V(buffer)                                                                    \
   V(builtins)                                                                  \
+  V(cares_wrap)                                                                \
   V(contextify)                                                                \
   V(credentials)                                                               \
   V(env_var)                                                                   \

--- a/test/common/snapshot.js
+++ b/test/common/snapshot.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const tmpdir = require('../common/tmpdir');
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const assert = require('assert');
+
+function buildSnapshot(entry, env) {
+  const child = spawnSync(process.execPath, [
+    '--snapshot-blob',
+    path.join(tmpdir.path, 'snapshot.blob'),
+    '--build-snapshot',
+    entry,
+  ], {
+    cwd: tmpdir.path,
+    env: {
+      ...process.env,
+      ...env
+    }
+  });
+
+  const stderr = child.stderr.toString();
+  const stdout = child.stdout.toString();
+  console.log('[stderr]');
+  console.log(stderr);
+  console.log('[stdout]');
+  console.log(stdout);
+
+  assert.strictEqual(child.status, 0);
+
+  const stats = fs.statSync(path.join(tmpdir.path, 'snapshot.blob'));
+  assert(stats.isFile());
+
+  return { child, stderr, stdout };
+}
+
+function runWithSnapshot(entry, env) {
+  const args = ['--snapshot-blob', path.join(tmpdir.path, 'snapshot.blob')];
+  if (entry !== undefined) {
+    args.push(entry);
+  }
+  const child = spawnSync(process.execPath, args, {
+    cwd: tmpdir.path,
+    env: {
+      ...process.env,
+      ...env
+    }
+  });
+
+  const stderr = child.stderr.toString();
+  const stdout = child.stdout.toString();
+  console.log('[stderr]');
+  console.log(stderr);
+  console.log('[stdout]');
+  console.log(stdout);
+
+  assert.strictEqual(child.status, 0);
+
+  return { child, stderr, stdout };
+}
+
+module.exports = {
+  buildSnapshot,
+  runWithSnapshot
+};

--- a/test/common/snapshot.js
+++ b/test/common/snapshot.js
@@ -16,8 +16,8 @@ function buildSnapshot(entry, env) {
     cwd: tmpdir.path,
     env: {
       ...process.env,
-      ...env
-    }
+      ...env,
+    },
   });
 
   const stderr = child.stderr.toString();
@@ -44,7 +44,7 @@ function runWithSnapshot(entry, env) {
     cwd: tmpdir.path,
     env: {
       ...process.env,
-      ...env
+      ...env,
     }
   });
 
@@ -62,5 +62,5 @@ function runWithSnapshot(entry, env) {
 
 module.exports = {
   buildSnapshot,
-  runWithSnapshot
+  runWithSnapshot,
 };

--- a/test/fixtures/snapshot/dns-lookup.js
+++ b/test/fixtures/snapshot/dns-lookup.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 assert(process.env.NODE_TEST_HOST);
 
 const {
-  setDeserializeMainFunction
+  setDeserializeMainFunction,
 } = require('v8').startupSnapshot;
 
 function onError(err) {

--- a/test/fixtures/snapshot/dns-lookup.js
+++ b/test/fixtures/snapshot/dns-lookup.js
@@ -1,0 +1,39 @@
+'use strict';
+const dns = require('dns');
+const assert = require('assert');
+
+assert(process.env.NODE_TEST_HOST);
+
+const {
+  setDeserializeMainFunction
+} = require('v8').startupSnapshot;
+
+function onError(err) {
+  console.error('error:', err);
+}
+
+function onLookup(address, family) {
+  console.log(`address: ${JSON.stringify(address)}`);
+  console.log(`family: ${JSON.stringify(family)}`);
+}
+
+function query() {
+  const host = process.env.NODE_TEST_HOST;
+  if (process.env.NODE_TEST_PROMISE === 'true') {
+    dns.promises.lookup(host, { family: 4 }).then(
+      ({address, family}) => onLookup(address, family),
+      onError);
+  } else {
+    dns.lookup(host, { family: 4 }, (err, address, family) => {
+      if (err) {
+        onError(err);
+      } else {
+        onLookup(address, family);
+      }
+    });
+  }
+}
+
+query();
+
+setDeserializeMainFunction(query);

--- a/test/fixtures/snapshot/dns-resolve.js
+++ b/test/fixtures/snapshot/dns-resolve.js
@@ -1,0 +1,59 @@
+'use strict';
+const dns = require('dns');
+const assert = require('assert');
+
+assert(process.env.NODE_TEST_HOST);
+
+const {
+  setDeserializeMainFunction
+} = require('v8').startupSnapshot;
+
+function onError(err) {
+  console.error('error:', err);
+}
+
+function onResolve(addresses) {
+  console.log(`addresses: ${JSON.stringify(addresses)}`);
+}
+
+function onReverse(hostnames) {
+  console.log(`hostnames: ${JSON.stringify(hostnames)}`);
+}
+
+function query() {
+  if (process.env.NODE_TEST_DNS) {
+    dns.setServers([process.env.NODE_TEST_DNS])
+  }
+
+  const host = process.env.NODE_TEST_HOST;
+  if (process.env.NODE_TEST_PROMISE === 'true') {
+    dns.promises.resolve4(host).then(onResolve, onError);
+  } else {
+    dns.resolve4(host, (err, addresses) => {
+      if (err) {
+        onError(err);
+      } else {
+        onResolve(addresses);
+      }
+    });
+  }
+
+  const ip = process.env.NODE_TEST_IP;
+  if (ip) {
+    if (process.env.NODE_TEST_PROMISE === 'true') {
+      dns.promises.reverse(ip).then(onReverse, onError);
+    } else {
+      dns.reverse(ip, (err, hostnames) => {
+        if (err) {
+          onError(err);
+        } else {
+          onReverse(hostnames);
+        }
+      });
+    }
+  }
+}
+
+query();
+
+setDeserializeMainFunction(query);

--- a/test/fixtures/snapshot/dns-resolve.js
+++ b/test/fixtures/snapshot/dns-resolve.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 assert(process.env.NODE_TEST_HOST);
 
 const {
-  setDeserializeMainFunction
+  setDeserializeMainFunction,
 } = require('v8').startupSnapshot;
 
 function onError(err) {

--- a/test/internet/test-snapshot-dns-lookup.js
+++ b/test/internet/test-snapshot-dns-lookup.js
@@ -8,13 +8,13 @@ const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
 const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
 const {
-  addresses: { INET4_HOST }
+  addresses: { INET4_HOST },
 } = require('../common/internet');
 
 const entry = fixtures.path('snapshot', 'dns-lookup.js');
 const env = {
   NODE_TEST_HOST: INET4_HOST,
-  NODE_TEST_PROMISE: 'false'
+  NODE_TEST_PROMISE: 'false',
 };
 
 tmpdir.refresh();

--- a/test/internet/test-snapshot-dns-lookup.js
+++ b/test/internet/test-snapshot-dns-lookup.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// This tests support for the dns module in snapshot.
+
+require('../common');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
+const {
+  addresses: { INET4_HOST }
+} = require('../common/internet');
+
+const entry = fixtures.path('snapshot', 'dns-lookup.js');
+const env = {
+  NODE_TEST_HOST: INET4_HOST,
+  NODE_TEST_PROMISE: 'false'
+};
+
+tmpdir.refresh();
+function checkOutput(stderr, stdout) {
+  assert(stdout.match(stdout, /address: "\d+\.\d+\.\d+\.\d+"/));
+  assert(stdout.match(stdout, /family: 4/));
+  assert.strictEqual(stdout.trim().split('\n').length, 2);
+}
+{
+  const { stderr, stdout } = buildSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}
+
+{
+  const { stderr, stdout } = runWithSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}

--- a/test/internet/test-snapshot-dns-resolve.js
+++ b/test/internet/test-snapshot-dns-resolve.js
@@ -8,7 +8,7 @@ const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
 const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
 const {
-  addresses: { DNS4_SERVER, INET4_IP, INET4_HOST }
+  addresses: { DNS4_SERVER, INET4_IP, INET4_HOST },
 } = require('../common/internet');
 
 const entry = fixtures.path('snapshot', 'dns-resolve.js');
@@ -16,7 +16,7 @@ const env = {
   NODE_TEST_IP: INET4_IP,
   NODE_TEST_HOST: INET4_HOST,
   NODE_TEST_DNS: DNS4_SERVER,
-  NODE_TEST_PROMISE: 'false'
+  NODE_TEST_PROMISE: 'false',
 };
 
 tmpdir.refresh();

--- a/test/internet/test-snapshot-dns-resolve.js
+++ b/test/internet/test-snapshot-dns-resolve.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// This tests support for the dns module in snapshot.
+
+require('../common');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
+const {
+  addresses: { DNS4_SERVER, INET4_IP, INET4_HOST }
+} = require('../common/internet');
+
+const entry = fixtures.path('snapshot', 'dns-resolve.js');
+const env = {
+  NODE_TEST_IP: INET4_IP,
+  NODE_TEST_HOST: INET4_HOST,
+  NODE_TEST_DNS: DNS4_SERVER,
+  NODE_TEST_PROMISE: 'false'
+};
+
+tmpdir.refresh();
+function checkOutput(stderr, stdout) {
+  assert(stdout.includes('hostnames: ['));
+  assert(stdout.includes('addresses: ['));
+  assert.strictEqual(stdout.trim().split('\n').length, 2);
+}
+{
+  const { stderr, stdout } = buildSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}
+
+{
+  const { stderr, stdout } = runWithSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}

--- a/test/parallel/test-snapshot-dns-lookup-localhost-promise.js
+++ b/test/parallel/test-snapshot-dns-lookup-localhost-promise.js
@@ -11,7 +11,7 @@ const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
 const entry = fixtures.path('snapshot', 'dns-lookup.js');
 const env = {
   NODE_TEST_HOST: 'localhost',
-  NODE_TEST_PROMISE: 'true'
+  NODE_TEST_PROMISE: 'true',
 };
 
 tmpdir.refresh();

--- a/test/parallel/test-snapshot-dns-lookup-localhost-promise.js
+++ b/test/parallel/test-snapshot-dns-lookup-localhost-promise.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// This tests support for the dns module in snapshot.
+
+require('../common');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
+
+const entry = fixtures.path('snapshot', 'dns-lookup.js');
+const env = {
+  NODE_TEST_HOST: 'localhost',
+  NODE_TEST_PROMISE: 'true'
+};
+
+tmpdir.refresh();
+function checkOutput(stderr, stdout) {
+  // We allow failures as it's not always possible to resolve localhost.
+  // Functional tests are done in test/internet instead.
+  if (!stderr.startsWith('error:')) {
+    assert(stdout.match(stdout, /address: "\d+\.\d+\.\d+\.\d+"/));
+    assert(stdout.match(stdout, /family: 4/));
+    assert.strictEqual(stdout.trim().split('\n').length, 2);
+  }
+}
+{
+  const { stderr, stdout } = buildSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}
+
+{
+  const { stderr, stdout } = runWithSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}

--- a/test/parallel/test-snapshot-dns-lookup-localhost.js
+++ b/test/parallel/test-snapshot-dns-lookup-localhost.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// This tests support for the dns module in snapshot.
+
+require('../common');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
+
+const entry = fixtures.path('snapshot', 'dns-lookup.js');
+const env = {
+  NODE_TEST_HOST: 'localhost',
+  NODE_TEST_PROMISE: 'false'
+};
+
+tmpdir.refresh();
+function checkOutput(stderr, stdout) {
+  // We allow failures as it's not always possible to resolve localhost.
+  // Functional tests are done in test/internet instead.
+  if (!stderr.startsWith('error:')) {
+    assert(stdout.match(stdout, /address: "\d+\.\d+\.\d+\.\d+"/));
+    assert(stdout.match(stdout, /family: 4/));
+    assert.strictEqual(stdout.trim().split('\n').length, 2);
+  }
+}
+{
+  const { stderr, stdout } = buildSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}
+
+{
+  const { stderr, stdout } = runWithSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}

--- a/test/parallel/test-snapshot-dns-lookup-localhost.js
+++ b/test/parallel/test-snapshot-dns-lookup-localhost.js
@@ -11,7 +11,7 @@ const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
 const entry = fixtures.path('snapshot', 'dns-lookup.js');
 const env = {
   NODE_TEST_HOST: 'localhost',
-  NODE_TEST_PROMISE: 'false'
+  NODE_TEST_PROMISE: 'false',
 };
 
 tmpdir.refresh();

--- a/test/parallel/test-snapshot-dns-resolve-localhost-promise.js
+++ b/test/parallel/test-snapshot-dns-resolve-localhost-promise.js
@@ -11,7 +11,7 @@ const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
 const entry = fixtures.path('snapshot', 'dns-resolve.js');
 const env = {
   NODE_TEST_HOST: 'localhost',
-  NODE_TEST_PROMISE: 'true'
+  NODE_TEST_PROMISE: 'true',
 };
 
 tmpdir.refresh();

--- a/test/parallel/test-snapshot-dns-resolve-localhost-promise.js
+++ b/test/parallel/test-snapshot-dns-resolve-localhost-promise.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// This tests support for the dns module in snapshot.
+
+require('../common');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
+
+const entry = fixtures.path('snapshot', 'dns-resolve.js');
+const env = {
+  NODE_TEST_HOST: 'localhost',
+  NODE_TEST_PROMISE: 'true'
+};
+
+tmpdir.refresh();
+function checkOutput(stderr, stdout) {
+  // We allow failures as it's not always possible to resolve localhost.
+  // Functional tests are done in test/internet instead.
+  if (!stderr.startsWith('error:')) {
+    assert(stdout.includes('addresses: ['));
+    assert.strictEqual(stdout.trim().split('\n').length, 1);
+  }
+}
+{
+  const { stderr, stdout } = buildSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}
+
+{
+  const { stderr, stdout } = runWithSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}

--- a/test/parallel/test-snapshot-dns-resolve-localhost.js
+++ b/test/parallel/test-snapshot-dns-resolve-localhost.js
@@ -11,7 +11,7 @@ const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
 const entry = fixtures.path('snapshot', 'dns-resolve.js');
 const env = {
   NODE_TEST_HOST: 'localhost',
-  NODE_TEST_PROMISE: 'false'
+  NODE_TEST_PROMISE: 'false',
 };
 
 tmpdir.refresh();

--- a/test/parallel/test-snapshot-dns-resolve-localhost.js
+++ b/test/parallel/test-snapshot-dns-resolve-localhost.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// This tests support for the dns module in snapshot.
+
+require('../common');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { buildSnapshot, runWithSnapshot } = require('../common/snapshot');
+
+const entry = fixtures.path('snapshot', 'dns-resolve.js');
+const env = {
+  NODE_TEST_HOST: 'localhost',
+  NODE_TEST_PROMISE: 'false'
+};
+
+tmpdir.refresh();
+function checkOutput(stderr, stdout) {
+  // We allow failures as it's not always possible to resolve localhost.
+  // Functional tests are done in test/internet instead.
+  if (!stderr.startsWith('error:')) {
+    assert(stdout.includes('addresses: ['));
+    assert.strictEqual(stdout.trim().split('\n').length, 1);
+  }
+}
+{
+  const { stderr, stdout } = buildSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}
+
+{
+  const { stderr, stdout } = runWithSnapshot(entry, env);
+  checkOutput(stderr, stdout);
+}


### PR DESCRIPTION
For the initial iteration, only the default resolver can be serialized/deserialized. If `dns.setServers()` has been called, we'll preserve the configured DNS servers in the snapshot. We can consider exposing the serialization method if it becomes necessary for user-land snapshots.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
