### PR TITLE
build: add --v8-disable-object-print flag

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -776,7 +776,13 @@ parser.add_argument('--v8-enable-object-print',
     action='store_true',
     dest='v8_enable_object_print',
     default=True,
-    help='compile V8 with auxiliar functions for native debuggers')
+    help='compile V8 with auxiliary functions for native debuggers')
+
+parser.add_argument('--v8-disable-object-print',
+    action='store_true',
+    dest='v8_disable_object_print',
+    default=False,
+    help='disable the V8 auxiliary functions for native debuggers')
 
 parser.add_argument('--v8-enable-hugepage',
     action='store_true',
@@ -1436,7 +1442,7 @@ def configure_v8(o):
   o['variables']['v8_no_strict_aliasing'] = 1  # Work around compiler bugs.
   o['variables']['v8_optimized_debug'] = 0 if options.v8_non_optimized_debug else 1
   o['variables']['dcheck_always_on'] = 1 if options.v8_with_dchecks else 0
-  o['variables']['v8_enable_object_print'] = 1 if options.v8_enable_object_print else 0
+  o['variables']['v8_enable_object_print'] = 0 if options.v8_disable_object_print else 1
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
   o['variables']['v8_promise_internal_field_count'] = 1 # Add internal field to promises for async hooks.
   o['variables']['v8_use_siphash'] = 0 if options.without_siphash else 1
@@ -1459,6 +1465,10 @@ def configure_v8(o):
   o['variables']['v8_enable_hugepage'] = 1 if options.v8_enable_hugepage else 0
   if options.v8_enable_short_builtin_calls or o['variables']['target_arch'] == 'x64':
     o['variables']['v8_enable_short_builtin_calls'] = 1
+  if options.v8_enable_object_print and options.v8_disable_object_print:
+    raise Exception(
+        'Only one of the --v8-enable-object-print or --v8-disable-object-print options '
+        'can be specified at a time.')
 
 def configure_openssl(o):
   variables = o['variables']


### PR DESCRIPTION
`--v8-enable-object-print` flag is set by default true. so, no way of disable this flag. 
remove `--v8-enable-object-print` flag. 
add a `--v8-disable-object-print` flag instead that defaults to false.

Fixes: https://github.com/nodejs/node/issues/45433

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
