### PR TITLE
build: add GitHub token to auto-start-ci workflow

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup node-core-utils
         run: |
           ncu-config set username ${{ secrets.JENKINS_USER }}
-          ncu-config set token none
+          ncu-config set token "${{ secrets.GH_USER_TOKEN }}"
           ncu-config set jenkins_token ${{ secrets.JENKINS_TOKEN }}
           ncu-config set owner "${{ github.repository_owner }}"
           ncu-config set repo "$(echo ${{ github.repository }} | cut -d/ -f2)"


### PR DESCRIPTION
Recent changes to node-core-utils attempt to read pull request labels when deciding whether or not to start a V8 CI. This requires a valid GitHub token with appropriate permissions to be set for node-core-utils.

Fixes: https://github.com/nodejs/node/issues/45163
Refs: https://github.com/nodejs/node-core-utils/pull/652

---

Untested -- change based on https://github.com/nodejs/node/blob/efd3c9cd31b746a3c8728b12f4d894e39ce6d10b/.github/workflows/commit-queue.yml#L80. I think `secrets.JENKINS_USER` and `secrets.GH_USER_NAME` are the same (since we use GitHub auth in our Jenkins server).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
