### PR TITLE
doc: make legacy banner slightly less bright

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -4,7 +4,7 @@
   --black1: #090c15;
   --black2: #2c3437;
   --black3: #0d111d;
-  --blue1: #00f;
+  --blue1: #0a56b2;
   --white: #ffffff;
   --white-smoke: #f2f2f2;
   --grey-smoke: #e9edf0;


### PR DESCRIPTION
It's a bit harsh right now. I confirmed that this change still passes WCAG AAA requirements for color contrast.

Before:

![image](https://user-images.githubusercontent.com/718899/190516030-c1cdf8df-725c-400f-843c-763ce4c81bbe.png)

After:

![image](https://user-images.githubusercontent.com/718899/190516080-410cc335-155d-41a2-88ce-1a13ffc50061.png)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
