### PR TITLE
lib: add cause to DOMException

### DIFF
--- a/lib/internal/per_context/domexception.js
+++ b/lib/internal/per_context/domexception.js
@@ -49,12 +49,31 @@ const disusedNamesSet = new SafeSet()
   .add('ValidationError');
 
 class DOMException {
-  constructor(message = '', name = 'Error') {
+  constructor(message = '', options = 'Error') {
     ErrorCaptureStackTrace(this);
-    internalsMap.set(this, {
-      message: `${message}`,
-      name: `${name}`
-    });
+
+    if (options && typeof options === 'object') {
+      const { name } = options;
+      internalsMap.set(this, {
+        message: `${message}`,
+        name: `${name}`
+      });
+
+      if ('cause' in options) {
+        ObjectDefineProperty(this, 'cause', {
+          __proto__: null,
+          value: options.cause,
+          configurable: true,
+          writable: true,
+          enumerable: false,
+        });
+      }
+    } else {
+      internalsMap.set(this, {
+        message: `${message}`,
+        name: `${options}`
+      });
+    }
   }
 
   get name() {

--- a/test/parallel/test-domexception-cause.js
+++ b/test/parallel/test-domexception-cause.js
@@ -1,0 +1,33 @@
+'use strict';
+
+require('../common');
+const { strictEqual, deepStrictEqual } = require('assert');
+
+{
+  const domException = new DOMException('no cause', 'abc');
+  strictEqual(domException.name, 'abc');
+  strictEqual('cause' in domException, false);
+  strictEqual(domException.cause, undefined);
+}
+
+{
+  const domException = new DOMException('with undefined cause', { name: 'abc', cause: undefined });
+  strictEqual(domException.name, 'abc');
+  strictEqual('cause' in domException, true);
+  strictEqual(domException.cause, undefined);
+}
+
+{
+  const domException = new DOMException('with string cause', { name: 'abc', cause: 'foo' });
+  strictEqual(domException.name, 'abc');
+  strictEqual('cause' in domException, true);
+  strictEqual(domException.cause, 'foo');
+}
+
+{
+  const object = { reason: 'foo' };
+  const domException = new DOMException('with object cause', { name: 'abc', cause: object });
+  strictEqual(domException.name, 'abc');
+  strictEqual('cause' in domException, true);
+  deepStrictEqual(domException.cause, object);
+}


### PR DESCRIPTION
Adds an optional `cause` field to DOMException as per the WebIDL standard added in [https://github.com/whatwg/webidl/pull/1179](https://github.com/whatwg/webidl/pull/1179)

@jasnell @panva 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
