### PR TITLE
doc: fix v14.x link maintaining openssl guide

### DIFF
--- a/doc/contributing/maintaining-openssl.md
+++ b/doc/contributing/maintaining-openssl.md
@@ -9,7 +9,7 @@ currently need to generate four PRs as follows:
   below for OpenSSL 3.x.x.
 * a PR for 16.x following the instructions in the v16.x-staging version
   of this guide.
-* a PR for 14.x following the instructions in the v14.x-staging version
+* a PR for 14.x following the instructions in the [v14.x-staging version][]
   of this guide.
 
 ## Use of the quictls/openssl fork
@@ -152,3 +152,5 @@ regenerated and committed by:
 ```
 
 Finally, build Node.js and run the tests.
+
+[v14.x-staging version]: https://github.com/nodejs/node/blob/v14.x-staging/doc/guides/maintaining-openssl.md


### PR DESCRIPTION
The document indicates the file lives under `/blob/v14.x-staging/doc/contributing/maintaining-openssl.md` which is false on v14.x branch.