### PR TITLE
doc: remove "currently" and comma splice from child_process.md

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -692,9 +692,9 @@ subprocess.on('error', (err) => {
 Certain platforms (macOS, Linux) will use the value of `argv[0]` for the process
 title while others (Windows, SunOS) will use `command`.
 
-Node.js currently overwrites `argv[0]` with `process.execPath` on startup, so
+Node.js overwrites `argv[0]` with `process.execPath` on startup, so
 `process.argv[0]` in a Node.js child process will not match the `argv0`
-parameter passed to `spawn` from the parent, retrieve it with the
+parameter passed to `spawn` from the parent. Retrieve it with the
 `process.argv0` property instead.
 
 If the `signal` option is enabled, calling `.abort()` on the corresponding
@@ -810,7 +810,7 @@ pipes between the parent and child. The value is one of the following:
    `child_process` object as [`subprocess.stdio[fd]`][`subprocess.stdio`]. Pipes
    created for fds 0, 1, and 2 are also available as [`subprocess.stdin`][],
    [`subprocess.stdout`][] and [`subprocess.stderr`][], respectively.
-   Currently, these are not actual Unix pipes and therefore the child process
+   These are not actual Unix pipes and therefore the child process
    can not use them by their descriptor files,
    e.g. `/dev/fd/2` or `/dev/stdout`.
 2. `'overlapped'`: Same as `'pipe'` except that the `FILE_FLAG_OVERLAPPED` flag
@@ -845,7 +845,7 @@ pipes between the parent and child. The value is one of the following:
    underlying descriptor (file streams do not until the `'open'` event has
    occurred).
 7. Positive integer: The integer value is interpreted as a file descriptor
-   that is currently open in the parent process. It is shared with the child
+   that is open in the parent process. It is shared with the child
    process, similar to how {Stream} objects can be shared. Passing sockets
    is not supported on Windows.
 8. `null`, `undefined`: Use default value. For stdio fds 0, 1, and 2 (in other
@@ -1274,7 +1274,7 @@ changes:
 * {Object} A pipe representing the IPC channel to the child process.
 
 The `subprocess.channel` property is a reference to the child's IPC channel. If
-no IPC channel currently exists, this property is `undefined`.
+no IPC channel exists, this property is `undefined`.
 
 #### `subprocess.channel.ref()`
 
@@ -1583,7 +1583,7 @@ can be handled by the parent and some by the child.
 While the example above uses a server created using the `node:net` module,
 `node:dgram` module servers use exactly the same workflow with the exceptions of
 listening on a `'message'` event instead of `'connection'` and using
-`server.bind()` instead of `server.listen()`. This is, however, currently only
+`server.bind()` instead of `server.listen()`. This is, however, only
 supported on Unix platforms.
 
 #### Example: sending a socket object


### PR DESCRIPTION
Remove redundant use of "currently" and fix a comma splice.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
