### PR TITLE
doc, http: add Uint8Array as allowed type

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -750,6 +750,9 @@ See [`writable.cork()`][].
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: v15.0.0
+    pr-url: https://github.com/nodejs/node/pull/33155
+    description: The `data` parameter can now be a `Uint8Array`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18780
     description: This method now returns a reference to `ClientRequest`.
@@ -1205,6 +1208,10 @@ before the [`'finish'`][] event is emitted.
 
 <!-- YAML
 added: v0.1.29
+changes:
+  - version: v15.0.0
+    pr-url: https://github.com/nodejs/node/pull/33155
+    description: The `chunk` parameter can now be a `Uint8Array`.
 -->
 
 * `chunk` {string|Buffer|Uint8Array}
@@ -1740,6 +1747,9 @@ See [`writable.cork()`][].
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: v15.0.0
+    pr-url: https://github.com/nodejs/node/pull/33155
+    description: The `data` parameter can now be a `Uint8Array`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18780
     description: This method now returns a reference to `ServerResponse`.
@@ -2094,6 +2104,10 @@ before the [`'finish'`][] event is emitted.
 
 <!-- YAML
 added: v0.1.29
+changes:
+  - version: v15.0.0
+    pr-url: https://github.com/nodejs/node/pull/33155
+    description: The `chunk` parameter can now be a `Uint8Array`.
 -->
 
 * `chunk` {string|Buffer|Uint8Array}
@@ -2784,6 +2798,9 @@ and is connected, that socket will be destroyed as well.
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: v15.0.0
+    pr-url: https://github.com/nodejs/node/pull/33155
+    description: The `chunk` parameter can now be a `Uint8Array`.
   - version: v0.11.6
     description: add `callback` argument.
 -->
@@ -3044,6 +3061,9 @@ Always `false`.
 <!-- YAML
 added: v0.1.29
 changes:
+  - version: v15.0.0
+    pr-url: https://github.com/nodejs/node/pull/33155
+    description: The `chunk` parameter can now be a `Uint8Array`.
   - version: v0.11.6
     description: The `callback` argument was added.
 -->

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -755,7 +755,7 @@ changes:
     description: This method now returns a reference to `ClientRequest`.
 -->
 
-* `data` {string|Buffer}
+* `data` {string|Buffer|Uint8Array}
 * `encoding` {string}
 * `callback` {Function}
 * Returns: {this}
@@ -1207,7 +1207,7 @@ before the [`'finish'`][] event is emitted.
 added: v0.1.29
 -->
 
-* `chunk` {string|Buffer}
+* `chunk` {string|Buffer|Uint8Array}
 * `encoding` {string}
 * `callback` {Function}
 * Returns: {boolean}
@@ -1745,7 +1745,7 @@ changes:
     description: This method now returns a reference to `ServerResponse`.
 -->
 
-* `data` {string|Buffer}
+* `data` {string|Buffer|Uint8Array}
 * `encoding` {string}
 * `callback` {Function}
 * Returns: {this}
@@ -2096,7 +2096,7 @@ before the [`'finish'`][] event is emitted.
 added: v0.1.29
 -->
 
-* `chunk` {string|Buffer}
+* `chunk` {string|Buffer|Uint8Array}
 * `encoding` {string} **Default:** `'utf8'`
 * `callback` {Function}
 * Returns: {boolean}
@@ -2788,7 +2788,7 @@ changes:
     description: add `callback` argument.
 -->
 
-* `chunk` {string | Buffer}
+* `chunk` {string|Buffer|Uint8Array}
 * `encoding` {string} Optional, **Default**: `utf8`
 * `callback` {Function} Optional
 * Returns: {this}
@@ -3048,7 +3048,7 @@ changes:
     description: The `callback` argument was added.
 -->
 
-* `chunk` {string | Buffer}
+* `chunk` {string|Buffer|Uint8Array}
 * `encoding` {string} **Default**: `utf8`
 * `callback` {Function}
 * Returns {boolean}


### PR DESCRIPTION
`OutgoingMessage.write()`/`end()` and their derived classes support also `Uint8Array` besides `string` and `Buffer`.

