### PR TITLE
doc,crypto: mark experimental algorithms more visually

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -343,28 +343,28 @@ async function digest(data, algorithm = 'SHA-512') {
 The table details the algorithms supported by the Node.js Web Crypto API
 implementation and the APIs supported for each:
 
-| Algorithm             | `generateKey` | `exportKey` | `importKey` | `encrypt` | `decrypt` | `wrapKey` | `unwrapKey` | `deriveBits` | `deriveKey` | `sign` | `verify` | `digest` |
-| --------------------- | ------------- | ----------- | ----------- | --------- | --------- | --------- | ----------- | ------------ | ----------- | ------ | -------- | -------- |
-| `'RSASSA-PKCS1-v1_5'` | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
-| `'RSA-PSS'`           | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
-| `'RSA-OAEP'`          | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
-| `'ECDSA'`             | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
-| `'Ed25519'`[^1]       | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
-| `'Ed448'`[^1]         | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
-| `'ECDH'`              | ✔             | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
-| `'X25519'`[^1]        | ✔             | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
-| `'X448'`[^1]          | ✔             | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
-| `'AES-CTR'`           | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
-| `'AES-CBC'`           | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
-| `'AES-GCM'`           | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
-| `'AES-KW'`            | ✔             | ✔           | ✔           |           |           | ✔         | ✔           |              |             |        |          |          |
-| `'HMAC'`              | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
-| `'HKDF'`              |               | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
-| `'PBKDF2'`            |               | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
-| `'SHA-1'`             |               |             |             |           |           |           |             |              |             |        |          | ✔        |
-| `'SHA-256'`           |               |             |             |           |           |           |             |              |             |        |          | ✔        |
-| `'SHA-384'`           |               |             |             |           |           |           |             |              |             |        |          | ✔        |
-| `'SHA-512'`           |               |             |             |           |           |           |             |              |             |        |          | ✔        |
+| Algorithm                                                 | `generateKey` | `exportKey` | `importKey` | `encrypt` | `decrypt` | `wrapKey` | `unwrapKey` | `deriveBits` | `deriveKey` | `sign` | `verify` | `digest` |
+| --------------------------------------------------------- | ------------- | ----------- | ----------- | --------- | --------- | --------- | ----------- | ------------ | ----------- | ------ | -------- | -------- |
+| `'RSASSA-PKCS1-v1_5'`                                     | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
+| `'RSA-PSS'`                                               | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
+| `'RSA-OAEP'`                                              | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
+| `'ECDSA'`                                                 | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
+| `'Ed25519'` <span class="experimental-inline"></span>[^1] | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
+| `'Ed448'` <span class="experimental-inline"></span>[^1]   | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
+| `'ECDH'`                                                  | ✔             | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
+| `'X25519'` <span class="experimental-inline"></span>[^1]  | ✔             | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
+| `'X448'` <span class="experimental-inline"></span>[^1]    | ✔             | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
+| `'AES-CTR'`                                               | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
+| `'AES-CBC'`                                               | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
+| `'AES-GCM'`                                               | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
+| `'AES-KW'`                                                | ✔             | ✔           | ✔           |           |           | ✔         | ✔           |              |             |        |          |          |
+| `'HMAC'`                                                  | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
+| `'HKDF'`                                                  |               | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
+| `'PBKDF2'`                                                |               | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
+| `'SHA-1'`                                                 |               |             |             |           |           |           |             |              |             |        |          | ✔        |
+| `'SHA-256'`                                               |               |             |             |           |           |           |             |              |             |        |          | ✔        |
+| `'SHA-384'`                                               |               |             |             |           |           |           |             |              |             |        |          | ✔        |
+| `'SHA-512'`                                               |               |             |             |           |           |           |             |              |             |        |          | ✔        |
 
 ## Class: `Crypto`
 
@@ -486,24 +486,24 @@ The possible usages are:
 Valid key usages depend on the key algorithm (identified by
 `cryptokey.algorithm.name`).
 
-| Key Type              | `'encrypt'` | `'decrypt'` | `'sign'` | `'verify'` | `'deriveKey'` | `'deriveBits'` | `'wrapKey'` | `'unwrapKey'` |
-| --------------------- | ----------- | ----------- | -------- | ---------- | ------------- | -------------- | ----------- | ------------- |
-| `'AES-CBC'`           | ✔           | ✔           |          |            |               |                | ✔           | ✔             |
-| `'AES-CTR'`           | ✔           | ✔           |          |            |               |                | ✔           | ✔             |
-| `'AES-GCM'`           | ✔           | ✔           |          |            |               |                | ✔           | ✔             |
-| `'AES-KW'`            |             |             |          |            |               |                | ✔           | ✔             |
-| `'ECDH'`              |             |             |          |            | ✔             | ✔              |             |               |
-| `'X25519'`[^1]        |             |             |          |            | ✔             | ✔              |             |               |
-| `'X448'`[^1]          |             |             |          |            | ✔             | ✔              |             |               |
-| `'ECDSA'`             |             |             | ✔        | ✔          |               |                |             |               |
-| `'Ed25519'`[^1]       |             |             | ✔        | ✔          |               |                |             |               |
-| `'Ed448'`[^1]         |             |             | ✔        | ✔          |               |                |             |               |
-| `'HDKF'`              |             |             |          |            | ✔             | ✔              |             |               |
-| `'HMAC'`              |             |             | ✔        | ✔          |               |                |             |               |
-| `'PBKDF2'`            |             |             |          |            | ✔             | ✔              |             |               |
-| `'RSA-OAEP'`          | ✔           | ✔           |          |            |               |                | ✔           | ✔             |
-| `'RSA-PSS'`           |             |             | ✔        | ✔          |               |                |             |               |
-| `'RSASSA-PKCS1-v1_5'` |             |             | ✔        | ✔          |               |                |             |               |
+| Key Type                                                  | `'encrypt'` | `'decrypt'` | `'sign'` | `'verify'` | `'deriveKey'` | `'deriveBits'` | `'wrapKey'` | `'unwrapKey'` |
+| --------------------------------------------------------- | ----------- | ----------- | -------- | ---------- | ------------- | -------------- | ----------- | ------------- |
+| `'AES-CBC'`                                               | ✔           | ✔           |          |            |               |                | ✔           | ✔             |
+| `'AES-CTR'`                                               | ✔           | ✔           |          |            |               |                | ✔           | ✔             |
+| `'AES-GCM'`                                               | ✔           | ✔           |          |            |               |                | ✔           | ✔             |
+| `'AES-KW'`                                                |             |             |          |            |               |                | ✔           | ✔             |
+| `'ECDH'`                                                  |             |             |          |            | ✔             | ✔              |             |               |
+| `'X25519'` <span class="experimental-inline"></span>[^1]  |             |             |          |            | ✔             | ✔              |             |               |
+| `'X448'` <span class="experimental-inline"></span>[^1]    |             |             |          |            | ✔             | ✔              |             |               |
+| `'ECDSA'`                                                 |             |             | ✔        | ✔          |               |                |             |               |
+| `'Ed25519'` <span class="experimental-inline"></span>[^1] |             |             | ✔        | ✔          |               |                |             |               |
+| `'Ed448'` <span class="experimental-inline"></span>[^1]   |             |             | ✔        | ✔          |               |                |             |               |
+| `'HDKF'`                                                  |             |             |          |            | ✔             | ✔              |             |               |
+| `'HMAC'`                                                  |             |             | ✔        | ✔          |               |                |             |               |
+| `'PBKDF2'`                                                |             |             |          |            | ✔             | ✔              |             |               |
+| `'RSA-OAEP'`                                              | ✔           | ✔           |          |            |               |                | ✔           | ✔             |
+| `'RSA-PSS'`                                               |             |             | ✔        | ✔          |               |                |             |               |
+| `'RSASSA-PKCS1-v1_5'`                                     |             |             | ✔        | ✔          |               |                |             |               |
 
 ## Class: `CryptoKeyPair`
 
@@ -588,7 +588,7 @@ The Node.js implementation requires that when `length` is a
 number it must be multiple of `8`.
 
 When `length` is `null` the maximum number of bits for a given algorithm is
-generated. This is allowed for the `'ECDH'`, `'X25519'`[^1], and `'X448'`[^1]
+generated. This is allowed for the `'ECDH'`, `'X25519'`, and `'X448'`
 algorithms.
 
 If successful, the returned promise will be resolved with an {ArrayBuffer}
@@ -597,8 +597,8 @@ containing the generated data.
 The algorithms currently supported include:
 
 * `'ECDH'`
-* `'X25519'`[^1]
-* `'X448'`[^1]
+* `'X25519'` <span class="experimental-inline"></span>[^1]
+* `'X448'` <span class="experimental-inline"></span>[^1]
 * `'HKDF'`
 * `'PBKDF2'`
 
@@ -637,8 +637,8 @@ generate raw keying material, then passing the result into the
 The algorithms currently supported include:
 
 * `'ECDH'`
-* `'X25519'`[^1]
-* `'X448'`[^1]
+* `'X25519'` <span class="experimental-inline"></span>[^1]
+* `'X448'` <span class="experimental-inline"></span>[^1]
 * `'HKDF'`
 * `'PBKDF2'`
 
@@ -720,22 +720,22 @@ When `format` is `'jwk'` and the export is successful, the returned promise
 will be resolved with a JavaScript object conforming to the [JSON Web Key][]
 specification.
 
-| Key Type              | `'spki'` | `'pkcs8'` | `'jwk'` | `'raw'` |
-| --------------------- | -------- | --------- | ------- | ------- |
-| `'AES-CBC'`           |          |           | ✔       | ✔       |
-| `'AES-CTR'`           |          |           | ✔       | ✔       |
-| `'AES-GCM'`           |          |           | ✔       | ✔       |
-| `'AES-KW'`            |          |           | ✔       | ✔       |
-| `'ECDH'`              | ✔        | ✔         | ✔       | ✔       |
-| `'ECDSA'`             | ✔        | ✔         | ✔       | ✔       |
-| `'Ed25519'`[^1]       | ✔        | ✔         | ✔       | ✔       |
-| `'Ed448'`[^1]         | ✔        | ✔         | ✔       | ✔       |
-| `'HDKF'`              |          |           |         |         |
-| `'HMAC'`              |          |           | ✔       | ✔       |
-| `'PBKDF2'`            |          |           |         |         |
-| `'RSA-OAEP'`          | ✔        | ✔         | ✔       |         |
-| `'RSA-PSS'`           | ✔        | ✔         | ✔       |         |
-| `'RSASSA-PKCS1-v1_5'` | ✔        | ✔         | ✔       |         |
+| Key Type                                                  | `'spki'` | `'pkcs8'` | `'jwk'` | `'raw'` |
+| --------------------------------------------------------- | -------- | --------- | ------- | ------- |
+| `'AES-CBC'`                                               |          |           | ✔       | ✔       |
+| `'AES-CTR'`                                               |          |           | ✔       | ✔       |
+| `'AES-GCM'`                                               |          |           | ✔       | ✔       |
+| `'AES-KW'`                                                |          |           | ✔       | ✔       |
+| `'ECDH'`                                                  | ✔        | ✔         | ✔       | ✔       |
+| `'ECDSA'`                                                 | ✔        | ✔         | ✔       | ✔       |
+| `'Ed25519'` <span class="experimental-inline"></span>[^1] | ✔        | ✔         | ✔       | ✔       |
+| `'Ed448'` <span class="experimental-inline"></span>[^1]   | ✔        | ✔         | ✔       | ✔       |
+| `'HDKF'`                                                  |          |           |         |         |
+| `'HMAC'`                                                  |          |           | ✔       | ✔       |
+| `'PBKDF2'`                                                |          |           |         |         |
+| `'RSA-OAEP'`                                              | ✔        | ✔         | ✔       |         |
+| `'RSA-PSS'`                                               | ✔        | ✔         | ✔       |         |
+| `'RSASSA-PKCS1-v1_5'`                                     | ✔        | ✔         | ✔       |         |
 
 ### `subtle.generateKey(algorithm, extractable, keyUsages)`
 
@@ -764,11 +764,11 @@ include:
 * `'RSA-PSS'`
 * `'RSA-OAEP'`
 * `'ECDSA'`
-* `'Ed25519'`[^1]
-* `'Ed448'`[^1]
+* `'Ed25519'` <span class="experimental-inline"></span>[^1]
+* `'Ed448'` <span class="experimental-inline"></span>[^1]
 * `'ECDH'`
-* `'X25519'`[^1]
-* `'X448'`[^1]
+* `'X25519'` <span class="experimental-inline"></span>[^1]
+* `'X448'` <span class="experimental-inline"></span>[^1]
 
 The {CryptoKey} (secret key) generating algorithms supported include:
 
@@ -816,24 +816,24 @@ If importing a `'PBKDF2'` key, `extractable` must be `false`.
 
 The algorithms currently supported include:
 
-| Key Type              | `'spki'` | `'pkcs8'` | `'jwk'` | `'raw'` |
-| --------------------- | -------- | --------- | ------- | ------- |
-| `'AES-CBC'`           |          |           | ✔       | ✔       |
-| `'AES-CTR'`           |          |           | ✔       | ✔       |
-| `'AES-GCM'`           |          |           | ✔       | ✔       |
-| `'AES-KW'`            |          |           | ✔       | ✔       |
-| `'ECDH'`              | ✔        | ✔         | ✔       | ✔       |
-| `'X25519'`[^1]        | ✔        | ✔         | ✔       | ✔       |
-| `'X448'`[^1]          | ✔        | ✔         | ✔       | ✔       |
-| `'ECDSA'`             | ✔        | ✔         | ✔       | ✔       |
-| `'Ed25519'`[^1]       | ✔        | ✔         | ✔       | ✔       |
-| `'Ed448'`[^1]         | ✔        | ✔         | ✔       | ✔       |
-| `'HDKF'`              |          |           |         | ✔       |
-| `'HMAC'`              |          |           | ✔       | ✔       |
-| `'PBKDF2'`            |          |           |         | ✔       |
-| `'RSA-OAEP'`          | ✔        | ✔         | ✔       |         |
-| `'RSA-PSS'`           | ✔        | ✔         | ✔       |         |
-| `'RSASSA-PKCS1-v1_5'` | ✔        | ✔         | ✔       |         |
+| Key Type                                                  | `'spki'` | `'pkcs8'` | `'jwk'` | `'raw'` |
+| --------------------------------------------------------- | -------- | --------- | ------- | ------- |
+| `'AES-CBC'`                                               |          |           | ✔       | ✔       |
+| `'AES-CTR'`                                               |          |           | ✔       | ✔       |
+| `'AES-GCM'`                                               |          |           | ✔       | ✔       |
+| `'AES-KW'`                                                |          |           | ✔       | ✔       |
+| `'ECDH'`                                                  | ✔        | ✔         | ✔       | ✔       |
+| `'X25519'` <span class="experimental-inline"></span>[^1]  | ✔        | ✔         | ✔       | ✔       |
+| `'X448'` <span class="experimental-inline"></span>[^1]    | ✔        | ✔         | ✔       | ✔       |
+| `'ECDSA'`                                                 | ✔        | ✔         | ✔       | ✔       |
+| `'Ed25519'` <span class="experimental-inline"></span>[^1] | ✔        | ✔         | ✔       | ✔       |
+| `'Ed448'` <span class="experimental-inline"></span>[^1]   | ✔        | ✔         | ✔       | ✔       |
+| `'HDKF'`                                                  |          |           |         | ✔       |
+| `'HMAC'`                                                  |          |           | ✔       | ✔       |
+| `'PBKDF2'`                                                |          |           |         | ✔       |
+| `'RSA-OAEP'`                                              | ✔        | ✔         | ✔       |         |
+| `'RSA-PSS'`                                               | ✔        | ✔         | ✔       |         |
+| `'RSASSA-PKCS1-v1_5'`                                     | ✔        | ✔         | ✔       |         |
 
 ### `subtle.sign(algorithm, key, data)`
 
@@ -866,8 +866,8 @@ The algorithms currently supported include:
 * `'RSASSA-PKCS1-v1_5'`
 * `'RSA-PSS'`
 * `'ECDSA'`
-* `'Ed25519'`[^1]
-* `'Ed448'`[^1]
+* `'Ed25519'` <span class="experimental-inline"></span>[^1]
+* `'Ed448'` <span class="experimental-inline"></span>[^1]
 * `'HMAC'`
 
 ### `subtle.unwrapKey(format, wrappedKey, unwrappingKey, unwrapAlgo, unwrappedKeyAlgo, extractable, keyUsages)`
@@ -914,11 +914,11 @@ The unwrapped key algorithms supported include:
 * `'RSA-PSS'`
 * `'RSA-OAEP'`
 * `'ECDSA'`
-* `'Ed25519'`[^1]
-* `'Ed448'`[^1]
+* `'Ed25519'` <span class="experimental-inline"></span>[^1]
+* `'Ed448'` <span class="experimental-inline"></span>[^1]
 * `'ECDH'`
-* `'X25519'`[^1]
-* `'X448'`[^1]
+* `'X25519'` <span class="experimental-inline"></span>[^1]
+* `'X448'` <span class="experimental-inline"></span>[^1]
 * `'HMAC'`
 * `'AES-CTR'`
 * `'AES-CBC'`
@@ -957,8 +957,8 @@ The algorithms currently supported include:
 * `'RSASSA-PKCS1-v1_5'`
 * `'RSA-PSS'`
 * `'ECDSA'`
-* `'Ed25519'`[^1]
-* `'Ed448'`[^1]
+* `'Ed25519'` <span class="experimental-inline"></span>[^1]
+* `'Ed448'` <span class="experimental-inline"></span>[^1]
 * `'HMAC'`
 
 ### `subtle.wrapKey(format, key, wrappingKey, wrapAlgo)`

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -616,6 +616,15 @@ hr {
   border-radius: 3px;
 }
 
+.experimental-inline::after {
+  background-color: var(--red3);
+  color: var(--white);
+  content: "experimental";
+  margin-left: .25rem;
+  padding: 1px 3px;
+  border-radius: 3px;
+}
+
 #apicontent li {
   margin-bottom: .5rem;
 }


### PR DESCRIPTION
Similar to #44588 this adds a Stability index color-coded indicator to experimental WebCryptoAPI algorithms' documentation.

<details>
<summary>🖼️ Dark mode - table</summary>

<img width="853" alt="Screenshot 2022-10-04 at 14 21 10" src="https://user-images.githubusercontent.com/241506/193818480-5e5084bf-a595-4824-9080-b67ee64f7d79.png">

</details>

<details>
<summary>🖼️ Light mode - table</summary>

<img width="1795" alt="Screenshot 2022-10-04 at 14 20 14" src="https://user-images.githubusercontent.com/241506/193818670-518df082-0924-4c5a-8971-7d7a7541ef34.png">

</details>

<details>
<summary>🖼️ Dark mode - list</summary>

<img width="1049" alt="Screenshot 2022-10-04 at 14 20 56" src="https://user-images.githubusercontent.com/241506/193818794-0f5cf6a7-0193-46a9-8493-7686bb3a03ff.png">

</details>

<details>
<summary>🖼️ Light mode - list</summary>

<img width="1412" alt="Screenshot 2022-10-04 at 14 20 32" src="https://user-images.githubusercontent.com/241506/193818826-991d1b35-e3f0-4751-a997-5d0c965bc71c.png">

</details>