### PR TITLE
diagnostics_channel: mark as stable

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -1,8 +1,16 @@
 # Diagnostics Channel
 
+<!-- YAML
+added: v15.1.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/45290
+    description: diagnostics_channel is now Stable.
+-->
+
 <!--introduced_in=v15.1.0-->
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 <!-- source_link=lib/diagnostics_channel.js -->
 


### PR DESCRIPTION
I'm proposing that we mark diagnostics_channel as stable. It has been used extensively in the Datadog tracer for awhile now and we're quite satisfied that it serves the intended purpose. Marking as stable will help significantly with pushing for ecosystem adoption in the future.

cc @nodejs/diagnostics 