### PR TITLE
stream: add compose operator

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1714,7 +1714,7 @@ const words = await wordsStream.toArray();
 console.log(words); // prints ['this', 'is', 'compose', 'as', 'operator']
 ```
 
-See [`stream.compose`](#streamcomposestreams) for more information.
+See [`stream.compose`][] for more information.
 
 ##### `readable.iterator([options])`
 
@@ -2750,7 +2750,7 @@ await finished(compose(s1, s2, s3));
 console.log(res); // prints 'HELLOWORLD'
 ```
 
-See [`readable.compose`](#readablecomposestream-options) for `stream.compose` as operator.
+See [`readable.compose(stream)`][] for `stream.compose` as operator.
 
 ### `stream.Readable.from(iterable[, options])`
 
@@ -4519,11 +4519,13 @@ contain multi-byte characters.
 [`process.stdin`]: process.md#processstdin
 [`process.stdout`]: process.md#processstdout
 [`readable._read()`]: #readable_readsize
+[`readable.compose(stream)`]: #readablecomposestream-options
 [`readable.map`]: #readablemapfn-options
 [`readable.push('')`]: #readablepush
 [`readable.setEncoding()`]: #readablesetencodingencoding
 [`stream.Readable.from()`]: #streamreadablefromiterable-options
 [`stream.addAbortSignal()`]: #streamaddabortsignalsignal-stream
+[`stream.compose`]: #streamcomposestreams
 [`stream.cork()`]: #writablecork
 [`stream.finished()`]: #streamfinishedstream-options-callback
 [`stream.pipe()`]: #readablepipedestination-options

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1681,6 +1681,25 @@ option. In the code example above, data will be in a single chunk if the file
 has less then 64 KiB of data because no `highWaterMark` option is provided to
 [`fs.createReadStream()`][].
 
+##### `readable.compose(stream[, options])`
+
+<!-- YAML
+added:
+-->
+
+> Stability: 1 - Experimental
+
+* `stream` {Stream|Iterable|AsyncIterable|Function}
+* `options` {Object}
+  * `signal` {AbortSignal} allows destroying the stream if the signal is
+    aborted.
+* Returns: {Duplex} a stream composed with the stream `stream`.
+
+
+
+See [`stream.compose`][] for more information.
+
+
 ##### `readable.iterator([options])`
 
 <!-- YAML

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1684,7 +1684,7 @@ has less then 64 KiB of data because no `highWaterMark` option is provided to
 ##### `readable.compose(stream[, options])`
 
 <!-- YAML
-added:
+added: REPLACEME
 -->
 
 > Stability: 1 - Experimental
@@ -1695,10 +1695,26 @@ added:
     aborted.
 * Returns: {Duplex} a stream composed with the stream `stream`.
 
+```mjs
+import { Readable } from 'node:stream';
 
+async function* splitToWords(source) {
+  for await (const chunk of source) {
+    const words = String(chunk).split(' ');
 
-See [`stream.compose`][] for more information.
+    for (const word of words) {
+      yield word;
+    }
+  }
+}
 
+const wordsStream = Readable.from(['this is', 'compose as operator']).compose(splitToWords);
+const words = await wordsStream.toArray();
+
+console.log(words); // prints ['this', 'is', 'compose', 'as', 'operator']
+```
+
+See [`stream.compose`](#streamcomposestreams) for more information.
 
 ##### `readable.iterator([options])`
 
@@ -2733,6 +2749,8 @@ await finished(compose(s1, s2, s3));
 
 console.log(res); // prints 'HELLOWORLD'
 ```
+
+See [`readable.compose`](#readablecomposestream-options) for `stream.compose` as operator.
 
 ### `stream.Readable.from(iterable[, options])`
 

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -17,7 +17,7 @@ const {
 } = require('internal/validators');
 const { kWeakHandler } = require('internal/event_target');
 const { finished } = require('internal/streams/end-of-stream');
-const composeFn = require('internal/streams/compose');
+const staticCompose = require('internal/streams/compose');
 
 const {
   ArrayPrototypePush,
@@ -35,7 +35,7 @@ const kEof = Symbol('kEof');
 
 function compose(fn, options) {
   // TODO - what about abort signal
-  return composeFn(this, fn);
+  return staticCompose(this, fn);
 }
 
 function map(fn, options) {

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -17,6 +17,7 @@ const {
 } = require('internal/validators');
 const { kWeakHandler } = require('internal/event_target');
 const { finished } = require('internal/streams/end-of-stream');
+const composeFn = require('internal/streams/compose');
 
 const {
   ArrayPrototypePush,
@@ -31,6 +32,11 @@ const {
 
 const kEmpty = Symbol('kEmpty');
 const kEof = Symbol('kEof');
+
+function compose(fn, options) {
+  // TODO - what about abort signal
+  return composeFn(this, fn);
+}
 
 function map(fn, options) {
   if (typeof fn !== 'function') {
@@ -392,6 +398,7 @@ module.exports.streamReturningOperators = {
   flatMap,
   map,
   take,
+  compose,
 };
 
 module.exports.promiseReturningOperators = {

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -18,6 +18,9 @@ const {
 const { kWeakHandler } = require('internal/event_target');
 const { finished } = require('internal/streams/end-of-stream');
 const staticCompose = require('internal/streams/compose');
+const {
+  addAbortSignalNoValidate,
+} = require('internal/streams/add-abort-signal');
 
 const {
   ArrayPrototypePush,
@@ -33,9 +36,25 @@ const {
 const kEmpty = Symbol('kEmpty');
 const kEof = Symbol('kEof');
 
-function compose(fn, options) {
-  // TODO - what about abort signal
-  return staticCompose(this, fn);
+function compose(stream, options) {
+  if (options != null) {
+    validateObject(options, 'options');
+  }
+  if (options?.signal != null) {
+    validateAbortSignal(options.signal, 'options.signal');
+  }
+
+  const composedStream = staticCompose(this, stream);
+
+  if (options?.signal) {
+    // Not validating as we already validated before
+    addAbortSignalNoValidate(
+      options.signal,
+      composedStream
+    );
+  }
+
+  return composedStream;
 }
 
 function map(fn, options) {

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -4,6 +4,7 @@ const { AbortController } = require('internal/abort_controller');
 
 const {
   codes: {
+    ERR_INVALID_ARG_VALUE,
     ERR_INVALID_ARG_TYPE,
     ERR_MISSING_ARGS,
     ERR_OUT_OF_RANGE,
@@ -21,6 +22,7 @@ const staticCompose = require('internal/streams/compose');
 const {
   addAbortSignalNoValidate,
 } = require('internal/streams/add-abort-signal');
+const { isWritable, isNodeStream } = require('internal/streams/utils');
 
 const {
   ArrayPrototypePush,
@@ -42,6 +44,10 @@ function compose(stream, options) {
   }
   if (options?.signal != null) {
     validateAbortSignal(options.signal, 'options.signal');
+  }
+
+  if (isNodeStream(stream) && !isWritable(stream)) {
+    throw new ERR_INVALID_ARG_VALUE('stream', stream, 'must be writable');
   }
 
   const composedStream = staticCompose(this, stream);

--- a/test/parallel/test-stream-compose-operator.js
+++ b/test/parallel/test-stream-compose-operator.js
@@ -5,16 +5,15 @@ const {
   Readable, Transform,
 } = require('stream');
 const assert = require('assert');
-const { once } = require('events');
 
 {
-  // compose operator with async generator
+  // with async generator
   const stream = Readable.from(['a', 'b', 'c', 'd']).compose(async function *(stream) {
     let str = '';
     for await (const chunk of stream) {
       str += chunk;
 
-      if(str.length === 2) {
+      if (str.length === 2) {
         yield str;
         str = '';
       }
@@ -29,12 +28,12 @@ const { once } = require('events');
 }
 
 {
-  // compose operator with Transformer
+  // With Transformer
   const stream = Readable.from(['a', 'b', 'c', 'd']).compose(new Transform({
     objectMode: true,
     transform: common.mustCall((chunk, encoding, callback) => {
       callback(null, chunk);
-    })
+    }, 4)
   }));
   const result = ['a', 'b', 'c', 'd'];
   (async () => {
@@ -46,7 +45,8 @@ const { once } = require('events');
 
 {
   // Throwing an error during `compose` (before waiting for data)
-  const stream = Readable.from([1, 2, 3, 4, 5]).compose(async function *(stream) {
+  const stream = Readable.from([1, 2, 3, 4, 5]).compose(async function *(stream) { // eslint-disable-line require-yield
+
     throw new Error('boom');
   });
 
@@ -76,7 +76,9 @@ const { once } = require('events');
 
 {
   // Throwing an error during `compose` (after finishing all readable data)
-  const stream = Readable.from([1, 2, 3, 4, 5]).compose(async function *(stream) {
+  const stream = Readable.from([1, 2, 3, 4, 5]).compose(async function *(stream) { // eslint-disable-line require-yield
+
+    // eslint-disable-next-line no-unused-vars,no-empty
     for await (const chunk of stream) {
     }
 
@@ -88,4 +90,27 @@ const { once } = require('events');
   ).then(common.mustCall());
 }
 
-// TODO - add here tests for abort signal and argument validation
+{
+  // AbortSignal
+  const ac = new AbortController();
+  const stream = Readable.from([1, 2, 3, 4, 5])
+    .compose(async function *(source) {
+      // Should not reach here
+      for await (const chunk of source) {
+        yield chunk;
+      }
+    }, { signal: ac.signal });
+
+  ac.abort();
+
+  assert.rejects(async () => {
+    for await (const item of stream) {
+      assert.fail('should not reach here, got ' + item);
+    }
+  }, {
+    name: 'AbortError',
+  }).then(common.mustCall());
+}
+
+
+// TODO - add tests for argument validation

--- a/test/parallel/test-stream-compose-operator.js
+++ b/test/parallel/test-stream-compose-operator.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const common = require('../common');
+const {
+  Readable, Transform,
+} = require('stream');
+const assert = require('assert');
+const { once } = require('events');
+
+{
+  // compose operator with async generator
+  const stream = Readable.from(['a', 'b', 'c', 'd']).compose(async function *(stream) {
+    let str = '';
+    for await (const chunk of stream) {
+      str += chunk;
+
+      if(str.length === 2) {
+        yield str;
+        str = '';
+      }
+    }
+  });
+  const result = ['ab', 'cd'];
+  (async () => {
+    for await (const item of stream) {
+      assert.strictEqual(item, result.shift());
+    }
+  })().then(common.mustCall());
+}
+
+{
+  // compose operator with Transformer
+  const stream = Readable.from(['a', 'b', 'c', 'd']).compose(new Transform({
+    objectMode: true,
+    transform: common.mustCall((chunk, encoding, callback) => {
+      callback(null, chunk);
+    })
+  }));
+  const result = ['a', 'b', 'c', 'd'];
+  (async () => {
+    for await (const item of stream) {
+      assert.strictEqual(item, result.shift());
+    }
+  })().then(common.mustCall());
+}
+
+{
+  // Throwing an error during `compose` (before waiting for data)
+  const stream = Readable.from([1, 2, 3, 4, 5]).compose(async function *(stream) {
+    throw new Error('boom');
+  });
+
+  assert.rejects(async () => {
+    for await (const item of stream) {
+      assert.fail('should not reach here, got ' + item);
+    }
+  }, /boom/).then(common.mustCall());
+}
+
+{
+  // Throwing an error during `compose` (when waiting for data)
+  const stream = Readable.from([1, 2, 3, 4, 5]).compose(async function *(stream) {
+    for await (const chunk of stream) {
+      if (chunk === 3) {
+        throw new Error('boom');
+      }
+      yield chunk;
+    }
+  });
+
+  assert.rejects(
+    stream.toArray(),
+    /boom/,
+  ).then(common.mustCall());
+}
+
+{
+  // Throwing an error during `compose` (after finishing all readable data)
+  const stream = Readable.from([1, 2, 3, 4, 5]).compose(async function *(stream) {
+    for await (const chunk of stream) {
+    }
+
+    throw new Error('boom');
+  });
+  assert.rejects(
+    stream.toArray(),
+    /boom/,
+  ).then(common.mustCall());
+}
+
+// TODO - add here tests for abort signal and argument validation

--- a/test/parallel/test-stream-compose-operator.js
+++ b/test/parallel/test-stream-compose-operator.js
@@ -116,12 +116,12 @@ const assert = require('assert');
   assert.throws(
     () => Readable.from(['a']).compose(Readable.from(['b'])),
     { code: 'ERR_INVALID_ARG_VALUE' }
-  )
+  );
 }
 
 {
   assert.throws(
     () => Readable.from(['a']).compose(),
     { code: 'ERR_INVALID_ARG_TYPE' }
-  )
+  );
 }

--- a/test/parallel/test-stream-compose-operator.js
+++ b/test/parallel/test-stream-compose-operator.js
@@ -112,5 +112,16 @@ const assert = require('assert');
   }).then(common.mustCall());
 }
 
+{
+  assert.throws(
+    () => Readable.from(['a']).compose(Readable.from(['b'])),
+    { code: 'ERR_INVALID_ARG_VALUE' }
+  )
+}
 
-// TODO - add tests for argument validation
+{
+  assert.throws(
+    () => Readable.from(['a']).compose(),
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  )
+}

--- a/test/parallel/test-stream-compose.js
+++ b/test/parallel/test-stream-compose.js
@@ -361,21 +361,21 @@ const assert = require('assert');
   assert.throws(
     () => compose(),
     { code: 'ERR_MISSING_ARGS' }
-  )
+  );
 }
 
 {
   assert.throws(
     () => compose(new Writable(), new PassThrough()),
     { code: 'ERR_INVALID_ARG_VALUE' }
-  )
+  );
 }
 
 {
   assert.throws(
     () => compose(new PassThrough(), new Readable({ read() {} }), new PassThrough()),
     { code: 'ERR_INVALID_ARG_VALUE' }
-  )
+  );
 }
 
 {

--- a/test/parallel/test-stream-compose.js
+++ b/test/parallel/test-stream-compose.js
@@ -358,27 +358,24 @@ const assert = require('assert');
 }
 
 {
-  try {
-    compose();
-  } catch (err) {
-    assert.strictEqual(err.code, 'ERR_MISSING_ARGS');
-  }
+  assert.throws(
+    () => compose(),
+    { code: 'ERR_MISSING_ARGS' }
+  )
 }
 
 {
-  try {
-    compose(new Writable(), new PassThrough());
-  } catch (err) {
-    assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
-  }
+  assert.throws(
+    () => compose(new Writable(), new PassThrough()),
+    { code: 'ERR_INVALID_ARG_VALUE' }
+  )
 }
 
 {
-  try {
-    compose(new PassThrough(), new Readable({ read() {} }), new PassThrough());
-  } catch (err) {
-    assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
-  }
+  assert.throws(
+    () => compose(new PassThrough(), new Readable({ read() {} }), new PassThrough()),
+    { code: 'ERR_INVALID_ARG_VALUE' }
+  )
 }
 
 {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Start adding compose function #43664

I've started implementing from scratch and then realized that I don't need to, Using the `compose` function is enough.

The only problem I have is with the abort signal as the static `compose` doesn't seem to support it so I used the `addAbortSignal` but we won't pass the stream the signal as the rest of the operators

Cc @benjamingr