### PR TITLE
http,http2: support more attributes for early hint link

### DIFF
--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -403,7 +403,7 @@ function validateUnion(value, name, union) {
   }
 }
 
-const linkValueRegExp = /^(?:<[^>]*>;)\s*(?:rel=(")?[^;"]*\1;?)\s*(?:(?:as|anchor|title)=(")?[^;"]*\2)?$/;
+const linkValueRegExp = /^(?:<[^>]*>;)\s*(?:rel=(")?[^;"]*\1;?)\s*(?:(?:as|anchor|title|crossorigin|disabled|fetchpriority|rel|referrerpolicy)=(")?[^;"]*\2)?$/;
 
 /**
  * @param {any} value

--- a/test/parallel/test-validators.js
+++ b/test/parallel/test-validators.js
@@ -12,6 +12,7 @@ const {
   validateString,
   validateInt32,
   validateUint32,
+  validateLinkHeaderValue,
 } = require('internal/validators');
 const { MAX_SAFE_INTEGER, MIN_SAFE_INTEGER } = Number;
 const outOfRangeError = {
@@ -153,4 +154,16 @@ const invalidArgValueError = {
   ].forEach((i) => assert.throws(() => validateNumber(i, 'name'), {
     code: 'ERR_INVALID_ARG_TYPE'
   }));
+}
+
+{
+  // validateLinkHeaderValue type validation.
+  [
+    ['</styles.css>; rel=preload; as=style', '</styles.css>; rel=preload; as=style'],
+    ['</styles.css>; rel=preload; title=hello', '</styles.css>; rel=preload; title=hello'],
+    ['</styles.css>; rel=preload; crossorigin=hello', '</styles.css>; rel=preload; crossorigin=hello'],
+    ['</styles.css>; rel=preload; disabled=true', '</styles.css>; rel=preload; disabled=true'],
+    ['</styles.css>; rel=preload; fetchpriority=high', '</styles.css>; rel=preload; fetchpriority=high'],
+    ['</styles.css>; rel=preload; referrerpolicy=origin', '</styles.css>; rel=preload; referrerpolicy=origin'],
+  ].forEach(([value, expected]) => assert.strictEqual(validateLinkHeaderValue(value), expected));
 }


### PR DESCRIPTION
Link header should eventually have to support all attributes of the HTML `link` element.

- The list of all available attributes is available [https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attributes](here).
- The syntax for the link header is available [https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link#syntax](here).

Resolves https://github.com/nodejs/node/issues/44843.
Dependent of https://github.com/nodejs/node/pull/44820.
