### PR TITLE
test: don't clobber RegExp.$_ on startup

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -126,7 +126,9 @@ const isPi = (() => {
     // the contents of `/sys/firmware/devicetree/base/model` but that doesn't
     // work inside a container. Match the chipset model number instead.
     const cpuinfo = fs.readFileSync('/proc/cpuinfo', { encoding: 'utf8' });
-    return /^Hardware\s*:\s*(.*)$/im.exec(cpuinfo)?.[1] === 'BCM2835';
+    const ok = /^Hardware\s*:\s*(.*)$/im.exec(cpuinfo)?.[1] === 'BCM2835';
+    /^/.test('');  // Clear RegExp.$_, some tests expect it to be empty.
+    return ok;
   } catch {
     return false;
   }


### PR DESCRIPTION
Some tests expect it to be empty so clear it again after running a regular expression against /proc/cpuinfo.

It didn't cause test failures on any of the CI machines, to the best of my knowledge, because most of the time /proc/cpuinfo doesn't contain the string it was looking for.

Fixes: https://github.com/nodejs/node/issues/44840

<hr>

A more general solution would be to put it at the bottom of test/common/index.js but there's only one regular expression now so :shrug: