### PR TITLE
No call to SetIdle() when terminating

### DIFF
--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -97,10 +97,11 @@ void InternalCallbackScope::Close() {
   if (closed_) return;
   closed_ = true;
 
+  if (!env_->can_call_into_js()) return;
+
   Isolate* isolate = env_->isolate();
   auto idle = OnScopeLeave([&]() { isolate->SetIdle(true); });
 
-  if (!env_->can_call_into_js()) return;
   auto perform_stopping_check = [&]() {
     if (env_->is_stopping()) {
       MarkAsFailed();

--- a/test/parallel/test-unhandled-exception-with-worker-inuse.js
+++ b/test/parallel/test-unhandled-exception-with-worker-inuse.js
@@ -1,0 +1,27 @@
+'use strict';
+require('../common');
+
+// Check that node will not call v8::Isolate::SetIdle() when exiting
+// due to an unhandled exception, otherwise the assertion(enabled in
+// debug build only) in the SetIdle() will fail.
+//
+// The root cause of this issue is that before PerIsolateMessageListener()
+// is invoked by v8, v8 preserves the vm state, which is JS. However,
+// SetIdle() requires the vm state is either EXTERNEL or IDLE when embedder
+// calling it.
+
+if (process.argv[2] === 'child') {
+  const { Worker } = require('worker_threads');
+  new Worker('', { eval: true });
+  throw new Error('xxx');
+} else {
+  const assert = require('assert');
+  const { spawnSync } = require('child_process');
+  const result = spawnSync(process.execPath, [__filename, 'child']);
+
+  const stderr = result.stderr.toString().trim();
+  // Expect error message to be preserved
+  assert.match(stderr, /xxx/);
+  // Expect no crash message
+  assert.doesNotMatch(stderr, /node::DumpBacktrace/);
+}

--- a/test/parallel/test-unhandled-exception-with-worker-inuse.js
+++ b/test/parallel/test-unhandled-exception-with-worker-inuse.js
@@ -7,7 +7,7 @@ require('../common');
 //
 // The root cause of this issue is that before PerIsolateMessageListener()
 // is invoked by v8, v8 preserves the vm state, which is JS. However,
-// SetIdle() requires the vm state is either EXTERNEL or IDLE when embedder
+// SetIdle() requires the vm state is either EXTERNAL or IDLE when embedder
 // calling it.
 
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-unhandled-exception-with-worker-inuse.js
+++ b/test/parallel/test-unhandled-exception-with-worker-inuse.js
@@ -25,5 +25,5 @@ if (process.argv[2] === 'child') {
   // Expect error message to be preserved
   assert.match(stderr, /xxx/);
   // Expect no crash
-  assert.ok(common.nodeProcessAborted(result.status, result.signal), stderr);
+  assert.ok(!common.nodeProcessAborted(result.status, result.signal), stderr);
 }

--- a/test/parallel/test-unhandled-exception-with-worker-inuse.js
+++ b/test/parallel/test-unhandled-exception-with-worker-inuse.js
@@ -1,6 +1,8 @@
 'use strict';
-require('../common');
+const common = require('../common');
 
+// https://github.com/nodejs/node/issues/45421
+//
 // Check that node will not call v8::Isolate::SetIdle() when exiting
 // due to an unhandled exception, otherwise the assertion(enabled in
 // debug build only) in the SetIdle() will fail.
@@ -22,6 +24,6 @@ if (process.argv[2] === 'child') {
   const stderr = result.stderr.toString().trim();
   // Expect error message to be preserved
   assert.match(stderr, /xxx/);
-  // Expect no crash message
-  assert.doesNotMatch(stderr, /node::DumpBacktrace/);
+  // Expect no crash
+  common.nodeProcessAborted(result.status, result.signal);
 }

--- a/test/parallel/test-unhandled-exception-with-worker-inuse.js
+++ b/test/parallel/test-unhandled-exception-with-worker-inuse.js
@@ -25,5 +25,5 @@ if (process.argv[2] === 'child') {
   // Expect error message to be preserved
   assert.match(stderr, /xxx/);
   // Expect no crash
-  common.nodeProcessAborted(result.status, result.signal);
+  assert.ok(common.nodeProcessAborted(result.status, result.signal), stderr);
 }


### PR DESCRIPTION
Fix https://github.com/nodejs/node/issues/45421, where you can find a helpful stack trace

One can argues that v8 is responsable for transfering vm state to EXTERNAL before invoking `PerIsolateMessageListener()`, if v8 agrees and changes for it, this issue is gone without any change of Node.js.  However, `SetIdle()` is basically for cpu profiling only, it's not necessary when terminating. Removing it is not harmful while otherwise will lead to crash before v8 makes that change.