### PR TITLE
doc: deprecate non-string `type` in `fs.symlink()`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3238,6 +3238,22 @@ details.
 These groups might be removed in future versions of Node.js. Applications that
 rely on these groups should evaluate using stronger MODP groups instead.
 
+### DEP0168: Invalid `type` in `fs.symlink()`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/99999
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+`type` is an optional parameter for Windows platforms that can be set to
+`'dir'`, `'file'`, `'junction'`, or `undefined`. Passing any other value in
+[`fs.symlink()`][], [`fs.symlinkSync()`][], and [`fsPromises.symlink()`][]
+is deprecated.
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
@@ -3302,9 +3318,12 @@ rely on these groups should evaluate using stronger MODP groups instead.
 [`fs.read()`]: fs.md#fsreadfd-buffer-offset-length-position-callback
 [`fs.readSync()`]: fs.md#fsreadsyncfd-buffer-offset-length-position
 [`fs.stat()`]: fs.md#fsstatpath-options-callback
+[`fs.symlink()`]: fs.md#fssymlinktarget-path-type-callback
+[`fs.symlinkSync()`]: fs.md#fssymlinksynctarget-path-type
 [`fs.write()`]: fs.md#fswritefd-buffer-offset-length-position-callback
 [`fs.writeFile()`]: fs.md#fswritefilefile-data-options-callback
 [`fs.writeFileSync()`]: fs.md#fswritefilesyncfile-data-options
+[`fsPromises.symlink()`]: fs.md#fspromisessymlinktarget-path-type
 [`http.ClientRequest`]: http.md#class-httpclientrequest
 [`http.IncomingMessage`]: http.md#class-httpincomingmessage
 [`http.ServerResponse`]: http.md#class-httpserverresponse

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3243,7 +3243,7 @@ rely on these groups should evaluate using stronger MODP groups instead.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/99999
+    pr-url: https://github.com/nodejs/node/pull/44641
     description: Documentation-only deprecation.
 -->
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1473,9 +1473,10 @@ added: v10.0.0
 Creates a symbolic link.
 
 The `type` argument is only used on Windows platforms and can be one of `'dir'`,
-`'file'`, or `'junction'`. Windows junction points require the destination path
-to be absolute. When using `'junction'`, the `target` argument will
-automatically be normalized to absolute path.
+`'file'`, or `'junction'`. If the `type` argument is undefined, Node.js will
+autodetect `target` type and use `'file'` or `'dir'`. Windows junction points
+require the destination path to be absolute. When using `'junction'`, the
+`target` argument will automatically be normalized to absolute path.
 
 ### `fsPromises.truncate(path[, len])`
 
@@ -4045,7 +4046,7 @@ See the POSIX symlink(2) documentation for more details.
 
 The `type` argument is only available on Windows and ignored on other platforms.
 It can be set to `'dir'`, `'file'`, or `'junction'`. If the `type` argument is
-not a string, Node.js will autodetect `target` type and use `'file'` or `'dir'`.
+undefined, Node.js will autodetect `target` type and use `'file'` or `'dir'`.
 If the `target` does not exist, `'file'` will be used. Windows junction points
 require the destination path to be absolute. When using `'junction'`, the
 `target` argument will automatically be normalized to absolute path.


### PR DESCRIPTION
Disallows any `type` except for `'dir'`, `'file'`, `'junction'`, or `undefined` in `fs.symlink()`, `fs.symlinkSync()`, and `fsPromises.symlink()`
The implementation would be unconditional validating with `validateOneOf(type, 'type', ['dir', 'file', 'junction', undefined])`, i.e. throwing an error instead of defaulting to autodetection (or instead of ignoring on non-windows platforms).

Refs: https://github.com/nodejs/node/pull/42894#discussion_r966152781

Not sure if it's worth the potential breakage. On a long run, replacing it with an object parameter (for example, `{ type: 'file', force: true, relative: false }`) to allow additional options might make more sense.