### PR TITLE
doc,crypto: add missing algorithms and types to webcrypto documentation

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -597,6 +597,8 @@ containing the generated data.
 The algorithms currently supported include:
 
 * `'ECDH'`
+* `'X25519'`[^1]
+* `'X448'`[^1]
 * `'HKDF'`
 * `'PBKDF2'`
 
@@ -635,6 +637,8 @@ generate raw keying material, then passing the result into the
 The algorithms currently supported include:
 
 * `'ECDH'`
+* `'X25519'`[^1]
+* `'X448'`[^1]
 * `'HKDF'`
 * `'PBKDF2'`
 
@@ -910,7 +914,11 @@ The unwrapped key algorithms supported include:
 * `'RSA-PSS'`
 * `'RSA-OAEP'`
 * `'ECDSA'`
+* `'Ed25519'`[^1]
+* `'Ed448'`[^1]
 * `'ECDH'`
+* `'X25519'`[^1]
+* `'X448'`[^1]
 * `'HMAC'`
 * `'AES-CTR'`
 * `'AES-CBC'`

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -575,16 +575,24 @@ changes:
 
 * `algorithm`: {AlgorithmIdentifier|EcdhKeyDeriveParams|HkdfParams|Pbkdf2Params}
 * `baseKey`: {CryptoKey}
-* `length`: {number}
+* `length`: {number|null}
 * Returns: {Promise} containing {ArrayBuffer}
 
 <!--lint enable maximum-line-length remark-lint-->
 
 Using the method and parameters specified in `algorithm` and the keying
 material provided by `baseKey`, `subtle.deriveBits()` attempts to generate
-`length` bits. The Node.js implementation requires that `length` is a
-multiple of `8`. If successful, the returned promise will be resolved with
-an {ArrayBuffer} containing the generated data.
+`length` bits.
+
+The Node.js implementation requires that when `length` is a
+number it must be multiple of `8`.
+
+When `length` is `null` the maximum number of bits for a given algorithm is
+generated. This is allowed for the `'ECDH'`, `'X25519'`[^1], and `'X448'`[^1]
+algorithms.
+
+If successful, the returned promise will be resolved with an {ArrayBuffer}
+containing the generated data.
 
 The algorithms currently supported include:
 


### PR DESCRIPTION
- adds `null` as an allowed deriveBits length
- adds CFRG curves to supported algorithms lists