### PR TITLE
fs(read(fd[, options], callback)): throw `ERR_INVALID_ARG_TYPE` when `options.buffer` is `null`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -619,7 +619,6 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
         // This is fs.read(fd, params, callback)
         params = buffer;
         ({ buffer = Buffer.alloc(16384) } = params ?? kEmptyObject);
-        validateBuffer(buffer);
       }
       callback = offsetOrOptions;
     } else {
@@ -633,7 +632,7 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
     }
     ({
       offset = 0,
-      length = buffer.byteLength - offset,
+      length = buffer?.byteLength - offset,
       position = null,
     } = params ?? kEmptyObject);
   }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -619,6 +619,7 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
         // This is fs.read(fd, params, callback)
         params = buffer;
         ({ buffer = Buffer.alloc(16384) } = params ?? kEmptyObject);
+        validateBuffer(buffer);
       }
       callback = offsetOrOptions;
     } else {

--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -79,7 +79,11 @@ assert.throws(
 
 assert.throws(
   () => fs.read(fd, { buffer: null }, common.mustNotCall()),
-  /TypeError: Cannot read properties of null \(reading 'byteLength'\)/,
+  {
+    name: 'TypeError',
+    message: 'The "buffer" argument must be an instance of Buffer, ' +
+    'TypedArray, or DataView. Received null',
+  },
   'throws when options.buffer is null'
 );
 

--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -79,11 +79,7 @@ assert.throws(
 
 assert.throws(
   () => fs.read(fd, { buffer: null }, common.mustNotCall()),
-  {
-    name: 'TypeError',
-    message: 'The "buffer" argument must be an instance of Buffer, ' +
-    'TypedArray, or DataView. Received null',
-  },
+  { code: 'ERR_INVALID_ARG_TYPE' },
   'throws when options.buffer is null'
 );
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

when `params` is `{ buffer: null }`, `buffer` is not initialized with `Buffer.alloc(16384)`. so error message became not user-friendly as seen in test case.
https://github.com/nodejs/node/blob/abfeed868442a0d808012607fed8cbd3f6a94137/lib/fs.js#L621