### PR TITLE
fs(readfile): merge `open` and `fstat`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -400,12 +400,17 @@ function readFile(path, options, callback) {
   const flagsNumber = stringToFlags(options.flag, 'options.flag');
   path = getValidatedPath(path);
 
+  const fdSlot = new Buffer.alloc(1);
   const req = new FSReqCallback();
   req.context = context;
-  req.oncomplete = readFileAfterOpen;
-  binding.open(pathModule.toNamespacedPath(path),
+  req.oncomplete = function (err, stats) {
+    context.fd = fdSlot[0];
+    readFileAfterStat.apply({ context }, [err, stats]);
+  }
+  binding.openFile(pathModule.toNamespacedPath(path),
                flagsNumber,
                0o666,
+               fdSlot,
                req);
 }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -829,7 +829,7 @@ void OpenFileAfterOpen(uv_fs_t* open_req) {
   if (result < 0) {
     FSReqAfterScope after(req_wrap, open_req);
     req_wrap->Reject(
-      UVException(req_wrap->env()->isolate(), result, "open"));
+      UVException(req_wrap->env()->isolate(), result, "open", nullptr, open_req->path));
 
     if (open_req->data != nullptr) {
       CleanOpenFileCtx(open_req);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3260,9 +3260,10 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "writeString", WriteString);
   SetMethod(isolate, target, "realpath", RealPath);
   SetMethod(isolate, target, "copyFile", CopyFile);
-  SetMethod(isolate, target, "fchmod", FChmod);
 
   SetMethod(isolate, target, "chmod", Chmod);
+  SetMethod(isolate, target, "fchmod", FChmod);
+
   SetMethod(isolate, target, "chown", Chown);
   SetMethod(isolate, target, "fchown", FChown);
   SetMethod(isolate, target, "lchown", LChown);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -806,7 +806,7 @@ void AfterStat(uv_fs_t* req) {
   }
 }
 
-void OpenFileAfterOpen(uv_fs_t* open_req) {
+void OpenAndFstatAfterOpen(uv_fs_t* open_req) {
   FSReqBase* req_wrap = FSReqBase::from_req(open_req);
   int result = static_cast<int>(open_req->result);
 
@@ -818,7 +818,6 @@ void OpenFileAfterOpen(uv_fs_t* open_req) {
     req_wrap->Reject(
       UVException(req_wrap->env()->isolate(), result, "open", nullptr, open_req->path));
 
-    req_wrap = nullptr;
     return;
   }
 
@@ -2095,7 +2094,7 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-static void OpenFile(const FunctionCallbackInfo<Value>& args) {
+static void OpenAndFstat(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   const int argc = args.Length();
@@ -2126,7 +2125,7 @@ static void OpenFile(const FunctionCallbackInfo<Value>& args) {
                *path,
                flags,
                mode,
-               OpenFileAfterOpen);
+               OpenAndFstatAfterOpen);
   }
 }
 
@@ -3352,7 +3351,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 
   registry->Register(Close);
   registry->Register(Open);
-  registry->Register(OpenFile);
+  registry->Register(OpenAndFstat);
   registry->Register(OpenFileHandle);
   registry->Register(Read);
   registry->Register(ReadBuffers);


### PR DESCRIPTION
## Context

@anonrig shared this [discussion](https://github.com/nodejs/node/discussions/44239) with me . I spent time during the last weeks around the `readFile`code. 

## Updates

Merge `open` and `fstat` into a single c++ function.

## Gains

It's where I'm stuck, and it's probably linked to my implementation (🙈). I failed to run the benchmark properly.

When I try to execute the targeted benchmark file: `benchmark/fs/readfile.fs`
- With my build
```bash
./node benchmark/fs/readfile.js
fs/readfile.js concurrent=1 len=16777216 encoding="" duration=5: 367.1841192868408
fs/readfile.js concurrent=1 len=16777216 encoding="utf-8" duration=5: 195.96019558527175
```
- With the main branch build
```bash
./node-main benchmark/fs/readfile.js
fs/readfile.js concurrent=1 len=1024 encoding="" duration=5: 34,928.87992225262
fs/readfile.js concurrent=10 len=1024 encoding="" duration=5: 98,718.82706159452
fs/readfile.js concurrent=1 len=16777216 encoding="" duration=5: 385.6378889225866
fs/readfile.js concurrent=10 len=16777216 encoding="" duration=5: 881.9940685898887
fs/readfile.js concurrent=1 len=1024 encoding="utf-8" duration=5: 35,145.19621474622
fs/readfile.js concurrent=10 len=1024 encoding="utf-8" duration=5: 99,417.17644259878
fs/readfile.js concurrent=1 len=16777216 encoding="utf-8" duration=5: 199.9139287372592
fs/readfile.js concurrent=10 len=16777216 encoding="utf-8" duration=5: 295.9984238083932
```

It looks like my implementation failed somewhere...

> Note: it's my first c++ code