### PR TITLE
doc,crypto: update webcrypto docs for global access

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -371,7 +371,7 @@ implementation and the APIs supported for each:
 added: v15.0.0
 -->
 
-`globalThis.crypto` returns an instance of the `Crypto`
+`globalThis.crypto` is an instance of the `Crypto`
 class. `Crypto` is a singleton that provides access to the remainder of the
 crypto API.
 

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -39,7 +39,8 @@ changes:
 
 Node.js provides an implementation of the standard [Web Crypto API][].
 
-Use `globalThis.crypto` to access this module.
+Use `globalThis.crypto` or `require('node:crypto').webcrypto` to access this
+module.
 
 ```js
 const { subtle } = globalThis.crypto;

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -39,10 +39,10 @@ changes:
 
 Node.js provides an implementation of the standard [Web Crypto API][].
 
-Use `require('node:crypto').webcrypto` to access this module.
+Use `globalThis.crypto` to access this module.
 
 ```js
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 (async function() {
 
@@ -72,7 +72,7 @@ or asymmetric key pairs (public key and private key).
 #### AES keys
 
 ```js
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 async function generateAesKey(length = 256) {
   const key = await subtle.generateKey({
@@ -87,7 +87,7 @@ async function generateAesKey(length = 256) {
 #### ECDSA key pairs
 
 ```js
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 async function generateEcKey(namedCurve = 'P-521') {
   const {
@@ -107,7 +107,7 @@ async function generateEcKey(namedCurve = 'P-521') {
 > Stability: 1 - Experimental
 
 ```js
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 async function generateEd25519Key() {
   return subtle.generateKey({
@@ -125,7 +125,7 @@ async function generateX25519Key() {
 #### HMAC keys
 
 ```js
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 async function generateHmacKey(hash = 'SHA-256') {
   const key = await subtle.generateKey({
@@ -140,7 +140,7 @@ async function generateHmacKey(hash = 'SHA-256') {
 #### RSA key pairs
 
 ```js
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 const publicExponent = new Uint8Array([1, 0, 1]);
 
 async function generateRsaKey(modulusLength = 2048, hash = 'SHA-256') {
@@ -161,7 +161,7 @@ async function generateRsaKey(modulusLength = 2048, hash = 'SHA-256') {
 ### Encryption and decryption
 
 ```js
-const crypto = require('node:crypto').webcrypto;
+const crypto = globalThis.crypto;
 
 async function aesEncrypt(plaintext) {
   const ec = new TextEncoder();
@@ -194,7 +194,7 @@ async function aesDecrypt(ciphertext, key, iv) {
 ### Exporting and importing keys
 
 ```js
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 async function generateAndExportHmacKey(format = 'jwk', hash = 'SHA-512') {
   const key = await subtle.generateKey({
@@ -218,7 +218,7 @@ async function importHmacKey(keyData, format = 'jwk', hash = 'SHA-512') {
 ### Wrapping and unwrapping keys
 
 ```js
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 async function generateAndWrapHmacKey(format = 'jwk', hash = 'SHA-512') {
   const [
@@ -261,7 +261,7 @@ async function unwrapHmacKey(
 ### Sign and verify
 
 ```js
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 async function sign(key, data) {
   const ec = new TextEncoder();
@@ -285,7 +285,7 @@ async function verify(key, signature, data) {
 ### Deriving bits and keys
 
 ```js
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 async function pbkdf2(pass, salt, iterations = 1000, length = 256) {
   const ec = new TextEncoder();
@@ -328,7 +328,7 @@ async function pbkdf2Key(pass, salt, iterations = 1000, length = 256) {
 ### Digest
 
 ```js
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 async function digest(data, algorithm = 'SHA-512') {
   const ec = new TextEncoder();
@@ -371,7 +371,7 @@ implementation and the APIs supported for each:
 added: v15.0.0
 -->
 
-Calling `require('node:crypto').webcrypto` returns an instance of the `Crypto`
+`globalThis.crypto` returns an instance of the `Crypto`
 class. `Crypto` is a singleton that provides access to the remainder of the
 crypto API.
 


### PR DESCRIPTION
Follow up to https://github.com/nodejs/node/labels/semver-major #42083 this updates the docs to reflect the standard global access to the module and its APIs.