### PR TITLE
Add automation for updating `base64` dependency

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -78,11 +78,24 @@ jobs:
                 echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
                 ./tools/update-undici.sh
               fi
+          - id: base64
+            subsystem: deps
+            label: dependencies
+            run: |
+              NEW_VERSION=$(gh api repos/aklomp/base64/releases/latest -q '.tag_name|ltrimstr("v")')
+              CURRENT_VERSION=$(grep "base64 LANGUAGES C VERSION" ./deps/base64/base64/CMakeLists.txt | \
+                                sed -n "s/^.*VERSION \(.*\))/\1/p")
+              if [ "$NEW_VERSION" != "$CURRENT_VERSION" ]; then
+                echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+                ./tools/update-base64.sh "$NEW_VERSION"
+              fi
     steps:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - run: ${{ matrix.run }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
       - uses: gr2m/create-or-update-pull-request-action@dc1726cbf4dd3ce766af4ec29cfb660e0125e8ee
         # Creates a PR or update the Action's existing PR, or
         # no-op if the base branch is already up-to-date.

--- a/tools/update-base64.sh
+++ b/tools/update-base64.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -e
+# Shell script to update base64 in the source tree to a specific version
+
+BASE_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DEPS_DIR="$BASE_DIR/deps"
+BASE64_VERSION=$1
+
+if [ "$#" -le 0 ]; then
+  echo "Error: please provide an base64 version to update to"
+  echo "	e.g. $0 0.4.0"
+  exit 1
+fi
+
+echo "Making temporary workspace"
+
+WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
+
+cleanup () {
+  EXIT_CODE=$?
+  [ -d "$WORKSPACE" ] && rm -rf "$WORKSPACE"
+  exit $EXIT_CODE
+}
+
+trap cleanup INT TERM EXIT
+
+cd "$WORKSPACE"
+
+echo "Fetching base64 source archive"
+curl -sL "https://api.github.com/repos/aklomp/base64/tarball/v$BASE64_VERSION" | tar xzf -
+mv aklomp-base64-* base64
+
+echo "Replacing existing base64"
+rm -rf "$DEPS_DIR/base64/base64"
+mv "$WORKSPACE/base64" "$DEPS_DIR/base64/"
+
+echo "All done!"
+echo ""
+echo "Please git add base64/base64, commit the new version:"
+echo ""
+echo "$ git add -A deps/base64/base64"
+echo "$ git commit -m \"deps: update base64 to $BASE64_VERSION\""
+echo ""


### PR DESCRIPTION
Add a Github Action that checks for new versions of the `base64` C library, and creates a PR to update it if a newer version than the one present in the repo is found.

Refs: https://github.com/nodejs/security-wg/issues/828
