### PR TITLE
[v14.x backport] loader: make `require.resolve` throw for unknown builtin modules

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -743,19 +743,19 @@ Module._load = function(request, parent, isMain) {
     }
   }
 
-  const filename = Module._resolveFilename(request, parent, isMain);
-  if (StringPrototypeStartsWith(filename, 'node:')) {
+  if (StringPrototypeStartsWith(request, 'node:')) {
     // Slice 'node:' prefix
-    const id = StringPrototypeSlice(filename, 5);
+    const id = StringPrototypeSlice(request, 5);
 
     const module = loadNativeModule(id, request);
     if (!module?.canBeRequiredByUsers) {
-      throw new ERR_UNKNOWN_BUILTIN_MODULE(filename);
+      throw new ERR_UNKNOWN_BUILTIN_MODULE(request);
     }
 
     return module.exports;
   }
 
+  const filename = Module._resolveFilename(request, parent, isMain);
   const cachedModule = Module._cache[filename];
   if (cachedModule !== undefined) {
     updateChildren(parent, cachedModule, true);
@@ -814,8 +814,12 @@ Module._load = function(request, parent, isMain) {
 };
 
 Module._resolveFilename = function(request, parent, isMain, options) {
-  if (StringPrototypeStartsWith(request, 'node:') ||
-      NativeModule.canBeRequiredByUsers(request)) {
+  if (
+    (
+      StringPrototypeStartsWith(request, 'node:') &&
+      NativeModule.canBeRequiredByUsers(StringPrototypeSlice(request, 5))
+    ) || NativeModule.canBeRequiredByUsers(request)
+  ) {
     return request;
   }
 

--- a/test/parallel/test-require-resolve.js
+++ b/test/parallel/test-require-resolve.js
@@ -80,3 +80,13 @@ require(fixtures.path('resolve-paths', 'default', 'verify-paths.js'));
     assert.strictEqual(resolvedPaths.includes('/node_modules'), false);
   });
 }
+
+{
+  assert.strictEqual(require.resolve('https'), 'https');
+  assert.strictEqual(require.resolve('fs'), 'fs');
+
+  assert.throws(
+    () => require.resolve('unknown'),
+    { code: 'MODULE_NOT_FOUND' },
+  );
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Backports https://github.com/nodejs/node/pull/43336