### PR TITLE
doc: remove unnecessary leading commas

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -484,7 +484,7 @@ same as [`it([name], { skip: true }[, fn])`][it options].
 Shorthand for marking a test as `TODO`,
 same as [`it([name], { todo: true }[, fn])`][it options].
 
-## `before([, fn][, options])`
+## `before([fn][, options])`
 
 <!-- YAML
 added: v18.8.0
@@ -512,7 +512,7 @@ describe('tests', async () => {
 });
 ```
 
-## `after([, fn][, options])`
+## `after([fn][, options])`
 
 <!-- YAML
 added: v18.8.0
@@ -540,7 +540,7 @@ describe('tests', async () => {
 });
 ```
 
-## `beforeEach([, fn][, options])`
+## `beforeEach([fn][, options])`
 
 <!-- YAML
 added: v18.8.0
@@ -569,7 +569,7 @@ describe('tests', async () => {
 });
 ```
 
-## `afterEach([, fn][, options])`
+## `afterEach([fn][, options])`
 
 <!-- YAML
 added: v18.8.0
@@ -651,7 +651,7 @@ An instance of `TestContext` is passed to each test function in order to
 interact with the test runner. However, the `TestContext` constructor is not
 exposed as part of the API.
 
-### `context.beforeEach([, fn][, options])`
+### `context.beforeEach([fn][, options])`
 
 <!-- YAML
 added: v18.8.0
@@ -683,7 +683,7 @@ test('top level test', async (t) => {
 });
 ```
 
-### `context.afterEach([, fn][, options])`
+### `context.afterEach([fn][, options])`
 
 <!-- YAML
 added: v18.8.0


### PR DESCRIPTION
There are several locations in the test_runner API docs where the optional first argument to a function was written with a leading comma. Since these are first arguments, the commas can be removed.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
