### PR TITLE
doc: use module names in stability overview table

### DIFF
--- a/tools/doc/stability.mjs
+++ b/tools/doc/stability.mjs
@@ -32,6 +32,7 @@ function collectStability(data) {
 
       stability.push({
         api: mod.name,
+        displayName: mod.textRaw,
         link: link,
         stability: mod.stability,
         stabilityText: `(${mod.stability}) ${mod.stabilityText}`,
@@ -39,7 +40,7 @@ function collectStability(data) {
     }
   }
 
-  stability.sort((a, b) => a.api.localeCompare(b.api));
+  stability.sort((a, b) => a.displayName.localeCompare(b.displayName));
   return stability;
 }
 
@@ -47,7 +48,7 @@ function createMarkdownTable(data) {
   const md = ['| API | Stability |', '| --- | --------- |'];
 
   for (const mod of data) {
-    md.push(`| [${mod.api}](${mod.link}) | ${mod.stabilityText} |`);
+    md.push(`| [${mod.displayName}](${mod.link}) | ${mod.stabilityText} |`);
   }
 
   return md.join('\n');


### PR DESCRIPTION
This updates the [Stability overview](https://nodejs.org/api/documentation.html#stability-index) to use the modules' names rather than their url friendly designation which can no longer be mapped to how they're accessed (e.g. web_crypto_api, performance_measurement_apis, asynchronous_context_tracking, webassembly_system_interface_(wasi)).

<details>
<summary>Before/After</summary>

| Before | After |
| - | - |
| ![Screenshot of the table before the changes](https://user-images.githubusercontent.com/14309773/199982280-a24375d0-2e0e-473b-be18-88ada64fd693.png) | ![The same table after the changes](https://user-images.githubusercontent.com/14309773/199980613-3dca1e8d-43fe-44de-8ce4-68e114bfbcd4.png) |



</details>