### PR TITLE
tls: add "ca" property to certificate object

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1173,6 +1173,9 @@ certificate.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/44935
+    description: Add "ca" property.
   - version:
       - v17.2.0
       - v16.14.0
@@ -1186,6 +1189,7 @@ changes:
 A certificate object has properties corresponding to the fields of the
 certificate.
 
+* `ca` {boolean} `true` if a Certificate Authority (CA), `false` otherwise.
 * `raw` {Buffer} The DER encoded X.509 certificate data.
 * `subject` {Object} The certificate subject, described in terms of
   Country (`C`), StateOrProvince (`ST`), Locality (`L`), Organization (`O`),

--- a/src/crypto/crypto_common.cc
+++ b/src/crypto/crypto_common.cc
@@ -27,6 +27,7 @@ namespace node {
 using v8::Array;
 using v8::ArrayBuffer;
 using v8::BackingStore;
+using v8::Boolean;
 using v8::Context;
 using v8::EscapableHandleScope;
 using v8::Integer;
@@ -1266,6 +1267,8 @@ MaybeLocal<Object> X509ToObject(
   BIOPointer bio(BIO_new(BIO_s_mem()));
   CHECK(bio);
 
+  // X509_check_ca() returns a range of values. Only 1 means "is a CA"
+  auto is_ca = Boolean::New(env->isolate(), 1 == X509_check_ca(cert));
   if (!Set<Value>(context,
                   info,
                   env->subject_string(),
@@ -1281,7 +1284,8 @@ MaybeLocal<Object> X509ToObject(
       !Set<Value>(context,
                   info,
                   env->infoaccess_string(),
-                  GetInfoAccessString(env, bio, cert))) {
+                  GetInfoAccessString(env, bio, cert)) ||
+      !Set<Boolean>(context, info, env->ca_string(), is_ca)) {
     return MaybeLocal<Object>();
   }
 

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -59,6 +59,7 @@
   V(bytes_parsed_string, "bytesParsed")                                        \
   V(bytes_read_string, "bytesRead")                                            \
   V(bytes_written_string, "bytesWritten")                                      \
+  V(ca_string, "ca")                                                           \
   V(cached_data_produced_string, "cachedDataProduced")                         \
   V(cached_data_rejected_string, "cachedDataRejected")                         \
   V(cached_data_string, "cachedData")                                          \

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -52,6 +52,8 @@ connect({
   debug('peerCert:\n', peerCert);
 
   assert.ok(peerCert.issuerCertificate);
+  assert.strictEqual(peerCert.ca, false);
+  assert.strictEqual(peerCert.issuerCertificate.ca, true);
   assert.strictEqual(peerCert.subject.emailAddress, 'ry@tinyclouds.org');
   assert.strictEqual(peerCert.serialNumber, '147D36C1C2F74206DE9FAB5F2226D78ADB00A426');
   assert.strictEqual(peerCert.exponent, '0x10001');


### PR DESCRIPTION
The objects returned by getPeerCertificate() now have an additional "ca" boolean property that indicates whether the certificate is a Certificate Authority certificate or not.

Fixes: https://github.com/nodejs/node/issues/44905