### PR TITLE
fs: fix opts.filter issue in cpSync

### DIFF
--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -55,12 +55,20 @@ function cpSyncFn(src, dest, opts) {
       'node is not recommended';
     process.emitWarning(warning, 'TimestampPrecisionWarning');
   }
-  const { srcStat, destStat } = checkPathsSync(src, dest, opts);
+  const { srcStat, destStat, skipped } = checkPathsSync(src, dest, opts);
+  if (skipped) return;
   checkParentPathsSync(src, srcStat, dest);
-  return handleFilterAndCopy(destStat, src, dest, opts);
+  return checkParentDir(destStat, src, dest, opts);
 }
 
 function checkPathsSync(src, dest, opts) {
+  if (opts.filter) {
+    const shouldCopy = opts.filter(src, dest);
+    if (isPromise(shouldCopy)) {
+      throw new ERR_INVALID_RETURN_VALUE('boolean', 'filter', shouldCopy);
+    }
+    if (!shouldCopy) return { __proto__: null, skipped: true };
+  }
   const { srcStat, destStat } = getStatsSync(src, dest, opts);
 
   if (destStat) {
@@ -104,7 +112,7 @@ function checkPathsSync(src, dest, opts) {
       code: 'EINVAL',
     });
   }
-  return { srcStat, destStat };
+  return { __proto__: null, srcStat, destStat, skipped: false };
 }
 
 function getStatsSync(src, dest, opts) {
@@ -145,21 +153,9 @@ function checkParentPathsSync(src, srcStat, dest) {
   return checkParentPathsSync(src, srcStat, destParent);
 }
 
-function handleFilterAndCopy(destStat, src, dest, opts) {
-  if (opts.filter) {
-    const shouldCopy = opts.filter(src, dest);
-    if (isPromise(shouldCopy)) {
-      throw new ERR_INVALID_RETURN_VALUE('boolean', 'filter', shouldCopy);
-    }
-    if (!shouldCopy) return;
-  }
+function checkParentDir(destStat, src, dest, opts) {
   const destParent = dirname(dest);
   if (!existsSync(destParent)) mkdirSync(destParent, { recursive: true });
-  return getStats(destStat, src, dest, opts);
-}
-
-function startCopy(destStat, src, dest, opts) {
-  if (opts.filter && !opts.filter(src, dest)) return;
   return getStats(destStat, src, dest, opts);
 }
 
@@ -284,9 +280,8 @@ function copyDir(src, dest, opts) {
       const { name } = dirent;
       const srcItem = join(src, name);
       const destItem = join(dest, name);
-      const { destStat } = checkPathsSync(srcItem, destItem, opts);
-
-      startCopy(destStat, srcItem, destItem, opts);
+      const { destStat, skipped } = checkPathsSync(srcItem, destItem, opts);
+      if (!skipped) getStats(destStat, srcItem, destItem, opts);
     }
   } finally {
     dir.closeSync();

--- a/test/parallel/test-fs-cp.mjs
+++ b/test/parallel/test-fs-cp.mjs
@@ -746,24 +746,26 @@ if (!isWindows) {
      }));
 }
 
-// Copy async should not throw exception if child folder is filtered out.
+// Copy should not throw exception if child folder is filtered out.
 {
   const src = nextdir();
-  mkdirSync(join(src, 'test-cp-async'), mustNotMutateObjectDeep({ recursive: true }));
+  mkdirSync(join(src, 'test-cp'), mustNotMutateObjectDeep({ recursive: true }));
 
   const dest = nextdir();
   mkdirSync(dest, mustNotMutateObjectDeep({ recursive: true }));
-  writeFileSync(join(dest, 'test-cp-async'), 'test-content', mustNotMutateObjectDeep({ mode: 0o444 }));
+  writeFileSync(join(dest, 'test-cp'), 'test-content', mustNotMutateObjectDeep({ mode: 0o444 }));
 
-  cp(src, dest, {
-    filter: (path) => !path.includes('test-cp-async'),
+  const opts = {
+    filter: (path) => !path.includes('test-cp'),
     recursive: true,
-  }, mustCall((err) => {
+  };
+  cp(src, dest, opts, mustCall((err) => {
     assert.strictEqual(err, null);
   }));
+  cpSync(src, dest, opts);
 }
 
-// Copy async should not throw exception if dest is invalid but filtered out.
+// Copy should not throw exception if dest is invalid but filtered out.
 {
   // Create dest as a file.
   // Expect: cp skips the copy logic entirely and won't throw any exception in path validation process.
@@ -775,12 +777,14 @@ if (!isWindows) {
   mkdirSync(destParent, mustNotMutateObjectDeep({ recursive: true }));
   writeFileSync(dest, 'test-content', mustNotMutateObjectDeep({ mode: 0o444 }));
 
-  cp(src, dest, {
+  const opts = {
     filter: (path) => !path.includes('bar'),
     recursive: true,
-  }, mustCall((err) => {
+  };
+  cp(src, dest, opts, mustCall((err) => {
     assert.strictEqual(err, null);
   }));
+  cpSync(src, dest, opts);
 }
 
 // It throws if options is not object.


### PR DESCRIPTION
Fixes: #44720

replicate #44922 for cpSync

issues:
- copy sync API doesn't handle `opts.filter` properly.
As a result, the path validation logic still gets triggered
even though the file or folder is filtered out
- no central place to handle `opts.filter`
e.g. need to call `opts.filter(src, dest)` in several places

changes:
- use `checkPathsSync` as a central place to validate the paths
(with consideration of opts.filter) before copying
- cleanup: remove `startCopy`, change function name `handleFilterAndCopy `
to `checkParentDir ` to make it consistent with [copy async](https://github.com/nodejs/node/blob/aab9f3246eab93bc33a8b770fe00f7aa6e9b19a7/lib/internal/fs/cp/cp.js#L69)
- update tests to test for both copy sync and async
