### PR TITLE
test: Remove mention of `--experimental-async-stack-tagging-api` flag

### DIFF
--- a/test/parallel/test-snapshot-console.js
+++ b/test/parallel/test-snapshot-console.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// TODO(joyeecheung): remove the flag when it is turned on by default in V8.
-// Flags: --experimental-async-stack-tagging-api
 // This tests the console works in the deserialized snapshot.
 
 const common = require('../common');
@@ -20,7 +18,6 @@ const entry = fixtures.path('snapshot', 'console.js');
 
 {
   const child = spawnSync(process.execPath, [
-    '--experimental-async-stack-tagging-api',
     '--snapshot-blob',
     blobPath,
     '--build-snapshot',
@@ -41,7 +38,6 @@ const entry = fixtures.path('snapshot', 'console.js');
 
 {
   const child = spawnSync(process.execPath, [
-    '--experimental-async-stack-tagging-api',
     '--snapshot-blob',
     blobPath,
   ], {


### PR DESCRIPTION
The flag was enabled by default with V10.6 (https://crrev.com/c/3809692) and we plan to remove the flag now in time for V8 10.9.