### PR TITLE
doc: improve the workflow to test release binaries

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -603,12 +603,13 @@ the build before moving forward. Use the following list as a baseline:
   must be in the expected updated version)
 * npm version (check it matches what we expect)
 * Run the test suite against the built binaries (optional)
+  * Remember to use the proposal branch
+  * Run `make build-addons` before running the tests
+  * Remove `config.gypi` file
 
 ```console
 ./tools/test.py --shell ~/Downloads/node-v18.5.0-linux-x64/bin/node
 ```
-
-<sup>There may be test issues if the branch used to test does not match the Node.js binary.</sup>
 
 ### 11. Tag and sign the release commit
 


### PR DESCRIPTION
Using this workflow we have a better test report.

I'm using it to test the new major (v19) and it only fails 2 tests (the ones I mentioned in the doc). Those failures are expected due to the test itself trusting in some variables not present in the final binary. 