### PR TITLE
lib: don't match `sourceMappingURL` in strings

### DIFF
--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -82,6 +82,8 @@ function setSourceMapsEnabled(val) {
 function extractSourceURLMagicComment(content) {
   let match;
   let matchSourceURL;
+  // A while loop is used here to get the last occurrence of sourceURL.
+  // This is needed so that we don't match sourceURL in string literals.
   while ((match = RegExpPrototypeExec(kSourceURLMagicComment, content))) {
     matchSourceURL = match;
   }
@@ -108,6 +110,8 @@ function maybeCacheSourceMap(filename, content, cjsModuleInstance, isGeneratedSo
 
   let match;
   let lastMatch;
+  // A while loop is used here to get the last occurrence of sourceMappingURL.
+  // This is needed so that we don't match sourceMappingURL in string literals.
   while ((match = RegExpPrototypeExec(kSourceMappingURLMagicComment, content))) {
     lastMatch = match;
   }

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -41,8 +41,8 @@ const esmSourceMapCache = new SafeMap();
 // The generated sources is not mutable, so we can use a Map without memory concerns:
 const generatedSourceMapCache = new SafeMap();
 const kLeadingProtocol = /^\w+:\/\//;
-const kSourceMappingURLMagicComment = /\/[*/]#\s+sourceMappingURL=(?<sourceMappingURL>[^\s]+)/;
-const kSourceURLMagicComment = /\/[*/]#\s+sourceURL=(?<sourceURL>[^\s]+)/;
+const kSourceMappingURLMagicComment = /\/[*/]#\s+sourceMappingURL=(?<sourceMappingURL>[^\s]+)/g;
+const kSourceURLMagicComment = /\/[*/]#\s+sourceURL=(?<sourceURL>[^\s]+)/g;
 
 const { fileURLToPath, pathToFileURL, URL } = require('internal/url');
 let SourceMap;
@@ -80,11 +80,12 @@ function setSourceMapsEnabled(val) {
 }
 
 function extractSourceURLMagicComment(content) {
-  const matchSourceURL = RegExpPrototypeExec(
-    kSourceURLMagicComment,
-    content
-  );
-  if (matchSourceURL === null) {
+  let match;
+  let matchSourceURL;
+  while ((match = RegExpPrototypeExec(kSourceURLMagicComment, content))) {
+    matchSourceURL = match;
+  }
+  if (matchSourceURL == null) {
     return null;
   }
   let sourceURL = matchSourceURL.groups.sourceURL;
@@ -104,13 +105,19 @@ function maybeCacheSourceMap(filename, content, cjsModuleInstance, isGeneratedSo
     debug(err);
     return;
   }
-  const match = RegExpPrototypeExec(kSourceMappingURLMagicComment, content);
+
+  let match;
+  let lastMatch;
+  while ((match = RegExpPrototypeExec(kSourceMappingURLMagicComment, content))) {
+    lastMatch = match;
+  }
+
   if (sourceURL === undefined) {
     sourceURL = extractSourceURLMagicComment(content);
   }
-  if (match) {
-    const data = dataFromUrl(filename, match.groups.sourceMappingURL);
-    const url = data ? null : match.groups.sourceMappingURL;
+  if (lastMatch) {
+    const data = dataFromUrl(filename, lastMatch.groups.sourceMappingURL);
+    const url = data ? null : lastMatch.groups.sourceMappingURL;
     if (cjsModuleInstance) {
       cjsSourceMapCache.set(cjsModuleInstance, {
         filename,

--- a/test/fixtures/source-map/typescript-sourcemapping_url_string.js
+++ b/test/fixtures/source-map/typescript-sourcemapping_url_string.js
@@ -1,0 +1,4 @@
+"use strict";
+const content = '//# sourceMappingURL=';
+throw new Error('an exception.');
+//# sourceMappingURL=typescript-sourcemapping_url_string.js.map

--- a/test/fixtures/source-map/typescript-sourcemapping_url_string.js.map
+++ b/test/fixtures/source-map/typescript-sourcemapping_url_string.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"typescript-sourcemapping_url_string.js","sourceRoot":"","sources":["typescript-sourcemapping_url_string.ts"],"names":[],"mappings":";AAAA,MAAM,OAAO,GAAG,uBAAuB,CAAC;AAExC,MAAM,IAAI,KAAK,CAAC,eAAe,CAAC,CAAC"}

--- a/test/message/source_map_sourcemapping_url_string.js
+++ b/test/message/source_map_sourcemapping_url_string.js
@@ -1,0 +1,13 @@
+// Flags:  --enable-source-maps
+
+'use strict';
+require('../common');
+Error.stackTraceLimit = 2;
+
+try {
+  require('../fixtures/source-map/typescript-sourcemapping_url_string');
+} catch (err) {
+  setTimeout(() => {
+    console.info(err);
+  }, 10);
+}

--- a/test/message/source_map_sourcemapping_url_string.out
+++ b/test/message/source_map_sourcemapping_url_string.out
@@ -1,3 +1,3 @@
 Error: an exception.
     at *typescript-sourcemapping_url_string.ts:3:7*
-    at Module._compile (node:internal/modules/cjs/loader:1129:14)
+    at Module._compile (node:internal/modules/cjs/loader:*)

--- a/test/message/source_map_sourcemapping_url_string.out
+++ b/test/message/source_map_sourcemapping_url_string.out
@@ -1,0 +1,3 @@
+Error: an exception.
+    at *typescript-sourcemapping_url_string.ts:3:7*
+    at Module._compile (node:internal/modules/cjs/loader:1129:14)


### PR DESCRIPTION
Prior to this change `sourceMappingURL` in string where being matched by the RegExp which caused sourcemaps not be loaded when using the `--enable-source-maps` flag. This commit changes the RegExp to match the last occurrence.

Fixes: https://github.com/nodejs/node/issues/44654

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
