### PR TITLE
test_runner: add extra fields in AssertionError YAML

### DIFF
--- a/lib/internal/test_runner/tap_stream.js
+++ b/lib/internal/test_runner/tap_stream.js
@@ -179,17 +179,30 @@ function jsToYaml(indent, name, value) {
       code,
       failureType,
       message,
+      expected,
+      actual,
+      operator,
       stack,
     } = value;
     let errMsg = message ?? '<unknown error>';
     let errStack = stack;
     let errCode = code;
+    let errExpected = expected;
+    let errActual = actual;
+    let errOperator = operator;
+    let errIsAssertion = isAssertionLike(value);
 
     // If the ERR_TEST_FAILURE came from an error provided by user code,
     // then try to unwrap the original error message and stack.
     if (code === 'ERR_TEST_FAILURE' && kUnwrapErrors.has(failureType)) {
       errStack = cause?.stack ?? errStack;
       errCode = cause?.code ?? errCode;
+      if (isAssertionLike(cause)) {
+        errExpected = cause.expected;
+        errActual = cause.actual;
+        errOperator = cause.operator ?? errOperator;
+        errIsAssertion = true;
+      }
       if (failureType === kTestCodeFailure) {
         errMsg = cause?.message ?? errMsg;
       }
@@ -199,6 +212,14 @@ function jsToYaml(indent, name, value) {
 
     if (errCode) {
       result += jsToYaml(indent, 'code', errCode);
+    }
+
+    if (errIsAssertion) {
+      result += jsToYaml(indent, 'expected', errExpected);
+      result += jsToYaml(indent, 'actual', errActual);
+      if (errOperator) {
+        result += jsToYaml(indent, 'operator', errOperator);
+      }
     }
 
     if (typeof errStack === 'string') {
@@ -227,6 +248,10 @@ function jsToYaml(indent, name, value) {
   }
 
   return result;
+}
+
+function isAssertionLike(value) {
+  return value && typeof value === 'object' && 'expected' in value && 'actual' in value;
 }
 
 module.exports = { TapStream };

--- a/test/message/test_runner_describe_it.out
+++ b/test/message/test_runner_describe_it.out
@@ -123,6 +123,9 @@ not ok 13 - async assertion fail
     true !== false
     
   code: 'ERR_ASSERTION'
+  expected: false
+  actual: true
+  operator: 'strictEqual'
   stack: |-
     *
     *

--- a/test/message/test_runner_output.out
+++ b/test/message/test_runner_output.out
@@ -133,6 +133,9 @@ not ok 13 - async assertion fail
     true !== false
     
   code: 'ERR_ASSERTION'
+  expected: false
+  actual: true
+  operator: 'strictEqual'
   stack: |-
     *
     *


### PR DESCRIPTION
Many TAP reporters offer special-case handling of YAML objects containing `expected`, `actual`, and `operator` fields, as produced by `AssertionError` and similar userland Error classes.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
