### PR TITLE
perf_hooks: align `@@toStringTag` with other Web Performance implementations

### DIFF
--- a/lib/internal/perf/resource_timing.js
+++ b/lib/internal/perf/resource_timing.js
@@ -29,10 +29,6 @@ class PerformanceResourceTiming extends PerformanceEntry {
     throw new ERR_ILLEGAL_CONSTRUCTOR();
   }
 
-  get [SymbolToStringTag]() {
-    return 'PerformanceResourceTiming';
-  }
-
   get name() {
     validateInternalField(this, kRequestedUrl, 'PerformanceResourceTiming');
     return this[kRequestedUrl];
@@ -185,6 +181,11 @@ ObjectDefineProperties(PerformanceResourceTiming.prototype, {
   encodedBodySize: kEnumerableProperty,
   decodedBodySize: kEnumerableProperty,
   toJSON: kEnumerableProperty,
+  [SymbolToStringTag]: {
+    __proto__: null,
+    configurable: true,
+    value: 'PerformanceResourceTiming',
+  },
 });
 
 function createPerformanceResourceTiming(requestedUrl, initiatorType, timingInfo, cacheMode = '') {

--- a/lib/internal/perf/usertiming.js
+++ b/lib/internal/perf/usertiming.js
@@ -98,10 +98,6 @@ class PerformanceMark {
     return this[kDetail];
   }
 
-  get [SymbolToStringTag]() {
-    return 'PerformanceMark';
-  }
-
   toJSON() {
     return {
       name: this.name,
@@ -116,6 +112,11 @@ ObjectSetPrototypeOf(PerformanceMark, PerformanceEntry);
 ObjectSetPrototypeOf(PerformanceMark.prototype, PerformanceEntry.prototype);
 ObjectDefineProperties(PerformanceMark.prototype, {
   detail: kEnumerableProperty,
+  [SymbolToStringTag]: {
+    __proto__: null,
+    configurable: true,
+    value: 'PerformanceMark',
+  },
 });
 
 class PerformanceMeasure extends PerformanceEntry {
@@ -127,13 +128,14 @@ class PerformanceMeasure extends PerformanceEntry {
     validateInternalField(this, kDetail, 'PerformanceMeasure');
     return this[kDetail];
   }
-
-  get [SymbolToStringTag]() {
-    return 'PerformanceMeasure';
-  }
 }
 ObjectDefineProperties(PerformanceMeasure.prototype, {
   detail: kEnumerableProperty,
+  [SymbolToStringTag]: {
+    __proto__: null,
+    configurable: true,
+    value: 'PerformanceMeasure',
+  },
 });
 
 function createPerformanceMeasure(name, start, duration, detail) {

--- a/test/parallel/test-perf-hooks-resourcetiming.js
+++ b/test/parallel/test-perf-hooks-resourcetiming.js
@@ -17,6 +17,11 @@ assert(PerformanceResourceTiming);
 assert(performance.clearResourceTimings);
 assert(performance.markResourceTiming);
 
+assert.deepStrictEqual(
+  Object.getOwnPropertyDescriptor(PerformanceResourceTiming.prototype, Symbol.toStringTag),
+  { configurable: true, enumerable: false, value: 'PerformanceResourceTiming', writable: false },
+);
+
 function createTimingInfo({
   startTime = 0,
   redirectStartTime = 0,

--- a/test/parallel/test-perf-hooks-usertiming.js
+++ b/test/parallel/test-perf-hooks-usertiming.js
@@ -26,7 +26,7 @@ assert(performance.measure);
       configurable: true,
       enumerable: false,
       writable: false,
-      value: c.prototype.constructor.name,
+      value: c.name,
     }
   );
 });

--- a/test/parallel/test-perf-hooks-usertiming.js
+++ b/test/parallel/test-perf-hooks-usertiming.js
@@ -6,6 +6,7 @@ const {
   PerformanceObserver,
   PerformanceEntry,
   PerformanceMark,
+  PerformanceMeasure,
   performance,
   performance: {
     nodeTiming,
@@ -17,6 +18,16 @@ assert(PerformanceEntry);
 assert(PerformanceMark);
 assert(performance.mark);
 assert(performance.measure);
+
+assert.deepStrictEqual(
+  Object.getOwnPropertyDescriptor(PerformanceMark.prototype, Symbol.toStringTag),
+  { configurable: true, enumerable: false, value: 'PerformanceMark', writable: false },
+);
+
+assert.deepStrictEqual(
+  Object.getOwnPropertyDescriptor(PerformanceMeasure.prototype, Symbol.toStringTag),
+  { configurable: true, enumerable: false, value: 'PerformanceMeasure', writable: false },
+);
 
 [undefined, 'a', 'null', 1, true].forEach((i) => {
   const m = performance.mark(i);

--- a/test/parallel/test-perf-hooks-usertiming.js
+++ b/test/parallel/test-perf-hooks-usertiming.js
@@ -19,15 +19,17 @@ assert(PerformanceMark);
 assert(performance.mark);
 assert(performance.measure);
 
-assert.deepStrictEqual(
-  Object.getOwnPropertyDescriptor(PerformanceMark.prototype, Symbol.toStringTag),
-  { configurable: true, enumerable: false, value: 'PerformanceMark', writable: false },
-);
-
-assert.deepStrictEqual(
-  Object.getOwnPropertyDescriptor(PerformanceMeasure.prototype, Symbol.toStringTag),
-  { configurable: true, enumerable: false, value: 'PerformanceMeasure', writable: false },
-);
+[PerformanceMark, PerformanceMeasure].forEach((c) => {
+  assert.deepStrictEqual(
+    Object.getOwnPropertyDescriptor(c.prototype, Symbol.toStringTag),
+    {
+      configurable: true,
+      enumerable: false,
+      writable: false,
+      value: c.prototype.constructor.name,
+    }
+  );
+});
 
 [undefined, 'a', 'null', 1, true].forEach((i) => {
   const m = performance.mark(i);


### PR DESCRIPTION
This gets `Symbol.toStringTag` on Web Performance APIs to be aligned 
with the other runtime implementations. (Tested on  Chromium, Firefox, and Safari)

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
