### PR TITLE
tools: include current release in the list of released versions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Get release version numbers
         if: ${{ github.event.pull_request && github.event.pull_request.base.ref == github.event.pull_request.base.repo.default_branch }}
         id: get-released-versions
-        run: ./tools/lint-md/list-released-versions-from-changelogs.mjs
+        run: ./tools/lint-md/list-released-versions-from-changelogs.mjs >> $GITHUB_OUTPUT
       - name: Lint markdown files
         run: |
           echo "::add-matcher::.github/workflows/remark-lint-problem-matcher.json"

--- a/tools/lint-md/list-released-versions-from-changelogs.mjs
+++ b/tools/lint-md/list-released-versions-from-changelogs.mjs
@@ -20,6 +20,8 @@ async function getVersionsFromFile(file) {
       return;
     } else if (toc && line.startsWith('<a')) {
       result.push(line.slice(line.indexOf('>') + 1, -'</a><br/>'.length));
+    } else if (toc && line.startsWith('<b><a')) {
+      result.push(line.slice(line.indexOf('>', 3) + 1, -'</a></b><br/>'.length));
     }
   }
 }
@@ -30,11 +32,11 @@ const dir = await fs.promises.opendir(dataFolder);
 for await (const dirent of dir) {
   if (dirent.isFile()) {
     filesToCheck.push(
-      getVersionsFromFile(new URL(`./${dirent.name}`, dataFolder))
+      getVersionsFromFile(new URL(dirent.name, dataFolder))
     );
   }
 }
 
 await Promise.all(filesToCheck);
 
-console.log(`::set-output name=NODE_RELEASED_VERSIONS::${result.join(',')}`);
+console.log(`NODE_RELEASED_VERSIONS=${result.join(',')}`);


### PR DESCRIPTION
This should fix the linter failure in https://github.com/nodejs/node/pull/45462. Not sure why we didn't see this failure sooner.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
