### PR TITLE
src: remove unused `contextify_global_private_symbol`

### DIFF
--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -20,7 +20,6 @@
 #define PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)                               \
   V(arrow_message_private_symbol, "node:arrowMessage")                         \
   V(contextify_context_private_symbol, "node:contextify:context")              \
-  V(contextify_global_private_symbol, "node:contextify:global")                \
   V(decorated_private_symbol, "node:decorated")                                \
   V(napi_type_tag, "node:napi:type_tag")                                       \
   V(napi_wrapper, "node:napi:wrapper")                                         \

--- a/typings/internalBinding/util.d.ts
+++ b/typings/internalBinding/util.d.ts
@@ -8,15 +8,14 @@ declare namespace InternalUtilBinding {
 }
 
 declare function InternalBinding(binding: 'util'): {
-  // PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES, defined in src/env.h
+  // PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES, defined in src/env_properties.h
   arrow_message_private_symbol: 1;
   contextify_context_private_symbol: 2;
-  contextify_global_private_symbol: 3;
-  decorated_private_symbol: 4;
-  napi_type_tag: 5;
-  napi_wrapper: 6;
-  untransferable_object_private_symbol: 7;
-  exiting_aliased_Uint32Array: 8;
+  decorated_private_symbol: 3;
+  napi_type_tag: 4;
+  napi_wrapper: 5;
+  untransferable_object_private_symbol: 6;
+  exiting_aliased_Uint32Array: 7;
 
   kPending: 0;
   kFulfilled: 1;


### PR DESCRIPTION
`contextify_global_private_symbol` is no longer used. It was used to hold a new 
context's global object. Apparently, the approach has been changed to hold a 
ContextifyContext wrapper using `contextify_context_private_symbol`.

Refs: https://github.com/nodejs/node/pull/44796

/cc @joyeecheung

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
