### PR TITLE
http2: improve session close/destroy procedures

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1108,19 +1108,25 @@ function finishSessionClose(session, error) {
   cleanupSession(session);
 
   if (socket && !socket.destroyed) {
+    socket.on('close', () => {
+      emitClose(session, error);
+    });
+    if (session.closed) {
+      // If we're gracefully closing the socket, call resume() so we can detect
+      // the peer closing in case binding.Http2Session is already gone.
+      socket.resume();
+    }
+
     // Always wait for writable side to finish.
     socket.end((err) => {
       debugSessionObj(session, 'finishSessionClose socket end', err, error);
-      // Due to the way the underlying stream is handled in Http2Session we
-      // won't get graceful Readable end from the other side even if it was sent
-      // as the stream is already considered closed and will neither be read
-      // from nor keep the event loop alive.
-      // Therefore destroy the socket immediately.
-      // Fixing this would require some heavy juggling of ReadStart/ReadStop
-      // mostly on Windows as on Unix it will be fine with just ReadStart
-      // after this 'ondone' callback.
-      socket.destroy(error);
-      emitClose(session, error);
+      // If session.destroy() was called, destroy the underlying socket. Delay
+      // it a bit to try to avoid ECONNRESET on Windows.
+      if (!session.closed) {
+        setImmediate(() => {
+          socket.destroy(error);
+        });
+      }
     });
   } else {
     process.nextTick(emitClose, session, error);

--- a/test/parallel/test-http2-server-close-callback.js
+++ b/test/parallel/test-http2-server-close-callback.js
@@ -13,7 +13,7 @@ let session;
 
 const countdown = new Countdown(2, () => {
   server.close(common.mustSucceed());
-  session.destroy();
+  session.close();
 });
 
 server.listen(0, common.mustCall(() => {

--- a/test/parallel/test-http2-server-sessionerror.js
+++ b/test/parallel/test-http2-server-sessionerror.js
@@ -44,17 +44,21 @@ server.on('sessionError', common.mustCall((err, session) => {
 server.listen(0, common.mustCall(() => {
   const url = `http://localhost:${server.address().port}`;
   http2.connect(url)
-    .on('error', common.expectsError({
-      code: 'ERR_HTTP2_SESSION_ERROR',
-      message: 'Session closed with error code 2',
+    .on('error', common.mustCall((err) => {
+      if (err.code !== 'ECONNRESET') {
+        assert.strictEqual(err.code, 'ERR_HTTP2_SESSION_ERROR');
+        assert.strictEqual(err.message, 'Session closed with error code 2');
+      }
     }))
     .on('close', () => {
       server.removeAllListeners('error');
       http2.connect(url)
-        .on('error', common.expectsError({
-          code: 'ERR_HTTP2_SESSION_ERROR',
-          message: 'Session closed with error code 2',
-        }))
+      .on('error', common.mustCall((err) => {
+        if (err.code !== 'ECONNRESET') {
+          assert.strictEqual(err.code, 'ERR_HTTP2_SESSION_ERROR');
+          assert.strictEqual(err.message, 'Session closed with error code 2');
+        }
+      }))
         .on('close', () => server.close());
     });
 }));

--- a/test/parallel/test-http2-too-many-settings.js
+++ b/test/parallel/test-http2-too-many-settings.js
@@ -29,9 +29,11 @@ function doTest(session) {
 
   server.listen(0, common.mustCall(() => {
     const client = h2.connect(`http://localhost:${server.address().port}`);
-    client.on('error', common.expectsError({
-      code: 'ERR_HTTP2_SESSION_ERROR',
-      message: 'Session closed with error code 2',
+    client.on('error', common.mustCall((err) => {
+      if (err.code !== 'ECONNRESET') {
+        assert.strictEqual(err.code, 'ERR_HTTP2_SESSION_ERROR');
+        assert.strictEqual(err.message, 'Session closed with error code 2');
+      }
     }));
     client.on('close', common.mustCall(() => server.close()));
   }));


### PR DESCRIPTION
Don't destroy the socket when closing the session but let it end gracefully.
Also, when destroying the session, on Windows, we would get ECONNRESET errors, make sure we take those into account in our tests.
This tries to fix some of the test errors uncovered when upgrading libuv in https://github.com/nodejs/node/pull/42340

/cc @nodejs/http2 