### PR TITLE
benchmark: fix startup benchmark

### DIFF
--- a/benchmark/fixtures/require-cachable.js
+++ b/benchmark/fixtures/require-cachable.js
@@ -2,8 +2,8 @@
 
 const { internalBinding } = require('internal/test/binding');
 const {
-  moduleCategories: { canBeRequired }
-} = internalBinding('native_module');
+  builtinCategories: { canBeRequired }
+} = internalBinding('builtins');
 
 for (const key of canBeRequired) {
   require(`node:${key}`);


### PR DESCRIPTION
This allows the misc/startup benchmark to run again
after the renaming of the C++ `native_module` to `builtins`

Refs: https://github.com/nodejs/node/pull/44135