### PR TITLE
src: condense experimental warning message

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -224,8 +224,7 @@ function slowCases(enc) {
 
 function emitExperimentalWarning(feature) {
   if (experimentalWarnings.has(feature)) return;
-  const msg = `${feature} is an experimental feature. This feature could ` +
-       'change at any time';
+  const msg = `${feature} is an experimental feature and might change at any time`;
   experimentalWarnings.add(feature);
   process.emitWarning(msg, 'ExperimentalWarning');
 }

--- a/src/node_process_events.cc
+++ b/src/node_process_events.cc
@@ -92,8 +92,7 @@ Maybe<bool> ProcessEmitExperimentalWarning(Environment* env,
 
   experimental_warnings.insert(warning);
   std::string message(warning);
-  message.append(
-      " is an experimental feature. This feature could change at any time");
+  message.append(" is an experimental feature and might change at any time");
   return ProcessEmitWarningGeneric(env, message.c_str(), "ExperimentalWarning");
 }
 

--- a/test/common/measure-memory.js
+++ b/test/common/measure-memory.js
@@ -43,9 +43,10 @@ function assertSingleDetailedShape(result) {
 }
 
 function expectExperimentalWarning() {
-  common.expectWarning('ExperimentalWarning',
-                       'vm.measureMemory is an experimental feature. ' +
-                       'This feature could change at any time');
+  common.expectWarning(
+    'ExperimentalWarning',
+    'vm.measureMemory is an experimental feature and might change at any time'
+  );
 }
 
 module.exports = {

--- a/test/parallel/test-vfs.js
+++ b/test/parallel/test-vfs.js
@@ -34,7 +34,8 @@ throws(() => require(vfsFile), { code: 'MODULE_NOT_FOUND' });
 
 common.expectWarning(
   'ExperimentalWarning',
-  'Module._stat is an experimental feature. This feature could change at any time');
+  'Module._stat is an experimental feature and might change at any time'
+);
 
 process.on('warning', common.mustCall());
 

--- a/test/wasi/test-wasi-symlinks.js
+++ b/test/wasi/test-wasi-symlinks.js
@@ -5,8 +5,7 @@ const path = require('path');
 
 if (process.argv[2] === 'wasi-child') {
   common.expectWarning('ExperimentalWarning',
-                       'WASI is an experimental feature. This feature could ' +
-                       'change at any time');
+                       'WASI is an experimental feature and might change at any time');
 
   const { WASI } = require('wasi');
   const wasmDir = path.join(__dirname, 'wasm');

--- a/test/wasi/test-wasi.js
+++ b/test/wasi/test-wasi.js
@@ -8,8 +8,7 @@ if (process.argv[2] === 'wasi-child') {
   const path = require('path');
 
   common.expectWarning('ExperimentalWarning',
-                       'WASI is an experimental feature. This feature could ' +
-                       'change at any time');
+                       'WASI is an experimental feature and might change at any time');
 
   const { WASI } = require('wasi');
   tmpdir.refresh();


### PR DESCRIPTION
Before:

```console
$ node --watch fhqwhgads
(node:26196) ExperimentalWarning: Watch mode is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```

After:

```console
$ ./node --watch fhqwhgads
(node:78033) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
