### PR TITLE
fs: don't hard code name in validatePosition()

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -884,17 +884,15 @@ const validateStringAfterArrayBufferView = hideStackFrames((buffer, name) => {
 
 const validatePosition = hideStackFrames((position, name) => {
   if (typeof position === 'number') {
-    validateInteger(position, 'position');
+    validateInteger(position, name);
   } else if (typeof position === 'bigint') {
     if (!(position >= -(2n ** 63n) && position <= 2n ** 63n - 1n)) {
-      throw new ERR_OUT_OF_RANGE('position',
+      throw new ERR_OUT_OF_RANGE(name,
                                  `>= ${-(2n ** 63n)} && <= ${2n ** 63n - 1n}`,
                                  position);
     }
   } else {
-    throw new ERR_INVALID_ARG_TYPE('position',
-                                   ['integer', 'bigint'],
-                                   position);
+    throw new ERR_INVALID_ARG_TYPE(name, ['integer', 'bigint'], position);
   }
 });
 


### PR DESCRIPTION
The name of the position being validated by `validatePosition()` was not being used. Instead, the string `'position'` was being used everywhere. It worked out because the only call sites were using the name `'position'` as well.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
