### PR TITLE
adding numeric_owner as a keyword argument

### DIFF
--- a/deps/npm/node_modules/node-gyp/update-gyp.py
+++ b/deps/npm/node_modules/node-gyp/update-gyp.py
@@ -49,7 +49,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
                     if not is_within_directory(path, member_path):
                         raise Exception("Attempted Path Traversal in Tar File")
             
-                tar.extractall(path, members, numeric_owner) 
+                tar.extractall(path, members, numeric_owner=numeric_owner) 
                 
             
             safe_extract(tar_ref, unzip_target)

--- a/deps/npm/node_modules/node-gyp/update-gyp.py
+++ b/deps/npm/node_modules/node-gyp/update-gyp.py
@@ -33,7 +33,26 @@ with tempfile.TemporaryDirectory() as tmp_dir:
 
         print("Unzipping...")
         with tarfile.open(tar_file, "r:gz") as tar_ref:
-            tar_ref.extractall(unzip_target)
+            def is_within_directory(directory, target):
+                
+                abs_directory = os.path.abspath(directory)
+                abs_target = os.path.abspath(target)
+            
+                prefix = os.path.commonprefix([abs_directory, abs_target])
+                
+                return prefix == abs_directory
+            
+            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+            
+                for member in tar.getmembers():
+                    member_path = os.path.join(path, member.name)
+                    if not is_within_directory(path, member_path):
+                        raise Exception("Attempted Path Traversal in Tar File")
+            
+                tar.extractall(path, members, numeric_owner) 
+                
+            
+            safe_extract(tar_ref, unzip_target)
 
         print("Moving to current checkout (" + CHECKOUT_PATH + ")...")
         if os.path.exists(CHECKOUT_GYP_PATH):


### PR DESCRIPTION
As of Python 3.5, the tarfile extractall() method has a numeric_owner keyword argument. This is change will support Python 3.5 and higher. Note that this keyword does not exist in Python 3.4 or lower so it will not work on those previous versions.
