### PR TITLE
[v16.x] deps: update OpenSSL 1.1.1s+quic

### DIFF
--- a/deps/openssl/config/archs/BSD-x86/asm/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "BSD-x86",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/BSD-x86/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86"
-#define DATE "built on: Tue Jul  5 15:02:24 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:45 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/BSD-x86/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "BSD-x86",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/BSD-x86/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86"
-#define DATE "built on: Tue Jul  5 15:02:26 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:47 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/BSD-x86/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86/no-asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "BSD-x86",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/BSD-x86/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86"
-#define DATE "built on: Tue Jul  5 15:02:28 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:49 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/BSD-x86_64/asm/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86_64/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "BSD-x86_64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/BSD-x86_64/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86_64/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86_64"
-#define DATE "built on: Tue Jul  5 15:02:29 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:50 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/BSD-x86_64/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86_64/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "BSD-x86_64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/BSD-x86_64/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86_64/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86_64"
-#define DATE "built on: Tue Jul  5 15:02:34 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:54 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/BSD-x86_64/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/BSD-x86_64/no-asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "BSD-x86_64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/BSD-x86_64/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/BSD-x86_64/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: BSD-x86_64"
-#define DATE "built on: Tue Jul  5 15:02:38 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:59 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN32/asm/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN32/asm/configdata.pm
@@ -115,8 +115,8 @@ our %config = (
   sourcedir => ".",
   target => "VC-WIN32",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (
@@ -132,7 +132,7 @@ our %target = (
   LDFLAGS => "/nologo /debug",
   MT => "mt",
   MTFLAGS => "-nologo",
-  RANLIB => "CODE(0x559678e64ef8)",
+  RANLIB => "CODE(0x564ed4fa0b78)",
   RC => "rc",
   _conf_fname_int => [ "Configurations/00-base-templates.conf", "Configurations/00-base-templates.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/00-base-templates.conf", "Configurations/10-main.conf", "Configurations/shared-info.pl" ],
   aes_asm_src => "aes_core.c aes_cbc.c vpaes-x86.s aesni-x86.s",

--- a/deps/openssl/config/archs/VC-WIN32/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN32/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Tue Jul  5 15:04:18 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:39 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN32/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN32/asm_avx2/configdata.pm
@@ -115,8 +115,8 @@ our %config = (
   sourcedir => ".",
   target => "VC-WIN32",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (
@@ -132,7 +132,7 @@ our %target = (
   LDFLAGS => "/nologo /debug",
   MT => "mt",
   MTFLAGS => "-nologo",
-  RANLIB => "CODE(0x563ad0697608)",
+  RANLIB => "CODE(0x55efb3826888)",
   RC => "rc",
   _conf_fname_int => [ "Configurations/00-base-templates.conf", "Configurations/00-base-templates.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/00-base-templates.conf", "Configurations/10-main.conf", "Configurations/shared-info.pl" ],
   aes_asm_src => "aes_core.c aes_cbc.c vpaes-x86.s aesni-x86.s",

--- a/deps/openssl/config/archs/VC-WIN32/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN32/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Tue Jul  5 15:04:20 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:41 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN32/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN32/no-asm/configdata.pm
@@ -114,8 +114,8 @@ our %config = (
   sourcedir => ".",
   target => "VC-WIN32",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (
@@ -131,7 +131,7 @@ our %target = (
   LDFLAGS => "/nologo /debug",
   MT => "mt",
   MTFLAGS => "-nologo",
-  RANLIB => "CODE(0x556fff3f0a98)",
+  RANLIB => "CODE(0x565161954908)",
   RC => "rc",
   _conf_fname_int => [ "Configurations/00-base-templates.conf", "Configurations/00-base-templates.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/shared-info.pl" ],
   aes_asm_src => "aes_core.c aes_cbc.c",

--- a/deps/openssl/config/archs/VC-WIN32/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN32/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Tue Jul  5 15:04:22 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:43 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/configdata.pm
@@ -113,8 +113,8 @@ our %config = (
   sourcedir => ".",
   target => "VC-WIN64-ARM",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (
@@ -128,7 +128,7 @@ our %target = (
   LDFLAGS => "/nologo /debug",
   MT => "mt",
   MTFLAGS => "-nologo",
-  RANLIB => "CODE(0x55ace5816308)",
+  RANLIB => "CODE(0x5640c6dbcd98)",
   RC => "rc",
   _conf_fname_int => [ "Configurations/00-base-templates.conf", "Configurations/00-base-templates.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/50-win-onecore.conf", "Configurations/shared-info.pl" ],
   aes_asm_src => "aes_core.c aes_cbc.c",

--- a/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN64-ARM/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: VC-WIN64-ARM"
-#define DATE "built on: Tue Jul  5 15:04:23 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:44 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN64A/asm/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN64A/asm/configdata.pm
@@ -116,8 +116,8 @@ our %config = (
   sourcedir => ".",
   target => "VC-WIN64A",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (
@@ -133,7 +133,7 @@ our %target = (
   LDFLAGS => "/nologo /debug",
   MT => "mt",
   MTFLAGS => "-nologo",
-  RANLIB => "CODE(0x56273ae20468)",
+  RANLIB => "CODE(0x5623689e4c68)",
   RC => "rc",
   _conf_fname_int => [ "Configurations/00-base-templates.conf", "Configurations/00-base-templates.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/00-base-templates.conf", "Configurations/10-main.conf", "Configurations/shared-info.pl" ],
   aes_asm_src => "aes_core.c aes_cbc.c vpaes-x86_64.s aesni-x86_64.s aesni-sha1-x86_64.s aesni-sha256-x86_64.s aesni-mb-x86_64.s",

--- a/deps/openssl/config/archs/VC-WIN64A/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN64A/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Tue Jul  5 15:04:08 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:30 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN64A/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN64A/asm_avx2/configdata.pm
@@ -116,8 +116,8 @@ our %config = (
   sourcedir => ".",
   target => "VC-WIN64A",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (
@@ -133,7 +133,7 @@ our %target = (
   LDFLAGS => "/nologo /debug",
   MT => "mt",
   MTFLAGS => "-nologo",
-  RANLIB => "CODE(0x562ee243ee48)",
+  RANLIB => "CODE(0x55c94531b138)",
   RC => "rc",
   _conf_fname_int => [ "Configurations/00-base-templates.conf", "Configurations/00-base-templates.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/00-base-templates.conf", "Configurations/10-main.conf", "Configurations/shared-info.pl" ],
   aes_asm_src => "aes_core.c aes_cbc.c vpaes-x86_64.s aesni-x86_64.s aesni-sha1-x86_64.s aesni-sha256-x86_64.s aesni-mb-x86_64.s",

--- a/deps/openssl/config/archs/VC-WIN64A/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN64A/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Tue Jul  5 15:04:13 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:34 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/VC-WIN64A/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/VC-WIN64A/no-asm/configdata.pm
@@ -115,8 +115,8 @@ our %config = (
   sourcedir => ".",
   target => "VC-WIN64A",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (
@@ -132,7 +132,7 @@ our %target = (
   LDFLAGS => "/nologo /debug",
   MT => "mt",
   MTFLAGS => "-nologo",
-  RANLIB => "CODE(0x5639f0faa118)",
+  RANLIB => "CODE(0x5638b3ddd4e8)",
   RC => "rc",
   _conf_fname_int => [ "Configurations/00-base-templates.conf", "Configurations/00-base-templates.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/10-main.conf", "Configurations/shared-info.pl" ],
   aes_asm_src => "aes_core.c aes_cbc.c",

--- a/deps/openssl/config/archs/VC-WIN64A/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/VC-WIN64A/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: "
-#define DATE "built on: Tue Jul  5 15:04:17 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:38 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/aix-gcc/asm/configdata.pm
+++ b/deps/openssl/config/archs/aix-gcc/asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "aix-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/aix-gcc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/aix-gcc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: aix-gcc"
-#define DATE "built on: Tue Jul  5 15:02:14 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:36 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/aix-gcc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/aix-gcc/asm_avx2/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "aix-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/aix-gcc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/aix-gcc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: aix-gcc"
-#define DATE "built on: Tue Jul  5 15:02:16 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:38 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/aix-gcc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/aix-gcc/no-asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "aix-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/aix-gcc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/aix-gcc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: aix-gcc"
-#define DATE "built on: Tue Jul  5 15:02:17 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:40 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/aix64-gcc/asm/configdata.pm
+++ b/deps/openssl/config/archs/aix64-gcc/asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "aix64-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/aix64-gcc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/aix64-gcc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: aix64-gcc"
-#define DATE "built on: Tue Jul  5 15:02:19 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:41 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/aix64-gcc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/aix64-gcc/asm_avx2/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "aix64-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/aix64-gcc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/aix64-gcc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: aix64-gcc"
-#define DATE "built on: Tue Jul  5 15:02:21 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:42 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/aix64-gcc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/aix64-gcc/no-asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "aix64-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/aix64-gcc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/aix64-gcc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: aix64-gcc"
-#define DATE "built on: Tue Jul  5 15:02:23 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:56:44 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin-i386-cc/asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin-i386-cc/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "darwin-i386-cc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/darwin-i386-cc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin-i386-cc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin-i386-cc"
-#define DATE "built on: Tue Jul  5 15:02:49 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:11 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin-i386-cc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/darwin-i386-cc/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "darwin-i386-cc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/darwin-i386-cc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin-i386-cc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin-i386-cc"
-#define DATE "built on: Tue Jul  5 15:02:52 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:13 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin-i386-cc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin-i386-cc/no-asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "darwin-i386-cc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/darwin-i386-cc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin-i386-cc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin-i386-cc"
-#define DATE "built on: Tue Jul  5 15:02:54 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:15 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-arm64-cc/asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "darwin64-arm64-cc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/darwin64-arm64-cc/asm/crypto/aes/aesv8-armx.S
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/asm/crypto/aes/aesv8-armx.S
@@ -599,17 +599,17 @@ _aes_v8_ctr32_encrypt_blocks:
 #ifndef __ARMEB__
 	rev	w8, w8
 #endif
+	orr	v1.16b,v0.16b,v0.16b
 	add	w10, w8, #1
+	orr	v18.16b,v0.16b,v0.16b
+	add	w8, w8, #2
 	orr	v6.16b,v0.16b,v0.16b
 	rev	w10, w10
-	mov	v6.s[3],w10
-	add	w8, w8, #2
-	orr	v1.16b,v6.16b,v6.16b
+	mov	v1.s[3],w10
 	b.ls	Lctr32_tail
 	rev	w12, w8
-	mov	v6.s[3],w12
 	sub	x2,x2,#3		// bias
-	orr	v18.16b,v6.16b,v6.16b
+	mov	v18.s[3],w12
 	b	Loop3x_ctr32
 
 .align	4
@@ -636,11 +636,11 @@ Loop3x_ctr32:
 	aese	v1.16b,v16.16b
 	aesmc	v5.16b,v1.16b
 	ld1	{v2.16b},[x0],#16
-	add	w9,w8,#1
+	orr	v0.16b,v6.16b,v6.16b
 	aese	v18.16b,v16.16b
 	aesmc	v18.16b,v18.16b
 	ld1	{v3.16b},[x0],#16
-	rev	w9,w9
+	orr	v1.16b,v6.16b,v6.16b
 	aese	v4.16b,v17.16b
 	aesmc	v4.16b,v4.16b
 	aese	v5.16b,v17.16b
@@ -649,6 +649,8 @@ Loop3x_ctr32:
 	mov	x7,x3
 	aese	v18.16b,v17.16b
 	aesmc	v17.16b,v18.16b
+	orr	v18.16b,v6.16b,v6.16b
+	add	w9,w8,#1
 	aese	v4.16b,v20.16b
 	aesmc	v4.16b,v4.16b
 	aese	v5.16b,v20.16b
@@ -664,22 +666,20 @@ Loop3x_ctr32:
 	aese	v5.16b,v21.16b
 	aesmc	v5.16b,v5.16b
 	eor	v19.16b,v19.16b,v7.16b
-	mov	v6.s[3], w9
+	rev	w9,w9
 	aese	v17.16b,v21.16b
 	aesmc	v17.16b,v17.16b
-	orr	v0.16b,v6.16b,v6.16b
+	mov	v0.s[3], w9
 	rev	w10,w10
 	aese	v4.16b,v22.16b
 	aesmc	v4.16b,v4.16b
-	mov	v6.s[3], w10
-	rev	w12,w8
 	aese	v5.16b,v22.16b
 	aesmc	v5.16b,v5.16b
-	orr	v1.16b,v6.16b,v6.16b
-	mov	v6.s[3], w12
+	mov	v1.s[3], w10
+	rev	w12,w8
 	aese	v17.16b,v22.16b
 	aesmc	v17.16b,v17.16b
-	orr	v18.16b,v6.16b,v6.16b
+	mov	v18.s[3], w12
 	subs	x2,x2,#3
 	aese	v4.16b,v23.16b
 	aese	v5.16b,v23.16b

--- a/deps/openssl/config/archs/darwin64-arm64-cc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-arm64-cc"
-#define DATE "built on: Tue Jul  5 15:02:55 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:16 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-arm64-cc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/asm_avx2/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "darwin64-arm64-cc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/darwin64-arm64-cc/asm_avx2/crypto/aes/aesv8-armx.S
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/asm_avx2/crypto/aes/aesv8-armx.S
@@ -599,17 +599,17 @@ _aes_v8_ctr32_encrypt_blocks:
 #ifndef __ARMEB__
 	rev	w8, w8
 #endif
+	orr	v1.16b,v0.16b,v0.16b
 	add	w10, w8, #1
+	orr	v18.16b,v0.16b,v0.16b
+	add	w8, w8, #2
 	orr	v6.16b,v0.16b,v0.16b
 	rev	w10, w10
-	mov	v6.s[3],w10
-	add	w8, w8, #2
-	orr	v1.16b,v6.16b,v6.16b
+	mov	v1.s[3],w10
 	b.ls	Lctr32_tail
 	rev	w12, w8
-	mov	v6.s[3],w12
 	sub	x2,x2,#3		// bias
-	orr	v18.16b,v6.16b,v6.16b
+	mov	v18.s[3],w12
 	b	Loop3x_ctr32
 
 .align	4
@@ -636,11 +636,11 @@ Loop3x_ctr32:
 	aese	v1.16b,v16.16b
 	aesmc	v5.16b,v1.16b
 	ld1	{v2.16b},[x0],#16
-	add	w9,w8,#1
+	orr	v0.16b,v6.16b,v6.16b
 	aese	v18.16b,v16.16b
 	aesmc	v18.16b,v18.16b
 	ld1	{v3.16b},[x0],#16
-	rev	w9,w9
+	orr	v1.16b,v6.16b,v6.16b
 	aese	v4.16b,v17.16b
 	aesmc	v4.16b,v4.16b
 	aese	v5.16b,v17.16b
@@ -649,6 +649,8 @@ Loop3x_ctr32:
 	mov	x7,x3
 	aese	v18.16b,v17.16b
 	aesmc	v17.16b,v18.16b
+	orr	v18.16b,v6.16b,v6.16b
+	add	w9,w8,#1
 	aese	v4.16b,v20.16b
 	aesmc	v4.16b,v4.16b
 	aese	v5.16b,v20.16b
@@ -664,22 +666,20 @@ Loop3x_ctr32:
 	aese	v5.16b,v21.16b
 	aesmc	v5.16b,v5.16b
 	eor	v19.16b,v19.16b,v7.16b
-	mov	v6.s[3], w9
+	rev	w9,w9
 	aese	v17.16b,v21.16b
 	aesmc	v17.16b,v17.16b
-	orr	v0.16b,v6.16b,v6.16b
+	mov	v0.s[3], w9
 	rev	w10,w10
 	aese	v4.16b,v22.16b
 	aesmc	v4.16b,v4.16b
-	mov	v6.s[3], w10
-	rev	w12,w8
 	aese	v5.16b,v22.16b
 	aesmc	v5.16b,v5.16b
-	orr	v1.16b,v6.16b,v6.16b
-	mov	v6.s[3], w12
+	mov	v1.s[3], w10
+	rev	w12,w8
 	aese	v17.16b,v22.16b
 	aesmc	v17.16b,v17.16b
-	orr	v18.16b,v6.16b,v6.16b
+	mov	v18.s[3], w12
 	subs	x2,x2,#3
 	aese	v4.16b,v23.16b
 	aese	v5.16b,v23.16b

--- a/deps/openssl/config/archs/darwin64-arm64-cc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-arm64-cc"
-#define DATE "built on: Tue Jul  5 15:02:57 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:18 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-arm64-cc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/no-asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "darwin64-arm64-cc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/darwin64-arm64-cc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-arm64-cc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-arm64-cc"
-#define DATE "built on: Tue Jul  5 15:02:59 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:20 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "darwin64-x86_64-cc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-x86_64-cc"
-#define DATE "built on: Tue Jul  5 15:02:39 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:00 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "darwin64-x86_64-cc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-x86_64-cc"
-#define DATE "built on: Tue Jul  5 15:02:44 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:05 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/no-asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "darwin64-x86_64-cc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/darwin64-x86_64-cc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/darwin64-x86_64-cc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: darwin64-x86_64-cc"
-#define DATE "built on: Tue Jul  5 15:02:48 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:10 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-aarch64/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-aarch64/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-aarch64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-aarch64/asm/crypto/aes/aesv8-armx.S
+++ b/deps/openssl/config/archs/linux-aarch64/asm/crypto/aes/aesv8-armx.S
@@ -599,17 +599,17 @@ aes_v8_ctr32_encrypt_blocks:
 #ifndef __ARMEB__
 	rev	w8, w8
 #endif
+	orr	v1.16b,v0.16b,v0.16b
 	add	w10, w8, #1
+	orr	v18.16b,v0.16b,v0.16b
+	add	w8, w8, #2
 	orr	v6.16b,v0.16b,v0.16b
 	rev	w10, w10
-	mov	v6.s[3],w10
-	add	w8, w8, #2
-	orr	v1.16b,v6.16b,v6.16b
+	mov	v1.s[3],w10
 	b.ls	.Lctr32_tail
 	rev	w12, w8
-	mov	v6.s[3],w12
 	sub	x2,x2,#3		// bias
-	orr	v18.16b,v6.16b,v6.16b
+	mov	v18.s[3],w12
 	b	.Loop3x_ctr32
 
 .align	4
@@ -636,11 +636,11 @@ aes_v8_ctr32_encrypt_blocks:
 	aese	v1.16b,v16.16b
 	aesmc	v5.16b,v1.16b
 	ld1	{v2.16b},[x0],#16
-	add	w9,w8,#1
+	orr	v0.16b,v6.16b,v6.16b
 	aese	v18.16b,v16.16b
 	aesmc	v18.16b,v18.16b
 	ld1	{v3.16b},[x0],#16
-	rev	w9,w9
+	orr	v1.16b,v6.16b,v6.16b
 	aese	v4.16b,v17.16b
 	aesmc	v4.16b,v4.16b
 	aese	v5.16b,v17.16b
@@ -649,6 +649,8 @@ aes_v8_ctr32_encrypt_blocks:
 	mov	x7,x3
 	aese	v18.16b,v17.16b
 	aesmc	v17.16b,v18.16b
+	orr	v18.16b,v6.16b,v6.16b
+	add	w9,w8,#1
 	aese	v4.16b,v20.16b
 	aesmc	v4.16b,v4.16b
 	aese	v5.16b,v20.16b
@@ -664,22 +666,20 @@ aes_v8_ctr32_encrypt_blocks:
 	aese	v5.16b,v21.16b
 	aesmc	v5.16b,v5.16b
 	eor	v19.16b,v19.16b,v7.16b
-	mov	v6.s[3], w9
+	rev	w9,w9
 	aese	v17.16b,v21.16b
 	aesmc	v17.16b,v17.16b
-	orr	v0.16b,v6.16b,v6.16b
+	mov	v0.s[3], w9
 	rev	w10,w10
 	aese	v4.16b,v22.16b
 	aesmc	v4.16b,v4.16b
-	mov	v6.s[3], w10
-	rev	w12,w8
 	aese	v5.16b,v22.16b
 	aesmc	v5.16b,v5.16b
-	orr	v1.16b,v6.16b,v6.16b
-	mov	v6.s[3], w12
+	mov	v1.s[3], w10
+	rev	w12,w8
 	aese	v17.16b,v22.16b
 	aesmc	v17.16b,v17.16b
-	orr	v18.16b,v6.16b,v6.16b
+	mov	v18.s[3], w12
 	subs	x2,x2,#3
 	aese	v4.16b,v23.16b
 	aese	v5.16b,v23.16b

--- a/deps/openssl/config/archs/linux-aarch64/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-aarch64/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-aarch64"
-#define DATE "built on: Tue Jul  5 15:03:00 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:21 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-aarch64/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-aarch64/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-aarch64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-aarch64/asm_avx2/crypto/aes/aesv8-armx.S
+++ b/deps/openssl/config/archs/linux-aarch64/asm_avx2/crypto/aes/aesv8-armx.S
@@ -599,17 +599,17 @@ aes_v8_ctr32_encrypt_blocks:
 #ifndef __ARMEB__
 	rev	w8, w8
 #endif
+	orr	v1.16b,v0.16b,v0.16b
 	add	w10, w8, #1
+	orr	v18.16b,v0.16b,v0.16b
+	add	w8, w8, #2
 	orr	v6.16b,v0.16b,v0.16b
 	rev	w10, w10
-	mov	v6.s[3],w10
-	add	w8, w8, #2
-	orr	v1.16b,v6.16b,v6.16b
+	mov	v1.s[3],w10
 	b.ls	.Lctr32_tail
 	rev	w12, w8
-	mov	v6.s[3],w12
 	sub	x2,x2,#3		// bias
-	orr	v18.16b,v6.16b,v6.16b
+	mov	v18.s[3],w12
 	b	.Loop3x_ctr32
 
 .align	4
@@ -636,11 +636,11 @@ aes_v8_ctr32_encrypt_blocks:
 	aese	v1.16b,v16.16b
 	aesmc	v5.16b,v1.16b
 	ld1	{v2.16b},[x0],#16
-	add	w9,w8,#1
+	orr	v0.16b,v6.16b,v6.16b
 	aese	v18.16b,v16.16b
 	aesmc	v18.16b,v18.16b
 	ld1	{v3.16b},[x0],#16
-	rev	w9,w9
+	orr	v1.16b,v6.16b,v6.16b
 	aese	v4.16b,v17.16b
 	aesmc	v4.16b,v4.16b
 	aese	v5.16b,v17.16b
@@ -649,6 +649,8 @@ aes_v8_ctr32_encrypt_blocks:
 	mov	x7,x3
 	aese	v18.16b,v17.16b
 	aesmc	v17.16b,v18.16b
+	orr	v18.16b,v6.16b,v6.16b
+	add	w9,w8,#1
 	aese	v4.16b,v20.16b
 	aesmc	v4.16b,v4.16b
 	aese	v5.16b,v20.16b
@@ -664,22 +666,20 @@ aes_v8_ctr32_encrypt_blocks:
 	aese	v5.16b,v21.16b
 	aesmc	v5.16b,v5.16b
 	eor	v19.16b,v19.16b,v7.16b
-	mov	v6.s[3], w9
+	rev	w9,w9
 	aese	v17.16b,v21.16b
 	aesmc	v17.16b,v17.16b
-	orr	v0.16b,v6.16b,v6.16b
+	mov	v0.s[3], w9
 	rev	w10,w10
 	aese	v4.16b,v22.16b
 	aesmc	v4.16b,v4.16b
-	mov	v6.s[3], w10
-	rev	w12,w8
 	aese	v5.16b,v22.16b
 	aesmc	v5.16b,v5.16b
-	orr	v1.16b,v6.16b,v6.16b
-	mov	v6.s[3], w12
+	mov	v1.s[3], w10
+	rev	w12,w8
 	aese	v17.16b,v22.16b
 	aesmc	v17.16b,v17.16b
-	orr	v18.16b,v6.16b,v6.16b
+	mov	v18.s[3], w12
 	subs	x2,x2,#3
 	aese	v4.16b,v23.16b
 	aese	v5.16b,v23.16b

--- a/deps/openssl/config/archs/linux-aarch64/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-aarch64/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-aarch64"
-#define DATE "built on: Tue Jul  5 15:03:02 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:23 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-aarch64/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-aarch64/no-asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-aarch64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-aarch64/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-aarch64/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-aarch64"
-#define DATE "built on: Tue Jul  5 15:03:04 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:24 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-armv4/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-armv4/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-armv4",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-armv4/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-armv4/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-armv4"
-#define DATE "built on: Tue Jul  5 15:03:05 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:25 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-armv4/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-armv4/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-armv4",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-armv4/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-armv4/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-armv4"
-#define DATE "built on: Tue Jul  5 15:03:07 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:27 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-armv4/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-armv4/no-asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-armv4",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-armv4/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-armv4/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-armv4"
-#define DATE "built on: Tue Jul  5 15:03:09 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:29 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-elf/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-elf/asm/configdata.pm
@@ -112,8 +112,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-elf",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-elf/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-elf/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-elf"
-#define DATE "built on: Tue Jul  5 15:03:10 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:30 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-elf/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-elf/asm_avx2/configdata.pm
@@ -112,8 +112,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-elf",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-elf/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-elf/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-elf"
-#define DATE "built on: Tue Jul  5 15:03:12 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:33 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-elf/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-elf/no-asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-elf",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-elf/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-elf/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-elf"
-#define DATE "built on: Tue Jul  5 15:03:14 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:35 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-ppc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-ppc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc"
-#define DATE "built on: Tue Jul  5 15:03:26 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:45 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-ppc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-ppc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc"
-#define DATE "built on: Tue Jul  5 15:03:27 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:47 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc/no-asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-ppc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-ppc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc"
-#define DATE "built on: Tue Jul  5 15:03:29 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:48 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc64/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc64/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-ppc64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-ppc64/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc64/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc64"
-#define DATE "built on: Tue Jul  5 15:03:30 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:50 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc64/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc64/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-ppc64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-ppc64/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc64/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc64"
-#define DATE "built on: Tue Jul  5 15:03:32 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:51 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc64/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc64/no-asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-ppc64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-ppc64/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc64/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc64"
-#define DATE "built on: Tue Jul  5 15:03:34 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:53 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc64le/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc64le/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-ppc64le",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-ppc64le/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc64le/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc64le"
-#define DATE "built on: Tue Jul  5 15:03:35 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:54 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc64le/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc64le/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-ppc64le",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-ppc64le/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc64le/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc64le"
-#define DATE "built on: Tue Jul  5 15:03:38 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:56 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-ppc64le/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-ppc64le/no-asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-ppc64le",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-ppc64le/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-ppc64le/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-ppc64le"
-#define DATE "built on: Tue Jul  5 15:03:39 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:58 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-x86_64/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-x86_64/asm/configdata.pm
@@ -112,8 +112,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-x86_64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-x86_64/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-x86_64/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-x86_64"
-#define DATE "built on: Tue Jul  5 15:03:16 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:36 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-x86_64/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux-x86_64/asm_avx2/configdata.pm
@@ -112,8 +112,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-x86_64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-x86_64/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-x86_64/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-x86_64"
-#define DATE "built on: Tue Jul  5 15:03:20 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:40 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux-x86_64/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux-x86_64/no-asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux-x86_64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux-x86_64/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux-x86_64/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux-x86_64"
-#define DATE "built on: Tue Jul  5 15:03:24 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:44 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux32-s390x/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux32-s390x/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux32-s390x",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux32-s390x/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux32-s390x/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux32-s390x"
-#define DATE "built on: Tue Jul  5 15:03:41 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:57:59 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux32-s390x/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux32-s390x/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux32-s390x",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux32-s390x/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux32-s390x/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux32-s390x"
-#define DATE "built on: Tue Jul  5 15:03:42 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:00 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux32-s390x/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux32-s390x/no-asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux32-s390x",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux32-s390x/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux32-s390x/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux32-s390x"
-#define DATE "built on: Tue Jul  5 15:03:44 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:02 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-mips64/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux64-mips64/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux64-mips64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux64-mips64/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-mips64/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-mips64"
-#define DATE "built on: Tue Jul  5 15:03:49 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:07 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-mips64/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux64-mips64/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux64-mips64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux64-mips64/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-mips64/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-mips64"
-#define DATE "built on: Tue Jul  5 15:03:50 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:08 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-mips64/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux64-mips64/no-asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux64-mips64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux64-mips64/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-mips64/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-mips64"
-#define DATE "built on: Tue Jul  5 15:03:52 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:09 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-riscv64/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux64-riscv64/no-asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux64-riscv64",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux64-riscv64/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-riscv64/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-riscv64"
-#define DATE "built on: Tue Jul  5 15:04:24 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:45 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-s390x/asm/configdata.pm
+++ b/deps/openssl/config/archs/linux64-s390x/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux64-s390x",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux64-s390x/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-s390x/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-s390x"
-#define DATE "built on: Tue Jul  5 15:03:45 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:03 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-s390x/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/linux64-s390x/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux64-s390x",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux64-s390x/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-s390x/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-s390x"
-#define DATE "built on: Tue Jul  5 15:03:46 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:04 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/linux64-s390x/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/linux64-s390x/no-asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "linux64-s390x",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/linux64-s390x/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/linux64-s390x/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: linux64-s390x"
-#define DATE "built on: Tue Jul  5 15:03:48 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:05 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris-x86-gcc/asm/configdata.pm
+++ b/deps/openssl/config/archs/solaris-x86-gcc/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "solaris-x86-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/solaris-x86-gcc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris-x86-gcc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris-x86-gcc"
-#define DATE "built on: Tue Jul  5 15:03:53 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:10 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris-x86-gcc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/solaris-x86-gcc/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "solaris-x86-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/solaris-x86-gcc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris-x86-gcc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris-x86-gcc"
-#define DATE "built on: Tue Jul  5 15:03:55 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:12 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris-x86-gcc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/solaris-x86-gcc/no-asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "solaris-x86-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/solaris-x86-gcc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris-x86-gcc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris-x86-gcc"
-#define DATE "built on: Tue Jul  5 15:03:57 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:16 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/asm/configdata.pm
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/asm/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "solaris64-x86_64-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris64-x86_64-gcc"
-#define DATE "built on: Tue Jul  5 15:03:58 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:17 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/asm_avx2/configdata.pm
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/asm_avx2/configdata.pm
@@ -111,8 +111,8 @@ our %config = (
   sourcedir => ".",
   target => "solaris64-x86_64-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/asm_avx2/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/asm_avx2/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris64-x86_64-gcc"
-#define DATE "built on: Tue Jul  5 15:04:03 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:22 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/no-asm/configdata.pm
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/no-asm/configdata.pm
@@ -110,8 +110,8 @@ our %config = (
   sourcedir => ".",
   target => "solaris64-x86_64-gcc",
   tdirs => [ "ossl_shim" ],
-  version => "1.1.1q+quic",
-  version_num => "0x1010111fL",
+  version => "1.1.1s+quic",
+  version_num => "0x1010113fL",
 );
 
 our %target = (

--- a/deps/openssl/config/archs/solaris64-x86_64-gcc/no-asm/crypto/buildinf.h
+++ b/deps/openssl/config/archs/solaris64-x86_64-gcc/no-asm/crypto/buildinf.h
@@ -11,7 +11,7 @@
  */
 
 #define PLATFORM "platform: solaris64-x86_64-gcc"
-#define DATE "built on: Tue Jul  5 15:04:07 2022 UTC"
+#define DATE "built on: Wed Nov  2 12:58:29 2022 UTC"
 
 /*
  * Generate compiler_flags as an array of individual characters. This is a

--- a/deps/openssl/openssl/CHANGES
+++ b/deps/openssl/openssl/CHANGES
@@ -7,6 +7,52 @@
  https://github.com/openssl/openssl/commits/ and pick the appropriate
  release branch.
 
+ Changes between 1.1.1r and 1.1.1s [1 Nov 2022]
+
+  *) Fixed a regression introduced in 1.1.1r version not refreshing the
+     certificate data to be signed before signing the certificate.
+
+     [Gibeom Gwon]
+
+ Changes between 1.1.1q and 1.1.1r [11 Oct 2022]
+
+  *) Fixed the linux-mips64 Configure target which was missing the
+     SIXTY_FOUR_BIT bn_ops flag. This was causing heap corruption on that
+     platform.
+     [Adam Joseph]
+
+  *) Fixed a strict aliasing problem in bn_nist. Clang-14 optimisation was
+     causing incorrect results in some cases as a result.
+     [Paul Dale]
+
+  *) Fixed SSL_pending() and SSL_has_pending() with DTLS which were failing to
+     report correct results in some cases
+     [Matt Caswell]
+
+  *) Fixed a regression introduced in 1.1.1o for re-signing certificates with
+     different key sizes
+     [Todd Short]
+
+  *) Added the loongarch64 target
+     [Shi Pujin]
+
+  *) Fixed a DRBG seed propagation thread safety issue
+     [Bernd Edlinger]
+
+  *) Fixed a memory leak in tls13_generate_secret
+     [Bernd Edlinger]
+
+  *) Fixed reported performance degradation on aarch64. Restored the
+     implementation prior to commit 2621751 ("aes/asm/aesv8-armx.pl: avoid
+     32-bit lane assignment in CTR mode") for 64bit targets only, since it is
+     reportedly 2-17% slower and the silicon errata only affects 32bit targets.
+     The new algorithm is still used for 32 bit targets.
+     [Bernd Edlinger]
+
+  *) Added a missing header for memcmp that caused compilation failure on some
+     platforms
+     [Gregor Jasny]
+
  Changes between 1.1.1p and 1.1.1q [5 Jul 2022]
 
   *) AES OCB mode for 32-bit x86 platforms using the AES-NI assembly optimised

--- a/deps/openssl/openssl/Configurations/10-main.conf
+++ b/deps/openssl/openssl/Configurations/10-main.conf
@@ -742,7 +742,7 @@ my %targets = (
         inherit_from     => [ "linux-generic32", asm("mips64_asm") ],
         cflags           => add("-mabi=n32"),
         cxxflags         => add("-mabi=n32"),
-        bn_ops           => "RC4_CHAR",
+        bn_ops           => "RC4_CHAR SIXTY_FOUR_BIT",
         perlasm_scheme   => "n32",
         multilib         => "32",
     },
@@ -757,6 +757,13 @@ my %targets = (
     # riscv64 below refers to contemporary RISCV Architecture
     # specifications,
     "linux64-riscv64" => {
+        inherit_from     => [ "linux-generic64"],
+        perlasm_scheme   => "linux64",
+    },
+
+    # loongarch64 below refers to contemporary LoongArch Architecture
+    # specifications,
+    "linux64-loongarch64" => {
         inherit_from     => [ "linux-generic64"],
         perlasm_scheme   => "linux64",
     },

--- a/deps/openssl/openssl/NEWS
+++ b/deps/openssl/openssl/NEWS
@@ -5,6 +5,16 @@
   This file gives a brief overview of the major changes between each OpenSSL
   release. For more details please read the CHANGES file.
 
+  Major changes between OpenSSL 1.1.1r and OpenSSL 1.1.1s [1 Nov 2022]
+
+      o Fixed a regression introduced in OpenSSL 1.1.1r not refreshing the
+        certificate data to be signed before signing the certificate.
+
+  Major changes between OpenSSL 1.1.1q and OpenSSL 1.1.1r [11 Oct 2022]
+
+      o Added a missing header for memcmp that caused compilation failure on
+        some platforms
+
   Major changes between OpenSSL 1.1.1p and OpenSSL 1.1.1q [5 Jul 2022]
 
       o Fixed AES OCB failure to encrypt some bytes on 32-bit x86 platforms

--- a/deps/openssl/openssl/README-OpenSSL.md
+++ b/deps/openssl/openssl/README-OpenSSL.md
@@ -1,5 +1,5 @@
 
- OpenSSL 1.1.1q 5 Jul 2022
+ OpenSSL 1.1.1s 1 Nov 2022
 
  Copyright (c) 1998-2022 The OpenSSL Project
  Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson

--- a/deps/openssl/openssl/README.md
+++ b/deps/openssl/openssl/README.md
@@ -4,7 +4,7 @@ What This Is
 This is a fork of [OpenSSL](https://www.openssl.org) to enable QUIC. In addition
 to the website, the official source distribution is at
 <https://github.com/openssl/openssl>. The OpenSSL `README` can be found at
-[README-OpenSSL.md](https://github.com/quictls/openssl/blob/OpenSSL_1_1_1q%2Bquic/README-OpenSSL.md).
+[README-OpenSSL.md](https://github.com/quictls/openssl/blob/OpenSSL_1_1_1s%2Bquic/README-OpenSSL.md).
 
 This fork adds APIs that can be used by QUIC implementations for connection
 handshakes. Quoting the IETF Working group

--- a/deps/openssl/openssl/apps/apps.c
+++ b/deps/openssl/openssl/apps/apps.c
@@ -1376,7 +1376,8 @@ static IMPLEMENT_LHASH_HASH_FN(index_name, OPENSSL_CSTRING)
 static IMPLEMENT_LHASH_COMP_FN(index_name, OPENSSL_CSTRING)
 #undef BSIZE
 #define BSIZE 256
-BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
+BIGNUM *load_serial(const char *serialfile, int *exists, int create,
+                    ASN1_INTEGER **retai)
 {
     BIO *in = NULL;
     BIGNUM *ret = NULL;
@@ -1388,6 +1389,8 @@ BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
         goto err;
 
     in = BIO_new_file(serialfile, "r");
+    if (exists != NULL)
+        *exists = in != NULL;
     if (in == NULL) {
         if (!create) {
             perror(serialfile);
@@ -1395,8 +1398,14 @@ BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
         }
         ERR_clear_error();
         ret = BN_new();
-        if (ret == NULL || !rand_serial(ret, ai))
+        if (ret == NULL) {
             BIO_printf(bio_err, "Out of memory\n");
+        } else if (!rand_serial(ret, ai)) {
+            BIO_printf(bio_err, "Error creating random number to store in %s\n",
+                       serialfile);
+            BN_free(ret);
+            ret = NULL;
+        }
     } else {
         if (!a2i_ASN1_INTEGER(in, ai, buf, 1024)) {
             BIO_printf(bio_err, "unable to load number from %s\n",
@@ -1416,6 +1425,8 @@ BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
         ai = NULL;
     }
  err:
+    if (ret == NULL)
+        ERR_print_errors(bio_err);
     BIO_free(in);
     ASN1_INTEGER_free(ai);
     return ret;

--- a/deps/openssl/openssl/apps/apps.h
+++ b/deps/openssl/openssl/apps/apps.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -527,9 +527,12 @@ typedef struct ca_db_st {
 } CA_DB;
 
 void* app_malloc(int sz, const char *what);
-BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai);
-int save_serial(const char *serialfile, const char *suffix, const BIGNUM *serial,
-                ASN1_INTEGER **retai);
+
+/* load_serial, save_serial, and rotate_serial are also used for CRL numbers */
+BIGNUM *load_serial(const char *serialfile, int *exists, int create,
+                    ASN1_INTEGER **retai);
+int save_serial(const char *serialfile, const char *suffix,
+                const BIGNUM *serial, ASN1_INTEGER **retai);
 int rotate_serial(const char *serialfile, const char *new_suffix,
                   const char *old_suffix);
 int rand_serial(BIGNUM *b, ASN1_INTEGER *ai);

--- a/deps/openssl/openssl/apps/ca.c
+++ b/deps/openssl/openssl/apps/ca.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -842,7 +842,8 @@ end_of_options:
                 goto end;
             }
         } else {
-            if ((serial = load_serial(serialfile, create_ser, NULL)) == NULL) {
+            serial = load_serial(serialfile, NULL, create_ser, NULL);
+            if (serial == NULL) {
                 BIO_printf(bio_err, "error while loading serial number\n");
                 goto end;
             }
@@ -1078,7 +1079,8 @@ end_of_options:
 
         if ((crlnumberfile = NCONF_get_string(conf, section, ENV_CRLNUMBER))
             != NULL)
-            if ((crlnumber = load_serial(crlnumberfile, 0, NULL)) == NULL) {
+            if ((crlnumber = load_serial(crlnumberfile, NULL, 0, NULL))
+                == NULL) {
                 BIO_printf(bio_err, "error while loading CRL number\n");
                 goto end;
             }

--- a/deps/openssl/openssl/apps/ocsp.c
+++ b/deps/openssl/openssl/apps/ocsp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2001-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -176,7 +176,7 @@ const OPTIONS ocsp_options[] = {
     {"no_intern", OPT_NO_INTERN, '-',
      "Don't search certificates contained in response for signer"},
     {"badsig", OPT_BADSIG, '-',
-        "Corrupt last byte of loaded OSCP response signature (for test)"},
+        "Corrupt last byte of loaded OCSP response signature (for test)"},
     {"text", OPT_TEXT, '-', "Print text form of request and response"},
     {"req_text", OPT_REQ_TEXT, '-', "Print text form of request"},
     {"resp_text", OPT_RESP_TEXT, '-', "Print text form of response"},

--- a/deps/openssl/openssl/apps/s_cb.c
+++ b/deps/openssl/openssl/apps/s_cb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -74,22 +74,28 @@ int verify_callback(int ok, X509_STORE_CTX *ctx)
     }
     switch (err) {
     case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
-        BIO_puts(bio_err, "issuer= ");
-        X509_NAME_print_ex(bio_err, X509_get_issuer_name(err_cert),
-                           0, get_nameopt());
-        BIO_puts(bio_err, "\n");
+        if (err_cert != NULL) {
+            BIO_puts(bio_err, "issuer= ");
+            X509_NAME_print_ex(bio_err, X509_get_issuer_name(err_cert),
+                               0, get_nameopt());
+            BIO_puts(bio_err, "\n");
+        }
         break;
     case X509_V_ERR_CERT_NOT_YET_VALID:
     case X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD:
-        BIO_printf(bio_err, "notBefore=");
-        ASN1_TIME_print(bio_err, X509_get0_notBefore(err_cert));
-        BIO_printf(bio_err, "\n");
+        if (err_cert != NULL) {
+            BIO_printf(bio_err, "notBefore=");
+            ASN1_TIME_print(bio_err, X509_get0_notBefore(err_cert));
+            BIO_printf(bio_err, "\n");
+        }
         break;
     case X509_V_ERR_CERT_HAS_EXPIRED:
     case X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD:
-        BIO_printf(bio_err, "notAfter=");
-        ASN1_TIME_print(bio_err, X509_get0_notAfter(err_cert));
-        BIO_printf(bio_err, "\n");
+        if (err_cert != NULL) {
+            BIO_printf(bio_err, "notAfter=");
+            ASN1_TIME_print(bio_err, X509_get0_notAfter(err_cert));
+            BIO_printf(bio_err, "\n");
+        }
         break;
     case X509_V_ERR_NO_EXPLICIT_POLICY:
         if (!verify_args.quiet)

--- a/deps/openssl/openssl/apps/x509.c
+++ b/deps/openssl/openssl/apps/x509.c
@@ -400,7 +400,7 @@ int x509_main(int argc, char **argv)
             aliasout = ++num;
             break;
         case OPT_CACREATESERIAL:
-            CA_createserial = ++num;
+            CA_createserial = 1;
             break;
         case OPT_CLREXT:
             clrext = 1;
@@ -590,7 +590,7 @@ int x509_main(int argc, char **argv)
         xca = load_cert(CAfile, CAformat, "CA Certificate");
         if (xca == NULL)
             goto end;
-        if (!X509_set_issuer_name(x, X509_get_subject_name(xca)))
+        if (reqfile && !X509_set_issuer_name(x, X509_get_subject_name(xca)))
             goto end;
     }
 
@@ -916,6 +916,7 @@ static ASN1_INTEGER *x509_load_serial(const char *CAfile,
     char *buf = NULL;
     ASN1_INTEGER *bs = NULL;
     BIGNUM *serial = NULL;
+    int defaultfile = 0, file_exists;
 
     if (serialfile == NULL) {
         const char *p = strrchr(CAfile, '.');
@@ -925,9 +926,10 @@ static ASN1_INTEGER *x509_load_serial(const char *CAfile,
         memcpy(buf, CAfile, len);
         memcpy(buf + len, POSTFIX, sizeof(POSTFIX));
         serialfile = buf;
+        defaultfile = 1;
     }
 
-    serial = load_serial(serialfile, create, NULL);
+    serial = load_serial(serialfile, &file_exists, create || defaultfile, NULL);
     if (serial == NULL)
         goto end;
 
@@ -936,8 +938,10 @@ static ASN1_INTEGER *x509_load_serial(const char *CAfile,
         goto end;
     }
 
-    if (!save_serial(serialfile, NULL, serial, &bs))
-        goto end;
+    if (file_exists || create)
+        save_serial(serialfile, NULL, serial, &bs);
+    else
+        bs = BN_to_ASN1_INTEGER(serial, NULL);
 
  end:
     OPENSSL_free(buf);
@@ -989,6 +993,8 @@ static int x509_certify(X509_STORE *ctx, const char *CAfile, const EVP_MD *diges
         goto end;
     }
 
+    if (!X509_set_issuer_name(x, X509_get_subject_name(xca)))
+        goto end;
     if (!X509_set_serialNumber(x, bs))
         goto end;
 

--- a/deps/openssl/openssl/crypto/aes/asm/aesv8-armx.pl
+++ b/deps/openssl/openssl/crypto/aes/asm/aesv8-armx.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2014-2020 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2014-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -740,6 +740,21 @@ $code.=<<___;
 #ifndef __ARMEB__
 	rev		$ctr, $ctr
 #endif
+___
+$code.=<<___	if ($flavour =~ /64/);
+	vorr		$dat1,$dat0,$dat0
+	add		$tctr1, $ctr, #1
+	vorr		$dat2,$dat0,$dat0
+	add		$ctr, $ctr, #2
+	vorr		$ivec,$dat0,$dat0
+	rev		$tctr1, $tctr1
+	vmov.32		${dat1}[3],$tctr1
+	b.ls		.Lctr32_tail
+	rev		$tctr2, $ctr
+	sub		$len,$len,#3		// bias
+	vmov.32		${dat2}[3],$tctr2
+___
+$code.=<<___	if ($flavour !~ /64/);
 	add		$tctr1, $ctr, #1
 	vorr		$ivec,$dat0,$dat0
 	rev		$tctr1, $tctr1
@@ -751,6 +766,8 @@ $code.=<<___;
 	vmov.32		${ivec}[3],$tctr2
 	sub		$len,$len,#3		// bias
 	vorr		$dat2,$ivec,$ivec
+___
+$code.=<<___;
 	b		.Loop3x_ctr32
 
 .align	4
@@ -777,11 +794,25 @@ $code.=<<___;
 	aese		$dat1,q8
 	aesmc		$tmp1,$dat1
 	 vld1.8		{$in0},[$inp],#16
+___
+$code.=<<___	if ($flavour =~ /64/);
+	 vorr		$dat0,$ivec,$ivec
+___
+$code.=<<___	if ($flavour !~ /64/);
 	 add		$tctr0,$ctr,#1
+___
+$code.=<<___;
 	aese		$dat2,q8
 	aesmc		$dat2,$dat2
 	 vld1.8		{$in1},[$inp],#16
+___
+$code.=<<___	if ($flavour =~ /64/);
+	 vorr		$dat1,$ivec,$ivec
+___
+$code.=<<___	if ($flavour !~ /64/);
 	 rev		$tctr0,$tctr0
+___
+$code.=<<___;
 	aese		$tmp0,q9
 	aesmc		$tmp0,$tmp0
 	aese		$tmp1,q9
@@ -790,6 +821,12 @@ $code.=<<___;
 	 mov		$key_,$key
 	aese		$dat2,q9
 	aesmc		$tmp2,$dat2
+___
+$code.=<<___	if ($flavour =~ /64/);
+	 vorr		$dat2,$ivec,$ivec
+	 add		$tctr0,$ctr,#1
+___
+$code.=<<___;
 	aese		$tmp0,q12
 	aesmc		$tmp0,$tmp0
 	aese		$tmp1,q12
@@ -805,22 +842,47 @@ $code.=<<___;
 	aese		$tmp1,q13
 	aesmc		$tmp1,$tmp1
 	 veor		$in2,$in2,$rndlast
+___
+$code.=<<___	if ($flavour =~ /64/);
+	 rev		$tctr0,$tctr0
+	aese		$tmp2,q13
+	aesmc		$tmp2,$tmp2
+	 vmov.32	${dat0}[3], $tctr0
+___
+$code.=<<___	if ($flavour !~ /64/);
 	 vmov.32	${ivec}[3], $tctr0
 	aese		$tmp2,q13
 	aesmc		$tmp2,$tmp2
 	 vorr		$dat0,$ivec,$ivec
+___
+$code.=<<___;
 	 rev		$tctr1,$tctr1
 	aese		$tmp0,q14
 	aesmc		$tmp0,$tmp0
+___
+$code.=<<___	if ($flavour !~ /64/);
 	 vmov.32	${ivec}[3], $tctr1
 	 rev		$tctr2,$ctr
+___
+$code.=<<___;
 	aese		$tmp1,q14
 	aesmc		$tmp1,$tmp1
+___
+$code.=<<___	if ($flavour =~ /64/);
+	 vmov.32	${dat1}[3], $tctr1
+	 rev		$tctr2,$ctr
+	aese		$tmp2,q14
+	aesmc		$tmp2,$tmp2
+	 vmov.32	${dat2}[3], $tctr2
+___
+$code.=<<___	if ($flavour !~ /64/);
 	 vorr		$dat1,$ivec,$ivec
 	 vmov.32	${ivec}[3], $tctr2
 	aese		$tmp2,q14
 	aesmc		$tmp2,$tmp2
 	 vorr		$dat2,$ivec,$ivec
+___
+$code.=<<___;
 	 subs		$len,$len,#3
 	aese		$tmp0,q15
 	aese		$tmp1,q15

--- a/deps/openssl/openssl/crypto/asn1/charmap.pl
+++ b/deps/openssl/openssl/crypto/asn1/charmap.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -7,6 +7,9 @@
 # https://www.openssl.org/source/license.html
 
 use strict;
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
 my ($i, @arr);
 
@@ -82,8 +85,8 @@ $arr[ord("?")] |= $PSTRING_CHAR;
 
 # Now generate the C code
 
-# Output year depends on the year of the script.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
+# Year the file was generated.
+my $YEAR = OpenSSL::copyright::year_of($0);
 print <<EOF;
 /*
  * WARNING: do not edit!

--- a/deps/openssl/openssl/crypto/bn/bn_nist.c
+++ b/deps/openssl/openssl/crypto/bn/bn_nist.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2002-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -249,17 +249,28 @@ const BIGNUM *BN_get0_nist_prime_521(void)
     return &_bignum_nist_p_521;
 }
 
-static void nist_cp_bn_0(BN_ULONG *dst, const BN_ULONG *src, int top, int max)
-{
-    int i;
-
-#ifdef BN_DEBUG
-    (void)ossl_assert(top <= max);
-#endif
-    for (i = 0; i < top; i++)
-        dst[i] = src[i];
-    for (; i < max; i++)
-        dst[i] = 0;
+/*
+ * To avoid more recent compilers (specifically clang-14) from treating this
+ * code as a violation of the strict aliasing conditions and omiting it, this
+ * cannot be declared as a function.  Moreover, the dst parameter cannot be
+ * cached in a local since this no longer references the union and again falls
+ * foul of the strict aliasing criteria.  Refer to #18225 for the initial
+ * diagnostics and llvm/llvm-project#55255 for the later discussions with the
+ * LLVM developers.  The problem boils down to if an array in the union is
+ * converted to a pointer or if it is used directly.
+ *
+ * This function was inlined regardless, so there is no space cost to be
+ * paid for making it a macro.
+ */
+#define nist_cp_bn_0(dst, src_in, top, max) \
+{                                           \
+    int ii;                                 \
+    const BN_ULONG *src = src_in;           \
+                                            \
+    for (ii = 0; ii < top; ii++)            \
+        (dst)[ii] = src[ii];                \
+    for (; ii < max; ii++)                  \
+        (dst)[ii] = 0;                      \
 }
 
 static void nist_cp_bn(BN_ULONG *dst, const BN_ULONG *src, int top)

--- a/deps/openssl/openssl/crypto/bn/bn_prime.pl
+++ b/deps/openssl/openssl/crypto/bn/bn_prime.pl
@@ -1,13 +1,16 @@
 #! /usr/bin/env perl
-# Copyright 1998-2019 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 1998-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
-# Output year depends on the year of the script.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
+# The year the output file is generated.
+my $YEAR = OpenSSL::copyright::year_of($0);
 print <<"EOF";
 /*
  * WARNING: do not edit!

--- a/deps/openssl/openssl/crypto/conf/keysets.pl
+++ b/deps/openssl/openssl/crypto/conf/keysets.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -8,6 +8,9 @@
 
 use strict;
 use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
 my $NUMBER      = 0x0001;
 my $UPPER       = 0x0002;
@@ -54,9 +57,8 @@ foreach (0 .. 127) {
     push(@V_w32, $v);
 }
 
-# Output year depends on the year of the script.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-
+# The year the output file is generated.
+my $YEAR = OpenSSL::copyright::year_of($0);
 print <<"EOF";
 /*
  * WARNING: do not edit!

--- a/deps/openssl/openssl/crypto/ec/ec_key.c
+++ b/deps/openssl/openssl/crypto/ec/ec_key.c
@@ -444,6 +444,16 @@ int EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *priv_key)
         return 0;
 
     /*
+     * Return `0` to comply with legacy behavior for this function, see
+     * https://github.com/openssl/openssl/issues/18744#issuecomment-1195175696
+     */
+    if (priv_key == NULL) {
+        BN_clear_free(key->priv_key);
+        key->priv_key = NULL;
+        return 0; /* intentional for legacy compatibility */
+    }
+
+    /*
      * We should never leak the bit length of the secret scalar in the key,
      * so we always set the `BN_FLG_CONSTTIME` flag on the internal `BIGNUM`
      * holding the secret scalar.

--- a/deps/openssl/openssl/crypto/objects/obj_dat.pl
+++ b/deps/openssl/openssl/crypto/objects/obj_dat.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -9,6 +9,9 @@
 use integer;
 use strict;
 use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
 # Generate the DER encoding for the given OID.
 sub der_it
@@ -36,10 +39,8 @@ sub der_it
     return $ret;
 }
 
-# Output year depends on the year of the script and the input file.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-my $iYEAR = [localtime([stat($ARGV[0])]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
+# The year the output file is generated.
+my $YEAR = OpenSSL::copyright::latest(($0, $ARGV[0]));
 
 # Read input, parse all #define's into OID name and value.
 # Populate %ln and %sn with long and short names (%dupln and %dupsn)

--- a/deps/openssl/openssl/crypto/objects/objects.pl
+++ b/deps/openssl/openssl/crypto/objects/objects.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -7,16 +7,15 @@
 # https://www.openssl.org/source/license.html
 
 use Getopt::Std;
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
 our($opt_n);
 getopts('n');
 
-# Output year depends on the year of the script and the input file.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-my $iYEAR = [localtime([stat($ARGV[0])]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
-$iYEAR = [localtime([stat($ARGV[1])]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
+# The year the output file is generated.
+my $YEAR = OpenSSL::copyright::latest(($0, $ARGV[1], $ARGV[0]));
 
 open (NUMIN,"$ARGV[1]") || die "Can't open number file $ARGV[1]";
 $max_nid=0;

--- a/deps/openssl/openssl/crypto/objects/objxref.pl
+++ b/deps/openssl/openssl/crypto/objects/objxref.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 1998-2019 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 1998-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -8,18 +8,17 @@
 
 
 use strict;
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
 my %xref_tbl;
 my %oid_tbl;
 
 my ($mac_file, $xref_file) = @ARGV;
 
-# Output year depends on the year of the script and the input file.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-my $iYEAR = [localtime([stat($mac_file)]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
-$iYEAR = [localtime([stat($xref_file)]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
+# The year the output file is generated.
+my $YEAR = OpenSSL::copyright::latest(($0, $mac_file, $xref_file));
 
 open(IN, $mac_file) || die "Can't open $mac_file, $!\n";
 

--- a/deps/openssl/openssl/crypto/pem/pem_lib.c
+++ b/deps/openssl/openssl/crypto/pem/pem_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -621,7 +621,7 @@ int PEM_write_bio(BIO *bp, const char *name, const char *header,
         (BIO_write(bp, "-----\n", 6) != 6))
         goto err;
 
-    i = strlen(header);
+    i = header != NULL ? strlen(header) : 0;
     if (i > 0) {
         if ((BIO_write(bp, header, i) != i) || (BIO_write(bp, "\n", 1) != 1))
             goto err;

--- a/deps/openssl/openssl/crypto/rand/drbg_lib.c
+++ b/deps/openssl/openssl/crypto/rand/drbg_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2011-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -354,13 +354,8 @@ int RAND_DRBG_instantiate(RAND_DRBG *drbg,
     drbg->state = DRBG_READY;
     drbg->generate_counter = 1;
     drbg->reseed_time = time(NULL);
-    if (drbg->enable_reseed_propagation) {
-        if (drbg->parent == NULL)
-            tsan_counter(&drbg->reseed_counter);
-        else
-            tsan_store(&drbg->reseed_counter,
-                       tsan_load(&drbg->parent->reseed_counter));
-    }
+    if (drbg->enable_reseed_propagation && drbg->parent == NULL)
+        tsan_counter(&drbg->reseed_counter);
 
  end:
     if (entropy != NULL && drbg->cleanup_entropy != NULL)
@@ -444,13 +439,8 @@ int RAND_DRBG_reseed(RAND_DRBG *drbg,
     drbg->state = DRBG_READY;
     drbg->generate_counter = 1;
     drbg->reseed_time = time(NULL);
-    if (drbg->enable_reseed_propagation) {
-        if (drbg->parent == NULL)
-            tsan_counter(&drbg->reseed_counter);
-        else
-            tsan_store(&drbg->reseed_counter,
-                       tsan_load(&drbg->parent->reseed_counter));
-    }
+    if (drbg->enable_reseed_propagation && drbg->parent == NULL)
+        tsan_counter(&drbg->reseed_counter);
 
  end:
     if (entropy != NULL && drbg->cleanup_entropy != NULL)

--- a/deps/openssl/openssl/crypto/rand/rand_win.c
+++ b/deps/openssl/openssl/crypto/rand/rand_win.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -26,7 +26,9 @@
 
 # ifdef USE_BCRYPTGENRANDOM
 #  include <bcrypt.h>
-#  pragma comment(lib, "bcrypt.lib")
+#  ifdef _MSC_VER
+#   pragma comment(lib, "bcrypt.lib")
+#  endif
 #  ifndef STATUS_SUCCESS
 #   define STATUS_SUCCESS ((NTSTATUS)0x00000000L)
 #  endif

--- a/deps/openssl/openssl/crypto/x509/x509_req.c
+++ b/deps/openssl/openssl/crypto/x509/x509_req.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -167,7 +167,9 @@ STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(X509_REQ *req)
         ext = X509_ATTRIBUTE_get0_type(attr, 0);
         break;
     }
-    if (!ext || (ext->type != V_ASN1_SEQUENCE))
+    if (ext == NULL) /* no extensions is not an error */
+        return sk_X509_EXTENSION_new_null();
+    if (ext->type != V_ASN1_SEQUENCE)
         return NULL;
     p = ext->value.sequence->data;
     return (STACK_OF(X509_EXTENSION) *)
@@ -227,44 +229,52 @@ X509_ATTRIBUTE *X509_REQ_get_attr(const X509_REQ *req, int loc)
 
 X509_ATTRIBUTE *X509_REQ_delete_attr(X509_REQ *req, int loc)
 {
-    return X509at_delete_attr(req->req_info.attributes, loc);
+    X509_ATTRIBUTE *attr = X509at_delete_attr(req->req_info.attributes, loc);
+
+    if (attr != NULL)
+        req->req_info.enc.modified = 1;
+    return attr;
 }
 
 int X509_REQ_add1_attr(X509_REQ *req, X509_ATTRIBUTE *attr)
 {
-    if (X509at_add1_attr(&req->req_info.attributes, attr))
-        return 1;
-    return 0;
+    if (!X509at_add1_attr(&req->req_info.attributes, attr))
+        return 0;
+    req->req_info.enc.modified = 1;
+    return 1;
 }
 
 int X509_REQ_add1_attr_by_OBJ(X509_REQ *req,
                               const ASN1_OBJECT *obj, int type,
                               const unsigned char *bytes, int len)
 {
-    if (X509at_add1_attr_by_OBJ(&req->req_info.attributes, obj,
-                                type, bytes, len))
-        return 1;
-    return 0;
+    if (!X509at_add1_attr_by_OBJ(&req->req_info.attributes, obj,
+                                 type, bytes, len))
+        return 0;
+    req->req_info.enc.modified = 1;
+    return 1;
 }
 
 int X509_REQ_add1_attr_by_NID(X509_REQ *req,
                               int nid, int type,
                               const unsigned char *bytes, int len)
 {
-    if (X509at_add1_attr_by_NID(&req->req_info.attributes, nid,
-                                type, bytes, len))
-        return 1;
-    return 0;
+    if (!X509at_add1_attr_by_NID(&req->req_info.attributes, nid,
+                                 type, bytes, len))
+        return 0;
+    req->req_info.enc.modified = 1;
+    return 1;
 }
 
 int X509_REQ_add1_attr_by_txt(X509_REQ *req,
                               const char *attrname, int type,
                               const unsigned char *bytes, int len)
 {
-    if (X509at_add1_attr_by_txt(&req->req_info.attributes, attrname,
-                                type, bytes, len))
-        return 1;
-    return 0;
+    if (!X509at_add1_attr_by_txt(&req->req_info.attributes, attrname,
+                                 type, bytes, len))
+        return 0;
+    req->req_info.enc.modified = 1;
+    return 1;
 }
 
 long X509_REQ_get_version(const X509_REQ *req)

--- a/deps/openssl/openssl/crypto/x509/x509_vfy.c
+++ b/deps/openssl/openssl/crypto/x509/x509_vfy.c
@@ -973,14 +973,14 @@ static int check_crl_time(X509_STORE_CTX *ctx, X509_CRL *crl, int notify)
     time_t *ptime;
     int i;
 
-    if (notify)
-        ctx->current_crl = crl;
     if (ctx->param->flags & X509_V_FLAG_USE_CHECK_TIME)
         ptime = &ctx->param->check_time;
     else if (ctx->param->flags & X509_V_FLAG_NO_CHECK_TIME)
         return 1;
     else
         ptime = NULL;
+    if (notify)
+        ctx->current_crl = crl;
 
     i = X509_cmp_time(X509_CRL_get0_lastUpdate(crl), ptime);
     if (i == 0) {

--- a/deps/openssl/openssl/crypto/x509v3/v3_addr.c
+++ b/deps/openssl/openssl/crypto/x509v3/v3_addr.c
@@ -392,12 +392,14 @@ static int range_should_be_prefix(const unsigned char *min,
 /*
  * Construct a prefix.
  */
-static int make_addressPrefix(IPAddressOrRange **result,
-                              unsigned char *addr, const int prefixlen)
+static int make_addressPrefix(IPAddressOrRange **result, unsigned char *addr,
+                              const int prefixlen, const int afilen)
 {
     int bytelen = (prefixlen + 7) / 8, bitlen = prefixlen % 8;
     IPAddressOrRange *aor = IPAddressOrRange_new();
 
+    if (prefixlen < 0 || prefixlen > (afilen * 8))
+        return 0;
     if (aor == NULL)
         return 0;
     aor->type = IPAddressOrRange_addressPrefix;
@@ -437,7 +439,7 @@ static int make_addressRange(IPAddressOrRange **result,
         return 0;
 
     if ((prefixlen = range_should_be_prefix(min, max, length)) >= 0)
-        return make_addressPrefix(result, min, prefixlen);
+        return make_addressPrefix(result, min, prefixlen, length);
 
     if ((aor = IPAddressOrRange_new()) == NULL)
         return 0;
@@ -599,7 +601,9 @@ int X509v3_addr_add_prefix(IPAddrBlocks *addr,
 {
     IPAddressOrRanges *aors = make_prefix_or_range(addr, afi, safi);
     IPAddressOrRange *aor;
-    if (aors == NULL || !make_addressPrefix(&aor, a, prefixlen))
+
+    if (aors == NULL
+            || !make_addressPrefix(&aor, a, prefixlen, length_from_afi(afi)))
         return 0;
     if (sk_IPAddressOrRange_push(aors, aor))
         return 1;
@@ -996,7 +1000,10 @@ static void *v2i_IPAddrBlocks(const struct v3_ext_method *method,
         switch (delim) {
         case '/':
             prefixlen = (int)strtoul(s + i2, &t, 10);
-            if (t == s + i2 || *t != '\0') {
+            if (t == s + i2
+                    || *t != '\0'
+                    || prefixlen > (length * 8)
+                    || prefixlen < 0) {
                 X509V3err(X509V3_F_V2I_IPADDRBLOCKS,
                           X509V3_R_EXTENSION_VALUE_ERROR);
                 X509V3_conf_err(val);

--- a/deps/openssl/openssl/crypto/x509v3/v3_lib.c
+++ b/deps/openssl/openssl/crypto/x509v3/v3_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -242,8 +242,10 @@ int X509V3_add1_i2d(STACK_OF(X509_EXTENSION) **x, int nid, void *value,
         }
         /* If delete, just delete it */
         if (ext_op == X509V3_ADD_DELETE) {
-            if (!sk_X509_EXTENSION_delete(*x, extidx))
+            extmp = sk_X509_EXTENSION_delete(*x, extidx);
+            if (extmp == NULL)
                 return -1;
+            X509_EXTENSION_free(extmp);
             return 1;
         }
     } else {

--- a/deps/openssl/openssl/crypto/x509v3/v3_utl.c
+++ b/deps/openssl/openssl/crypto/x509v3/v3_utl.c
@@ -1087,11 +1087,16 @@ int a2i_ipadd(unsigned char *ipout, const char *ipasc)
 
 static int ipv4_from_asc(unsigned char *v4, const char *in)
 {
-    int a0, a1, a2, a3;
-    if (sscanf(in, "%d.%d.%d.%d", &a0, &a1, &a2, &a3) != 4)
+    const char *p;
+    int a0, a1, a2, a3, n;
+
+    if (sscanf(in, "%d.%d.%d.%d%n", &a0, &a1, &a2, &a3, &n) != 4)
         return 0;
     if ((a0 < 0) || (a0 > 255) || (a1 < 0) || (a1 > 255)
         || (a2 < 0) || (a2 > 255) || (a3 < 0) || (a3 > 255))
+        return 0;
+    p = in + n;
+    if (!(*p == '\0' || ossl_isspace(*p)))
         return 0;
     v4[0] = a0;
     v4[1] = a1;

--- a/deps/openssl/openssl/doc/man1/x509.pod
+++ b/deps/openssl/openssl/doc/man1/x509.pod
@@ -434,22 +434,26 @@ the CA certificate file.
 
 Sets the CA serial number file to use.
 
-When the B<-CA> option is used to sign a certificate it uses a serial
-number specified in a file. This file consists of one line containing
-an even number of hex digits with the serial number to use. After each
-use the serial number is incremented and written out to the file again.
+When creating a certificate with this option, and with the B<-CA> option,
+the certificate serial number is stored in the given file.
+This file consists of one line containing
+an even number of hex digits with the serial number used last time.
+After reading this number, it is incremented and used, and the file is updated.
 
 The default filename consists of the CA certificate file base name with
 ".srl" appended. For example if the CA certificate file is called
 "mycacert.pem" it expects to find a serial number file called "mycacert.srl".
 
+If the B<-CA> option is specified and neither <-CAserial> or <-CAcreateserial>
+is given and the default serial number file does not exist,
+a random number is generated; this is the recommended practice.
+
 =item B<-CAcreateserial>
 
-With this option the CA serial number file is created if it does not exist:
-it will contain the serial number "02" and the certificate being signed will
-have the 1 as its serial number. If the B<-CA> option is specified
-and the serial number file does not exist a random number is generated;
-this is the recommended practice.
+With this option and the B<-CA> option
+the CA serial number file is created if it does not exist.
+A random number is generated, used for the certificate,
+and saved into the serial number file determined as described above.
 
 =item B<-extfile filename>
 
@@ -932,7 +936,7 @@ the old form must have their links rebuilt using B<c_rehash> or similar.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2021 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/deps/openssl/openssl/doc/man3/CMS_add0_cert.pod
+++ b/deps/openssl/openssl/doc/man3/CMS_add0_cert.pod
@@ -19,25 +19,33 @@ CMS_add0_cert, CMS_add1_cert, CMS_get1_certs, CMS_add0_crl, CMS_add1_crl, CMS_ge
 
 =head1 DESCRIPTION
 
-CMS_add0_cert() and CMS_add1_cert() add certificate B<cert> to B<cms>.
-must be of type signed data or enveloped data.
+CMS_add0_cert() and CMS_add1_cert() add certificate I<cert> to I<cms>.
+I<cms> must be of type signed data or (authenticated) enveloped data.
+For signed data, such a certificate can be used when signing or verifying
+to fill in the signer certificate or to provide an extra CA certificate
+that may be needed for chain building in certificate validation.
 
-CMS_get1_certs() returns all certificates in B<cms>.
+CMS_get1_certs() returns all certificates in I<cms>.
 
-CMS_add0_crl() and CMS_add1_crl() add CRL B<crl> to B<cms>. CMS_get1_crls()
-returns any CRLs in B<cms>.
+CMS_add0_crl() and CMS_add1_crl() add CRL I<crl> to I<cms>.
+I<cms> must be of type signed data or (authenticated) enveloped data.
+For signed data, such a CRL may be used in certificate validation.
+It may be given both for inclusion when signing a CMS message
+and when verifying a signed CMS message.
+
+CMS_get1_crls() returns all CRLs in I<cms>.
 
 =head1 NOTES
 
-The CMS_ContentInfo structure B<cms> must be of type signed data or enveloped
+The CMS_ContentInfo structure I<cms> must be of type signed data or enveloped
 data or an error will be returned.
 
-For signed data certificates and CRLs are added to the B<certificates> and
-B<crls> fields of SignedData structure. For enveloped data they are added to
+For signed data certificates and CRLs are added to the I<certificates> and
+I<crls> fields of SignedData structure. For enveloped data they are added to
 B<OriginatorInfo>.
 
-As the B<0> implies CMS_add0_cert() adds B<cert> internally to B<cms> and it
-must not be freed up after the call as opposed to CMS_add1_cert() where B<cert>
+As the I<0> implies CMS_add0_cert() adds I<cert> internally to I<cms> and it
+must not be freed up after the call as opposed to CMS_add1_cert() where I<cert>
 must be freed up.
 
 The same certificate or CRL must not be added to the same cms structure more
@@ -50,7 +58,7 @@ CMS_add0_cert(), CMS_add1_cert() and CMS_add0_crl() and CMS_add1_crl() return
 
 CMS_get1_certs() and CMS_get1_crls() return the STACK of certificates or CRLs
 or NULL if there are none or an error occurs. The only error which will occur
-in practice is if the B<cms> type is invalid.
+in practice is if the I<cms> type is invalid.
 
 =head1 SEE ALSO
 
@@ -60,7 +68,7 @@ L<CMS_encrypt(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2008-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2008-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/deps/openssl/openssl/doc/man3/CMS_verify.pod
+++ b/deps/openssl/openssl/doc/man3/CMS_verify.pod
@@ -15,50 +15,58 @@ CMS_verify, CMS_get0_signers - verify a CMS SignedData structure
 
 =head1 DESCRIPTION
 
-CMS_verify() verifies a CMS SignedData structure. B<cms> is the CMS_ContentInfo
-structure to verify. B<certs> is a set of certificates in which to search for
-the signing certificate(s). B<store> is a trusted certificate store used for
-chain verification. B<indata> is the detached content if the content is not
-present in B<cms>. The content is written to B<out> if it is not NULL.
+CMS_verify() is very similar to L<PKCS7_verify(3)>. It verifies a
+B<CMS SignedData> structure contained in a structure of type B<CMS_ContentInfo>.
+I<cms> points to the B<CMS_ContentInfo> structure to verify.
+The optional I<certs> parameter refers to a set of certificates
+in which to search for signing certificates.
+I<cms> may contain extra untrusted CA certificates that may be used for
+chain building as well as CRLs that may be used for certificate validation.
+I<store> may be NULL or point to
+the trusted certificate store to use for chain verification.
+I<indata> refers to the signed data if the content is detached from I<cms>.
+Otherwise I<indata> should be NULL and the signed data must be in I<cms>.
+The content is written to the BIO I<out> unless it is NULL.
+I<flags> is an optional set of flags, which can be used to modify the operation.
 
-B<flags> is an optional set of flags, which can be used to modify the verify
-operation.
-
-CMS_get0_signers() retrieves the signing certificate(s) from B<cms>, it may only
+CMS_get0_signers() retrieves the signing certificate(s) from I<cms>, it may only
 be called after a successful CMS_verify() operation.
 
 =head1 VERIFY PROCESS
 
 Normally the verify process proceeds as follows.
 
-Initially some sanity checks are performed on B<cms>. The type of B<cms> must
+Initially some sanity checks are performed on I<cms>. The type of I<cms> must
 be SignedData. There must be at least one signature on the data and if
-the content is detached B<indata> cannot be B<NULL>.
+the content is detached I<indata> cannot be NULL.
 
 An attempt is made to locate all the signing certificate(s), first looking in
-the B<certs> parameter (if it is not NULL) and then looking in any
-certificates contained in the B<cms> structure itself. If any signing
-certificate cannot be located the operation fails.
+the I<certs> parameter (if it is not NULL) and then looking in any
+certificates contained in the I<cms> structure unless B<CMS_NOINTERN> is set.
+If any signing certificate cannot be located the operation fails.
 
-Each signing certificate is chain verified using the B<smimesign> purpose and
-the supplied trusted certificate store. Any internal certificates in the message
-are used as untrusted CAs. If CRL checking is enabled in B<store> any internal
-CRLs are used in addition to attempting to look them up in B<store>. If any
-chain verify fails an error code is returned.
+Each signing certificate is chain verified using the I<smimesign> purpose and
+using the trusted certificate store I<store> if supplied.
+Any internal certificates in the message, which may have been added using
+L<CMS_add1_cert(3)>, are used as untrusted CAs.
+If CRL checking is enabled in I<store> and B<CMS_NOCRL> is not set,
+any internal CRLs, which may have been added using L<CMS_add1_crl(3)>,
+are used in addition to attempting to look them up in I<store>.
+If I<store> is not NULL and any chain verify fails an error code is returned.
 
-Finally the signed content is read (and written to B<out> if it is not NULL)
-and the signature's checked.
+Finally the signed content is read (and written to I<out> unless it is NULL)
+and the signature is checked.
 
-If all signature's verify correctly then the function is successful.
+If all signatures verify correctly then the function is successful.
 
-Any of the following flags (ored together) can be passed in the B<flags>
+Any of the following flags (ored together) can be passed in the I<flags>
 parameter to change the default verify behaviour.
 
 If B<CMS_NOINTERN> is set the certificates in the message itself are not
-searched when locating the signing certificate(s). This means that all the
-signing certificates must be in the B<certs> parameter.
+searched when locating the signing certificate(s).
+This means that all the signing certificates must be in the I<certs> parameter.
 
-If B<CMS_NOCRL> is set and CRL checking is enabled in B<store> then any
+If B<CMS_NOCRL> is set and CRL checking is enabled in I<store> then any
 CRLs in the message itself are ignored.
 
 If the B<CMS_TEXT> flag is set MIME headers for type B<text/plain> are deleted
@@ -66,7 +74,7 @@ from the content. If the content is not of type B<text/plain> then an error is
 returned.
 
 If B<CMS_NO_SIGNER_CERT_VERIFY> is set the signing certificates are not
-verified.
+chain verified.
 
 If B<CMS_NO_ATTR_VERIFY> is set the signed attributes signature is not
 verified.
@@ -77,20 +85,20 @@ If B<CMS_NO_CONTENT_VERIFY> is set then the content digest is not checked.
 
 One application of B<CMS_NOINTERN> is to only accept messages signed by
 a small number of certificates. The acceptable certificates would be passed
-in the B<certs> parameter. In this case if the signer is not one of the
-certificates supplied in B<certs> then the verify will fail because the
+in the I<certs> parameter. In this case if the signer certificate is not one
+of the certificates supplied in I<certs> then the verify will fail because the
 signer cannot be found.
 
 In some cases the standard techniques for looking up and validating
 certificates are not appropriate: for example an application may wish to
 lookup certificates in a database or perform customised verification. This
-can be achieved by setting and verifying the signers certificates manually
+can be achieved by setting and verifying the signer certificates manually
 using the signed data utility functions.
 
 Care should be taken when modifying the default verify behaviour, for example
 setting B<CMS_NO_CONTENT_VERIFY> will totally disable all content verification
 and any modified content will be considered valid. This combination is however
-useful if one merely wishes to write the content to B<out> and its validity
+useful if one merely wishes to write the content to I<out> and its validity
 is not considered important.
 
 Chain verification should arguably be performed using the signing time rather
@@ -100,8 +108,7 @@ timestamp).
 
 =head1 RETURN VALUES
 
-CMS_verify() returns 1 for a successful verification and zero if an error
-occurred.
+CMS_verify() returns 1 for a successful verification and 0 if an error occurred.
 
 CMS_get0_signers() returns all signers or NULL if an error occurred.
 
@@ -109,8 +116,8 @@ The error can be obtained from L<ERR_get_error(3)>
 
 =head1 BUGS
 
-The trusted certificate store is not searched for the signing certificate,
-this is primarily due to the inadequacies of the current B<X509_STORE>
+The trusted certificate store is not searched for the signing certificate.
+This is primarily due to the inadequacies of the current B<X509_STORE>
 functionality.
 
 The lack of single pass processing means that the signed content must all
@@ -118,11 +125,13 @@ be held in memory if it is not detached.
 
 =head1 SEE ALSO
 
+L<PKCS7_verify(3)>, L<CMS_add1_cert(3)>, L<CMS_add1_crl(3)>,
+L<OSSL_ESS_check_signing_certs(3)>,
 L<ERR_get_error(3)>, L<CMS_sign(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2008-2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2008-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/deps/openssl/openssl/doc/man3/EC_KEY_new.pod
+++ b/deps/openssl/openssl/doc/man3/EC_KEY_new.pod
@@ -33,7 +33,7 @@ EC_KEY objects
  const EC_GROUP *EC_KEY_get0_group(const EC_KEY *key);
  int EC_KEY_set_group(EC_KEY *key, const EC_GROUP *group);
  const BIGNUM *EC_KEY_get0_private_key(const EC_KEY *key);
- int EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *prv);
+ int EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *priv_key);
  const EC_POINT *EC_KEY_get0_public_key(const EC_KEY *key);
  int EC_KEY_set_public_key(EC_KEY *key, const EC_POINT *pub);
  point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *key);
@@ -102,7 +102,9 @@ that it is valid.
 The functions EC_KEY_get0_group(), EC_KEY_set_group(),
 EC_KEY_get0_private_key(), EC_KEY_set_private_key(), EC_KEY_get0_public_key(),
 and EC_KEY_set_public_key() get and set the EC_GROUP object, the private key,
-and the EC_POINT public key for the B<key> respectively.
+and the EC_POINT public key for the B<key> respectively. The function
+EC_KEY_set_private_key() accepts NULL as the priv_key argument to securely clear
+the private key component from the EC_KEY.
 
 The functions EC_KEY_get_conv_form() and EC_KEY_set_conv_form() get and set the
 point_conversion_form for the B<key>. For a description of
@@ -160,10 +162,14 @@ EC_KEY_copy() returns a pointer to the destination key, or NULL on error.
 
 EC_KEY_get0_engine() returns a pointer to an ENGINE, or NULL if it wasn't set.
 
-EC_KEY_up_ref(), EC_KEY_set_group(), EC_KEY_set_private_key(),
-EC_KEY_set_public_key(), EC_KEY_precompute_mult(), EC_KEY_generate_key(),
-EC_KEY_check_key(), EC_KEY_set_public_key_affine_coordinates(),
-EC_KEY_oct2key() and EC_KEY_oct2priv() return 1 on success or 0 on error.
+EC_KEY_up_ref(), EC_KEY_set_group(), EC_KEY_set_public_key(),
+EC_KEY_precompute_mult(), EC_KEY_generate_key(), EC_KEY_check_key(),
+EC_KEY_set_public_key_affine_coordinates(), EC_KEY_oct2key() and
+EC_KEY_oct2priv() return 1 on success or 0 on error.
+
+EC_KEY_set_private_key() returns 1 on success or 0 on error except when the
+priv_key argument is NULL, in that case it returns 0, for legacy compatibility,
+and should not be treated as an error.
 
 EC_KEY_get0_group() returns the EC_GROUP associated with the EC_KEY.
 
@@ -184,7 +190,7 @@ L<d2i_ECPKParameters(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2013-2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2013-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/deps/openssl/openssl/doc/man3/EVP_EncryptInit.pod
+++ b/deps/openssl/openssl/doc/man3/EVP_EncryptInit.pod
@@ -313,7 +313,7 @@ length.
 EVP_CIPHER_CTX_set_padding() always returns 1.
 
 EVP_CIPHER_iv_length() and EVP_CIPHER_CTX_iv_length() return the IV
-length or zero if the cipher does not use an IV.
+length, zero if the cipher does not use an IV and a negative value on error.
 
 EVP_CIPHER_type() and EVP_CIPHER_CTX_type() return the NID of the cipher's
 OBJECT IDENTIFIER or NID_undef if it has no defined OBJECT IDENTIFIER.
@@ -661,7 +661,7 @@ EVP_CIPHER_CTX_reset().
 
 =head1 COPYRIGHT
 
-Copyright 2000-2021 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/deps/openssl/openssl/doc/man3/OPENSSL_LH_COMPFUNC.pod
+++ b/deps/openssl/openssl/doc/man3/OPENSSL_LH_COMPFUNC.pod
@@ -23,7 +23,7 @@ lh_TYPE_doall, lh_TYPE_doall_arg, lh_TYPE_error - dynamic hash table
 
  TYPE *lh_TYPE_insert(LHASH_OF(TYPE) *table, TYPE *data);
  TYPE *lh_TYPE_delete(LHASH_OF(TYPE) *table, TYPE *data);
- TYPE *lh_retrieve(LHASH_OF(TYPE) *table, TYPE *data);
+ TYPE *lh_TYPE_retrieve(LHASH_OF(TYPE) *table, TYPE *data);
 
  void lh_TYPE_doall(LHASH_OF(TYPE) *table, OPENSSL_LH_DOALL_FUNC func);
  void lh_TYPE_doall_arg(LHASH_OF(TYPE) *table, OPENSSL_LH_DOALL_FUNCARG func,
@@ -229,7 +229,7 @@ type checking.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/deps/openssl/openssl/doc/man3/OPENSSL_init_crypto.pod
+++ b/deps/openssl/openssl/doc/man3/OPENSSL_init_crypto.pod
@@ -81,7 +81,7 @@ B<OPENSSL_INIT_NO_ADD_ALL_CIPHERS> will be ignored.
 With this option the library will automatically load and make available all
 libcrypto digests. This option is a default option. Once selected subsequent
 calls to OPENSSL_init_crypto() with the option
-B<OPENSSL_INIT_NO_ADD_ALL_CIPHERS> will be ignored.
+B<OPENSSL_INIT_NO_ADD_ALL_DIGESTS> will be ignored.
 
 =item OPENSSL_INIT_NO_ADD_ALL_CIPHERS
 
@@ -264,7 +264,7 @@ and OPENSSL_INIT_free() functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2016-2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/deps/openssl/openssl/doc/man3/PKCS7_sign.pod
+++ b/deps/openssl/openssl/doc/man3/PKCS7_sign.pod
@@ -13,29 +13,26 @@ PKCS7_sign - create a PKCS#7 signedData structure
 
 =head1 DESCRIPTION
 
-PKCS7_sign() creates and returns a PKCS#7 signedData structure. B<signcert> is
-the certificate to sign with, B<pkey> is the corresponding private key.
-B<certs> is an optional additional set of certificates to include in the PKCS#7
-structure (for example any intermediate CAs in the chain).
+PKCS7_sign() creates and returns a PKCS#7 signedData structure.
+I<signcert> is the certificate to sign with, I<pkey> is the corresponding
+private key. I<certs> is an optional set of extra certificates to include
+in the PKCS#7 structure (for example any intermediate CAs in the chain).
 
-The data to be signed is read from BIO B<data>.
+The data to be signed is read from BIO I<data>.
 
-B<flags> is an optional set of flags.
+I<flags> is an optional set of flags.
 
-=head1 NOTES
-
-Any of the following flags (ored together) can be passed in the B<flags>
-parameter.
+Any of the following flags (ored together) can be passed in the I<flags>
 
 Many S/MIME clients expect the signed content to include valid MIME headers. If
-the B<PKCS7_TEXT> flag is set MIME headers for type B<text/plain> are prepended
+the B<PKCS7_TEXT> flag is set MIME headers for type C<text/plain> are prepended
 to the data.
 
-If B<PKCS7_NOCERTS> is set the signer's certificate will not be included in the
-PKCS7 structure, the signer's certificate must still be supplied in the
-B<signcert> parameter though. This can reduce the size of the signature if the
-signers certificate can be obtained by other means: for example a previously
-signed message.
+If B<PKCS7_NOCERTS> is set the signer's certificate and the extra I<certs>
+will not be included in the PKCS7 structure.
+The signer's certificate must still be supplied in the I<signcert> parameter
+though. This can reduce the size of the signatures if the signer's certificates
+can be obtained by other means: for example a previously signed message.
 
 The data being signed is included in the PKCS7 structure, unless
 B<PKCS7_DETACHED> is set in which case it is omitted. This is used for PKCS7
@@ -59,7 +56,7 @@ these algorithms is disabled then it will not be included.
 
 If the flags B<PKCS7_STREAM> is set then the returned B<PKCS7> structure is
 just initialized ready to perform the signing operation. The signing is however
-B<not> performed and the data to be signed is not read from the B<data>
+B<not> performed and the data to be signed is not read from the I<data>
 parameter. Signing is deferred until after the data has been written. In this
 way data can be signed in a single pass.
 
@@ -80,17 +77,17 @@ BIO_new_PKCS7().
 If a signer is specified it will use the default digest for the signing
 algorithm. This is B<SHA1> for both RSA and DSA keys.
 
-The B<certs>, B<signcert> and B<pkey> parameters can all be
-B<NULL> if the B<PKCS7_PARTIAL> flag is set. One or more signers can be added
+The I<certs>, I<signcert> and I<pkey> parameters can all be
+NULL if the B<PKCS7_PARTIAL> flag is set. One or more signers can be added
 using the function PKCS7_sign_add_signer(). PKCS7_final() must also be
 called to finalize the structure if streaming is not enabled. Alternative
 signing digests can also be specified using this method.
 
-If B<signcert> and B<pkey> are NULL then a certificates only
+If I<signcert> and I<pkey> are NULL then a certificates only
 PKCS#7 structure is output.
 
-In versions of OpenSSL before 1.0.0 the B<signcert> and B<pkey> parameters must
-B<NOT> be NULL.
+In versions of OpenSSL before 1.0.0 the I<signcert> and I<pkey> parameters must
+not be NULL.
 
 =head1 BUGS
 
@@ -107,14 +104,14 @@ L<ERR_get_error(3)>, L<PKCS7_verify(3)>
 
 =head1 HISTORY
 
-The B<PKCS7_PARTIAL> flag, and the ability for B<certs>, B<signcert>,
-and B<pkey> parameters to be B<NULL> were added in OpenSSL 1.0.0.
+The B<PKCS7_PARTIAL> flag, and the ability for I<certs>, I<signcert>,
+and I<pkey> parameters to be NULL were added in OpenSSL 1.0.0.
 
 The B<PKCS7_STREAM> flag was added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 
-Copyright 2002-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2002-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/deps/openssl/openssl/doc/man3/PKCS7_sign_add_signer.pod
+++ b/deps/openssl/openssl/doc/man3/PKCS7_sign_add_signer.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-PKCS7_sign_add_signer - add a signer PKCS7 signed data structure
+PKCS7_sign_add_signer,
+PKCS7_add_certificate, PKCS7_add_crl - add information to PKCS7 structure
 
 =head1 SYNOPSIS
 
@@ -10,22 +11,22 @@ PKCS7_sign_add_signer - add a signer PKCS7 signed data structure
 
  PKCS7_SIGNER_INFO *PKCS7_sign_add_signer(PKCS7 *p7, X509 *signcert,
                                           EVP_PKEY *pkey, const EVP_MD *md, int flags);
-
+ int PKCS7_add_certificate(PKCS7 *p7, X509 *cert);
+ int PKCS7_add_crl(PKCS7 *p7, X509_CRL *crl);
 
 =head1 DESCRIPTION
 
-PKCS7_sign_add_signer() adds a signer with certificate B<signcert> and private
-key B<pkey> using message digest B<md> to a PKCS7 signed data structure
-B<p7>.
+PKCS7_sign_add_signer() adds a signer with certificate I<signcert> and private
+key I<pkey> using message digest I<md> to a PKCS7 signed data structure I<p7>.
 
-The PKCS7 structure should be obtained from an initial call to PKCS7_sign()
-with the flag B<PKCS7_PARTIAL> set or in the case or re-signing a valid PKCS7
+The B<PKCS7> structure should be obtained from an initial call to PKCS7_sign()
+with the flag B<PKCS7_PARTIAL> set or in the case or re-signing a valid PKCS#7
 signed data structure.
 
-If the B<md> parameter is B<NULL> then the default digest for the public
+If the I<md> parameter is NULL then the default digest for the public
 key algorithm will be used.
 
-Unless the B<PKCS7_REUSE_DIGEST> flag is set the returned PKCS7 structure
+Unless the B<PKCS7_REUSE_DIGEST> flag is set the returned B<PKCS7> structure
 is not complete and must be finalized either by streaming (if applicable) or
 a call to PKCS7_final().
 
@@ -37,13 +38,13 @@ signed data structure where the simpler PKCS7_sign() function defaults are
 not appropriate. For example if multiple signers or non default digest
 algorithms are needed.
 
-Any of the following flags (ored together) can be passed in the B<flags>
+Any of the following flags (ored together) can be passed in the I<flags>
 parameter.
 
 If B<PKCS7_REUSE_DIGEST> is set then an attempt is made to copy the content
-digest value from the PKCS7 structure: to add a signer to an existing structure.
+digest value from the B<PKCS7> structure: to add a signer to an existing structure.
 An error occurs if a matching digest value cannot be found to copy. The
-returned PKCS7 structure will be valid and finalized when this flag is set.
+returned B<PKCS7> structure will be valid and finalized when this flag is set.
 
 If B<PKCS7_PARTIAL> is set in addition to B<PKCS7_REUSE_DIGEST> then the
 B<PKCS7_SIGNER_INO> structure will not be finalized so additional attributes
@@ -51,8 +52,8 @@ can be added. In this case an explicit call to PKCS7_SIGNER_INFO_sign() is
 needed to finalize it.
 
 If B<PKCS7_NOCERTS> is set the signer's certificate will not be included in the
-PKCS7 structure, the signer's certificate must still be supplied in the
-B<signcert> parameter though. This can reduce the size of the signature if the
+B<PKCS7> structure, the signer's certificate must still be supplied in the
+I<signcert> parameter though. This can reduce the size of the signature if the
 signers certificate can be obtained by other means: for example a previously
 signed message.
 
@@ -66,20 +67,32 @@ If present the SMIMECapabilities attribute indicates support for the following
 algorithms: triple DES, 128 bit RC2, 64 bit RC2, DES and 40 bit RC2. If any of
 these algorithms is disabled then it will not be included.
 
-
-PKCS7_sign_add_signers() returns an internal pointer to the PKCS7_SIGNER_INFO
-structure just added, this can be used to set additional attributes
+PKCS7_sign_add_signers() returns an internal pointer to the B<PKCS7_SIGNER_INFO>
+structure just added, which can be used to set additional attributes
 before it is finalized.
+
+PKCS7_add_certificate() adds to the B<PKCS7> structure I<p7> the certificate
+I<cert>, which may be an end-entity (signer) certificate
+or a CA certificate useful for chain building.
+This is done internally by L<PKCS7_sign_ex(3)> and similar signing functions.
+It may have to be used before calling L<PKCS7_verify(3)>
+in order to provide any missing certificate(s) needed for verification.
+
+PKCS7_add_crl() adds the CRL I<crl> to the B<PKCS7> structure I<p7>.
+This may be called to provide certificate status information
+to be included when signing or to use when verifying the B<PKCS7> structure.
 
 =head1 RETURN VALUES
 
-PKCS7_sign_add_signers() returns an internal pointer to the PKCS7_SIGNER_INFO
+PKCS7_sign_add_signers() returns an internal pointer to the B<PKCS7_SIGNER_INFO>
 structure just added or NULL if an error occurs.
+
+PKCS7_add_certificate() and PKCS7_add_crl() return 1 on success, 0 on error.
 
 =head1 SEE ALSO
 
-L<ERR_get_error(3)>, L<PKCS7_sign(3)>,
-L<PKCS7_final(3)>,
+L<ERR_get_error(3)>, L<PKCS7_sign_ex(3)>,
+L<PKCS7_final(3)>, L<PKCS7_verify(3)>
 
 =head1 HISTORY
 
@@ -87,7 +100,7 @@ The PPKCS7_sign_add_signer() function was added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 
-Copyright 2007-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2007-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/deps/openssl/openssl/doc/man3/PKCS7_verify.pod
+++ b/deps/openssl/openssl/doc/man3/PKCS7_verify.pod
@@ -15,64 +15,76 @@ PKCS7_verify, PKCS7_get0_signers - verify a PKCS#7 signedData structure
 
 =head1 DESCRIPTION
 
-PKCS7_verify() verifies a PKCS#7 signedData structure. B<p7> is the PKCS7
-structure to verify. B<certs> is a set of certificates in which to search for
-the signer's certificate. B<store> is a trusted certificate store (used for
-chain verification). B<indata> is the signed data if the content is not
-present in B<p7> (that is it is detached). The content is written to B<out>
-if it is not NULL.
+PKCS7_verify() is very similar to L<CMS_verify(3)>.
+It verifies a PKCS#7 signedData structure given in I<p7>.
+The optional I<certs> parameter refers to a set of certificates
+in which to search for signer's certificates.
+I<p7> may contain extra untrusted CA certificates that may be used for
+chain building as well as CRLs that may be used for certificate validation.
+I<store> may be NULL or point to
+the trusted certificate store to use for chain verification.
+I<indata> refers to the signed data if the content is detached from I<p7>.
+Otherwise I<indata> should be NULL, and then the signed data must be in I<p7>.
+The content is written to the BIO I<out> unless it is NULL.
+I<flags> is an optional set of flags, which can be used to modify the operation.
 
-B<flags> is an optional set of flags, which can be used to modify the verify
-operation.
-
-PKCS7_get0_signers() retrieves the signer's certificates from B<p7>, it does
-B<not> check their validity or whether any signatures are valid. The B<certs>
-and B<flags> parameters have the same meanings as in PKCS7_verify().
+PKCS7_get0_signers() retrieves the signer's certificates from I<p7>, it does
+B<not> check their validity or whether any signatures are valid. The I<certs>
+and I<flags> parameters have the same meanings as in PKCS7_verify().
 
 =head1 VERIFY PROCESS
 
 Normally the verify process proceeds as follows.
 
-Initially some sanity checks are performed on B<p7>. The type of B<p7> must
-be signedData. There must be at least one signature on the data and if
-the content is detached B<indata> cannot be B<NULL>.  If the content is
-not detached and B<indata> is not B<NULL>, then the structure has both
+Initially some sanity checks are performed on I<p7>. The type of I<p7> must
+be SignedData. There must be at least one signature on the data and if
+the content is detached I<indata> cannot be NULL.  If the content is
+not detached and I<indata> is not NULL then the structure has both
 embedded and external content. To treat this as an error, use the flag
 B<PKCS7_NO_DUAL_CONTENT>.
 The default behavior allows this, for compatibility with older
 versions of OpenSSL.
 
 An attempt is made to locate all the signer's certificates, first looking in
-the B<certs> parameter (if it is not B<NULL>) and then looking in any certificates
-contained in the B<p7> structure itself. If any signer's certificates cannot be
-located the operation fails.
+the I<certs> parameter (if it is not NULL). Then they are looked up in any
+certificates contained in the I<p7> structure unless B<PKCS7_NOINTERN> is set.
+If any signer's certificates cannot be located the operation fails.
 
 Each signer's certificate is chain verified using the B<smimesign> purpose and
-the supplied trusted certificate store. Any internal certificates in the message
-are used as untrusted CAs. If any chain verify fails an error code is returned.
+using the trusted certificate store I<store> if supplied.
+Any internal certificates in the message, which may have been added using
+L<PKCS7_add_certificate(3)>, are used as untrusted CAs unless B<PKCS7_NOCHAIN>
+is set.
+If CRL checking is enabled in I<store> and B<PKCS7_NOCRL> is not set,
+any internal CRLs, which may have been added using L<PKCS7_add_crl(3)>,
+are used in addition to attempting to look them up in I<store>.
+If I<store> is not NULL and any chain verify fails an error code is returned.
 
-Finally the signed content is read (and written to B<out> is it is not NULL) and
-the signature's checked.
+Finally the signed content is read (and written to I<out> unless it is NULL)
+and the signature is checked.
 
-If all signature's verify correctly then the function is successful.
+If all signatures verify correctly then the function is successful.
 
-Any of the following flags (ored together) can be passed in the B<flags> parameter
-to change the default verify behaviour. Only the flag B<PKCS7_NOINTERN> is
-meaningful to PKCS7_get0_signers().
+Any of the following flags (ored together) can be passed in the I<flags>
+parameter to change the default verify behaviour.
+Only the flag B<PKCS7_NOINTERN> is meaningful to PKCS7_get0_signers().
 
 If B<PKCS7_NOINTERN> is set the certificates in the message itself are not
-searched when locating the signer's certificate. This means that all the signers
-certificates must be in the B<certs> parameter.
+searched when locating the signer's certificates.
+This means that all the signer's certificates must be in the I<certs> parameter.
 
-If the B<PKCS7_TEXT> flag is set MIME headers for type B<text/plain> are deleted
-from the content. If the content is not of type B<text/plain> then an error is
+If B<PKCS7_NOCRL> is set and CRL checking is enabled in I<store> then any
+CRLs in the message itself are ignored.
+
+If the B<PKCS7_TEXT> flag is set MIME headers for type C<text/plain> are deleted
+from the content. If the content is not of type C<text/plain> then an error is
 returned.
 
 If B<PKCS7_NOVERIFY> is set the signer's certificates are not chain verified.
 
 If B<PKCS7_NOCHAIN> is set then the certificates contained in the message are
 not used as untrusted CAs. This means that the whole verify chain (apart from
-the signer's certificate) must be contained in the trusted store.
+the signer's certificates) must be contained in the trusted store.
 
 If B<PKCS7_NOSIGS> is set then the signatures on the data are not checked.
 
@@ -80,46 +92,46 @@ If B<PKCS7_NOSIGS> is set then the signatures on the data are not checked.
 
 One application of B<PKCS7_NOINTERN> is to only accept messages signed by
 a small number of certificates. The acceptable certificates would be passed
-in the B<certs> parameter. In this case if the signer is not one of the
-certificates supplied in B<certs> then the verify will fail because the
+in the I<certs> parameter. In this case if the signer's certificate is not one
+of the certificates supplied in I<certs> then the verify will fail because the
 signer cannot be found.
 
 Care should be taken when modifying the default verify behaviour, for example
 setting B<PKCS7_NOVERIFY|PKCS7_NOSIGS> will totally disable all verification
 and any signed message will be considered valid. This combination is however
-useful if one merely wishes to write the content to B<out> and its validity
+useful if one merely wishes to write the content to I<out> and its validity
 is not considered important.
 
-Chain verification should arguably be performed  using the signing time rather
+Chain verification should arguably be performed using the signing time rather
 than the current time. However, since the signing time is supplied by the
 signer it cannot be trusted without additional evidence (such as a trusted
 timestamp).
 
 =head1 RETURN VALUES
 
-PKCS7_verify() returns one for a successful verification and zero
-if an error occurs.
+PKCS7_verify() returns 1 for a successful verification and 0 if an error occurs.
 
-PKCS7_get0_signers() returns all signers or B<NULL> if an error occurred.
+PKCS7_get0_signers() returns all signers or NULL if an error occurred.
 
-The error can be obtained from L<ERR_get_error(3)>
+The error can be obtained from L<ERR_get_error(3)>.
 
 =head1 BUGS
 
-The trusted certificate store is not searched for the signers certificate,
-this is primarily due to the inadequacies of the current B<X509_STORE>
+The trusted certificate store is not searched for the signer's certificates.
+This is primarily due to the inadequacies of the current B<X509_STORE>
 functionality.
 
-The lack of single pass processing and need to hold all data in memory as
-mentioned in PKCS7_sign() also applies to PKCS7_verify().
+The lack of single pass processing means that the signed content must all
+be held in memory if it is not detached.
 
 =head1 SEE ALSO
 
+L<CMS_verify(3)>, L<PKCS7_add_certificate(3)>, L<PKCS7_add_crl(3)>,
 L<ERR_get_error(3)>, L<PKCS7_sign(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2002-2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2002-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/deps/openssl/openssl/doc/man3/X509_STORE_CTX_new.pod
+++ b/deps/openssl/openssl/doc/man3/X509_STORE_CTX_new.pod
@@ -175,14 +175,18 @@ It should not normally be necessary for end user applications to call
 X509_STORE_CTX_purpose_inherit() directly. Typically applications should call
 X509_STORE_CTX_set_purpose() or X509_STORE_CTX_set_trust() instead. Using this
 function it is possible to set the purpose and trust values for the I<ctx> at
-the same time. The I<def_purpose> and I<purpose> arguments can have the same
+the same time.
+Both I<ctx> and its internal verification parameter pointer must not be NULL.
+The I<def_purpose> and I<purpose> arguments can have the same
 purpose values as described for X509_STORE_CTX_set_purpose() above. The I<trust>
 argument can have the same trust values as described in
 X509_STORE_CTX_set_trust() above. Any of the I<def_purpose>, I<purpose> or
 I<trust> values may also have the value 0 to indicate that the supplied
 parameter should be ignored. After calling this function the purpose to be used
-for verification is set from the I<purpose> argument, and the trust is set from
-the I<trust> argument. If I<trust> is 0 then the trust value will be set from
+for verification is set from the I<purpose> argument unless the purpose was
+already set in I<ctx> before, and the trust is set from the I<trust> argument
+unless the trust was already set in I<ctx> before.
+If I<trust> is 0 then the trust value will be set from
 the default trust value for I<purpose>. If the default trust value for the
 purpose is I<X509_TRUST_DEFAULT> and I<trust> is 0 then the default trust value
 associated with the I<def_purpose> value is used for the trust setting instead.

--- a/deps/openssl/openssl/include/crypto/bn_conf.h
+++ b/deps/openssl/openssl/include/crypto/bn_conf.h
@@ -1,1 +1,0 @@
-#include "../../../config/bn_conf.h"

--- a/deps/openssl/openssl/include/crypto/bn_conf.h
+++ b/deps/openssl/openssl/include/crypto/bn_conf.h
@@ -1,0 +1,1 @@
+#include "../../../config/bn_conf.h"

--- a/deps/openssl/openssl/include/crypto/dso_conf.h
+++ b/deps/openssl/openssl/include/crypto/dso_conf.h
@@ -1,0 +1,1 @@
+#include "../../../config/dso_conf.h"

--- a/deps/openssl/openssl/include/crypto/dso_conf.h
+++ b/deps/openssl/openssl/include/crypto/dso_conf.h
@@ -1,1 +1,0 @@
-#include "../../../config/dso_conf.h"

--- a/deps/openssl/openssl/include/openssl/opensslconf.h
+++ b/deps/openssl/openssl/include/openssl/opensslconf.h
@@ -1,0 +1,1 @@
+#include "../../config/opensslconf.h"

--- a/deps/openssl/openssl/include/openssl/opensslconf.h
+++ b/deps/openssl/openssl/include/openssl/opensslconf.h
@@ -1,1 +1,0 @@
-#include "../../config/opensslconf.h"

--- a/deps/openssl/openssl/include/openssl/opensslv.h
+++ b/deps/openssl/openssl/include/openssl/opensslv.h
@@ -39,8 +39,8 @@ extern "C" {
  * (Prior to 0.9.5a beta1, a different scheme was used: MMNNFFRBB for
  *  major minor fix final patch/beta)
  */
-# define OPENSSL_VERSION_NUMBER  0x1010111fL
-# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1q+quic  5 Jul 2022"
+# define OPENSSL_VERSION_NUMBER  0x1010113fL
+# define OPENSSL_VERSION_TEXT    "OpenSSL 1.1.1s+quic  1 Nov 2022"
 
 /*-
  * The macros below are to be used for shared library (.so, .dll, ...)

--- a/deps/openssl/openssl/ssl/packet.c
+++ b/deps/openssl/openssl/ssl/packet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2015-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -161,7 +161,7 @@ int WPACKET_set_flags(WPACKET *pkt, unsigned int flags)
 }
 
 /* Store the |value| of length |len| at location |data| */
-static int put_value(unsigned char *data, size_t value, size_t len)
+static int put_value(unsigned char *data, uint64_t value, size_t len)
 {
     for (data += len - 1; len > 0; len--) {
         *data = (unsigned char)(value & 0xff);
@@ -306,12 +306,12 @@ int WPACKET_start_sub_packet(WPACKET *pkt)
     return WPACKET_start_sub_packet_len__(pkt, 0);
 }
 
-int WPACKET_put_bytes__(WPACKET *pkt, unsigned int val, size_t size)
+int WPACKET_put_bytes__(WPACKET *pkt, uint64_t val, size_t size)
 {
     unsigned char *data;
 
     /* Internal API, so should not fail */
-    if (!ossl_assert(size <= sizeof(unsigned int))
+    if (!ossl_assert(size <= sizeof(uint64_t))
             || !WPACKET_allocate_bytes(pkt, size, &data)
             || !put_value(data, val, size))
         return 0;

--- a/deps/openssl/openssl/ssl/packet_local.h
+++ b/deps/openssl/openssl/ssl/packet_local.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2015-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -227,6 +227,28 @@ __owur static ossl_inline int PACKET_peek_net_4(const PACKET *pkt,
     return 1;
 }
 
+/*
+ * Peek ahead at 8 bytes in network order from |pkt| and store the value in
+ * |*data|
+ */
+__owur static ossl_inline int PACKET_peek_net_8(const PACKET *pkt,
+                                                uint64_t *data)
+{
+    if (PACKET_remaining(pkt) < 8)
+        return 0;
+
+    *data = ((uint64_t)(*pkt->curr)) << 56;
+    *data |= ((uint64_t)(*(pkt->curr + 1))) << 48;
+    *data |= ((uint64_t)(*(pkt->curr + 2))) << 40;
+    *data |= ((uint64_t)(*(pkt->curr + 3))) << 32;
+    *data |= ((uint64_t)(*(pkt->curr + 4))) << 24;
+    *data |= ((uint64_t)(*(pkt->curr + 5))) << 16;
+    *data |= ((uint64_t)(*(pkt->curr + 6))) << 8;
+    *data |= *(pkt->curr + 7);
+
+    return 1;
+}
+
 /* Equivalent of n2l */
 /* Get 4 bytes in network order from |pkt| and store the value in |*data| */
 __owur static ossl_inline int PACKET_get_net_4(PACKET *pkt, unsigned long *data)
@@ -249,6 +271,17 @@ __owur static ossl_inline int PACKET_get_net_4_len(PACKET *pkt, size_t *data)
         *data = (size_t)i;
 
     return ret;
+}
+
+/* Get 8 bytes in network order from |pkt| and store the value in |*data| */
+__owur static ossl_inline int PACKET_get_net_8(PACKET *pkt, uint64_t *data)
+{
+    if (!PACKET_peek_net_8(pkt, data))
+        return 0;
+
+    packet_forward(pkt, 8);
+
+    return 1;
 }
 
 /* Peek ahead at 1 byte from |pkt| and store the value in |*data| */
@@ -808,7 +841,7 @@ int WPACKET_sub_reserve_bytes__(WPACKET *pkt, size_t len,
  * 1 byte will fail. Don't call this directly. Use the convenience macros below
  * instead.
  */
-int WPACKET_put_bytes__(WPACKET *pkt, unsigned int val, size_t bytes);
+int WPACKET_put_bytes__(WPACKET *pkt, uint64_t val, size_t bytes);
 
 /*
  * Convenience macros for calling WPACKET_put_bytes with different
@@ -822,6 +855,8 @@ int WPACKET_put_bytes__(WPACKET *pkt, unsigned int val, size_t bytes);
     WPACKET_put_bytes__((pkt), (val), 3)
 #define WPACKET_put_bytes_u32(pkt, val) \
     WPACKET_put_bytes__((pkt), (val), 4)
+#define WPACKET_put_bytes_u64(pkt, val) \
+    WPACKET_put_bytes__((pkt), (val), 8)
 
 /* Set a maximum size that we will not allow the WPACKET to grow beyond */
 int WPACKET_set_max_size(WPACKET *pkt, size_t maxsize);

--- a/deps/openssl/openssl/ssl/ssl_ciph.c
+++ b/deps/openssl/openssl/ssl/ssl_ciph.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  * Copyright 2005 Nokia. All rights reserved.
  *
@@ -1026,9 +1026,7 @@ static int ssl_cipher_process_rulestr(const char *rule_str,
                  * alphanumeric, so we call this an error.
                  */
                 SSLerr(SSL_F_SSL_CIPHER_PROCESS_RULESTR, SSL_R_INVALID_COMMAND);
-                retval = found = 0;
-                l++;
-                break;
+                return 0;
             }
 
             if (rule == CIPHER_SPECIAL) {

--- a/deps/openssl/openssl/ssl/ssl_lib.c
+++ b/deps/openssl/openssl/ssl/ssl_lib.c
@@ -1577,12 +1577,26 @@ int SSL_has_pending(const SSL *s)
 {
     /*
      * Similar to SSL_pending() but returns a 1 to indicate that we have
-     * unprocessed data available or 0 otherwise (as opposed to the number of
-     * bytes available). Unlike SSL_pending() this will take into account
-     * read_ahead data. A 1 return simply indicates that we have unprocessed
-     * data. That data may not result in any application data, or we may fail
-     * to parse the records for some reason.
+     * processed or unprocessed data available or 0 otherwise (as opposed to the
+     * number of bytes available). Unlike SSL_pending() this will take into
+     * account read_ahead data. A 1 return simply indicates that we have data.
+     * That data may not result in any application data, or we may fail to parse
+     * the records for some reason.
      */
+
+    /* Check buffered app data if any first */
+    if (SSL_IS_DTLS(s)) {
+        DTLS1_RECORD_DATA *rdata;
+        pitem *item, *iter;
+
+        iter = pqueue_iterator(s->rlayer.d->buffered_app_data.q);
+        while ((item = pqueue_next(&iter)) != NULL) {
+            rdata = item->data;
+            if (rdata->rrec.length > 0)
+                return 1;
+        }
+    }
+
     if (RECORD_LAYER_processed_read_pending(&s->rlayer))
         return 1;
 

--- a/deps/openssl/openssl/ssl/ssl_rsa.c
+++ b/deps/openssl/openssl/ssl/ssl_rsa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -727,6 +727,34 @@ static int serverinfoex_srv_parse_cb(SSL *s, unsigned int ext_type,
     return 1;
 }
 
+static size_t extension_contextoff(unsigned int version)
+{
+    return version == SSL_SERVERINFOV1 ? 4 : 0;
+}
+
+static size_t extension_append_length(unsigned int version, size_t extension_length)
+{
+    return extension_length + extension_contextoff(version);
+}
+
+static void extension_append(unsigned int version,
+                             const unsigned char *extension,
+                             const size_t extension_length,
+                             unsigned char *serverinfo)
+{
+    const size_t contextoff = extension_contextoff(version);
+
+    if (contextoff > 0) {
+        /* We know this only uses the last 2 bytes */
+        serverinfo[0] = 0;
+        serverinfo[1] = 0;
+        serverinfo[2] = (SYNTHV1CONTEXT >> 8) & 0xff;
+        serverinfo[3] = SYNTHV1CONTEXT & 0xff;
+    }
+
+    memcpy(serverinfo + contextoff, extension, extension_length);
+}
+
 static int serverinfo_srv_parse_cb(SSL *s, unsigned int ext_type,
                                    const unsigned char *in,
                                    size_t inlen, int *al, void *arg)
@@ -842,11 +870,35 @@ int SSL_CTX_use_serverinfo_ex(SSL_CTX *ctx, unsigned int version,
                               const unsigned char *serverinfo,
                               size_t serverinfo_length)
 {
-    unsigned char *new_serverinfo;
+    unsigned char *new_serverinfo = NULL;
 
     if (ctx == NULL || serverinfo == NULL || serverinfo_length == 0) {
         SSLerr(SSL_F_SSL_CTX_USE_SERVERINFO_EX, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
+    }
+    if (version == SSL_SERVERINFOV1) {
+        /*
+         * Convert serverinfo version v1 to v2 and call yourself recursively
+         * over the converted serverinfo.
+         */
+        const size_t sinfo_length = extension_append_length(SSL_SERVERINFOV1,
+                                                            serverinfo_length);
+        unsigned char *sinfo;
+        int ret;
+
+        sinfo = OPENSSL_malloc(sinfo_length);
+        if (sinfo == NULL) {
+            SSLerr(SSL_F_SSL_CTX_USE_SERVERINFO_EX, ERR_R_MALLOC_FAILURE);
+            return 0;
+        }
+
+        extension_append(SSL_SERVERINFOV1, serverinfo, serverinfo_length, sinfo);
+
+        ret = SSL_CTX_use_serverinfo_ex(ctx, SSL_SERVERINFOV2, sinfo,
+                                        sinfo_length);
+
+        OPENSSL_free(sinfo);
+        return ret;
     }
     if (!serverinfo_process_buffer(version, serverinfo, serverinfo_length,
                                    NULL)) {
@@ -899,7 +951,7 @@ int SSL_CTX_use_serverinfo_file(SSL_CTX *ctx, const char *file)
     char namePrefix2[] = "SERVERINFOV2 FOR ";
     int ret = 0;
     BIO *bin = NULL;
-    size_t num_extensions = 0, contextoff = 0;
+    size_t num_extensions = 0;
 
     if (ctx == NULL || file == NULL) {
         SSLerr(SSL_F_SSL_CTX_USE_SERVERINFO_FILE, ERR_R_PASSED_NULL_PARAMETER);
@@ -918,6 +970,7 @@ int SSL_CTX_use_serverinfo_file(SSL_CTX *ctx, const char *file)
 
     for (num_extensions = 0;; num_extensions++) {
         unsigned int version;
+        size_t append_length;
 
         if (PEM_read_bio(bin, &name, &header, &extension, &extension_length)
             == 0) {
@@ -962,11 +1015,6 @@ int SSL_CTX_use_serverinfo_file(SSL_CTX *ctx, const char *file)
                 SSLerr(SSL_F_SSL_CTX_USE_SERVERINFO_FILE, SSL_R_BAD_DATA);
                 goto end;
             }
-            /*
-             * File does not have a context value so we must take account of
-             * this later.
-             */
-            contextoff = 4;
         } else {
             /* 8 byte header: 4 bytes context, 2 bytes type, 2 bytes len */
             if (extension_length < 8
@@ -977,25 +1025,16 @@ int SSL_CTX_use_serverinfo_file(SSL_CTX *ctx, const char *file)
             }
         }
         /* Append the decoded extension to the serverinfo buffer */
-        tmp = OPENSSL_realloc(serverinfo, serverinfo_length + extension_length
-                                          + contextoff);
+        append_length = extension_append_length(version, extension_length);
+        tmp = OPENSSL_realloc(serverinfo, serverinfo_length + append_length);
         if (tmp == NULL) {
             SSLerr(SSL_F_SSL_CTX_USE_SERVERINFO_FILE, ERR_R_MALLOC_FAILURE);
             goto end;
         }
         serverinfo = tmp;
-        if (contextoff > 0) {
-            unsigned char *sinfo = serverinfo + serverinfo_length;
-
-            /* We know this only uses the last 2 bytes */
-            sinfo[0] = 0;
-            sinfo[1] = 0;
-            sinfo[2] = (SYNTHV1CONTEXT >> 8) & 0xff;
-            sinfo[3] = SYNTHV1CONTEXT & 0xff;
-        }
-        memcpy(serverinfo + serverinfo_length + contextoff,
-               extension, extension_length);
-        serverinfo_length += extension_length + contextoff;
+        extension_append(version, extension, extension_length,
+                         serverinfo + serverinfo_length);
+        serverinfo_length += append_length;
 
         OPENSSL_free(name);
         name = NULL;

--- a/deps/openssl/openssl/ssl/statem/extensions_clnt.c
+++ b/deps/openssl/openssl/ssl/statem/extensions_clnt.c
@@ -1002,7 +1002,7 @@ EXT_RETURN tls_construct_ctos_psk(SSL *s, WPACKET *pkt, unsigned int context,
                                   X509 *x, size_t chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
-    uint32_t now, agesec, agems = 0;
+    uint32_t agesec, agems = 0;
     size_t reshashsize = 0, pskhashsize = 0, binderoffset, msglen;
     unsigned char *resbinder = NULL, *pskbinder = NULL, *msgstart = NULL;
     const EVP_MD *handmd = NULL, *mdres = NULL, *mdpsk = NULL;
@@ -1059,8 +1059,7 @@ EXT_RETURN tls_construct_ctos_psk(SSL *s, WPACKET *pkt, unsigned int context,
          * this in multiple places in the code, so portability shouldn't be an
          * issue.
          */
-        now = (uint32_t)time(NULL);
-        agesec = now - (uint32_t)s->session->time;
+        agesec = (uint32_t)(time(NULL) - s->session->time);
         /*
          * We calculate the age in seconds but the server may work in ms. Due to
          * rounding errors we could overestimate the age by up to 1s. It is

--- a/deps/openssl/openssl/ssl/statem/extensions_srvr.c
+++ b/deps/openssl/openssl/ssl/statem/extensions_srvr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -12,16 +12,16 @@
 #include "statem_local.h"
 #include "internal/cryptlib.h"
 
-#define COOKIE_STATE_FORMAT_VERSION     0
+#define COOKIE_STATE_FORMAT_VERSION     1
 
 /*
  * 2 bytes for packet length, 2 bytes for format version, 2 bytes for
  * protocol version, 2 bytes for group id, 2 bytes for cipher id, 1 byte for
- * key_share present flag, 4 bytes for timestamp, 2 bytes for the hashlen,
+ * key_share present flag, 8 bytes for timestamp, 2 bytes for the hashlen,
  * EVP_MAX_MD_SIZE for transcript hash, 1 byte for app cookie length, app cookie
  * length bytes, SHA256_DIGEST_LENGTH bytes for the HMAC of the whole thing.
  */
-#define MAX_COOKIE_SIZE (2 + 2 + 2 + 2 + 2 + 1 + 4 + 2 + EVP_MAX_MD_SIZE + 1 \
+#define MAX_COOKIE_SIZE (2 + 2 + 2 + 2 + 2 + 1 + 8 + 2 + EVP_MAX_MD_SIZE + 1 \
                          + SSL_COOKIE_LENGTH + SHA256_DIGEST_LENGTH)
 
 /*
@@ -741,7 +741,7 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     unsigned char hmac[SHA256_DIGEST_LENGTH];
     unsigned char hrr[MAX_HRR_SIZE];
     size_t rawlen, hmaclen, hrrlen, ciphlen;
-    unsigned long tm, now;
+    uint64_t tm, now;
 
     /* Ignore any cookie if we're not set up to verify it */
     if (s->ctx->verify_stateless_cookie_cb == NULL
@@ -851,7 +851,7 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     }
 
     if (!PACKET_get_1(&cookie, &key_share)
-            || !PACKET_get_net_4(&cookie, &tm)
+            || !PACKET_get_net_8(&cookie, &tm)
             || !PACKET_get_length_prefixed_2(&cookie, &chhash)
             || !PACKET_get_length_prefixed_1(&cookie, &appcookie)
             || PACKET_remaining(&cookie) != SHA256_DIGEST_LENGTH) {
@@ -861,7 +861,7 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     }
 
     /* We tolerate a cookie age of up to 10 minutes (= 60 * 10 seconds) */
-    now = (unsigned long)time(NULL);
+    now = time(NULL);
     if (tm > now || (now - tm) > 600) {
         /* Cookie is stale. Ignore it */
         return 1;
@@ -1167,7 +1167,7 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                 s->ext.early_data_ok = 1;
             s->ext.ticket_expected = 1;
         } else {
-            uint32_t ticket_age = 0, now, agesec, agems;
+            uint32_t ticket_age = 0, agesec, agems;
             int ret;
 
             /*
@@ -1209,8 +1209,7 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
             }
 
             ticket_age = (uint32_t)ticket_agel;
-            now = (uint32_t)time(NULL);
-            agesec = now - (uint32_t)sess->time;
+            agesec = (uint32_t)(time(NULL) - sess->time);
             agems = agesec * (uint32_t)1000;
             ticket_age -= sess->ext.tick_age_add;
 
@@ -1837,7 +1836,7 @@ EXT_RETURN tls_construct_stoc_cookie(SSL *s, WPACKET *pkt, unsigned int context,
                                               &ciphlen)
                /* Is there a key_share extension present in this HRR? */
             || !WPACKET_put_bytes_u8(pkt, s->s3->peer_tmp == NULL)
-            || !WPACKET_put_bytes_u32(pkt, (unsigned int)time(NULL))
+            || !WPACKET_put_bytes_u64(pkt, time(NULL))
             || !WPACKET_start_sub_packet_u16(pkt)
             || !WPACKET_reserve_bytes(pkt, EVP_MAX_MD_SIZE, &hashval1)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_STOC_COOKIE,

--- a/deps/openssl/openssl/ssl/tls13_enc.c
+++ b/deps/openssl/openssl/ssl/tls13_enc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -190,6 +190,7 @@ int tls13_generate_secret(SSL *s, const EVP_MD *md,
     if (!ossl_assert(mdleni >= 0)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS13_GENERATE_SECRET,
                  ERR_R_INTERNAL_ERROR);
+        EVP_PKEY_CTX_free(pctx);
         return 0;
     }
     mdlen = (size_t)mdleni;

--- a/deps/openssl/openssl/test/dtlstest.c
+++ b/deps/openssl/openssl/test/dtlstest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -328,6 +328,93 @@ static int test_dtls_duplicate_records(void)
     return testresult;
 }
 
+/*
+ * Test that swapping an app data record so that it is received before the
+ * Finished message still works.
+ */
+static int test_swap_app_data(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *sssl = NULL, *cssl = NULL;
+    int testresult = 0;
+    BIO *bio;
+    char msg[] = { 0x00, 0x01, 0x02, 0x03 };
+    char buf[10];
+
+    if (!TEST_true(create_ssl_ctx_pair(DTLS_server_method(),
+                                       DTLS_client_method(),
+                                       DTLS1_VERSION, 0,
+                                       &sctx, &cctx, cert, privkey)))
+        return 0;
+
+#ifndef OPENSSL_NO_DTLS1_2
+    if (!TEST_true(SSL_CTX_set_cipher_list(cctx, "AES128-SHA")))
+        goto end;
+#else
+    /* Default sigalgs are SHA1 based in <DTLS1.2 which is in security level 0 */
+    if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "AES128-SHA:@SECLEVEL=0"))
+            || !TEST_true(SSL_CTX_set_cipher_list(cctx,
+                                                  "AES128-SHA:@SECLEVEL=0")))
+        goto end;
+#endif
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl,
+                                      NULL, NULL)))
+        goto end;
+
+    /* Send flight 1: ClientHello */
+    if (!TEST_int_le(SSL_connect(cssl), 0))
+        goto end;
+
+    /* Recv flight 1, send flight 2: ServerHello, Certificate, ServerHelloDone */
+    if (!TEST_int_le(SSL_accept(sssl), 0))
+        goto end;
+
+    /* Recv flight 2, send flight 3: ClientKeyExchange, CCS, Finished */
+    if (!TEST_int_le(SSL_connect(cssl), 0))
+        goto end;
+
+    /* Recv flight 3, send flight 4: datagram 1(NST, CCS) datagram 2(Finished) */
+    if (!TEST_int_gt(SSL_accept(sssl), 0))
+        goto end;
+
+    /* Send flight 5: app data */
+    if (!TEST_int_eq(SSL_write(sssl, msg, sizeof(msg)), (int)sizeof(msg)))
+        goto end;
+
+    bio = SSL_get_wbio(sssl);
+    if (!TEST_ptr(bio)
+            || !TEST_true(mempacket_swap_recent(bio)))
+        goto end;
+
+    /*
+     * Recv flight 4 (datagram 1): NST, CCS, + flight 5: app data
+     *      + flight 4 (datagram 2): Finished
+     */
+    if (!TEST_int_gt(SSL_connect(cssl), 0))
+        goto end;
+
+    /* The app data should be buffered already */
+    if (!TEST_int_eq(SSL_pending(cssl), (int)sizeof(msg))
+            || !TEST_true(SSL_has_pending(cssl)))
+        goto end;
+
+    /*
+     * Recv flight 5 (app data)
+     * We already buffered this so it should be available.
+     */
+    if (!TEST_int_eq(SSL_read(cssl, buf, sizeof(buf)), (int)sizeof(msg)))
+        goto end;
+
+    testresult = 1;
+ end:
+    SSL_free(cssl);
+    SSL_free(sssl);
+    SSL_CTX_free(cctx);
+    SSL_CTX_free(sctx);
+    return testresult;
+}
+
 int setup_tests(void)
 {
     if (!TEST_ptr(cert = test_get_argument(0))
@@ -338,6 +425,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_dtls_drop_records, TOTAL_RECORDS);
     ADD_TEST(test_cookie);
     ADD_TEST(test_dtls_duplicate_records);
+    ADD_TEST(test_swap_app_data);
 
     return 1;
 }

--- a/deps/openssl/openssl/test/ec_internal_test.c
+++ b/deps/openssl/openssl/test/ec_internal_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -184,6 +184,39 @@ static int field_tests_default(int n)
 }
 
 /*
+ * Tests behavior of the EC_KEY_set_private_key
+ */
+static int set_private_key(void)
+{
+    EC_KEY *key = NULL, *aux_key = NULL;
+    int testresult = 0;
+
+    key = EC_KEY_new_by_curve_name(NID_secp224r1);
+    aux_key = EC_KEY_new_by_curve_name(NID_secp224r1);
+    if (!TEST_ptr(key)
+        || !TEST_ptr(aux_key)
+        || !TEST_int_eq(EC_KEY_generate_key(key), 1)
+        || !TEST_int_eq(EC_KEY_generate_key(aux_key), 1))
+        goto err;
+
+    /* Test setting a valid private key */
+    if (!TEST_int_eq(EC_KEY_set_private_key(key, aux_key->priv_key), 1))
+        goto err;
+
+    /* Test compliance with legacy behavior for NULL private keys */
+    if (!TEST_int_eq(EC_KEY_set_private_key(key, NULL), 0)
+        || !TEST_ptr_null(key->priv_key))
+        goto err;
+
+    testresult = 1;
+
+ err:
+    EC_KEY_free(key);
+    EC_KEY_free(aux_key);
+    return testresult;
+}
+
+/*
  * Tests behavior of the decoded_from_explicit_params flag and API
  */
 static int decoded_flag_test(void)
@@ -337,6 +370,7 @@ int setup_tests(void)
     ADD_TEST(field_tests_ec2_simple);
 #endif
     ADD_ALL_TESTS(field_tests_default, crv_len);
+    ADD_TEST(set_private_key);
     ADD_TEST(decoded_flag_test);
     ADD_ALL_TESTS(ecpkparams_i2d2i_test, crv_len);
 

--- a/deps/openssl/openssl/test/recipes/25-test_x509.t
+++ b/deps/openssl/openssl/test/recipes/25-test_x509.t
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2015-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -15,7 +15,11 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_x509");
 
-plan tests => 9;
+plan tests => 16;
+
+# Prevent MSys2 filename munging for arguments that look like file paths but
+# aren't
+$ENV{MSYS2_ARG_CONV_EXCL} = "/CN=";
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
@@ -46,4 +50,59 @@ subtest 'x509 -- second x.509 v3 certificate' => sub {
 
 subtest 'x509 -- pathlen' => sub {
     ok(run(test(["v3ext", srctop_file("test/certs", "pathlen.pem")])));
+};
+
+# extracts issuer from a -text formatted-output
+sub get_issuer {
+    my $f = shift(@_);
+    my $issuer = "";
+    open my $fh, $f or die;
+    while (my $line = <$fh>) {
+        if ($line =~ /Issuer:/) {
+            $issuer = $line;
+        }
+    }
+    close $fh;
+    return $issuer;
 }
+
+# Tests for signing certs (broken in 1.1.1o)
+my $a_key = "a-key.pem";
+my $a_cert = "a-cert.pem";
+my $a2_cert = "a2-cert.pem";
+my $ca_key = "ca-key.pem";
+my $ca_cert = "ca-cert.pem";
+my $cnf = srctop_file('apps', 'openssl.cnf');
+
+# Create cert A
+ok(run(app(["openssl", "req", "-x509", "-newkey", "rsa:2048",
+            "-config", $cnf,
+            "-keyout", $a_key, "-out", $a_cert, "-days", "365",
+            "-nodes", "-subj", "/CN=test.example.com"])));
+# Create cert CA - note key size
+ok(run(app(["openssl", "req", "-x509", "-newkey", "rsa:4096",
+            "-config", $cnf,
+            "-keyout", $ca_key, "-out", $ca_cert, "-days", "3650",
+            "-nodes", "-subj", "/CN=ca.example.com"])));
+# Sign cert A with CA (errors on 1.1.1o)
+ok(run(app(["openssl", "x509", "-in", $a_cert, "-CA", $ca_cert,
+            "-CAkey", $ca_key, "-set_serial", "1234567890",
+            "-preserve_dates", "-sha256", "-text", "-out", $a2_cert])));
+# verify issuer is CA
+ok (get_issuer($a2_cert) =~ /CN = ca.example.com/);
+
+# Tests for issue #16080 (fixed in 1.1.1o)
+my $b_key = "b-key.pem";
+my $b_csr = "b-cert.csr";
+my $b_cert = "b-cert.pem";
+# Create the CSR
+ok(run(app(["openssl", "req", "-new", "-newkey", "rsa:4096",
+            "-keyout", $b_key, "-out", $b_csr, "-nodes",
+            "-config", $cnf,
+            "-subj", "/CN=b.example.com"])));
+# Sign it - position of "-text" matters!
+ok(run(app(["openssl", "x509", "-req", "-text", "-CAcreateserial",
+            "-CA", $ca_cert, "-CAkey", $ca_key,
+            "-in", $b_csr, "-out", $b_cert])));
+# Verify issuer is CA
+ok(get_issuer($b_cert) =~ /CN = ca.example.com/);

--- a/deps/openssl/openssl/test/sslapitest.c
+++ b/deps/openssl/openssl/test/sslapitest.c
@@ -85,20 +85,6 @@ struct sslapitest_log_counts {
 };
 
 
-static unsigned char serverinfov1[] = {
-    0xff, 0xff, /* Dummy extension type */
-    0x00, 0x01, /* Extension length is 1 byte */
-    0xff        /* Dummy extension data */
-};
-
-static unsigned char serverinfov2[] = {
-    0x00, 0x00, 0x00,
-    (unsigned char)(SSL_EXT_CLIENT_HELLO & 0xff), /* Dummy context - 4 bytes */
-    0xff, 0xff, /* Dummy extension type */
-    0x00, 0x01, /* Extension length is 1 byte */
-    0xff        /* Dummy extension data */
-};
-
 static int hostname_cb(SSL *s, int *al, void *arg)
 {
     const char *hostname = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
@@ -4511,62 +4497,137 @@ end:
     return testresult;
 }
 
-/*
- * Test loading of serverinfo data in various formats. test_sslmessages actually
- * tests to make sure the extensions appear in the handshake
- */
-static int test_serverinfo(int tst)
-{
-    unsigned int version;
-    unsigned char *sibuf;
-    size_t sibuflen;
-    int ret, expected, testresult = 0;
-    SSL_CTX *ctx;
+#if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_TLS1_3)
 
-    ctx = SSL_CTX_new(TLS_method());
-    if (!TEST_ptr(ctx))
+#define  SYNTHV1CONTEXT     (SSL_EXT_TLS1_2_AND_BELOW_ONLY \
+                             | SSL_EXT_CLIENT_HELLO \
+                             | SSL_EXT_TLS1_2_SERVER_HELLO \
+                             | SSL_EXT_IGNORE_ON_RESUMPTION)
+
+#define TLS13CONTEXT (SSL_EXT_TLS1_3_CERTIFICATE \
+                      | SSL_EXT_TLS1_2_SERVER_HELLO \
+                      | SSL_EXT_CLIENT_HELLO)
+
+#define SERVERINFO_CUSTOM                                 \
+    0x00, (char)TLSEXT_TYPE_signed_certificate_timestamp, \
+    0x00, 0x03,                                           \
+    0x04, 0x05, 0x06                                      \
+
+static const unsigned char serverinfo_custom_tls13[] = {
+    0x00, 0x00, (TLS13CONTEXT >> 8) & 0xff, TLS13CONTEXT & 0xff,
+    SERVERINFO_CUSTOM
+};
+static const unsigned char serverinfo_custom_v2[] = {
+    0x00, 0x00, (SYNTHV1CONTEXT >> 8) & 0xff,  SYNTHV1CONTEXT & 0xff,
+    SERVERINFO_CUSTOM
+};
+static const unsigned char serverinfo_custom_v1[] = {
+    SERVERINFO_CUSTOM
+};
+static const size_t serverinfo_custom_tls13_len = sizeof(serverinfo_custom_tls13);
+static const size_t serverinfo_custom_v2_len = sizeof(serverinfo_custom_v2);
+static const size_t serverinfo_custom_v1_len = sizeof(serverinfo_custom_v1);
+
+static int serverinfo_custom_parse_cb(SSL *s, unsigned int ext_type,
+                                      unsigned int context,
+                                      const unsigned char *in,
+                                      size_t inlen, X509 *x,
+                                      size_t chainidx, int *al,
+                                      void *parse_arg)
+{
+    const size_t len = serverinfo_custom_v1_len;
+    const unsigned char *si = &serverinfo_custom_v1[len - 3];
+    int *p_cb_result = (int*)parse_arg;
+    *p_cb_result = TEST_mem_eq(in, inlen, si, 3);
+    return 1;
+}
+
+static int test_serverinfo_custom(const int idx)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+    int cb_result = 0;
+
+    /*
+     * Following variables are set in the switch statement
+     *  according to the test iteration.
+     * Default values do not make much sense: test would fail with them.
+     */
+    int serverinfo_version = 0;
+    int protocol_version = 0;
+    unsigned int extension_context = 0;
+    const unsigned char *si = NULL;
+    size_t si_len = 0;
+
+    const int call_use_serverinfo_ex = idx > 0;
+    switch (idx) {
+    case 0: /* FALLTHROUGH */
+    case 1:
+        serverinfo_version = SSL_SERVERINFOV1;
+        protocol_version = TLS1_2_VERSION;
+        extension_context = SYNTHV1CONTEXT;
+        si = serverinfo_custom_v1;
+        si_len = serverinfo_custom_v1_len;
+        break;
+    case 2:
+        serverinfo_version = SSL_SERVERINFOV2;
+        protocol_version = TLS1_2_VERSION;
+        extension_context = SYNTHV1CONTEXT;
+        si = serverinfo_custom_v2;
+        si_len = serverinfo_custom_v2_len;
+        break;
+    case 3:
+        serverinfo_version = SSL_SERVERINFOV2;
+        protocol_version = TLS1_3_VERSION;
+        extension_context = TLS13CONTEXT;
+        si = serverinfo_custom_tls13;
+        si_len = serverinfo_custom_tls13_len;
+        break;
+    }
+
+    if (!TEST_true(create_ssl_ctx_pair(TLS_method(),
+                                       TLS_method(),
+                                       protocol_version,
+                                       protocol_version,
+                                       &sctx, &cctx, cert, privkey)))
         goto end;
 
-    if ((tst & 0x01) == 0x01)
-        version = SSL_SERVERINFOV2;
-    else
-        version = SSL_SERVERINFOV1;
-
-    if ((tst & 0x02) == 0x02) {
-        sibuf = serverinfov2;
-        sibuflen = sizeof(serverinfov2);
-        expected = (version == SSL_SERVERINFOV2);
+    if (call_use_serverinfo_ex) {
+        if (!TEST_true(SSL_CTX_use_serverinfo_ex(sctx, serverinfo_version,
+                                                 si, si_len)))
+            goto end;
     } else {
-        sibuf = serverinfov1;
-        sibuflen = sizeof(serverinfov1);
-        expected = (version == SSL_SERVERINFOV1);
+        if (!TEST_true(SSL_CTX_use_serverinfo(sctx, si, si_len)))
+            goto end;
     }
 
-    if ((tst & 0x04) == 0x04) {
-        ret = SSL_CTX_use_serverinfo_ex(ctx, version, sibuf, sibuflen);
-    } else {
-        ret = SSL_CTX_use_serverinfo(ctx, sibuf, sibuflen);
+    if (!TEST_true(SSL_CTX_add_custom_ext(cctx, TLSEXT_TYPE_signed_certificate_timestamp,
+                                          extension_context,
+                                          NULL, NULL, NULL,
+                                          serverinfo_custom_parse_cb,
+                                          &cb_result))
+        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                         NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+                                            SSL_ERROR_NONE))
+        || !TEST_int_eq(SSL_do_handshake(clientssl), 1))
+        goto end;
 
-        /*
-         * The version variable is irrelevant in this case - it's what is in the
-         * buffer that matters
-         */
-        if ((tst & 0x02) == 0x02)
-            expected = 0;
-        else
-            expected = 1;
-    }
-
-    if (!TEST_true(ret == expected))
+    if (!TEST_true(cb_result))
         goto end;
 
     testresult = 1;
 
  end:
-    SSL_CTX_free(ctx);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
 
     return testresult;
 }
+#endif
 
 /*
  * Test that SSL_export_keying_material() produces expected results. There are
@@ -7691,7 +7752,6 @@ int setup_tests(void)
 #else
     ADD_ALL_TESTS(test_custom_exts, 3);
 #endif
-    ADD_ALL_TESTS(test_serverinfo, 8);
     ADD_ALL_TESTS(test_export_key_mat, 6);
 #ifndef OPENSSL_NO_TLS1_3
     ADD_ALL_TESTS(test_export_key_mat_early, 3);
@@ -7723,6 +7783,9 @@ int setup_tests(void)
     ADD_TEST(test_set_verify_cert_store_ssl_ctx);
     ADD_TEST(test_set_verify_cert_store_ssl);
     ADD_TEST(test_inherit_verify_param);
+#if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_TLS1_3)
+    ADD_ALL_TESTS(test_serverinfo_custom, 4);
+#endif
 #ifndef OPENSSL_NO_QUIC
     ADD_ALL_TESTS(test_quic_api, 9);
     ADD_ALL_TESTS(test_quic_early_data, 3);

--- a/deps/openssl/openssl/test/ssltestlib.h
+++ b/deps/openssl/openssl/test/ssltestlib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -46,6 +46,7 @@ void bio_s_always_retry_free(void);
 #define MEMPACKET_CTRL_GET_DROP_REC         (3 << 15)
 #define MEMPACKET_CTRL_SET_DUPLICATE_REC    (4 << 15)
 
+int mempacket_swap_recent(BIO *bio);
 int mempacket_test_inject(BIO *bio, const char *in, int inl, int pktnum,
                           int type);
 

--- a/deps/openssl/openssl/test/v3ext.c
+++ b/deps/openssl/openssl/test/v3ext.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/pem.h>
@@ -224,6 +225,104 @@ static int test_addr_ranges(void)
     ASN1_OCTET_STRING_free(ip2);
     return testresult;
 }
+
+static struct extvalues_st {
+    const char *value;
+    int pass;
+} extvalues[] = {
+    /* No prefix is ok */
+    { "sbgp-ipAddrBlock = IPv4:192.0.0.1\n", 1 },
+    { "sbgp-ipAddrBlock = IPv4:192.0.0.0/0\n", 1 },
+    { "sbgp-ipAddrBlock = IPv4:192.0.0.0/1\n", 1 },
+    { "sbgp-ipAddrBlock = IPv4:192.0.0.0/32\n", 1 },
+    /* Prefix is too long */
+    { "sbgp-ipAddrBlock = IPv4:192.0.0.0/33\n", 0 },
+    /* Unreasonably large prefix */
+    { "sbgp-ipAddrBlock = IPv4:192.0.0.0/12341234\n", 0 },
+    /* Invalid IP addresses */
+    { "sbgp-ipAddrBlock = IPv4:192.0.0\n", 0 },
+    { "sbgp-ipAddrBlock = IPv4:256.0.0.0\n", 0 },
+    { "sbgp-ipAddrBlock = IPv4:-1.0.0.0\n", 0 },
+    { "sbgp-ipAddrBlock = IPv4:192.0.0.0.0\n", 0 },
+    { "sbgp-ipAddrBlock = IPv3:192.0.0.0\n", 0 },
+
+    /* IPv6 */
+    /* No prefix is ok */
+    { "sbgp-ipAddrBlock = IPv6:2001:db8::\n", 1 },
+    { "sbgp-ipAddrBlock = IPv6:2001::db8\n", 1 },
+    { "sbgp-ipAddrBlock = IPv6:2001:0db8:0000:0000:0000:0000:0000:0000\n", 1 },
+    { "sbgp-ipAddrBlock = IPv6:2001:db8::/0\n", 1 },
+    { "sbgp-ipAddrBlock = IPv6:2001:db8::/1\n", 1 },
+    { "sbgp-ipAddrBlock = IPv6:2001:db8::/32\n", 1 },
+    { "sbgp-ipAddrBlock = IPv6:2001:0db8:0000:0000:0000:0000:0000:0000/32\n", 1 },
+    { "sbgp-ipAddrBlock = IPv6:2001:db8::/128\n", 1 },
+    /* Prefix is too long */
+    { "sbgp-ipAddrBlock = IPv6:2001:db8::/129\n", 0 },
+    /* Unreasonably large prefix */
+    { "sbgp-ipAddrBlock = IPv6:2001:db8::/12341234\n", 0 },
+    /* Invalid IP addresses */
+    /* Not enough blocks of numbers */
+    { "sbgp-ipAddrBlock = IPv6:2001:0db8:0000:0000:0000:0000:0000\n", 0 },
+    /* Too many blocks of numbers */
+    { "sbgp-ipAddrBlock = IPv6:2001:0db8:0000:0000:0000:0000:0000:0000:0000\n", 0 },
+    /* First value too large */
+    { "sbgp-ipAddrBlock = IPv6:1ffff:0db8:0000:0000:0000:0000:0000:0000\n", 0 },
+    /* First value with invalid characters */
+    { "sbgp-ipAddrBlock = IPv6:fffg:0db8:0000:0000:0000:0000:0000:0000\n", 0 },
+    /* First value is negative */
+    { "sbgp-ipAddrBlock = IPv6:-1:0db8:0000:0000:0000:0000:0000:0000\n", 0 }
+};
+
+static int test_ext_syntax(void)
+{
+    size_t i;
+    int testresult = 1;
+
+    for (i = 0; i < OSSL_NELEM(extvalues); i++) {
+        X509V3_CTX ctx;
+        BIO *extbio = BIO_new_mem_buf(extvalues[i].value,
+                                      strlen(extvalues[i].value));
+        CONF *conf;
+        long eline;
+
+        if (!TEST_ptr(extbio))
+            return 0 ;
+
+        conf = NCONF_new(NULL);
+        if (!TEST_ptr(conf)) {
+            BIO_free(extbio);
+            return 0;
+        }
+        if (!TEST_long_gt(NCONF_load_bio(conf, extbio, &eline), 0)) {
+            testresult = 0;
+        } else {
+            X509V3_set_ctx_test(&ctx);
+            X509V3_set_nconf(&ctx, conf);
+
+            if (extvalues[i].pass) {
+                if (!TEST_true(X509V3_EXT_add_nconf(conf, &ctx, "default",
+                                                    NULL))) {
+                    TEST_info("Value: %s", extvalues[i].value);
+                    testresult = 0;
+                }
+            } else {
+                ERR_set_mark();
+                if (!TEST_false(X509V3_EXT_add_nconf(conf, &ctx, "default",
+                                                     NULL))) {
+                    testresult = 0;
+                    TEST_info("Value: %s", extvalues[i].value);
+                    ERR_clear_last_mark();
+                } else {
+                    ERR_pop_to_mark();
+                }
+            }
+        }
+        BIO_free(extbio);
+        NCONF_free(conf);
+    }
+
+    return testresult;
+}
 #endif /* OPENSSL_NO_RFC3779 */
 
 int setup_tests(void)
@@ -235,6 +334,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_RFC3779
     ADD_TEST(test_asid);
     ADD_TEST(test_addr_ranges);
+    ADD_TEST(test_ext_syntax);
 #endif /* OPENSSL_NO_RFC3779 */
     return 1;
 }

--- a/deps/openssl/openssl/test/x509_internal_test.c
+++ b/deps/openssl/openssl/test/x509_internal_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -57,8 +57,63 @@ static int test_standard_exts(void)
     return good;
 }
 
+typedef struct {
+    const char *ipasc;
+    const char *data;
+    int length;
+} IP_TESTDATA;
+
+static IP_TESTDATA a2i_ipaddress_tests[] = {
+    {"127.0.0.1", "\x7f\x00\x00\x01", 4},
+    {"1.2.3.4", "\x01\x02\x03\x04", 4},
+    {"1.2.3.255", "\x01\x02\x03\xff", 4},
+    {"1.2.3", NULL, 0},
+    {"1.2.3 .4", NULL, 0},
+
+    {"::1", "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", 16},
+    {"1:1:1:1:1:1:1:1", "\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01", 16},
+    {"2001:db8::ff00:42:8329", "\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\xff\x00\x00\x42\x83\x29", 16},
+    {"1:1:1:1:1:1:1:1.test", NULL, 0},
+    {":::1", NULL, 0},
+    {"2001::123g", NULL, 0},
+
+    {"example.test", NULL, 0},
+    {"", NULL, 0},
+
+    {"1.2.3.4 ", "\x01\x02\x03\x04", 4},
+    {" 1.2.3.4", "\x01\x02\x03\x04", 4},
+    {" 1.2.3.4 ", "\x01\x02\x03\x04", 4},
+    {"1.2.3.4.example.test", NULL, 0},
+};
+
+
+static int test_a2i_ipaddress(int idx)
+{
+    int good = 1;
+    ASN1_OCTET_STRING *ip;
+    int len = a2i_ipaddress_tests[idx].length;
+
+    ip = a2i_IPADDRESS(a2i_ipaddress_tests[idx].ipasc);
+    if (len == 0) {
+        if (!TEST_ptr_null(ip)) {
+            good = 0;
+            TEST_note("'%s' should not be parsed as IP address", a2i_ipaddress_tests[idx].ipasc);
+        }
+    } else {
+        if (!TEST_ptr(ip)
+            || !TEST_int_eq(ASN1_STRING_length(ip), len)
+            || !TEST_mem_eq(ASN1_STRING_get0_data(ip), len,
+                            a2i_ipaddress_tests[idx].data, len)) {
+            good = 0;
+        }
+    }
+    ASN1_OCTET_STRING_free(ip);
+    return good;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_standard_exts);
+    ADD_ALL_TESTS(test_a2i_ipaddress, OSSL_NELEM(a2i_ipaddress_tests));
     return 1;
 }

--- a/deps/openssl/openssl/util/perl/OpenSSL/copyright.pm
+++ b/deps/openssl/openssl/util/perl/OpenSSL/copyright.pm
@@ -1,0 +1,41 @@
+#! /usr/bin/env perl
+# Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+package OpenSSL::copyright;
+
+sub year_of {
+    my $file = shift;
+
+    return $ENV{'OSSL_COPYRIGHT_YEAR'} if defined $ENV{'OSSL_COPYRIGHT_YEAR'};
+
+    # Use the file date for backward compatibility.
+    my $YEAR = [localtime([stat($file)]->[9])]->[5] + 1900;
+
+    # See if git's available
+    open my $FH,
+       "git log -1 --date=short --format=format:%cd $file 2>/dev/null|"
+           or return $YEAR;
+    my $LINE = <$FH>;
+    close $FH;
+    $LINE =~ s/^([0-9]*)-.*/$1/ if $LINE;
+    $YEAR = $LINE if $LINE;
+    return $YEAR;
+}
+
+sub latest {
+    my $l = 0;
+    foreach my $f (@_ ) {
+        my $y = year_of($f);
+        $l = $y if $y > $l;
+    }
+    return $l
+}
+1;


### PR DESCRIPTION
Updated openssl dep to openssl-1.1.1s+quic using the maintenance guide.

Refs: https://mta.openssl.org/pipermail/openssl-announce/2022-November/000242.html