### PR TITLE
tools: add update-llhttp.sh

### DIFF
--- a/deps/llhttp/CMakeLists.txt
+++ b/deps/llhttp/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5.1)
 cmake_policy(SET CMP0069 NEW)
 
-project(llhttp VERSION )
+project(llhttp VERSION 6.0.9)
 include(GNUInstallDirs)
 
 set(CMAKE_C_STANDARD 99)

--- a/doc/contributing/maintaining-http.md
+++ b/doc/contributing/maintaining-http.md
@@ -78,12 +78,12 @@ are maintained in the [llhttp](https://github.com/nodejs/llhttp)
 repository. Updates are pulled into Node.js under
 [deps/llhttp](https://github.com/nodejs/node/tree/HEAD/deps/llhttp).
 
-In order to update Node.js with a new version of llhttp you can use the 
+In order to update Node.js with a new version of llhttp you can use the
 `tools/update-llhttp.sh` script.
 
 The contents of the `deps/llhttp` folder should look like the following:
 
-```sh
+```bash
 $ find deps/llhttp
 
 deps/llhttp/
@@ -102,7 +102,7 @@ deps/llhttp/src/llhttp.c
 ```
 
 After updating, make sure the version in `CMakeLists.txt` and `include/llhttp.h`
-are the same and that they match the one you are expecting. 
+are the same and that they match the one you are expecting.
 
 The low-level implementation is made available in the Node.js API through
 JavaScript code in the [lib](https://github.com/nodejs/node/tree/HEAD/lib)

--- a/doc/contributing/maintaining-http.md
+++ b/doc/contributing/maintaining-http.md
@@ -78,31 +78,31 @@ are maintained in the [llhttp](https://github.com/nodejs/llhttp)
 repository. Updates are pulled into Node.js under
 [deps/llhttp](https://github.com/nodejs/node/tree/HEAD/deps/llhttp).
 
-In order to update Node.js with a new version of llhttp:
+In order to update Node.js with a new version of llhttp you can use the 
+`tools/update-llhttp.sh` script.
 
-* check out the tagged release that you want to update to (a release
-  should be created in the llhttp repo before updating Node.js).
-* run `npm install` in the directory that you checked out llhttp.
-* run `make release` in the directory that you checked out llhttp.
-* copy the contents of the `release` directory from the directory you
-  checked llhttp out to
-  [deps/llhttp](https://github.com/nodejs/node/tree/HEAD/deps/llhttp)
+The contents of the `deps/llhttp` folder should look like the following:
 
-It should look like the following:
+```sh
+$ find deps/llhttp
 
-```console
-├── CMakeLists.txt
-├── common.gypi
-├── include
-│   └── llhttp.h
-├── LICENSE-MIT
-├── llhttp.gyp
-├── README.md
-└── src
-    ├── api.c
-    ├── http.c
-    └── llhttp.c
+deps/llhttp/
+deps/llhttp/CMakeLists.txt
+deps/llhttp/include
+deps/llhttp/include/llhttp.h
+deps/llhttp/llhttp.gyp
+deps/llhttp/README.md
+deps/llhttp/common.gypi
+deps/llhttp/libllhttp.pc.in
+deps/llhttp/LICENSE-MIT
+deps/llhttp/src
+deps/llhttp/src/api.c
+deps/llhttp/src/http.c
+deps/llhttp/src/llhttp.c
 ```
+
+After updating, make sure the version in `CMakeLists.txt` and `include/llhttp.h`
+are the same and that they match the one you are expecting. 
 
 The low-level implementation is made available in the Node.js API through
 JavaScript code in the [lib](https://github.com/nodejs/node/tree/HEAD/lib)

--- a/tools/update-llhttp.sh
+++ b/tools/update-llhttp.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-set -euo pipefail
-shopt -s inherit_errexit
+set -e
+
 # Shell script to update llhttp in the source tree to specific version
 
 BASE_DIR="$( pwd )"/

--- a/tools/update-llhttp.sh
+++ b/tools/update-llhttp.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -e
+# Shell script to update nghttp2 in the source treee to specific version
+
+BASE_DIR="$( pwd )"/
+DEPS_DIR="$BASE_DIR"deps/
+LLHTTP_VERSION=$1
+
+if [ "$#" -le 0 ]; then
+  echo "Error: Please provide an llhttp version to update to."
+  echo "Error: To download directly from GitHub, use the organization/repository syntax, without the .git suffix."
+  exit 1
+fi
+
+cleanup () {
+  EXIT_CODE=$?
+  [ -d "$WORKSPACE" ] && rm -rf "$WORKSPACE"
+  exit $EXIT_CODE
+}
+
+echo "Making temporary workspace ..."
+WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
+trap cleanup INT TERM EXIT
+
+cd "$WORKSPACE"
+
+if echo $LLHTTP_VERSION | grep -s "/" > /dev/null; then # Download a release
+  REPO=git@github.com:$LLHTTP_VERSION.git
+  BRANCH=$2
+  [ -z $BRANCH ] && BRANCH=main
+
+  echo "Cloning llhttp source archive $REPO ..."
+  git clone $REPO llhttp
+  cd llhttp
+  echo "Checking out branch $BRANCH ..."
+  git checkout $BRANCH
+
+  echo "Building llhtttp ..."
+  npm install
+  make release
+
+  echo "Copying llhtttp release ..."
+  rm -rf $DEPS_DIR/llhttp
+  cp -a release $DEPS_DIR/llhttp 
+else
+  echo "Download llhttp release $LLHTTP_VERSION ..."
+  curl -sL -o llhttp.tar.gz "https://github.com/nodejs/llhttp/archive/refs/tags/release/v$LLHTTP_VERSION.tar.gz"
+  gzip -dc llhttp.tar.gz | tar xf -
+
+  echo "Copying llhtttp release ..."
+  rm -rf $DEPS_DIR/llhttp
+  cp -a llhttp-release-v$LLHTTP_VERSION $DEPS_DIR/llhttp 
+fi
+
+echo ""
+echo "All done!"
+echo ""
+echo "Please git add llhttp, commit the new version:"
+echo ""
+echo "$ git add -A deps/llhttp"
+echo "$ git commit -m \"deps: update nghttp2 to $LLHTTP_VERSION\""
+echo ""

--- a/tools/update-llhttp.sh
+++ b/tools/update-llhttp.sh
@@ -1,10 +1,11 @@
-#!/bin/sh
-set -e
-# Shell script to update nghttp2 in the source treee to specific version
+#!/bin/bash
+set -euo pipefail
+shopt -s inherit_errexit
+# Shell script to update llhttp in the source tree to specific version
 
 BASE_DIR="$( pwd )"/
-DEPS_DIR="$BASE_DIR"deps/
-LLHTTP_VERSION=$1
+DEPS_DIR="${BASE_DIR}deps/"
+LLHTTP_VERSION="$1"
 
 if [ "$#" -le 0 ]; then
   echo "Error: Please provide an llhttp version to update to."
@@ -24,32 +25,32 @@ trap cleanup INT TERM EXIT
 
 cd "$WORKSPACE"
 
-if echo $LLHTTP_VERSION | grep -s "/" > /dev/null; then # Download a release
-  REPO=git@github.com:$LLHTTP_VERSION.git
+if echo "$LLHTTP_VERSION" | grep -qs "/" ; then # Download a release
+  REPO="git@github.com:$LLHTTP_VERSION.git"
   BRANCH=$2
-  [ -z $BRANCH ] && BRANCH=main
+  [ -z "$BRANCH" ] && BRANCH=main
 
   echo "Cloning llhttp source archive $REPO ..."
-  git clone $REPO llhttp
+  git clone "$REPO" llhttp
   cd llhttp
   echo "Checking out branch $BRANCH ..."
-  git checkout $BRANCH
+  git checkout "$BRANCH"
 
   echo "Building llhtttp ..."
   npm install
   make release
 
   echo "Copying llhtttp release ..."
-  rm -rf $DEPS_DIR/llhttp
-  cp -a release $DEPS_DIR/llhttp 
+  rm -rf "$DEPS_DIR/llhttp"
+  cp -a release "$DEPS_DIR/llhttp"
 else
   echo "Download llhttp release $LLHTTP_VERSION ..."
   curl -sL -o llhttp.tar.gz "https://github.com/nodejs/llhttp/archive/refs/tags/release/v$LLHTTP_VERSION.tar.gz"
   gzip -dc llhttp.tar.gz | tar xf -
 
   echo "Copying llhtttp release ..."
-  rm -rf $DEPS_DIR/llhttp
-  cp -a llhttp-release-v$LLHTTP_VERSION $DEPS_DIR/llhttp 
+  rm -rf "$DEPS_DIR/llhttp"
+  cp -a "llhttp-release-v$LLHTTP_VERSION" "$DEPS_DIR/llhttp"
 fi
 
 echo ""

--- a/tools/update-llhttp.sh
+++ b/tools/update-llhttp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -euo pipefail
 shopt -s inherit_errexit
 # Shell script to update llhttp in the source tree to specific version


### PR DESCRIPTION
I added a tool which allow to update llhttp in more deterministic way.
It works from both releases or from a git repo (for security releases).
If this land, it superseded #44136.