### PR TITLE
lib: throws when invalid hex string in http request

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -334,6 +334,12 @@ OutgoingMessage.prototype.destroy = function destroy(error) {
 
 // This abstract either writing directly to the socket or buffering it.
 OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
+  if (typeof data === 'string' && encoding === 'hex') {
+    if (data.length % 2 !== 0) {
+      throw new ERR_INVALID_ARG_VALUE('data', data, 'is invalid hex string');
+    }
+  }
+
   // This is a shameful hack to get the headers and first body chunk onto
   // the same packet. Future versions of Node are going to take care of
   // this at a lower level and in a more general way.


### PR DESCRIPTION
Signed-off-by: Juan José Arboleda <soyjuanarbol@gmail.com>

May fix: https://github.com/nodejs/node/issues/45150

I don't know why a string that does not follow this condition is considered an invalid hex string, but It is better to throw an exception instead of crashing the whole thing (IMO).

The condition: `CHECK(str->Length() % 2 == 0 && "invalid hex string length");`