### PR TITLE
src: expose `LookupAndCompile` with parameters

### DIFF
--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -373,7 +373,6 @@ MaybeLocal<Function> BuiltinLoader::LookupAndCompileInternal(
 // Otherwise return a Local<Object> containing the cache.
 MaybeLocal<Function> BuiltinLoader::LookupAndCompile(
     Local<Context> context, const char* id, Environment* optional_env) {
-  Result result;
   std::vector<Local<String>> parameters;
   Isolate* isolate = context->GetIsolate();
   // Detects parameters of the scripts based on module ids.
@@ -424,8 +423,17 @@ MaybeLocal<Function> BuiltinLoader::LookupAndCompile(
     };
   }
 
-  MaybeLocal<Function> maybe = GetInstance()->LookupAndCompileInternal(
-      context, id, &parameters, &result);
+  return LookupAndCompile(context, id, &parameters, optional_env);
+}
+
+MaybeLocal<Function> BuiltinLoader::LookupAndCompile(
+    Local<Context> context,
+    const char* id,
+    std::vector<Local<String>>* parameters,
+    Environment* optional_env) {
+  Result result;
+  MaybeLocal<Function> maybe =
+      GetInstance()->LookupAndCompileInternal(context, id, parameters, &result);
   if (optional_env != nullptr) {
     RecordResult(id, result, optional_env);
   }

--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -56,6 +56,14 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
       const char* id,
       Environment* optional_env);
 
+  // A variant of LookupAndCompile where parameters are explicitly
+  // passed instead of guessed based on id pattern - used by embedders.
+  static v8::MaybeLocal<v8::Function> LookupAndCompile(
+      v8::Local<v8::Context> context,
+      const char* id,
+      std::vector<v8::Local<v8::String>>* parameters,
+      Environment* optional_env);
+
   static v8::MaybeLocal<v8::Value> CompileAndCall(
       v8::Local<v8::Context> context,
       const char* id,


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/44018.

This PR exposes a version of `LookupAndCompile` that takes parameters instead of detecting them based on module IDs. 

Electron currently maintains a [wrapper to `LookupAndCompile`](https://github.com/electron/electron/blob/ba0561e1e341a29b8c9f200cb0b51fcab1230cdb/shell/common/node_util.cc#L12-L35), which specifically requires parameters because we pass our own modules to `LookupAndCompile` in several places:
- [`shell/common/api/electron_api_asar.cc`](https://github.com/electron/electron/blob/06a00b74e817a61f20e2734d50d8eb7bc9b099f6/shell/common/api/electron_api_asar.cc#L201-L206)
- [`shell/renderer/electron_sandboxed_renderer_client.cc`](https://github.com/electron/electron/blob/7ca3f55b1070594589244a81095884dcc152af37/shell/renderer/electron_sandboxed_renderer_client.cc#L211-L218)
- [`shell/renderer/renderer_client_base.cc`](https://github.com/electron/electron/blob/16f459228b5c083be6aebe8b3d3eb7a04cb43cc2/shell/renderer/renderer_client_base.cc#L623-L630)

and therefore need to be able to able to expose the ability to set that.

I do, however, see that Node.js recently [added back](https://github.com/nodejs/node/pull/44488) a version of `CompileAndCall` which is effectively the same as our own `CompileAndCall` wrapper, so if it would be better to modify that to allow parameters I would also be happy to take that path.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
