### PR TITLE
test: set process code to 0 for verifying npm

### DIFF
--- a/test/parallel/test-release-npm.js
+++ b/test/parallel/test-release-npm.js
@@ -17,7 +17,7 @@ if (!releaseReg.test(process.version) || !common.hasCrypto) {
 
   const npmCli = path.join(__dirname, '../../deps/npm/bin/npm-cli.js');
   const npmExec = child_process.spawnSync(process.execPath, [npmCli]);
-  assert.strictEqual(npmExec.status, 1);
+  assert.strictEqual(npmExec.status, 0);
 
   const stderr = npmExec.stderr.toString();
   assert.strictEqual(stderr.length, 0, 'npm is not ready for this release ' +


### PR DESCRIPTION
man `ls` [documentation](https://man7.org/linux/man-pages/man1/ls.1.html) states that:

```
   Exit status:
       0      if OK,

       1      if minor problems (e.g., cannot access subdirectory),

       2      if serious trouble (e.g., cannot access command-line
              argument).
```

Fixes https://github.com/nodejs/node/issues/45318