### PR TITLE
test: fix flaky test-repl-sigint-nested-eval

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -5,8 +5,6 @@ prefix parallel
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
-# https://github.com/nodejs/node/issues/41123
-test-repl-sigint-nested-eval: PASS, FLAKY
 # https://github.com/nodejs/node/issues/43084
 test-worker-http2-stream-terminate: PASS, FLAKY
 

--- a/test/parallel/test-repl-sigint-nested-eval.js
+++ b/test/parallel/test-repl-sigint-nested-eval.js
@@ -10,7 +10,6 @@ if (!common.isMainThread)
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
-process.env.REPL_TEST_PPID = process.pid;
 const child = spawn(process.execPath, [ '-i' ], {
   stdio: [null, null, 2, 'ipc']
 });

--- a/test/parallel/test-repl-sigint-nested-eval.js
+++ b/test/parallel/test-repl-sigint-nested-eval.js
@@ -12,7 +12,7 @@ const spawn = require('child_process').spawn;
 
 process.env.REPL_TEST_PPID = process.pid;
 const child = spawn(process.execPath, [ '-i' ], {
-  stdio: [null, null, 2]
+  stdio: [null, null, 2, 'ipc']
 });
 
 let stdout = '';
@@ -22,7 +22,8 @@ child.stdout.on('data', function(c) {
 });
 
 child.stdout.once('data', common.mustCall(() => {
-  process.on('SIGUSR2', common.mustCall(() => {
+  child.on('message', common.mustCall((msg) => {
+    assert.strictEqual(msg, 'repl is busy');
     process.kill(child.pid, 'SIGINT');
     child.stdout.once('data', common.mustCall(() => {
       // Make sure REPL still works.
@@ -30,9 +31,10 @@ child.stdout.once('data', common.mustCall(() => {
     }));
   }));
 
-  child.stdin.write('process.kill(+process.env.REPL_TEST_PPID, "SIGUSR2");' +
-                    'vm.runInThisContext("while(true){}", ' +
-                    '{ breakOnSigint: true });\n');
+  child.stdin.write(
+    'vm.runInThisContext("process.send(\'repl is busy\'); while(true){}", ' +
+    '{ breakOnSigint: true });\n'
+  );
 }));
 
 child.on('close', function(code) {


### PR DESCRIPTION
There is a race condition where process.kill can be sent before the target is ready to receive the signal. Or at least that's what I think is going on. Regardless, objectively, using setTimeout() to slightly delay the invocation causes the test to not fail anymore using: tools/test.py --repeat=1000 test/parallel/test-repl-sigint-nested-eval

Fixes: https://github.com/nodejs/node/issues/41123

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
