### PR TITLE
deps: V8: backport bbd800c6e359

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.22',
+    'v8_embedder_string': '-node.23',
 
     ##### V8 defaults for Node.js #####
 


### PR DESCRIPTION
Original commit message:

    [heap] Fix incorrect from space committed size

    NewSpace page operations like RemovePage, PrependPage, and
    EnsureCurrentCapacity should account for committed page size.

    This may happen when a page was promoted from the new space to
    old space on mark-compact.

    Also, add DCHECKs on Commit and Uncommit to ensure the final
    committed page size is the same as the current state.

    Bug: v8:12657
    Change-Id: I7aebc1fd3f51f177ae2ef6420f757f0c573e126b
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3504766
    Reviewed-by: Dominik Inführ <dinfuehr@chromium.org>
    Commit-Queue: Chengzhong Wu <legendecas@gmail.com>
    Cr-Commit-Position: refs/heads/main@{#79426}

Refs: https://github.com/v8/v8/commit/bbd800c6e3598a3756733a9c7eba00d7de168226

Fixes that v8 may report incorrect new space size in certain conditions: https://bugs.chromium.org/p/v8/issues/detail?id=12657.