### PR TITLE
node-api: declare type napi_cleanup_hook

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -897,6 +897,24 @@ typedef void (*napi_threadsafe_function_call_js)(napi_env env,
 Unless for reasons discussed in [Object Lifetime Management][], creating a
 handle and/or callback scope inside the function body is not necessary.
 
+#### `napi_cleanup_hook`
+
+<!-- YAML
+added: REPLACEME
+napiVersion: 3
+-->
+
+Function pointer used with [`napi_add_env_cleanup_hook`][]. It will be called
+when the environment is being torn down.
+
+Callback functions must satisfy the following signature:
+
+```c
+typedef void (*napi_cleanup_hook)(void* data);
+```
+
+* `[in] data`: The data that was passed to [`napi_add_env_cleanup_hook`][].
+
 #### `napi_async_cleanup_hook`
 
 <!-- YAML
@@ -1798,7 +1816,7 @@ napiVersion: 3
 
 ```c
 NODE_EXTERN napi_status napi_add_env_cleanup_hook(napi_env env,
-                                                  void (*fun)(void* arg),
+                                                  napi_cleanup_hook fun,
                                                   void* arg);
 ```
 

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -671,8 +671,9 @@ void NAPI_CDECL napi_module_register(napi_module* mod) {
   node::node_module_register(nm);
 }
 
-napi_status NAPI_CDECL napi_add_env_cleanup_hook(
-    napi_env env, void(NAPI_CDECL* fun)(void* arg), void* arg) {
+napi_status NAPI_CDECL napi_add_env_cleanup_hook(napi_env env,
+                                                 napi_cleanup_hook fun,
+                                                 void* arg) {
   CHECK_ENV(env);
   CHECK_ARG(env, fun);
 
@@ -681,8 +682,9 @@ napi_status NAPI_CDECL napi_add_env_cleanup_hook(
   return napi_ok;
 }
 
-napi_status NAPI_CDECL napi_remove_env_cleanup_hook(
-    napi_env env, void(NAPI_CDECL* fun)(void* arg), void* arg) {
+napi_status NAPI_CDECL napi_remove_env_cleanup_hook(napi_env env,
+                                                    napi_cleanup_hook fun,
+                                                    void* arg) {
   CHECK_ENV(env);
   CHECK_ARG(env, fun);
 

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -206,11 +206,11 @@ napi_get_uv_event_loop(napi_env env, struct uv_loop_s** loop);
 NAPI_EXTERN napi_status NAPI_CDECL napi_fatal_exception(napi_env env,
                                                         napi_value err);
 
-NAPI_EXTERN napi_status NAPI_CDECL napi_add_env_cleanup_hook(
-    napi_env env, void(NAPI_CDECL* fun)(void* arg), void* arg);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_add_env_cleanup_hook(napi_env env, napi_cleanup_hook fun, void* arg);
 
-NAPI_EXTERN napi_status NAPI_CDECL napi_remove_env_cleanup_hook(
-    napi_env env, void(NAPI_CDECL* fun)(void* arg), void* arg);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_remove_env_cleanup_hook(napi_env env, napi_cleanup_hook fun, void* arg);
 
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_open_callback_scope(napi_env env,

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -6,6 +6,11 @@
 typedef struct napi_callback_scope__* napi_callback_scope;
 typedef struct napi_async_context__* napi_async_context;
 typedef struct napi_async_work__* napi_async_work;
+
+#if NAPI_VERSION >= 3
+typedef void(NAPI_CDECL* napi_cleanup_hook)(void* arg);
+#endif  // NAPI_VERSION >= 3
+
 #if NAPI_VERSION >= 4
 typedef struct napi_threadsafe_function__* napi_threadsafe_function;
 #endif  // NAPI_VERSION >= 4


### PR DESCRIPTION
Declare type `napi_cleanup_hook` so that the function signature can be
shared across the codebase.

This has no behavioral change. The type declaration can be available once
addons updated their node-api header files, e.g. with https://github.com/nodejs/node-api-headers.