### PR TITLE
worker: inherits mutated NODE_OPTIONS

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -189,7 +189,7 @@ class Worker extends EventEmitter {
 
     // Set up the C++ handle for the worker, as well as some internal wiring.
     this[kHandle] = new WorkerImpl(url,
-                                   env,
+                                   env === process.env ? null : env,
                                    options.execArgv,
                                    parseResourceLimits(options.resourceLimits),
                                    !!(options.trackUnmanagedFds ?? true));

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -189,7 +189,7 @@ class Worker extends EventEmitter {
 
     // Set up the C++ handle for the worker, as well as some internal wiring.
     this[kHandle] = new WorkerImpl(url,
-                                   env === process.env ? null : env,
+                                   env,
                                    options.execArgv,
                                    parseResourceLimits(options.resourceLimits),
                                    !!(options.trackUnmanagedFds ?? true));

--- a/test/fixtures/assert-global.js
+++ b/test/fixtures/assert-global.js
@@ -1,0 +1,3 @@
+'use strict';
+const assert = require('assert');
+assert.strictEqual(global.a, 'test');

--- a/test/parallel/test-worker-process-env-options.js
+++ b/test/parallel/test-worker-process-env-options.js
@@ -1,10 +1,11 @@
 'use strict';
+require('../common');
 const { Worker } = require('node:worker_threads');
 
 if (!require.main) {
   globalThis.setup = true;
 } else {
-  process.env.NODE_OPTIONS ??= ``;
+  process.env.NODE_OPTIONS ??= '';
   process.env.NODE_OPTIONS += ` --require ${JSON.stringify(__filename)}`;
 
   new Worker(`

--- a/test/parallel/test-worker-process-env-options.js
+++ b/test/parallel/test-worker-process-env-options.js
@@ -1,0 +1,14 @@
+'use strict';
+const { Worker } = require('node:worker_threads');
+
+if (!require.main) {
+  globalThis.setup = true;
+} else {
+  process.env.NODE_OPTIONS ??= ``;
+  process.env.NODE_OPTIONS += ` --require ${JSON.stringify(__filename)}`;
+
+  new Worker(`
+    const assert = require('assert');
+    assert.strictEqual(globalThis.setup, true);
+  `, { eval: true });
+}

--- a/test/parallel/test-worker-process-env-options.js
+++ b/test/parallel/test-worker-process-env-options.js
@@ -1,15 +1,11 @@
 'use strict';
+
 require('../common');
+
+const fixtures = require('../common/fixtures');
 const { Worker } = require('node:worker_threads');
 
-if (!require.main) {
-  globalThis.setup = true;
-} else {
-  process.env.NODE_OPTIONS ??= '';
-  process.env.NODE_OPTIONS += ` --require ${JSON.stringify(__filename)}`;
+process.env.NODE_OPTIONS ??= '';
+process.env.NODE_OPTIONS += ` --require ${JSON.stringify(fixtures.path('define-global.js'))}`;
 
-  new Worker(`
-    const assert = require('assert');
-    assert.strictEqual(globalThis.setup, true);
-  `, { eval: true });
-}
+new Worker(fixtures.path('assert-global.js'));


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Changes made to the NODE_OPTIONS environment variables weren't properly taken into account when spawning workers, unlike how `child_process.fork` works.

Fixes part of https://github.com/nodejs/node/issues/37410 (I didn't touch the `process.execArgv` part, I was worried it'd be a breaking change otherwise).
