### PR TITLE
meta: add mailmap entry for dnlup

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -137,6 +137,7 @@ David Mark Clements <david.clements@nearform.com> <huperekchuno@googlemail.com>
 David Siegel <david@artcom.de> <david.siegel@artcom.de>
 DC <dcposch@dcpos.ch>
 Deepjyoti Mondal <djmdeveloper060796@gmail.com>
+dnlup <dnlup.dev@gmail.com> <dwon.dnl@gmail.com>
 Domenic Denicola <domenic@domenicdenicola.com>
 Domenic Denicola <domenic@domenicdenicola.com> <d@domenic.me>
 Doug Wade <doug@dougwade.io> <doug.wade@redfin.com>
@@ -200,7 +201,6 @@ Hannes Magnusson <hannes.magnusson@gmail.com> <hannes.magnusson@creditkarma.com>
 Hassaan Pasha <pasha.hassaan@gmail.com> <hassaan.pasha@teamo.io>
 Hendrik Schwalm <mail@hendrikschwalm.de>
 Henry Chin <hheennrryy@gmail.com>
-Nick Sia <nicholas.sia@vgw.co> <31839263+nicksia-vgw@users.noreply.github.com>
 Herbert Vojčík <herby@mailbox.sk>
 Hitesh Kanwathirtha <hiteshk@microsoft.com> <digitalinfinity@gmail.com>
 Icer Liang <liangshuangde@163.com> <wizicer@users.noreply.github.com>
@@ -374,6 +374,7 @@ Nam Nguyen <nam.nguyen@de.ibm.com>
 Nebu Pookins <nebu@nebupookins.net>
 Netto Farah <nettofarah@gmail.com>
 Nicholas Kinsey <pyrotechnick@feistystudios.com>
+Nick Sia <nicholas.sia@vgw.co> <31839263+nicksia-vgw@users.noreply.github.com>
 Nick Soggin <nicksoggin@gmail.com> <iSkore@users.noreply.github.com>
 Nigel Kibodeaux <nigelmail@gmail.com> <nigel@team.about.me>
 Nikola Glavina <glavina.nikola5@gmail.com> <nikola.glavina@student.um.si>

--- a/AUTHORS
+++ b/AUTHORS
@@ -2694,7 +2694,7 @@ Yann Hamon <yann.hamon@contentful.com>
 Ben Swinburne <ben.swinburne@gmail.com>
 Colin Prince <col@colinprince.com>
 TJKoury <TJKoury@gmail.com>
-dnlup <dwon.dnl@gmail.com>
+dnlup <dnlup.dev@gmail.com>
 Hang Jiang <jianghangscu@gmail.com>
 Vladislav Kaminsky <wlodzislav@outlook.com>
 Daiki Ihara <sasurau4@gmail.com>


### PR DESCRIPTION
This updates dnlup's name to their preferred email per their last pull request.

This will also prevent duplicate entries for dnlup when the update-authors job runs.

It also moves one unrelated line in .mailmap so that all lines are sorted in lexical order.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
