### PR TITLE
tools: refactor dynamic strings creation in shell scripts

### DIFF
--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -30,91 +30,91 @@ fi
 
 
 # Dependencies bundled in distributions
-licenseText="$(cat "${rootdir}"/deps/acorn/acorn/LICENSE)"
+licenseText="$(cat "${rootdir}/deps/acorn/acorn/LICENSE")"
 addlicense "Acorn" "deps/acorn" "$licenseText"
-licenseText="$(tail -n +3 "${rootdir}"/deps/cares/LICENSE.md)"
+licenseText="$(tail -n +3 "${rootdir}/deps/cares/LICENSE.md")"
 addlicense "c-ares" "deps/cares" "$licenseText"
-licenseText="$(cat "${rootdir}"/deps/cjs-module-lexer/LICENSE)"
+licenseText="$(cat "${rootdir}/deps/cjs-module-lexer/LICENSE")"
 addlicense "cjs-module-lexer" "deps/cjs-module-lexer" "$licenseText"
 if [ -f "${rootdir}/deps/icu/LICENSE" ]; then
   # ICU 57 and following. Drop the BOM
-  licenseText="$(sed -e '1s/^[^a-zA-Z ]*ICU/ICU/' -e :a -e 's/<[^>]*>//g;s/	/ /g;s/ +$//;/</N;//ba' "${rootdir}"/deps/icu/LICENSE)"
+  licenseText="$(sed -e '1s/^[^a-zA-Z ]*ICU/ICU/' -e :a -e 's/<[^>]*>//g;s/	/ /g;s/ +$//;/</N;//ba' "${rootdir}/deps/icu/LICENSE")"
   addlicense "ICU" "deps/icu" "$licenseText"
 elif [ -f "${rootdir}/deps/icu/license.html" ]; then
   # ICU 56 and prior
-  licenseText="$(sed -e '1,/ICU License - ICU 1\.8\.1 and later/d' -e :a -e 's/<[^>]*>//g;s/	/ /g;s/ +$//;/</N;//ba' "${rootdir}"/deps/icu/license.html)"
+  licenseText="$(sed -e '1,/ICU License - ICU 1\.8\.1 and later/d' -e :a -e 's/<[^>]*>//g;s/	/ /g;s/ +$//;/</N;//ba' "${rootdir}/deps/icu/license.html")"
   addlicense "ICU" "deps/icu" "$licenseText"
 elif [ -f "${rootdir}/deps/icu-small/LICENSE" ]; then
   # ICU 57 and following. Drop the BOM
-  licenseText="$(sed -e '1s/^[^a-zA-Z ]*ICU/ICU/' -e :a -e 's/<[^>]*>//g;s/	/ /g;s/ +$//;/</N;//ba' "${rootdir}"/deps/icu-small/LICENSE)"
+  licenseText="$(sed -e '1s/^[^a-zA-Z ]*ICU/ICU/' -e :a -e 's/<[^>]*>//g;s/	/ /g;s/ +$//;/</N;//ba' "${rootdir}/deps/icu-small/LICENSE")"
   addlicense "ICU" "deps/icu-small" "$licenseText"
 elif [ -f "${rootdir}/deps/icu-small/license.html" ]; then
   # ICU 56 and prior
-  licenseText="$(sed -e '1,/ICU License - ICU 1\.8\.1 and later/d' -e :a -e 's/<[^>]*>//g;s/	/ /g;s/ +$//;/</N;//ba' "${rootdir}"/deps/icu-small/license.html)"
+  licenseText="$(sed -e '1,/ICU License - ICU 1\.8\.1 and later/d' -e :a -e 's/<[^>]*>//g;s/	/ /g;s/ +$//;/</N;//ba' "${rootdir}/deps/icu-small/license.html")"
   addlicense "ICU" "deps/icu-small" "$licenseText"
 else
   echo "Could not find an ICU license file."
   exit 1
 fi
 
-licenseText="$(cat "${rootdir}"/deps/uv/LICENSE)"
+licenseText="$(cat "${rootdir}/deps/uv/LICENSE")"
 addlicense "libuv" "deps/uv" "$licenseText"
 licenseText="$(cat deps/llhttp/LICENSE-MIT)"
 addlicense "llhttp" "deps/llhttp" "$licenseText"
-licenseText="$(cat "${rootdir}"/deps/corepack/LICENSE.md)"
+licenseText="$(cat "${rootdir}/deps/corepack/LICENSE.md")"
 addlicense "corepack" "deps/corepack" "$licenseText"
-licenseText="$(cat "${rootdir}"/deps/undici/LICENSE)"
+licenseText="$(cat "${rootdir}/deps/undici/LICENSE")"
 addlicense "undici" "deps/undici" "$licenseText"
-licenseText="$(cat "${rootdir}"/deps/openssl/openssl/LICENSE.txt)"
+licenseText="$(cat "${rootdir}/deps/openssl/openssl/LICENSE.txt")"
 addlicense "OpenSSL" "deps/openssl" "$licenseText"
 licenseText="$(curl -sL https://raw.githubusercontent.com/bestiejs/punycode.js/HEAD/LICENSE-MIT.txt)"
 addlicense "Punycode.js" "lib/punycode.js" "$licenseText"
-licenseText="$(cat "${rootdir}"/deps/v8/LICENSE)"
+licenseText="$(cat "${rootdir}/deps/v8/LICENSE")"
 addlicense "V8" "deps/v8" "$licenseText"
 licenseText="$(sed -e '/You should have received a copy of the CC0/,$d' -e 's/^\/\* *//' -e 's/^ \* *//' deps/v8/src/third_party/siphash/halfsiphash.cc)"
 addlicense "SipHash" "deps/v8/src/third_party/siphash" "$licenseText"
-licenseText="$(sed -e '/The data format used by the zlib library/,$d' -e 's/^\/\* *//' -e 's/^ *//' "${rootdir}"/deps/zlib/zlib.h)"
+licenseText="$(sed -e '/The data format used by the zlib library/,$d' -e 's/^\/\* *//' -e 's/^ *//' "${rootdir}/deps/zlib/zlib.h")"
 addlicense "zlib" "deps/zlib" "$licenseText"
 
 # npm
-licenseText="$(cat "${rootdir}"/deps/npm/LICENSE)"
+licenseText="$(cat "${rootdir}/deps/npm/LICENSE")"
 addlicense "npm" "deps/npm" "$licenseText"
 
 # Build tools
-licenseText="$(cat "${rootdir}"/tools/gyp/LICENSE)"
+licenseText="$(cat "${rootdir}/tools/gyp/LICENSE")"
 addlicense "GYP" "tools/gyp" "$licenseText"
-licenseText="$(cat "${rootdir}"/tools/inspector_protocol/LICENSE)"
+licenseText="$(cat "${rootdir}/tools/inspector_protocol/LICENSE")"
 addlicense "inspector_protocol" "tools/inspector_protocol" "$licenseText"
-licenseText="$(cat "${rootdir}"/tools/inspector_protocol/jinja2/LICENSE)"
+licenseText="$(cat "${rootdir}/tools/inspector_protocol/jinja2/LICENSE")"
 addlicense "jinja2" "tools/inspector_protocol/jinja2" "$licenseText"
-licenseText="$(cat "${rootdir}"/tools/inspector_protocol/markupsafe/LICENSE)"
+licenseText="$(cat "${rootdir}/tools/inspector_protocol/markupsafe/LICENSE")"
 addlicense "markupsafe" "tools/inspector_protocol/markupsafe" "$licenseText"
 
 # Testing tools
-licenseText="$(sed -e '/^$/,$d' -e 's/^#$//' -e 's/^# //' "${rootdir}"/tools/cpplint.py | tail -n +3)"
+licenseText="$(sed -e '/^$/,$d' -e 's/^#$//' -e 's/^# //' "${rootdir}/tools/cpplint.py | tail -n +3")"
 addlicense "cpplint.py" "tools/cpplint.py" "$licenseText"
-licenseText="$(cat "${rootdir}"/tools/node_modules/eslint/LICENSE)"
+licenseText="$(cat "${rootdir}/tools/node_modules/eslint/LICENSE")"
 addlicense "ESLint" "tools/node_modules/eslint" "$licenseText"
-licenseText="$(cat "${rootdir}"/deps/googletest/LICENSE)"
+licenseText="$(cat "${rootdir}/deps/googletest/LICENSE")"
 addlicense "gtest" "deps/googletest" "$licenseText"
 
 # nghttp2
-licenseText="$(cat "${rootdir}"/deps/nghttp2/COPYING)"
+licenseText="$(cat "${rootdir}/deps/nghttp2/COPYING")"
 addlicense "nghttp2" "deps/nghttp2" "$licenseText"
 
 # large_pages
-licenseText="$(sed -e '/SPDX-License-Identifier/,$d' -e 's/^\/\///' "${rootdir}"/src/large_pages/node_large_page.h)"
+licenseText="$(sed -e '/SPDX-License-Identifier/,$d' -e 's/^\/\///' "${rootdir}/src/large_pages/node_large_page.h")"
 addlicense "large_pages" "src/large_pages" "$licenseText"
 
 # deep_freeze
-licenseText="$(sed -e '/SPDX-License-Identifier/,$d' -e 's/^\/\///' "${rootdir}"/lib/internal/freeze_intrinsics.js)"
+licenseText="$(sed -e '/SPDX-License-Identifier/,$d' -e 's/^\/\///' "${rootdir}/lib/internal/freeze_intrinsics.js")"
 addlicense "caja" "lib/internal/freeze_intrinsics.js" "$licenseText"
 
 # brotli
-licenseText="$(cat "${rootdir}"/deps/brotli/LICENSE)"
+licenseText="$(cat "${rootdir}/deps/brotli/LICENSE")"
 addlicense "brotli" "deps/brotli" "$licenseText"
 
-licenseText="$(cat "${rootdir}"/deps/histogram/LICENSE.txt)"
+licenseText="$(cat "${rootdir}/deps/histogram/LICENSE.txt")"
 addlicense "HdrHistogram" "deps/histogram" "$licenseText"
 
 licenseText="$(curl -sL https://raw.githubusercontent.com/highlightjs/highlight.js/63f367c46f2eeb6f9b7a3545e325eeeb917f9942/LICENSE)"
@@ -126,16 +126,16 @@ addlicense "node-heapdump" "src/heap_utils.cc" "$licenseText"
 licenseText="$(curl -sL https://raw.githubusercontent.com/isaacs/rimraf/0e365ac4e4d64a25aa2a3cc026348f13410210e1/LICENSE)"
 addlicense "rimraf" "lib/internal/fs/rimraf.js" "$licenseText"
 
-licenseText="$(cat "${rootdir}"/deps/uvwasi/LICENSE)"
+licenseText="$(cat "${rootdir}/deps/uvwasi/LICENSE")"
 addlicense "uvwasi" "deps/uvwasi" "$licenseText"
-licenseText="$(cat "${rootdir}"/deps/ngtcp2/LICENSE_ngtcp2)"
+licenseText="$(cat "${rootdir}/deps/ngtcp2/LICENSE_ngtcp2")"
 addlicense "ngtcp2" "deps/ngtcp2/ngtcp2/" "$licenseText"
-licenseText="$(cat "${rootdir}"/deps/ngtcp2/LICENSE_nghttp3)"
+licenseText="$(cat "${rootdir}/deps/ngtcp2/LICENSE_nghttp3")"
 addlicense "nghttp3" "deps/ngtcp2/nghttp3/" "$licenseText"
 
 licenseText="$(curl -sL https://raw.githubusercontent.com/jprichardson/node-fs-extra/b34da2762a4865b025cac06d02d6a2f1f1027b65/LICENSE)"
 addlicense "node-fs-extra" "lib/internal/fs/cp" "$licenseText"
 
-addlicense "base64" "deps/base64/base64/" "$(cat "${rootdir}"/deps/base64/base64/LICENSE)"
+addlicense "base64" "deps/base64/base64/" "$(cat "${rootdir}/deps/base64/base64/LICENSE" || true)"
 
 mv "$tmplicense" "$licensefile"

--- a/tools/update-cares.sh
+++ b/tools/update-cares.sh
@@ -2,8 +2,8 @@
 set -e
 # Shell script to update c-ares in the source tree to a specific version
 
-BASE_DIR="$( pwd )"/
-DEPS_DIR="$BASE_DIR"deps/
+BASE_DIR="$( pwd )"
+DEPS_DIR="$BASE_DIR/deps"
 ARES_VERSION=$1
 
 if [ "$#" -le 0 ]; then

--- a/tools/update-llhttp.sh
+++ b/tools/update-llhttp.sh
@@ -3,8 +3,8 @@ set -e
 
 # Shell script to update llhttp in the source tree to specific version
 
-BASE_DIR="$( pwd )"/
-DEPS_DIR="${BASE_DIR}deps/"
+BASE_DIR="$( pwd )"
+DEPS_DIR="${BASE_DIR}/deps"
 LLHTTP_VERSION="$1"
 
 if [ "$#" -le 0 ]; then

--- a/tools/update-nghttp2.sh
+++ b/tools/update-nghttp2.sh
@@ -2,8 +2,8 @@
 set -e
 # Shell script to update nghttp2 in the source tree to specific version
 
-BASE_DIR="$( pwd )"/
-DEPS_DIR="$BASE_DIR"deps/
+BASE_DIR="$( pwd )"
+DEPS_DIR="$BASE_DIR/deps"
 NGHTTP2_VERSION=$1
 
 if [ "$#" -le 0 ]; then

--- a/tools/update-npm.sh
+++ b/tools/update-npm.sh
@@ -2,8 +2,8 @@
 set -e
 # Shell script to update npm in the source tree to a specific version
 
-BASE_DIR="$( pwd )"/
-DEPS_DIR="$BASE_DIR"deps/
+BASE_DIR="$( pwd )"
+DEPS_DIR="$BASE_DIR/deps"
 NPM_VERSION=$1
 
 if [ "$#" -le 0 ]; then
@@ -40,7 +40,7 @@ rm -rf npm/
 
 echo "Copying new npm"
 
-tar zxf "$WORKSPACE"/cli/release/npm-"$NPM_VERSION".tgz
+tar zxf "$WORKSPACE/cli/release/npm-$NPM_VERSION.tgz"
 
 echo ""
 echo "All done!"


### PR DESCRIPTION
IMHO it's much easier to read the code when the whole string goes in one chunk, rather than having unnecessary concatenation – and that seems to work better with syntax highlighting as well.

E.g. if find https://github.com/nodejs/node/blob/b585516eb8fb55f75e356965b4ea09237bbb30fd/tools/update-npm.sh#L43 more readable than https://github.com/nodejs/node/blob/b6c6cc70009d5f09400e9bb72a41ca32793c9fe9/tools/update-npm.sh#L43
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
