### PR TITLE
test: skip some binding tests on IBMi PASE

### DIFF
--- a/test/addons/addons.status
+++ b/test/addons/addons.status
@@ -12,6 +12,11 @@ openssl-binding/test: PASS,FLAKY
 
 [$system==ibmi]
 openssl-binding/test: SKIP
+openssl-providers/test-default-only-config: SKIP
+openssl-providers/test-legacy-provider-config: SKIP
+openssl-providers/test-legacy-provider-inactive-config: SKIP
+openssl-providers/test-legacy-provider-option: SKIP
+openssl-providers/test-no-legacy-provider-option: SKIP
 zlib-binding/test: SKIP
 # https://github.com/nodejs/node/issues/34410
 register-signal-handler/test: PASS,FLAKY


### PR DESCRIPTION
IBM i PASE Node.js always links to shared openssl
libraries. Skip recently added OpenSSL addons
tests as we do for other OpenSSL addons tests on
IBM i.

Refs: https://github.com/nodejs/node/pull/31967
Refs: https://github.com/nodejs/node/pull/44148

cc @nodejs/platform-ibmi 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
