### PR TITLE
test: address coverity issue

### DIFF
--- a/test/cctest/test_crypto_clienthello.cc
+++ b/test/cctest/test_crypto_clienthello.cc
@@ -48,8 +48,9 @@ class OverrunGuardedBuffer {
  public:
   OverrunGuardedBuffer() {
 #if defined(USE_MPROTECT) || defined(USE_VIRTUALPROTECT)
-    size_t page = GetPageSize();
-    EXPECT_GE(page, N);
+    int page_size_int = GetPageSize();
+    EXPECT_GE(page_size_int, N);
+    size_t page = page_size_int;
 #endif
 #ifdef USE_MPROTECT
     // Place the packet right before a guard page, which, when accessed, causes


### PR DESCRIPTION
Coverity is reporting issues with negative
returns. I think that is because

size_t page = GetPageSize();

will always result in page being positive even if GetPageSize fails and returns -1 since size_t cannot be negative. This then would result n the check right afterwards not catching the failure.

Fix by converting to size_t after we do the check.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
