### PR TITLE
doc, async_hooks: improve and add migration hints

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -3,7 +3,6 @@
 <!--introduced_in=v8.1.0-->
 
 > Stability: 1 - Experimental
-> state. Please migrate to other APIs.
 
 <!-- source_link=lib/async_hooks.js -->
 

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -571,7 +571,7 @@ will never be called, causing a memory leak in the application. If the resource
 does not depend on garbage collection, then this will not be an issue.
 
 Using the destroy hook results in additional overhead because it enables
-tracking of `Promise` instances via garbage collector.
+tracking of `Promise` instances via the garbage collector.
 
 #### `promiseResolve(asyncId)`
 

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -2,7 +2,7 @@
 
 <!--introduced_in=v8.1.0-->
 
-> Stability: 1 - Experimental. This module will most likely never reach stable
+> Stability: 1 - Experimental
 > state. Please migrate to other APIs.
 
 <!-- source_link=lib/async_hooks.js -->

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -871,10 +871,10 @@ The documentation for this class has moved [`AsyncLocalStorage`][].
 [`AsyncLocalStorage`]: async_context.md#class-asynclocalstorage
 [`AsyncResource`]: async_context.md#class-asyncresource
 [`Worker`]: worker_threads.md#class-worker
-[`process.getActiveResourcesInfo()`]: process.md#processgetactiveresourcesinfo
 [`after` callback]: #afterasyncid
 [`before` callback]: #beforeasyncid
 [`destroy` callback]: #destroyasyncid
 [`init` callback]: #initasyncid-type-triggerasyncid-resource
+[`process.getActiveResourcesInfo()`]: process.md#processgetactiveresourcesinfo
 [`promiseResolve` callback]: #promiseresolveasyncid
 [promise execution tracking]: #promise-execution-tracking

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -2,17 +2,16 @@
 
 <!--introduced_in=v8.1.0-->
 
-> Stability: 1 - Experimental
+> Stability: 1 - Experimental. This module will most likely never reach stable
+> state. Please migrate to other APIs.
 
 <!-- source_link=lib/async_hooks.js -->
 
-This module will most likely never reach stable state. Please migrate to
-other APIs.
+There are other APIs available to replace async_hooks at least for most use
+cases. Migrate/use them instead of using async_hooks. For example:
 
-* [`AsyncLocalStorage`][] is stable and designed to cover one of the
-main usecases to track async context
-* [`process.getActiveResourcesInfo()`][] might fit better to track active
-resources
+* [`AsyncLocalStorage`][] tracks async context
+* [`process.getActiveResourcesInfo()`][] tracks active resources
 
 The `node:async_hooks` module provides an API to track asynchronous resources.
 It can be accessed using:

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -336,7 +336,7 @@ The `type` is a string identifying the type of resource that caused
 resource's constructor.
 
 The `type` of resources created by Node.js itself can change in any Node.js
-release. Valid values at the time of writing are for example `TLSWRAP`,
+release. Valid values are `TLSWRAP`,
 `TCPWRAP`, `TCPSERVERWRAP`, `GETADDRINFOREQWRAP`, `FSREQCALLBACK`,
 `Microtask`, `Timeout`. Inspect the source code of the Node.js version used
 to get the full list.

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -418,7 +418,7 @@ of propagating what resource is responsible for the new resource's existence.
 `resource` is an object that represents the actual async resource that has
 been initialized. The API to access the object may be specified by the
 creator of the resource. Resources created by Node.js itself are internal
-and may change at any time therefore no API is specified for these.
+and may change at any time. Therefore no API is specified for these.
 
 In some cases the resource object is reused for performance reasons, it is
 thus not safe to use it as a key in a `WeakMap` or add properties to it.

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -338,7 +338,7 @@ resource's constructor.
 The `type` of resources created by Node.js itself can change in any Node.js
 release. Valid values are `TLSWRAP`,
 `TCPWRAP`, `TCPSERVERWRAP`, `GETADDRINFOREQWRAP`, `FSREQCALLBACK`,
-`Microtask`, `Timeout`. Inspect the source code of the Node.js version used
+`Microtask`, and `Timeout`. Inspect the source code of the Node.js version used
 to get the full list.
 
 Furthermore users of [`AsyncResource`][] create async resources independent

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -7,8 +7,8 @@
 
 <!-- source_link=lib/async_hooks.js -->
 
-There are other APIs available to replace async_hooks at least for most use
-cases. Migrate/use them instead of using async_hooks. For example:
+There are other APIs available to replace `async_hooks` at least for most use
+cases. Migrate/use them instead of using `async_hooks`. For example:
 
 * [`AsyncLocalStorage`][] tracks async context
 * [`process.getActiveResourcesInfo()`][] tracks active resources

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -871,7 +871,7 @@ The documentation for this class has moved [`AsyncLocalStorage`][].
 [`AsyncLocalStorage`]: async_context.md#class-asynclocalstorage
 [`AsyncResource`]: async_context.md#class-asyncresource
 [`Worker`]: worker_threads.md#class-worker
-[`process.getActiveResourcesInfo()`]: process.md#processgetActiveResourcesInfo
+[`process.getActiveResourcesInfo()`]: process.md#processgetactiveresourcesinfo
 [`after` callback]: #afterasyncid
 [`before` callback]: #beforeasyncid
 [`destroy` callback]: #destroyasyncid

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -336,7 +336,7 @@ The `type` is a string identifying the type of resource that caused
 resource's constructor.
 
 The `type` of resources created by Node.js itself can change in any Node.js
-release. Valid values are `TLSWRAP`,
+release. Valid values include `TLSWRAP`,
 `TCPWRAP`, `TCPSERVERWRAP`, `GETADDRINFOREQWRAP`, `FSREQCALLBACK`,
 `Microtask`, and `Timeout`. Inspect the source code of the Node.js version used
 to get the full list.

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -335,8 +335,13 @@ current Node.js instance.
 
 The `type` is a string identifying the type of resource that caused
 `init` to be called. Generally, it will correspond to the name of the
-resource's constructor. The `type` of resources created by Node.js itself
-can change in any Node.js release.
+resource's constructor.
+
+The `type` of resources created by Node.js itself can change in any Node.js
+release. Valid values at the time of writing are for example `TLSWRAP`,
+`TCPWRAP`, `TCPSERVERWRAP`, `GETADDRINFOREQWRAP`, `FSREQCALLBACK`,
+`Microtask`, `Timeout`. Inspect the source code of the Node.js version used
+to get the full list.
 
 Furthermore users of [`AsyncResource`][] create async resources independent
 of Node.js itself.

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -870,8 +870,8 @@ The documentation for this class has moved [`AsyncLocalStorage`][].
 [PromiseHooks]: https://docs.google.com/document/d/1rda3yKGHimKIhg5YeoAmCOtyURgsbTH_qaYR79FELlk/edit
 [`AsyncLocalStorage`]: async_context.md#class-asynclocalstorage
 [`AsyncResource`]: async_context.md#class-asyncresource
-[`process.getActiveResourcesInfo()`]: process.md#processgetActiveResourcesInfo
 [`Worker`]: worker_threads.md#class-worker
+[`process.getActiveResourcesInfo()`]: process.md#processgetActiveResourcesInfo
 [`after` callback]: #afterasyncid
 [`before` callback]: #beforeasyncid
 [`destroy` callback]: #destroyasyncid

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -7,8 +7,8 @@
 
 <!-- source_link=lib/async_hooks.js -->
 
-There are other APIs available to replace `async_hooks` at least for most use
-cases. Migrate/use them instead of using `async_hooks`. For example:
+We strongly discourage the use of the `async_hooks` API.
+Other APIs that can cover most of its use cases include:
 
 * [`AsyncLocalStorage`][] tracks async context
 * [`process.getActiveResourcesInfo()`][] tracks active resources


### PR DESCRIPTION
Add hints to migrate away from async hooks.
Change docs at various places to be more clear that resources are internals and may change at any time.

This might replace and/or extend #45335. 

Main differences (besides the few additions):
* don't announce the `We plan to remove this API`
* don't refer to diagnostics_channel because I'm not aware of any async hooks use case which is solved by diagnostics_channel (well, we could create `async.init`, `async.before`, `async.after` and `async.destroy` channels to hide async hooks API but this would be of no real help)

I think it's easier to provide my view/input via a new PR. Anyhow, if people prefer the wording/message of #45335 I'm also fine and will close this one.

Refs: #45335

fyi @GeoffreyBooth @nodejs/diagnostics 
