### PR TITLE
doc: add extra step reporter pre-approval

### DIFF
--- a/doc/contributing/security-release-process.md
+++ b/doc/contributing/security-release-process.md
@@ -44,6 +44,8 @@ The current security stewards are documented in the main Node.js
     the date in the slug so that it will move to the top of the blog list.)
   * (Consider using a [Vulnerability Score System](https://www.first.org/cvss/calculator/3.1)
     to identify severity of each report)
+  * Share the patch with the reporter when applicable.
+    It will increase the fix accuracy.
   * [ ] pre-release: _**LINK TO PR**_
   * [ ] post-release: _**LINK TO PR**_
     * List vulnerabilities in order of descending severity
@@ -66,6 +68,10 @@ The current security stewards are documented in the main Node.js
 * [ ] Check that all vulnerabilities are ready for release integration:
   * PRs against all affected release lines or cherry-pick clean
   * Approved
+  * (optional) Approved by the reporter
+    * Build and send the binary to the reporter according to its architecture
+      and ask for a review. This step is important to avoid insufficient fixes
+      between Security Releases.
   * Pass `make test`
   * Have CVEs
     * Make sure that dependent libraries have CVEs for their issues. We should


### PR DESCRIPTION
As discussed in the #security-triagge (OpenJS channel). To avoid insufficient CVE fixes across Security Release, might make sense to request a reporter pre-approval.

cc: @nodejs/tsc