### PR TITLE
bootstrap: merge main thread and worker thread initializations

### DIFF
--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -14,24 +14,8 @@ const {
 } = primordials;
 
 const {
-  patchProcessObject,
-  setupCoverageHooks,
-  setupInspectorHooks,
-  setupWarningHandler,
-  setupFetch,
-  setupWebCrypto,
-  setupCustomEvent,
-  setupDebugEnv,
-  setupPerfHooks,
-  initializeDeprecations,
-  initializeWASI,
-  initializeCJSLoader,
-  initializeESMLoader,
-  initializeFrozenIntrinsics,
-  initializeReport,
-  initializeSourceMapsHandlers,
-  loadPreloadModules,
-  setupTraceCategoryState,
+  prepareWorkerThreadExecution,
+  setupUserModules,
   markBootstrapComplete
 } = require('internal/process/pre_execution');
 
@@ -60,28 +44,13 @@ const {
   onGlobalUncaughtException
 } = require('internal/process/execution');
 
-const publicWorker = require('worker_threads');
 let debug = require('internal/util/debuglog').debuglog('worker', (fn) => {
   debug = fn;
 });
 
 const assert = require('internal/assert');
 
-patchProcessObject();
-setupInspectorHooks();
-setupDebugEnv();
-
-setupWarningHandler();
-setupFetch();
-setupWebCrypto();
-setupCustomEvent();
-initializeSourceMapsHandlers();
-
-// Since worker threads cannot switch cwd, we do not need to
-// overwrite the process.env.NODE_V8_COVERAGE variable.
-if (process.env.NODE_V8_COVERAGE) {
-  setupCoverageHooks(process.env.NODE_V8_COVERAGE);
-}
+prepareWorkerThreadExecution();
 
 debug(`[${threadId}] is setting up worker child environment`);
 
@@ -126,23 +95,11 @@ port.on('message', (message) => {
       hasStdin
     } = message;
 
-    setupTraceCategoryState();
-    setupPerfHooks();
-    initializeReport();
-    if (manifestSrc) {
-      require('internal/process/policy').setup(manifestSrc, manifestURL);
-    }
-    initializeDeprecations();
-    initializeWASI();
-
-    require('internal/dns/utils').initializeDns();
-
-    initializeCJSLoader();
-    initializeESMLoader();
-
     if (argv !== undefined) {
       ArrayPrototypePushApply(process.argv, argv);
     }
+
+    const publicWorker = require('worker_threads');
     publicWorker.parentPort = publicPort;
     publicWorker.workerData = workerData;
 
@@ -164,10 +121,10 @@ port.on('message', (message) => {
     };
     workerIo.sharedCwdCounter = cwdCounter;
 
-    const CJSLoader = require('internal/modules/cjs/loader');
-    assert(!CJSLoader.hasLoadedAnyUserCJSModule);
-    loadPreloadModules();
-    initializeFrozenIntrinsics();
+    if (manifestSrc) {
+      require('internal/process/policy').setup(manifestSrc, manifestURL);
+    }
+    setupUserModules();
 
     if (!hasStdin)
       process.stdin.push(null);
@@ -198,6 +155,7 @@ port.on('message', (message) => {
       // runMain here might be monkey-patched by users in --require.
       // XXX: the monkey-patchability here should probably be deprecated.
       ArrayPrototypeSplice(process.argv, 1, 0, filename);
+      const CJSLoader = require('internal/modules/cjs/loader');
       CJSLoader.Module.runMain(filename);
     }
   } else if (message.type === STDIO_PAYLOAD) {

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -34,12 +34,26 @@ const {
   isBuildingSnapshot,
 } = require('v8').startupSnapshot;
 
-function prepareMainThreadExecution(expandArgv1 = false,
-                                    initialzeModules = true) {
-  refreshRuntimeOptions();
+function prepareMainThreadExecution(expandArgv1 = false, initialzeModules = true) {
+  prepareExecution({
+    expandArgv1,
+    initialzeModules,
+    isMainThread: true
+  });
+}
 
-  // TODO(joyeecheung): this is also necessary for workers when they deserialize
-  // this toggle from the snapshot.
+function prepareWorkerThreadExecution() {
+  prepareExecution({
+    expandArgv1: false,
+    initialzeModules: false,  // Will need to initialize it after policy setup
+    isMainThread: false
+  });
+}
+
+function prepareExecution(options) {
+  const { expandArgv1, initialzeModules, isMainThread } = options;
+
+  refreshRuntimeOptions();
   reconnectZeroFillToggle();
 
   // Patch the process object with legacy properties and normalizations
@@ -61,48 +75,57 @@ function prepareMainThreadExecution(expandArgv1 = false,
   }
 
   setupDebugEnv();
-
-  // Print stack trace on `SIGINT` if option `--trace-sigint` presents.
-  setupStacktracePrinterOnSigint();
-
   // Process initial diagnostic reporting configuration, if present.
   initializeReport();
-  initializeReportSignalHandlers();  // Main-thread-only.
-
-  initializeHeapSnapshotSignalHandlers();
-
-  // If the process is spawned with env NODE_CHANNEL_FD, it's probably
-  // spawned by our child_process module, then initialize IPC.
-  // This attaches some internal event listeners and creates:
-  // process.send(), process.channel, process.connected,
-  // process.disconnect().
-  setupChildProcessIpcChannel();
-
-  // Load policy from disk and parse it.
-  initializePolicy();
-
-  // If this is a worker in cluster mode, start up the communication
-  // channel. This needs to be done before any user code gets executed
-  // (including preload modules).
-  initializeClusterIPC();
-
   initializeSourceMapsHandlers();
   initializeDeprecations();
   initializeWASI();
-
   require('internal/dns/utils').initializeDns();
 
-  require('internal/v8/startup_snapshot').runDeserializeCallbacks();
+  if (isMainThread) {
+    assert(internalBinding('worker').isMainThread);
+    // Worker threads will get the manifest in the message handler.
+    const policy = readPolicyFromDisk();
+    if (policy) {
+      require('internal/process/policy')
+        .setup(policy.manifestSrc, policy.manifestURL);
+    }
 
-  if (!initialzeModules) {
-    return;
+    // Print stack trace on `SIGINT` if option `--trace-sigint` presents.
+    setupStacktracePrinterOnSigint();
+    initializeReportSignalHandlers();  // Main-thread-only.
+    initializeHeapSnapshotSignalHandlers();
+    // If the process is spawned with env NODE_CHANNEL_FD, it's probably
+    // spawned by our child_process module, then initialize IPC.
+    // This attaches some internal event listeners and creates:
+    // process.send(), process.channel, process.connected,
+    // process.disconnect().
+    setupChildProcessIpcChannel();
+    // If this is a worker in cluster mode, start up the communication
+    // channel. This needs to be done before any user code gets executed
+    // (including preload modules).
+    initializeClusterIPC();
+
+    // TODO(joyeecheung): do this for worker threads as well.
+    require('internal/v8/startup_snapshot').runDeserializeCallbacks();
+  } else {
+    assert(!internalBinding('worker').isMainThread);
+    // The setup should be called in LOAD_SCRIPT message handler.
+    assert(!initialzeModules);
   }
 
+  if (initialzeModules) {
+    setupUserModules();
+  }
+}
+
+function setupUserModules() {
   initializeCJSLoader();
   initializeESMLoader();
   const CJSLoader = require('internal/modules/cjs/loader');
   assert(!CJSLoader.hasLoadedAnyUserCJSModule);
   loadPreloadModules();
+  // Need to be done after --require setup.
   initializeFrozenIntrinsics();
 }
 
@@ -483,7 +506,7 @@ function initializeClusterIPC() {
   }
 }
 
-function initializePolicy() {
+function readPolicyFromDisk() {
   const experimentalPolicy = getOptionValue('--experimental-policy');
   if (experimentalPolicy) {
     process.emitWarning('Policies are experimental.',
@@ -527,8 +550,9 @@ function initializePolicy() {
         throw new ERR_MANIFEST_ASSERT_INTEGRITY(manifestURL, realIntegrities);
       }
     }
-    require('internal/process/policy')
-      .setup(src, manifestURL.href);
+    return {
+      manifestSrc: src, manifestURL: manifestURL.href
+    };
   }
 }
 
@@ -610,25 +634,8 @@ function markBootstrapComplete() {
 }
 
 module.exports = {
-  refreshRuntimeOptions,
-  patchProcessObject,
-  setupCoverageHooks,
-  setupWarningHandler,
-  setupFetch,
-  setupWebCrypto,
-  setupCustomEvent,
-  setupDebugEnv,
-  setupPerfHooks,
+  setupUserModules,
   prepareMainThreadExecution,
-  initializeDeprecations,
-  initializeESMLoader,
-  initializeFrozenIntrinsics,
-  initializeSourceMapsHandlers,
-  loadPreloadModules,
-  setupTraceCategoryState,
-  setupInspectorHooks,
-  initializeReport,
-  initializeCJSLoader,
-  initializeWASI,
+  prepareWorkerThreadExecution,
   markBootstrapComplete
 };


### PR DESCRIPTION
Instead of doing the initializations of worker threads using small helper functions that are also used by the main thread initialization, wrap everything into a common prepareExecution() function with an isMainThread switch to turn off initializations that shouldn't be done for worker threads, so that we don't have to replicate all the initialization steps in the worker code, which can be error-prone.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
