### PR TITLE
test: fix catching failed assertion

### DIFF
--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -142,7 +142,7 @@ const { Blob } = require('buffer');
       }
       assert.strictEqual(ret, 'abcdefghi');
     },
-    common.mustCall(),
+    common.mustSucceed(),
   );
 }
 


### PR DESCRIPTION
There is a test that ignores assertion failures in `test/parallel/test-stream-duplex-from.js`. This PR simply adds check to capture any error and actually fail the test.