### PR TITLE
[v16.x backport] crypto: fix webcrypto generateKey() AES key length validation error

### DIFF
--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -60,11 +60,6 @@ const {
   generateKey,
 } = require('internal/crypto/keygen');
 
-const {
-  validateInteger,
-  validateOneOf,
-} = require('internal/validators');
-
 const kMaxCounterLength = 128;
 const kTagLengths = [32, 64, 96, 104, 112, 120, 128];
 
@@ -227,8 +222,11 @@ function aesCipher(mode, key, data, algorithm) {
 
 async function aesGenerateKey(algorithm, extractable, keyUsages) {
   const { name, length } = algorithm;
-  validateInteger(length, 'algorithm.length');
-  validateOneOf(length, 'algorithm.length', kAesKeyLengths);
+  if (!ArrayPrototypeIncludes(kAesKeyLengths, length)) {
+    throw lazyDOMException(
+      'AES key length must be 128, 192, or 256 bits',
+      'OperationError');
+  }
 
   const checkUsages = ['wrapKey', 'unwrapKey'];
   if (name !== 'AES-KW')

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -512,14 +512,14 @@ const vectors = {
     [1, 100, 257].forEach(async (length) => {
       await assert.rejects(
         subtle.generateKey({ name, length }, true, usages), {
-          code: 'ERR_INVALID_ARG_VALUE'
+          name: 'OperationError'
         });
     });
 
     ['', {}, [], false, null, undefined].forEach(async (length) => {
       await assert.rejects(
         subtle.generateKey({ name, length }, true, usages), {
-          code: 'ERR_INVALID_ARG_TYPE'
+          name: 'OperationError',
         });
     });
   }


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/44170

This backports the runtime functionality without the portion that updated the wpt status file which in turn depended on the WPT Runner update (#43455).