### PR TITLE
doc: update process.release

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2711,17 +2711,17 @@ tarball.
   only the source header files for the current release. This file is
   significantly smaller than the full source file and can be used for compiling
   Node.js native add-ons.
-* `libUrl` {string} an absolute URL pointing to a _`node.lib`_ file matching the
-  architecture and version of the current release. This file is used for
-  compiling Node.js native add-ons. _This property is only present on Windows
-  builds of Node.js and will be missing on all other platforms._
-* `lts` {string} a string label identifying the [LTS][] label for this release.
-  This property only exists for LTS releases and is `undefined` for all other
-  release types, including _Current_ releases.
-  Valid values include the LTS Release code names (including those
-  that are no longer supported).
-  * `'Dubnium'` for the 10.x LTS line beginning with 10.13.0.
-  * `'Erbium'` for the 12.x LTS line beginning with 12.13.0.
+* `libUrl` {string|undefined} an absolute URL pointing to a _`node.lib`_ file
+  matching the architecture and version of the current release. This file is
+  used for compiling Node.js native add-ons. _This property is only present on
+  Windows builds of Node.js and will be missing on all other platforms._
+* `lts` {string|undefined} a string label identifying the [LTS][] label for this
+  release. This property only exists for LTS releases and is `undefined` for all
+  other release types, including _Current_ releases. Valid values include the
+  LTS Release code names (including those that are no longer supported).
+  * `'Fermium'` for the 14.x LTS line beginning with 14.15.0.
+  * `'Gallium'` for the 16.x LTS line beginning with 16.13.0.
+  * `'Hydrogen'` for the 18.x LTS line beginning with 18.12.0.
     For other LTS Release code names, see [Node.js Changelog Archive](https://github.com/nodejs/node/blob/HEAD/doc/changelogs/CHANGELOG_ARCHIVE.md)
 
 <!-- eslint-skip -->
@@ -2729,10 +2729,10 @@ tarball.
 ```js
 {
   name: 'node',
-  lts: 'Erbium',
-  sourceUrl: 'https://nodejs.org/download/release/v12.18.1/node-v12.18.1.tar.gz',
-  headersUrl: 'https://nodejs.org/download/release/v12.18.1/node-v12.18.1-headers.tar.gz',
-  libUrl: 'https://nodejs.org/download/release/v12.18.1/win-x64/node.lib'
+  lts: 'Hydrogen',
+  sourceUrl: 'https://nodejs.org/download/release/v18.12.0/node-v18.12.0.tar.gz',
+  headersUrl: 'https://nodejs.org/download/release/v18.12.0/node-v18.12.0-headers.tar.gz',
+  libUrl: 'https://nodejs.org/download/release/v18.12.0/win-x64/node.lib'
 }
 ```
 


### PR DESCRIPTION
`process.release` doc is outdated, last touched in #35167. This PR brings in info about LTS releases 14, 16, and 18. It also updates the optional properties type.

The rest of the changes is just formatting to fit 80 characters.