### PR TITLE
url: disallow percent in hosts for url.parse()

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -30,7 +30,6 @@ const {
   decodeURIComponent,
 } = primordials;
 
-const { toASCII } = require('internal/idna');
 const { encodeStr, hexTable } = require('internal/querystring');
 const querystring = require('querystring');
 
@@ -130,7 +129,6 @@ const {
   CHAR_QUESTION_MARK,
   CHAR_DOUBLE_QUOTE,
   CHAR_SINGLE_QUOTE,
-  CHAR_PERCENT,
   CHAR_SEMICOLON,
   CHAR_BACKWARD_SLASH,
   CHAR_CIRCUMFLEX_ACCENT,
@@ -325,7 +323,6 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
           break;
         case CHAR_SPACE:
         case CHAR_DOUBLE_QUOTE:
-        case CHAR_PERCENT:
         case CHAR_SINGLE_QUOTE:
         case CHAR_SEMICOLON:
         case CHAR_LEFT_ANGLE_BRACKET:
@@ -407,10 +404,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
         // It only converts parts of the domain name that
         // have non-ASCII characters, i.e. it doesn't matter if
         // you call it with a domain that already is ASCII-only.
-
-        // Use lenient mode (`true`) to try to support even non-compliant
-        // URLs.
-        this.hostname = toASCII(this.hostname, true);
+        this.hostname = domainToASCII(this.hostname);
 
         // Prevent two potential routes of hostname spoofing.
         // 1. If this.hostname is empty, it must have become empty due to toASCII
@@ -418,9 +412,6 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
         // 2. If any of forbiddenHostChars appears in this.hostname, it must have
         //    also gotten in due to toASCII. This is since getHostname would have
         //    filtered them out otherwise.
-        // Rather than trying to correct this by moving the non-host part into
-        // the pathname as we've done in getHostname, throw an exception to
-        // convey the severity of this issue.
         if (this.hostname === '' || forbiddenHostChars.test(this.hostname)) {
           throw new ERR_INVALID_URL(url);
         }

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -70,7 +70,6 @@ const expectedModules = new Set([
   'NativeModule internal/fs/watchers',
   'NativeModule internal/heap_utils',
   'NativeModule internal/histogram',
-  'NativeModule internal/idna',
   'NativeModule internal/linkedlist',
   'NativeModule internal/mime',
   'NativeModule internal/modules/cjs/helpers',

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -991,6 +991,21 @@ const parseTests = {
     path: '/',
     href: 'https://evil.com$.example.com/'
   },
+
+  'https://%E4%BD%A0/fhqwhgads': {
+    protocol: 'https:',
+    slashes: true,
+    auth: null,
+    host: 'xn--6qq',
+    port: null,
+    hostname: 'xn--6qq',
+    hash: null,
+    search: null,
+    query: null,
+    pathname: '/fhqwhgads',
+    path: '/fhqwhgads',
+    href: 'https://xn--6qq/fhqwhgads'
+  }
 };
 
 for (const u in parseTests) {

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -79,6 +79,7 @@ if (common.hasIntl) {
   const badURLs = [
     'https://evil.com:.example.com',
     'git+ssh://git@github.com:npm/npm',
+    'http://a%b.com/fhqwhgads',
   ];
   badURLs.forEach((badURL) => {
     assert.throws(() => { url.parse(badURL); },


### PR DESCRIPTION
Emulate WHATWG URL by throwing if there is a % character that is not part of a valid percent-encoding in the hostname. Otherwise, return punycode representation of encoded characters (also aligned with WHATWG URL).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
