### PR TITLE
http: Add priority to common http headers

### DIFF
--- a/src/node_http_common.h
+++ b/src/node_http_common.h
@@ -24,61 +24,62 @@ class Environment;
   V(PATH, ":path")                                                            \
   V(PROTOCOL, ":protocol")
 
-#define HTTP_REGULAR_HEADERS(V)                                               \
-  V(ACCEPT_ENCODING, "accept-encoding")                                       \
-  V(ACCEPT_LANGUAGE, "accept-language")                                       \
-  V(ACCEPT_RANGES, "accept-ranges")                                           \
-  V(ACCEPT, "accept")                                                         \
-  V(ACCESS_CONTROL_ALLOW_CREDENTIALS, "access-control-allow-credentials")     \
-  V(ACCESS_CONTROL_ALLOW_HEADERS, "access-control-allow-headers")             \
-  V(ACCESS_CONTROL_ALLOW_METHODS, "access-control-allow-methods")             \
-  V(ACCESS_CONTROL_ALLOW_ORIGIN, "access-control-allow-origin")               \
-  V(ACCESS_CONTROL_EXPOSE_HEADERS, "access-control-expose-headers")           \
-  V(ACCESS_CONTROL_REQUEST_HEADERS, "access-control-request-headers")         \
-  V(ACCESS_CONTROL_REQUEST_METHOD, "access-control-request-method")           \
-  V(AGE, "age")                                                               \
-  V(AUTHORIZATION, "authorization")                                           \
-  V(CACHE_CONTROL, "cache-control")                                           \
-  V(CONNECTION, "connection")                                                 \
-  V(CONTENT_DISPOSITION, "content-disposition")                               \
-  V(CONTENT_ENCODING, "content-encoding")                                     \
-  V(CONTENT_LENGTH, "content-length")                                         \
-  V(CONTENT_TYPE, "content-type")                                             \
-  V(COOKIE, "cookie")                                                         \
-  V(DATE, "date")                                                             \
-  V(ETAG, "etag")                                                             \
-  V(FORWARDED, "forwarded")                                                   \
-  V(HOST, "host")                                                             \
-  V(IF_MODIFIED_SINCE, "if-modified-since")                                   \
-  V(IF_NONE_MATCH, "if-none-match")                                           \
-  V(IF_RANGE, "if-range")                                                     \
-  V(LAST_MODIFIED, "last-modified")                                           \
-  V(LINK, "link")                                                             \
-  V(LOCATION, "location")                                                     \
-  V(RANGE, "range")                                                           \
-  V(REFERER, "referer")                                                       \
-  V(SERVER, "server")                                                         \
-  V(SET_COOKIE, "set-cookie")                                                 \
-  V(STRICT_TRANSPORT_SECURITY, "strict-transport-security")                   \
-  V(TRANSFER_ENCODING, "transfer-encoding")                                   \
-  V(TE, "te")                                                                 \
-  V(UPGRADE_INSECURE_REQUESTS, "upgrade-insecure-requests")                   \
-  V(UPGRADE, "upgrade")                                                       \
-  V(USER_AGENT, "user-agent")                                                 \
-  V(VARY, "vary")                                                             \
-  V(X_CONTENT_TYPE_OPTIONS, "x-content-type-options")                         \
-  V(X_FRAME_OPTIONS, "x-frame-options")                                       \
-  V(KEEP_ALIVE, "keep-alive")                                                 \
-  V(PROXY_CONNECTION, "proxy-connection")                                     \
-  V(X_XSS_PROTECTION, "x-xss-protection")                                     \
-  V(ALT_SVC, "alt-svc")                                                       \
-  V(CONTENT_SECURITY_POLICY, "content-security-policy")                       \
-  V(EARLY_DATA, "early-data")                                                 \
-  V(EXPECT_CT, "expect-ct")                                                   \
-  V(ORIGIN, "origin")                                                         \
-  V(PURPOSE, "purpose")                                                       \
-  V(TIMING_ALLOW_ORIGIN, "timing-allow-origin")                               \
-  V(X_FORWARDED_FOR, "x-forwarded-for")
+#define HTTP_REGULAR_HEADERS(V)                                                \
+  V(ACCEPT_ENCODING, "accept-encoding")                                        \
+  V(ACCEPT_LANGUAGE, "accept-language")                                        \
+  V(ACCEPT_RANGES, "accept-ranges")                                            \
+  V(ACCEPT, "accept")                                                          \
+  V(ACCESS_CONTROL_ALLOW_CREDENTIALS, "access-control-allow-credentials")      \
+  V(ACCESS_CONTROL_ALLOW_HEADERS, "access-control-allow-headers")              \
+  V(ACCESS_CONTROL_ALLOW_METHODS, "access-control-allow-methods")              \
+  V(ACCESS_CONTROL_ALLOW_ORIGIN, "access-control-allow-origin")                \
+  V(ACCESS_CONTROL_EXPOSE_HEADERS, "access-control-expose-headers")            \
+  V(ACCESS_CONTROL_REQUEST_HEADERS, "access-control-request-headers")          \
+  V(ACCESS_CONTROL_REQUEST_METHOD, "access-control-request-method")            \
+  V(AGE, "age")                                                                \
+  V(AUTHORIZATION, "authorization")                                            \
+  V(CACHE_CONTROL, "cache-control")                                            \
+  V(CONNECTION, "connection")                                                  \
+  V(CONTENT_DISPOSITION, "content-disposition")                                \
+  V(CONTENT_ENCODING, "content-encoding")                                      \
+  V(CONTENT_LENGTH, "content-length")                                          \
+  V(CONTENT_TYPE, "content-type")                                              \
+  V(COOKIE, "cookie")                                                          \
+  V(DATE, "date")                                                              \
+  V(ETAG, "etag")                                                              \
+  V(FORWARDED, "forwarded")                                                    \
+  V(HOST, "host")                                                              \
+  V(IF_MODIFIED_SINCE, "if-modified-since")                                    \
+  V(IF_NONE_MATCH, "if-none-match")                                            \
+  V(IF_RANGE, "if-range")                                                      \
+  V(LAST_MODIFIED, "last-modified")                                            \
+  V(LINK, "link")                                                              \
+  V(LOCATION, "location")                                                      \
+  V(RANGE, "range")                                                            \
+  V(REFERER, "referer")                                                        \
+  V(SERVER, "server")                                                          \
+  V(SET_COOKIE, "set-cookie")                                                  \
+  V(STRICT_TRANSPORT_SECURITY, "strict-transport-security")                    \
+  V(TRANSFER_ENCODING, "transfer-encoding")                                    \
+  V(TE, "te")                                                                  \
+  V(UPGRADE_INSECURE_REQUESTS, "upgrade-insecure-requests")                    \
+  V(UPGRADE, "upgrade")                                                        \
+  V(USER_AGENT, "user-agent")                                                  \
+  V(VARY, "vary")                                                              \
+  V(X_CONTENT_TYPE_OPTIONS, "x-content-type-options")                          \
+  V(X_FRAME_OPTIONS, "x-frame-options")                                        \
+  V(KEEP_ALIVE, "keep-alive")                                                  \
+  V(PROXY_CONNECTION, "proxy-connection")                                      \
+  V(X_XSS_PROTECTION, "x-xss-protection")                                      \
+  V(ALT_SVC, "alt-svc")                                                        \
+  V(CONTENT_SECURITY_POLICY, "content-security-policy")                        \
+  V(EARLY_DATA, "early-data")                                                  \
+  V(EXPECT_CT, "expect-ct")                                                    \
+  V(ORIGIN, "origin")                                                          \
+  V(PURPOSE, "purpose")                                                        \
+  V(TIMING_ALLOW_ORIGIN, "timing-allow-origin")                                \
+  V(X_FORWARDED_FOR, "x-forwarded-for")                                        \
+  V(PRIORITY, "priority")
 
 #define HTTP_ADDITIONAL_HEADERS(V)                                            \
   V(ACCEPT_CHARSET, "accept-charset")                                         \

--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -180,6 +180,7 @@ const expectedHeaderNames = {
   HTTP2_HEADER_PURPOSE: 'purpose',
   HTTP2_HEADER_TIMING_ALLOW_ORIGIN: 'timing-allow-origin',
   HTTP2_HEADER_X_FORWARDED_FOR: 'x-forwarded-for',
+  HTTP2_HEADER_PRIORITY: 'priority',
 };
 
 const expectedNGConstants = {


### PR DESCRIPTION
The standard `Priority` header is defined in RFC 9218.

This is added as part of the precusor to quic/http3 work.

Signed-off-by: James M Snell <jasnell@gmail.com>

Extracted from the quic PR here: https://github.com/nodejs/node/pull/44325

/cc @nodejs/http @nodejs/http2
