### PR TITLE
util: add fast path for utf8 encoding

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -4,6 +4,7 @@
 // https://encoding.spec.whatwg.org
 
 const {
+  Boolean,
   ObjectCreate,
   ObjectDefineProperties,
   ObjectGetOwnPropertyDescriptors,
@@ -28,6 +29,8 @@ const kFlags = Symbol('flags');
 const kEncoding = Symbol('encoding');
 const kDecoder = Symbol('decoder');
 const kEncoder = Symbol('encoder');
+const kUTF8FastPath = Symbol('kUTF8FastPath');
+const kIgnoreBOM = Symbol('kIgnoreBOM');
 
 const {
   getConstructorOf,
@@ -49,7 +52,8 @@ const {
 
 const {
   encodeInto,
-  encodeUtf8String
+  encodeUtf8String,
+  decodeUTF8,
 } = internalBinding('buffer');
 
 let Buffer;
@@ -397,19 +401,40 @@ function makeTextDecoderICU() {
         flags |= options.ignoreBOM ? CONVERTER_FLAGS_IGNORE_BOM : 0;
       }
 
-      const handle = getConverter(enc, flags);
-      if (handle === undefined)
-        throw new ERR_ENCODING_NOT_SUPPORTED(encoding);
+      // Only support fast path for UTF-8 without FATAL flag
+      const fastPathAvailable = enc === 'utf-8' && !(options?.fatal);
 
       this[kDecoder] = true;
-      this[kHandle] = handle;
       this[kFlags] = flags;
       this[kEncoding] = enc;
+      this[kIgnoreBOM] = Boolean(options?.ignoreBOM);
+      this[kUTF8FastPath] = fastPathAvailable;
+      this[kHandle] = undefined;
+
+      if (!fastPathAvailable) {
+        this.#prepareConverter();
+      }
     }
 
+    #prepareConverter() {
+      if (this[kHandle] !== undefined) return;
+      const handle = getConverter(this[kEncoding], this[kFlags]);
+      if (handle === undefined)
+        throw new ERR_ENCODING_NOT_SUPPORTED(this[kEncoding]);
+      this[kHandle] = handle;
+    }
 
     decode(input = empty, options = kEmptyObject) {
       validateDecoder(this);
+
+      this[kUTF8FastPath] &&= !(options?.stream);
+
+      if (this[kUTF8FastPath]) {
+        return decodeUTF8(input, this[kIgnoreBOM]);
+      }
+
+      this.#prepareConverter();
+
       validateObject(options, 'options', {
         nullable: true,
         allowArray: true,

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -24,6 +24,7 @@
 #include "node_blob.h"
 #include "node_errors.h"
 #include "node_external_reference.h"
+#include "node_i18n.h"
 #include "node_internals.h"
 
 #include "env-inl.h"
@@ -565,6 +566,48 @@ void StringSlice(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(ret);
 }
 
+// Convert the input into an encoded string
+void DecodeUTF8(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);  // list, flags
+
+  if (!(args[0]->IsArrayBuffer() || args[0]->IsSharedArrayBuffer() ||
+        args[0]->IsArrayBufferView())) {
+    return node::THROW_ERR_INVALID_ARG_TYPE(
+        env->isolate(),
+        "The \"list\" argument must be an instance of SharedArrayBuffer, "
+        "ArrayBuffer or ArrayBufferView.");
+  }
+
+  ArrayBufferViewContents<char> buffer(args[0]);
+
+  CHECK(args[1]->IsBoolean());
+  bool ignore_bom = args[1]->IsTrue();
+
+  const char* data = buffer.data();
+  size_t length = buffer.length();
+
+  if (!ignore_bom && length >= 3) {
+    if (memcmp(data, "\xEF\xBB\xBF", 3) == 0) {
+      data += 3;
+      length -= 3;
+    }
+  }
+
+  if (length == 0) return args.GetReturnValue().SetEmptyString();
+
+  Local<Value> error;
+  MaybeLocal<Value> maybe_ret =
+      StringBytes::Encode(env->isolate(), data, length, UTF8, &error);
+  Local<Value> ret;
+
+  if (!maybe_ret.ToLocal(&ret)) {
+    CHECK(!error.IsEmpty());
+    env->isolate()->ThrowException(error);
+    return;
+  }
+
+  args.GetReturnValue().Set(ret);
+}
 
 // bytesCopied = copy(buffer, target[, targetStart][, sourceStart][, sourceEnd])
 void Copy(const FunctionCallbackInfo<Value> &args) {
@@ -1282,6 +1325,7 @@ void Initialize(Local<Object> target,
 
   SetMethod(context, target, "setBufferPrototype", SetBufferPrototype);
   SetMethodNoSideEffect(context, target, "createFromString", CreateFromString);
+  SetMethodNoSideEffect(context, target, "decodeUTF8", DecodeUTF8);
 
   SetMethodNoSideEffect(context, target, "byteLengthUtf8", ByteLengthUtf8);
   SetMethod(context, target, "copy", Copy);
@@ -1339,6 +1383,7 @@ void Initialize(Local<Object> target,
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(SetBufferPrototype);
   registry->Register(CreateFromString);
+  registry->Register(DecodeUTF8);
 
   registry->Register(ByteLengthUtf8);
   registry->Register(Copy);

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -113,7 +113,7 @@ if (common.hasIntl) {
       '  fatal: false,\n' +
       '  ignoreBOM: true,\n' +
       '  [Symbol(flags)]: 4,\n' +
-      '  [Symbol(handle)]: Converter {}\n' +
+      '  [Symbol(handle)]: undefined\n' +
       '}'
     );
   } else {


### PR DESCRIPTION
Adds a fast path for UTF8. I'll remove my local benchmark and share the Benchmark CI result asap. 

Fixes https://github.com/nodejs/performance/issues/3

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1219/

```
                                                                                                 confidence improvement accuracy (*)    (**)   (***)
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='iso-8859-3'                       -6.27 %       ±8.96% ±11.92% ±15.52%
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='latin1'                           -4.62 %       ±8.01% ±10.67% ±13.90%
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='utf-8'                    ***     85.34 %      ±11.75% ±15.71% ±20.61%
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='iso-8859-3'                        1.61 %       ±8.75% ±11.65% ±15.16%
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='latin1'                           -0.09 %      ±10.96% ±14.59% ±19.00%
util/text-decoder.js type='ArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='utf-8'                    ***     96.26 %      ±11.34% ±15.15% ±19.83%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='iso-8859-3'                         -1.29 %      ±10.21% ±13.59% ±17.69%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='latin1'                             -7.53 %       ±9.26% ±12.32% ±16.03%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='utf-8'                      ***     81.43 %      ±15.18% ±20.26% ±26.49%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='iso-8859-3'                         -3.66 %      ±10.59% ±14.10% ±18.36%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='latin1'                             -4.73 %       ±9.51% ±12.65% ±16.46%
util/text-decoder.js type='ArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='utf-8'                      ***     66.13 %      ±11.97% ±15.98% ±20.89%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='iso-8859-3'                      -4.66 %       ±7.36%  ±9.81% ±12.80%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='latin1'                          -1.26 %       ±6.54%  ±8.70% ±11.32%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='utf-8'                   ***    124.06 %      ±12.94% ±17.35% ±22.86%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='iso-8859-3'                       3.27 %       ±7.37%  ±9.81% ±12.77%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='latin1'                           4.71 %       ±7.29%  ±9.70% ±12.63%
util/text-decoder.js type='ArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='utf-8'                   ***    123.17 %      ±11.09% ±14.83% ±19.46%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=0 encoding='iso-8859-3'                             0.89 %      ±11.22% ±14.94% ±19.48%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=0 encoding='latin1'                                -1.94 %       ±9.74% ±12.96% ±16.88%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=0 encoding='utf-8'                                  6.38 %      ±10.23% ±13.62% ±17.75%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=1 encoding='iso-8859-3'                             8.49 %      ±13.25% ±17.64% ±22.99%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=1 encoding='latin1'                                -4.59 %       ±8.69% ±11.56% ±15.05%
util/text-decoder.js type='Buffer' n=100 len=16384 ignoreBOM=1 encoding='utf-8'                                  3.23 %      ±11.88% ±15.82% ±20.61%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=0 encoding='iso-8859-3'                              -8.39 %      ±11.13% ±14.81% ±19.29%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=0 encoding='latin1'                                  -8.45 %       ±8.95% ±11.94% ±15.59%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=0 encoding='utf-8'                           ***     75.48 %      ±13.57% ±18.10% ±23.65%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=1 encoding='iso-8859-3'                              -8.57 %       ±9.88% ±13.15% ±17.12%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=1 encoding='latin1'                                   0.43 %      ±10.28% ±13.68% ±17.81%
util/text-decoder.js type='Buffer' n=100 len=256 ignoreBOM=1 encoding='utf-8'                           ***     61.38 %      ±11.32% ±15.08% ±19.68%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=0 encoding='iso-8859-3'                            1.93 %       ±6.77%  ±9.01% ±11.73%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=0 encoding='latin1'                                1.13 %       ±6.69%  ±8.91% ±11.61%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=0 encoding='utf-8'                          *      5.78 %       ±5.42%  ±7.22%  ±9.41%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=1 encoding='iso-8859-3'                    **     11.05 %       ±7.37%  ±9.82% ±12.82%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=1 encoding='latin1'                               -1.59 %       ±6.92%  ±9.21% ±11.98%
util/text-decoder.js type='Buffer' n=100 len=524288 ignoreBOM=1 encoding='utf-8'                                 4.86 %       ±6.02%  ±8.01% ±10.44%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='iso-8859-3'                 -3.19 %       ±8.34% ±11.10% ±14.45%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='latin1'                     -3.23 %       ±8.85% ±11.77% ±15.33%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=0 encoding='utf-8'              ***     99.12 %      ±13.72% ±18.35% ±24.08%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='iso-8859-3'                  6.40 %       ±9.11% ±12.12% ±15.78%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='latin1'                     -0.48 %       ±9.58% ±12.75% ±16.59%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=16384 ignoreBOM=1 encoding='utf-8'              ***     82.03 %      ±10.49% ±14.00% ±18.30%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='iso-8859-3'             *     -9.66 %       ±8.65% ±11.51% ±14.99%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='latin1'                **    -11.56 %       ±7.87% ±10.50% ±13.70%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=0 encoding='utf-8'                ***     79.82 %      ±15.42% ±20.58% ±26.90%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='iso-8859-3'                   -6.23 %      ±10.78% ±14.38% ±18.77%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='latin1'                       -1.80 %       ±7.99% ±10.64% ±13.85%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=256 ignoreBOM=1 encoding='utf-8'                ***     86.66 %      ±13.49% ±18.04% ±23.67%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='iso-8859-3'                -2.70 %       ±6.82%  ±9.07% ±11.81%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='latin1'                     0.29 %       ±7.20%  ±9.58% ±12.47%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=0 encoding='utf-8'             ***    117.44 %      ±11.62% ±15.52% ±20.31%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='iso-8859-3'                 3.90 %       ±7.74% ±10.29% ±13.40%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='latin1'                    -2.62 %       ±7.05%  ±9.39% ±12.22%
util/text-decoder.js type='SharedArrayBuffer' n=100 len=524288 ignoreBOM=1 encoding='utf-8'             ***    112.07 %      ±12.49% ±16.73% ±21.99%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 54 comparisons, you can thus
expect the following amount of false-positive results:
  2.70 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.54 false positives, when considering a   1% risk acceptance (**, ***),
  0.05 false positives, when considering a 0.1% risk acceptance (***)
```