### PR TITLE
Revert "deps: make V8 compilable with older glibc"

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.17',
+    'v8_embedder_string': '-node.18',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/base/platform/platform-posix.cc
+++ b/deps/v8/src/base/platform/platform-posix.cc
@@ -618,7 +618,26 @@ void OS::FreeAddressSpaceReservation(AddressSpaceReservation reservation) {
 // Need to disable CFI_ICALL due to the indirect call to memfd_create.
 DISABLE_CFI_ICALL
 PlatformSharedMemoryHandle OS::CreateSharedMemoryHandleForTesting(size_t size) {
+#if V8_OS_LINUX && !V8_OS_ANDROID
+  // Use memfd_create if available, otherwise mkstemp.
+  using memfd_create_t = int (*)(const char*, unsigned int);
+  memfd_create_t memfd_create =
+      reinterpret_cast<memfd_create_t>(dlsym(RTLD_DEFAULT, "memfd_create"));
+  int fd = -1;
+  if (memfd_create) {
+    fd = memfd_create("V8MemFDForTesting", 0);
+  }
+  if (fd == -1) {
+    char filename[] = "/tmp/v8_tmp_file_for_testing_XXXXXX";
+    fd = mkstemp(filename);
+    if (fd != -1) CHECK_EQ(0, unlink(filename));
+  }
+  if (fd == -1) return kInvalidSharedMemoryHandle;
+  CHECK_EQ(0, ftruncate(fd, size));
+  return SharedMemoryHandleFromFileDescriptor(fd);
+#else
   return kInvalidSharedMemoryHandle;
+#endif
 }
 
 // static


### PR DESCRIPTION
This reverts commit 84d455e08e4129f7d1b3c68d62cbb129458619ec.

Refs: https://github.com/nodejs/node/issues/45118
