### PR TITLE
doc,crypto: cleanup removed pbkdf2 behaviours

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -4392,9 +4392,6 @@ otherwise `err` will be `null`. By default, the successfully generated
 `derivedKey` will be passed to the callback as a [`Buffer`][]. An error will be
 thrown if any of the input arguments specify invalid values or types.
 
-If `digest` is `null`, `'sha1'` will be used. This behavior is deprecated,
-please specify a `digest` explicitly.
-
 The `iterations` argument must be a number set as high as possible. The
 higher the number of iterations, the more secure the derived key will be,
 but will take a longer amount of time to complete.
@@ -4489,9 +4486,6 @@ applied to derive a key of the requested byte length (`keylen`) from the
 
 If an error occurs an `Error` will be thrown, otherwise the derived key will be
 returned as a [`Buffer`][].
-
-If `digest` is `null`, `'sha1'` will be used. This behavior is deprecated,
-please specify a `digest` explicitly.
 
 The `iterations` argument must be a number set as high as possible. The
 higher the number of iterations, the more secure the derived key will be,


### PR DESCRIPTION
Refs https://nodejs.org/api/deprecations.html#DEP0009, #11305, #31166.

```
> crypto.pbkdf2('f', 'f', 1, 20, null, console.log)
Uncaught:
TypeError [ERR_INVALID_ARG_TYPE]: The "digest" argument must be of type string. Received null
    at __node_internal_captureLargerStackTrace (node:internal/errors:477:5)
    at new NodeError (node:internal/errors:387:5)
    at validateString (node:internal/validators:121:11)
    at check (node:internal/crypto/pbkdf2:90:3)
    at Object.pbkdf2 (node:internal/crypto/pbkdf2:43:5) {
  code: 'ERR_INVALID_ARG_TYPE'
}
> crypto.pbkdf2('f', 'f', 1, 20, undefined, console.log)
Uncaught:
TypeError [ERR_INVALID_ARG_TYPE]: The "digest" argument must be of type string. Received undefined
    at __node_internal_captureLargerStackTrace (node:internal/errors:477:5)
    at new NodeError (node:internal/errors:387:5)
    at validateString (node:internal/validators:121:11)
    at check (node:internal/crypto/pbkdf2:90:3)
    at Object.pbkdf2 (node:internal/crypto/pbkdf2:43:5) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```