### PR TITLE
module: require.resolve.paths returns null with node schema

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -712,8 +712,13 @@ if (isWindows) {
 }
 
 Module._resolveLookupPaths = function(request, parent) {
-  if (BuiltinModule.canBeRequiredByUsers(request) &&
-      BuiltinModule.canBeRequiredWithoutScheme(request)) {
+  if ((
+    StringPrototypeStartsWith(request, 'node:') &&
+    BuiltinModule.canBeRequiredByUsers(StringPrototypeSlice(request, 5))
+  ) || (
+    BuiltinModule.canBeRequiredByUsers(request) &&
+    BuiltinModule.canBeRequiredWithoutScheme(request)
+  )) {
     debug('looking for %j in []', request);
     return null;
   }

--- a/test/parallel/test-require-resolve.js
+++ b/test/parallel/test-require-resolve.js
@@ -63,6 +63,10 @@ require(fixtures.path('resolve-paths', 'default', 'verify-paths.js'));
     assert.strictEqual(require.resolve.paths(mod), null);
   });
 
+  builtinModules.forEach((mod) => {
+    assert.strictEqual(require.resolve.paths(`node:${mod}`), null);
+  });
+
   // node_modules.
   const resolvedPaths = require.resolve.paths('eslint');
   assert.strictEqual(Array.isArray(resolvedPaths), true);


### PR DESCRIPTION
require.resolve.paths should returns null with builtin module. when builtin module without `node:` schema, `paths` returns null. But, it don't return null when builtin module with `node:` schema.

Fixes: https://github.com/nodejs/node/issues/45001

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
