### PR TITLE
Add automation for updating `libuv` dependency

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -109,6 +109,22 @@ jobs:
                 echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
                 ./tools/update-acorn-walk.sh
               fi
+          - id: libuv
+            subsystem: deps
+            label: dependencies
+            run: |
+              NEW_VERSION=$(gh api repos/libuv/libuv/releases/latest -q '.tag_name|ltrimstr("v")')
+              VERSION_H="./deps/uv/include/uv/version.h"
+              CURRENT_MAJOR_VERSION=$(grep "#define UV_VERSION_MAJOR" $VERSION_H | sed -n "s/^.*MAJOR \(.*\)/\1/p")
+              CURRENT_MINOR_VERSION=$(grep "#define UV_VERSION_MINOR" $VERSION_H | sed -n "s/^.*MINOR \(.*\)/\1/p")
+              CURRENT_PATCH_VERSION=$(grep "#define UV_VERSION_PATCH" $VERSION_H | sed -n "s/^.*PATCH \(.*\)/\1/p")
+              CURRENT_SUFFIX_VERSION=$(grep "#define UV_VERSION_SUFFIX" $VERSION_H | sed -n "s/^.*SUFFIX \"\(.*\)\"/\1/p")
+              SUFFIX_STRING=$([[ -z "$CURRENT_SUFFIX_VERSION" ]] && echo "" || echo "-$CURRENT_SUFFIX_VERSION")
+              CURRENT_VERSION="$CURRENT_MAJOR_VERSION.$CURRENT_MINOR_VERSION.$CURRENT_PATCH_VERSION$SUFFIX_STRING"
+              if [ "$NEW_VERSION" != "$CURRENT_VERSION" ]; then
+                echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+                ./tools/update-libuv.sh "$NEW_VERSION"
+              fi
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -123,7 +123,7 @@ jobs:
               CURRENT_VERSION="$CURRENT_MAJOR_VERSION.$CURRENT_MINOR_VERSION.$CURRENT_PATCH_VERSION$SUFFIX_STRING"
               if [ "$NEW_VERSION" != "$CURRENT_VERSION" ]; then
                 echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-                ./tools/update-libuv.sh "$NEW_VERSION"
+                ./tools/dep_updaters/update-libuv.sh "$NEW_VERSION"
               fi
     steps:
       - uses: actions/checkout@v3

--- a/tools/dep_updaters/README.md
+++ b/tools/dep_updaters/README.md
@@ -1,0 +1,37 @@
+# Dependency update scripts
+
+This folder contains scripts used to automatically update a Node.js dependency.
+These scripts are usually run by CI (see `.github/workflows/tools.yml`) in order
+to download a new dependency version, and replace the old version with it.
+
+Since these scripts only update to the upstream code, changes might be needed in
+this repository in order to successfully update (e.g: changing API calls to
+conform to upstream changes, updating GYP build files, etc.)
+
+## libuv
+
+The `update-libuv.sh` script takes the target version to update as its only
+argument, downloads it from the [GitHub repo](https://github.com/libuv/libuv)
+and uses it to replace the contents of `deps/uv/`. The contents are replaced
+entirely except for the `*.gyp` and `*.gypi` build files, which are part of the
+Node.js build definitions and are not present in the upstream repo.
+
+For example, in order to update to version `1.44.2`, the following command can
+be run:
+
+```bash
+./tools/dep_updaters/update-libuv.sh 1.44.2
+```
+
+Once the script has run (either manually, or by CI in which case a PR will have
+been created with the changes), do the following:
+
+1. Check the [changelog](https://github.com/libuv/libuv/blob/v1.x/ChangeLog) for
+   things that might require changes in Node.js.
+2. If necessary, update `common.gypi` and `uv.gyp` with build-related changes.
+3. Check that Node.js compiles without errors and the tests pass.
+4. Create a commit for the update and in the commit message include the
+   important/relevant items from the changelog (see [`c61870c`][] for an
+   example).
+
+[`c61870c`]: https://github.com/nodejs/node/commit/c61870c376e2f5b0dbaa939972c46745e21cdbdd

--- a/tools/dep_updaters/update-libuv.sh
+++ b/tools/dep_updaters/update-libuv.sh
@@ -2,7 +2,7 @@
 set -e
 # Shell script to update libuv in the source tree to a specific version
 
-BASE_DIR=$(cd "$(dirname "$0")/.." && pwd)
+BASE_DIR=$(cd "$(dirname "$0")/../.." && pwd)
 DEPS_DIR="$BASE_DIR/deps"
 LIBUV_VERSION=$1
 
@@ -12,7 +12,7 @@ if [ "$#" -le 0 ]; then
   exit 1
 fi
 
-echo "Making temporary workspace"
+echo "Making temporary workspace..."
 
 WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
 
@@ -26,7 +26,7 @@ trap cleanup INT TERM EXIT
 
 cd "$WORKSPACE"
 
-echo "Fetching libuv source archive"
+echo "Fetching libuv source archive..."
 curl -sL "https://api.github.com/repos/libuv/libuv/tarball/v$LIBUV_VERSION" | tar xzf -
 mv libuv-libuv-* uv
 

--- a/tools/update-libuv.sh
+++ b/tools/update-libuv.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -e
+# Shell script to update libuv in the source tree to a specific version
+
+BASE_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DEPS_DIR="$BASE_DIR/deps"
+LIBUV_VERSION=$1
+
+if [ "$#" -le 0 ]; then
+  echo "Error: please provide an libuv version to update to"
+  echo "	e.g. $0 1.44.2"
+  exit 1
+fi
+
+echo "Making temporary workspace"
+
+WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
+
+cleanup () {
+  EXIT_CODE=$?
+  [ -d "$WORKSPACE" ] && rm -rf "$WORKSPACE"
+  exit $EXIT_CODE
+}
+
+trap cleanup INT TERM EXIT
+
+cd "$WORKSPACE"
+
+echo "Fetching libuv source archive"
+curl -sL "https://api.github.com/repos/libuv/libuv/tarball/v$LIBUV_VERSION" | tar xzf -
+mv libuv-libuv-* uv
+
+echo "Replacing existing libuv (except GYP build files)"
+mv "$DEPS_DIR/uv/"*.gyp "$DEPS_DIR/uv/"*.gypi "$WORKSPACE/uv/"
+rm -rf "$DEPS_DIR/uv"
+mv "$WORKSPACE/uv" "$DEPS_DIR/"
+
+echo "All done!"
+echo ""
+echo "Please git add uv, commit the new version:"
+echo ""
+echo "$ git add -A deps/uv"
+echo "$ git commit -m \"deps: update libuv to $LIBUV_VERSION\""
+echo ""


### PR DESCRIPTION
## Description
Add a Github Action that checks for new versions of the `libuv` C library, and creates a PR to update it if a newer version than the one present in the repo is found.

Refs: https://github.com/nodejs/security-wg/issues/828

## Details
Currently, if one runs the script to update to version `1.44.2`, the `uv` folder will end up with changes (even though Node's `libuv` version is also at `1.44.2`):
```bash
bash tools/dep_updaters/update-libuv.sh 1.44.2
# (...script output....)

git status
# Changes not staged for commit:
#  (use "git add <file>..." to update what will be committed)
#  (use "git restore <file>..." to discard changes in working directory)
#        modified:   deps/uv/include/uv/win.h
#        modified:   deps/uv/src/win/poll.c

```

This is due to a change made when merging https://github.com/nodejs/node/pull/42340. More specifically, see https://github.com/nodejs/node/pull/42340#issuecomment-1290894883. This accounts for the differences between Node's repo and upstream.

Since this seems to be a change that will be reverted in the next release (as per the comment), it should already be taken care of when the `update-libuv.sh` script is run for that next version.

cc: @lpinca 
