### PR TITLE
deps: V8: cherry-pick 031b98b25cba

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.18',
+    'v8_embedder_string': '-node.19',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/execution/isolate.cc
+++ b/deps/v8/src/execution/isolate.cc
@@ -1949,6 +1949,15 @@ Object Isolate::UnwindAndFindHandler() {
   // Special handling of termination exceptions, uncatchable by JavaScript and
   // Wasm code, we unwind the handlers until the top ENTRY handler is found.
   bool catchable_by_js = is_catchable_by_javascript(exception);
+  if (!catchable_by_js && !context().is_null()) {
+    // Because the array join stack will not pop the elements when throwing the
+    // uncatchable terminate exception, we need to clear the array join stack to
+    // avoid leaving the stack in an invalid state.
+    // See also CycleProtectedArrayJoin.
+    raw_native_context().set_array_join_stack(
+        ReadOnlyRoots(this).undefined_value());
+  }
+
   int visited_frames = 0;
 
 #if V8_ENABLE_WEBASSEMBLY

--- a/deps/v8/test/inspector/runtime/evaluate-repl-mode-side-effecting-array-join-expected.txt
+++ b/deps/v8/test/inspector/runtime/evaluate-repl-mode-side-effecting-array-join-expected.txt
@@ -1,0 +1,48 @@
+Tests that Runtime.evaluate with REPL mode correctly handles Array.prototype.join.
+{
+    id : <messageId>
+    result : {
+        result : {
+            className : Array
+            description : Array(1)
+            objectId : <objectId>
+            subtype : array
+            type : object
+        }
+    }
+}
+{
+    id : <messageId>
+    result : {
+        exceptionDetails : {
+            columnNumber : -1
+            exception : {
+                className : EvalError
+                description : EvalError: Possible side-effect in debug-evaluate
+                objectId : <objectId>
+                subtype : error
+                type : object
+            }
+            exceptionId : <exceptionId>
+            lineNumber : -1
+            scriptId : <scriptId>
+            text : Uncaught
+        }
+        result : {
+            className : EvalError
+            description : EvalError: Possible side-effect in debug-evaluate
+            objectId : <objectId>
+            subtype : error
+            type : object
+        }
+    }
+}
+{
+    id : <messageId>
+    result : {
+        result : {
+            type : string
+            value : /a/
+        }
+    }
+}

--- a/deps/v8/test/inspector/runtime/evaluate-repl-mode-side-effecting-array-join.js
+++ b/deps/v8/test/inspector/runtime/evaluate-repl-mode-side-effecting-array-join.js
@@ -1,0 +1,32 @@
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+let {Protocol} = InspectorTest.start(
+  'Tests that Runtime.evaluate with REPL mode correctly handles \
+Array.prototype.join.');
+
+Protocol.Runtime.enable();
+(async function () {
+  await evaluateReplWithSideEffects('a=[/a/]')
+  await evaluateRepl('a.toString()');
+  await evaluateReplWithSideEffects('a.toString()');
+
+  InspectorTest.completeTest();
+})();
+
+async function evaluateRepl(expression) {
+  InspectorTest.logMessage(await Protocol.Runtime.evaluate({
+    expression: expression,
+    replMode: true,
+    throwOnSideEffect: true
+  }));
+}
+
+async function evaluateReplWithSideEffects(expression) {
+  InspectorTest.logMessage(await Protocol.Runtime.evaluate({
+    expression: expression,
+    replMode: true,
+    throwOnSideEffect: false
+  }));
+}


### PR DESCRIPTION
Original commit message:

    [runtime] Clear array join stack when throwing uncatchable

    ... exception.

    Array#join depends array_join_stack to avoid infinite loop
    and ensures symmetric pushes/pops through catch blocks to
    correctly maintain the elements in the join stack.
    However, the stack does not pop the elements and leaves in
    an invalid state when throwing the uncatchable termination
    exception. And the invalid join stack state will affect
    subsequent Array#join calls. Because all the terminate
    exception will be handled by Isolate::UnwindAndFindHandler,
    we could clear the array join stack when unwinding the terminate
    exception.

    Bug: v8:13259
    Change-Id: I23823e823c5fe0b089528c5cf654864cea78ebeb
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3878451
    Reviewed-by: Jakob Linke <jgruber@chromium.org>
    Commit-Queue: 王澳 <wangao.james@bytedance.com>
    Cr-Commit-Position: refs/heads/main@{#83465}

Refs: https://github.com/v8/v8/commit/031b98b25cbaaa4c62d8544f5f667d33ea4076c4
Closes: https://github.com/nodejs/node/issues/44417
