### PR TITLE
test: remove a snapshot blob from test-inspect-address-in-use.js

### DIFF
--- a/test/parallel/test-inspect-address-in-use.js
+++ b/test/parallel/test-inspect-address-in-use.js
@@ -5,6 +5,7 @@ common.skipIfInspectorDisabled();
 const { spawnSync } = require('child_process');
 const { createServer } = require('http');
 const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
 const entry = fixtures.path('empty.js');
 const { Worker } = require('worker_threads');
@@ -21,10 +22,10 @@ function testOnServerListen(fn) {
   server.listen(0, '127.0.0.1');
 }
 
-function testChildProcess(getArgs, exitCode) {
+function testChildProcess(getArgs, exitCode, options) {
   testOnServerListen((server) => {
     const { port } = server.address();
-    const child = spawnSync(process.execPath, getArgs(port));
+    const child = spawnSync(process.execPath, getArgs(port), options);
     const stderr = child.stderr.toString().trim();
     const stdout = child.stdout.toString().trim();
     console.log('[STDERR]');
@@ -40,8 +41,12 @@ function testChildProcess(getArgs, exitCode) {
   });
 }
 
+tmpdir.refresh();
+
 testChildProcess(
-  (port) => [`--inspect=${port}`, '--build-snapshot', entry], 0);
+  (port) => [`--inspect=${port}`, '--build-snapshot', entry], 0,
+  { cwd: tmpdir.path });
+
 testChildProcess(
   (port) => [`--inspect=${port}`, entry], 0);
 


### PR DESCRIPTION
This removes a snapshot blob generated by `test/parallel/test-inspect-address-in-use.js`.

Fixes: https://github.com/nodejs/node/issues/45017

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
