### PR TITLE
test: loosen test for negative timestamps in `test-fs-stat-date`

### DIFF
--- a/test/parallel/test-fs-stat-date.mjs
+++ b/test/parallel/test-fs-stat-date.mjs
@@ -31,6 +31,14 @@ function closeEnough(actual, expected, margin) {
   if (process.arch === 'ppc64') {
     margin += 1000;
   }
+
+  // Filesystems without support for timestamps before 1970-01-01, such as NFSv3,
+  // should return 0 for negative numbers. Do not treat it as error.
+  if (actual === 0 && expected < 0) {
+    console.log(`ignored 0 while expecting ${expected}`);
+    return;
+  }
+
   assert.ok(Math.abs(Number(actual - expected)) < margin,
             `expected ${expected} ± ${margin}, got ${actual}`);
 }


### PR DESCRIPTION
One more attempt to make test from https://github.com/nodejs/node/pull/43714 pass on `v16.x-staging` and avoid similar test failures on `main` in the future.

If filesystem doesn't support negative timestamps and `stat` returns `0`, print a warning and proceed.

cc @targos 

