### PR TITLE
lib: delete unused parameter calls of the cjs module loader findPath method

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1009,7 +1009,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
   }
 
   // Look up the filename first, since that's the cache key.
-  const filename = Module._findPath(request, paths, isMain, false);
+  const filename = Module._findPath(request, paths, isMain);
   if (filename) return filename;
   const requireStack = [];
   for (let cursor = parent;


### PR DESCRIPTION
Delete unused parameter calls of the cjs module loader findPath method

**Checklist**
 
- [x] make -j4 test (UNIX), or vcbuild test (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines)