### PR TITLE
test: skip test-fs-largefile if not enough disk space

### DIFF
--- a/test/pummel/test-fs-largefile.js
+++ b/test/pummel/test-fs-largefile.js
@@ -29,21 +29,29 @@ const path = require('path');
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-const filepath = path.join(tmpdir.path, 'large.txt');
-const fd = fs.openSync(filepath, 'w+');
-const offset = 5 * 1024 * 1024 * 1024; // 5GB
-const message = 'Large File';
+try {
 
-fs.ftruncateSync(fd, offset);
-assert.strictEqual(fs.statSync(filepath).size, offset);
-const writeBuf = Buffer.from(message);
-fs.writeSync(fd, writeBuf, 0, writeBuf.length, offset);
-const readBuf = Buffer.allocUnsafe(writeBuf.length);
-fs.readSync(fd, readBuf, 0, readBuf.length, offset);
-assert.strictEqual(readBuf.toString(), message);
-fs.readSync(fd, readBuf, 0, 1, 0);
-assert.strictEqual(readBuf[0], 0);
+  const filepath = path.join(tmpdir.path, 'large.txt');
+  const fd = fs.openSync(filepath, 'w+');
+  const offset = 5 * 1024 * 1024 * 1024; // 5GB
+  const message = 'Large File';
 
-// Verify that floating point positions do not throw.
-fs.writeSync(fd, writeBuf, 0, writeBuf.length, 42.000001);
-fs.close(fd, common.mustCall());
+  fs.ftruncateSync(fd, offset);
+  assert.strictEqual(fs.statSync(filepath).size, offset);
+  const writeBuf = Buffer.from(message);
+  fs.writeSync(fd, writeBuf, 0, writeBuf.length, offset);
+  const readBuf = Buffer.allocUnsafe(writeBuf.length);
+  fs.readSync(fd, readBuf, 0, readBuf.length, offset);
+  assert.strictEqual(readBuf.toString(), message);
+  fs.readSync(fd, readBuf, 0, 1, 0);
+  assert.strictEqual(readBuf[0], 0);
+
+  // Verify that floating point positions do not throw.
+  fs.writeSync(fd, writeBuf, 0, writeBuf.length, 42.000001);
+  fs.close(fd, common.mustCall());
+} catch (e) {
+  if (e.code !== 'ENOSPC') {
+    throw e;
+  }
+  common.skip('insufficient disk space');
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/build/issues/3071

I'm guessing this is the test that then causes other cascading disk failures, but maybe there are others. Let's run CI here and find out....

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
