### PR TITLE
[v19.x] lib: fix eslint early return

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1091,8 +1091,6 @@ function on(emitter, event, options) {
       { once: true });
   }
 
-  return iterator;
-
   function abortListener() {
     errorHandler(new AbortError(undefined, { cause: signal?.reason }));
   }
@@ -1120,4 +1118,5 @@ function on(emitter, event, options) {
 
     iterator.return();
   }
+  return iterator;
 }


### PR DESCRIPTION
The https://github.com/nodejs/node/pull/45243 updated eslint, and apparently when you specify a `@returns` early returns aren't considered valid. This PR fixes this lint issue.

In the `main` branch it's not failing because https://github.com/nodejs/node/pull/41276 fixes it indirectly.

FYI @Trott 

cc: @nodejs/releasers this probably needs to be backported/cherry-picked to all active release lines. 