### PR TITLE
lib: make properties on Blob and URL enumerable

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -4,6 +4,7 @@ const {
   ArrayFrom,
   MathMax,
   MathMin,
+  ObjectDefineProperties,
   ObjectDefineProperty,
   PromiseResolve,
   PromiseReject,
@@ -45,6 +46,7 @@ const {
   createDeferredPromise,
   customInspectSymbol: kInspect,
   kEmptyObject,
+  kEnumerableProperty,
 } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
 
@@ -360,6 +362,15 @@ ObjectDefineProperty(Blob.prototype, SymbolToStringTag, {
   __proto__: null,
   configurable: true,
   value: 'Blob',
+});
+
+ObjectDefineProperties(Blob.prototype, {
+  size: kEnumerableProperty,
+  type: kEnumerableProperty,
+  slice: kEnumerableProperty,
+  stream: kEnumerableProperty,
+  text: kEnumerableProperty,
+  arrayBuffer: kEnumerableProperty,
 });
 
 function resolveObjectURL(url) {

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1065,6 +1065,11 @@ ObjectDefineProperties(URL.prototype, {
   toJSON: kEnumerableProperty,
 });
 
+ObjectDefineProperties(URL, {
+  createObjectURL: kEnumerableProperty,
+  revokeObjectURL: kEnumerableProperty,
+});
+
 function update(url, params) {
   if (!url)
     return;

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -188,6 +188,23 @@ assert.throws(() => new Blob({}), {
 }
 
 {
+  const descriptors = Object.getOwnPropertyDescriptors(Blob.prototype);
+  const enumerable = [
+    'size',
+    'type',
+    'slice',
+    'stream',
+    'text',
+    'arrayBuffer'
+  ];
+
+  for (const prop of enumerable) {
+    assert.notStrictEqual(descriptors[prop], undefined);
+    assert.strictEqual(descriptors[prop].enumerable, true);
+  }
+}
+
+{
   const b = new Blob(['test', 42]);
   b.text().then(common.mustCall((text) => {
     assert.strictEqual(text, 'test42');

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -195,7 +195,7 @@ assert.throws(() => new Blob({}), {
     'slice',
     'stream',
     'text',
-    'arrayBuffer'
+    'arrayBuffer',
   ];
 
   for (const prop of enumerable) {

--- a/test/parallel/test-whatwg-url-properties.js
+++ b/test/parallel/test-whatwg-url-properties.js
@@ -29,6 +29,13 @@ const { URL, URLSearchParams } = require('url');
 });
 
 [
+  { name: 'createObjectURL' },
+  { name: 'revokeObjectURL' },
+].forEach(({ name }) => {
+  testStaticAccessor(URL, name);
+});
+
+[
   { name: 'append' },
   { name: 'delete' },
   { name: 'get' },
@@ -97,4 +104,13 @@ function testAccessor(target, name, readonly = false) {
       false,
     );
   }
+}
+
+function testStaticAccessor(target, name) {
+  const desc = Object.getOwnPropertyDescriptor(target, name);
+  assert.notDeepStrictEqual(desc, undefined);
+
+  assert.deepStrictEqual(desc.configurable, true);
+  assert.deepStrictEqual(desc.enumerable, true);
+  assert.deepStrictEqual(desc.writable, true);
 }

--- a/test/parallel/test-whatwg-url-properties.js
+++ b/test/parallel/test-whatwg-url-properties.js
@@ -108,9 +108,9 @@ function testAccessor(target, name, readonly = false) {
 
 function testStaticAccessor(target, name) {
   const desc = Object.getOwnPropertyDescriptor(target, name);
-  assert.notDeepStrictEqual(desc, undefined);
+  assert.notStrictEqual(desc, undefined);
 
-  assert.deepStrictEqual(desc.configurable, true);
-  assert.deepStrictEqual(desc.enumerable, true);
-  assert.deepStrictEqual(desc.writable, true);
+  assert.strictEqual(desc.configurable, true);
+  assert.strictEqual(desc.enumerable, true);
+  assert.strictEqual(desc.writable, true);
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This makes properties on both URL and Blob enumerable that were not.

Refs: https://github.com/nodejs/undici/pull/1690.