### PR TITLE
process: fix uid/gid validation to avoid crash

### DIFF
--- a/lib/internal/bootstrap/switches/does_own_process_state.js
+++ b/lib/internal/bootstrap/switches/does_own_process_state.js
@@ -76,7 +76,7 @@ function wrapPosixCredentialSetters(credentials) {
   function wrapIdSetter(type, method) {
     return function(id) {
       validateId(id, 'id');
-      if (typeof id === 'number') id |= 0;
+      if (typeof id === 'number') id >>>= 0;
       // Result is 0 on success, 1 if credential is unknown.
       const result = method(id);
       if (result === 1) {

--- a/test/parallel/test-process-uid-gid.js
+++ b/test/parallel/test-process-uid-gid.js
@@ -53,17 +53,13 @@ assert.throws(() => {
 
 // Passing -0 shouldn't crash the process
 // Refs: https://github.com/nodejs/node/issues/32750
-try { process.setuid(-0); } catch {
-  // Continue regardless of error.
-}
-try { process.seteuid(-0); } catch {
-  // Continue regardless of error.
-}
-try { process.setgid(-0); } catch {
-  // Continue regardless of error.
-}
-try { process.setegid(-0); } catch {
-  // Continue regardless of error.
+// And neither should values exceeding 2 ** 31 - 1.
+for (const id of [-0, 2 ** 31, 2 ** 32 - 1]) {
+  for (const fn of [process.setuid, process.setuid, process.setgid, process.setegid]) {
+    try { fn(id); } catch {
+      // Continue regardless of error.
+    }
+  }
 }
 
 // If we're not running as super user...


### PR DESCRIPTION
`id |= 0` turns unsigned 32-bit integer values exceeding the unsigned 31-bit range into negative integers, causing a crash. Use `id >>>= 0` instead, which works properly for all unsigned 32-bit integers.

Refs: https://github.com/nodejs/node/pull/36786

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
