### PR TITLE
test: check server status in test-tls-psk-client

### DIFF
--- a/test/sequential/test-tls-psk-client.js
+++ b/test/sequential/test-tls-psk-client.js
@@ -23,7 +23,18 @@ const server = spawn(common.opensslCli, [
   '-psk_hint', IDENTITY,
   '-nocert',
   '-rev',
-]);
+], { encoding: 'utf8' });
+let serverErr = '';
+let serverOut = '';
+server.stderr.on('data', (data) => serverErr += data);
+server.stdout.on('data', (data) => serverOut += data);
+server.on('error', common.mustNotCall());
+server.on('exit', (code, signal) => {
+  // Server is expected to be terminated by cleanUp().
+  assert.strictEqual(code, null,
+                     `'${server.spawnfile} ${server.spawnargs.join(' ')}' unexpected exited with output:\n${serverOut}\n${serverErr}`);
+  assert.strictEqual(signal, 'SIGTERM');
+});
 
 const cleanUp = (err) => {
   clearTimeout(timeout);


### PR DESCRIPTION
Add assertions to sequential/test-tls-psk-client to check if the spawned OpenSSL server has exited in any way except for the expected termination by the cleanUp() function. The added assertions will prevent the test from spinning forever trying to connect to the non-existent server in the case that the spawned process has exited. Include stderr and stdout in the assertion failure message to aid debugging.

Refs: https://github.com/nodejs/node/issues/44821
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
