### PR TITLE
[v16.x backport] crypto: fix webcrypto deriveBits validations

### DIFF
--- a/lib/internal/crypto/hkdf.js
+++ b/lib/internal/crypto/hkdf.js
@@ -142,7 +142,6 @@ function hkdfSync(hash, key, salt, info, length) {
 }
 
 async function hkdfDeriveBits(algorithm, baseKey, length) {
-  validateUint32(length, 'length');
   const { hash } = algorithm;
   const salt = getArrayBufferOrView(algorithm.salt, 'algorithm.salt');
   const info = getArrayBufferOrView(algorithm.info, 'algorithm.info');
@@ -153,6 +152,9 @@ async function hkdfDeriveBits(algorithm, baseKey, length) {
   if (length !== undefined) {
     if (length === 0)
       throw lazyDOMException('length cannot be zero', 'OperationError');
+    if (length === null)
+      throw lazyDOMException('length cannot be null', 'OperationError');
+    validateUint32(length, 'length');
     if (length % 8) {
       throw lazyDOMException(
         'length must be a multiple of 8',

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -98,13 +98,16 @@ function check(password, salt, iterations, keylen, digest) {
 }
 
 async function pbkdf2DeriveBits(algorithm, baseKey, length) {
-  validateUint32(length, 'length');
   const { iterations } = algorithm;
   let { hash } = algorithm;
   const salt = getArrayBufferOrView(algorithm.salt, 'algorithm.salt');
   if (hash === undefined)
     throw new ERR_MISSING_OPTION('algorithm.hash');
-  validateInteger(iterations, 'algorithm.iterations', 1);
+  validateInteger(iterations, 'algorithm.iterations');
+  if (iterations === 0)
+    throw lazyDOMException(
+      'iterations cannot be zero',
+      'OperationError');
 
   hash = normalizeHashName(hash.name);
 
@@ -114,6 +117,9 @@ async function pbkdf2DeriveBits(algorithm, baseKey, length) {
   if (length !== undefined) {
     if (length === 0)
       throw lazyDOMException('length cannot be zero', 'OperationError');
+    if (length === null)
+      throw lazyDOMException('length cannot be null', 'OperationError');
+    validateUint32(length, 'length');
     if (length % 8) {
       throw lazyDOMException(
         'length must be a multiple of 8',

--- a/test/parallel/test-webcrypto-derivebits-hkdf.js
+++ b/test/parallel/test-webcrypto-derivebits-hkdf.js
@@ -259,15 +259,18 @@ async function testDeriveBitsBadLengths(
   return Promise.all([
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], 0), {
-        message: /length cannot be zero/
+        message: /length cannot be zero/,
+        name: 'OperationError',
       }),
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], null), {
-        code: 'ERR_INVALID_ARG_TYPE'
+        message: 'length cannot be null',
+        name: 'OperationError',
       }),
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], 15), {
-        message: /length must be a multiple of 8/
+        message: /length must be a multiple of 8/,
+        name: 'OperationError',
       }),
   ]);
 }

--- a/test/pummel/test-webcrypto-derivebits-pbkdf2.js
+++ b/test/pummel/test-webcrypto-derivebits-pbkdf2.js
@@ -448,15 +448,18 @@ async function testDeriveBitsBadLengths(
   return Promise.all([
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], 0), {
-        message: /length cannot be zero/
+        message: /length cannot be zero/,
+        name: 'OperationError',
       }),
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], null), {
-        code: 'ERR_INVALID_ARG_TYPE'
+        message: 'length cannot be null',
+        name: 'OperationError',
       }),
     assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], 15), {
-        message: /length must be a multiple of 8/
+        message: /length must be a multiple of 8/,
+        name: 'OperationError',
       }),
   ]);
 }


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/44173

This backports the runtime functionality without the portion that updated the wpt status file which in turn depended on the WPT Runner update (#43455).