### PR TITLE
stream: don't push null from closed promise #42694

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -32,7 +32,6 @@ const {
 const {
   isDestroyed,
   isReadable,
-  isReadableEnded,
   isWritable,
   isWritableEnded,
 } = require('internal/streams/utils');
@@ -528,8 +527,6 @@ function newStreamReadableFromReadableStream(readableStream, options = kEmptyObj
     reader.closed,
     () => {
       closed = true;
-      if (!isReadableEnded(readable))
-        readable.push(null);
     },
     (error) => {
       closed = true;
@@ -794,8 +791,6 @@ function newStreamDuplexFromReadableWritablePair(pair = kEmptyObject, options = 
     reader.closed,
     () => {
       readableClosed = true;
-      if (!isReadableEnded(duplex))
-        duplex.push(null);
     },
     (error) => {
       writableClosed = true;

--- a/test/parallel/test-readable-from-web-enqueue-then-close.js
+++ b/test/parallel/test-readable-from-web-enqueue-then-close.js
@@ -1,0 +1,26 @@
+'use strict';
+const { mustCall } = require('../common');
+const { Readable, Duplex } = require('stream');
+const { strictEqual } = require('assert');
+
+function start(controller) {
+  controller.enqueue(new Uint8Array(1));
+  controller.close();
+}
+
+Readable.fromWeb(new ReadableStream({ start }))
+.on('data', mustCall((d) => {
+  strictEqual(d.length, 1);
+}))
+.on('end', mustCall())
+.resume();
+
+Duplex.fromWeb({
+  readable: new ReadableStream({ start }),
+  writable: new WritableStream({ write(chunk) {} })
+})
+.on('data', mustCall((d) => {
+  strictEqual(d.length, 1);
+}))
+.on('end', mustCall())
+.resume();


### PR DESCRIPTION
closed promise is subscribed to first so will be
resolved first, before any read promise.

This causes data after EOF error to be thrown.

Remove the push null from the closed promise handler. The push null gets done from the read handler
when it detects done.

Fixes: https://github.com/nodejs/node/issues/42694

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
