### PR TITLE
node-api: handle no support for external buffers

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2362,7 +2362,7 @@ This API allocates a JavaScript value with external data attached to it. This
 is used to pass external data through JavaScript code, so it can be retrieved
 later by native code using [`napi_get_value_external`][].
 
-**Some runtimes other than Node.ja have dropped support for external buffers**.
+**Some runtimes other than Node.js have dropped support for external buffers**.
 On runtimes other than Node.js this method may return
 `napi_no_external_buffers_allowed` to indicate that external
 buffers are not supported. One such runtime is electron as

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -579,6 +579,7 @@ typedef enum {
   napi_arraybuffer_expected,
   napi_detachable_arraybuffer_expected,
   napi_would_deadlock,  /* unused */
+  napi_no_external_buffers_allowed
 } napi_status;
 ```
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2362,7 +2362,7 @@ This API allocates a JavaScript value with external data attached to it. This
 is used to pass external data through JavaScript code, so it can be retrieved
 later by native code using [`napi_get_value_external`][].
 
-**Some runtimes other than Node.ja hasve dropped support for external buffers**.
+**Some runtimes other than Node.ja have dropped support for external buffers**.
 On runtimes other than Node.js this method may return
 `napi_no_external_buffers_allowed` to indicate that external
 buffers are not supported. One such runtime is electron as

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2362,6 +2362,19 @@ This API allocates a JavaScript value with external data attached to it. This
 is used to pass external data through JavaScript code, so it can be retrieved
 later by native code using [`napi_get_value_external`][].
 
+**Some runtimes other than Node.ja hasve dropped support for external buffers**.
+On runtimes other than Node.js this method may return
+`napi_no_external_buffers_allowed` to indicate that external
+buffers are not supported. One such runtime is electron as
+described in this issue
+[electron/issues/35801](https://github.com/electron/electron/issues/35801).
+
+In order to maintain broadest compatibility with all runtimes
+you may define `NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED` in your addon before
+includes for the node-api headers. Doing so will hide the 2 methods
+that create external buffers. This will ensure a compilation error
+occurs if you accidentally use one of these methods.
+
 The API adds a `napi_finalize` callback which will be called when the JavaScript
 object just created is ready for garbage collection. It is similar to
 `napi_wrap()` except that:

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2371,7 +2371,7 @@ described in this issue
 
 In order to maintain broadest compatibility with all runtimes
 you may define `NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED` in your addon before
-includes for the node-api headers. Doing so will hide the 2 methods
+includes for the node-api headers. Doing so will hide the 2 functions
 that create external buffers. This will ensure a compilation error
 occurs if you accidentally use one of these methods.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2362,19 +2362,6 @@ This API allocates a JavaScript value with external data attached to it. This
 is used to pass external data through JavaScript code, so it can be retrieved
 later by native code using [`napi_get_value_external`][].
 
-**Some runtimes other than Node.js have dropped support for external buffers**.
-On runtimes other than Node.js this method may return
-`napi_no_external_buffers_allowed` to indicate that external
-buffers are not supported. One such runtime is electron as
-described in this issue
-[electron/issues/35801](https://github.com/electron/electron/issues/35801).
-
-In order to maintain broadest compatibility with all runtimes
-you may define `NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED` in your addon before
-includes for the node-api headers. Doing so will hide the 2 functions
-that create external buffers. This will ensure a compilation error
-occurs if you accidentally use one of these methods.
-
 The API adds a `napi_finalize` callback which will be called when the JavaScript
 object just created is ready for garbage collection. It is similar to
 `napi_wrap()` except that:
@@ -2415,6 +2402,19 @@ napi_create_external_arraybuffer(napi_env env,
 * `[out] result`: A `napi_value` representing a JavaScript `ArrayBuffer`.
 
 Returns `napi_ok` if the API succeeded.
+
+**Some runtimes other than Node.js have dropped support for external buffers**.
+On runtimes other than Node.js this method may return
+`napi_no_external_buffers_allowed` to indicate that external
+buffers are not supported. One such runtime is Electron as
+described in this issue
+[electron/issues/35801](https://github.com/electron/electron/issues/35801).
+
+In order to maintain broadest compatibility with all runtimes
+you may define `NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED` in your addon before
+includes for the node-api headers. Doing so will hide the 2 functions
+that create external buffers. This will ensure a compilation error
+occurs if you accidentally use one of these methods.
 
 This API returns a Node-API value corresponding to a JavaScript `ArrayBuffer`.
 The underlying byte buffer of the `ArrayBuffer` is externally allocated and
@@ -2459,6 +2459,19 @@ napi_status napi_create_external_buffer(napi_env env,
 * `[out] result`: A `napi_value` representing a `node::Buffer`.
 
 Returns `napi_ok` if the API succeeded.
+
+**Some runtimes other than Node.js have dropped support for external buffers**.
+On runtimes other than Node.js this method may return
+`napi_no_external_buffers_allowed` to indicate that external
+buffers are not supported. One such runtime is Electron as
+described in this issue
+[electron/issues/35801](https://github.com/electron/electron/issues/35801).
+
+In order to maintain broadest compatibility with all runtimes
+you may define `NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED` in your addon before
+includes for the node-api headers. Doing so will hide the 2 functions
+that create external buffers. This will ensure a compilation error
+occurs if you accidentally use one of these methods.
 
 This API allocates a `node::Buffer` object and initializes it with data
 backed by the passed in buffer. While this is still a fully-supported data

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -402,12 +402,14 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_create_arraybuffer(napi_env env,
                                                            void** data,
                                                            napi_value* result);
 NAPI_EXTERN napi_status NAPI_CDECL
+#ifndef NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
 napi_create_external_arraybuffer(napi_env env,
                                  void* external_data,
                                  size_t byte_length,
                                  napi_finalize finalize_cb,
                                  void* finalize_hint,
                                  napi_value* result);
+#endif  // NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
 NAPI_EXTERN napi_status NAPI_CDECL napi_get_arraybuffer_info(
     napi_env env, napi_value arraybuffer, void** data, size_t* byte_length);
 NAPI_EXTERN napi_status NAPI_CDECL napi_is_typedarray(napi_env env,

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -401,8 +401,8 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_create_arraybuffer(napi_env env,
                                                            size_t byte_length,
                                                            void** data,
                                                            napi_value* result);
-NAPI_EXTERN napi_status NAPI_CDECL
 #ifndef NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
+NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_external_arraybuffer(napi_env env,
                                  void* external_data,
                                  size_t byte_length,

--- a/src/js_native_api_types.h
+++ b/src/js_native_api_types.h
@@ -98,7 +98,8 @@ typedef enum {
   napi_date_expected,
   napi_arraybuffer_expected,
   napi_detachable_arraybuffer_expected,
-  napi_would_deadlock  // unused
+  napi_would_deadlock,  // unused
+  napi_no_external_buffers_allowed
 } napi_status;
 // Note: when adding a new enum value to `napi_status`, please also update
 //   * `const int last_status` in the definition of `napi_get_last_error_info()'

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -746,6 +746,7 @@ static const char* error_messages[] = {
     "An arraybuffer was expected",
     "A detachable arraybuffer was expected",
     "Main thread would deadlock",
+    "External buffers are not allowed",
 };
 
 napi_status NAPI_CDECL napi_get_last_error_info(
@@ -757,7 +758,7 @@ napi_status NAPI_CDECL napi_get_last_error_info(
   // message in the `napi_status` enum each time a new error message is added.
   // We don't have a napi_status_last as this would result in an ABI
   // change each time a message was added.
-  const int last_status = napi_would_deadlock;
+  const int last_status = napi_no_external_buffers_allowed;
 
   static_assert(NAPI_ARRAYSIZE(error_messages) == last_status + 1,
                 "Count of error messages must match count of error values");

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -950,6 +950,10 @@ napi_status NAPI_CDECL napi_create_external_buffer(napi_env env,
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
+#if defined(V8_COMPRESS_POINTERS_IN_SHARED_CAGE)
+  return napi_set_last_error(env, napi_no_external_buffers_allowed);
+#endif
+
   v8::Isolate* isolate = env->isolate;
 
   // The finalizer object will delete itself after invoking the callback.

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -950,7 +950,7 @@ napi_status NAPI_CDECL napi_create_external_buffer(napi_env env,
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
-#if defined(V8_COMPRESS_POINTERS_IN_SHARED_CAGE)
+#if defined(V8_ENABLE_SANDBOX)
   return napi_set_last_error(env, napi_no_external_buffers_allowed);
 #endif
 

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -153,6 +153,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_create_buffer(napi_env env,
                                                       size_t length,
                                                       void** data,
                                                       napi_value* result);
+#ifndef NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_external_buffer(napi_env env,
                             size_t length,
@@ -160,6 +161,7 @@ napi_create_external_buffer(napi_env env,
                             napi_finalize finalize_cb,
                             void* finalize_hint,
                             napi_value* result);
+#endif  // NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
 NAPI_EXTERN napi_status NAPI_CDECL napi_create_buffer_copy(napi_env env,
                                                            size_t length,
                                                            const void* data,

--- a/test/js-native-api/test_general/test_general.c
+++ b/test/js-native-api/test_general/test_general.c
@@ -1,3 +1,8 @@
+// we define this here to validate that it can
+// be used as a form of test itself. It is
+// not related to any of the other tests
+// defined in the file
+#define NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/test/js-native-api/test_general/test_general.c
+++ b/test/js-native-api/test_general/test_general.c
@@ -1,5 +1,5 @@
-// we define this here to validate that it can
-// be used as a form of test itself. It is
+// we define NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED here to
+// validate that it can be used as a form of test itself. It is
 // not related to any of the other tests
 // defined in the file
 #define NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED

--- a/test/node-api/test_general/test_general.c
+++ b/test/node-api/test_general/test_general.c
@@ -1,5 +1,5 @@
 #define NAPI_EXPERIMENTAL
-// we define this here to validate that it can
+// we define NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED here to validate that it can
 // be used as a form of test itself. It is
 // not related to any of the other tests
 // defined in the file

--- a/test/node-api/test_general/test_general.c
+++ b/test/node-api/test_general/test_general.c
@@ -1,4 +1,9 @@
 #define NAPI_EXPERIMENTAL
+// we define this here to validate that it can
+// be used as a form of test itself. It is
+// not related to any of the other tests
+// defined in the file
+#define NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
 #include <node_api.h>
 #include <stdlib.h>
 #include "../../js-native-api/common.h"


### PR DESCRIPTION
Refs: https://github.com/electron/electron/issues/35801 Refs: https://github.com/nodejs/abi-stable-node/issues/441

Electron recently dropped support for external
buffers. Provide a way for addon authors to:
- hide the methods to create external buffers so they can avoid using them if they want the broadest compatibility.
- call the methods that create external buffers at runtime to check if external buffers are supported and either use them or not based on the return code.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
