### PR TITLE
tools: fix timezone update tool

### DIFF
--- a/tools/update-timezone.mjs
+++ b/tools/update-timezone.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Usage: tools/update-timezone.mjs
-import { execSync, spawnSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { renameSync, readdirSync, rmSync } from 'node:fs';
 import { exit } from 'node:process';
 
@@ -26,13 +26,7 @@ if (latestVersion === currentVersion) {
 execSync('bzip2 -d deps/icu-small/source/data/in/icudt*.dat.bz2');
 fileNames.forEach((file) => {
   renameSync(`icu-data/tzdata/icunew/${latestVersion}/44/le/${file}`, `deps/icu-small/source/data/in/${file}`);
-  spawnSync(
-    'icupkg', [
-      '-a',
-      file,
-      'icudt*.dat',
-    ], { cwd: 'deps/icu-small/source/data/in/' }
-  );
+  execSync(`icupkg -a ${file} icudt*.dat`, { cwd: 'deps/icu-small/source/data/in/' });
   rmSync(`deps/icu-small/source/data/in/${file}`);
 });
 execSync('bzip2 -z deps/icu-small/source/data/in/icudt*.dat');

--- a/tools/update-timezone.mjs
+++ b/tools/update-timezone.mjs
@@ -2,7 +2,6 @@
 // Usage: tools/update-timezone.mjs
 import { execSync } from 'node:child_process';
 import { renameSync, readdirSync, rmSync } from 'node:fs';
-import { exit } from 'node:process';
 
 const fileNames = [
   'zoneinfo64.res',
@@ -15,13 +14,7 @@ const availableVersions = readdirSync('icu-data/tzdata/icunew', { withFileTypes:
 .filter((dirent) => dirent.isDirectory())
 .map((dirent) => dirent.name);
 
-const currentVersion = process.versions.tz;
 const latestVersion = availableVersions.sort().at(-1);
-
-if (latestVersion === currentVersion) {
-  console.log(`Terminating early, tz version is latest @ ${currentVersion}`);
-  exit();
-}
 
 execSync('bzip2 -d deps/icu-small/source/data/in/icudt*.dat.bz2');
 fileNames.forEach((file) => {


### PR DESCRIPTION
#### tools: fix timezone update tool

The `spawnSync()` call was previously silently failing with this error:
```sh
icupkg: unable to open input file "icudt*.dat"
```
because `spawnSync()` doesn't support globbing. This change replaces the `spawnSync()` call with `execSync()` because that supports globbing.

I have tested this workflow with some minor modifications in my fork and I can confirm that it works as expected now. The bot opened this PR - https://github.com/RaisinTen/node/pull/2 which updates `deps/icu-small/source/data/in/icudt71l.dat.bz2` in https://github.com/RaisinTen/node/pull/2/commits/44c24009f6bfa796a3a06e6bda00a16230e27167.

Fixes: https://github.com/nodejs/node/issues/44865
Signed-off-by: Darshan Sen <raisinten@gmail.com>

---

#### tools: remove faulty early termination logic from `update-timezone.mjs`

We do not build Node.js in the workflow so
https://github.com/nodejs/node/blob/f4815fcd7691364d8139b44c1295dbc46f6ee4a8/tools/update-timezone.mjs#L18
is actually the version of `tzdata` in the Node.js in the runner instead
of what's in `main`.

The script is pretty fast even when the versions differ and there is an
update, so this optimization doesn't seem to be worth having given the
problem.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
