### PR TITLE
lib: add ability to add separate event name to defineEventHandler

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -1022,12 +1022,12 @@ function makeEventHandler(handler) {
   return eventHandler;
 }
 
-function defineEventHandler(emitter, name) {
+function defineEventHandler(emitter, name, event = name) {
   // 8.1.5.1 Event handlers - basically `on[eventName]` attributes
   const propName = `on${name}`;
   function get() {
     validateInternalField(this, kHandlers, 'EventTarget');
-    return this[kHandlers]?.get(name)?.handler ?? null;
+    return this[kHandlers]?.get(event)?.handler ?? null;
   }
   ObjectDefineProperty(get, 'name', {
     __proto__: null,
@@ -1036,24 +1036,24 @@ function defineEventHandler(emitter, name) {
 
   function set(value) {
     validateInternalField(this, kHandlers, 'EventTarget');
-    let wrappedHandler = this[kHandlers]?.get(name);
+    let wrappedHandler = this[kHandlers]?.get(event);
     if (wrappedHandler) {
       if (typeof wrappedHandler.handler === 'function') {
-        this[kEvents].get(name).size--;
-        const size = this[kEvents].get(name).size;
-        this[kRemoveListener](size, name, wrappedHandler.handler, false);
+        this[kEvents].get(event).size--;
+        const size = this[kEvents].get(event).size;
+        this[kRemoveListener](size, event, wrappedHandler.handler, false);
       }
       wrappedHandler.handler = value;
       if (typeof wrappedHandler.handler === 'function') {
-        this[kEvents].get(name).size++;
-        const size = this[kEvents].get(name).size;
-        this[kNewListener](size, name, value, false, false, false, false);
+        this[kEvents].get(event).size++;
+        const size = this[kEvents].get(event).size;
+        this[kNewListener](size, event, value, false, false, false, false);
       }
     } else {
       wrappedHandler = makeEventHandler(value);
-      this.addEventListener(name, wrappedHandler);
+      this.addEventListener(event, wrappedHandler);
     }
-    this[kHandlers].set(name, wrappedHandler);
+    this[kHandlers].set(event, wrappedHandler);
   }
   ObjectDefineProperty(set, 'name', {
     __proto__: null,

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -615,6 +615,15 @@ let asyncTest = Promise.resolve();
   deepStrictEqual(output, [1, 2, 3, 4]);
 }
 {
+  const target = new EventTarget();
+  defineEventHandler(target, 'foo', 'bar');
+  const output = [];
+  target.addEventListener('bar', () => output.push(1));
+  target.onfoo = () => output.push(2);
+  target.dispatchEvent(new Event('bar'));
+  deepStrictEqual(output, [1, 2]);
+}
+{
   const et = new EventTarget();
   const listener = common.mustNotCall();
   et.addEventListener('foo', common.mustCall((e) => {


### PR DESCRIPTION
Adds an optional third argument to `defineEventHandler()` to specify an event name that is separate from the name used for the property. This will be used, for instance, by the quic implementation to support generating the `on...` events where the event name itself is hyphenated. For instance `defineEventHandler(target, 'streamreset', 'stream-reset')`

Separated out from https://github.com/nodejs/node/pull/44325

This is an internal only api so no documentation change is needed.

Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
