### PR TITLE
test: convert test-debugger-pid to async/await

### DIFF
--- a/test/sequential/test-debugger-pid.js
+++ b/test/sequential/test-debugger-pid.js
@@ -9,44 +9,27 @@ const startCLI = require('../common/debugger');
 const assert = require('assert');
 const { spawn } = require('child_process');
 
+const script = fixtures.path('debugger', 'alive.js');
 
-function launchTarget(...args) {
-  const childProc = spawn(process.execPath, args);
-  return Promise.resolve(childProc);
-}
+const runTest = async () => {
+  const target = spawn(process.execPath, [script]);
+  const cli = startCLI(['-p', `${target.pid}`]);
 
-{
-  const script = fixtures.path('debugger', 'alive.js');
-  let cli = null;
-  let target = null;
-
-  function cleanup(error) {
-    if (cli) {
-      cli.quit();
-      cli = null;
-    }
-    if (target) {
-      target.kill();
-      target = null;
-    }
+  try {  
+    await cli.waitForPrompt();
+    await cli.command('sb("alive.js", 3)');
+    await cli.waitFor(/break/);
+    await cli.waitForPrompt();
+    assert.match(
+      cli.output,
+      /> 3 {3}\+\+x;/,
+      'marks the 3rd line');
+  } catch (error) {
     assert.ifError(error);
+  } finally {
+    await cli.quit();
+    target.kill();
   }
-
-  return launchTarget(script)
-    .then((childProc) => {
-      target = childProc;
-      cli = startCLI(['-p', `${target.pid}`]);
-      return cli.waitForPrompt();
-    })
-    .then(() => cli.command('sb("alive.js", 3)'))
-    .then(() => cli.waitFor(/break/))
-    .then(() => cli.waitForPrompt())
-    .then(() => {
-      assert.match(
-        cli.output,
-        /> 3 {3}\+\+x;/,
-        'marks the 3rd line');
-    })
-    .then(() => cleanup())
-    .then(null, cleanup);
 }
+
+runTest()

--- a/test/sequential/test-debugger-pid.js
+++ b/test/sequential/test-debugger-pid.js
@@ -15,7 +15,7 @@ const runTest = async () => {
   const target = spawn(process.execPath, [script]);
   const cli = startCLI(['-p', `${target.pid}`]);
 
-  try {  
+  try {
     await cli.waitForPrompt();
     await cli.command('sb("alive.js", 3)');
     await cli.waitFor(/break/);
@@ -30,6 +30,6 @@ const runTest = async () => {
     await cli.quit();
     target.kill();
   }
-}
+};
 
-runTest()
+runTest();

--- a/test/sequential/test-debugger-pid.js
+++ b/test/sequential/test-debugger-pid.js
@@ -32,4 +32,4 @@ const runTest = async () => {
   }
 };
 
-runTest();
+runTest().then(common.mustCall());


### PR DESCRIPTION
This is a small pull request to convert `test/sequential/test-debugger-pid.js` to `async/await`. I used some of the other tests to get a sense of the style, and I believe this is a 1-to-1 replacement for the previous behavior, except without the use of `Promise.then()`

As a meta note, this is also to get familiar with the contributing process in light of #44828. 