### PR TITLE
build: fix icu-small build on mac with ICU 72.1

### DIFF
--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -419,7 +419,7 @@
       'target_name': 'genrb',
       'type': 'executable',
       'toolsets': [ 'host' ],
-      'dependencies': [ 'icutools' ],
+      'dependencies': [ 'icutools', 'icu_implementation' ],
       'sources': [
         '<@(icu_src_genrb)'
       ],


### PR DESCRIPTION
- RTTI is needed for genrb now

Fixes: https://github.com/nodejs/node/issues/45174
