### PR TITLE
diagnostics_channel: add storage channel

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -90,6 +90,7 @@ let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
 });
 
 const dc = require('diagnostics_channel');
+const storageChannel = dc.storageChannel('http.server');
 const onRequestStartChannel = dc.channel('http.server.request.start');
 const onResponseFinishChannel = dc.channel('http.server.response.finish');
 
@@ -1009,62 +1010,77 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
     });
   }
 
-  if (socket._httpMessage) {
-    // There are already pending outgoing res, append.
-    state.outgoing.push(res);
-  } else {
-    res.assignSocket(socket);
-  }
-
-  // When we're finished writing the response, check if this is the last
-  // response, if so destroy the socket.
-  res.on('finish',
-         resOnFinish.bind(undefined,
-                          req, res, socket, state, server));
-
-  let handled = false;
-
-  if (req.httpVersionMajor === 1 && req.httpVersionMinor === 1) {
-    const isRequestsLimitSet = (
-      typeof server.maxRequestsPerSocket === 'number' &&
-      server.maxRequestsPerSocket > 0
-    );
-
-    if (isRequestsLimitSet) {
-      state.requestsCount++;
-      res.maxRequestsOnConnectionReached = (
-        server.maxRequestsPerSocket <= state.requestsCount);
+  try {
+    if (storageChannel.hasSubscribers) {
+      storageChannel._enter({
+        request: req,
+        response: res,
+        socket,
+        server
+      });
     }
 
-    if (isRequestsLimitSet &&
-      (server.maxRequestsPerSocket < state.requestsCount)) {
-      handled = true;
-      server.emit('dropRequest', req, socket);
-      res.writeHead(503);
-      res.end();
-    } else if (req.headers.expect !== undefined) {
-      handled = true;
+    if (socket._httpMessage) {
+      // There are already pending outgoing res, append.
+      state.outgoing.push(res);
+    } else {
+      res.assignSocket(socket);
+    }
 
-      if (RegExpPrototypeExec(continueExpression, req.headers.expect) !== null) {
-        res._expect_continue = true;
+    // When we're finished writing the response, check if this is the last
+    // response, if so destroy the socket.
+    res.on('finish',
+           resOnFinish.bind(undefined,
+                            req, res, socket, state, server));
 
-        if (server.listenerCount('checkContinue') > 0) {
-          server.emit('checkContinue', req, res);
-        } else {
-          res.writeContinue();
-          server.emit('request', req, res);
-        }
-      } else if (server.listenerCount('checkExpectation') > 0) {
-        server.emit('checkExpectation', req, res);
-      } else {
-        res.writeHead(417);
+    let handled = false;
+
+    if (req.httpVersionMajor === 1 && req.httpVersionMinor === 1) {
+      const isRequestsLimitSet = (
+        typeof server.maxRequestsPerSocket === 'number' &&
+        server.maxRequestsPerSocket > 0
+      );
+
+      if (isRequestsLimitSet) {
+        state.requestsCount++;
+        res.maxRequestsOnConnectionReached = (
+          server.maxRequestsPerSocket <= state.requestsCount);
+      }
+
+      if (isRequestsLimitSet &&
+        (server.maxRequestsPerSocket < state.requestsCount)) {
+        handled = true;
+        server.emit('dropRequest', req, socket);
+        res.writeHead(503);
         res.end();
+      } else if (req.headers.expect !== undefined) {
+        handled = true;
+
+        if (RegExpPrototypeExec(continueExpression, req.headers.expect) !== null) {
+          res._expect_continue = true;
+
+          if (server.listenerCount('checkContinue') > 0) {
+            server.emit('checkContinue', req, res);
+          } else {
+            res.writeContinue();
+            server.emit('request', req, res);
+          }
+        } else if (server.listenerCount('checkExpectation') > 0) {
+          server.emit('checkExpectation', req, res);
+        } else {
+          res.writeHead(417);
+          res.end();
+        }
       }
     }
-  }
 
-  if (!handled) {
-    server.emit('request', req, res);
+    if (!handled) {
+      server.emit('request', req, res);
+    }
+  } finally {
+    if (storageChannel.hasSubscribers) {
+      storageChannel._exit();
+    }
   }
 
   return 0;  // No special treatment.

--- a/lib/diagnostics_channel.js
+++ b/lib/diagnostics_channel.js
@@ -3,11 +3,13 @@
 const {
   ArrayPrototypeIndexOf,
   ArrayPrototypePush,
+  ArrayPrototypeSome,
   ArrayPrototypeSplice,
   ObjectCreate,
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
-  SymbolHasInstance,
+  ReflectApply,
+  SymbolHasInstance
 } = primordials;
 
 const {
@@ -136,10 +138,169 @@ function hasSubscribers(name) {
   return channel.hasSubscribers;
 }
 
+class StoreBinding {
+  constructor(store, build = (v) => v) {
+    this.store = store;
+    this.build = build;
+    this.stack = [];
+
+    this.onEnter = this.onEnter.bind(this);
+    this.onExit = this.onExit.bind(this);
+  }
+
+  onEnter(data) {
+    try {
+      const ctx = this.build(data);
+      this.stack.push(this.store.getStore());
+      this.store.enterWith(ctx);
+    } catch (err) {
+      process.nextTick(() => {
+        triggerUncaughtException(err, false);
+      });
+    }
+  }
+
+  onExit() {
+    if (!this.stack.length) return;
+    this.store.enterWith(this.stack.pop());
+  }
+}
+
+class ActiveStorageChannel {
+  get hasSubscribers() {
+    return true;
+  }
+
+  isBoundToStore(store) {
+    return ArrayPrototypeSome(this._bindings, (v) => v.store === store);
+  }
+
+  _bindStore(store, build) {
+    if (this.isBoundToStore(store)) return false;
+    ArrayPrototypePush(this._bindings, new StoreBinding(store, build));
+    return true;
+  }
+
+  _unbindStore(store) {
+    if (!this.isBoundToStore(store)) return false;
+
+    let found = false;
+    for (let index = 0; index < this._bindings.length; index++) {
+      if (this._bindings[index].store === store) {
+        ArrayPrototypeSplice(this._bindings, index, 1);
+        found = true;
+        break;
+      }
+    }
+
+    if (!this._bindings.length) {
+      // eslint-disable-next-line no-use-before-define
+      ObjectSetPrototypeOf(this, StorageChannel.prototype);
+      this._bindings = undefined;
+    }
+
+    return found;
+  }
+
+  _enter(data) {
+    for (const binding of this._bindings) {
+      binding.onEnter(data);
+    }
+  }
+
+  _exit() {
+    for (const binding of this._bindings) {
+      binding.onExit();
+    }
+  }
+
+  run(data, fn, thisArg, ...args) {
+    this._enter(data);
+    try {
+      return ReflectApply(fn, thisArg, args);
+    } finally {
+      this._exit();
+    }
+  }
+}
+
+class StorageChannel {
+  constructor() {
+    this._bindings = undefined;
+  }
+
+  static [SymbolHasInstance](instance) {
+    const prototype = ObjectGetPrototypeOf(instance);
+    return prototype === StorageChannel.prototype ||
+      prototype === ActiveStorageChannel.prototype;
+  }
+
+  get hasSubscribers() {
+    return false;
+  }
+
+  isBoundToStore(_) {
+    return false;
+  }
+
+  _bindStore(store, build) {
+    ObjectSetPrototypeOf(this, ActiveStorageChannel.prototype);
+    this._bindings = [];
+    return this._bindStore(store, build);
+  }
+
+  _unbindStore(_) {
+    return false;
+  }
+
+  _enter(_) {}
+  _exit() {}
+
+  run(_, fn, thisArg, ...args) {
+    return ReflectApply(fn, thisArg, args);
+  }
+}
+
+const storageChannels = ObjectCreate(null);
+
+function storageChannel(name) {
+  let channel;
+  const ref = storageChannels[name];
+  if (ref) channel = ref.get();
+  if (channel) return channel;
+
+  if (typeof name !== 'string' && typeof name !== 'symbol') {
+    throw new ERR_INVALID_ARG_TYPE('channel', ['string', 'symbol'], name);
+  }
+
+  channel = new StorageChannel(name);
+  storageChannels[name] = new WeakReference(channel);
+  return channel;
+}
+
+function bindStore(name, store, build) {
+  const chan = storageChannel(name);
+  storageChannels[name].incRef();
+  chan._bindStore(store, build);
+}
+
+function unbindStore(name, store) {
+  const chan = storageChannel(name);
+  if (!chan._unbindStore(store)) {
+    return false;
+  }
+
+  storageChannels[name].decRef();
+  return true;
+}
+
 module.exports = {
+  bindStore,
   channel,
   hasSubscribers,
+  storageChannel,
   subscribe,
+  unbindStore,
   unsubscribe,
   Channel
 };

--- a/test/parallel/test-diagnostics-channel-storage-channel-http.js
+++ b/test/parallel/test-diagnostics-channel-storage-channel-http.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const common = require('../common');
+const dc = require('diagnostics_channel');
+const { AsyncLocalStorage } = require('async_hooks');
+const { createServer, get } = require('http');
+const assert = require('assert');
+
+const store = new AsyncLocalStorage();
+
+const channel = dc.storageChannel('http.server');
+
+// Test optional build function behaviour
+channel.bindStore(store);
+
+assert.strictEqual(store.getStore(), undefined);
+const app = createServer(common.mustCall((req, res) => {
+  const data = store.getStore();
+  assert.ok(data);
+
+  // Verify context data was passed through
+  const { request, response, server, socket } = data;
+  assert.deepStrictEqual(request, req);
+  assert.deepStrictEqual(response, res);
+  assert.deepStrictEqual(socket, req.socket);
+  assert.deepStrictEqual(server, app);
+
+  res.end();
+  app.close();
+}));
+assert.strictEqual(store.getStore(), undefined);
+
+app.listen(() => {
+  const { port } = app.address();
+  assert.strictEqual(store.getStore(), undefined);
+  get(`http://localhost:${port}`, (res) => res.resume());
+  assert.strictEqual(store.getStore(), undefined);
+});

--- a/test/parallel/test-diagnostics-channel-storage-channel.js
+++ b/test/parallel/test-diagnostics-channel-storage-channel.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const common = require('../common');
+const dc = require('diagnostics_channel');
+const { AsyncLocalStorage } = require('async_hooks');
+const assert = require('assert');
+
+const store = new AsyncLocalStorage();
+
+const input = {
+  foo: 'bar'
+};
+
+const output = {
+  baz: 'buz'
+};
+
+const channel = dc.storageChannel('test');
+
+// Should only be called once to verify unbind works
+const build = common.mustCall((foundInput) => {
+  assert.deepStrictEqual(foundInput, input);
+  return output;
+});
+
+channel.bindStore(store, build);
+
+// Should have an empty store before run
+assert.strictEqual(store.getStore(), undefined);
+
+// Should return the result of its runner function
+const result = channel.run(input, common.mustCall(() => {
+  // Should have a store containing the result of the build function
+  assert.deepStrictEqual(store.getStore(), output);
+  return output;
+}));
+assert.deepStrictEqual(result, output);
+
+// Should have an empty store after run
+assert.strictEqual(store.getStore(), undefined);
+
+// Should have an empty store during run after unbinding
+channel.unbindStore(store, build);
+channel.run(input, common.mustCall(function(arg) {
+  assert.deepStrictEqual(this, input);
+  assert.deepStrictEqual(arg, output);
+  assert.strictEqual(store.getStore(), undefined);
+}), input, output);
+
+// Should allow omitting build on bind
+const a = dc.storageChannel('test');
+a.bindStore(store);
+
+// Should allow nested runs
+const b = dc.storageChannel('test');
+b.run(1, common.mustCall(() => {
+  assert.strictEqual(store.getStore(), 1);
+  b.run(2, common.mustCall(() => {
+    assert.strictEqual(store.getStore(), 2);
+  }));
+  assert.strictEqual(store.getStore(), 1);
+}));

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -56,6 +56,8 @@ const customTypesMap = {
   'Module Namespace Object':
     'https://tc39.github.io/ecma262/#sec-module-namespace-exotic-objects',
 
+  'AsyncLocalStorage': 'async_context.html#class-asynclocalstorage',
+
   'AsyncHook': 'async_hooks.html#async_hookscreatehookcallbacks',
   'AsyncResource': 'async_hooks.html#class-asyncresource',
 
@@ -107,6 +109,7 @@ const customTypesMap = {
   'dgram.Socket': 'dgram.html#class-dgramsocket',
 
   'Channel': 'diagnostics_channel.html#class-channel',
+  'StorageChannel': 'diagnostics_channel.html#class-storagechannel',
 
   'Domain': 'domain.html#class-domain',
 


### PR DESCRIPTION
A storage channel integrates between diagnostics_channel and AsyncLocalStorage for the publisher to define a scope in which a store should run and what data to provide in the scope when running.

I'll write some proper docs for this after some discussion first to verify the current design satisfies those of us that need this.

cc @nodejs/diagnostics @jasnell 