### PR TITLE
doc: define "react-native" community condition

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -706,6 +706,9 @@ is provided below to assist with ecosystem coordination.
   the given export. _This condition should always be included first._
 * `"deno"` - indicates a variation for the Deno platform.
 * `"browser"` - any web browser environment.
+* `"react-native"` - will be matched by the React Native framework (all
+  platforms). _To target React Native for Web, `"browser"` should be specified
+  before this condition._
 * `"development"` - can be used to define a development-only environment
   entry point, for example to provide additional debugging context such as
   better error messages when running in a development mode. _Must always be


### PR DESCRIPTION
I'm a [React Native](https://reactnative.dev/) maintainer working on [Metro](https://facebook.github.io/metro/), our first-party JavaScript bundler. Here I'm proposing the inclusion of a `"react-native"` condition under the "Community Conditions Definitions" section of Node's docs.

This is linked to our framework proposal for package exports support: https://github.com/react-native-community/discussions-and-proposals/pull/534.

### Why this condition is needed

React Native is a popular platform within the JS ecosystem, where code can be executed in non-browser environments, such as our [Hermes JavaScript engine](https://hermesengine.dev/). When package maintainers want to target React Native, we have historically provided a top-level `"react-native"` root field within `package.json` — which was an extension of the [`"browser"` field spec](https://github.com/defunctzombie/package-browser-field-spec) (now itself a community condition).

e.g. Used by [pusher-js](https://github.com/pusher/pusher-js/blob/07f1e09134bd5d6b2024179304891c480c28a949/package.json#L5-L7):

<img width="883" alt="image" src="https://user-images.githubusercontent.com/2547783/200377725-9b340e8b-8c25-4ce2-a8e7-ae70b5d6fec3.png">

As with `"browser"`, we are aiming to translate `"react-native"` to the conditional exports concept.

#### What the `"react-native"` condition will represent

These are unchanged from current use of the `"react-native"` root field.

- Modules are being required by a React Native app.
- JavaScript code will be executed under the Hermes or [JavaScriptCore](https://developer.apple.com/documentation/javascriptcore) runtimes, or a web browser.
- Modules are most likely being loaded under Metro and [babel-preset-react-native](https://www.npmjs.com/package/babel-preset-react-native).

What will change when this is used as a condition via `"exports"`:

- Because `"exports"` allows packages to define the order of conditional exports, package maintainers will have more fine-grained control over what is selected for their package (e.g. matching before, or after, `"browser"`).

### Prior usage

#### Use of `"react-native"` root field

This is a popular feature and is used by both React Native-specific libraries and larger multiplatform libraries (such as the above pusher-js example). [Searching across GitHub](https://cs.github.com/?q=path%3Apackage.json+%2F%5E++%22react-native%22%2F&p=1&pt=269a5b475bcfd529eef3a2944675377dc771dbea615ab7a40ab2d35b052a3f00cd0096d251f73cff9befbab36b3dab1c46e0af3f10af3a8b42194bd99cce05cfecbecf62c9ac89661c13147481a847e6d14362281f9cecc59982d28aa7868273d6efa9980d7300e69fbd56192c31295c829ef129af6dfadb331a58a7f5e72556ae2cebf44121bd020db2f1a7c45139cebf79464fb8febb80b102b8d2788adb21ce002511cd8446e01ecf43e5b3ceb14128d87d65cbc8a24640efe8e374bcdd52e1568804fbf03d8bb6d4c9e9b56f24648d95b45286dc95ad5992c97c58f45de1549273e82d52f86659510c323f6ce75528198cd0e81aa8018ed7566328babaa4729f755e422d87763994b1a01ff9615fb10abec3f8acb6ea3db97e04743708d21fd52d9738c5c784faf2d691bbb4680f75ba3a5a71b2fc5d1df8e4dea60ff7ee19e0139ae90db8fd48b8df843a4e0513ced0f02c2b0b4586b8352c0d59b822a18b0dfd0ee0a4a183e933a16a772a4d11cfec4463a95dbb0a813aebec28f8452ca053e7f55e3bb069be351a27945343c7&scope=&scopeName=All+repos), use of the top-level `"react-native"` field for specifying alternate source files is present in ~20k repositories.

<img width="811" alt="image" src="https://user-images.githubusercontent.com/2547783/200358921-359e4f68-02ef-42e9-9610-b15b14686471.png">

#### Use of `"react-native"` package exports condition

Webpack [already lists `"react-native"`](https://webpack.js.org/guides/package-exports/#target-environment) under its docs for _Package exports_, which is enabled when configured by the user or in templates under React Native projects.

<img width="748" alt="image" src="https://user-images.githubusercontent.com/2547783/200374889-6d9e8f41-ea24-4e7f-92df-934c216a8330.png">

From this we can infer there is independent desire for such a condition, and perhaps limited use today. The definition it provides is "TBD", leaving us to provide the concrete and canonical definition with this PR.

### How we teach this

Once "exports" support is ready in Metro:

- We will update the primary template for new React Native libraries: [create-react-native-library](https://www.npmjs.com/package/create-react-native-library).
- We aim to publish a Metro/React Native website blog post with an upgrade guide for package maintainers.

With the merging of this PR:

- Package maintainers can optionally get their packages ready for conditional exports in React Native using the documented definition, which [**we are set on**](https://github.com/react-native-community/discussions-and-proposals/pull/534#issuecomment-1290478632).
    - This will work in Webpack today, but not Metro (until support is shipped).

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
