### PR TITLE
stream: fix `size` function returned from QueuingStrategies

### DIFF
--- a/lib/internal/webstreams/queuingstrategies.js
+++ b/lib/internal/webstreams/queuingstrategies.js
@@ -2,6 +2,7 @@
 
 const {
   ObjectDefineProperties,
+  ObjectDefineProperty,
   SymbolToStringTag,
 } = primordials;
 
@@ -47,11 +48,13 @@ const isCountQueuingStrategy =
  * }} QueuingStrategy
  */
 
-// eslint-disable-next-line func-name-matching,func-style
-const byteSizeFunction = function size(chunk) { return chunk.byteLength; };
-
-// eslint-disable-next-line func-name-matching,func-style
-const countSizeFunction = function size() { return 1; };
+const nameDescriptor = { __proto__: null, value: 'size' };
+const byteSizeFunction = ObjectDefineProperty(
+  (chunk) => chunk.byteLength,
+  'name',
+  nameDescriptor
+);
+const countSizeFunction = ObjectDefineProperty(() => 1, 'name', nameDescriptor);
 
 /**
  * @type {QueuingStrategy}

--- a/test/wpt/status/streams.json
+++ b/test/wpt/status/streams.json
@@ -2,16 +2,6 @@
   "queuing-strategies-size-function-per-global.window.js": {
     "skip": "Browser-specific test"
   },
-  "queuing-strategies.any.js": {
-    "fail": {
-      "expected": [
-        "CountQueuingStrategy: size should not have a prototype property",
-        "ByteLengthQueuingStrategy: size should not have a prototype property",
-        "CountQueuingStrategy: size should not be a constructor",
-        "ByteLengthQueuingStrategy: size should not be a constructor"
-      ]
-    }
-  },
   "readable-streams/cross-realm-crash.window.js": {
     "skip": "Browser-specific test"
   },


### PR DESCRIPTION
The `size` function returned from the `size` getter of `ByteLengthQueuingStrategy` or 
`CountQueuingStrategy` should not have a prototype property, nor be a constructor.

Refs: https://streams.spec.whatwg.org/#blqs-size
Refs: https://streams.spec.whatwg.org/#cqs-size

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
