### PR TITLE
doc: add history section to `fetch`-related globals

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -463,6 +463,10 @@ This variable may appear to be global but is not. See [`exports`][].
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: v18.0.0
+    pr-url: https://github.com/nodejs/node/pull/41811
+    description: No longer behind `--experimental-global-fetch` CLI flag.
 -->
 
 > Stability: 1 - Experimental. Disable this API with the [`--no-experimental-fetch`][]
@@ -476,6 +480,10 @@ A browser-compatible implementation of the [`fetch()`][] function.
 added:
   - v17.6.0
   - v16.15.0
+changes:
+  - version: v18.0.0
+    pr-url: https://github.com/nodejs/node/pull/41811
+    description: No longer behind `--experimental-global-fetch` CLI flag.
 -->
 
 > Stability: 1 - Experimental. Disable this API with the [`--no-experimental-fetch`][]
@@ -504,6 +512,10 @@ Node.js this is different. The top-level scope is not the global scope;
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: v18.0.0
+    pr-url: https://github.com/nodejs/node/pull/41811
+    description: No longer behind `--experimental-global-fetch` CLI flag.
 -->
 
 > Stability: 1 - Experimental. Disable this API with the [`--no-experimental-fetch`][]
@@ -737,6 +749,10 @@ This variable may appear to be global but is not. See [`require()`][].
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: v18.0.0
+    pr-url: https://github.com/nodejs/node/pull/41811
+    description: No longer behind `--experimental-global-fetch` CLI flag.
 -->
 
 > Stability: 1 - Experimental. Disable this API with the [`--no-experimental-fetch`][]
@@ -750,6 +766,10 @@ A browser-compatible implementation of {Response}.
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: v18.0.0
+    pr-url: https://github.com/nodejs/node/pull/41811
+    description: No longer behind `--experimental-global-fetch` CLI flag.
 -->
 
 > Stability: 1 - Experimental. Disable this API with the [`--no-experimental-fetch`][]


### PR DESCRIPTION
Currently the docs shows:

> fetch[#](https://nodejs.org/api/globals.html#fetch)
> Added in: v17.5.0, v16.15.0

That's a bit misleading, as it was behind a flag on those release lines.

Refs: https://github.com/nodejs/node/pull/41811

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
