### PR TITLE
util: improve text-decoder performance

### DIFF
--- a/benchmark/util/text-decoder.js
+++ b/benchmark/util/text-decoder.js
@@ -14,6 +14,8 @@ function main({ encoding, len, n, ignoreBOM }) {
   const decoder = new TextDecoder(encoding, { ignoreBOM });
 
   bench.start();
-  decoder.decode(buf);
+  for (let i = 0; i < n; i++) {
+    decoder.decode(buf);
+  }
   bench.end(n);
 }

--- a/benchmark/util/text-decoder.js
+++ b/benchmark/util/text-decoder.js
@@ -6,12 +6,28 @@ const bench = common.createBenchmark(main, {
   encoding: ['utf-8', 'latin1', 'iso-8859-3'],
   ignoreBOM: [0, 1],
   len: [256, 1024 * 16, 1024 * 512],
-  n: [1e6]
+  n: [1e2],
+  type: ['SharedArrayBuffer', 'ArrayBuffer', 'Buffer']
 });
 
-function main({ encoding, len, n, ignoreBOM }) {
-  const buf = Buffer.allocUnsafe(len);
+function main({ encoding, len, n, ignoreBOM, type }) {
   const decoder = new TextDecoder(encoding, { ignoreBOM });
+  let buf;
+
+  switch (type) {
+    case 'SharedArrayBuffer': {
+      buf = new SharedArrayBuffer(len);
+      break;
+    }
+    case 'ArrayBuffer': {
+      buf = new ArrayBuffer(len);
+      break;
+    }
+    case 'Buffer': {
+      buf = Buffer.allocUnsafe(len);
+      break;
+    }
+  }
 
   bench.start();
   for (let i = 0; i < n; i++) {

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -411,15 +411,7 @@ function makeTextDecoderICU() {
 
     decode(input = empty, options = kEmptyObject) {
       validateDecoder(this);
-      if (isAnyArrayBuffer(input)) {
-        try {
-          input = lazyBuffer().from(input);
-        } catch {
-          // If the buffer is detached,
-          // use an empty Uint8Array to avoid TypeError
-          input = empty;
-        }
-      } else if (!isArrayBufferView(input)) {
+      if (!isAnyArrayBuffer(input) && !isArrayBufferView(input)) {
         throw new ERR_INVALID_ARG_TYPE('input',
                                        ['ArrayBuffer', 'ArrayBufferView'],
                                        input);

--- a/src/util.h
+++ b/src/util.h
@@ -506,6 +506,7 @@ class ArrayBufferViewContents {
   explicit inline ArrayBufferViewContents(v8::Local<v8::Object> value);
   explicit inline ArrayBufferViewContents(v8::Local<v8::ArrayBufferView> abv);
   inline void Read(v8::Local<v8::ArrayBufferView> abv);
+  inline void ReadValue(v8::Local<v8::Value> buf);
 
   inline const T* data() const { return data_; }
   inline size_t length() const { return length_; }


### PR DESCRIPTION
This pull request fixes previous benchmarks, improves it, and later improves the performance of the input for SharedArrayBuffer and ArrayBuffer on TextDecoder.decode

Based on @jasnell's recommendation

cc @nodejs/performance

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1212/

```
                                                                                                 confidence improvement accuracy (*)    (**)   (***)
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='iso-8859-3'                        7.47 %       ±9.99% ±13.30% ±17.31%
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='latin1'                     *     10.43 %       ±8.50% ±11.30% ±14.71%
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='utf-8'                             5.30 %       ±6.78%  ±9.04% ±11.81%
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='iso-8859-3'                        0.11 %       ±9.96% ±13.25% ±17.24%
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='latin1'                            2.40 %       ±8.54% ±11.36% ±14.78%
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='utf-8'                             3.43 %       ±8.74% ±11.64% ±15.17%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='iso-8859-3'                 ***     32.84 %      ±12.48% ±16.65% ±21.74%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='latin1'                     ***     27.25 %      ±10.74% ±14.31% ±18.66%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='utf-8'                      ***     36.39 %      ±13.64% ±18.18% ±23.73%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='iso-8859-3'                 ***     29.60 %      ±11.42% ±15.21% ±19.81%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='latin1'                     ***     26.58 %      ±11.86% ±15.78% ±20.54%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='utf-8'                      ***     26.81 %      ±10.96% ±14.58% ±18.98%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='iso-8859-3'                      -3.16 %       ±6.15%  ±8.18% ±10.65%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='latin1'                           2.83 %       ±7.06%  ±9.40% ±12.24%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='utf-8'                           -3.08 %       ±6.04%  ±8.05% ±10.48%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='iso-8859-3'                      -2.60 %       ±7.61% ±10.13% ±13.19%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='latin1'                          -2.27 %       ±7.37%  ±9.80% ±12.76%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='utf-8'                            4.71 %       ±6.94%  ±9.24% ±12.03%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=0 encoding='iso-8859-3'                             6.20 %      ±11.38% ±15.15% ±19.73%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=0 encoding='latin1'                                 5.15 %       ±9.10% ±12.12% ±15.79%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=0 encoding='utf-8'                                  0.88 %      ±11.25% ±14.96% ±19.48%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=1 encoding='iso-8859-3'                            -5.50 %       ±9.90% ±13.18% ±17.15%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=1 encoding='latin1'                                 1.15 %       ±8.39% ±11.17% ±14.55%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=1 encoding='utf-8'                                  3.79 %      ±14.27% ±18.99% ±24.71%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=0 encoding='iso-8859-3'                               9.18 %      ±11.30% ±15.04% ±19.58%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=0 encoding='latin1'                            *     15.81 %      ±13.25% ±17.73% ±23.28%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=0 encoding='utf-8'                                    2.84 %      ±10.10% ±13.45% ±17.51%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=1 encoding='iso-8859-3'                              -0.79 %      ±11.28% ±15.02% ±19.58%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=1 encoding='latin1'                                   3.46 %       ±9.30% ±12.38% ±16.13%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=1 encoding='utf-8'                                    2.41 %       ±9.73% ±12.96% ±16.87%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=0 encoding='iso-8859-3'                            6.12 %       ±6.78%  ±9.02% ±11.74%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=0 encoding='latin1'                                3.18 %       ±6.18%  ±8.22% ±10.70%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=0 encoding='utf-8'                                 0.28 %       ±7.33%  ±9.77% ±12.73%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=1 encoding='iso-8859-3'                           -3.97 %       ±6.21%  ±8.27% ±10.76%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=1 encoding='latin1'                               -4.25 %       ±6.72%  ±8.94% ±11.63%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=1 encoding='utf-8'                                -0.13 %       ±4.92%  ±6.54%  ±8.51%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='iso-8859-3'           *     12.96 %      ±10.21% ±13.59% ±17.71%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='latin1'               *     15.27 %      ±13.12% ±17.54% ±23.00%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='utf-8'                *      9.76 %       ±8.54% ±11.37% ±14.80%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='iso-8859-3'                  7.90 %       ±8.94% ±11.92% ±15.55%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='latin1'                      5.69 %      ±10.00% ±13.31% ±17.33%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='utf-8'                       8.02 %       ±9.13% ±12.15% ±15.82%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='iso-8859-3'           ***     37.73 %      ±13.23% ±17.71% ±23.27%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='latin1'               ***     33.53 %      ±10.06% ±13.40% ±17.49%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='utf-8'                 **     18.71 %      ±10.85% ±14.45% ±18.82%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='iso-8859-3'           ***     36.62 %      ±10.20% ±13.58% ±17.71%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='latin1'               ***     29.98 %       ±6.95%  ±9.24% ±12.04%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='utf-8'                ***     29.35 %       ±9.48% ±12.62% ±16.43%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='iso-8859-3'                -0.31 %       ±6.59%  ±8.77% ±11.42%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='latin1'                    -0.23 %       ±7.59% ±10.11% ±13.16%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='utf-8'                     -0.15 %       ±6.81%  ±9.06% ±11.79%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='iso-8859-3'                 0.32 %       ±7.52% ±10.01% ±13.04%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='latin1'                    -2.21 %       ±7.33%  ±9.76% ±12.71%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='utf-8'                     -1.12 %       ±7.53% ±10.02% ±13.05%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 54 comparisons, you can thus
expect the following amount of false-positive results:
  2.70 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.54 false positives, when considering a   1% risk acceptance (**, ***),
  0.05 false positives, when considering a 0.1% risk acceptance (***)
```