### PR TITLE
crypto: add causes to applicable webcrypto's OperationError

### DIFF
--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -241,11 +241,10 @@ async function aesGenerateKey(algorithm, extractable, keyUsages) {
   }
 
   const key = await generateKey('aes', { length }).catch((err) => {
-    // TODO(@panva): add err as cause to DOMException
     throw lazyDOMException(
       'The operation failed for an operation-specific reason' +
       `[${err.message}]`,
-      'OperationError');
+      { name: 'OperationError', cause: err });
   });
 
   return new InternalCryptoKey(

--- a/lib/internal/crypto/cfrg.js
+++ b/lib/internal/crypto/cfrg.js
@@ -150,10 +150,9 @@ async function cfrgGenerateKey(algorithm, extractable, keyUsages) {
   }
 
   const keyPair = await generateKeyPair(genKeyType).catch((err) => {
-    // TODO(@panva): add err as cause to DOMException
     throw lazyDOMException(
       'The operation failed for an operation-specific reason',
-      'OperationError');
+      { name: 'OperationError', cause: err });
   });
 
   let publicUsages;

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -112,10 +112,9 @@ async function ecGenerateKey(algorithm, extractable, keyUsages) {
   }
 
   const keypair = await generateKeyPair('ec', { namedCurve }).catch((err) => {
-    // TODO(@panva): add err as cause to DOMException
     throw lazyDOMException(
       'The operation failed for an operation-specific reason',
-      'OperationError');
+      { name: 'OperationError', cause: err });
   });
 
   let publicUsages;

--- a/lib/internal/crypto/mac.js
+++ b/lib/internal/crypto/mac.js
@@ -66,10 +66,9 @@ async function hmacGenerateKey(algorithm, extractable, keyUsages) {
   }
 
   const key = await generateKey('hmac', { length }).catch((err) => {
-    // TODO(@panva): add err as cause to DOMException
     throw lazyDOMException(
       'The operation failed for an operation-specific reason',
-      'OperationError');
+      { name: 'OperationError', cause: err });
   });
 
   return new InternalCryptoKey(

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -178,10 +178,9 @@ async function rsaKeyGenerate(
     modulusLength,
     publicExponent: publicExponentConverted,
   }).catch((err) => {
-    // TODO(@panva): add err as cause to DOMException
     throw lazyDOMException(
       'The operation failed for an operation-specific reason',
-      'OperationError');
+      { name: 'OperationError', cause: err });
   });
 
   const keyAlgorithm = {

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -279,10 +279,9 @@ const validateByteSource = hideStackFrames((val, name) => {
 
 function onDone(resolve, reject, err, result) {
   if (err) {
-    // TODO(@panva): add err as cause to DOMException
     return reject(lazyDOMException(
       'The operation failed for an operation-specific reason',
-      'OperationError'));
+      { name: 'OperationError', cause: err }));
   }
   resolve(result);
 }


### PR DESCRIPTION
Builds on top of #44703, adding the underlying error as `cause` to WebCryptoAPI `DOMException`s.