### PR TITLE
url: remove \t \n \r in url.parse() similar to WHATWG

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -175,9 +175,6 @@ const forbiddenHostCharsIpv6 = /[\0\t\n\r #%/<>?@\\^|]/;
 Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
   validateString(url, 'url');
 
-  // WHATWG URL removes tabs, newlines, and carriage returns. Let's do that too.
-  url = url.replace(/[\t\r\n]/g, '');
-
   // Copy chrome, IE, opera backslash-handling behavior.
   // Back slashes before the query string get converted to forward slashes
   // See: https://code.google.com/p/chromium/issues/detail?id=25916
@@ -322,6 +319,10 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
         case CHAR_TAB:
         case CHAR_LINE_FEED:
         case CHAR_CARRIAGE_RETURN:
+          // WHATWG URL removes tabs, newlines, and carriage returns. Let's do that too.
+          rest = rest.slice(0, i) + rest.slice(i + 1);
+          i -= 1;
+          break;
         case CHAR_SPACE:
         case CHAR_DOUBLE_QUOTE:
         case CHAR_PERCENT:

--- a/lib/url.js
+++ b/lib/url.js
@@ -175,6 +175,9 @@ const forbiddenHostCharsIpv6 = /[\0\t\n\r #%/<>?@\\^|]/;
 Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
   validateString(url, 'url');
 
+  // WHATWG URL removes tabs, newlines, and carriage returns. Let's do that too.
+  url = url.replace(/[\t\r\n]/g, '');
+
   // Copy chrome, IE, opera backslash-handling behavior.
   // Back slashes before the query string get converted to forward slashes
   // See: https://code.google.com/p/chromium/issues/detail?id=25916

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -843,26 +843,26 @@ const parseTests = {
     port: null,
     hostname: 'a.b',
     hash: null,
-    pathname: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E',
-    path: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
+    pathname: '/bcdref%20g%22hq%27j%3Ckl%3E',
+    path: '/bcdref%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
     search: '?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
     query: 'mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
-    href: 'http://a.b/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz'
+    href: 'http://a.b/bcdref%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz'
   },
 
   'http://a\r" \t\n<\'b:b@c\r\nd/e?f': {
     protocol: 'http:',
     slashes: true,
-    auth: 'a\r" \t\n<\'b:b',
-    host: 'c',
+    auth: 'a" <\'b:b',
+    host: 'cd',
     port: null,
-    hostname: 'c',
+    hostname: 'cd',
     hash: null,
     search: '?f',
     query: 'f',
-    pathname: '%0D%0Ad/e',
-    path: '%0D%0Ad/e?f',
-    href: 'http://a%0D%22%20%09%0A%3C\'b:b@c/%0D%0Ad/e?f'
+    pathname: '/e',
+    path: '/e?f',
+    href: 'http://a%22%20%3C\'b:b@cd/e?f'
   },
 
   'https://*': {
@@ -1007,7 +1007,7 @@ for (const u in parseTests) {
   assert.deepStrictEqual(
     actual,
     expected,
-    `expected ${inspect(expected)}, got ${inspect(actual)}`
+    `parsing ${u} and expected ${inspect(expected)} but got ${inspect(actual)}`
   );
   assert.deepStrictEqual(
     spaced,

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -843,11 +843,11 @@ const parseTests = {
     port: null,
     hostname: 'a.b',
     hash: null,
-    pathname: '/bcdref%20g%22hq%27j%3Ckl%3E',
-    path: '/bcdref%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
+    pathname: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E',
+    path: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
     search: '?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
     query: 'mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
-    href: 'http://a.b/bcdref%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz'
+    href: 'http://a.b/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz'
   },
 
   'http://a\r" \t\n<\'b:b@c\r\nd/e?f': {


### PR DESCRIPTION
WHATWG URL removes tab, new line, and carraige return characters before processing URL strings. To narrow the differences between WHATWG URL and url.parse(), and thus reduce opportunities for host spoofing etc. due to differences between the two APIs, let's do the same with url.parse().

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
