### PR TITLE
buffer: fix validation of options in `Blob` constructor

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -61,7 +61,6 @@ const {
 } = require('internal/errors');
 
 const {
-  validateObject,
   isUint32,
   validateDictionary,
 } = require('internal/validators');

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -63,6 +63,7 @@ const {
 const {
   validateObject,
   isUint32,
+  validateDictionary,
 } = require('internal/validators');
 
 const kHandle = Symbol('kHandle');
@@ -138,17 +139,17 @@ class Blob {
    * }} [options]
    * @constructs {Blob}
    */
-  constructor(sources = [], options = kEmptyObject) {
+  constructor(sources = [], options) {
     if (sources === null ||
         typeof sources[SymbolIterator] !== 'function' ||
         typeof sources === 'string') {
       throw new ERR_INVALID_ARG_TYPE('sources', 'a sequence', sources);
     }
-    validateObject(options, 'options');
+    validateDictionary(options, 'options');
     let {
       type = '',
       endings = 'transparent',
-    } = options;
+    } = options ?? kEmptyObject;
 
     endings = `${endings}`;
     if (endings !== 'transparent' && endings !== 'native')

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -271,7 +271,7 @@ const validateObject = hideStackFrames(
 const validateDictionary = hideStackFrames(
   (value, name) => {
     if (value != null && typeof value !== 'object' && typeof value !== 'function') {
-      throw new ERR_INVALID_ARG_TYPE(name, 'Object or Function', value);
+      throw new ERR_INVALID_ARG_TYPE(name, 'a dictionary', value);
     }
   });
 

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -258,6 +258,20 @@ const validateObject = hideStackFrames(
   });
 
 /**
+ * @callback validateDictionary
+ * @param {*} value
+ * @param {string} name
+ */
+
+/** @type {validateDictionary} */
+const validateDictionary = hideStackFrames(
+  (value, name) => {
+    if (value != null && typeof value !== 'object' && typeof value !== 'function') {
+      throw new ERR_INVALID_ARG_TYPE(name, 'Object or Function', value);
+    }
+  });
+
+/**
  * @callback validateArray
  * @param {*} value
  * @param {string} name
@@ -511,6 +525,7 @@ module.exports = {
   validateBooleanArray,
   validateBoolean,
   validateBuffer,
+  validateDictionary,
   validateEncoding,
   validateFunction,
   validateInt32,

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -265,6 +265,7 @@ const validateObject = hideStackFrames(
  * @param {*} value
  * @param {string} name
  * @see https://webidl.spec.whatwg.org/#es-dictionary
+ * @see https://tc39.es/ecma262/#table-typeof-operator-results
  */
 
 /** @type {validateDictionary} */

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -258,9 +258,13 @@ const validateObject = hideStackFrames(
   });
 
 /**
- * @callback validateDictionary
+ * @callback validateDictionary - We are using the Web IDL Standard definition
+ *                                of "dictionary" here, which means any value
+ *                                whose Type is either Undefined, Null, or
+ *                                Object (which includes functions).
  * @param {*} value
  * @param {string} name
+ * @see https://webidl.spec.whatwg.org/#es-dictionary
  */
 
 /** @type {validateDictionary} */

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -287,3 +287,32 @@ assert.throws(() => new Blob({}), {
   assert.strictEqual(blob.size, 28);
   assert.strictEqual(blob.type, '');
 })().then(common.mustCall());
+
+{
+  // Testing the defaults
+  [undefined, null, Object.create(null), { type: undefined }, {
+    get type() {}, // eslint-disable-line getter-return
+  }].forEach((options) => {
+    assert.strictEqual(
+      new Blob([], options).type,
+      new Blob([]).type,
+    );
+  });
+
+  Reflect.defineProperty(Object.prototype, 'type', {
+    __proto__: null,
+    configurable: true,
+    get: common.mustCall(() => 3, 7),
+  });
+
+  [{}, [], () => {}, Number, new Number(), new String(), new Boolean()].forEach(
+    (options) => {
+      assert.strictEqual(new Blob([], options).type, '3');
+    },
+  );
+  [0, '', true, Symbol(), 0n].forEach((options) => {
+    assert.throws(() => new Blob([], options), { code: 'ERR_INVALID_ARG_TYPE' });
+  });
+
+  delete Object.prototype.type;
+}


### PR DESCRIPTION
To align more Node.js `Blob` implementations with other runtimes (I've tested the behavior on Firefox, Safari, Chromium, and Deno).

Refs: https://webidl.spec.whatwg.org/#es-dictionary

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
