### PR TITLE
doc, esm: correct default calls in loader examples

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1034,7 +1034,7 @@ export function resolve(specifier, context, nextResolve) {
   }
 
   // Let Node.js handle all other specifiers.
-  return nextResolve(specifier);
+  return nextResolve(specifier, context);
 }
 
 export function load(url, context, nextLoad) {
@@ -1057,7 +1057,7 @@ export function load(url, context, nextLoad) {
   }
 
   // Let Node.js handle all other URLs.
-  return nextLoad(url);
+  return nextLoad(url, context);
 }
 ```
 
@@ -1110,7 +1110,7 @@ export async function resolve(specifier, context, nextResolve) {
   }
 
   // Let Node.js handle all other specifiers.
-  return nextResolve(specifier);
+  return nextResolve(specifier, context);
 }
 
 export async function load(url, context, nextLoad) {
@@ -1151,7 +1151,7 @@ export async function load(url, context, nextLoad) {
   }
 
   // Let Node.js handle all other URLs.
-  return nextLoad(url);
+  return nextLoad(url, context);
 }
 
 async function getPackageType(url) {


### PR DESCRIPTION
The default ESM functions `load` and `resolve` does require the context parameter, see:
- `defaultLoad` https://github.com/nodejs/node/blob/v18.9.0/lib/internal/modules/esm/load.js#L72-L100
- `defaultResolve` https://github.com/nodejs/node/blob/v18.9.0/lib/internal/modules/esm/resolve.js#L984

> I found this because of nested dependency loading when I'm writing a custom loader, so I think we need to fix it in the document so other users don't have the same problem :)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
