### PR TITLE
fs: fix operation not permitted

### DIFF
--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -158,11 +158,6 @@ function handleFilterAndCopy(destStat, src, dest, opts) {
   return getStats(destStat, src, dest, opts);
 }
 
-function startCopy(destStat, src, dest, opts) {
-  if (opts.filter && !opts.filter(src, dest)) return;
-  return getStats(destStat, src, dest, opts);
-}
-
 function getStats(destStat, src, dest, opts) {
   const statSyncFn = opts.dereference ? statSync : lstatSync;
   const srcStat = statSyncFn(src);
@@ -284,9 +279,9 @@ function copyDir(src, dest, opts) {
       const { name } = dirent;
       const srcItem = join(src, name);
       const destItem = join(dest, name);
+      if (opts.filter && !opts.filter(srcItem, destItem)) continue;
       const { destStat } = checkPathsSync(srcItem, destItem, opts);
-
-      startCopy(destStat, srcItem, destItem, opts);
+      getStats(destStat, src, dest, opts);
     }
   } finally {
     dir.closeSync();

--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -281,7 +281,7 @@ function copyDir(src, dest, opts) {
       const destItem = join(dest, name);
       if (opts.filter && !opts.filter(srcItem, destItem)) continue;
       const { destStat } = checkPathsSync(srcItem, destItem, opts);
-      getStats(destStat, src, dest, opts);
+      getStats(destStat, srcItem, destItem, opts);
     }
   } finally {
     dir.closeSync();


### PR DESCRIPTION
fix: #44720

issue:
- `copyDir()` calls `checkPathsSync()`, which invokes `lstat()`
which causes error because of not checking the opts.filter

changes:
- check opts.filter before calling `checkPathsSync` and copy logic
- cleanup `startCopy` function

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
