### PR TITLE
doc: mention `corepack prepare` supports dist-tag

### DIFF
--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -67,7 +67,8 @@ corepack prepare yarn@x.y.z --activate
 Alternately, a [`dist-tag`][] may be used:
 
 ```bash
-corepack prepare yarn@latest --activate
+corepack prepare pnpm@latest --activate
+corepack prepare yarn@stable --activate
 ```
 
 ### Offline workflow

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -64,6 +64,12 @@ package manager version you wish to set:
 corepack prepare yarn@x.y.z --activate
 ```
 
+Alternately, a [`dist-tag`](https://docs.npmjs.com/downloading-and-installing-packages-locally#installing-a-package-with-dist-tags) may be used:
+
+```bash
+corepack prepare yarn@latest --activate
+```
+
 ### Offline workflow
 
 Many production environments don't have network access. Since Corepack

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -64,7 +64,7 @@ package manager version you wish to set:
 corepack prepare yarn@x.y.z --activate
 ```
 
-Alternately, a [`dist-tag`][] may be used:
+Alternately, a tag or range may be used:
 
 ```bash
 corepack prepare pnpm@latest --activate
@@ -124,7 +124,6 @@ install. To avoid this problem, consider one of the following options:
 [`corepack enable`]: https://github.com/nodejs/corepack#corepack-enable--name
 [`corepack prepare`]: https://github.com/nodejs/corepack#corepack-prepare--nameversion
 [Corepack repository]: https://github.com/nodejs/corepack
-[`dist-tag`]: https://docs.npmjs.com/downloading-and-installing-packages-locally#installing-a-package-with-dist-tags
 [`package.json`]: packages.md#nodejs-packagejson-field-definitions
 [`"packageManager"`]: packages.md#packagemanager
 [pnpm]: https://pnpm.js.org

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -119,15 +119,15 @@ install. To avoid this problem, consider one of the following options:
   [`corepack enable`][] to add them back.)
 
 [Corepack]: https://github.com/nodejs/corepack
-[`corepack disable`]: https://github.com/nodejs/corepack#corepack-disable--name
 [Corepack documentation]: https://github.com/nodejs/corepack#readme
+[Corepack repository]: https://github.com/nodejs/corepack
+[Yarn]: https://yarnpkg.com
+[`"packageManager"`]: packages.md#packagemanager
+[`corepack disable`]: https://github.com/nodejs/corepack#corepack-disable--name
 [`corepack enable`]: https://github.com/nodejs/corepack#corepack-enable--name
 [`corepack prepare`]: https://github.com/nodejs/corepack#corepack-prepare--nameversion
-[Corepack repository]: https://github.com/nodejs/corepack
 [`package.json`]: packages.md#nodejs-packagejson-field-definitions
-[`"packageManager"`]: packages.md#packagemanager
 [pnpm]: https://pnpm.js.org
 [supported binaries]: #supported-package-managers
 [supported package manager]: #supported-package-managers
 [various flags]: https://github.com/nodejs/corepack#utility-commands
-[Yarn]: https://yarnpkg.com

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -64,7 +64,7 @@ package manager version you wish to set:
 corepack prepare yarn@x.y.z --activate
 ```
 
-Alternately, a [`dist-tag`](https://docs.npmjs.com/downloading-and-installing-packages-locally#installing-a-package-with-dist-tags) may be used:
+Alternately, a [`dist-tag`][] may be used:
 
 ```bash
 corepack prepare yarn@latest --activate
@@ -118,15 +118,16 @@ install. To avoid this problem, consider one of the following options:
   [`corepack enable`][] to add them back.)
 
 [Corepack]: https://github.com/nodejs/corepack
-[Corepack documentation]: https://github.com/nodejs/corepack#readme
-[Corepack repository]: https://github.com/nodejs/corepack
-[Yarn]: https://yarnpkg.com
-[`"packageManager"`]: packages.md#packagemanager
 [`corepack disable`]: https://github.com/nodejs/corepack#corepack-disable--name
+[Corepack documentation]: https://github.com/nodejs/corepack#readme
 [`corepack enable`]: https://github.com/nodejs/corepack#corepack-enable--name
 [`corepack prepare`]: https://github.com/nodejs/corepack#corepack-prepare--nameversion
+[Corepack repository]: https://github.com/nodejs/corepack
+[`dist-tag`]: https://docs.npmjs.com/downloading-and-installing-packages-locally#installing-a-package-with-dist-tags
 [`package.json`]: packages.md#nodejs-packagejson-field-definitions
+[`"packageManager"`]: packages.md#packagemanager
 [pnpm]: https://pnpm.js.org
 [supported binaries]: #supported-package-managers
 [supported package manager]: #supported-package-managers
 [various flags]: https://github.com/nodejs/corepack#utility-commands
+[Yarn]: https://yarnpkg.com


### PR DESCRIPTION
`corepack prepare yarn@latest --activate` is a useful alternative to `corepack prepare yarn@x.y.z --activate`, added in [Corepack v0.120](https://github.com/nodejs/corepack/releases/tag/v0.12.0).

Latest pnpm docs ([1](https://pnpm.io/next/installation#using-corepack), [2](https://github.com/pnpm/pnpm.github.io/blob/b0a2107/docs/installation.md?plain=1#L42-L46)) mention this option, seems like Node.js Corepack docs should too!

>With Node.js v16.17 or newer, you may install the `latest` version of pnpm by just specifying the tag:
>
>```
>corepack prepare pnpm@latest --activate
>```

Oh, hmm, [Node.js v18.6.0](https://github.com/nodejs/node/releases/tag/v18.6.0) is the oldest version with corepack >= 0.12.0, is that worth mentioning?

(For v16: [v16.17.0](https://github.com/nodejs/node/releases/tag/v16.17.0) is the oldest version with corepack >= 0.12.0)

I can see this that:
```
<div class="api_metadata">
  <span>Added in: v16.9.0, v14.19.0</span>
</div>
```

is being added with:

```
<!-- YAML
added:
  - v16.9.0
  - v14.19.0
-->
```

Not sure if that can also be used further down to show when `dist-tag` support was added...

Double oh, I thought I was somehow specifically editing the v18 version of the docs, but now I'm not sure how that works. [docs/latest-v16.x/api/corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) & [docs/latest-v18.x/api/corepack](https://nodejs.org/docs/latest-v18.x/api/corepack.html) are identical, and "Options" --> "Edit on GitHub" leads to [the same place](https://github.com/nodejs/node/edit/main/doc/api/corepack.md) for both versions.

Ah, OK, I see:
https://github.com/nodejs/node/blob/v18.x/doc/api/corepack.md
https://github.com/nodejs/node/blob/v16.x/doc/api/corepack.md
https://github.com/nodejs/node/blob/v14.x/doc/api/corepack.md (includes "simply", v18 & v16 do not)

Anyhoo, advice on how best to show when `dist-tag` support was added would be welcome.