### PR TITLE
test: fix watch mode test flake

### DIFF
--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -94,8 +94,10 @@ describe('watch mode', { concurrency: true, timeout: 60_0000 }, () => {
     const file = fixtures.path('watch-mode/failing.js');
     const { stderr, stdout } = await spawnWithRestarts({ file });
 
+    // Use match first to pretty print diff on failure
     assert.match(stderr, /Error: fails\r?\n/);
-    assert.strictEqual(stderr.match(/Error: fails\r?\n/g).length, 2);
+    // Test that failures happen once per restart
+    assert(stderr.match(/Error: fails\r?\n/g).length >= 2);
     assertRestartedCorrectly({
       stdout,
       messages: { completed: `Failed running ${inspect(file)}`, restarted: `Restarting ${inspect(file)}` },


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/44735

after the previous fix, `spawnWithRestarts` restarts a minimal amount of restarts but continues updating watched file until the test complets 