### PR TITLE
src,worker: fix race of WorkerHeapSnapshotTaker

### DIFF
--- a/src/base_object.h
+++ b/src/base_object.h
@@ -241,7 +241,9 @@ inline T* Unwrap(v8::Local<v8::Value> obj) {
 // circumstances such as the GC or Environment cleanup.
 // If weak, destruction behaviour is not affected, but the pointer will be
 // reset to nullptr once the BaseObject is destroyed.
-// The API matches std::shared_ptr closely.
+// The API matches std::shared_ptr closely. However, this class is not thread
+// safe, that is, we can't have different BaseObjectPtrImpl instances in
+// different threads refering to the same BaseObject instance.
 template <typename T, bool kIsWeak>
 class BaseObjectPtrImpl final {
  public:


### PR DESCRIPTION
Fix: https://github.com/nodejs/node/issues/44515 https://github.com/nodejs/node/issues/39686
maybe more... there are serval crash reports about `worker heap snapshot`

With one extra line of code, this concurency bug can be easily demonstrated and reproduced.
Since `BaseObjectPtr` is not thread safe(no synchronization around checking and manipulating the refcnt), the fix is to ensure `WorkerHeapSnapshotTaker` is not shared by worker thread and main thread

```diff
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -771,28 +771,45 @@ void Worker::TakeHeapSnapshot(const FunctionCallbackInfo<Value>& args) {
       ->NewInstance(env->context()).ToLocal(&wrap)) {
     return;
   }
   BaseObjectPtr<WorkerHeapSnapshotTaker> taker =
       MakeDetachedBaseObject<WorkerHeapSnapshotTaker>(env, wrap);
 
   // Interrupt the worker thread and take a snapshot, then schedule a call
   // on the parent thread that turns that snapshot into a readable stream.
   bool scheduled = w->RequestInterrupt([taker, env](Environment* worker_env) {
+     // executed in worker thread
+    // now worker thread holds one strong BaseObjectPtr

      heap::HeapSnapshotPointer snapshot {
         worker_env->isolate()->GetHeapProfiler()->TakeHeapSnapshot() };
      CHECK(snapshot);
      env->SetImmediateThreadsafe(
+        // executed in main thread
+       // now main thread holds another strong BaseObjectPtr

         [taker, snapshot = std::move(snapshot)](Environment* env) mutable {
           HandleScope handle_scope(env->isolate());
           Context::Scope context_scope(env->context());
 
           AsyncHooks::DefaultTriggerAsyncIdScope trigger_id_scope(taker.get());
           BaseObjectPtr<AsyncWrap> stream = heap::CreateHeapSnapshotStream(
               env, std::move(snapshot));
           Local<Value> args[] = { stream->object() };
           taker->MakeCallback(env->ondone_string(), arraysize(args), args);
         }, CallbackFlags::kUnrefed);
+      
+    // wait for the main thread to finish executing the callback above
+    // remember to include <thread> and <chrono> in the head of this file
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    
+    // now the worker thread holds the only one strong BaseObjectPtr refering to the
+    // WorkerHeapSnapshotTaker instance and it is destructed here, as a result, that
+    // WorkerHeapSnapshotTaker instance is destructed here, too.
+    // The destructor try to access the associated JS object, however, since that JS object 
+    // is owned by main thread's Isolate, the v8 complains:
+    // HandleScope::HandleScope Entering the V8 API without proper locking in place
   });
   args.GetReturnValue().Set(scheduled ? taker->object() : Local<Object>());
 }
 
 void Worker::LoopIdleTime(const FunctionCallbackInfo<Value>& args) {
```
