### PR TITLE
dns: remove unnecessary parameter from validateOneOf

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -154,7 +154,7 @@ function lookup(hostname, options, callback) {
   } else if (typeof options === 'number') {
     validateFunction(callback, 'callback');
 
-    validateOneOf(options, 'family', validFamilies, true);
+    validateOneOf(options, 'family', validFamilies);
     family = options;
   } else if (options !== undefined && typeof options !== 'object') {
     validateFunction(arguments.length === 2 ? options : callback, 'callback');
@@ -176,7 +176,7 @@ function lookup(hostname, options, callback) {
           family = 6;
           break;
         default:
-          validateOneOf(options.family, 'options.family', validFamilies, true);
+          validateOneOf(options.family, 'options.family', validFamilies);
           family = options.family;
           break;
       }

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -166,7 +166,7 @@ function lookup(hostname, options) {
   }
 
   if (typeof options === 'number') {
-    validateOneOf(options, 'family', validFamilies, true);
+    validateOneOf(options, 'family', validFamilies);
     family = options;
   } else if (options !== undefined && typeof options !== 'object') {
     throw new ERR_INVALID_ARG_TYPE('options', ['integer', 'object'], options);
@@ -177,7 +177,7 @@ function lookup(hostname, options) {
       validateHints(hints);
     }
     if (options?.family != null) {
-      validateOneOf(options.family, 'options.family', validFamilies, true);
+      validateOneOf(options.family, 'options.family', validFamilies);
       family = options.family;
     }
     if (options?.all != null) {


### PR DESCRIPTION
`validateOneOf` only takes 3 arguments, not 4.