### PR TITLE
fs: trace more fs api

### DIFF
--- a/src/node_dir.cc
+++ b/src/node_dir.cc
@@ -135,7 +135,9 @@ void DirHandle::MemoryInfo(MemoryTracker* tracker) const {
 inline void DirHandle::GCClose() {
   if (closed_) return;
   uv_fs_t req;
+  FS_DIR_SYNC_TRACE_BEGIN(closedir);
   int ret = uv_fs_closedir(nullptr, &req, dir_, nullptr);
+  FS_DIR_SYNC_TRACE_END(closedir);
   uv_fs_req_cleanup(&req);
   closing_ = false;
   closed_ = true;


### PR DESCRIPTION
trace more fs api.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
