### PR TITLE
test_runner: call {before,after}Each() on suites

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -731,13 +731,24 @@ class Suite extends Test {
       }
 
       const hookArgs = this.getRunArgs();
+
+      if (this.parent?.hooks.beforeEach.length > 0) {
+        await this.parent[kRunHook]('beforeEach', hookArgs);
+      }
+
       await this[kRunHook]('before', hookArgs);
+
       const stopPromise = stopTest(this.timeout, this.signal);
       const subtests = this.skipped || this.error ? [] : this.subtests;
       const promise = SafePromiseAll(subtests, (subtests) => subtests.start());
 
       await SafePromiseRace([promise, stopPromise]);
       await this[kRunHook]('after', hookArgs);
+
+      if (this.parent?.hooks.afterEach.length > 0) {
+        await this.parent[kRunHook]('afterEach', hookArgs);
+      }
+
       this.pass();
     } catch (err) {
       if (isTestFailureError(err)) {

--- a/test/message/test_runner_hooks.js
+++ b/test/message/test_runner_hooks.js
@@ -15,10 +15,12 @@ describe('describe hooks', () => {
       'before describe hooks',
       'beforeEach 1', '1', 'afterEach 1',
       'beforeEach 2', '2', 'afterEach 2',
+      'beforeEach nested',
       'before nested',
       'beforeEach nested 1', 'nested 1', 'afterEach nested 1',
       'beforeEach nested 2', 'nested 2', 'afterEach nested 2',
       'after nested',
+      'afterEach nested',
       'after describe hooks',
     ]);
   });

--- a/test/message/test_runner_test_name_pattern.js
+++ b/test/message/test_runner_test_name_pattern.js
@@ -34,8 +34,8 @@ test('top level test enabled', common.mustCall(async (t) => {
 
 describe('top level describe enabled', () => {
   before(common.mustCall());
-  beforeEach(common.mustCall(2));
-  afterEach(common.mustCall(2));
+  beforeEach(common.mustCall(4));
+  afterEach(common.mustCall(4));
   after(common.mustCall());
 
   it('nested it disabled', common.mustNotCall());


### PR DESCRIPTION
Prior to this commit, `beforeEach()` and `afterEach()` hooks were not called on test suites (`describe()`). This commit addresses that.

Fixes: https://github.com/nodejs/node/issues/45028

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
