### PR TITLE
diagnostics_channel: built-in channels should remain experimental

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -409,6 +409,12 @@ channel.unsubscribe(onMessage);
 
 ### Built-in Channels
 
+> Stability: 1 - Experimental
+
+While the diagnostics\_channel API is now considered stable, the built-in
+channels currently available are not. Each channel must be declared stable
+independently.
+
 #### HTTP
 
 `http.client.request.start`


### PR DESCRIPTION
An unintended side effect of stabilizing diagnostics_channel was that it was unclear that the built-in channels were not part of that stabilization. The built-in channels should be stabilized independently.

Fixes #45400

cc @nodejs/diagnostics 