### PR TITLE
test: update uses of _jabber._tcp.google.com

### DIFF
--- a/test/common/internet.js
+++ b/test/common/internet.js
@@ -25,7 +25,7 @@ const addresses = {
   // record not found. Use this to guarantee record not found.
   NOT_FOUND: 'come.on.fhqwhgads.test',
   // A host with SRV records registered
-  SRV_HOST: '_jabber._tcp.google.com',
+  SRV_HOST: '_caldav._tcp.google.com',
   // A host with PTR records registered
   PTR_HOST: '8.8.8.8.in-addr.arpa',
   // A host with NAPTR records registered

--- a/test/internet/test-dns-any.js
+++ b/test/internet/test-dns-any.js
@@ -141,10 +141,10 @@ TEST(async function test_google_for_cname_and_srv(done) {
     assert.ok(types.SRV);
   }
 
-  validateResult(await dnsPromises.resolve('_jabber._tcp.google.com', 'ANY'));
+  validateResult(await dnsPromises.resolve('_caldav._tcp.google.com', 'ANY'));
 
   const req = dns.resolve(
-    '_jabber._tcp.google.com',
+    '_caldav._tcp.google.com',
     'ANY',
     common.mustSucceed((ret) => {
       validateResult(ret);


### PR DESCRIPTION
_jabber._tcp.google.com seems to have stopped working, causing a couple failures in the internet test suite. This commit changes the host to _caldav._tcp.google.com. After this change there is still one unrelated failure in the internet suite.

Refs: https://github.com/denoland/deno_std/pull/2881

Upstreamed with permission from @kt3k.