### PR TITLE
test: fix addon tests compilation with OpenSSL 1.1.1

### DIFF
--- a/test/addons/openssl-providers/binding.cc
+++ b/test/addons/openssl-providers/binding.cc
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <node.h>
 
+#include <openssl/opensslv.h>
 #if OPENSSL_VERSION_MAJOR >= 3
 #include <openssl/provider.h>
 #endif

--- a/test/addons/openssl-providers/binding.cc
+++ b/test/addons/openssl-providers/binding.cc
@@ -1,6 +1,9 @@
 #include <assert.h>
 #include <node.h>
+
+#if OPENSSL_VERSION_MAJOR >= 3
 #include <openssl/provider.h>
+#endif
 
 namespace {
 


### PR DESCRIPTION
openssl/provider.h header is not part of OpenSSL 1.1.1 so do not include it when building with an older instance.

Fixes: https://github.com/nodejs/node/issues/44722

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
