### PR TITLE
tools: add GitHub token permissions to label flaky-test issues

### DIFF
--- a/.github/workflows/label-flaky-test-issue.yml
+++ b/.github/workflows/label-flaky-test-issue.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   label:
     if: github.event.label.name == 'flaky-test'


### PR DESCRIPTION
Add minimum GITHUB_TOKEN permissions for `label-flaky-test-issue.yml` workflow.

Motivation: Setting minimum permissions on workflow's top level is good practice. Similar changes were previously discussed in https://github.com/nodejs/node/pull/43743. Since label flaky-test issues workflow was recently added, this PR is a small update to restrict it's permissions.

------

About me: I'm Gabriela and I work on behalf of Google and the OpenSSF suggesting supply-chain security changes :)

Signed-off-by: Gabriela Gutierrez <gabigutierrez@google.com>
