### PR TITLE
module: fix invalid segment deprecation for imports field

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -100,15 +100,15 @@ function emitTrailingSlashPatternDeprecation(match, pjsonUrl, base) {
 
 const doubleSlashRegEx = /[/\\][/\\]/;
 
-function emitInvalidSegmentDeprecation(target, request, match, pjsonUrl, base) {
+function emitInvalidSegmentDeprecation(target, request, match, pjsonUrl, internal, base, isTarget) {
   const pjsonPath = fileURLToPath(pjsonUrl);
-  const double = RegExpPrototypeExec(doubleSlashRegEx, target) !== null;
+  const double = RegExpPrototypeExec(doubleSlashRegEx, isTarget ? target : request) !== null;
   process.emitWarning(
     `Use of deprecated ${double ? 'double slash' :
       'leading or trailing slash matching'} resolving "${target}" for module ` +
       `request "${request}" ${request !== match ? `matched to "${match}" ` : ''
-      }in the "exports" field module resolution of the package at ${pjsonPath}${
-        base ? ` imported from ${fileURLToPath(base)}` : ''}.`,
+      }in the "${internal ? 'imports' : 'exports'}" field module resolution of the package at ${
+        pjsonPath}${base ? ` imported from ${fileURLToPath(base)}` : ''}.`,
     'DeprecationWarning',
     'DEP0166'
   );
@@ -436,7 +436,7 @@ function resolvePackageTargetString(
         const resolvedTarget = pattern ?
           RegExpPrototypeSymbolReplace(patternRegEx, target, () => subpath) :
           target;
-        emitInvalidSegmentDeprecation(resolvedTarget, request, match, packageJSONUrl, base);
+        emitInvalidSegmentDeprecation(resolvedTarget, request, match, packageJSONUrl, internal, base, true);
       }
     } else {
       throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
@@ -459,7 +459,7 @@ function resolvePackageTargetString(
         const resolvedTarget = pattern ?
           RegExpPrototypeSymbolReplace(patternRegEx, target, () => subpath) :
           target;
-        emitInvalidSegmentDeprecation(resolvedTarget, request, match, packageJSONUrl, base);
+        emitInvalidSegmentDeprecation(resolvedTarget, request, match, packageJSONUrl, internal, base, false);
       }
     } else {
       throwInvalidSubpath(request, match, packageJSONUrl, internal, base);

--- a/test/es-module/test-esm-imports-deprecations.mjs
+++ b/test/es-module/test-esm-imports-deprecations.mjs
@@ -1,0 +1,27 @@
+// Flags: --pending-deprecation
+import { mustCall } from '../common/index.mjs';
+import assert from 'assert';
+
+let curWarning = 0;
+const expectedWarnings = [
+  'Use of deprecated double slash',
+  'Use of deprecated double slash',
+  './sub//null',
+  './sub/////null',
+  './sub//internal/test',
+  './sub//internal//test',
+  '#subpath/////internal',
+  '#subpath//asdf.asdf',
+  '#subpath/as//df.asdf',
+  './sub//null',
+  './sub/////null',
+  './sub//internal/test',
+  './sub//internal//test',
+  '#subpath/////internal',
+];
+
+process.addListener('warning', mustCall((warning) => {
+  assert(warning.stack.includes(expectedWarnings[curWarning++]), warning.stack);
+}, expectedWarnings.length));
+
+await import('./test-esm-imports.mjs');

--- a/test/es-module/test-esm-imports.mjs
+++ b/test/es-module/test-esm-imports.mjs
@@ -22,6 +22,10 @@ const { requireImport, importImport } = importer;
     ['#external/subpath/asdf.js', { default: 'asdf' }],
     // Trailing pattern imports
     ['#subpath/asdf.asdf', { default: 'test' }],
+    // Leading slash
+    ['#subpath//asdf.asdf', { default: 'test' }],
+    // Double slash
+    ['#subpath/as//df.asdf', { default: 'test' }],
   ]);
 
   for (const [validSpecifier, expected] of internalImports) {

--- a/test/fixtures/es-modules/pkgimports/package.json
+++ b/test/fixtures/es-modules/pkgimports/package.json
@@ -1,6 +1,5 @@
 {
   "imports": {
-    "#test": "./test.js",
     "#branch": {
       "import": "./importbranch.js",
       "require": "./requirebranch.js"
@@ -26,6 +25,7 @@
     },
     "#subpath/nullshadow/*": [null],
     "#": "./test.js",
+    "#*est": "./*est.js",
     "#/initialslash": "./test.js",
     "#notfound": "./notfound.js",
     "#encodedslash": "./..%2F/x.js",


### PR DESCRIPTION
While reviewing the backport requirements for https://github.com/nodejs/node/pull/44477 today I noticed I missed handling the `"imports"` case properly in the runtime deprecation message - this fixes that so that the deprecation message references the `"imports"` or `"exports"` field properly depending on which is causing the issue (it always logs it as an `"exports"` issue even for imports otherwise).

I also noticed that the double slash message wasn't being shown when the double slash is part of the pattern match and pattern replacement (invalid module specifier error instead of package target error). I've also made this adjustment as well.

//cc @nodejs/modules 