### PR TITLE
report: add rss and use/kernel cpu usage fields

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -198,10 +198,13 @@ is provided below for reference.
     }
   },
   "resourceUsage": {
-    "userCpuSeconds": 0.069595,
-    "kernelCpuSeconds": 0.019163,
-    "cpuConsumptionPercent": 0.000000,
-    "maxRss": 18079744,
+    "rss": 45768704,
+    "userCpuSeconds": 0.040072,
+    "kernelCpuSeconds": 0.016029,
+    "cpuConsumptionPercent": 5.6101,
+    "userCpuConsumptionPercent": 4.0072,
+    "kernelCpuConsumptionPercent": 1.6029,
+    "maxRss": 45768704,
     "pageFaults": {
       "IORequired": 0,
       "IONotRequired": 4610
@@ -212,9 +215,11 @@ is provided below for reference.
     }
   },
   "uvthreadResourceUsage": {
-    "userCpuSeconds": 0.068457,
-    "kernelCpuSeconds": 0.019127,
-    "cpuConsumptionPercent": 0.000000,
+    "userCpuSeconds": 0.039843,
+    "kernelCpuSeconds": 0.015937,
+    "cpuConsumptionPercent": 5.578,
+    "userCpuConsumptionPercent": 3.9843,
+    "kernelCpuConsumptionPercent": 1.5937,
     "fsActivity": {
       "reads": 0,
       "writes": 0

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -627,6 +627,13 @@ static void PrintResourceUsage(JSONWriter* writer) {
   // Process and current thread usage statistics
   uv_rusage_t rusage;
   writer->json_objectstart("resourceUsage");
+
+  size_t rss;
+  int err = uv_resident_set_memory(&rss);
+  if (!err) {
+    writer->json_keyvalue("rss", rss);
+  }
+
   if (uv_getrusage(&rusage) == 0) {
     double user_cpu =
         rusage.ru_utime.tv_sec + SEC_PER_MICROS * rusage.ru_utime.tv_usec;
@@ -636,7 +643,11 @@ static void PrintResourceUsage(JSONWriter* writer) {
     writer->json_keyvalue("kernelCpuSeconds", kernel_cpu);
     double cpu_abs = user_cpu + kernel_cpu;
     double cpu_percentage = (cpu_abs / uptime) * 100.0;
+    double user_cpu_percentage = (user_cpu / uptime) * 100.0;
+    double kernel_cpu_percentage = (kernel_cpu / uptime) * 100.0;
     writer->json_keyvalue("cpuConsumptionPercent", cpu_percentage);
+    writer->json_keyvalue("userCpuConsumptionPercent", user_cpu_percentage);
+    writer->json_keyvalue("kernelCpuConsumptionPercent", kernel_cpu_percentage);
     writer->json_keyvalue("maxRss", rusage.ru_maxrss * 1024);
     writer->json_objectstart("pageFaults");
     writer->json_keyvalue("IORequired", rusage.ru_majflt);
@@ -660,7 +671,11 @@ static void PrintResourceUsage(JSONWriter* writer) {
     writer->json_keyvalue("kernelCpuSeconds", kernel_cpu);
     double cpu_abs = user_cpu + kernel_cpu;
     double cpu_percentage = (cpu_abs / uptime) * 100.0;
+    double user_cpu_percentage = (user_cpu / uptime) * 100.0;
+    double kernel_cpu_percentage = (kernel_cpu / uptime) * 100.0;
     writer->json_keyvalue("cpuConsumptionPercent", cpu_percentage);
+    writer->json_keyvalue("userCpuConsumptionPercent", user_cpu_percentage);
+    writer->json_keyvalue("kernelCpuConsumptionPercent", kernel_cpu_percentage);
     writer->json_objectstart("fsActivity");
     writer->json_keyvalue("reads", stats.ru_inblock);
     writer->json_keyvalue("writes", stats.ru_oublock);

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -234,12 +234,16 @@ function _validateContent(report, fields = []) {
   // Verify the format of the resourceUsage section.
   const usage = report.resourceUsage;
   const resourceUsageFields = ['userCpuSeconds', 'kernelCpuSeconds',
-                               'cpuConsumptionPercent', 'maxRss',
+                               'cpuConsumptionPercent', 'userCpuConsumptionPercent',
+                               'kernelCpuConsumptionPercent', 'rss', 'maxRss',
                                'pageFaults', 'fsActivity'];
   checkForUnknownFields(usage, resourceUsageFields);
   assert.strictEqual(typeof usage.userCpuSeconds, 'number');
   assert.strictEqual(typeof usage.kernelCpuSeconds, 'number');
   assert.strictEqual(typeof usage.cpuConsumptionPercent, 'number');
+  assert.strictEqual(typeof usage.userCpuConsumptionPercent, 'number');
+  assert.strictEqual(typeof usage.kernelCpuConsumptionPercent, 'number');
+  assert(Number.isSafeInteger(usage.rss));
   assert(Number.isSafeInteger(usage.maxRss));
   assert(typeof usage.pageFaults === 'object' && usage.pageFaults !== null);
   checkForUnknownFields(usage.pageFaults, ['IORequired', 'IONotRequired']);
@@ -254,11 +258,15 @@ function _validateContent(report, fields = []) {
   if (report.uvthreadResourceUsage) {
     const usage = report.uvthreadResourceUsage;
     const threadUsageFields = ['userCpuSeconds', 'kernelCpuSeconds',
-                               'cpuConsumptionPercent', 'fsActivity'];
+                               'cpuConsumptionPercent', 'fsActivity',
+                               'userCpuConsumptionPercent',
+                               'kernelCpuConsumptionPercent'];
     checkForUnknownFields(usage, threadUsageFields);
     assert.strictEqual(typeof usage.userCpuSeconds, 'number');
     assert.strictEqual(typeof usage.kernelCpuSeconds, 'number');
     assert.strictEqual(typeof usage.cpuConsumptionPercent, 'number');
+    assert.strictEqual(typeof usage.userCpuConsumptionPercent, 'number');
+    assert.strictEqual(typeof usage.kernelCpuConsumptionPercent, 'number');
     assert(typeof usage.fsActivity === 'object' && usage.fsActivity !== null);
     checkForUnknownFields(usage.fsActivity, ['reads', 'writes']);
     assert(Number.isSafeInteger(usage.fsActivity.reads));


### PR DESCRIPTION
add `userCpuConsumptionPercent`, `kernelCpuConsumptionPercent` and `rss` to diagnostics report.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
