### PR TITLE
test: fix test-performance-measure

### DIFF
--- a/test/parallel/test-performance-measure.js
+++ b/test/parallel/test-performance-measure.js
@@ -5,11 +5,12 @@ const assert = require('assert');
 
 const { PerformanceObserver, performance } = require('perf_hooks');
 const DELAY = 1000;
+const ALLOWED_MARGIN = 10;
 
 const expected = ['Start to Now', 'A to Now', 'A to B'];
 const obs = new PerformanceObserver(common.mustCall((items) => {
   items.getEntries().forEach(({ name, duration }) => {
-    assert.ok(duration > DELAY);
+    assert.ok(duration > (DELAY - ALLOWED_MARGIN));
     assert.strictEqual(expected.shift(), name);
   });
 }));


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/42949

Looking at the documentation for setTimeout
(https://nodejs.org/api/timers.html#settimeoutcallback-delay-args) there is no guarantee that setTimeout won't complete early.

From the failure of https://github.com/nodejs/node/issues/42949 this is likely what happened.

I have updated the assert.ok test to allow some variation in the test.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
