### PR TITLE
src: remove uid_t/gid_t casts

### DIFF
--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -215,7 +215,8 @@ static const char* name_by_gid(gid_t gid) {
 
 static uid_t uid_by_name(Isolate* isolate, Local<Value> value) {
   if (value->IsUint32()) {
-    return static_cast<uid_t>(value.As<Uint32>()->Value());
+    static_assert(std::is_same<uid_t, uint32_t>::value);
+    return value.As<Uint32>()->Value();
   } else {
     Utf8Value name(isolate, value);
     return uid_by_name(*name);
@@ -224,7 +225,8 @@ static uid_t uid_by_name(Isolate* isolate, Local<Value> value) {
 
 static gid_t gid_by_name(Isolate* isolate, Local<Value> value) {
   if (value->IsUint32()) {
-    return static_cast<gid_t>(value.As<Uint32>()->Value());
+    static_assert(std::is_same<gid_t, uint32_t>::value);
+    return value.As<Uint32>()->Value();
   } else {
     Utf8Value name(isolate, value);
     return gid_by_name(*name);


### PR DESCRIPTION
If `uid_t`/`gid_t` are `uint32_t`, then the casts are unnecessary. This appears to be true in all recent versions of all supported platforms, so this change makes that assumption explicit and removes the casts.

Conversely, if `uid_t`/`gid_t` are smaller unsigned integer types (such as `uint16_t` in earlier versions of Linux) or signed integer types (such as `int32_t`), then the casts are potentially dangerous because they might change the value of the uid/gid. If this happens on any platform, the added `static_assert` will fail, and additional bound checks should be introduced.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
