### PR TITLE
buffer: remove async tick and improve perf by 48%

### DIFF
--- a/benchmark/blob/blob-text.js
+++ b/benchmark/blob/blob-text.js
@@ -1,0 +1,30 @@
+'use strict';
+const common = require('../common.js');
+const { Blob } = require('buffer');
+
+const bench = common.createBenchmark(main, {
+  bytes: [0, 8, 128],
+  n: [1e6],
+  operation: ['text', 'arrayBuffer']
+});
+
+async function run(n, bytes, operation) {
+  const buff = Buffer.allocUnsafe(bytes);
+  const source = new Blob(buff);
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    switch (operation) {
+      case 'text':
+        await source.text();
+        break;
+      case 'arrayBuffer':
+        await source.arrayBuffer();
+        break;
+    }
+  }
+  bench.end(n);
+}
+
+function main(conf) {
+  run(conf.n, conf.bytes, conf.operation).catch(console.log);
+}

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -8,6 +8,7 @@ const {
   PromiseResolve,
   PromiseReject,
   SafePromisePrototypeFinally,
+  PromisePrototypeThen,
   ReflectConstruct,
   RegExpPrototypeExec,
   RegExpPrototypeSymbolReplace,
@@ -308,13 +309,13 @@ class Blob {
   /**
    * @returns {Promise<string>}
    */
-  async text() {
+  text() {
     if (!isBlob(this))
-      throw new ERR_INVALID_THIS('Blob');
+      return PromiseReject(new ERR_INVALID_THIS('Blob'));
 
     dec ??= new TextDecoder();
 
-    return dec.decode(await this.arrayBuffer());
+    return PromisePrototypeThen(this.arrayBuffer(), (value) => dec.decode(value));
   }
 
   /**


### PR DESCRIPTION
I ran the benchmarks only for `blob.text()` since it's the only relevant one, but added more for future reference.

```
                                                       confidence improvement accuracy (*)   (**)  (***)
blob/blob-text.js operation='text' n=1000000 bytes=0          ***     48.33 %       ±1.65% ±2.20% ±2.87%
blob/blob-text.js operation='text' n=1000000 bytes=128        ***      9.65 %       ±2.33% ±3.10% ±4.04%
blob/blob-text.js operation='text' n=1000000 bytes=8          ***      8.20 %       ±1.84% ±2.45% ±3.19%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 3 comparisons, you can thus expect the following amount of false-positive results:
  0.15 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.03 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```