### PR TITLE
crypto: handle unsupported AES ciphers in webcrypto

### DIFF
--- a/src/crypto/crypto_aes.cc
+++ b/src/crypto/crypto_aes.cc
@@ -556,7 +556,10 @@ Maybe<bool> AESCipherTraits::AdditionalConfig(
   }
 
   params->cipher = EVP_get_cipherbynid(cipher_nid);
-  CHECK_NOT_NULL(params->cipher);
+  if (params->cipher == nullptr) {
+    THROW_ERR_CRYPTO_UNKNOWN_CIPHER(env);
+    return Nothing<bool>();
+  }
 
   if (params->iv.size() <
       static_cast<size_t>(EVP_CIPHER_iv_length(params->cipher))) {


### PR DESCRIPTION
This fixes Electron's exit (and other runtimes that embed Node.js?) caused by missing ciphers due to use of BoringSSL.

Refs: https://github.com/electron/electron/issues/36256