### PR TITLE
doc: add `node:` prefix for examples

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -165,7 +165,7 @@ will be run synchronously whenever a message is published to the channel. Any
 errors thrown in the message handler will trigger an [`'uncaughtException'`][].
 
 ```mjs
-import diagnostics_channel from 'diagnostics_channel';
+import diagnostics_channel from 'node:diagnostics_channel';
 
 diagnostics_channel.subscribe('my-channel', (message, name) => {
   // Received data
@@ -173,7 +173,7 @@ diagnostics_channel.subscribe('my-channel', (message, name) => {
 ```
 
 ```cjs
-const diagnostics_channel = require('diagnostics_channel');
+const diagnostics_channel = require('node:diagnostics_channel');
 
 diagnostics_channel.subscribe('my-channel', (message, name) => {
   // Received data
@@ -196,7 +196,7 @@ Remove a message handler previously registered to this channel with
 [`diagnostics_channel.subscribe(name, onMessage)`][].
 
 ```mjs
-import diagnostics_channel from 'diagnostics_channel';
+import diagnostics_channel from 'node:diagnostics_channel';
 
 function onMessage(message, name) {
   // Received data
@@ -208,7 +208,7 @@ diagnostics_channel.unsubscribe('my-channel', onMessage);
 ```
 
 ```cjs
-const diagnostics_channel = require('diagnostics_channel');
+const diagnostics_channel = require('node:diagnostics_channel');
 
 function onMessage(message, name) {
   // Received data

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -923,17 +923,17 @@ contains the following script:
 ```cjs
 'use strict';
 
-const fs = require('fs');
-const zlib = require('zlib');
-const path = require('path');
-const assert = require('assert');
+const fs = require('node:fs');
+const zlib = require('node:zlib');
+const path = require('node:path');
+const assert = require('node:assert');
 
 const {
   isBuildingSnapshot,
   addSerializeCallback,
   addDeserializeCallback,
   setDeserializeMainFunction
-} = require('v8').startupSnapshot;
+} = require('node:v8').startupSnapshot;
 
 const filePath = path.resolve(__dirname, '../x1024.txt');
 const storage = {};

--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -1478,8 +1478,8 @@ console.log(`from readable: ${data.byteLength}`);
 
 ```cjs
 const { arrayBuffer } = require('node:stream/consumers');
-const { Readable } = require('stream');
-const { TextEncoder } = require('util');
+const { Readable } = require('node:stream');
+const { TextEncoder } = require('node:util');
 
 const encoder = new TextEncoder();
 const dataArray = encoder.encode(['hello world from consumers!']);


### PR DESCRIPTION
Core modules are currently distinguished with the `node:` prefix. 
This updates a few examples in docs to use the prefix for consistency.

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
