### PR TITLE
fs: define `rs` flag as `O_RDONLY`, not `O_RDONLY` | `O_SYNC`

### DIFF
--- a/deps/uv/test/test-fs-open-flags.c
+++ b/deps/uv/test/test-fs-open-flags.c
@@ -283,6 +283,16 @@ static void fs_open_flags(int add_flags) {
   writeFail(empty_dir, UV_EBADF);
   readFail(empty_dir, UV_EISDIR);
 
+  /* rs */
+  flags = add_flags | UV_FS_O_RDONLY | UV_FS_O_SYNC;
+  openFail(absent_file, UV_ENOENT);
+  writeFail(empty_file, UV_EBADF);
+  readExpect(empty_file, "", 0);
+  writeFail(dummy_file, UV_EBADF);
+  readExpect(dummy_file, "a", 1);
+  writeFail(empty_dir, UV_EBADF);
+  readFail(empty_dir, UV_EISDIR);
+
   /* r+ */
   flags = add_flags | UV_FS_O_RDWR;
   openFail(absent_file, UV_ENOENT);

--- a/deps/uv/test/test-fs-open-flags.c
+++ b/deps/uv/test/test-fs-open-flags.c
@@ -283,16 +283,6 @@ static void fs_open_flags(int add_flags) {
   writeFail(empty_dir, UV_EBADF);
   readFail(empty_dir, UV_EISDIR);
 
-  /* rs */
-  flags = add_flags | UV_FS_O_RDONLY | UV_FS_O_SYNC;
-  openFail(absent_file, UV_ENOENT);
-  writeFail(empty_file, UV_EBADF);
-  readExpect(empty_file, "", 0);
-  writeFail(dummy_file, UV_EBADF);
-  readExpect(dummy_file, "a", 1);
-  writeFail(empty_dir, UV_EBADF);
-  readFail(empty_dir, UV_EISDIR);
-
   /* r+ */
   flags = add_flags | UV_FS_O_RDWR;
   openFail(absent_file, UV_ENOENT);

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -568,7 +568,9 @@ function stringToFlags(flags, name = 'flags') {
   }
 
   switch (flags) {
-    case 'r' : return O_RDONLY;
+    case 'r' : // Fall through.
+    case 'rs' : // Fall through.
+    case 'sr' : return O_RDONLY;
     case 'r+' : return O_RDWR;
     case 'rs+' : // Fall through.
     case 'sr+' : return O_RDWR | O_SYNC;

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -569,8 +569,6 @@ function stringToFlags(flags, name = 'flags') {
 
   switch (flags) {
     case 'r' : return O_RDONLY;
-    case 'rs' : // Fall through.
-    case 'sr' : return O_RDONLY | O_SYNC;
     case 'r+' : return O_RDWR;
     case 'rs+' : // Fall through.
     case 'sr+' : return O_RDWR | O_SYNC;

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -42,8 +42,6 @@ fs.open(__filename, common.mustSucceed());
 
 fs.open(__filename, 'r', common.mustSucceed());
 
-fs.open(__filename, 'rs', common.mustSucceed());
-
 fs.open(__filename, 'r', 0, common.mustSucceed());
 
 fs.open(__filename, 'r', null, common.mustSucceed());

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -42,6 +42,9 @@ fs.open(__filename, common.mustSucceed());
 
 fs.open(__filename, 'r', common.mustSucceed());
 
+// 'rs' is defined as O_RDONLY, same as 'r'
+fs.open(__filename, 'rs', common.mustSucceed());
+
 fs.open(__filename, 'r', 0, common.mustSucceed());
 
 fs.open(__filename, 'r', null, common.mustSucceed());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

`O_SYNC` means "**Write** operations on the file will complete according to the requirements of synchronized I/O file integrity completion"([ref](https://man7.org/linux/man-pages/man2/open.2.html)).
So, setting `O_RDONLY` and `O_SYNC` at the same time is inconsistent.
According to the following test, `rs` has the same result as `r`.
https://github.com/nodejs/node/blob/2a4452a53af65a13db4efae474162a7dcfd38dd5/deps/uv/test/test-fs-open-flags.c#L276-L294
Also, `rs` is not in document https://nodejs.org/api/fs.html#file-system-flags .
