### PR TITLE
[v16.x] deps: V8: Fix incorrect from space committed size

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.22',
+    'v8_embedder_string': '-node.23',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.23',
+    'v8_embedder_string': '-node.24',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/extensions/statistics-extension.cc
+++ b/deps/v8/src/extensions/statistics-extension.cc
@@ -124,36 +124,41 @@ void StatisticsExtension::GetCounters(
 
   AddNumber64(args.GetIsolate(), result, heap->external_memory(),
               "amount_of_external_allocated_memory");
-  args.GetReturnValue().Set(result);
 
-  DisallowGarbageCollection no_gc;
-  HeapObjectIterator iterator(
-      reinterpret_cast<Isolate*>(args.GetIsolate())->heap());
   int reloc_info_total = 0;
   int source_position_table_total = 0;
-  for (HeapObject obj = iterator.Next(); !obj.is_null();
-       obj = iterator.Next()) {
-    Object maybe_source_positions;
-    if (obj.IsCode()) {
-      Code code = Code::cast(obj);
-      reloc_info_total += code.relocation_info().Size();
-      maybe_source_positions = code.source_position_table();
-    } else if (obj.IsBytecodeArray()) {
-      maybe_source_positions =
-          BytecodeArray::cast(obj).source_position_table(kAcquireLoad);
-    } else {
-      continue;
+  {
+    HeapObjectIterator iterator(
+        reinterpret_cast<Isolate*>(args.GetIsolate())->heap());
+    DCHECK(!AllowGarbageCollection::IsAllowed());
+    for (HeapObject obj = iterator.Next(); !obj.is_null();
+         obj = iterator.Next()) {
+      Object maybe_source_positions;
+      if (obj.IsCode()) {
+        Code code = Code::cast(obj);
+        reloc_info_total += code.relocation_info().Size();
+        // Baseline code doesn't have source positions since it uses
+        // interpreter code positions.
+        if (code.kind() == CodeKind::BASELINE) continue;
+        maybe_source_positions = code.source_position_table();
+      } else if (obj.IsBytecodeArray()) {
+        maybe_source_positions =
+            BytecodeArray::cast(obj).source_position_table(kAcquireLoad);
+      } else {
+        continue;
+      }
+      if (!maybe_source_positions.IsByteArray()) continue;
+      ByteArray source_positions = ByteArray::cast(maybe_source_positions);
+      if (source_positions.length() == 0) continue;
+      source_position_table_total += source_positions.Size();
     }
-    if (!maybe_source_positions.IsByteArray()) continue;
-    ByteArray source_positions = ByteArray::cast(maybe_source_positions);
-    if (source_positions.length() == 0) continue;
-    source_position_table_total += source_positions.Size();
   }
 
   AddNumber(args.GetIsolate(), result, reloc_info_total,
             "reloc_info_total_size");
   AddNumber(args.GetIsolate(), result, source_position_table_total,
             "source_position_table_total_size");
+  args.GetReturnValue().Set(result);
 }
 
 }  // namespace internal

--- a/deps/v8/src/flags/flag-definitions.h
+++ b/deps/v8/src/flags/flag-definitions.h
@@ -1390,6 +1390,7 @@ DEFINE_STRING(expose_gc_as, nullptr,
 DEFINE_IMPLICATION(expose_gc_as, expose_gc)
 DEFINE_BOOL(expose_externalize_string, false,
             "expose externalize string extension")
+DEFINE_BOOL(expose_statistics, false, "expose statistics extension")
 DEFINE_BOOL(expose_trigger_failure, false, "expose trigger-failure extension")
 DEFINE_BOOL(expose_ignition_statistics, false,
             "expose ignition-statistics extension (requires building with "

--- a/deps/v8/src/init/bootstrapper.cc
+++ b/deps/v8/src/init/bootstrapper.cc
@@ -5089,7 +5089,7 @@ bool Genesis::InstallExtensions(Isolate* isolate,
           InstallExtension(isolate, "v8/gc", &extension_states)) &&
          (!FLAG_expose_externalize_string ||
           InstallExtension(isolate, "v8/externalize", &extension_states)) &&
-         (!TracingFlags::is_gc_stats_enabled() ||
+         (!(FLAG_expose_statistics || TracingFlags::is_gc_stats_enabled()) ||
           InstallExtension(isolate, "v8/statistics", &extension_states)) &&
          (!FLAG_expose_trigger_failure ||
           InstallExtension(isolate, "v8/trigger-failure", &extension_states)) &&

--- a/deps/v8/test/mjsunit/regress/regress-12657.js
+++ b/deps/v8/test/mjsunit/regress/regress-12657.js
@@ -1,0 +1,11 @@
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --gc-global --expose-statistics --max-semi-space-size=1
+
+const a = new Array();
+for (var i = 0; i < 50000; i++) {
+  a[i] = new Object();
+}
+assertTrue(getV8Statistics().new_space_commited_bytes <= 2 * 1024 * 1024);

--- a/deps/v8/test/mjsunit/statistics-extension.js
+++ b/deps/v8/test/mjsunit/statistics-extension.js
@@ -1,0 +1,12 @@
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --expose-statistics
+
+assertEquals(typeof getV8Statistics, 'function');
+var result = getV8Statistics();
+assertEquals(typeof result, 'object');
+for (let key of Object.keys(result)) {
+  assertEquals(typeof result[key], 'number');
+}


### PR DESCRIPTION
Backports commits that fix the issue where V8 reports incorrect new space size: https://bugs.chromium.org/p/v8/issues/detail?id=12657.

#### deps: V8: backport bbd800c6e359

Original commit message:

    [heap] Fix incorrect from space committed size

    NewSpace page operations like RemovePage, PrependPage, and
    EnsureCurrentCapacity should account for committed page size.

    This may happen when a page was promoted from the new space to
    old space on mark-compact.

    Also, add DCHECKs on Commit and Uncommit to ensure the final
    committed page size is the same as the current state.

    Bug: v8:12657
    Change-Id: I7aebc1fd3f51f177ae2ef6420f757f0c573e126b
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3504766
    Reviewed-by: Dominik Inführ <dinfuehr@chromium.org>
    Commit-Queue: Chengzhong Wu <legendecas@gmail.com>
    Cr-Commit-Position: refs/heads/main@{#79426}

Refs: https://github.com/v8/v8/commit/bbd800c6e3598a3756733a9c7eba00d7de168226


#### deps: V8: cherry-pick b95354290941

Original commit message:

    [extensions] Fix dcheck failures in getV8Statistics

    HeapObjectIterator creates a SafepointScope which requires the heap to
    allow garbage collection. This collides with the outer
    DisallowGarbageCollection scope. HeapObjectIterator already ensures
    there is no allocation during its lifetime, so there is no need to
    create an outer DisallowGarbageCollection scope.

    Code::source_position_table requires their kind not equals to
    CodeKind::BASELINE.

    This also exposes the statistics extension through flag
    --expose-statistics.

    Bug: v8:12657
    Change-Id: I1bf11cf499285a742dd99ec8c228ebc36152b597
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3496552
    Reviewed-by: Camillo Bruni <cbruni@chromium.org>
    Reviewed-by: Marja Hölttä <marja@chromium.org>
    Commit-Queue: Chengzhong Wu <legendecas@gmail.com>
    Cr-Commit-Position: refs/heads/main@{#79425}

Refs: https://github.com/v8/v8/commit/b953542909416a5be11220d9adf6da1aff1f009c