### PR TITLE
test: use common/tmpdir in watch-mode ipc test

### DIFF
--- a/test/fixtures/watch-mode/ipc.js
+++ b/test/fixtures/watch-mode/ipc.js
@@ -1,9 +1,9 @@
 const path = require('node:path');
 const url = require('node:url');
-const os = require('node:os');
 const fs = require('node:fs');
+const tmpdir = require('../../common/tmpdir');
 
-const tmpfile = path.join(os.tmpdir(), 'file');
+const tmpfile = path.join(tmpdir.path, 'file');
 fs.writeFileSync(tmpfile, '');
 
 process.send({ 'watch:require': path.resolve(__filename) });

--- a/test/parallel/test-watch-mode-files_watcher.mjs
+++ b/test/parallel/test-watch-mode-files_watcher.mjs
@@ -5,7 +5,6 @@ import tmpdir from '../common/tmpdir.js';
 import path from 'node:path';
 import assert from 'node:assert';
 import process from 'node:process';
-import os from 'node:os';
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { setTimeout } from 'node:timers/promises';
@@ -153,7 +152,7 @@ describe('watch mode file watcher', () => {
     const child = spawn(process.execPath, [file], { stdio: ['pipe', 'pipe', 'pipe', 'ipc'], encoding: 'utf8' });
     watcher.watchChildProcessModules(child);
     await once(child, 'exit');
-    let expected = [file, path.join(os.tmpdir(), 'file')];
+    let expected = [file, path.join(tmpdir.path, 'file')];
     if (supportsRecursiveWatching) {
       expected = expected.map((file) => path.dirname(file));
     }


### PR DESCRIPTION
Using `path.join(os.tmpdir(), 'file')` on a multi-user system can lead to file collisions where the file already exists but is owned by a different user and cannot be removed or overwritten. Other tests in `parallel/test-watch-mode-files_watcher` use `common/tmpdir` instead so switch to that for consistency.

Refs: https://github.com/nodejs/node/pull/44366

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
