### PR TITLE
src: return void in InitializeInspector()

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -370,7 +370,6 @@ Environment* CreateEnvironment(
   Environment* env = new Environment(
       isolate_data, context, args, exec_args, nullptr, flags, thread_id);
 #if HAVE_INSPECTOR
-  // TODO(joyeecheung): handle the exit code returned by InitializeInspector().
   if (env->should_create_inspector()) {
     if (inspector_parent_handle) {
       env->InitializeInspector(

--- a/src/env.h
+++ b/src/env.h
@@ -617,7 +617,7 @@ class Environment : public MemoryRetainer {
 #if HAVE_INSPECTOR
   // If the environment is created for a worker, pass parent_handle and
   // the ownership if transferred into the Environment.
-  ExitCode InitializeInspector(
+  void InitializeInspector(
       std::unique_ptr<inspector::ParentInspectorHandle> parent_handle);
 #endif
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -166,7 +166,7 @@ void SignalExit(int signo, siginfo_t* info, void* ucontext) {
 #endif  // __POSIX__
 
 #if HAVE_INSPECTOR
-ExitCode Environment::InitializeInspector(
+void Environment::InitializeInspector(
     std::unique_ptr<inspector::ParentInspectorHandle> parent_handle) {
   std::string inspector_path;
   bool is_main = !parent_handle;
@@ -187,7 +187,7 @@ ExitCode Environment::InitializeInspector(
                           is_main);
   if (options_->debug_options().inspector_enabled &&
       !inspector_agent_->IsListening()) {
-    return ExitCode::kInvalidCommandLineArgument2;  // Signal internal error
+    return;
   }
 
   profiler::StartProfilers(this);
@@ -196,7 +196,7 @@ ExitCode Environment::InitializeInspector(
     inspector_agent_->PauseOnNextJavascriptStatement("Break at bootstrap");
   }
 
-  return ExitCode::kNoFailure;
+  return;
 }
 #endif  // HAVE_INSPECTOR
 

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -181,8 +181,6 @@ NodeMainInstance::CreateMainEnvironment(ExitCode* exit_code) {
     SetIsolateErrorHandlers(isolate_, {});
     env->InitializeMainContext(context, &(snapshot_data_->env_info));
 #if HAVE_INSPECTOR
-    // TODO(joyeecheung): handle the exit code returned by
-    // InitializeInspector().
     env->InitializeInspector({});
 #endif
 
@@ -201,8 +199,6 @@ NodeMainInstance::CreateMainEnvironment(ExitCode* exit_code) {
                               EnvironmentFlags::kDefaultFlags,
                               {}));
 #if HAVE_INSPECTOR
-    // TODO(joyeecheung): handle the exit code returned by
-    // InitializeInspector().
     env->InitializeInspector({});
 #endif
     if (env->principal_realm()->RunBootstrapping().IsEmpty()) {

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1173,8 +1173,6 @@ ExitCode SnapshotBuilder::Generate(SnapshotData* out,
       // in the future).
       if (snapshot_type == SnapshotMetadata::Type::kFullyCustomized) {
 #if HAVE_INSPECTOR
-        // TODO(joyeecheung): handle the exit code returned by
-        // InitializeInspector().
         env->InitializeInspector({});
 #endif
         if (LoadEnvironment(env, StartExecutionCallback{}).IsEmpty()) {

--- a/test/parallel/test-inspect-address-in-use.js
+++ b/test/parallel/test-inspect-address-in-use.js
@@ -1,0 +1,59 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const { spawnSync } = require('child_process');
+const { createServer } = require('http');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const entry = fixtures.path('empty.js');
+const { Worker } = require('worker_threads');
+
+function testOnServerListen(fn) {
+  const server = createServer((socket) => {
+    socket.end('echo');
+  });
+
+  server.on('listening', () => {
+    fn(server);
+    server.close();
+  });
+  server.listen(0, '127.0.0.1');
+}
+
+function testChildProcess(getArgs, exitCode) {
+  testOnServerListen((server) => {
+    const { port } = server.address();
+    const child = spawnSync(process.execPath, getArgs(port));
+    const stderr = child.stderr.toString().trim();
+    const stdout = child.stdout.toString().trim();
+    console.log('[STDERR]');
+    console.log(stderr);
+    console.log('[STDOUT]');
+    console.log(stdout);
+    const match = stderr.match(
+      /Starting inspector on 127\.0\.0\.1:(\d+) failed: address already in use/
+    );
+    assert.notStrictEqual(match, null);
+    assert.strictEqual(match[1], port + '');
+    assert.strictEqual(child.status, exitCode);
+  });
+}
+
+testChildProcess(
+  (port) => [`--inspect=${port}`, '--build-snapshot', entry], 0);
+testChildProcess(
+  (port) => [`--inspect=${port}`, entry], 0);
+
+testOnServerListen((server) => {
+  const { port } = server.address();
+  const worker = new Worker(entry, {
+    execArgv: [`--inspect=${port}`]
+  });
+
+  worker.on('error', common.mustNotCall());
+
+  worker.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+  }));
+});


### PR DESCRIPTION
We have been ignoring inspector port binding errors during startup. Handling this error would be a breaking change and it's probably surprising to refuse to launch the Node.js instance simply because the inspector cannot listen to the port anyway. So just turn the return value of InitializeInspector() void and remove the TODOs for handling the error.

(I have a different branch at https://github.com/joyeecheung/node/tree/inspector-code that actually handles the error, but TBH I find that behavior to be a bit surprising when I play around with it locally, so I've decided to open this PR instead.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
