### PR TITLE
doc: add more LTS update steps to the release guide

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -1034,6 +1034,25 @@ existing labels for that release line, such as `vN.x`.
 If the release is transitioning from Active LTS to Maintenance, the
 `backport-requested-vN.x` label must be deleted.
 
+### Add new codename to nodejs-latest-linker
+
+In order to make sure a download URL
+(e.g: <https://nodejs.org/download/release/latest-codename/>) will be available
+for the new LTS release line you need to submit a PR to
+<https://github.com/nodejs/nodejs-latest-linker> and add a new entry for the
+new LTS codename in its `ltsNames` map located in the `./latest-linker.js`
+file.
+
+Make sure to reach out to the Build WG in order to validate that the new URL is
+available as part of the LTS release promotion.
+
+### Update Release repo info
+
+Add the new LTS codename to the release schedule table located in the
+`./README.md` file located at the <https://github.com/nodejs/Release>
+repository along with the addition of the new codename to the `./schedule.json`
+file in that same repo.
+
 ## Major releases
 
 The process for cutting a new Node.js major release has a number of differences


### PR DESCRIPTION
This changeset adds references to two steps required for promoting a release line to LTS:

- Adding the new codename to **nodejs-latest-linker** repo
- Adding codename info to the **Release** repo

cc @nodejs/releasers 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
