### PR TITLE
tools: update V8 gypfiles for RISC-V

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1639,7 +1639,7 @@
               }],
               ['_toolset == "host" and host_arch == "riscv64" or _toolset == "target" and target_arch=="riscv64"', {
                 'sources': [
-                  '<(V8_ROOT)/src/heap/base/asm/riscv64/push_registers_asm.cc',
+                  '<(V8_ROOT)/src/heap/base/asm/riscv/push_registers_asm.cc',
                 ],
               }],
               ['_toolset == "host" and host_arch == "loong64" or _toolset == "target" and target_arch=="loong64"', {


### PR DESCRIPTION
With the inclusion of the RISC-V 32-bit support in V8 the directory
src/heap/base/asm/riscv64 has been renamed to riscv.

Fixes https://github.com/nodejs/node/issues/45059