### PR TITLE
src: optimize ALPN callback

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -786,11 +786,8 @@ TLSSocket.prototype._init = function(socket, wrap) {
     ssl.enableCertCb();
   }
 
-  if (options.ALPNProtocols) {
-    // Keep reference in secureContext not to be GC-ed
-    ssl._secureContext.alpnBuffer = options.ALPNProtocols;
-    ssl.setALPNProtocols(ssl._secureContext.alpnBuffer);
-  }
+  if (options.ALPNProtocols)
+    ssl.setALPNProtocols(options.ALPNProtocols);
 
   if (options.pskCallback && ssl.enablePskCallback) {
     validateFunction(options.pskCallback, 'pskCallback');

--- a/src/crypto/crypto_common.cc
+++ b/src/crypto/crypto_common.cc
@@ -89,12 +89,6 @@ void LogSecret(
   keylog_cb(ssl.get(), line.c_str());
 }
 
-bool SetALPN(const SSLPointer& ssl, std::string_view alpn) {
-  return SSL_set_alpn_protos(ssl.get(),
-                             reinterpret_cast<const uint8_t*>(alpn.data()),
-                             alpn.length()) == 0;
-}
-
 MaybeLocal<Value> GetSSLOCSPResponse(
     Environment* env,
     SSL* ssl,

--- a/src/crypto/crypto_common.h
+++ b/src/crypto/crypto_common.h
@@ -33,9 +33,6 @@ void LogSecret(
     const unsigned char* secret,
     size_t secretlen);
 
-// TODO(tniessen): use std::u8string_view when we switch to C++20.
-bool SetALPN(const SSLPointer& ssl, std::string_view alpn);
-
 v8::MaybeLocal<v8::Value> GetSSLOCSPResponse(
     Environment* env,
     SSL* ssl,

--- a/src/crypto/crypto_tls.h
+++ b/src/crypto/crypto_tls.h
@@ -34,6 +34,7 @@
 #include <openssl/ssl.h>
 
 #include <string>
+#include <vector>
 
 namespace node {
 namespace crypto {
@@ -283,6 +284,9 @@ class TLSWrap : public AsyncWrap,
   void* cert_cb_arg_ = nullptr;
 
   BIOPointer bio_trace_;
+
+ public:
+  std::vector<unsigned char> alpn_protos_;  // Accessed by SelectALPNCallback.
 };
 
 }  // namespace crypto

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -18,7 +18,6 @@
 // for the sake of convenience.  Strings should be ASCII-only and have a
 // "node:" prefix to avoid name clashes with third-party code.
 #define PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)                               \
-  V(alpn_buffer_private_symbol, "node:alpnBuffer")                             \
   V(arrow_message_private_symbol, "node:arrowMessage")                         \
   V(contextify_context_private_symbol, "node:contextify:context")              \
   V(contextify_global_private_symbol, "node:contextify:global")                \

--- a/typings/internalBinding/util.d.ts
+++ b/typings/internalBinding/util.d.ts
@@ -9,7 +9,6 @@ declare namespace InternalUtilBinding {
 
 declare function InternalBinding(binding: 'util'): {
   // PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES, defined in src/env.h
-  alpn_buffer_private_symbol: 0;
   arrow_message_private_symbol: 1;
   contextify_context_private_symbol: 2;
   contextify_global_private_symbol: 3;


### PR DESCRIPTION
It doesn't make sense from a performance perspective to retain an
arraybuffer with the ALPN byte string and look it up as a property on
the JS context object for every TLS handshake.

Store the byte string in the C++ TLSWrap object instead. That's both
a lot faster and a lot simpler.

<hr>

First commit is minor cleanup for readability++.