### PR TITLE
tls: add ALPNCallback server option for dynamic ALPN negotiation

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2746,6 +2746,20 @@ This error represents a failed test. Additional information about the failure
 is available via the `cause` property. The `failureType` property specifies
 what the test was doing when the failure occurred.
 
+<a id="ERR_TLS_ALPN_CALLBACK_INVALID_RESULT"></a>
+
+### `ERR_TLS_ALPN_CALLBACK_INVALID_RESULT`
+
+This error is thrown when an `ALPNCallback` returns a value that is not in the
+list of ALPN protocols offered by the client.
+
+<a id="ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS"></a>
+
+### `ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS`
+
+This error is thrown when creating a `TLSServer` if the TLS options include
+both `ALPNProtocols` and `ALPNCallback`. These options are mutually exclusive.
+
 <a id="ERR_TLS_CERT_ALTNAME_FORMAT"></a>
 
 ### `ERR_TLS_CERT_ALTNAME_FORMAT`

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -2049,6 +2049,9 @@ where `secureSocket` has the same API as `pair.cleartext`.
 <!-- YAML
 added: v0.3.2
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/45190
+    description: The `options` parameter can now include `ALPNCallback`.
   - version: v19.0.0
     pr-url: https://github.com/nodejs/node/pull/44031
     description: If `ALPNProtocols` is set, incoming connections that send an
@@ -2079,6 +2082,17 @@ changes:
     e.g. `0x05hello0x05world`, where the first byte is the length of the next
     protocol name. Passing an array is usually much simpler, e.g.
     `['hello', 'world']`. (Protocols should be ordered by their priority.)
+  * `ALPNCallback(params)`: {Function} If set, this will be called when a
+    client opens a connection using the ALPN extension. One argument will
+    be passed to the callback: an object containing `serverName` and
+    `clientALPNProtocols` fields, respectively containing the server name from
+    the SNI extension (if any) and an array of ALPN protocol name strings. The
+    callback must return either one of the strings listed in
+    `clientALPNProtocols`, which will be returned to the client as the selected
+    ALPN protocol, or `undefined`, to reject the connection with a fatal alert.
+    If a string is returned that does not match one of the client's ALPN
+    protocols, an error will be thrown. This option cannot be used with the
+    `ALPNProtocols` option, and setting both options will throw an error.
   * `clientCertEngine` {string} Name of an OpenSSL engine which can provide the
     client certificate.
   * `enableTrace` {boolean} If `true`, [`tls.TLSSocket.enableTrace()`][] will be

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -2082,13 +2082,13 @@ changes:
     e.g. `0x05hello0x05world`, where the first byte is the length of the next
     protocol name. Passing an array is usually much simpler, e.g.
     `['hello', 'world']`. (Protocols should be ordered by their priority.)
-  * `ALPNCallback(params)`: {Function} If set, this will be called when a
+  * `ALPNCallback`: {Function} If set, this will be called when a
     client opens a connection using the ALPN extension. One argument will
-    be passed to the callback: an object containing `serverName` and
-    `clientALPNProtocols` fields, respectively containing the server name from
+    be passed to the callback: an object containing `servername` and
+    `protocols` fields, respectively containing the server name from
     the SNI extension (if any) and an array of ALPN protocol name strings. The
     callback must return either one of the strings listed in
-    `clientALPNProtocols`, which will be returned to the client as the selected
+    `protocols`, which will be returned to the client as the selected
     ALPN protocol, or `undefined`, to reject the connection with a fatal alert.
     If a string is returned that does not match one of the client's ALPN
     protocols, an error will be thrown. This option cannot be used with the

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -72,6 +72,8 @@ const {
   ERR_INVALID_ARG_VALUE,
   ERR_MULTIPLE_CALLBACK,
   ERR_SOCKET_CLOSED,
+  ERR_TLS_ALPN_CALLBACK_INVALID_RESULT,
+  ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS,
   ERR_TLS_DH_PARAM_SIZE,
   ERR_TLS_HANDSHAKE_TIMEOUT,
   ERR_TLS_INVALID_CONTEXT,
@@ -231,6 +233,46 @@ function loadSNI(info) {
 
     requestOCSP(owner, info);
   });
+}
+
+
+function callALPNCallback(protocolsBuffer) {
+  const handle = this;
+  const socket = handle[owner_symbol];
+
+  const serverName = handle.getServername();
+
+  // Collect all the protocols from the given buffer:
+  const protocols = [];
+  let offset = 0;
+  while (offset < protocolsBuffer.length) {
+    const protocolLen = protocolsBuffer[offset];
+    offset += 1;
+
+    const protocol = protocolsBuffer.slice(offset, offset + protocolLen);
+    offset += protocolLen;
+
+    protocols.push(protocol.toString('ascii'));
+  }
+
+  const selectedProtocol = socket._ALPNCallback({
+    serverName,
+    clientALPNProtocols: protocols
+  });
+
+  // Undefined -> all proposed protocols rejected
+  if (selectedProtocol === undefined) return undefined;
+
+  const protocolIndex = protocols.indexOf(selectedProtocol);
+  if (protocolIndex === -1) {
+    throw new ERR_TLS_ALPN_CALLBACK_INVALID_RESULT(selectedProtocol, protocols);
+  }
+  let protocolOffset = 0;
+  for (let i = 0; i < protocolIndex; i++) {
+    protocolOffset += 1 + protocols[i].length;
+  }
+
+  return protocolOffset;
 }
 
 
@@ -493,6 +535,7 @@ function TLSSocket(socket, opts) {
   this._controlReleased = false;
   this.secureConnecting = true;
   this._SNICallback = null;
+  this._ALPNCallback = null;
   this.servername = null;
   this.alpnProtocol = null;
   this.authorized = false;
@@ -754,6 +797,13 @@ TLSSocket.prototype._init = function(socket, wrap) {
     ssl.onnewsession = onnewsession;
     ssl.lastHandshakeTime = 0;
     ssl.handshakes = 0;
+
+    if (options.ALPNCallback) {
+      assert(typeof options.ALPNCallback === 'function');
+      this._ALPNCallback = options.ALPNCallback;
+      ssl.ALPNCallback = callALPNCallback;
+      ssl.enableALPNCb();
+    }
 
     if (this.server) {
       if (this.server.listenerCount('resumeSession') > 0 ||
@@ -1133,6 +1183,7 @@ function tlsConnectionListener(rawSocket) {
     rejectUnauthorized: this.rejectUnauthorized,
     handshakeTimeout: this[kHandshakeTimeout],
     ALPNProtocols: this.ALPNProtocols,
+    ALPNCallback: this.ALPNCallback,
     SNICallback: this[kSNICallback] || SNICallback,
     enableTrace: this[kEnableTrace],
     pauseOnConnect: this.pauseOnConnect,
@@ -1231,6 +1282,11 @@ function Server(options, listener) {
   this._contexts = [];
   this.requestCert = options.requestCert === true;
   this.rejectUnauthorized = options.rejectUnauthorized !== false;
+
+  this.ALPNCallback = options.ALPNCallback;
+  if (this.ALPNCallback && options.ALPNProtocols) {
+    throw new ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS();
+  }
 
   if (options.sessionTimeout)
     this.sessionTimeout = options.sessionTimeout;

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -110,6 +110,7 @@ const kErrorEmitted = Symbol('error-emitted');
 const kHandshakeTimeout = Symbol('handshake-timeout');
 const kRes = Symbol('res');
 const kSNICallback = Symbol('snicallback');
+const kALPNCallback = Symbol('alpncallback');
 const kEnableTrace = Symbol('enableTrace');
 const kPskCallback = Symbol('pskcallback');
 const kPskIdentityHint = Symbol('pskidentityhint');
@@ -240,7 +241,7 @@ function callALPNCallback(protocolsBuffer) {
   const handle = this;
   const socket = handle[owner_symbol];
 
-  const serverName = handle.getServername();
+  const servername = handle.getServername();
 
   // Collect all the protocols from the given buffer:
   const protocols = [];
@@ -255,9 +256,9 @@ function callALPNCallback(protocolsBuffer) {
     protocols.push(protocol.toString('ascii'));
   }
 
-  const selectedProtocol = socket._ALPNCallback({
-    serverName,
-    clientALPNProtocols: protocols
+  const selectedProtocol = socket[kALPNCallback]({
+    servername,
+    protocols,
   });
 
   // Undefined -> all proposed protocols rejected
@@ -535,7 +536,7 @@ function TLSSocket(socket, opts) {
   this._controlReleased = false;
   this.secureConnecting = true;
   this._SNICallback = null;
-  this._ALPNCallback = null;
+  this[kALPNCallback] = null;
   this.servername = null;
   this.alpnProtocol = null;
   this.authorized = false;
@@ -799,8 +800,11 @@ TLSSocket.prototype._init = function(socket, wrap) {
     ssl.handshakes = 0;
 
     if (options.ALPNCallback) {
+      if (typeof options.ALPNCallback !== 'function') {
+        throw new ERR_INVALID_ARG_TYPE('options.ALPNCallback', 'Function', options.ALPNCallback);
+      }
       assert(typeof options.ALPNCallback === 'function');
-      this._ALPNCallback = options.ALPNCallback;
+      this[kALPNCallback] = options.ALPNCallback;
       ssl.ALPNCallback = callALPNCallback;
       ssl.enableALPNCb();
     }

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -276,7 +276,6 @@ function callALPNCallback(protocolsBuffer) {
   return protocolOffset;
 }
 
-
 function requestOCSP(socket, info) {
   if (!info.OCSPRequest || !socket.server)
     return requestOCSPDone(socket);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1628,6 +1628,16 @@ E('ERR_TEST_FAILURE', function(error, failureType) {
   this.cause = error;
   return msg;
 }, Error);
+E('ERR_TLS_ALPN_CALLBACK_INVALID_RESULT', (value, protocols) => {
+  return `ALPN callback returned a value (${
+    value
+  }) that did not match any of the client's offered protocols (${
+    protocols.join(', ')
+  })`;
+}, TypeError);
+E('ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS',
+  'The ALPNCallback and ALPNProtocols TLS options are mutually exclusive',
+  TypeError);
 E('ERR_TLS_CERT_ALTNAME_FORMAT', 'Invalid subject alternative name string',
   SyntaxError);
 E('ERR_TLS_CERT_ALTNAME_INVALID', function(reason, host, cert) {

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -226,6 +226,7 @@ int SelectALPNCallback(
   TLSWrap* w = static_cast<TLSWrap*>(arg);
   if (w->alpn_callback_enabled_) {
     Environment* env = w->env();
+    HandleScope handle_scope(env->isolate());
 
     Local<Value> callback_arg =
         Buffer::Copy(env, reinterpret_cast<const char*>(in), inlen)

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -224,6 +224,43 @@ int SelectALPNCallback(
     unsigned int inlen,
     void* arg) {
   TLSWrap* w = static_cast<TLSWrap*>(arg);
+  if (w->alpn_callback_enabled_) {
+    Environment* env = w->env();
+
+    Local<Value> callback_arg =
+        Buffer::Copy(env, reinterpret_cast<const char*>(in), inlen)
+            .ToLocalChecked();
+
+    MaybeLocal<Value> maybe_callback_result =
+        w->MakeCallback(env->alpn_callback_string(), 1, &callback_arg);
+
+    if (UNLIKELY(maybe_callback_result.IsEmpty())) {
+      // Implies the callback didn't return, because some exception was thrown
+      // during processing, e.g. if callback returned an invalid ALPN value.
+      return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
+
+    Local<Value> callback_result = maybe_callback_result.ToLocalChecked();
+
+    if (callback_result->IsUndefined()) {
+      // If you set an ALPN callback, but you return undefined for an ALPN
+      // request, you're rejecting all proposed ALPN protocols, and so we send
+      // a fatal alert:
+      return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
+
+    CHECK(callback_result->IsNumber());
+    unsigned int result_int = callback_result.As<v8::Number>()->Value();
+
+    // The callback returns an offset into the given buffer, for the selected
+    // protocol that should be returned. We then set outlen & out to point
+    // to the selected input length & value directly:
+    *outlen = *(in + result_int);
+    *out = (in + result_int + 1);
+
+    return SSL_TLSEXT_ERR_OK;
+  }
+
   const std::vector<unsigned char>& alpn_protos = w->alpn_protos_;
 
   if (alpn_protos.empty()) return SSL_TLSEXT_ERR_NOACK;
@@ -1224,6 +1261,15 @@ void TLSWrap::OnClientHelloParseEnd(void* arg) {
   c->Cycle();
 }
 
+void TLSWrap::EnableALPNCb(const FunctionCallbackInfo<Value>& args) {
+  TLSWrap* wrap;
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+  wrap->alpn_callback_enabled_ = true;
+
+  SSL* ssl = wrap->ssl_.get();
+  SSL_CTX_set_alpn_select_cb(SSL_get_SSL_CTX(ssl), SelectALPNCallback, wrap);
+}
+
 void TLSWrap::GetServername(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -2034,6 +2080,7 @@ void TLSWrap::Initialize(
   SetProtoMethod(isolate, t, "certCbDone", CertCbDone);
   SetProtoMethod(isolate, t, "destroySSL", DestroySSL);
   SetProtoMethod(isolate, t, "enableCertCb", EnableCertCb);
+  SetProtoMethod(isolate, t, "enableALPNCb", EnableALPNCb);
   SetProtoMethod(isolate, t, "endParser", EndParser);
   SetProtoMethod(isolate, t, "enableKeylogCallback", EnableKeylogCallback);
   SetProtoMethod(isolate, t, "enableSessionCallbacks", EnableSessionCallbacks);
@@ -2099,6 +2146,7 @@ void TLSWrap::RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(CertCbDone);
   registry->Register(DestroySSL);
   registry->Register(EnableCertCb);
+  registry->Register(EnableALPNCb);
   registry->Register(EndParser);
   registry->Register(EnableKeylogCallback);
   registry->Register(EnableSessionCallbacks);

--- a/src/crypto/crypto_tls.h
+++ b/src/crypto/crypto_tls.h
@@ -172,6 +172,7 @@ class TLSWrap : public AsyncWrap,
   static void CertCbDone(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void DestroySSL(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void EnableCertCb(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void EnableALPNCb(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void EnableKeylogCallback(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void EnableSessionCallbacks(
@@ -285,6 +286,7 @@ class TLSWrap : public AsyncWrap,
 
  public:
   std::vector<unsigned char> alpn_protos_;  // Accessed by SelectALPNCallback.
+  bool alpn_callback_enabled_ = false;      // Accessed by SelectALPNCallback.
 };
 
 }  // namespace crypto

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -50,6 +50,7 @@
   V(ack_string, "ack")                                                         \
   V(address_string, "address")                                                 \
   V(aliases_string, "aliases")                                                 \
+  V(alpn_callback_string, "ALPNCallback")                                      \
   V(args_string, "args")                                                       \
   V(asn1curve_string, "asn1Curve")                                             \
   V(async_ids_stack_string, "async_ids_stack")                                 \

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -221,9 +221,9 @@ function TestFatalAlert() {
 function TestALPNCallback() {
   // Server always selects the client's 2nd preference:
   const serverOptions = {
-    ALPNCallback: ({ clientALPNProtocols }) => {
-      return clientALPNProtocols[1];
-    }
+    ALPNCallback: common.mustCall(({ protocols }) => {
+      return protocols[1];
+    }, 2)
   };
 
   const clientsOptions = [{
@@ -249,7 +249,7 @@ function TestALPNCallback() {
 function TestBadALPNCallback() {
   // Server always returns a fixed invalid value:
   const serverOptions = {
-    ALPNCallback: () => 'http/5'
+    ALPNCallback: common.mustCall(() => 'http/5')
   };
 
   const clientsOptions = [{

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -41,9 +41,8 @@ function runTest(clientsOptions, serverOptions, cb) {
     opt.rejectUnauthorized = false;
 
     results[clientIndex] = {};
-    const client = tls.connect(opt, function() {
-      results[clientIndex].client = { ALPN: client.alpnProtocol };
-      client.end();
+
+    function startNextClient() {
       if (options.length) {
         clientIndex++;
         connectClient(options);
@@ -53,6 +52,15 @@ function runTest(clientsOptions, serverOptions, cb) {
           cb(results);
         });
       }
+    }
+
+    const client = tls.connect(opt, function() {
+      results[clientIndex].client = { ALPN: client.alpnProtocol };
+      client.end();
+      startNextClient();
+    }).on('error', function(err) {
+      results[clientIndex].client = { error: err };
+      startNextClient();
     });
   }
 
@@ -200,12 +208,63 @@ function TestFatalAlert() {
           .on('close', common.mustCall(() => {
             assert.match(stderr, /SSL alert number 120/);
             server.close();
+            TestALPNCallback();
           }));
       } else {
         server.close();
+        TestALPNCallback();
       }
     }));
   }));
+}
+
+function TestALPNCallback() {
+  // Server always selects the client's 2nd preference:
+  const serverOptions = {
+    ALPNCallback: ({ clientALPNProtocols }) => {
+      return clientALPNProtocols[1];
+    }
+  };
+
+  const clientsOptions = [{
+    ALPNProtocols: ['a', 'b', 'c'],
+  }, {
+    ALPNProtocols: ['a'],
+  }];
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // Callback picks 2nd preference => picks 'b'
+    checkResults(results[0],
+                 { server: { ALPN: 'b' },
+                   client: { ALPN: 'b' } });
+
+    // Callback picks 2nd preference => undefined => ALPN rejected:
+    assert.strictEqual(results[1].server, undefined);
+    assert.strictEqual(results[1].client.error.code, 'ECONNRESET');
+
+    TestBadALPNCallback();
+  });
+}
+
+function TestBadALPNCallback() {
+  // Server always returns a fixed invalid value:
+  const serverOptions = {
+    ALPNCallback: () => 'http/5'
+  };
+
+  const clientsOptions = [{
+    ALPNProtocols: ['http/1', 'h2'],
+  }];
+
+  process.once('uncaughtException', common.mustCall((error) => {
+    assert.strictEqual(error.code, 'ERR_TLS_ALPN_CALLBACK_INVALID_RESULT');
+  }));
+
+  runTest(clientsOptions, serverOptions, function(results) {
+    // Callback returns 'http/5' => doesn't match client ALPN => error & reset
+    assert.strictEqual(results[0].server, undefined);
+    assert.strictEqual(results[0].client.error.code, 'ECONNRESET');
+  });
 }
 
 Test1();

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -264,7 +264,17 @@ function TestBadALPNCallback() {
     // Callback returns 'http/5' => doesn't match client ALPN => error & reset
     assert.strictEqual(results[0].server, undefined);
     assert.strictEqual(results[0].client.error.code, 'ECONNRESET');
+
+    TestALPNOptionsCallback();
   });
+}
+
+function TestALPNOptionsCallback() {
+  // Server sets two incompatible ALPN options:
+  assert.throws(() => tls.createServer({
+    ALPNCallback: () => 'a',
+    ALPNProtocols: ['b', 'c']
+  }), (error) => error.code === 'ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS');
 }
 
 Test1();


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This is an alternate fix for #45056 (which replaces #45075).

I'd definitely appreciate careful reviewing of the native parts of this, I'm not familiar with a lot of the standard approaches and concerns there and this is definitely more complex than the other approach.

A few open questions:

* ~~I've used `serverName` as the field for the server name that's passed to the callback. Some of the existing API uses `servername` instead, but that casing seems very odd. Which do we prefer?~~ Resolved in favour of `servername`
* The implementation here throws an error if the server callback returns a string that isn't in the client's offered protocols. Reading the RFC that's _implicitly_ what you should do, but I don't think it's strictly required - it's weird but not 100% invalid as far as I can tell to send an ALPN response telling the client you're speaking a protocol they didn't ask for. I assume we're fine with being strict here, but worth considering.
* The implementation here doesn't support returning no ALPN extension if you set a callback. If you've provided an ALPN callback, then when an ALPN-using client arrives you must either return an ALPN response or reject the connection entirely. That's equivalent to the current `ALPNProtocols` behaviour, but is that correct? We could relax this with some other special return value, either now or in future, e.g. "return `undefined` if no ALPN values match to reject the handshake, or `false` to skip ALPN and send no handshake at all" (or some other pair of non-string values). I'm not sure if anybody will need this, but it's perfectly legitimate behaviour (servers aren't _required_ to send ALPN responses AFAICT) so it's probably good to at least leave space for this in the API design in case we want it later.