### PR TITLE
test: add trailing commas in event tests

### DIFF
--- a/test/parallel/test-event-capture-rejections.js
+++ b/test/parallel/test-event-capture-rejections.js
@@ -18,7 +18,7 @@ function NoConstructor() {
         name: 'TypeError',
         code: 'ERR_INVALID_ARG_TYPE',
         message: 'The "options.captureRejections" property must be of type boolean.' +
-                 common.invalidArgTypeHelper(arg)
+                 common.invalidArgTypeHelper(arg),
       }
     );
   });
@@ -160,7 +160,7 @@ function thenable() {
           assert.strictEqual(resolved, undefined);
           rejected(_err);
         });
-      }, 1) // Only 1 call for Promises/A+ compat.
+      }, 1), // Only 1 call for Promises/A+ compat.
     });
 
     return obj;
@@ -235,7 +235,7 @@ function thenableThatThrows() {
     Object.defineProperty(obj, 'then', {
       get: common.mustCall(() => {
         throw _err;
-      }, 1) // Only 1 call for Promises/A+ compat.
+      }, 1), // Only 1 call for Promises/A+ compat.
     });
 
     return obj;
@@ -301,14 +301,14 @@ function argValidation() {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
       message: 'The "options.captureRejections" property must be of type ' +
-               `boolean. Received ${received}`
+               `boolean. Received ${received}`,
     });
 
     assert.throws(() => EventEmitter.captureRejections = obj, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
       message: 'The "EventEmitter.captureRejections" property must be of ' +
-               `type boolean. Received ${received}`
+               `type boolean. Received ${received}`,
     });
   }
 

--- a/test/parallel/test-event-emitter-errors.js
+++ b/test/parallel/test-event-emitter-errors.js
@@ -11,7 +11,7 @@ assert.throws(
   {
     code: 'ERR_UNHANDLED_ERROR',
     name: 'Error',
-    message: "Unhandled error. ('Accepts a string')"
+    message: "Unhandled error. ('Accepts a string')",
   }
 );
 
@@ -20,18 +20,18 @@ assert.throws(
   {
     code: 'ERR_UNHANDLED_ERROR',
     name: 'Error',
-    message: "Unhandled error. ({ message: 'Error!' })"
+    message: "Unhandled error. ({ message: 'Error!' })",
   }
 );
 
 assert.throws(
   () => EE.emit('error', {
     message: 'Error!',
-    [util.inspect.custom]() { throw new Error(); }
+    [util.inspect.custom]() { throw new Error(); },
   }),
   {
     code: 'ERR_UNHANDLED_ERROR',
     name: 'Error',
-    message: 'Unhandled error. ([object Object])'
+    message: 'Unhandled error. ([object Object])',
   }
 );

--- a/test/parallel/test-event-emitter-invalid-listener.js
+++ b/test/parallel/test-event-emitter-invalid-listener.js
@@ -15,6 +15,6 @@ for (const method of eventsMethods) {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
     message: 'The "listener" argument must be of type function. ' +
-             'Received null'
+             'Received null',
   }, `event.${method}('foo', null) should throw the proper error`);
 }

--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -40,7 +40,7 @@ for (const obj of throwsObjs) {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
       message: 'The value of "n" is out of range. ' +
-               `It must be a non-negative number. Received ${inspect(obj)}`
+               `It must be a non-negative number. Received ${inspect(obj)}`,
     }
   );
 
@@ -50,7 +50,7 @@ for (const obj of throwsObjs) {
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
       message: 'The value of "defaultMaxListeners" is out of range. ' +
-               `It must be a non-negative number. Received ${inspect(obj)}`
+               `It must be a non-negative number. Received ${inspect(obj)}`,
     }
   );
 }

--- a/test/parallel/test-eventemitter-asyncresource.js
+++ b/test/parallel/test-eventemitter-asyncresource.js
@@ -41,7 +41,7 @@ function makeHook(trackedTypes) {
 
     before(asyncId) { log(asyncId, 'before'); },
     after(asyncId) { log(asyncId, 'after'); },
-    destroy(asyncId) { log(asyncId, 'destroy'); }
+    destroy(asyncId) { log(asyncId, 'destroy'); },
   }).enable();
 
   return {
@@ -51,7 +51,7 @@ function makeHook(trackedTypes) {
     },
     ids() {
       return new Set(eventMap.keys());
-    }
+    },
   };
 }
 
@@ -150,7 +150,7 @@ throws(
       code: 'ERR_INVALID_THIS',
       name: /TypeError/,
       message: 'Value of "this" must be of type EventEmitterAsyncResource',
-      stack: new RegExp(`at get ${getter}`)
+      stack: new RegExp(`at get ${getter}`),
     }
   );
 });

--- a/test/parallel/test-events-on-async-iterator.js
+++ b/test/parallel/test-events-on-async-iterator.js
@@ -5,7 +5,7 @@ const common = require('../common');
 const assert = require('assert');
 const { on, EventEmitter } = require('events');
 const {
-  NodeEventTarget
+  NodeEventTarget,
 } = require('internal/event_target');
 
 async function basic() {
@@ -131,18 +131,18 @@ async function next() {
 
   assert.deepStrictEqual(results, [{
     value: ['bar'],
-    done: false
+    done: false,
   }, {
     value: [42],
-    done: false
+    done: false,
   }, {
     value: undefined,
-    done: true
+    done: true,
   }]);
 
   assert.deepStrictEqual(await iterable.next(), {
     value: undefined,
-    done: true
+    done: true,
   });
 }
 
@@ -160,19 +160,19 @@ async function nextError() {
   ]);
   assert.deepStrictEqual(results, [{
     status: 'rejected',
-    reason: _err
+    reason: _err,
   }, {
     status: 'fulfilled',
     value: {
       value: undefined,
-      done: true
-    }
+      done: true,
+    },
   }, {
     status: 'fulfilled',
     value: {
       value: undefined,
-      done: true
-    }
+      done: true,
+    },
   }]);
   assert.strictEqual(ee.listeners('error').length, 0);
 }
@@ -196,7 +196,7 @@ async function iterableThrow() {
   }, {
     message: 'The "EventEmitter.AsyncIterator" property must be' +
     ' an instance of Error. Received undefined',
-    name: 'TypeError'
+    name: 'TypeError',
   });
 
   const expected = [['bar'], [42]];
@@ -258,11 +258,11 @@ async function abortableOnBefore() {
   const abortedSignal = AbortSignal.abort();
   [1, {}, null, false, 'hi'].forEach((signal) => {
     assert.throws(() => on(ee, 'foo', { signal }), {
-      code: 'ERR_INVALID_ARG_TYPE'
+      code: 'ERR_INVALID_ARG_TYPE',
     });
   });
   assert.throws(() => on(ee, 'foo', { signal: abortedSignal }), {
-    name: 'AbortError'
+    name: 'AbortError',
   });
 }
 
@@ -271,11 +271,11 @@ async function eventTargetAbortableOnBefore() {
   const abortedSignal = AbortSignal.abort();
   [1, {}, null, false, 'hi'].forEach((signal) => {
     assert.throws(() => on(et, 'foo', { signal }), {
-      code: 'ERR_INVALID_ARG_TYPE'
+      code: 'ERR_INVALID_ARG_TYPE',
     });
   });
   assert.throws(() => on(et, 'foo', { signal: abortedSignal }), {
-    name: 'AbortError'
+    name: 'AbortError',
   });
 }
 

--- a/test/parallel/test-events-once.js
+++ b/test/parallel/test-events-once.js
@@ -165,12 +165,12 @@ async function abortSignalBefore() {
 
   await Promise.all([1, {}, 'hi', null, false].map((signal) => {
     return rejects(once(ee, 'foo', { signal }), {
-      code: 'ERR_INVALID_ARG_TYPE'
+      code: 'ERR_INVALID_ARG_TYPE',
     });
   }));
 
   return rejects(once(ee, 'foo', { signal: abortedSignal }), {
-    name: 'AbortError'
+    name: 'AbortError',
   });
 }
 
@@ -179,7 +179,7 @@ async function abortSignalAfter() {
   const ac = new AbortController();
   ee.on('error', common.mustNotCall());
   const r = rejects(once(ee, 'foo', { signal: ac.signal }), {
-    name: 'AbortError'
+    name: 'AbortError',
   });
   process.nextTick(() => ac.abort());
   return r;
@@ -217,12 +217,12 @@ async function eventTargetAbortSignalBefore() {
 
   await Promise.all([1, {}, 'hi', null, false].map((signal) => {
     return rejects(once(et, 'foo', { signal }), {
-      code: 'ERR_INVALID_ARG_TYPE'
+      code: 'ERR_INVALID_ARG_TYPE',
     });
   }));
 
   return rejects(once(et, 'foo', { signal: abortedSignal }), {
-    name: 'AbortError'
+    name: 'AbortError',
   });
 }
 
@@ -230,7 +230,7 @@ async function eventTargetAbortSignalAfter() {
   const et = new EventTarget();
   const ac = new AbortController();
   const r = rejects(once(et, 'foo', { signal: ac.signal }), {
-    name: 'AbortError'
+    name: 'AbortError',
   });
   process.nextTick(() => ac.abort());
   return r;

--- a/test/parallel/test-events-static-geteventlisteners.js
+++ b/test/parallel/test-events-static-geteventlisteners.js
@@ -5,7 +5,7 @@ const { kWeakHandler } = require('internal/event_target');
 
 const {
   deepStrictEqual,
-  throws
+  throws,
 } = require('assert');
 
 const { getEventListeners, EventEmitter } = require('events');

--- a/test/parallel/test-eventtarget-memoryleakwarning.js
+++ b/test/parallel/test-eventtarget-memoryleakwarning.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const {
   setMaxListeners,
-  EventEmitter
+  EventEmitter,
 } = require('events');
 const assert = require('assert');
 

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -65,7 +65,7 @@ let asyncTest = Promise.resolve();
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
       message: 'The "options" argument must be of type object.' +
-               common.invalidArgTypeHelper(i)
+               common.invalidArgTypeHelper(i),
     })
   ));
 }
@@ -141,7 +141,7 @@ let asyncTest = Promise.resolve();
     handleEvent: common.mustCall(function(event) {
       strictEqual(event.type, 'foo');
       strictEqual(this, ev2);
-    })
+    }),
   };
 
   eventTarget.addEventListener('foo', ev1);
@@ -318,7 +318,7 @@ let asyncTest = Promise.resolve();
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
       message: 'The "event" argument must be an instance of Event.' +
-               common.invalidArgTypeHelper(i)
+               common.invalidArgTypeHelper(i),
     });
   });
 
@@ -326,7 +326,7 @@ let asyncTest = Promise.resolve();
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
     message: 'The "listener" argument must be an instance of EventListener.' +
-             common.invalidArgTypeHelper(arg)
+             common.invalidArgTypeHelper(arg),
   });
 
   [
@@ -388,7 +388,7 @@ let asyncTest = Promise.resolve();
   const event = new Event('foo');
   target1.addEventListener('foo', common.mustCall((event) => {
     throws(() => target2.dispatchEvent(event), {
-      code: 'ERR_EVENT_RECURSION'
+      code: 'ERR_EVENT_RECURSION',
     });
   }));
   target1.dispatchEvent(event);
@@ -486,7 +486,7 @@ let asyncTest = Promise.resolve();
     /a/,
   ].forEach((i) => {
     throws(() => target.dispatchEvent.call(i, event), {
-      code: 'ERR_INVALID_THIS'
+      code: 'ERR_INVALID_THIS',
     });
   });
 }
@@ -636,12 +636,12 @@ let asyncTest = Promise.resolve();
 {
   const ev = new Event('test');
   const evConstructorName = inspect(ev, {
-    depth: -1
+    depth: -1,
   });
   strictEqual(evConstructorName, 'Event');
 
   const inspectResult = inspect(ev, {
-    depth: 1
+    depth: 1,
   });
   ok(inspectResult.includes('Event'));
 }
@@ -649,7 +649,7 @@ let asyncTest = Promise.resolve();
 {
   const et = new EventTarget();
   const inspectResult = inspect(et, {
-    depth: 1
+    depth: 1,
   });
   ok(inspectResult.includes('EventTarget'));
 }


### PR DESCRIPTION
As much as I would like to do this everywhere and then modify the lint rule to enforce it, the churn would be too big. However if we're going to have relatively frequent nits for this sort of thing (as we do), I'd prefer we migrate a few files at a time to never actually getting around to doing it.

Ref: https://github.com/nodejs/node/pull/45448#pullrequestreview-1179370442

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
