### PR TITLE
lib: enable global CustomEvent by default

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -341,16 +341,6 @@ when `Error.stack` is accessed. If you access `Error.stack` frequently
 in your application, take into account the performance implications
 of `--enable-source-maps`.
 
-### `--experimental-global-customevent`
-
-<!-- YAML
-added:
-  - v18.7.0
-  - v16.17.0
--->
-
-Expose the [CustomEvent Web API][] on the global scope.
-
 ### `--experimental-import-meta-resolve`
 
 <!-- YAML
@@ -410,6 +400,14 @@ added: REPLACEME
 -->
 
 Disable exposition of [Web Crypto API][] on the global scope.
+
+### `--no-experimental-global-customevent`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Disable exposition of [CustomEvent Web API][] on the global scope.
 
 ### `--no-experimental-repl-await`
 
@@ -1836,7 +1834,6 @@ Node.js options that are allowed are:
 * `--enable-fips`
 * `--enable-source-maps`
 * `--experimental-abortcontroller`
-* `--experimental-global-customevent`
 * `--experimental-import-meta-resolve`
 * `--experimental-json-modules`
 * `--experimental-loader`
@@ -1869,6 +1866,7 @@ Node.js options that are allowed are:
 * `--no-addons`
 * `--no-deprecation`
 * `--no-experimental-fetch`
+* `--no-experimental-global-customevent`
 * `--no-experimental-global-webcrypto`
 * `--no-experimental-repl-await`
 * `--no-extra-info-on-fatal-exception`

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -400,10 +400,14 @@ only if the Node.js binary was compiled with including support for the
 added:
   - v18.7.0
   - v16.17.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/44860
+    description: No longer behind `--experimental-global-customevent` CLI flag.
 -->
 
-> Stability: 1 - Experimental. Enable this API with the
-> [`--experimental-global-customevent`][] CLI flag.
+> Stability: 1 - Experimental. Disable this API with the
+> [`--no-experimental-global-customevent`][] CLI flag.
 
 <!-- type=global -->
 
@@ -885,8 +889,8 @@ added: v18.0.0
 A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 
 [Web Crypto API]: webcrypto.md
-[`--experimental-global-customevent`]: cli.md#--experimental-global-customevent
 [`--no-experimental-fetch`]: cli.md#--no-experimental-fetch
+[`--no-experimental-global-customevent`]: cli.md#--no-experimental-global-customevent
 [`--no-experimental-global-webcrypto`]: cli.md#--no-experimental-global-webcrypto
 [`AbortController`]: https://developer.mozilla.org/en-US/docs/Web/API/AbortController
 [`ByteLengthQueuingStrategy`]: webstreams.md#class-bytelengthqueuingstrategy

--- a/doc/node.1
+++ b/doc/node.1
@@ -139,9 +139,6 @@ Requires Node.js to be built with
 .It Fl -enable-source-maps
 Enable Source Map V3 support for stack traces.
 .
-.It Fl -experimental-global-customevent
-Expose the CustomEvent on the global scope.
-.
 .It Fl -experimental-global-webcrypto
 Expose the Web Crypto API on the global scope.
 .
@@ -164,6 +161,9 @@ Use this flag to enable ShadowRealm support.
 .
 .It Fl -no-experimental-fetch
 Disable experimental support for the Fetch API.
+.
+.It Fl -no-experimental-global-customevent
+Disable exposition of the CustomEvent on the global scope.
 .
 .It Fl -no-experimental-global-webcrypto
 Disable exposition of the Web Crypto API on the global scope.

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -278,7 +278,7 @@ function setupWebCrypto() {
 //                removed.
 function setupCustomEvent() {
   if (process.config.variables.node_no_browser_globals ||
-      !getOptionValue('--experimental-global-customevent')) {
+      getOptionValue('--no-experimental-global-customevent')) {
     return;
   }
   const { CustomEvent } = require('internal/event_target');

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -366,7 +366,8 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--experimental-global-customevent",
             "expose experimental CustomEvent on the global scope",
             &EnvironmentOptions::experimental_global_customevent,
-            kAllowedInEnvironment);
+            kAllowedInEnvironment,
+            true);
   AddOption("--experimental-global-webcrypto",
             "expose experimental Web Crypto API on the global scope",
             &EnvironmentOptions::experimental_global_web_crypto,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -109,7 +109,7 @@ class EnvironmentOptions : public Options {
   std::string dns_result_order;
   bool enable_source_maps = false;
   bool experimental_fetch = true;
-  bool experimental_global_customevent = false;
+  bool experimental_global_customevent = true;
   bool experimental_global_web_crypto = true;
   bool experimental_https_modules = false;
   std::string experimental_specifier_resolution;

--- a/test/parallel/test-global-customevent-disabled.js
+++ b/test/parallel/test-global-customevent-disabled.js
@@ -1,0 +1,7 @@
+// Flags: --no-experimental-global-customevent
+'use strict';
+
+require('../common');
+const { strictEqual } = require('node:assert');
+
+strictEqual(typeof CustomEvent, 'undefined');

--- a/test/parallel/test-global-customevent.js
+++ b/test/parallel/test-global-customevent.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-global-customevent --expose-internals
+// Flags: --expose-internals
 'use strict';
 
 require('../common');

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -405,7 +405,7 @@ putIn.run([
   'var custom = "test";',
 ]);
 testMe.complete('cus', common.mustCall(function(error, data) {
-  assert.deepStrictEqual(data, [['custom'], 'cus']);
+  assert.deepStrictEqual(data, [['CustomEvent', 'custom'], 'cus']);
 }));
 
 // Make sure tab completion doesn't crash REPL with half-baked proxy objects.

--- a/test/wpt/test-events.js
+++ b/test/wpt/test-events.js
@@ -4,6 +4,4 @@ const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('dom/events');
 
-runner.setFlags(['--experimental-global-customevent']);
-
 runner.runJsTests();


### PR DESCRIPTION
This proposes to expose `CustomEvent` class on the global object by default.
 
Refs: https://github.com/nodejs/node/pull/43885

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
