### PR TITLE
worker: allow retrieving elu from parent

### DIFF
--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -29,6 +29,7 @@ const {
   messageTypes: {
     // Messages that may be received by workers
     LOAD_SCRIPT,
+    PARENT_LOOP_START,
     // Messages that may be posted from workers
     UP_AND_RUNNING,
     ERROR_MESSAGE,
@@ -159,6 +160,8 @@ port.on('message', (message) => {
       const CJSLoader = require('internal/modules/cjs/loader');
       CJSLoader.Module.runMain(filename);
     }
+  } else if (message.type === PARENT_LOOP_START) {
+    require('internal/worker').setParentEventLoopStartTime(message.value);
   } else if (message.type === STDIO_PAYLOAD) {
     const { stream, chunks } = message;
     ArrayPrototypeForEach(chunks, ({ chunk, encoding }) => {

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -27,6 +27,7 @@ const {
 const EventEmitter = require('events');
 const assert = require('internal/assert');
 const path = require('path');
+const { setImmediate } = require('timers');
 const {
   internalEventLoopUtilization
 } = require('internal/perf/event_loop_utilization');
@@ -61,6 +62,13 @@ const { kEmptyObject } = require('internal/util');
 const { validateArray } = require('internal/validators');
 
 const {
+  constants: {
+    NODE_PERFORMANCE_MILESTONE_LOOP_START,
+  },
+  milestones,
+} = internalBinding('performance');
+
+const {
   ownsProcessState,
   isMainThread,
   resourceLimits: resourceLimitsRaw,
@@ -70,7 +78,8 @@ const {
   kMaxOldGenerationSizeMb,
   kCodeRangeSizeMb,
   kStackSizeMb,
-  kTotalResourceLimitCount
+  kTotalResourceLimitCount,
+  parentLoopIdleTime,
 } = internalBinding('worker');
 
 const kHandle = Symbol('kHandle');
@@ -83,6 +92,7 @@ const kOnErrorMessage = Symbol('kOnErrorMessage');
 const kParentSideStdio = Symbol('kParentSideStdio');
 const kLoopStartTime = Symbol('kLoopStartTime');
 const kIsOnline = Symbol('kIsOnline');
+const kSendLoopStart = Symbol('kSendLoopStart');
 
 const SHARE_ENV = SymbolFor('nodejs.worker_threads.SHARE_ENV');
 let debug = require('internal/util/debuglog').debuglog('worker', (fn) => {
@@ -265,6 +275,13 @@ class Worker extends EventEmitter {
     this[kHandle].startThread();
 
     process.nextTick(() => process.emit('worker', this));
+    // Send current thread loopStart to the worker. In case the loop has not yet
+    // started, send it after the poll phase of the loop has completed.
+    if (milestones[NODE_PERFORMANCE_MILESTONE_LOOP_START] === -1) {
+      setImmediate(() => this[kSendLoopStart]());
+    } else {
+      this[kSendLoopStart]();
+    }
     if (workerThreadsChannel.hasSubscribers) {
       workerThreadsChannel.publish({
         worker: this,
@@ -344,6 +361,13 @@ class Worker extends EventEmitter {
       debug(`[${threadId}] explicitly closes stderr for ${this.threadId}`);
       stderr.push(null);
     }
+  }
+
+  [kSendLoopStart]() {
+    this[kPort]?.postMessage({
+      type: messageTypes.PARENT_LOOP_START,
+      value: milestones[NODE_PERFORMANCE_MILESTONE_LOOP_START] / 1e6
+    });
   }
 
   postMessage(...args) {
@@ -494,6 +518,24 @@ function eventLoopUtilization(util1, util2) {
   );
 }
 
+let parentEventLoopStartTime = -1;
+function setParentEventLoopStartTime(time) {
+  parentEventLoopStartTime = time;
+}
+
+function parentEventLoopUtilization(util1, util2) {
+  if (parentEventLoopStartTime === -1) {
+    return { idle: 0, active: 0, utilization: 0 };
+  }
+
+  return internalEventLoopUtilization(
+    parentEventLoopStartTime,
+    parentLoopIdleTime(),
+    util1,
+    util2,
+  );
+}
+
 module.exports = {
   ownsProcessState,
   isMainThread,
@@ -505,4 +547,6 @@ module.exports = {
   assignEnvironmentData,
   threadId,
   Worker,
+  setParentEventLoopStartTime,
+  parentEventLoopUtilization,
 };

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -89,7 +89,8 @@ const messageTypes = {
   ERROR_MESSAGE: 'errorMessage',
   STDIO_PAYLOAD: 'stdioPayload',
   STDIO_WANTS_MORE_DATA: 'stdioWantsMoreData',
-  LOAD_SCRIPT: 'loadScript'
+  LOAD_SCRIPT: 'loadScript',
+  PARENT_LOOP_START: 'parentLoopStart',
 };
 
 // We have to mess with the MessagePort prototype a bit, so that a) we can make

--- a/lib/worker_threads.js
+++ b/lib/worker_threads.js
@@ -7,7 +7,8 @@ const {
   setEnvironmentData,
   getEnvironmentData,
   threadId,
-  Worker
+  Worker,
+  parentEventLoopUtilization,
 } = require('internal/worker');
 
 const {
@@ -38,4 +39,9 @@ module.exports = {
   BroadcastChannel,
   setEnvironmentData,
   getEnvironmentData,
+  parent: isMainThread ? null : {
+    performance: {
+      eventLoopUtilization: parentEventLoopUtilization,
+    },
+  },
 };

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -75,6 +75,7 @@ class Worker : public AsyncWrap {
   static void TakeHeapSnapshot(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void LoopIdleTime(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void LoopStartTime(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void ParentLoopIdleTime(const v8::FunctionCallbackInfo<v8::Value>&);
 
  private:
   bool CreateEnvMessagePort(Environment* env);
@@ -90,6 +91,8 @@ class Worker : public AsyncWrap {
   std::optional<uv_thread_t> tid_;  // Set while the thread is running
 
   std::unique_ptr<InspectorParentHandle> inspector_parent_handle_;
+
+  uv_loop_t* parent_loop_;
 
   // This mutex protects access to all variables listed below it.
   mutable Mutex mutex_;

--- a/test/parallel/test-worker-parent-performance-eventlooputil.js
+++ b/test/parallel/test-worker-parent-performance-eventlooputil.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { mustCall } = require('../common');
+
+const TIMEOUT = 10;
+const SPIN_DUR = 50;
+
+const assert = require('assert');
+const { Worker, parent, workerData } = require('worker_threads');
+
+// Do not use isMainThread directly, otherwise the test would time out in case
+// it's started inside of another worker thread.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = '1';
+  const i32arr = new Int32Array(new SharedArrayBuffer(4));
+  const w = new Worker(__filename, { workerData: i32arr });
+  w.on('online', mustCall(() => {
+    Atomics.wait(i32arr, 0, 0);
+
+    const t = Date.now();
+    while (Date.now() - t < SPIN_DUR);
+
+    Atomics.store(i32arr, 0, 0);
+    Atomics.notify(i32arr, 0);
+    Atomics.wait(i32arr, 0, 0);
+  }));
+} else {
+  setTimeout(() => {
+    const { eventLoopUtilization } = parent.performance;
+    const i32arr = workerData;
+    const elu1 = eventLoopUtilization();
+
+    Atomics.store(i32arr, 0, 1);
+    Atomics.notify(i32arr, 0);
+    Atomics.wait(i32arr, 0, 1);
+
+    const elu2 = eventLoopUtilization(elu1);
+    const elu3 = eventLoopUtilization();
+    const elu4 = eventLoopUtilization(elu3, elu1);
+
+    assert.strictEqual(elu2.idle, 0);
+    assert.strictEqual(elu4.idle, 0);
+    assert.strictEqual(elu2.utilization, 1);
+    assert.strictEqual(elu4.utilization, 1);
+    assert.strictEqual(elu3.active - elu1.active, elu4.active);
+    assert.ok(elu2.active > SPIN_DUR - 10, `${elu2.active} <= ${SPIN_DUR - 10}`);
+    assert.ok(elu2.active < elu4.active, `${elu2.active} >= ${elu4.active}`);
+    assert.ok(elu3.active > elu2.active, `${elu3.active} <= ${elu2.active}`);
+    assert.ok(elu3.active > elu4.active, `${elu3.active} <= ${elu4.active}`);
+
+    Atomics.store(i32arr, 0, 1);
+    Atomics.notify(i32arr, 0);
+  }, TIMEOUT);
+}


### PR DESCRIPTION
Usually, when extracting the ELU from a specific JS thread is better to do it from a different thread as the event loop we're observing might already be blocked. The `Worker.performance.eventLoopUtilization()` method allows us to do this for worker threads, but there's not a way to do this for the main thread. This new API, which allows us to retrieve the ELU of the parent thread from a specific worker, is going to enable this.

For the moment, I have defined this new API in
```
require('worker_threads').parent.performance.eventLoopUtilization()
```
though I haven't added documentation yet as
a) I want to know first whether this approach is acceptable, and in case it is,
b) I'm not really sure whether that's the place the API should live in. Would love receiving feedback on this.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
