### PR TITLE
stream: fix duplexify premature destroy

### DIFF
--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -262,8 +262,6 @@ function _duplexify(pair) {
       cb(err);
     } else if (err) {
       d.destroy(err);
-    } else if (!readable && !writable) {
-      d.destroy();
     }
   }
 

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { Duplex, Readable, Writable, pipeline } = require('stream');
+const { Duplex, Readable, Writable, pipeline, PassThrough } = require('stream');
 const { Blob } = require('buffer');
 
 {
@@ -277,4 +277,25 @@ const { Blob } = require('buffer');
   }));
 
   duplex.write('test');
+}
+
+{
+  const through = new PassThrough({ objectMode: true });
+
+  let res = '';
+  const d = Readable.from(['foo', 'bar'], { objectMode: true })
+    .pipe(Duplex.from({
+      writable: through,
+      readable: through
+    }));
+
+  d.on('data', (data) => {
+    d.pause();
+    setImmediate(() => {
+      d.resume();
+    });
+    res += data;
+  }).on('end', common.mustCall(() => {
+    assert.strictEqual(res, 'foobar');
+  }));
 }

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -297,5 +297,5 @@ const { Blob } = require('buffer');
     res += data;
   }).on('end', common.mustCall(() => {
     assert.strictEqual(res, 'foobar');
-  }));
+  })).on('close', common.mustCall());
 }


### PR DESCRIPTION
The duplexified Duplex should be autoDestroyed instead of prematurely destroyed when the readable and writable sides have finished without error.

Fixes: https://github.com/nodejs/node/issues/44925

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
