### PR TITLE
doc: fix undici version in changelog

### DIFF
--- a/doc/changelogs/CHANGELOG_V16.md
+++ b/doc/changelogs/CHANGELOG_V16.md
@@ -130,7 +130,7 @@ More detailed information on each of the vulnerabilities can be found in [Septem
 * \[[`67cbbcc902`](https://github.com/nodejs/node/commit/67cbbcc902)] - **deps**: update corepack to 0.14.0 (Node.js GitHub Bot) [#44509](https://github.com/nodejs/node/pull/44509)
 * \[[`9f14dc1a8f`](https://github.com/nodejs/node/commit/9f14dc1a8f)] - **deps**: update Acorn to v8.8.0 (Michaël Zasso) [#44437](https://github.com/nodejs/node/pull/44437)
 * \[[`1811a6aaa8`](https://github.com/nodejs/node/commit/1811a6aaa8)] - **deps**: update icu tzdata to 2022b (Matías Zúñiga) [#44283](https://github.com/nodejs/node/pull/44283)
-* \[[`0c4953cbd1`](https://github.com/nodejs/node/commit/0c4953cbd1)] - **deps**: update undici to 5.9.1 (Node.js GitHub Bot) [#44319](https://github.com/nodejs/node/pull/44319)
+* \[[`0c4953cbd1`](https://github.com/nodejs/node/commit/0c4953cbd1)] - **deps**: update undici to 5.10.0(Node.js GitHub Bot) [#44319](https://github.com/nodejs/node/pull/44319)
 * \[[`8a921fea74`](https://github.com/nodejs/node/commit/8a921fea74)] - **deps**: upgrade npm to 8.19.1 (npm team) [#44486](https://github.com/nodejs/node/pull/44486)
 * \[[`763a63c14b`](https://github.com/nodejs/node/commit/763a63c14b)] - **deps**: update corepack to 0.13.0 (Node.js GitHub Bot) [#44318](https://github.com/nodejs/node/pull/44318)
 * \[[`fdb699c84a`](https://github.com/nodejs/node/commit/fdb699c84a)] - **deps**: upgrade npm to 8.18.0 (npm team) [#44263](https://github.com/nodejs/node/pull/44263)

--- a/doc/changelogs/CHANGELOG_V18.md
+++ b/doc/changelogs/CHANGELOG_V18.md
@@ -243,7 +243,7 @@ More detailed information on each of the vulnerabilities can be found in [Septem
 * \[[`754d26a53e`](https://github.com/nodejs/node/commit/754d26a53e)] - **deps**: patch V8 to 10.2.154.15 (Michaël Zasso) [#44294](https://github.com/nodejs/node/pull/44294)
 * \[[`1b50ff2600`](https://github.com/nodejs/node/commit/1b50ff2600)] - **deps**: update icu tzdata to 2022b (Matías Zúñiga) [#44283](https://github.com/nodejs/node/pull/44283)
 * \[[`1e451dca99`](https://github.com/nodejs/node/commit/1e451dca99)] - **deps**: upgrade llhttp to 6.0.9 (Paolo Insogna) [#44344](https://github.com/nodejs/node/pull/44344)
-* \[[`57da3db522`](https://github.com/nodejs/node/commit/57da3db522)] - **deps**: update undici to 5.9.1 (Node.js GitHub Bot) [#44319](https://github.com/nodejs/node/pull/44319)
+* \[[`57da3db522`](https://github.com/nodejs/node/commit/57da3db522)] - **deps**: update undici to 5.10.0 (Node.js GitHub Bot) [#44319](https://github.com/nodejs/node/pull/44319)
 * \[[`1c87a7e8f6`](https://github.com/nodejs/node/commit/1c87a7e8f6)] - **doc**: add missing parenthesis in TLSSocket section (Tobias Nießen) [#44512](https://github.com/nodejs/node/pull/44512)
 * \[[`05006eddb2`](https://github.com/nodejs/node/commit/05006eddb2)] - **doc**: do not use "Returns:" for crypto.constants (Tobias Nießen) [#44481](https://github.com/nodejs/node/pull/44481)
 * \[[`54b6ed58bc`](https://github.com/nodejs/node/commit/54b6ed58bc)] - **doc**: use serial comma in addons docs (Tobias Nießen) [#44482](https://github.com/nodejs/node/pull/44482)


### PR DESCRIPTION
The last PR to update the undici version in V18 and V16 had two commits. One to update to 5.9.1 and one to upodate to 5.10.0. Unfortunately it looks like
when squashed the commit indicates 5.9.1 which was reported as confusing in the changelogs.

I don't think we can necessarily change the commit message in the commit, but I think having the
changelogs indicate the correct version makes sense even without that change.

This PR updates the version in the two changelogs.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
