### PR TITLE
doc: mention v18.x openssl maintaining guide

### DIFF
--- a/doc/contributing/maintaining-openssl.md
+++ b/doc/contributing/maintaining-openssl.md
@@ -7,6 +7,8 @@ currently need to generate four PRs as follows:
 
 * a PR for `main` which is generated following the instructions
   below for OpenSSL 3.x.x.
+* a PR for 18.x following the instructions in the v18.x-staging version
+  of this guide.
 * a PR for 16.x following the instructions in the v16.x-staging version
   of this guide.
 * a PR for 14.x following the instructions in the v14.x-staging version


### PR DESCRIPTION
Nothing really changed. However, it's important to ensure `main` now refers to the 'Current' release, v19.x.