### PR TITLE
crypto: simplify webcrypto ECDH deriveBits

### DIFF
--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -2,10 +2,8 @@
 
 const {
   ArrayBufferPrototypeSlice,
-  FunctionPrototypeCall,
   MathCeil,
   ObjectDefineProperty,
-  Promise,
   SafeSet,
 } = primordials;
 
@@ -33,7 +31,6 @@ const {
 } = require('internal/errors');
 
 const {
-  validateFunction,
   validateInt32,
   validateObject,
   validateString,
@@ -57,6 +54,7 @@ const {
 const {
   getArrayBufferOrView,
   getDefaultEncoding,
+  jobPromise,
   toBuf,
   kHandle,
   kKeyObject,
@@ -317,22 +315,9 @@ function diffieHellman(options) {
   return statelessDH(privateKey[kHandle], publicKey[kHandle]);
 }
 
-// The deriveBitsECDH function is part of the Web Crypto API and serves both
+// The ecdhDeriveBits function is part of the Web Crypto API and serves both
 // deriveKeys and deriveBits functions.
-function deriveBitsECDH(name, publicKey, privateKey, callback) {
-  validateString(name, 'name');
-  validateObject(publicKey, 'publicKey');
-  validateObject(privateKey, 'privateKey');
-  validateFunction(callback, 'callback');
-  const job = new ECDHBitsJob(kCryptoJobAsync, name, publicKey, privateKey);
-  job.ondone = (error, bits) => {
-    if (error) return FunctionPrototypeCall(callback, job, error);
-    FunctionPrototypeCall(callback, job, null, bits);
-  };
-  job.run();
-}
-
-async function asyncDeriveBitsECDH(algorithm, baseKey, length) {
+async function ecdhDeriveBits(algorithm, baseKey, length) {
   const { 'public': key } = algorithm;
 
   // Null means that we're not asking for a specific number of bits, just
@@ -372,15 +357,11 @@ async function asyncDeriveBitsECDH(algorithm, baseKey, length) {
     throw lazyDOMException('Named curve mismatch', 'InvalidAccessError');
   }
 
-  const bits = await new Promise((resolve, reject) => {
-    deriveBitsECDH(
-      key.algorithm.name === 'ECDH' ? baseKey.algorithm.namedCurve : baseKey.algorithm.name,
-      key[kKeyObject][kHandle],
-      baseKey[kKeyObject][kHandle], (err, bits) => {
-        if (err) return reject(err);
-        resolve(bits);
-      });
-  });
+  const bits = await jobPromise(new ECDHBitsJob(
+    kCryptoJobAsync,
+    key.algorithm.name === 'ECDH' ? baseKey.algorithm.namedCurve : baseKey.algorithm.name,
+    key[kKeyObject][kHandle],
+    baseKey[kKeyObject][kHandle]));
 
   // If a length is not specified, return the full derived secret
   if (length === null)
@@ -407,6 +388,5 @@ module.exports = {
   DiffieHellmanGroup,
   ECDH,
   diffieHellman,
-  deriveBitsECDH,
-  asyncDeriveBitsECDH,
+  ecdhDeriveBits,
 };

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -177,7 +177,7 @@ async function deriveBits(algorithm, baseKey, length) {
       // Fall through
     case 'ECDH':
       return lazyRequire('internal/crypto/diffiehellman')
-        .asyncDeriveBitsECDH(algorithm, baseKey, length);
+        .ecdhDeriveBits(algorithm, baseKey, length);
     case 'HKDF':
       return lazyRequire('internal/crypto/hkdf')
         .hkdfDeriveBits(algorithm, baseKey, length);
@@ -256,7 +256,7 @@ async function deriveKey(
       // Fall through
     case 'ECDH':
       bits = await lazyRequire('internal/crypto/diffiehellman')
-        .asyncDeriveBitsECDH(algorithm, baseKey, length);
+        .ecdhDeriveBits(algorithm, baseKey, length);
       break;
     case 'HKDF':
       bits = await lazyRequire('internal/crypto/hkdf')


### PR DESCRIPTION
This refactors webcrypto's ECDH deriveBits operation used by the ECDH, X25519, and X448 algorithms.