### PR TITLE
http: be more aggressive to reply 400, 408 and 431

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1311,8 +1311,9 @@ type other than {net.Socket}.
 
 Default behavior is to try close the socket with a HTTP '400 Bad Request',
 or a HTTP '431 Request Header Fields Too Large' in the case of a
-[`HPE_HEADER_OVERFLOW`][] error. If the socket is not writable or has already
-written data it is immediately destroyed.
+[`HPE_HEADER_OVERFLOW`][] error. If the socket is not writable or headers
+of the current attached [`http.ServerResponse`][] has been sent, it is
+immediately destroyed.
 
 `socket` is the [`net.Socket`][] object that the error originated from.
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -823,9 +823,9 @@ function socketOnError(e) {
   }
 
   if (!this.server.emit('clientError', e, this)) {
-    // Cautions must be taken to avoid corrupting the remote peer,
-    // reply an error segment if no in-flight ServerResponse
-    // or data of the in-flight one is not yet written to this socket
+    // Caution must be taken to avoid corrupting the remote peer.
+    // Reply an error segment if there is no in-flight `ServerResponse`,
+    // or no data of the in-flight one has been written yet to this socket.
     if (this.writable &&
         (!this._httpMessage || !this._httpMessage._headerSent)) {
       let response;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -823,13 +823,11 @@ function socketOnError(e) {
   }
 
   if (!this.server.emit('clientError', e, this)) {
-    if (this.writable && 
-      // Cautions must be taken to avoid corrupting the remote peer,
-      // reply an error segment if
-        // no in-flight ServerResponse
-        (!this._httpMessage ||
-        // or data of the in-flight one is not yet written to this socket
-        !this._httpMessage._headerSent)) {
+    // Cautions must be taken to avoid corrupting the remote peer,
+    // reply an error segment if no in-flight ServerResponse
+    // or data of the in-flight one is not yet written to this socket
+    if (this.writable &&
+        (!this._httpMessage || !this._httpMessage._headerSent)) {
       let response;
 
       switch (e.code) {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -823,7 +823,13 @@ function socketOnError(e) {
   }
 
   if (!this.server.emit('clientError', e, this)) {
-    if (this.writable && this.bytesWritten === 0) {
+    if (this.writable && 
+      // Cautions must be taken to avoid corrupting the remote peer,
+      // reply an error segment if
+        // no in-flight ServerResponse
+        (!this._httpMessage ||
+        // or data of the in-flight one is not yet written to this socket
+        !this._httpMessage._headerSent)) {
       let response;
 
       switch (e.code) {

--- a/test/parallel/test-http-server-headers-timeout-keepalive.js
+++ b/test/parallel/test-http-server-headers-timeout-keepalive.js
@@ -82,8 +82,7 @@ server.listen(0, common.mustCall(() => {
     assert.strictEqual(
       response,
       // Empty because of https://github.com/nodejs/node/commit/e8d7fedf7cad6e612e4f2e0456e359af57608ac7
-      // 'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
-      ''
+      'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();
   });

--- a/test/parallel/test-http-server-headers-timeout-keepalive.js
+++ b/test/parallel/test-http-server-headers-timeout-keepalive.js
@@ -81,7 +81,6 @@ server.listen(0, common.mustCall(() => {
     assert.strictEqual(second, true);
     assert.strictEqual(
       response,
-      // Empty because of https://github.com/nodejs/node/commit/e8d7fedf7cad6e612e4f2e0456e359af57608ac7
       'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();

--- a/test/parallel/test-http-server-headers-timeout-pipelining.js
+++ b/test/parallel/test-http-server-headers-timeout-pipelining.js
@@ -57,8 +57,7 @@ server.listen(0, common.mustCall(() => {
     assert.strictEqual(
       response,
       // Empty because of https://github.com/nodejs/node/commit/e8d7fedf7cad6e612e4f2e0456e359af57608ac7
-      // 'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
-      ''
+      'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();
   });

--- a/test/parallel/test-http-server-headers-timeout-pipelining.js
+++ b/test/parallel/test-http-server-headers-timeout-pipelining.js
@@ -56,7 +56,6 @@ server.listen(0, common.mustCall(() => {
 
     assert.strictEqual(
       response,
-      // Empty because of https://github.com/nodejs/node/commit/e8d7fedf7cad6e612e4f2e0456e359af57608ac7
       'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();

--- a/test/parallel/test-http-server-request-timeout-keepalive.js
+++ b/test/parallel/test-http-server-request-timeout-keepalive.js
@@ -80,8 +80,7 @@ server.listen(0, common.mustCall(() => {
     assert.strictEqual(
       response,
       // Empty because of https://github.com/nodejs/node/commit/e8d7fedf7cad6e612e4f2e0456e359af57608ac7
-      // 'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
-      ''
+      'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();
   });

--- a/test/parallel/test-http-server-request-timeout-keepalive.js
+++ b/test/parallel/test-http-server-request-timeout-keepalive.js
@@ -79,7 +79,6 @@ server.listen(0, common.mustCall(() => {
     assert.strictEqual(second, true);
     assert.strictEqual(
       response,
-      // Empty because of https://github.com/nodejs/node/commit/e8d7fedf7cad6e612e4f2e0456e359af57608ac7
       'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();

--- a/test/parallel/test-http-server-request-timeout-pipelining.js
+++ b/test/parallel/test-http-server-request-timeout-pipelining.js
@@ -51,8 +51,7 @@ server.listen(0, common.mustCall(() => {
     assert.strictEqual(
       response,
       // Empty because of https://github.com/nodejs/node/commit/e8d7fedf7cad6e612e4f2e0456e359af57608ac7
-      // 'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
-      ''
+      'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();
   });

--- a/test/parallel/test-http-server-request-timeout-pipelining.js
+++ b/test/parallel/test-http-server-request-timeout-pipelining.js
@@ -50,7 +50,6 @@ server.listen(0, common.mustCall(() => {
 
     assert.strictEqual(
       response,
-      // Empty because of https://github.com/nodejs/node/commit/e8d7fedf7cad6e612e4f2e0456e359af57608ac7
       'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();


### PR DESCRIPTION
Fix https://github.com/nodejs/node/issues/37685, which is introduced in https://github.com/nodejs/node/commit/e8d7fedf7cad6e612e4f2e0456e359af57608ac7. It is too conservate (from the perspective from avoiding corrupting the client) to reply an error message.

Cases where we should reply an error message are covered in those 4 tests this PR modified, while the case where the socket should be immediately destroyed is covered in [test/parallel/test-http-header-badrequest.js.](https://github.com/ywave620/node/blob/ImproveHandleHttpClientError/test/parallel/test-http-header-badrequest.js)