### PR TITLE
lock-free init_process_flags for all archs

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -429,7 +429,7 @@ void ResetSignalHandlers() {
 #endif  // __POSIX__
 }
 
-static std::atomic<uint64_t> init_process_flags = 0;
+static std::atomic<uint32_t> init_process_flags = 0;
 
 static void PlatformInit(ProcessInitializationFlags::Flags flags) {
   // init_process_flags is accessed in ResetStdio(),

--- a/src/node.h
+++ b/src/node.h
@@ -228,6 +228,8 @@ class MultiIsolatePlatform;
 class InitializationResultImpl;
 
 namespace ProcessFlags {
+// TODO(addaleax): Switch to uint32_t to match std::atomic<uint32_t>
+// init_process_flags in node.cc
 enum Flags : uint64_t {
   kNoFlags = 0,
   // Enable stdio inheritance, which is disabled by default.


### PR DESCRIPTION
Fix https://github.com/nodejs/node/issues/45152
