### PR TITLE
events: refactor to use validator

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -33,7 +33,6 @@ const {
   ErrorCaptureStackTrace,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
-  NumberIsNaN,
   NumberMAX_SAFE_INTEGER,
   ObjectCreate,
   ObjectDefineProperty,
@@ -70,7 +69,6 @@ const {
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_THIS,
-    ERR_OUT_OF_RANGE,
     ERR_UNHANDLED_ERROR
   },
   genericNodeError,
@@ -81,6 +79,7 @@ const {
   validateAbortSignal,
   validateBoolean,
   validateFunction,
+  validateNumber,
   validateString,
 } = require('internal/validators');
 
@@ -279,11 +278,7 @@ ObjectDefineProperty(EventEmitter, 'defaultMaxListeners', {
     return defaultMaxListeners;
   },
   set: function(arg) {
-    if (typeof arg !== 'number' || arg < 0 || NumberIsNaN(arg)) {
-      throw new ERR_OUT_OF_RANGE('defaultMaxListeners',
-                                 'a non-negative number',
-                                 arg);
-    }
+    validateNumber(arg, 'defaultMaxListeners', 0);
     defaultMaxListeners = arg;
   }
 });
@@ -313,8 +308,7 @@ ObjectDefineProperties(EventEmitter, {
  */
 EventEmitter.setMaxListeners =
   function(n = defaultMaxListeners, ...eventTargets) {
-    if (typeof n !== 'number' || n < 0 || NumberIsNaN(n))
-      throw new ERR_OUT_OF_RANGE('n', 'a non-negative number', n);
+    validateNumber(n, 'n', 0);
     if (eventTargets.length === 0) {
       defaultMaxListeners = n;
     } else {
@@ -410,9 +404,7 @@ function emitUnhandledRejectionOrErr(ee, err, type, args) {
  * @returns {EventEmitter}
  */
 EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
-  if (typeof n !== 'number' || n < 0 || NumberIsNaN(n)) {
-    throw new ERR_OUT_OF_RANGE('n', 'a non-negative number', n);
-  }
+  validateNumber(n, 'n', 0);
   this._maxListeners = n;
   return this;
 };

--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -41,7 +41,7 @@ const throwOutOfRange = [-1, NaN];
       () => e.setMaxListeners(obj),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError'
+        name: 'TypeError',
       }
     );
   }
@@ -51,7 +51,7 @@ const throwOutOfRange = [-1, NaN];
       () => e.setMaxListeners(obj),
       {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError'
+        name: 'RangeError',
       }
     );
   }
@@ -66,7 +66,7 @@ const throwOutOfRange = [-1, NaN];
       () => events.defaultMaxListeners = obj,
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError'
+        name: 'TypeError',
       }
     );
   }
@@ -76,7 +76,7 @@ const throwOutOfRange = [-1, NaN];
       () => events.defaultMaxListeners = obj,
       {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError'
+        name: 'RangeError',
       }
     );
   }

--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -23,7 +23,6 @@
 const common = require('../common');
 const assert = require('assert');
 const events = require('events');
-const { inspect } = require('util');
 
 const throwInvalidType = [true, 'string'];
 const throwOutOfRange = [-1, NaN];
@@ -42,8 +41,7 @@ const throwOutOfRange = [-1, NaN];
       () => e.setMaxListeners(obj),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError',
-        message: `The "n" argument must be of type number. Received type ${typeof obj} (${inspect(obj)})`
+        name: 'TypeError'
       }
     );
   }
@@ -53,9 +51,7 @@ const throwOutOfRange = [-1, NaN];
       () => e.setMaxListeners(obj),
       {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError',
-        message: 'The value of "n" is out of range. ' +
-                 `It must be >= 0. Received ${inspect(obj)}`
+        name: 'RangeError'
       }
     );
   }
@@ -70,8 +66,7 @@ const throwOutOfRange = [-1, NaN];
       () => events.defaultMaxListeners = obj,
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        name: 'TypeError',
-        message: `The "defaultMaxListeners" argument must be of type number. Received type ${typeof obj} (${inspect(obj)})`
+        name: 'TypeError'
       }
     );
   }
@@ -81,9 +76,7 @@ const throwOutOfRange = [-1, NaN];
       () => events.defaultMaxListeners = obj,
       {
         code: 'ERR_OUT_OF_RANGE',
-        name: 'RangeError',
-        message: 'The value of "defaultMaxListeners" is out of range. ' +
-                 `It must be >= 0. Received ${inspect(obj)}`
+        name: 'RangeError'
       }
     );
   }


### PR DESCRIPTION
Use `validateNumber()` for `events(setMaxListeners/defaultMaxListeners)`.

If passed wrong parameter types, `validateNumber()` will throw `ERR_INVALID_ARG_TYPE` instead of original error code: `ERR_OUT_OF_RANGE`. I think `ERR_INVALID_ARG_TYPE` is more accurate.