### PR TITLE
tools: do not use the set-output command in workflows

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -28,12 +28,13 @@ jobs:
       - name: Get Pull Requests
         id: get_prs_for_ci
         run: >
-          gh pr list \
+          numbers=$(gh pr list \
                   --repo ${{ github.repository }} \
                   --label 'request-ci' \
                   --json 'number' \
-                  -t '::set-output name=numbers::{{ range . }}{{ .number }} {{ end }}' \
-                  --limit 100
+                  -t '{{ range . }}{{ .number }} {{ end }}' \
+                  --limit 100)
+          echo "numbers=$numbers" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   start-ci:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Compute number of commits in the PR
         id: nb-of-commits
         run: |
-          echo "::set-output name=plusOne::$((${{ github.event.pull_request.commits }} + 1))"
-          echo "::set-output name=minusOne::$((${{ github.event.pull_request.commits }} - 1))"
+          echo "plusOne=$((${{ github.event.pull_request.commits }} + 1))" >> $GITHUB_OUTPUT
+          echo "minusOne=$((${{ github.event.pull_request.commits }} - 1))" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
         with:
           fetch-depth: ${{ steps.nb-of-commits.outputs.plusOne }}

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -33,13 +33,14 @@ jobs:
       - name: Get Pull Requests
         id: get_mergeable_prs
         run: >
-          gh pr list \
+          numbers=$(gh pr list \
                   --repo ${{ github.repository }} \
                   --base ${{ github.ref_name }} \
                   --label 'commit-queue' \
                   --json 'number' \
-                  -t '::set-output name=numbers::{{ range . }}{{ .number }} {{ end }}' \
-                  --limit 100
+                  -t '{{ range . }}{{ .number }} {{ end }}' \
+                  --limit 100)
+          echo "numbers=$numbers" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   commitQueue:

--- a/.github/workflows/label-flaky-test-issue.yml
+++ b/.github/workflows/label-flaky-test-issue.yml
@@ -41,7 +41,7 @@ jobs:
             labels="${labels}${platform2label[$platform]},"; \
           done;
 
-          echo "::set-output name=LABELS::${labels::-1}"
+          echo "LABELS=${labels::-1}" >> $GITHUB_OUTPUT
 
       - name: Add labels
         env:


### PR DESCRIPTION
The `set-output` command is deprecated. Use the `GITHUB_OUTPUT` environment file.

Refs: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
