### PR TITLE
doc: fix http and http2 writeEarlyHints() parameter

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2175,7 +2175,9 @@ response.writeEarlyHints({
 });
 
 const earlyHintsCallback = () => console.log('early hints message sent');
-response.writeEarlyHints(earlyHintsLinks, earlyHintsCallback);
+response.writeEarlyHints({
+  'link': earlyHintsLinks,
+}, earlyHintsCallback);
 ```
 
 ### `response.writeHead(statusCode[, statusMessage][, headers])`

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3787,7 +3787,7 @@ Removes a header that has been queued for implicit sending.
 response.removeHeader('Content-Encoding');
 ```
 
-### `response.req`
+#### `response.req`
 
 <!-- YAML
 added: v15.7.0
@@ -4005,30 +4005,34 @@ Sends a status `100 Continue` to the client, indicating that the request body
 should be sent. See the [`'checkContinue'`][] event on `Http2Server` and
 `Http2SecureServer`.
 
-### `response.writeEarlyHints(links)`
+#### `response.writeEarlyHints(hints)`
 
 <!-- YAML
 added: v18.11.0
 -->
 
-* `links` {string|Array}
+* `hints` {Object}
 
 Sends a status `103 Early Hints` to the client with a Link header,
 indicating that the user agent can preload/preconnect the linked resources.
-The `links` can be a string or an array of strings containing the values
-of the `Link` header.
+The `hints` is an object containing the values of headers to be sent with
+early hints message.
 
 **Example**
 
 ```js
 const earlyHintsLink = '</styles.css>; rel=preload; as=style';
-response.writeEarlyHints(earlyHintsLink);
+response.writeEarlyHints({
+  'link': earlyHintsLink,
+});
 
 const earlyHintsLinks = [
   '</styles.css>; rel=preload; as=style',
   '</scripts.js>; rel=preload; as=script',
 ];
-response.writeEarlyHints(earlyHintsLinks);
+response.writeEarlyHints({
+  'link': earlyHintsLinks,
+});
 ```
 
 #### `response.writeHead(statusCode[, statusMessage][, headers])`


### PR DESCRIPTION
Both http and http2 `response.writeEarlyHints()` take an object, not an array, as their first parameter. For http, this was updated in the examples via #44820 except for the final example, which this patch fixes.
The doc for the http2 version was not touched in #44820 although I am pretty sure from skimming the code that it behaves identically to http, and so propose to change its doc as well. Finally, some bogus headline levels are fixed in http2 docs.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
