### PR TITLE
src: implement GetDetachedness() in MemoryRetainerNode

### DIFF
--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -98,6 +98,11 @@ bool BaseObject::IsWeakOrDetached() const {
   return pd->wants_weak_jsobj || pd->is_detached;
 }
 
+v8::EmbedderGraph::Node::Detachedness BaseObject::GetDetachedness() const {
+  return IsWeakOrDetached() ? v8::EmbedderGraph::Node::Detachedness::kDetached
+                            : v8::EmbedderGraph::Node::Detachedness::kUnknown;
+}
+
 template <int Field>
 void BaseObject::InternalFieldGet(
     v8::Local<v8::String> property,

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -88,6 +88,9 @@ class BaseObject : public MemoryRetainer {
   // to it anymore.
   inline bool IsWeakOrDetached() const;
 
+  inline virtual v8::EmbedderGraph::Node::Detachedness GetDetachedness()
+      const override;
+
   // Utility to create a FunctionTemplate with one internal field (used for
   // the `BaseObject*` pointer) and a constructor that initializes that field
   // to `nullptr`.

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -88,8 +88,7 @@ class BaseObject : public MemoryRetainer {
   // to it anymore.
   inline bool IsWeakOrDetached() const;
 
-  inline virtual v8::EmbedderGraph::Node::Detachedness GetDetachedness()
-      const override;
+  inline v8::EmbedderGraph::Node::Detachedness GetDetachedness() const override;
 
   // Utility to create a FunctionTemplate with one internal field (used for
   // the `BaseObject*` pointer) and a constructor that initializes that field

--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -31,6 +31,7 @@ class MemoryRetainerNode : public v8::EmbedderGraph::Node {
 
     name_ = retainer_->MemoryInfoName();
     size_ = retainer_->SelfSize();
+    detachedness_ = retainer_->GetDetachedness();
   }
 
   inline MemoryRetainerNode(MemoryTracker* tracker,
@@ -57,6 +58,9 @@ class MemoryRetainerNode : public v8::EmbedderGraph::Node {
     }
     return is_root_node_;
   }
+  v8::EmbedderGraph::Node::Detachedness GetDetachedness() override {
+    return detachedness_;
+  }
 
  private:
   friend class MemoryTracker;
@@ -73,6 +77,8 @@ class MemoryRetainerNode : public v8::EmbedderGraph::Node {
   bool is_root_node_ = false;
   std::string name_;
   size_t size_ = 0;
+  v8::EmbedderGraph::Node::Detachedness detachedness_ =
+      v8::EmbedderGraph::Node::Detachedness::kUnknown;
 };
 
 void MemoryTracker::TrackFieldWithSize(const char* edge_name,

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -127,6 +127,9 @@ class MemoryRetainer {
   }
 
   virtual bool IsRootNode() const { return false; }
+  virtual v8::EmbedderGraph::Node::Detachedness GetDetachedness() const {
+    return v8::EmbedderGraph::Node::Detachedness::kUnknown;
+  }
 };
 
 class MemoryTracker {

--- a/test/common/heap.js
+++ b/test/common/heap.js
@@ -142,6 +142,22 @@ class State {
           }
         }
       }
+
+      if (expectation.detachedness !== undefined) {
+        const matchedNodes = rootNodes.filter(
+          (node) => node.detachedness === expectation.detachedness);
+        if (loose) {
+          assert(matchedNodes.length >= rootNodes.length,
+                 `Expect to find at least ${rootNodes.length} with ` +
+                `detachedness ${expectation.detachedness}, ` +
+                `found ${matchedNodes.length}`);
+        } else {
+          assert.strictEqual(
+            matchedNodes.length, rootNodes.length,
+            `Expect to find ${rootNodes.length} with detachedness ` +
+            `${expectation.detachedness},  found ${matchedNodes.length}`);
+        }
+      }
     }
   }
 

--- a/test/pummel/test-heapdump-dns.js
+++ b/test/pummel/test-heapdump-dns.js
@@ -13,6 +13,7 @@ validateSnapshotNodes('Node / ChannelWrap', [
       { node_name: 'Node / NodeAresTask::List', edge_name: 'task_list' },
       // `Node / ChannelWrap` (C++) -> `ChannelWrap` (JS)
       { node_name: 'ChannelWrap', edge_name: 'wrapped' },
-    ]
+    ],
+    detachedness: 2
   },
 ]);


### PR DESCRIPTION
This allows us to mark weak/detached references in the heap snapshot. Also mark weak/detached BaseObject with Detachedness::kDetached so that the state of the reference can be displayed by frontend consuming the heap snapshot.

With the following snippet:

```js
const dns = require('dns');
dns.resolve('localhost', () => {
  setTimeout(write, 1000);
});

function write() {
  const v8 = require('v8');
  v8.writeHeapSnapshot();
}
```

The cleanup queue in the generated heap snapshot previously looked like this in the DevTools - nodes that will be GC'ed once they are no longer referenced from JS land are not distinguished from nodes that are kept alive from the C++ land.

<img width="526" alt="Screen Shot 2022-09-27 at 15 13 43" src="https://user-images.githubusercontent.com/4299420/192459015-333e710b-49ec-4433-8324-bc8587f26170.png">

Now it looks like this - nodes that will be GC'ed once they are no longer referenced from JS have  the `Detached` label (note that in the case of ChannelWrap, if we take the snapshot *before* the query completes, the ChannelWrap won't be marked as `Detached`, because it would still be reachable from the QueryWrap which is kept alive by C++ i.e. being attached - objects reachable from attached objects are also considered attached by DevTools):

<img width="598" alt="Screen Shot 2022-09-27 at 15 13 49" src="https://user-images.githubusercontent.com/4299420/192459044-debb5df7-79b2-4b06-86c7-e97c588d102f.png">


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
