### PR TITLE
doc: add arm64 to os.machine()

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -462,8 +462,8 @@ added:
 
 * Returns {string}
 
-Returns the machine type as a string, such as `arm`, `aarch64`, `mips`,
-`mips64`, `ppc64`, `ppc64le`, `s390`, `s390x`, `i386`, `i686`, `x86_64`.
+Returns the machine type as a string, such as `arm`, `arm64`, `aarch64`,
+`mips`, `mips64`, `ppc64`, `ppc64le`, `s390`, `s390x`, `i386`, `i686`, `x86_64`.
 
 On POSIX systems, the machine type is determined by calling
 [`uname(3)`][]. On Windows, `RtlGetVersion()` is used, and if it is not


### PR DESCRIPTION
`arm64` is a much more common machine name than `s390x` so I think it deserves a spot on in the sunlight.