### PR TITLE
dns: fix port validation

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1569,7 +1569,7 @@ E('ERR_SOCKET_BAD_PORT', (name, port, allowZero = true) => {
   assert(typeof allowZero === 'boolean',
          "The 'allowZero' argument must be of type boolean.");
   const operator = allowZero ? '>=' : '>';
-  return `${name} should be ${operator} 0 and < 65536. Received ${port}.`;
+  return `${name} should be ${operator} 0 and < 65536. Received ${determineSpecificType(port)}.`;
 }, RangeError);
 E('ERR_SOCKET_BAD_TYPE',
   'Bad socket type specified. Valid types are: udp4, udp6', TypeError);

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -310,8 +310,6 @@ dns.lookup('', {
 const portErr = (port) => {
   const err = {
     code: 'ERR_SOCKET_BAD_PORT',
-    message:
-      `Port should be >= 0 and < 65536. Received ${port}.`,
     name: 'RangeError'
   };
 
@@ -323,10 +321,7 @@ const portErr = (port) => {
     dns.lookupService('0.0.0.0', port, common.mustNotCall());
   }, err);
 };
-portErr(null);
-portErr(undefined);
-portErr(65538);
-portErr('test');
+[null, undefined, 65538, 'test', NaN, Infinity, Symbol(), 0n, true, false, '', () => {}, {}].forEach(portErr);
 
 assert.throws(() => {
   dns.lookupService('0.0.0.0', 80, null);


### PR DESCRIPTION
Previously the error message generation would throw if the port was of type `"symbol"`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
