### PR TITLE
deps: V8: cherry-pick 56816d76c121

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.18',
+    'v8_embedder_string': '-node.19',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8config.h
+++ b/deps/v8/include/v8config.h
@@ -703,6 +703,8 @@ V8 shared library set USING_V8_SHARED.
 #define V8_TARGET_ARCH_ARM 1
 #elif defined(__mips64)
 #define V8_TARGET_ARCH_MIPS64 1
+#elif defined(__loongarch64)
+#define V8_TARGET_ARCH_LOONG64 1
 #elif defined(_ARCH_PPC64)
 #define V8_TARGET_ARCH_PPC64 1
 #elif defined(_ARCH_PPC)


### PR DESCRIPTION
Original commit message:
```    
[loong64] Supplement a LoongArch support in include/v8config.h
    
Change-Id: I658c1b781163bcd3ca39bfceb74aef9d255247b8
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3894795
Reviewed-by: Toon Verwaest <verwaest@chromium.org>
Commit-Queue: Liu Yu <liuyu@loongson.cn>
Cr-Commit-Position: refs/heads/main@{#83374}
```
Refs: https://github.com/v8/v8/commit/56816d76c121c8dd5b406dc6019350eee05f4abd