### PR TITLE
src: call uv_library_shutdown before DisposePlatform

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -773,8 +773,13 @@ void DefaultProcessExitHandlerInternal(Environment* env, ExitCode exit_code) {
   env->set_can_call_into_js(false);
   env->stop_sub_worker_contexts();
   env->isolate()->DumpAndResetStats();
-  DisposePlatform();
+  // When the process exits, the tasks in the thread pool may also need to
+  // access the data of V8Platform, such as trace agent, or a field
+  // added in the future. So make sure the thread pool exits first.
+  // And make sure V8Platform don not call into Libuv threadpool, see Dispose
+  // in node_v8_platform-inl.h
   uv_library_shutdown();
+  DisposePlatform();
   Exit(exit_code);
 }
 

--- a/src/node_v8_platform-inl.h
+++ b/src/node_v8_platform-inl.h
@@ -103,7 +103,8 @@ struct V8Platform {
     platform_ = new NodePlatform(thread_pool_size, controller);
     v8::V8::InitializePlatform(platform_);
   }
-
+  // Make sure V8Platform don not call into Libuv threadpool,
+  // see DefaultProcessExitHandlerInternal in environment.cc
   inline void Dispose() {
     if (!initialized_)
       return;


### PR DESCRIPTION
When the process exits, the tasks in the thread pool may also need to access the data of platform object, such as trace agent, or a field added in the future. So make sure the thread pool exits first.

Refs: https://github.com/nodejs/node/pull/44458

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
