### PR TITLE
lib: promise version of `streams.finished` call cleanup after eos

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2377,7 +2377,7 @@ changes:
     underlying stream will _not_ be aborted if the signal is aborted. The
     callback will get called with an `AbortError`. All registered
     listeners added by this function will also be removed.
-  * `autoCleanup` {boolean} remove all registered stream listeners.
+  * `cleanup` {boolean} remove all registered stream listeners.
     **Default:** `false`.
 
 * `callback` {Function} A callback function that takes an optional error

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2363,6 +2363,7 @@ changes:
 -->
 
 * `stream` {Stream} A readable and/or writable stream.
+
 * `options` {Object}
   * `error` {boolean} If set to `false`, then a call to `emit('error', err)` is
     not treated as finished. **Default:** `true`.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2377,10 +2377,11 @@ changes:
     callback will get called with an `AbortError`. All registered
     listeners added by this function will also be removed.
   * `autoCleanup` {boolean} remove all registered stream listeners.
-    **Default:** `true`.
+    **Default:** `false`.
 
 * `callback` {Function} A callback function that takes an optional error
   argument.
+
 * Returns: {Function} A cleanup function which removes all registered
   listeners.
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2376,6 +2376,9 @@ changes:
     underlying stream will _not_ be aborted if the signal is aborted. The
     callback will get called with an `AbortError`. All registered
     listeners added by this function will also be removed.
+  * `autoCleanup` {boolean} remove all registered stream listeners.
+    **Default:** `true`.
+
 * `callback` {Function} A callback function that takes an optional error
   argument.
 * Returns: {Function} A cleanup function which removes all registered

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -248,9 +248,9 @@ function finished(stream, opts) {
   if (opts === null) {
     opts = kEmptyObject;
   }
-  if (opts?.autoCleanup) {
-    validateBoolean(opts.autoCleanup, 'autoCleanup');
-    autoCleanup = opts.autoCleanup;
+  if (opts?.cleanup) {
+    validateBoolean(opts.cleanup, 'cleanup');
+    autoCleanup = opts.cleanup;
   }
   return new Promise((resolve, reject) => {
     const cleanup = eos(stream, opts, (err) => {

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -19,6 +19,7 @@ const {
   validateAbortSignal,
   validateFunction,
   validateObject,
+  validateBoolean
 } = require('internal/validators');
 
 const { Promise } = primordials;
@@ -243,8 +244,19 @@ function eos(stream, options, callback) {
 }
 
 function finished(stream, opts) {
+  let autoCleanup = true;
+  if (opts === null) {
+    opts = kEmptyObject;
+  }
+  if (opts.autoCleanup) {
+    validateBoolean(opts.autoCleanup, 'autoCleanup');
+    autoCleanup = opts.autoCleanup;
+  }
   return new Promise((resolve, reject) => {
-    eos(stream, opts, (err) => {
+    const cleanup = eos(stream, opts, (err) => {
+      if (autoCleanup) {
+        cleanup();
+      }
       if (err) {
         reject(err);
       } else {

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -244,11 +244,11 @@ function eos(stream, options, callback) {
 }
 
 function finished(stream, opts) {
-  let autoCleanup = true;
+  let autoCleanup = false;
   if (opts === null) {
     opts = kEmptyObject;
   }
-  if (opts.autoCleanup) {
+  if (opts?.autoCleanup) {
     validateBoolean(opts.autoCleanup, 'autoCleanup');
     autoCleanup = opts.autoCleanup;
   }

--- a/test/parallel/test-stream-promises.js
+++ b/test/parallel/test-stream-promises.js
@@ -101,3 +101,53 @@ assert.strictEqual(finished, promisify(stream.finished));
     code: 'ENOENT'
   }).then(common.mustCall());
 }
+
+{
+  const streamObj = new Readable();
+  assert.throws(
+    () => {
+      // Passing autoCleanup option not as boolean
+      // should throw error
+      finished(streamObj, {autoCleanup: 2});
+    },
+    {code: 'ERR_INVALID_ARG_TYPE'}
+  );
+}
+
+// Below code should not throw any errors as the
+// streamObj is `Stream` and autoCleanup is boolean
+{
+  const streamObj = new Readable();
+  finished(streamObj, {autoCleanup: true})
+}
+
+
+// cleanup function should not be called when autoCleanup is set to false
+// listenerCount should be 1 after calling finish
+{
+  const streamObj = new Writable();
+  assert(streamObj.listenerCount('end') === 0);
+  finished(streamObj, {autoCleanup: false}).then(() => {
+    assert(streamObj.listenerCount('end') === 1);
+  })
+}
+
+// cleanup function should  be called when autoCleanup is set to true
+// listenerCount should be 0 after calling finish
+{
+  const streamObj = new Writable();
+  assert(streamObj.listenerCount('end') === 0);
+  finished(streamObj, {autoCleanup: true}).then(() => {
+    assert(streamObj.listenerCount('end') === 0);
+  })
+}
+
+// cleanup function should not be called when autoCleanup has not been set
+// listenerCount should be 1 after calling finish
+{
+  const streamObj = new Writable();
+  assert(streamObj.listenerCount('end') === 0);
+  finished(streamObj).then(() => {
+    assert(streamObj.listenerCount('end') === 1);
+  })
+}

--- a/test/parallel/test-stream-promises.js
+++ b/test/parallel/test-stream-promises.js
@@ -3,13 +3,10 @@
 const common = require('../common');
 const stream = require('stream');
 const {
-  Readable,
-  Writable,
-  promises,
+  Readable, Writable, promises,
 } = stream;
 const {
-  finished,
-  pipeline,
+  finished, pipeline,
 } = require('stream/promises');
 const fs = require('fs');
 const assert = require('assert');
@@ -24,14 +21,11 @@ assert.strictEqual(finished, promisify(stream.finished));
 {
   let finished = false;
   const processed = [];
-  const expected = [
-    Buffer.from('a'),
-    Buffer.from('b'),
-    Buffer.from('c'),
-  ];
+  const expected = [Buffer.from('a'), Buffer.from('b'), Buffer.from('c')];
 
   const read = new Readable({
-    read() { }
+    read() {
+    }
   });
 
   const write = new Writable({
@@ -59,7 +53,8 @@ assert.strictEqual(finished, promisify(stream.finished));
 // pipeline error
 {
   const read = new Readable({
-    read() { }
+    read() {
+    }
   });
 
   const write = new Writable({
@@ -104,50 +99,47 @@ assert.strictEqual(finished, promisify(stream.finished));
 
 {
   const streamObj = new Readable();
-  assert.throws(
-    () => {
-      // Passing autoCleanup option not as boolean
-      // should throw error
-      finished(streamObj, {autoCleanup: 2});
-    },
-    {code: 'ERR_INVALID_ARG_TYPE'}
-  );
+  assert.throws(() => {
+    // Passing autoCleanup option not as boolean
+    // should throw error
+    finished(streamObj, { autoCleanup: 2 });
+  }, { code: 'ERR_INVALID_ARG_TYPE' });
 }
 
 // Below code should not throw any errors as the
 // streamObj is `Stream` and autoCleanup is boolean
 {
   const streamObj = new Readable();
-  finished(streamObj, {autoCleanup: true})
+  finished(streamObj, { autoCleanup: true });
 }
 
 
-// cleanup function should not be called when autoCleanup is set to false
+// Cleanup function should not be called when autoCleanup is set to false
 // listenerCount should be 1 after calling finish
 {
   const streamObj = new Writable();
-  assert(streamObj.listenerCount('end') === 0);
-  finished(streamObj, {autoCleanup: false}).then(() => {
-    assert(streamObj.listenerCount('end') === 1);
-  })
+  assert.strictEqual(streamObj.listenerCount('end'), 0);
+  finished(streamObj, { autoCleanup: false }).then(() => {
+    assert.strictEqual(streamObj.listenerCount('end'), 1);
+  });
 }
 
-// cleanup function should  be called when autoCleanup is set to true
+// Cleanup function should be called when autoCleanup is set to true
 // listenerCount should be 0 after calling finish
 {
   const streamObj = new Writable();
-  assert(streamObj.listenerCount('end') === 0);
-  finished(streamObj, {autoCleanup: true}).then(() => {
-    assert(streamObj.listenerCount('end') === 0);
-  })
+  assert.strictEqual(streamObj.listenerCount('end'), 0);
+  finished(streamObj, { autoCleanup: true }).then(() => {
+    assert.strictEqual(streamObj.listenerCount('end'), 0);
+  });
 }
 
-// cleanup function should not be called when autoCleanup has not been set
+// Cleanup function should not be called when autoCleanup has not been set
 // listenerCount should be 1 after calling finish
 {
   const streamObj = new Writable();
-  assert(streamObj.listenerCount('end') === 0);
+  assert.strictEqual(streamObj.listenerCount('end'), 0);
   finished(streamObj).then(() => {
-    assert(streamObj.listenerCount('end') === 1);
-  })
+    assert.strictEqual(streamObj.listenerCount('end'), 1);
+  });
 }

--- a/test/parallel/test-stream-promises.js
+++ b/test/parallel/test-stream-promises.js
@@ -100,41 +100,41 @@ assert.strictEqual(finished, promisify(stream.finished));
 {
   const streamObj = new Readable();
   assert.throws(() => {
-    // Passing autoCleanup option not as boolean
+    // Passing cleanup option not as boolean
     // should throw error
-    finished(streamObj, { autoCleanup: 2 });
+    finished(streamObj, { cleanup: 2 });
   }, { code: 'ERR_INVALID_ARG_TYPE' });
 }
 
 // Below code should not throw any errors as the
-// streamObj is `Stream` and autoCleanup is boolean
+// streamObj is `Stream` and cleanup is boolean
 {
   const streamObj = new Readable();
-  finished(streamObj, { autoCleanup: true });
+  finished(streamObj, { cleanup: true });
 }
 
 
-// Cleanup function should not be called when autoCleanup is set to false
+// Cleanup function should not be called when cleanup is set to false
 // listenerCount should be 1 after calling finish
 {
   const streamObj = new Writable();
   assert.strictEqual(streamObj.listenerCount('end'), 0);
-  finished(streamObj, { autoCleanup: false }).then(() => {
+  finished(streamObj, { cleanup: false }).then(() => {
     assert.strictEqual(streamObj.listenerCount('end'), 1);
   });
 }
 
-// Cleanup function should be called when autoCleanup is set to true
+// Cleanup function should be called when cleanup is set to true
 // listenerCount should be 0 after calling finish
 {
   const streamObj = new Writable();
   assert.strictEqual(streamObj.listenerCount('end'), 0);
-  finished(streamObj, { autoCleanup: true }).then(() => {
+  finished(streamObj, { cleanup: true }).then(() => {
     assert.strictEqual(streamObj.listenerCount('end'), 0);
   });
 }
 
-// Cleanup function should not be called when autoCleanup has not been set
+// Cleanup function should not be called when cleanup has not been set
 // listenerCount should be 1 after calling finish
 {
   const streamObj = new Writable();


### PR DESCRIPTION
ref: https://github.com/nodejs/node/issues/44556
src: add autoCleanup logic to finished
docs: add autoCleanup true as default
