### PR TITLE
doc: deprecate coercion to integer in `process.exitCode`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3238,6 +3238,21 @@ details.
 These groups might be removed in future versions of Node.js. Applications that
 rely on these groups should evaluate using stronger MODP groups instead.
 
+### DEP0168: `process.exitCode` coercion to integer
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/44712
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+Similarly to the deprecation, DEP0164, setting `exitCode` values other than
+`undefined`, `null`, integer numbers and integer strings (e.g., '1') are
+deprecated.
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3


### PR DESCRIPTION
This warns of invalid uses of `process.exitCode` (such as mentioned in https://github.com/nodejs/node/pull/43716#issuecomment-1242824575).


In a quick search for `process.exitCode` below, I can't find invalid uses. 
However, I open this PR since it may need the doc-only deprecation first instead of throwing a validation error.

- [process.exitCode = ](https://cs.github.com/?scopeName=All+repos&scope=&q=%22process.exitCode+%3D+%22+language%3AJavaScript)
- [process.exitCode = undefined](https://cs.github.com/?scopeName=All+repos&scope=&q=%22process.exitCode+%3D+undefined%22+language%3AJavaScript)
  - The [doc](https://nodejs.org/dist/latest-v18.x/docs/api/process.html#processexitcode_1) says that the type of `process.exitCode` is `integer`, but it should be `integer|undefined`. Its default value is `undefined`.

Refs: https://github.com/nodejs/node/pull/43716
Refs: https://github.com/nodejs/node/pull/43738

Signed-off-by: Daeyeon Jeong daeyeon.dev@gmail.com

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
