### PR TITLE
test: bump memory limit for abort fatal error

### DIFF
--- a/test/abort/test-abort-fatal-error.js
+++ b/test/abort/test-abort-fatal-error.js
@@ -28,7 +28,7 @@ const assert = require('assert');
 const exec = require('child_process').exec;
 
 let cmdline = `ulimit -c 0; ${process.execPath}`;
-cmdline += ' --max-old-space-size=4 --max-semi-space-size=1';
+cmdline += ' --max-old-space-size=16 --max-semi-space-size=4';
 cmdline += ' -e "a = []; for (i = 0; i < 1e9; i++) { a.push({}) }"';
 
 exec(cmdline, function(err, stdout, stderr) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Fixes a failing test (`test.abort/test-abort-fatal-error`) in `v18.x-staging` by bumping the memory limits in the test.
