### PR TITLE
doc: add link to triage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,9 @@ maintaining the Node.js project.
 * [VoltrexMaster](https://github.com/VoltrexMaster) -
   **Mohammed Keyvanzadeh** <<mohammadkeyvanzade94@gmail.com>> (he/him)
 
+Triagers follow the [Triage Guide](./doc/contributing/issues.md#triaging-a-bug-report) when
+responding to new issues.
+
 ### Release keys
 
 Primary GPG keys for Node.js Releasers (some Releasers sign with subkeys):


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

> This is a bit of a meta-pull request.

I'm interested in helping out more within the Node.js project on the heels of GHC Open Source Day mentoring.

In researching the landscape a bit, I determined that the triage role (PR for that forthcoming...) would be a great place to start, but it took me a while to find the triage guidance from `README` ➡️ `GOVERNANCE` ➡️ `.doc/contributing/issues`

This PR makes a direct reference to the triage guide, emulating the pattern of the collaborator guide in the previous section.