### PR TITLE
[v16.x backport] crypto: fix webcrypto EC key namedCurve validation errors

### DIFF
--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  ArrayPrototypeIncludes,
   ObjectKeys,
   Promise,
   SafeSet,
@@ -16,11 +17,6 @@ const {
   kSignJobModeVerify,
   kSigEncP1363,
 } = internalBinding('crypto');
-
-const {
-  validateOneOf,
-  validateString,
-} = require('internal/validators');
 
 const {
   codes: {
@@ -88,11 +84,12 @@ function createECPublicKeyRaw(namedCurve, keyData) {
 
 async function ecGenerateKey(algorithm, extractable, keyUsages) {
   const { name, namedCurve } = algorithm;
-  validateString(namedCurve, 'algorithm.namedCurve');
-  validateOneOf(
-    namedCurve,
-    'algorithm.namedCurve',
-    ObjectKeys(kNamedCurveAliases));
+
+  if (!ArrayPrototypeIncludes(ObjectKeys(kNamedCurveAliases), namedCurve)) {
+    throw lazyDOMException(
+      'Unrecognized namedCurve',
+      'NotSupportedError');
+  }
 
   const usageSet = new SafeSet(keyUsages);
   switch (name) {
@@ -168,11 +165,13 @@ async function ecImportKey(
   keyUsages) {
 
   const { name, namedCurve } = algorithm;
-  validateString(namedCurve, 'algorithm.namedCurve');
-  validateOneOf(
-    namedCurve,
-    'algorithm.namedCurve',
-    ObjectKeys(kNamedCurveAliases));
+
+  if (!ArrayPrototypeIncludes(ObjectKeys(kNamedCurveAliases), namedCurve)) {
+    throw lazyDOMException(
+      'Unrecognized namedCurve',
+      'NotSupportedError');
+  }
+
   let keyObject;
   const usagesSet = new SafeSet(keyUsages);
   switch (format) {

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -452,7 +452,7 @@ const vectors = {
     [1, true, {}, [], undefined, null].forEach(async (namedCurve) => {
       await assert.rejects(
         subtle.generateKey({ name, namedCurve }, true, privateUsages), {
-          code: 'ERR_INVALID_ARG_TYPE'
+          name: 'NotSupportedError'
         });
     });
   }


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/44172

This backports the runtime functionality without the portion that updated the wpt status file which in turn depended on the WPT Runner update (#43455).