### PR TITLE
url: improve port validation

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -525,13 +525,12 @@ function getHostname(self, rest, hostname, url) {
 
     // Invalid host character
     if (!isValid) {
-      self.hostname = hostname.slice(0, i);
-      const leftover = hostname.slice(i);
       // If leftover starts with :, then it represents an invalid port.
-      if (leftover.startsWith(':')) {
+      if (hostname.charCodeAt(i) === 58) {
         throw new ERR_INVALID_URL(url);
       }
-      return `/${leftover}${rest}`;
+      self.hostname = hostname.slice(0, i);
+      return `/${hostname.slice(i)}${rest}`;
     }
   }
   return rest;

--- a/lib/url.js
+++ b/lib/url.js
@@ -377,7 +377,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     }
 
     // pull out port.
-    this.parseHost(url);
+    this.parseHost();
 
     // We've indicated that there is a hostname,
     // so even if it's empty, it has to be present.

--- a/lib/url.js
+++ b/lib/url.js
@@ -377,7 +377,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     }
 
     // pull out port.
-    this.parseHost();
+    this.parseHost(url);
 
     // We've indicated that there is a hostname,
     // so even if it's empty, it has to be present.
@@ -392,7 +392,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
 
     // validate a little.
     if (!ipv6Hostname) {
-      rest = getHostname(this, rest, hostname);
+      rest = getHostname(this, rest, hostname, url);
     }
 
     if (this.hostname.length > hostnameMaxLen) {
@@ -511,7 +511,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
   return this;
 };
 
-function getHostname(self, rest, hostname) {
+function getHostname(self, rest, hostname, url) {
   for (let i = 0; i < hostname.length; ++i) {
     const code = hostname.charCodeAt(i);
     const isValid = (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z) ||
@@ -526,7 +526,12 @@ function getHostname(self, rest, hostname) {
     // Invalid host character
     if (!isValid) {
       self.hostname = hostname.slice(0, i);
-      return `/${hostname.slice(i)}${rest}`;
+      const leftover = hostname.slice(i);
+      // If leftover starts with :, then it represents an invalid port.
+      if (leftover.startsWith(':')) {
+        throw new ERR_INVALID_URL(url);
+      }
+      return `/${leftover}${rest}`;
     }
   }
   return rest;

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -865,22 +865,6 @@ const parseTests = {
     href: 'http://a%0D%22%20%09%0A%3C\'b:b@c/%0D%0Ad/e?f'
   },
 
-  // Git urls used by npm
-  'git+ssh://git@github.com:npm/npm': {
-    protocol: 'git+ssh:',
-    slashes: true,
-    auth: 'git',
-    host: 'github.com',
-    port: null,
-    hostname: 'github.com',
-    hash: null,
-    search: null,
-    query: null,
-    pathname: '/:npm/npm',
-    path: '/:npm/npm',
-    href: 'git+ssh://git@github.com/:npm/npm'
-  },
-
   'https://*': {
     protocol: 'https:',
     slashes: true,

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -74,3 +74,15 @@ if (common.hasIntl) {
                 (e) => e.code === 'ERR_INVALID_URL',
                 'parsing http://\u00AD/bad.com/');
 }
+
+{
+  const badURLs = [
+    'https://evil.com:.example.com',
+    'git+ssh://git@github.com:npm/npm',
+  ];
+  badURLs.forEach((badURL) => {
+    assert.throws(() => { url.parse(badURL); },
+                  (e) => e.code === 'ERR_INVALID_URL',
+                  `parsing ${badURL}`);
+  });
+}


### PR DESCRIPTION
If a port is not a number, throw rather than treating the `:` that delineates the port as part of the path. This is consistent with WHATWG URL and also mitigates hostname-spoofing.

Concerns about hostname-spoofing were raised and presented in excellent detail by pyozzi-toss (pyozzi@toss.im/Security-Tech Team in Toss).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
