### PR TITLE
meta: fix `test_runner` labeling

### DIFF
--- a/.github/label-pr-config.yml
+++ b/.github/label-pr-config.yml
@@ -99,10 +99,11 @@ subSystemLabels:
   /^lib\/\w+\/streams$/: stream
   /^lib\/.*http2/: http2
   /^lib\/worker_threads.js$/: worker
+  /^lib\/test.js$/: test_runner, dont-land-on-v14.x
   /^lib\/internal\/url\.js$/: whatwg-url
   /^lib\/internal\/modules\/esm/: esm
   /^lib\/internal\/webstreams/: web streams
-  /^lib\/internal\/test_runner/: dont-land-on-v14.x
+  /^lib\/internal\/test_runner/: test_runner, dont-land-on-v14.x
 
   # All other lib/ files map directly
   /^lib\/_(\w+)_\w+\.js?$/: $1  # e.g. _(stream)_wrap
@@ -140,6 +141,8 @@ exlusiveLabels:
   /^doc\/api\/quic.md$/: doc, quic, dont-land-on-v14.x, dont-land-on-v12.x
   # Add worker label to PRs that affect doc/api/worker_threads.md
   /^doc\/api\/worker_threads.md$/: doc, worker
+  # test runner documentation
+  /^doc\/api\/test.md$/: doc, test_runner, dont-land-on-v14.x
   # Automatically tag JS subsystem-specific API doc changes
   /^doc\/api\/(\w+)\.md$/: doc, $1
   # Add deprecations label to PRs that affect doc/api/deprecations.md


### PR DESCRIPTION
there are 3 issues fixed by this PR (I tested the changes locally)
1. `doc/api/test.md` was converted to https://github.com/nodejs/node/labels/test instead of https://github.com/nodejs/node/labels/test_runner
2. `lib/test.js` was converted to https://github.com/nodejs/node/labels/test instead of https://github.com/nodejs/node/labels/test_runner
3. `lib/internal/test_runner/*` only adds https://github.com/nodejs/node/labels/dont-land-on-v14.x but does not add https://github.com/nodejs/node/labels/test_runner (caused by https://github.com/nodejs/node/pull/44615)

examples:
https://github.com/nodejs/node/pull/44854
https://github.com/nodejs/node/pull/44844

the third issue did not occur yet so there is no example for it