### PR TITLE
node-api,test: fix test_reference_double_free crash

### DIFF
--- a/test/js-native-api/test_reference_double_free/test_reference_double_free.c
+++ b/test/js-native-api/test_reference_double_free/test_reference_double_free.c
@@ -49,7 +49,6 @@ static napi_value DeleteImmediately(napi_env env, napi_callback_info info) {
   napi_value js_obj;
   napi_ref ref;
   napi_valuetype type;
-  napi_value undefined;
 
   NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &js_obj, NULL, NULL));
 
@@ -60,8 +59,7 @@ static napi_value DeleteImmediately(napi_env env, napi_callback_info info) {
   NODE_API_CALL(env, napi_delete_reference(env, ref));
   NODE_API_CALL(env, napi_remove_wrap(env, js_obj, NULL));
 
-  NODE_API_CALL(env, napi_get_undefined(env, &undefined));
-  return undefined;
+  return NULL;
 }
 
 EXTERN_C_START

--- a/test/js-native-api/test_reference_double_free/test_reference_double_free.c
+++ b/test/js-native-api/test_reference_double_free/test_reference_double_free.c
@@ -44,21 +44,24 @@ static napi_value New(napi_env env, napi_callback_info info) {
 
 static void NoopDeleter(napi_env env, void* data, void* hint) {}
 
-static void DeleteImmediately(napi_env env, napi_callback_info info) {
+static napi_value DeleteImmediately(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value js_obj;
   napi_ref ref;
-
-  NODE_API_CALL_RETURN_VOID(env,
-      napi_get_cb_info(env, info, &argc, &js_obj, NULL, NULL));
-
   napi_valuetype type;
-  NODE_API_CALL_RETURN_VOID(env, napi_typeof(env, js_obj, &type));
+  napi_value undefined;
 
-  NODE_API_CALL_RETURN_VOID(env,
-      napi_wrap(env, js_obj, NULL, NoopDeleter, NULL, &ref));
-  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, ref));
-  NODE_API_CALL_RETURN_VOID(env, napi_remove_wrap(env, js_obj, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &js_obj, NULL, NULL));
+
+  NODE_API_CALL(env, napi_typeof(env, js_obj, &type));
+  NODE_API_ASSERT(env, type == napi_object, "Expected object parameter");
+
+  NODE_API_CALL(env, napi_wrap(env, js_obj, NULL, NoopDeleter, NULL, &ref));
+  NODE_API_CALL(env, napi_delete_reference(env, ref));
+  NODE_API_CALL(env, napi_remove_wrap(env, js_obj, NULL));
+
+  NODE_API_CALL(env, napi_get_undefined(env, &undefined));
+  return undefined;
 }
 
 EXTERN_C_START


### PR DESCRIPTION
### The issue

The `js-native-api\test_reference_double_free\test_wrap.js` test always crashes when I use Visual Studio 2022.
The cause of the crash is that the `deleteImmediately` function callback is returning an invalid `napi_value`.
It happens because the `DeleteImmediately` function that implements the `deleteImmediately` callback returns `void` instead of `napi_value`. It causes it to return a random value kept in `RAX` register - in my case it was `0x40`.

### The fix

The return type of the `DeleteImmediately` function is changed to `napi_value`.
The related changes:
- Changed use of macro `NODE_API_CALL_RETURN_VOID` to `NODE_API_CALL` because we changed the return type.
- Added `NODE_API_ASSERT` to verify argument type - previously we retrieved the type, but never used it.
- Return `NULL` from the function.

### Notes

I did a quick search for `void.*napi_callback_info` in other tests to see if we have any other cases like this, but it found nothing.
It seems that it is the only place where we have this issue.

