### PR TITLE
util: improve `TextDecoder` performance

### DIFF
--- a/benchmark/util/text-decoder.js
+++ b/benchmark/util/text-decoder.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  encoding: ['utf-8', 'latin1', 'iso-8859-3'],
+  ignoreBOM: [0, 1],
+  len: [256, 1024 * 16, 1024 * 512],
+  n: [1e6]
+});
+
+function main({ encoding, len, n, ignoreBOM }) {
+  const buf = Buffer.allocUnsafe(len);
+  const decoder = new TextDecoder(encoding, { ignoreBOM });
+
+  bench.start();
+  decoder.decode(buf);
+  bench.end(n);
+}

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -438,7 +438,7 @@ function makeTextDecoderICU() {
       if (typeof ret === 'number') {
         throw new ERR_ENCODING_INVALID_ENCODED_DATA(this.encoding, ret);
       }
-      return ret.toString('ucs2');
+      return ret;
     }
   }
 

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -502,7 +502,7 @@ void ConverterObject::Decode(const FunctionCallbackInfo<Value>& args) {
     }
 
     Local<Value> error;
-    const UChar* output = result.out();
+    UChar* output = result.out();
     size_t beginning = 0;
     size_t length = result.length() * sizeof(UChar);
 
@@ -512,7 +512,12 @@ void ConverterObject::Decode(const FunctionCallbackInfo<Value>& args) {
       length -= 2;
     }
 
-    const char* value = reinterpret_cast<const char*>(output) + beginning;
+    char* value = reinterpret_cast<char*>(output) + beginning;
+
+    if (IsBigEndian()) {
+      SwapBytes16(value, length);
+    }
+
     MaybeLocal<Value> encoded =
         StringBytes::Encode(env->isolate(), value, length, UCS2, &error);
 


### PR DESCRIPTION
Improves the text decoder by 32%. Happy to update the benchmark according to the reviews.

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1211/

```
17:23:35                                                                             confidence improvement accuracy (*)    (**)   (***)
17:23:35 util/text-decoder.js n=1000000 len=16384 ignoreBOM=0 encoding='iso-8859-3'         ***     20.18 %       ±7.84% ±10.44% ±13.61%
17:23:35 util/text-decoder.js n=1000000 len=16384 ignoreBOM=0 encoding='latin1'             ***     16.72 %       ±7.16%  ±9.54% ±12.44%
17:23:35 util/text-decoder.js n=1000000 len=16384 ignoreBOM=0 encoding='utf-8'              ***     14.24 %       ±7.64% ±10.16% ±13.23%
17:23:35 util/text-decoder.js n=1000000 len=16384 ignoreBOM=1 encoding='iso-8859-3'         ***     19.93 %       ±7.42%  ±9.89% ±12.92%
17:23:35 util/text-decoder.js n=1000000 len=16384 ignoreBOM=1 encoding='latin1'             ***     21.41 %       ±8.10% ±10.79% ±14.06%
17:23:35 util/text-decoder.js n=1000000 len=16384 ignoreBOM=1 encoding='utf-8'              ***     15.44 %       ±8.85% ±11.78% ±15.37%
17:23:35 util/text-decoder.js n=1000000 len=256 ignoreBOM=0 encoding='iso-8859-3'           ***     26.89 %       ±6.35%  ±8.45% ±11.01%
17:23:35 util/text-decoder.js n=1000000 len=256 ignoreBOM=0 encoding='latin1'               ***     27.35 %       ±7.95% ±10.64% ±13.99%
17:23:35 util/text-decoder.js n=1000000 len=256 ignoreBOM=0 encoding='utf-8'                ***     26.06 %       ±7.02%  ±9.34% ±12.17%
17:23:35 util/text-decoder.js n=1000000 len=256 ignoreBOM=1 encoding='iso-8859-3'           ***     20.31 %       ±8.01% ±10.66% ±13.88%
17:23:35 util/text-decoder.js n=1000000 len=256 ignoreBOM=1 encoding='latin1'               ***     26.52 %       ±6.93%  ±9.25% ±12.11%
17:23:35 util/text-decoder.js n=1000000 len=256 ignoreBOM=1 encoding='utf-8'                ***     20.07 %       ±7.89% ±10.51% ±13.69%
17:23:35 util/text-decoder.js n=1000000 len=524288 ignoreBOM=0 encoding='iso-8859-3'                -1.38 %       ±5.57%  ±7.41%  ±9.64%
17:23:35 util/text-decoder.js n=1000000 len=524288 ignoreBOM=0 encoding='latin1'                    -0.70 %       ±6.39%  ±8.50% ±11.06%
17:23:35 util/text-decoder.js n=1000000 len=524288 ignoreBOM=0 encoding='utf-8'                      2.67 %       ±5.81%  ±7.73% ±10.08%
17:23:35 util/text-decoder.js n=1000000 len=524288 ignoreBOM=1 encoding='iso-8859-3'                -0.31 %       ±6.09%  ±8.10% ±10.55%
17:23:35 util/text-decoder.js n=1000000 len=524288 ignoreBOM=1 encoding='latin1'                    -5.15 %       ±6.94%  ±9.24% ±12.03%
17:23:35 util/text-decoder.js n=1000000 len=524288 ignoreBOM=1 encoding='utf-8'                      1.20 %       ±6.66%  ±8.88% ±11.57%
17:23:35 
17:23:36 Be aware that when doing many comparisons the risk of a false-positive
17:23:36 result increases. In this case, there are 18 comparisons, you can thus
17:23:36 expect the following amount of false-positive results:
17:23:36   0.90 false positives, when considering a   5% risk acceptance (*, **, ***),
17:23:36   0.18 false positives, when considering a   1% risk acceptance (**, ***),
17:23:36   0.02 false positives, when considering a 0.1% risk acceptance (***)
```

cc @nodejs/buffer @nodejs/util @nodejs/performance 