### PR TITLE
node-api: create reference only when needed

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -2387,10 +2387,12 @@ napi_status NAPI_CDECL napi_create_external(napi_env env,
 
   v8::Local<v8::Value> external_value = v8::External::New(isolate, data);
 
-  // The Reference object will delete itself after invoking the finalizer
-  // callback.
-  v8impl::Reference::New(
-      env, external_value, 0, true, finalize_cb, data, finalize_hint);
+  if (finalize_cb) {
+    // The Reference object will delete itself after invoking the finalizer
+    // callback.
+    v8impl::Reference::New(
+        env, external_value, 0, true, finalize_cb, data, finalize_hint);
+  }
 
   *result = v8impl::JsValueFromV8LocalValue(external_value);
 


### PR DESCRIPTION
Optimize `napi_create_external()` to create the reference for calling finalizer only if user actually provides a finalizer callback.

