### PR TITLE
build: arm64 cross-compile time improvement

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -283,11 +283,7 @@
           '-std:c++17'
         ],
         'BufferSecurityCheck': 'true',
-        'target_conditions': [
-          ['_toolset=="target"', {
-            'DebugInformationFormat': 1      # /Z7 embed info in .obj files
-          }],
-        ],
+        'DebugInformationFormat': 1,          # /Z7 embed info in .obj files
         'ExceptionHandling': 0,               # /EHsc
         'MultiProcessorCompilation': 'true',
         'StringPooling': 'true',              # pool string literals

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -325,7 +325,7 @@
              '<(V8_ROOT)/src/builtins/builtins-intl-gen.cc',
            ],
          }],
-        ['OS=="win" and _toolset=="target"', {
+        ['OS=="win"', {
           'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
           'msvs_precompiled_source': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.cc',
           'sources': [
@@ -683,7 +683,7 @@
       ],
       'sources': ['<@(v8_compiler_sources)'],
       'conditions': [
-        ['OS=="win" and _toolset=="target"', {
+        ['OS=="win"', {
           'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
           'msvs_precompiled_source': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.cc',
           'sources': [
@@ -708,7 +708,7 @@
       ],
       'sources': ['<@(v8_compiler_sources)'],
       'conditions': [
-        ['OS=="win" and _toolset=="target"', {
+        ['OS=="win"', {
           'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
           'msvs_precompiled_source': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.cc',
           'sources': [
@@ -908,15 +908,13 @@
             '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_base_without_compiler.*?v8_current_cpu == \\"loong64\\".*?sources \\+= ")',
           ],
         }],        
-        ['OS=="win" and _toolset=="target"', {
+        ['OS=="win"', {
           'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
           'msvs_precompiled_source': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.cc',
           'sources': [
             '<(_msvs_precompiled_header)',
             '<(_msvs_precompiled_source)',
-          ]
-        }],
-        ['OS=="win"', {
+          ],
           # This will prevent V8's .cc files conflicting with the inspector's
           # .cpp files in the same shard.
           'msvs_settings': {


### PR DESCRIPTION
It can be observed on Jenkins, that Windows ARM64 build times of Node [v14](https://ci.nodejs.org/job/node-compile-windows/nodes=win-vs2019-arm64/47934/) and [the latest version](https://ci.nodejs.org/job/node-compile-windows/nodes=win-vs2019-arm64/47935/) differ very much (v14 is built 3 times faster than the current version). After bisecting commits, I've found out that [this change](https://github.com/nodejs/node/pull/42538) introduced that compilation time increment. I've reverted this change and tested cross-compilation locally and I didn't encounter any problems. As a result, I'm opening this PR to see if the results will be the same in the CI.

@nsait-linaro @targos I'm tagging the two of you for visibility because you've opened the original PR and approved it respectively.

Refs: https://github.com/nodejs/node/pull/42538
Refs: https://github.com/nodejs/node/issues/42375