### PR TITLE
trace_events: fix getCategories

### DIFF
--- a/src/inspector/tracing_agent.cc
+++ b/src/inspector/tracing_agent.cc
@@ -173,14 +173,25 @@ DispatchResponse TracingAgent::stop() {
 DispatchResponse TracingAgent::getCategories(
     std::unique_ptr<protocol::Array<String>>* categories) {
   *categories = Array<String>::create();
-  categories->get()->addItem("node");
-  categories->get()->addItem("node.async");
-  categories->get()->addItem("node.bootstrap");
-  categories->get()->addItem("node.fs.sync");
-  categories->get()->addItem("node.perf");
-  categories->get()->addItem("node.perf.usertiming");
-  categories->get()->addItem("node.perf.timerify");
-  categories->get()->addItem("v8");
+  protocol::Array<String>* categories_list = categories->get();
+  categories_list->addItem("node");
+  categories_list->addItem("node.async_hooks");
+  categories_list->addItem("node.bootstrap");
+  categories_list->addItem("node.console");
+  categories_list->addItem("node.dns.native");
+  categories_list->addItem("node.net.native");
+  categories_list->addItem("node.environment");
+  categories_list->addItem("node.fs.sync");
+  categories_list->addItem("node.fs_dir.sync");
+  categories_list->addItem("node.fs.async");
+  categories_list->addItem("node.fs_dir.async");
+  categories_list->addItem("node.perf");
+  categories_list->addItem("node.perf.usertiming");
+  categories_list->addItem("node.perf.timerify");
+  categories_list->addItem("node.promises.rejections");
+  categories_list->addItem("node.vm.script");
+  categories_list->addItem("v8");
+  categories_list->addItem("node.http");
   return DispatchResponse::OK();
 }
 

--- a/test/parallel/test-inspector-tracing-domain.js
+++ b/test/parallel/test-inspector-tracing-domain.js
@@ -48,10 +48,25 @@ async function test() {
   session.on('NodeTracing.dataCollected', (n) => traceNotification = n);
   session.on('NodeTracing.tracingComplete', () => tracingComplete = true);
   const { categories } = await post('NodeTracing.getCategories');
-  compareIgnoringOrder(['node', 'node.async', 'node.bootstrap', 'node.fs.sync',
-                        'node.perf', 'node.perf.usertiming',
-                        'node.perf.timerify', 'v8'],
-                       categories);
+  compareIgnoringOrder(['node',
+                        'node.async_hooks',
+                        'node.bootstrap',
+                        'node.console',
+                        'node.dns.native',
+                        'node.net.native',
+                        'node.environment',
+                        'node.fs.sync',
+                        'node.fs_dir.sync',
+                        'node.fs.async',
+                        'node.fs_dir.async',
+                        'node.perf',
+                        'node.perf.usertiming',
+                        'node.perf.timerify',
+                        'node.promises.rejections',
+                        'node.vm.script',
+                        'v8',
+                        'node.http',
+  ], categories);
 
   const traceConfig = { includedCategories: ['v8'] };
   await post('NodeTracing.start', { traceConfig });


### PR DESCRIPTION
 fix `getCategories` of `trace_events`.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
