### PR TITLE
test: remove experimental-wasm-threads flag

### DIFF
--- a/test/parallel/test-worker-message-port-wasm-threads.js
+++ b/test/parallel/test-worker-message-port-wasm-threads.js
@@ -1,4 +1,3 @@
-// Flags: --experimental-wasm-threads
 'use strict';
 const common = require('../common');
 const assert = require('assert');


### PR DESCRIPTION
It is already true by default in V8.

Refs: https://github.com/v8/v8/commit/be9ff65a06963f9326756c056a338e1b9e07499c
