### PR TITLE
async_hooks: AsyncLocalStorage to diagnostics_channel integration

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -92,6 +92,7 @@ let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
 
 const dc = require('diagnostics_channel');
 const onRequestStartChannel = dc.channel('http.server.request.start');
+const onRequestEndChannel = dc.channel('http.server.request.end');
 const onResponseFinishChannel = dc.channel('http.server.response.finish');
 
 const kServerResponse = Symbol('ServerResponse');
@@ -996,13 +997,18 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
   res.shouldKeepAlive = keepAlive;
   res[kUniqueHeaders] = server[kUniqueHeaders];
 
-  if (onRequestStartChannel.hasSubscribers) {
-    onRequestStartChannel.publish({
+  const dcMessage = (
+    onRequestStartChannel.hasSubscribers ||
+    onRequestEndChannel.hasSubscribers
+  ) ? {
       request: req,
       response: res,
       socket,
       server
-    });
+    } : undefined;
+
+  if (onRequestStartChannel.hasSubscribers) {
+    onRequestStartChannel.publish(dcMessage);
   }
 
   if (socket._httpMessage) {
@@ -1061,6 +1067,10 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
 
   if (!handled) {
     server.emit('request', req, res);
+  }
+
+  if (onRequestEndChannel.hasSubscribers) {
+    onRequestEndChannel.publish(dcMessage);
   }
 
   return 0;  // No special treatment.

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -9,6 +9,7 @@ const {
   FunctionPrototypeBind,
   NumberIsSafeInteger,
   ObjectDefineProperties,
+  ObjectPrototypeHasOwnProperty,
   ObjectIs,
   ReflectApply,
   Symbol,
@@ -26,6 +27,7 @@ const {
   validateString,
 } = require('internal/validators');
 const internal_async_hooks = require('internal/async_hooks');
+const { tracingChannel } = require('diagnostics_channel');
 
 // Get functions
 // For userland AsyncResources, make sure to emit a destroy event when the
@@ -351,6 +353,47 @@ class AsyncLocalStorage {
       return resource[this.kResourceStore];
     }
   }
+
+  bindToTracingChannel(channel, transform = (v) => v) {
+    if (typeof channel === 'string') {
+      channel = tracingChannel(channel);
+    }
+
+    const store = this;
+
+    function start(register) {
+      register(store, transform);
+    }
+
+    channel.subscribe({ start });
+    return () => {
+      channel.unsubscribe({ start });
+    };
+  }
+
+  static runInTracingChannel(channel, data, runner) {
+    if (typeof channel === 'string') {
+      channel = tracingChannel(channel);
+    }
+
+    const bindings = [];
+
+    function register(store, transform) {
+      bindings.push({ store, data: transform(data) });
+    }
+
+    return channel.traceSync(() => {
+      for (const { store, data } of bindings) {
+        runner = wrapRunInStoreBinding(store, data, runner);
+      }
+
+      return runner();
+    }, register);
+  }
+}
+
+function wrapRunInStoreBinding(store, data, next) {
+  return () => store.run(data, next);
 }
 
 // Placing all exports down here because the exported classes won't export

--- a/lib/diagnostics_channel.js
+++ b/lib/diagnostics_channel.js
@@ -289,5 +289,6 @@ module.exports = {
   subscribe,
   tracingChannel,
   unsubscribe,
-  Channel
+  Channel,
+  TracingChannel
 };

--- a/lib/diagnostics_channel.js
+++ b/lib/diagnostics_channel.js
@@ -30,6 +30,7 @@ class ActiveChannel {
   subscribe(subscription) {
     validateFunction(subscription, 'subscription');
     ArrayPrototypePush(this._subscribers, subscription);
+    this._weak.incRef();
   }
 
   unsubscribe(subscription) {
@@ -37,6 +38,7 @@ class ActiveChannel {
     if (index === -1) return false;
 
     ArrayPrototypeSplice(this._subscribers, index, 1);
+    this._weak.decRef();
 
     // When there are no more active subscribers, restore to fast prototype.
     if (!this._subscribers.length) {
@@ -68,6 +70,7 @@ class ActiveChannel {
 class Channel {
   constructor(name) {
     this._subscribers = undefined;
+    this._weak = undefined;
     this.name = name;
   }
 
@@ -107,24 +110,17 @@ function channel(name) {
   }
 
   channel = new Channel(name);
-  channels[name] = new WeakReference(channel);
+  channel._weak = new WeakReference(channel);
+  channels[name] = channel._weak;
   return channel;
 }
 
 function subscribe(name, subscription) {
-  const chan = channel(name);
-  channels[name].incRef();
-  chan.subscribe(subscription);
+  return channel(name).subscribe(subscription);
 }
 
 function unsubscribe(name, subscription) {
-  const chan = channel(name);
-  if (!chan.unsubscribe(subscription)) {
-    return false;
-  }
-
-  channels[name].decRef();
-  return true;
+  return channel(name).unsubscribe(subscription);
 }
 
 function hasSubscribers(name) {
@@ -139,46 +135,54 @@ function hasSubscribers(name) {
 }
 
 class TracingChannel {
+  #channels;
+
   constructor(name) {
     this.name = name;
-    this.channels = {
-      start: channel(`${name}.start`),
-      end: channel(`${name}.end`),
-      asyncEnd: channel(`${name}.asyncEnd`),
-      error: channel(`${name}.error`)
+    this.#channels = {
+      start: new Channel(Symbol(`tracing.start`)),
+      end: new Channel(Symbol(`tracing.end`)),
+      asyncEnd: new Channel(Symbol(`tracing.asyncEnd`)),
+      error: new Channel(Symbol(`tracing.error`))
     };
   }
 
+  // Attach WeakReference to all the sub-channels so the liveness management
+  // in subscribe/unsubscribe keeps the TracingChannel the sub-channels are
+  // attached to alive.
+  set _weak(weak) {
+    for (const key in this.#channels) {
+      this.#channels[key]._weak = weak;
+    }
+  }
+
   get hasSubscribers() {
-    const { channels } = this;
-    for (const key in channels) {
-      if (channels[key].hasSubscribers) return true;
+    for (const key in this.#channels) {
+      if (this.#channels[key].hasSubscribers) {
+        return true;
+      }
     }
     return false;
   }
 
   subscribe(handlers) {
-    let subscribed = true;
     for (const key in handlers) {
-      if (!subscribe(`${this.name}.${key}`, handlers[key])) {
-        subscribed = false;
-      }
+      this.#channels[key]?.subscribe(handlers[key]);
     }
-    return subscribed;
   }
 
   unsubscribe(handlers) {
-    let unsubscribed = true;
     for (const key in handlers) {
-      if (!unsubscribe(`${this.name}.${key}`, handlers[key])) {
-        unsubscribed = false;
+      const channel = this.#channels[key];
+      if (!channel || !channel.unsubscribe(handlers[key])) {
+        return false;
       }
     }
-    return unsubscribed;
+    return true;
   }
 
   traceSync(fn, ctx = {}, thisArg, ...args) {
-    const { start, end, error } = this.channels;
+    const { start, end, error } = this.#channels;
     start.publish(ctx);
     try {
       const result = ReflectApply(fn, thisArg, args);
@@ -194,7 +198,7 @@ class TracingChannel {
   }
 
   tracePromise(fn, ctx = {}, thisArg, ...args) {
-    const { asyncEnd, start, end, error } = this.channels;
+    const { asyncEnd, start, end, error } = this.#channels;
     start.publish(ctx);
 
     const reject = (err) => {
@@ -223,7 +227,7 @@ class TracingChannel {
   }
 
   traceCallback(fn, position = 0, ctx = {}, thisArg, ...args) {
-    const { start, end, asyncEnd, error } = this.channels;
+    const { start, end, asyncEnd, error } = this.#channels;
     start.publish(ctx);
 
     function wrap(fn) {
@@ -258,8 +262,22 @@ class TracingChannel {
   }
 }
 
+const tracingChannels = ObjectCreate(null);
+
 function tracingChannel(name) {
-  return new TracingChannel(name);
+  let channel;
+  const ref = tracingChannels[name];
+  if (ref) channel = ref.get();
+  if (channel) return channel;
+
+  if (typeof name !== 'string' && typeof name !== 'symbol') {
+    throw new ERR_INVALID_ARG_TYPE('tracingChannel', ['string', 'symbol'], name);
+  }
+
+  channel = new TracingChannel(name);
+  channel._weak = new WeakReference(channel);
+  tracingChannels[name] = channel._weak;
+  return channel;
 }
 
 module.exports = {

--- a/lib/diagnostics_channel.js
+++ b/lib/diagnostics_channel.js
@@ -7,6 +7,8 @@ const {
   ObjectCreate,
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
+  PromisePrototypeThen,
+  ReflectApply,
   SymbolHasInstance,
 } = primordials;
 
@@ -136,10 +138,135 @@ function hasSubscribers(name) {
   return channel.hasSubscribers;
 }
 
+class TracingChannel {
+  constructor(name) {
+    this.name = name;
+    this.channels = {
+      start: channel(`${name}.start`),
+      end: channel(`${name}.end`),
+      asyncEnd: channel(`${name}.asyncEnd`),
+      error: channel(`${name}.error`)
+    };
+  }
+
+  get hasSubscribers() {
+    const { channels } = this;
+    for (const key in channels) {
+      if (channels[key].hasSubscribers) return true;
+    }
+    return false;
+  }
+
+  subscribe(handlers) {
+    let subscribed = true;
+    for (const key in handlers) {
+      if (!subscribe(`${this.name}.${key}`, handlers[key])) {
+        subscribed = false;
+      }
+    }
+    return subscribed;
+  }
+
+  unsubscribe(handlers) {
+    let unsubscribed = true;
+    for (const key in handlers) {
+      if (!unsubscribe(`${this.name}.${key}`, handlers[key])) {
+        unsubscribed = false;
+      }
+    }
+    return unsubscribed;
+  }
+
+  traceSync(fn, ctx = {}, thisArg, ...args) {
+    const { start, end, error } = this.channels;
+    start.publish(ctx);
+    try {
+      const result = ReflectApply(fn, thisArg, args);
+      ctx.result = result;
+      return result;
+    } catch (err) {
+      ctx.error = err;
+      error.publish(ctx);
+      throw err;
+    } finally {
+      end.publish(ctx);
+    }
+  }
+
+  tracePromise(fn, ctx = {}, thisArg, ...args) {
+    const { asyncEnd, start, end, error } = this.channels;
+    start.publish(ctx);
+
+    const reject = (err) => {
+      ctx.error = err;
+      error.publish(ctx);
+      asyncEnd.publish(ctx);
+      throw err;
+    };
+
+    const resolve = (result) => {
+      ctx.result = result;
+      asyncEnd.publish(ctx);
+      return result;
+    };
+
+    try {
+      const promise = ReflectApply(fn, thisArg, args);
+      return PromisePrototypeThen(promise, resolve, reject);
+    } catch (err) {
+      ctx.error = err;
+      error.publish(ctx);
+      throw err;
+    } finally {
+      end.publish(ctx);
+    }
+  }
+
+  traceCallback(fn, position = 0, ctx = {}, thisArg, ...args) {
+    const { start, end, asyncEnd, error } = this.channels;
+    start.publish(ctx);
+
+    function wrap(fn) {
+      return function wrappedCallback (err, res) {
+        if (err) {
+          ctx.error = err;
+          error.publish(ctx);
+        } else {
+          ctx.result = res;
+        }
+
+        asyncEnd.publish(ctx);
+        if (fn) {
+          return ReflectApply(fn, this, arguments);
+        }
+      }
+    }
+
+    if (position >= 0) {
+      args.splice(position, 1, wrap(args.at(position)));
+    }
+
+    try {
+      return ReflectApply(fn, thisArg, args);
+    } catch (err) {
+      ctx.error = err;
+      error.publish(ctx);
+      throw err;
+    } finally {
+      end.publish(ctx);
+    }
+  }
+}
+
+function tracingChannel(name) {
+  return new TracingChannel(name);
+}
+
 module.exports = {
   channel,
   hasSubscribers,
   subscribe,
+  tracingChannel,
   unsubscribe,
   Channel
 };

--- a/lib/diagnostics_channel.js
+++ b/lib/diagnostics_channel.js
@@ -182,6 +182,7 @@ class TracingChannel {
   }
 
   traceSync(fn, ctx = {}, thisArg, ...args) {
+    if (!this.hasSubscribers) return ReflectApply(fn, thisArg, args);
     const { start, end, error } = this.#channels;
     start.publish(ctx);
     try {
@@ -198,6 +199,7 @@ class TracingChannel {
   }
 
   tracePromise(fn, ctx = {}, thisArg, ...args) {
+    if (!this.hasSubscribers) return ReflectApply(fn, thisArg, args);
     const { asyncEnd, start, end, error } = this.#channels;
     start.publish(ctx);
 
@@ -227,6 +229,7 @@ class TracingChannel {
   }
 
   traceCallback(fn, position = 0, ctx = {}, thisArg, ...args) {
+    if (!this.hasSubscribers) return ReflectApply(fn, thisArg, args);
     const { start, end, asyncEnd, error } = this.#channels;
     start.publish(ctx);
 

--- a/test/parallel/test-async-local-storage-tracing-channel-integration.js
+++ b/test/parallel/test-async-local-storage-tracing-channel-integration.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { AsyncLocalStorage } = require('async_hooks');
+
+const contextA = {
+  foo: 'bar'
+};
+const contextB = {
+  baz: 'buz'
+};
+
+const expected = [
+  contextA,
+  contextB
+];
+
+let builds = 0;
+let runs = 0;
+
+const storageA = new AsyncLocalStorage();
+const storageB = new AsyncLocalStorage();
+
+// Check both passthrough bindings and transformed bindings
+storageA.bindToTracingChannel('test');
+storageB.bindToTracingChannel('test', common.mustCall((received) => {
+  assert.deepStrictEqual(received, expected[builds++]);
+  return { received };
+}, 2));
+
+function check(context) {
+  assert.deepStrictEqual(storageA.getStore(), context);
+  assert.deepStrictEqual(storageB.getStore(), {
+    received: context
+  });
+}
+
+// Should have no context before run
+assert.strictEqual(storageA.getStore(), undefined);
+assert.strictEqual(storageB.getStore(), undefined);
+
+AsyncLocalStorage.runInTracingChannel('test', expected[runs], common.mustCall(() => {
+  // Should have set expected context
+  check(expected[runs]);
+
+  // Should support nested contexts
+  runs++;
+  AsyncLocalStorage.runInTracingChannel('test', expected[runs], common.mustCall(() => {
+    check(expected[runs]);
+  }));
+  runs--;
+
+  // Should have restored outer context
+  check(expected[runs]);
+}));
+
+// Should have no context after run
+assert.strictEqual(storageA.getStore(), undefined);
+assert.strictEqual(storageB.getStore(), undefined);

--- a/test/parallel/test-diagnostics-channel-tracing-channel-async-error.js
+++ b/test/parallel/test-diagnostics-channel-tracing-channel-async-error.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const common = require('../common');
+const dc = require('diagnostics_channel');
+const assert = require('assert');
+
+const channel = dc.tracingChannel('test');
+
+const expectedError = new Error('test');
+const input = { foo: 'bar' };
+const thisArg = { baz: 'buz' };
+
+function check(found) {
+  assert.deepStrictEqual(found, input);
+}
+
+const handlers = {
+  start: common.mustCall(check, 2),
+  end: common.mustCall(check, 2),
+  asyncEnd: common.mustCall(check, 2),
+  error: common.mustCall((found) => {
+    check(found);
+    assert.deepStrictEqual(found.error, expectedError);
+  }, 2)
+};
+
+channel.subscribe(handlers);
+
+channel.traceCallback(function (cb, err) {
+  assert.deepStrictEqual(this, thisArg);
+  setImmediate(cb, err);
+}, 0, input, thisArg, common.mustCall((err, res) => {
+  assert.strictEqual(err, expectedError);
+  assert.deepStrictEqual(res, undefined);
+}), expectedError);
+
+channel.tracePromise(function (value) {
+  assert.deepStrictEqual(this, thisArg);
+  return Promise.reject(value);
+}, input, thisArg, expectedError).then(
+  common.mustNotCall(),
+  common.mustCall(value => {
+    assert.deepStrictEqual(value, expectedError);
+  })
+);

--- a/test/parallel/test-diagnostics-channel-tracing-channel-async.js
+++ b/test/parallel/test-diagnostics-channel-tracing-channel-async.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const common = require('../common');
+const dc = require('diagnostics_channel');
+const assert = require('assert');
+
+const channel = dc.tracingChannel('test');
+
+const expectedResult = { foo: 'bar' };
+const input = { foo: 'bar' };
+const thisArg = { baz: 'buz' };
+
+function check(found) {
+  assert.deepStrictEqual(found, input);
+}
+
+const handlers = {
+  start: common.mustCall(check, 2),
+  end: common.mustCall(check, 2),
+  asyncEnd: common.mustCall((found) => {
+    check(found);
+    assert.strictEqual(found.error, undefined);
+    assert.deepStrictEqual(found.result, expectedResult);
+  }, 2),
+  error: common.mustNotCall()
+};
+
+channel.subscribe(handlers);
+
+channel.traceCallback(function (cb, err, res) {
+  assert.deepStrictEqual(this, thisArg);
+  setImmediate(cb, err, res);
+}, 0, input, thisArg, common.mustCall((err, res) => {
+  assert.strictEqual(err, null);
+  assert.deepStrictEqual(res, expectedResult);
+}), null, expectedResult);
+
+channel.tracePromise(function (value) {
+  assert.deepStrictEqual(this, thisArg);
+  return Promise.resolve(value);
+}, input, thisArg, expectedResult).then(
+  common.mustCall(value => {
+    assert.deepStrictEqual(value, expectedResult);
+  }),
+  common.mustNotCall()
+);

--- a/test/parallel/test-diagnostics-channel-tracing-channel-sync-error.js
+++ b/test/parallel/test-diagnostics-channel-tracing-channel-sync-error.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const common = require('../common');
+const dc = require('diagnostics_channel');
+const assert = require('assert');
+
+const channel = dc.tracingChannel('test');
+
+const expectedError = new Error('test');
+const input = { foo: 'bar' };
+const thisArg = { baz: 'buz' };
+
+function check(found) {
+  assert.deepStrictEqual(found, input);
+}
+
+const handlers = {
+  start: common.mustCall(check),
+  end: common.mustCall(check),
+  asyncEnd: common.mustNotCall(),
+  error: common.mustCall((found) => {
+    check(found);
+    assert.deepStrictEqual(found.error, expectedError);
+  })
+};
+
+channel.subscribe(handlers);
+try {
+  channel.traceSync(function (err) {
+    assert.deepStrictEqual(this, thisArg);
+    assert.strictEqual(err, expectedError);
+    throw err;
+  }, input, thisArg, expectedError);
+
+  throw new Error('It should not reach this error');
+} catch (error) {
+  assert.deepStrictEqual(error, expectedError);
+}

--- a/test/parallel/test-diagnostics-channel-tracing-channel-sync.js
+++ b/test/parallel/test-diagnostics-channel-tracing-channel-sync.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const common = require('../common');
+const dc = require('diagnostics_channel');
+const assert = require('assert');
+
+const channel = dc.tracingChannel('test');
+
+const expectedResult = { foo: 'bar' };
+const input = { foo: 'bar' };
+
+function check(found) {
+  assert.deepStrictEqual(found, input);
+}
+
+const handlers = {
+  start: common.mustCall(check),
+  end: common.mustCall((found) => {
+    check(found);
+    assert.deepStrictEqual(found.result, expectedResult);
+  }),
+  asyncEnd: common.mustNotCall(),
+  error: common.mustNotCall()
+};
+
+assert.strictEqual(channel.hasSubscribers, false);
+channel.subscribe(handlers);
+assert.strictEqual(channel.hasSubscribers, true);
+channel.traceSync(() => {
+  return expectedResult;
+}, input);
+
+channel.unsubscribe(handlers);
+assert.strictEqual(channel.hasSubscribers, false);
+channel.traceSync(() => {
+  return expectedResult;
+}, input);


### PR DESCRIPTION
This is an alternate and simplified way to express the integration between AsyncLocalStorage and diagnostics_channel attempted in #44894. I think this might be a better approach. What do other @nodejs/diagnostics folks think? I'll write up some docs for it soon, if this seems like a clearer, more coherent approach.

Depends on #44943