### PR TITLE
test: deflake test-http2-empty-frame-without-eof

### DIFF
--- a/test/parallel/test-http2-empty-frame-without-eof.js
+++ b/test/parallel/test-http2-empty-frame-without-eof.js
@@ -10,7 +10,9 @@ const { once } = require('events');
 async function main() {
   const blobWithEmptyFrame = readSync('emptyframe.http2');
   const server = net.createServer((socket) => {
-    socket.end(blobWithEmptyFrame);
+    socket.once('data', () => {
+      socket.end(blobWithEmptyFrame);
+    });
   }).listen(0);
   await once(server, 'listening');
 


### PR DESCRIPTION
It may happen that the data in `emptyframe.http2` reaches the client even before the client has started sending the request, causing an `ERR_HTTP2_STREAM_ERROR` instead. Fix this by making sure the frame is not sent until some data reaches the server.

Observed on windows when working on https://github.com/nodejs/node/pull/42340
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
