### PR TITLE
src: simplify exit code accesses

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -81,11 +81,9 @@ const {
 } = require('internal/validators');
 const {
   exiting_aliased_Uint32Array,
+  exit_info_private_symbol,
   getHiddenValue,
 } = internalBinding('util');
-const {
-  exit_code_symbol: kExitCode,
-} = internalBinding('symbols');
 
 setupProcessObject();
 
@@ -111,6 +109,11 @@ process.domain = null;
 process._exiting = false;
 
 {
+  // Must match `Environment::ExitInfo::Fields` in `src/env.h`.
+  const kExitCode = 0;
+  const kHasExitCode = 1;
+  const fields = getHiddenValue(process, exit_info_private_symbol);
+
   let exitCode;
 
   ObjectDefineProperty(process, 'exitCode', {
@@ -126,10 +129,10 @@ process._exiting = false;
           value = code;
         }
         validateInteger(value, 'code');
-        process[kExitCode] = value;
+        fields[kExitCode] = value;
+        fields[kHasExitCode] = 1;
       } else {
-        // unset exit code
-        process[kExitCode] = code;
+        fields[kHasExitCode] = 0;
       }
       exitCode = code;
     },

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -80,7 +80,6 @@ const {
   validateInteger,
 } = require('internal/validators');
 const {
-  exiting_aliased_Uint32Array,
   exit_info_private_symbol,
   getHiddenValue,
 } = internalBinding('util');
@@ -91,31 +90,28 @@ setupGlobalProxy();
 setupBuffer();
 
 process.domain = null;
+
+// process._exiting and process.exitCode
 {
-  const exitingAliasedUint32Array =
-    getHiddenValue(process, exiting_aliased_Uint32Array);
+  // Must match `Environment::ExitInfoFields` in `src/env.h`.
+  const kExiting = 0;
+  const kExitCode = 1;
+  const kHasExitCode = 2;
+  const fields = getHiddenValue(process, exit_info_private_symbol);
+
   ObjectDefineProperty(process, '_exiting', {
     __proto__: null,
     get() {
-      return exitingAliasedUint32Array[0] === 1;
+      return fields[kExiting] === 1;
     },
     set(value) {
-      exitingAliasedUint32Array[0] = value ? 1 : 0;
+      fields[kExiting] = value ? 1 : 0;
     },
     enumerable: true,
     configurable: true,
   });
-}
-process._exiting = false;
-
-{
-  // Must match `Environment::ExitInfo::Fields` in `src/env.h`.
-  const kExitCode = 0;
-  const kHasExitCode = 1;
-  const fields = getHiddenValue(process, exit_info_private_symbol);
 
   let exitCode;
-
   ObjectDefineProperty(process, 'exitCode', {
     __proto__: null,
     get() {
@@ -140,6 +136,7 @@ process._exiting = false;
     configurable: false,
   });
 }
+process._exiting = false;
 
 // process.config is serialized config.gypi
 const nativeModule = internalBinding('builtins');

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -82,6 +82,9 @@ const {
 const {
   exit_info_private_symbol,
   getHiddenValue,
+  kExitCode,
+  kExiting,
+  kHasExitCode,
 } = internalBinding('util');
 
 setupProcessObject();
@@ -93,10 +96,6 @@ process.domain = null;
 
 // process._exiting and process.exitCode
 {
-  // Must match `Environment::ExitInfoFields` in `src/env.h`.
-  const kExiting = 0;
-  const kExitCode = 1;
-  const kHasExitCode = 2;
   const fields = getHiddenValue(process, exit_info_private_symbol);
 
   ObjectDefineProperty(process, '_exiting', {

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -83,6 +83,9 @@ const {
   exiting_aliased_Uint32Array,
   getHiddenValue,
 } = internalBinding('util');
+const {
+  exit_code_symbol: kExitCode,
+} = internalBinding('symbols');
 
 setupProcessObject();
 
@@ -123,6 +126,10 @@ process._exiting = false;
           value = code;
         }
         validateInteger(value, 'code');
+        process[kExitCode] = value;
+      } else {
+        // unset exit code
+        process[kExitCode] = code;
       }
       exitCode = code;
     },

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -39,7 +39,7 @@ Maybe<bool> EmitProcessBeforeExit(Environment* env) {
   HandleScope handle_scope(isolate);
   Context::Scope context_scope(env->context());
 
-  Local<Integer> exit_code = v8::Integer::New(
+  Local<Integer> exit_code = Integer::New(
       isolate,
       env->maybe_exit_code(static_cast<int32_t>(ExitCode::kNoFailure)));
 

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -39,6 +39,10 @@ Maybe<bool> EmitProcessBeforeExit(Environment* env) {
   HandleScope handle_scope(isolate);
   Context::Scope context_scope(env->context());
 
+  if (isolate->IsExecutionTerminating()) {
+    return Nothing<bool>();
+  }
+
   Local<Integer> exit_code = Integer::New(
       isolate, static_cast<int32_t>(env->exit_code(ExitCode::kNoFailure)));
 
@@ -61,6 +65,10 @@ Maybe<ExitCode> EmitProcessExitInternal(Environment* env) {
   Context::Scope context_scope(env->context());
 
   env->set_exiting(true);
+
+  if (isolate->IsExecutionTerminating()) {
+    return Nothing<ExitCode>();
+  }
 
   Local<Integer> exit_code = Integer::New(
       isolate, static_cast<int32_t>(env->exit_code(ExitCode::kNoFailure)));

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -40,8 +40,7 @@ Maybe<bool> EmitProcessBeforeExit(Environment* env) {
   Context::Scope context_scope(env->context());
 
   Local<Integer> exit_code = Integer::New(
-      isolate,
-      env->maybe_exit_code(static_cast<int32_t>(ExitCode::kNoFailure)));
+      isolate, static_cast<int32_t>(env->exit_code(ExitCode::kNoFailure)));
 
   return ProcessEmit(env, "beforeExit", exit_code).IsEmpty() ?
       Nothing<bool>() : Just(true);
@@ -63,15 +62,14 @@ Maybe<ExitCode> EmitProcessExitInternal(Environment* env) {
 
   env->set_exiting(true);
 
-  const int no_failure = static_cast<int32_t>(ExitCode::kNoFailure);
+  Local<Integer> exit_code = Integer::New(
+      isolate, static_cast<int32_t>(env->exit_code(ExitCode::kNoFailure)));
 
-  if (ProcessEmit(
-          env, "exit", Integer::New(isolate, env->maybe_exit_code(no_failure)))
-          .IsEmpty()) {
+  if (ProcessEmit(env, "exit", exit_code).IsEmpty()) {
     return Nothing<ExitCode>();
   }
   // Reload exit code, it may be changed by `emit('exit')`
-  return Just(static_cast<ExitCode>(env->maybe_exit_code(no_failure)));
+  return Just(env->exit_code(ExitCode::kNoFailure));
 }
 
 Maybe<int> EmitProcessExit(Environment* env) {

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -39,7 +39,7 @@ Maybe<bool> EmitProcessBeforeExit(Environment* env) {
   HandleScope handle_scope(isolate);
   Context::Scope context_scope(env->context());
 
-  if (isolate->IsExecutionTerminating()) {
+  if (!env->can_call_into_js()) {
     return Nothing<bool>();
   }
 
@@ -66,7 +66,7 @@ Maybe<ExitCode> EmitProcessExitInternal(Environment* env) {
 
   env->set_exiting(true);
 
-  if (isolate->IsExecutionTerminating()) {
+  if (!env->can_call_into_js()) {
     return Nothing<ExitCode>();
   }
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -171,6 +171,18 @@ inline bool TickInfo::has_rejection_to_warn() const {
   return fields_[kHasRejectionToWarn] == 1;
 }
 
+inline const AliasedInt32Array& ExitInfo::fields() {
+  return fields_;
+}
+
+inline bool ExitInfo::has_exit_code() const {
+  return fields_[kHasExitCode] == 1;
+}
+
+inline int32_t ExitInfo::exit_code() const {
+  return fields_[kExitCode];
+}
+
 inline Environment* Environment::GetCurrent(v8::Isolate* isolate) {
   if (UNLIKELY(!isolate->InContext())) return nullptr;
   v8::HandleScope handle_scope(isolate);
@@ -327,6 +339,14 @@ inline TickInfo* Environment::tick_info() {
   return &tick_info_;
 }
 
+inline ExitInfo* Environment::exit_info() {
+  return &exit_info_;
+}
+
+inline int32_t Environment::maybe_exit_code(const int32_t default_code) const {
+  return exit_info_.has_exit_code() ? exit_info_.exit_code() : default_code;
+}
+
 inline uint64_t Environment::timer_base() const {
   return timer_base_;
 }
@@ -369,14 +389,6 @@ inline void Environment::set_exiting(bool value) {
 
 inline AliasedUint32Array& Environment::exiting() {
   return exiting_;
-}
-
-inline void Environment::set_exit_code(const std::optional<int32_t> value) {
-  exit_code_ = value;
-}
-
-inline const std::optional<int32_t>& Environment::exit_code() const {
-  return exit_code_;
 }
 
 inline void Environment::set_abort_on_uncaught_exception(bool value) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -371,6 +371,14 @@ inline AliasedUint32Array& Environment::exiting() {
   return exiting_;
 }
 
+inline void Environment::set_exit_code(const std::optional<int32_t> value) {
+  exit_code_ = value;
+}
+
+inline const std::optional<int32_t>& Environment::exit_code() const {
+  return exit_code_;
+}
+
 inline void Environment::set_abort_on_uncaught_exception(bool value) {
   options_->abort_on_uncaught_exception = value;
 }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -171,18 +171,6 @@ inline bool TickInfo::has_rejection_to_warn() const {
   return fields_[kHasRejectionToWarn] == 1;
 }
 
-inline const AliasedInt32Array& ExitInfo::fields() {
-  return fields_;
-}
-
-inline bool ExitInfo::has_exit_code() const {
-  return fields_[kHasExitCode] == 1;
-}
-
-inline int32_t ExitInfo::exit_code() const {
-  return fields_[kExitCode];
-}
-
 inline Environment* Environment::GetCurrent(v8::Isolate* isolate) {
   if (UNLIKELY(!isolate->InContext())) return nullptr;
   v8::HandleScope handle_scope(isolate);
@@ -339,14 +327,6 @@ inline TickInfo* Environment::tick_info() {
   return &tick_info_;
 }
 
-inline ExitInfo* Environment::exit_info() {
-  return &exit_info_;
-}
-
-inline int32_t Environment::maybe_exit_code(const int32_t default_code) const {
-  return exit_info_.has_exit_code() ? exit_info_.exit_code() : default_code;
-}
-
 inline uint64_t Environment::timer_base() const {
   return timer_base_;
 }
@@ -384,11 +364,15 @@ inline bool Environment::force_context_aware() const {
 }
 
 inline void Environment::set_exiting(bool value) {
-  exiting_[0] = value ? 1 : 0;
+  exit_info_[kExiting] = value ? 1 : 0;
 }
 
-inline AliasedUint32Array& Environment::exiting() {
-  return exiting_;
+inline int32_t Environment::maybe_exit_code(const int32_t default_code) const {
+  return exit_info_[kHasExitCode] == 0 ? default_code : exit_info_[kExitCode];
+}
+
+inline AliasedInt32Array& Environment::exit_info() {
+  return exit_info_;
 }
 
 inline void Environment::set_abort_on_uncaught_exception(bool value) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -367,8 +367,10 @@ inline void Environment::set_exiting(bool value) {
   exit_info_[kExiting] = value ? 1 : 0;
 }
 
-inline int32_t Environment::maybe_exit_code(const int32_t default_code) const {
-  return exit_info_[kHasExitCode] == 0 ? default_code : exit_info_[kExitCode];
+inline ExitCode Environment::exit_code(const ExitCode default_code) const {
+  return exit_info_[kHasExitCode] == 0
+             ? default_code
+             : static_cast<ExitCode>(exit_info_[kExitCode]);
 }
 
 inline AliasedInt32Array& Environment::exit_info() {

--- a/src/env.cc
+++ b/src/env.cc
@@ -640,12 +640,11 @@ Environment::Environment(IsolateData* isolate_data,
       async_hooks_(isolate, MAYBE_FIELD_PTR(env_info, async_hooks)),
       immediate_info_(isolate, MAYBE_FIELD_PTR(env_info, immediate_info)),
       tick_info_(isolate, MAYBE_FIELD_PTR(env_info, tick_info)),
-      exit_info_(isolate, MAYBE_FIELD_PTR(env_info, exit_info)),
       timer_base_(uv_now(isolate_data->event_loop())),
       exec_argv_(exec_args),
       argv_(args),
       exec_path_(GetExecPath(args)),
-      exiting_(isolate_, 1, MAYBE_FIELD_PTR(env_info, exiting)),
+      exit_info_(isolate_, 3, MAYBE_FIELD_PTR(env_info, exit_info)),
       should_abort_on_uncaught_toggle_(
           isolate_,
           1,
@@ -1508,29 +1507,6 @@ void AsyncHooks::FailWithCorruptedAsyncStack(double expected_async_id) {
   ABORT_NO_BACKTRACE();
 }
 
-ExitInfo::SerializeInfo ExitInfo::Serialize(Local<Context> context,
-                                            SnapshotCreator* creator) {
-  return {fields_.Serialize(context, creator)};
-}
-
-void ExitInfo::Deserialize(Local<Context> context) {
-  fields_.Deserialize(context);
-}
-
-std::ostream& operator<<(std::ostream& output,
-                         const ExitInfo::SerializeInfo& i) {
-  output << "{ " << i.fields << " }";
-  return output;
-}
-
-void ExitInfo::MemoryInfo(MemoryTracker* tracker) const {
-  tracker->TrackField("fields", fields_);
-}
-
-ExitInfo::ExitInfo(Isolate* isolate, const SerializeInfo* info)
-    : fields_(
-          isolate, kFieldsCount, info == nullptr ? nullptr : &(info->fields)) {}
-
 void Environment::Exit(ExitCode exit_code) {
   if (options()->trace_exit) {
     HandleScope handle_scope(isolate());
@@ -1619,9 +1595,8 @@ EnvSerializeInfo Environment::Serialize(SnapshotCreator* creator) {
   info.async_hooks = async_hooks_.Serialize(ctx, creator);
   info.immediate_info = immediate_info_.Serialize(ctx, creator);
   info.tick_info = tick_info_.Serialize(ctx, creator);
-  info.exit_info = exit_info_.Serialize(ctx, creator);
   info.performance_state = performance_state_->Serialize(ctx, creator);
-  info.exiting = exiting_.Serialize(ctx, creator);
+  info.exit_info = exit_info_.Serialize(ctx, creator);
   info.stream_base_state = stream_base_state_.Serialize(ctx, creator);
   info.should_abort_on_uncaught_toggle =
       should_abort_on_uncaught_toggle_.Serialize(ctx, creator);
@@ -1662,9 +1637,8 @@ void Environment::DeserializeProperties(const EnvSerializeInfo* info) {
   async_hooks_.Deserialize(ctx);
   immediate_info_.Deserialize(ctx);
   tick_info_.Deserialize(ctx);
-  exit_info_.Deserialize(ctx);
   performance_state_->Deserialize(ctx);
-  exiting_.Deserialize(ctx);
+  exit_info_.Deserialize(ctx);
   stream_base_state_.Deserialize(ctx);
   should_abort_on_uncaught_toggle_.Deserialize(ctx);
 
@@ -1851,7 +1825,7 @@ void Environment::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("builtins_without_cache", builtins_without_cache);
   tracker->TrackField("destroy_async_id_list", destroy_async_id_list_);
   tracker->TrackField("exec_argv", exec_argv_);
-  tracker->TrackField("exiting", exiting_);
+  tracker->TrackField("exit_info", exit_info_);
   tracker->TrackField("should_abort_on_uncaught_toggle",
                       should_abort_on_uncaught_toggle_);
   tracker->TrackField("stream_base_state", stream_base_state_);
@@ -1859,7 +1833,6 @@ void Environment::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("async_hooks", async_hooks_);
   tracker->TrackField("immediate_info", immediate_info_);
   tracker->TrackField("tick_info", tick_info_);
-  tracker->TrackField("exit_info", exit_info_);
   tracker->TrackField("principal_realm", principal_realm_);
 
   // FIXME(joyeecheung): track other fields in Environment.

--- a/src/env.cc
+++ b/src/env.cc
@@ -644,7 +644,8 @@ Environment::Environment(IsolateData* isolate_data,
       exec_argv_(exec_args),
       argv_(args),
       exec_path_(GetExecPath(args)),
-      exit_info_(isolate_, 3, MAYBE_FIELD_PTR(env_info, exit_info)),
+      exit_info_(
+          isolate_, kExitInfoFieldCount, MAYBE_FIELD_PTR(env_info, exit_info)),
       should_abort_on_uncaught_toggle_(
           isolate_,
           1,

--- a/src/env.h
+++ b/src/env.h
@@ -1038,6 +1038,9 @@ class Environment : public MemoryRetainer {
 
   inline void RemoveHeapSnapshotNearHeapLimitCallback(size_t heap_limit);
 
+  // Field identifiers for exit_info_
+  enum ExitInfoField { kExiting = 0, kExitCode, kHasExitCode };
+
  private:
   inline void ThrowError(v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),
                          const char* errmsg);
@@ -1103,7 +1106,6 @@ class Environment : public MemoryRetainer {
   uint32_t script_id_counter_ = 0;
   uint32_t function_id_counter_ = 0;
 
-  enum ExitInfoFields { kExiting = 0, kExitCode, kHasExitCode };
   AliasedInt32Array exit_info_;
 
   AliasedUint32Array should_abort_on_uncaught_toggle_;

--- a/src/env.h
+++ b/src/env.h
@@ -746,7 +746,7 @@ class Environment : public MemoryRetainer {
   // a pseudo-boolean to indicate whether the exit code is undefined.
   inline AliasedInt32Array& exit_info();
   inline void set_exiting(bool value);
-  inline int32_t maybe_exit_code(const int32_t default_code) const;
+  inline ExitCode exit_code(const ExitCode default_code) const;
 
   // This stores whether the --abort-on-uncaught-exception flag was passed
   // to Node.

--- a/src/env.h
+++ b/src/env.h
@@ -459,8 +459,8 @@ class TickInfo : public MemoryRetainer {
   AliasedUint8Array fields_;
 };
 
-class TrackingTraceStateObserver
-    : public v8::TracingController::TraceStateObserver {
+class TrackingTraceStateObserver :
+    public v8::TracingController::TraceStateObserver {
  public:
   explicit TrackingTraceStateObserver(Environment* env) : env_(env) {}
 
@@ -1039,7 +1039,12 @@ class Environment : public MemoryRetainer {
   inline void RemoveHeapSnapshotNearHeapLimitCallback(size_t heap_limit);
 
   // Field identifiers for exit_info_
-  enum ExitInfoField { kExiting = 0, kExitCode, kHasExitCode };
+  enum ExitInfoField {
+    kExiting = 0,
+    kExitCode,
+    kHasExitCode,
+    kExitInfoFieldCount
+  };
 
  private:
   inline void ThrowError(v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),

--- a/src/env.h
+++ b/src/env.h
@@ -54,6 +54,7 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <set>
 #include <string>
@@ -746,6 +747,9 @@ class Environment : public MemoryRetainer {
   inline void set_exiting(bool value);
   inline AliasedUint32Array& exiting();
 
+  inline void set_exit_code(const std::optional<int32_t> value);
+  inline const std::optional<int32_t>& exit_code() const;
+
   // This stores whether the --abort-on-uncaught-exception flag was passed
   // to Node.
   inline bool abort_on_uncaught_exception() const;
@@ -1102,6 +1106,7 @@ class Environment : public MemoryRetainer {
   uint32_t function_id_counter_ = 0;
 
   AliasedUint32Array exiting_;
+  std::optional<int32_t> exit_code_;
 
   AliasedUint32Array should_abort_on_uncaught_toggle_;
   int should_not_abort_scope_counter_ = 0;

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -25,7 +25,8 @@
   V(napi_type_tag, "node:napi:type_tag")                                       \
   V(napi_wrapper, "node:napi:wrapper")                                         \
   V(untransferable_object_private_symbol, "node:untransferableObject")         \
-  V(exiting_aliased_Uint32Array, "node:exiting_aliased_Uint32Array")
+  V(exiting_aliased_Uint32Array, "node:exiting_aliased_Uint32Array")           \
+  V(exit_info_private_symbol, "node:exit_info_private_symbol")
 
 // Symbols are per-isolate primitives but Environment proxies them
 // for the sake of convenience.
@@ -41,8 +42,7 @@
   V(owner_symbol, "owner_symbol")                                              \
   V(onpskexchange_symbol, "onpskexchange")                                     \
   V(resource_symbol, "resource_symbol")                                        \
-  V(trigger_async_id_symbol, "trigger_async_id_symbol")                        \
-  V(exit_code_symbol, "exit_code_symbol")
+  V(trigger_async_id_symbol, "trigger_async_id_symbol")
 
 // Strings are per-isolate primitives but Environment proxies them
 // for the sake of convenience.  Strings should be ASCII-only.

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -25,7 +25,6 @@
   V(napi_type_tag, "node:napi:type_tag")                                       \
   V(napi_wrapper, "node:napi:wrapper")                                         \
   V(untransferable_object_private_symbol, "node:untransferableObject")         \
-  V(exiting_aliased_Uint32Array, "node:exiting_aliased_Uint32Array")           \
   V(exit_info_private_symbol, "node:exit_info_private_symbol")
 
 // Symbols are per-isolate primitives but Environment proxies them

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -41,7 +41,8 @@
   V(owner_symbol, "owner_symbol")                                              \
   V(onpskexchange_symbol, "onpskexchange")                                     \
   V(resource_symbol, "resource_symbol")                                        \
-  V(trigger_async_id_symbol, "trigger_async_id_symbol")
+  V(trigger_async_id_symbol, "trigger_async_id_symbol")                        \
+  V(exit_code_symbol, "exit_code_symbol")
 
 // Strings are per-isolate primitives but Environment proxies them
 // for the sake of convenience.  Strings should be ASCII-only.
@@ -114,7 +115,6 @@
   V(errno_string, "errno")                                                     \
   V(error_string, "error")                                                     \
   V(exchange_string, "exchange")                                               \
-  V(exit_code_string, "exitCode")                                              \
   V(expire_string, "expire")                                                   \
   V(exponent_string, "exponent")                                               \
   V(exports_string, "exports")                                                 \

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -1152,8 +1152,8 @@ void TriggerUncaughtException(Isolate* isolate,
 
   // If the global uncaught exception handler sets process.exitCode,
   // exit with that code. Otherwise, exit with `ExitCode::kGenericUserError`.
-  env->Exit(static_cast<ExitCode>(env->exit_code().value_or(
-      static_cast<int32_t>(ExitCode::kGenericUserError))));
+  env->Exit(static_cast<ExitCode>(
+      env->maybe_exit_code(static_cast<int>(ExitCode::kGenericUserError))));
 }
 
 void TriggerUncaughtException(Isolate* isolate, const v8::TryCatch& try_catch) {

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -1151,15 +1151,9 @@ void TriggerUncaughtException(Isolate* isolate,
   RunAtExit(env);
 
   // If the global uncaught exception handler sets process.exitCode,
-  // exit with that code. Otherwise, exit with 1.
-  Local<String> exit_code = env->exit_code_string();
-  Local<Value> code;
-  if (process_object->Get(env->context(), exit_code).ToLocal(&code) &&
-      code->IsInt32()) {
-    env->Exit(static_cast<ExitCode>(code.As<Int32>()->Value()));
-  } else {
-    env->Exit(ExitCode::kGenericUserError);
-  }
+  // exit with that code. Otherwise, exit with `ExitCode::kGenericUserError`.
+  env->Exit(static_cast<ExitCode>(env->exit_code().value_or(
+      static_cast<int32_t>(ExitCode::kGenericUserError))));
 }
 
 void TriggerUncaughtException(Isolate* isolate, const v8::TryCatch& try_catch) {

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -1152,8 +1152,7 @@ void TriggerUncaughtException(Isolate* isolate,
 
   // If the global uncaught exception handler sets process.exitCode,
   // exit with that code. Otherwise, exit with `ExitCode::kGenericUserError`.
-  env->Exit(static_cast<ExitCode>(
-      env->maybe_exit_code(static_cast<int>(ExitCode::kGenericUserError))));
+  env->Exit(env->exit_code(ExitCode::kGenericUserError));
 }
 
 void TriggerUncaughtException(Isolate* isolate, const v8::TryCatch& try_catch) {

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -414,6 +414,8 @@ std::ostream& operator<<(std::ostream& output,
 std::ostream& operator<<(std::ostream& output,
                          const AsyncHooks::SerializeInfo& d);
 std::ostream& operator<<(std::ostream& output, const SnapshotMetadata& d);
+std::ostream& operator<<(std::ostream& output,
+                         const ExitInfo::SerializeInfo& d);
 
 namespace performance {
 std::ostream& operator<<(std::ostream& output,

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -414,8 +414,6 @@ std::ostream& operator<<(std::ostream& output,
 std::ostream& operator<<(std::ostream& output,
                          const AsyncHooks::SerializeInfo& d);
 std::ostream& operator<<(std::ostream& output, const SnapshotMetadata& d);
-std::ostream& operator<<(std::ostream& output,
-                         const ExitInfo::SerializeInfo& d);
 
 namespace performance {
 std::ostream& operator<<(std::ostream& output,

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -92,20 +92,11 @@ MaybeLocal<Object> CreateProcessObject(Realm* realm) {
     return MaybeLocal<Object>();
   }
 
-  // process[exiting_aliased_Uint32Array]
-  if (process
-          ->SetPrivate(context,
-                       realm->env()->exiting_aliased_Uint32Array(),
-                       realm->env()->exiting().GetJSArray())
-          .IsNothing()) {
-    return {};
-  }
-
   // process[exit_info_private_symbol]
   if (process
           ->SetPrivate(context,
                        realm->env()->exit_info_private_symbol(),
-                       realm->env()->exit_info()->fields().GetJSArray())
+                       realm->env()->exit_info().GetJSArray())
           .IsNothing()) {
     return {};
   }

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -14,7 +14,6 @@
 namespace node {
 using v8::Context;
 using v8::DEFAULT;
-using v8::DontEnum;
 using v8::EscapableHandleScope;
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -74,27 +73,6 @@ static void DebugPortSetter(Local<Name> property,
   host_port->set_port(static_cast<int>(port));
 }
 
-static void ExitCodeGetter(Local<Name> property,
-                           const PropertyCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info);
-  std::optional<int32_t> maybe_exit_code = env->exit_code();
-  if (maybe_exit_code) {
-    info.GetReturnValue().Set(*maybe_exit_code);
-  }
-}
-
-static void ExitCodeSetter(Local<Name> property,
-                           Local<Value> value,
-                           const PropertyCallbackInfo<void>& info) {
-  Environment* env = Environment::GetCurrent(info);
-  if (value->IsNullOrUndefined()) {
-    return env->set_exit_code(std::nullopt);
-  }
-  env->set_exit_code(
-      value->Int32Value(env->context())
-          .FromMaybe(static_cast<int32_t>(ExitCode::kNoFailure)));
-}
-
 static void GetParentProcessId(Local<Name> property,
                                const PropertyCallbackInfo<Value>& info) {
   info.GetReturnValue().Set(uv_os_getppid());
@@ -119,6 +97,15 @@ MaybeLocal<Object> CreateProcessObject(Realm* realm) {
           ->SetPrivate(context,
                        realm->env()->exiting_aliased_Uint32Array(),
                        realm->env()->exiting().GetJSArray())
+          .IsNothing()) {
+    return {};
+  }
+
+  // process[exit_info_private_symbol]
+  if (process
+          ->SetPrivate(context,
+                       realm->env()->exit_info_private_symbol(),
+                       realm->env()->exit_info()->fields().GetJSArray())
           .IsNothing()) {
     return {};
   }
@@ -238,17 +225,6 @@ void PatchProcessObject(const FunctionCallbackInfo<Value>& args) {
                           env->owns_process_state() ? DebugPortSetter : nullptr,
                           Local<Value>())
             .FromJust());
-
-  // process[exit_code_symbol]
-  CHECK(process
-            ->SetAccessor(context,
-                          env->exit_code_symbol(),
-                          ExitCodeGetter,
-                          ExitCodeSetter,
-                          Local<Value>(),
-                          DEFAULT,
-                          DontEnum)
-            .FromJust());
 }
 
 void RegisterProcessExternalReferences(ExternalReferenceRegistry* registry) {
@@ -258,8 +234,6 @@ void RegisterProcessExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(DebugPortGetter);
   registry->Register(ProcessTitleSetter);
   registry->Register(ProcessTitleGetter);
-  registry->Register(ExitCodeSetter);
-  registry->Register(ExitCodeGetter);
 }
 
 }  // namespace node

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -124,7 +124,6 @@ std::ostream& operator<<(std::ostream& output, const EnvSerializeInfo& i) {
          << i.performance_state << ",\n"
          << "// -- performance_state ends --\n"
          << i.exit_info << ",  // exit_info\n"
-         << i.exiting << ",  // exiting\n"
          << i.stream_base_state << ",  // stream_base_state\n"
          << i.should_abort_on_uncaught_toggle
          << ",  // should_abort_on_uncaught_toggle\n"
@@ -667,36 +666,6 @@ size_t FileWriter::Write(
   return written_total;
 }
 
-// Layout of ExitInfo::SerializeInfo
-// [ 4/8 bytes ]  snapshot index of fields
-template <>
-ExitInfo::SerializeInfo FileReader::Read() {
-  Debug("Read<ExitInfo::SerializeInfo>()\n");
-
-  ExitInfo::SerializeInfo result;
-  result.fields = Read<AliasedBufferIndex>();
-
-  if (is_debug) {
-    std::string str = ToStr(result);
-    Debug("Read<ExitInfo::SerializeInfo>() %s\n", str.c_str());
-  }
-
-  return result;
-}
-
-template <>
-size_t FileWriter::Write(const ExitInfo::SerializeInfo& data) {
-  if (is_debug) {
-    std::string str = ToStr(data);
-    Debug("Write<ExitInfo::SerializeInfo>() %s\n", str.c_str());
-  }
-
-  size_t written_total = Write<AliasedBufferIndex>(data.fields);
-
-  Debug("Write<ExitInfo::SerializeInfo>() wrote %d bytes\n", written_total);
-  return written_total;
-}
-
 // Layout of IsolateDataSerializeInfo
 // [ 4/8 bytes ]  length of primitive_values vector
 // [    ...    ]  |length| of primitive_values indices
@@ -767,8 +736,7 @@ EnvSerializeInfo FileReader::Read() {
   result.immediate_info = Read<ImmediateInfo::SerializeInfo>();
   result.performance_state =
       Read<performance::PerformanceState::SerializeInfo>();
-  result.exit_info = Read<ExitInfo::SerializeInfo>();
-  result.exiting = Read<AliasedBufferIndex>();
+  result.exit_info = Read<AliasedBufferIndex>();
   result.stream_base_state = Read<AliasedBufferIndex>();
   result.should_abort_on_uncaught_toggle = Read<AliasedBufferIndex>();
   result.principal_realm = Read<RealmSerializeInfo>();
@@ -789,8 +757,7 @@ size_t FileWriter::Write(const EnvSerializeInfo& data) {
   written_total += Write<ImmediateInfo::SerializeInfo>(data.immediate_info);
   written_total += Write<performance::PerformanceState::SerializeInfo>(
       data.performance_state);
-  written_total += Write<ExitInfo::SerializeInfo>(data.exit_info);
-  written_total += Write<AliasedBufferIndex>(data.exiting);
+  written_total += Write<AliasedBufferIndex>(data.exit_info);
   written_total += Write<AliasedBufferIndex>(data.stream_base_state);
   written_total +=
       Write<AliasedBufferIndex>(data.should_abort_on_uncaught_toggle);

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -123,6 +123,7 @@ std::ostream& operator<<(std::ostream& output, const EnvSerializeInfo& i) {
          << "// -- performance_state begins --\n"
          << i.performance_state << ",\n"
          << "// -- performance_state ends --\n"
+         << i.exit_info << ",  // exit_info\n"
          << i.exiting << ",  // exiting\n"
          << i.stream_base_state << ",  // stream_base_state\n"
          << i.should_abort_on_uncaught_toggle
@@ -666,6 +667,36 @@ size_t FileWriter::Write(
   return written_total;
 }
 
+// Layout of ExitInfo::SerializeInfo
+// [ 4/8 bytes ]  snapshot index of fields
+template <>
+ExitInfo::SerializeInfo FileReader::Read() {
+  Debug("Read<ExitInfo::SerializeInfo>()\n");
+
+  ExitInfo::SerializeInfo result;
+  result.fields = Read<AliasedBufferIndex>();
+
+  if (is_debug) {
+    std::string str = ToStr(result);
+    Debug("Read<ExitInfo::SerializeInfo>() %s\n", str.c_str());
+  }
+
+  return result;
+}
+
+template <>
+size_t FileWriter::Write(const ExitInfo::SerializeInfo& data) {
+  if (is_debug) {
+    std::string str = ToStr(data);
+    Debug("Write<ExitInfo::SerializeInfo>() %s\n", str.c_str());
+  }
+
+  size_t written_total = Write<AliasedBufferIndex>(data.fields);
+
+  Debug("Write<ExitInfo::SerializeInfo>() wrote %d bytes\n", written_total);
+  return written_total;
+}
+
 // Layout of IsolateDataSerializeInfo
 // [ 4/8 bytes ]  length of primitive_values vector
 // [    ...    ]  |length| of primitive_values indices
@@ -736,6 +767,7 @@ EnvSerializeInfo FileReader::Read() {
   result.immediate_info = Read<ImmediateInfo::SerializeInfo>();
   result.performance_state =
       Read<performance::PerformanceState::SerializeInfo>();
+  result.exit_info = Read<ExitInfo::SerializeInfo>();
   result.exiting = Read<AliasedBufferIndex>();
   result.stream_base_state = Read<AliasedBufferIndex>();
   result.should_abort_on_uncaught_toggle = Read<AliasedBufferIndex>();
@@ -757,6 +789,7 @@ size_t FileWriter::Write(const EnvSerializeInfo& data) {
   written_total += Write<ImmediateInfo::SerializeInfo>(data.immediate_info);
   written_total += Write<performance::PerformanceState::SerializeInfo>(
       data.performance_state);
+  written_total += Write<ExitInfo::SerializeInfo>(data.exit_info);
   written_total += Write<AliasedBufferIndex>(data.exiting);
   written_total += Write<AliasedBufferIndex>(data.stream_base_state);
   written_total +=

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -424,6 +424,17 @@ void Initialize(Local<Object> target,
   V(kRejected);
 #undef V
 
+#define V(name)                                                                \
+  target                                                                       \
+      ->Set(context,                                                           \
+            FIXED_ONE_BYTE_STRING(env->isolate(), #name),                      \
+            Integer::New(env->isolate(), Environment::ExitInfoField::name))    \
+      .FromJust()
+  V(kExiting);
+  V(kExitCode);
+  V(kHasExitCode);
+#undef V
+
   SetMethodNoSideEffect(context, target, "getHiddenValue", GetHiddenValue);
   SetMethod(context, target, "setHiddenValue", SetHiddenValue);
   SetMethodNoSideEffect(


### PR DESCRIPTION
This simplifies getting the exit code which is set through `process.exitCode` by removing 
manually reading the JS property from the native side.

Addresses this TODO:

https://github.com/nodejs/node/blob/5815e3e232ef31221f25a9b1997c1f161c5cffdc/src/api/hooks.cc#L72-L75

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
