### PR TITLE
test: fix textdecoder test for small-icu builds

### DIFF
--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -201,8 +201,13 @@ if (common.hasIntl) {
 }
 
 if (common.hasIntl) {
-  const decoder = new TextDecoder('Shift_JIS');
-  const chunk = new Uint8Array([-1]);
-  const str = decoder.decode(chunk);
-  assert.strictEqual(str, '\ufffd');
+  try {
+    const decoder = new TextDecoder('Shift_JIS');
+    const chunk = new Uint8Array([-1]);
+    const str = decoder.decode(chunk);
+    assert.strictEqual(str, '\ufffd');
+  } catch (e) {
+    // Encoding may not be available, e.g. small-icu builds
+    assert.strictEqual(e.code, 'ERR_ENCODING_NOT_SUPPORTED');
+  }
 }


### PR DESCRIPTION
The `Shift_JIS` encoding may not be available, e.g. when Node.js is configured with `--with-intl=small-icu`.

---

For some context, I'm looking at https://github.com/nodejs/build/issues/2998 after the recent ICU update broke small-icu builds (https://github.com/nodejs/node/issues/45174). Without this PR, building Node.js with the `--with-intl=small-icu` `configure` option results in this test failure:
```
=== release test-whatwg-encoding-custom-textdecoder ===
Path: parallel/test-whatwg-encoding-custom-textdecoder
node:internal/encoding:403
        throw new ERR_ENCODING_NOT_SUPPORTED(encoding);
        ^

RangeError [ERR_ENCODING_NOT_SUPPORTED]: The "Shift_JIS" encoding is not supported
    at new NodeError (node:internal/errors:393:5)
    at new TextDecoder (node:internal/encoding:403:15)
    at Object.<anonymous> (/home/rlau/sandbox/github/node/test/parallel/test-whatwg-encoding-custom-textdecoder.js:204:19)
    at Module._compile (node:internal/modules/cjs/loader:1175:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1229:10)
    at Module.load (node:internal/modules/cjs/loader:1038:32)
    at Module._load (node:internal/modules/cjs/loader:879:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:82:12)
    at node:internal/main/run_main_module:23:47 {
  code: 'ERR_ENCODING_NOT_SUPPORTED'
}

Node.js v20.0.0-pre
Command: out/Release/node --expose-internals /home/rlau/sandbox/github/node/test/parallel/test-whatwg-encoding-custom-textdecoder.js
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
