### PR TITLE
Add automation for updating `acorn` dependency

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -89,6 +89,26 @@ jobs:
                 echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
                 ./tools/update-base64.sh "$NEW_VERSION"
               fi
+          - id: acorn
+            subsystem: deps
+            label: dependencies
+            run: |
+              NEW_VERSION=$(npm view acorn dist-tags.latest)
+              CURRENT_VERSION=$(node -p "require('./deps/acorn/acorn/package.json').version")
+              if [ "$NEW_VERSION" != "$CURRENT_VERSION" ]; then
+                echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+                ./tools/update-acorn.sh
+              fi
+          - id: acorn-walk
+            subsystem: deps
+            label: dependencies
+            run: |
+              NEW_VERSION=$(npm view acorn-walk dist-tags.latest)
+              CURRENT_VERSION=$(node -p "require('./deps/acorn/acorn-walk/package.json').version")
+              if [ "$NEW_VERSION" != "$CURRENT_VERSION" ]; then
+                echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+                ./tools/update-acorn-walk.sh
+              fi
     steps:
       - uses: actions/checkout@v3
         with:

--- a/tools/update-acorn-walk.sh
+++ b/tools/update-acorn-walk.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Shell script to update acorn-walk in the source tree to the latest release.
+
+# This script must be in the tools directory when it runs because it uses the
+# script source file path to determine directories to work in.
+
+set -ex
+
+cd "$( dirname "$0" )/.." || exit
+rm -rf deps/acorn/acorn-walk
+
+(
+    rm -rf acorn-walk-tmp
+    mkdir acorn-walk-tmp
+    cd acorn-walk-tmp || exit
+
+    ROOT="$PWD/.."
+    [ -z "$NODE" ] && NODE="$ROOT/out/Release/node"
+    [ -x "$NODE" ] || NODE=$(command -v node)
+    NPM="$ROOT/deps/npm/bin/npm-cli.js"
+
+    "$NODE" "$NPM" init --yes
+
+    "$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts acorn-walk
+)
+
+mv acorn-walk-tmp/node_modules/acorn-walk deps/acorn
+
+rm -rf acorn-walk-tmp/

--- a/tools/update-acorn.sh
+++ b/tools/update-acorn.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Shell script to update acorn in the source tree to the latest release.
+
+# This script must be in the tools directory when it runs because it uses the
+# script source file path to determine directories to work in.
+
+set -ex
+
+cd "$( dirname "$0" )/.." || exit
+rm -rf deps/acorn/acorn
+
+(
+    rm -rf acorn-tmp
+    mkdir acorn-tmp
+    cd acorn-tmp || exit
+
+    ROOT="$PWD/.."
+    [ -z "$NODE" ] && NODE="$ROOT/out/Release/node"
+    [ -x "$NODE" ] || NODE=$(command -v node)
+    NPM="$ROOT/deps/npm/bin/npm-cli.js"
+
+    "$NODE" "$NPM" init --yes
+
+    "$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts acorn
+)
+
+mv acorn-tmp/node_modules/acorn deps/acorn
+
+rm -rf acorn-tmp/


### PR DESCRIPTION
Add a Github Action that checks for new versions of the `acorn` and `acorn-walk` dependencies, and creates PRs to update them if newer versions than the ones present in the repo are found.

Refs: https://github.com/nodejs/security-wg/issues/828

