### PR TITLE
http2: fix crash on Http2Stream::diagnostic_name()

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2060,9 +2060,12 @@ void Http2Stream::MemoryInfo(MemoryTracker* tracker) const {
 }
 
 std::string Http2Stream::diagnostic_name() const {
+  const Http2Session* sess = session();
+  const std::string sname =
+      sess ? sess->diagnostic_name() : "session already destroyed";
   return "HttpStream " + std::to_string(id()) + " (" +
-      std::to_string(static_cast<int64_t>(get_async_id())) + ") [" +
-      session()->diagnostic_name() + "]";
+         std::to_string(static_cast<int64_t>(get_async_id())) + ") [" + sname +
+         "]";
 }
 
 // Notify the Http2Stream that a new block of HEADERS is being processed.


### PR DESCRIPTION
It can happen that the Http2Stream::session_ has already been deleted when the Http2Stream destructor is called, causing `diagnostic_name()` to crash. Observed when running some http2 tests on Windows with the debug logs activated.