### PR TITLE
test: add lint rule to enforce trailing commas

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -72,21 +72,21 @@ globals:
 
 overrides:
   - files:
-    - addons/*/*.js
-    - async-hooks/*.js
-    - common/*.js
-    - es-module/*.js
-    - es-module/*.mjs
-    - internet/*.js
-    - js-native-api/*/*.js
-    - known_issues/*.js
-    - message/*.js
-    - node-api/*/*.js
-    - parallel/*.js
-    - parallel/*.mjs
-    - pseudo-tty/*.js
-    - pummel/*.js
-    - sequential/*.js
-    - sequential/*.mjs
+      - addons/*/*.js
+      - async-hooks/*.js
+      - common/*.js
+      - es-module/*.js
+      - es-module/*.mjs
+      - internet/*.js
+      - js-native-api/*/*.js
+      - known_issues/*.js
+      - message/*.js
+      - node-api/*/*.js
+      - parallel/*.js
+      - parallel/*.mjs
+      - pseudo-tty/*.js
+      - pummel/*.js
+      - sequential/*.js
+      - sequential/*.mjs
     rules:
       comma-dangle: off

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -8,6 +8,7 @@ rules:
   multiline-comment-style: [error, separate-lines]
   prefer-const: error
   symbol-description: off
+  comma-dangle: [error, always-multiline]
 
   no-restricted-syntax:
     # Config copied from .eslintrc.js
@@ -68,3 +69,24 @@ rules:
 # Global scoped methods and vars
 globals:
   WebAssembly: false
+
+overrides:
+  - files:
+    - addons/*/*.js
+    - async-hooks/*.js
+    - common/*.js
+    - es-module/*.js
+    - es-module/*.mjs
+    - internet/*.js
+    - js-native-api/*/*.js
+    - known_issues/*.js
+    - message/*.js
+    - node-api/*/*.js
+    - parallel/*.js
+    - parallel/*.mjs
+    - pseudo-tty/*.js
+    - pummel/*.js
+    - sequential/*.js
+    - sequential/*.mjs
+    rules:
+      comma-dangle: off

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -89,4 +89,10 @@ overrides:
       - sequential/*.js
       - sequential/*.mjs
     rules:
-      comma-dangle: off
+      comma-dangle: [error, {
+        arrays: always-multiline,
+        exports: only-multiline,
+        functions: only-multiline,
+        imports: only-multiline,
+        objects: only-multiline,
+      }]

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -110,20 +110,20 @@ expectWarning('DeprecationWarning', [
 
 expectWarning('DeprecationWarning', {
   DEP0XXX: 'Foobar is deprecated',
-  DEP0XX2: 'Baz is also deprecated'
+  DEP0XX2: 'Baz is also deprecated',
 });
 
 expectWarning({
   DeprecationWarning: {
     DEP0XXX: 'Foobar is deprecated',
-    DEP0XX1: 'Baz is also deprecated'
+    DEP0XX1: 'Baz is also deprecated',
   },
   Warning: [
     ['Multiple array entries are fine', 'SpecialWarningCode'],
     ['No code is also fine'],
   ],
   SingleEntry: ['This will also work', 'WarningCode'],
-  SingleString: 'Single string entries without code will also work'
+  SingleString: 'Single string entries without code will also work',
 });
 ```
 
@@ -720,7 +720,7 @@ validateSnapshotNodes('TLSWRAP', [
       { name: 'enc_out' },
       { name: 'enc_in' },
       { name: 'TLSWrap' },
-    ]
+    ],
   },
 ]);
 ```

--- a/test/common/wpt/worker.js
+++ b/test/common/wpt/worker.js
@@ -9,7 +9,7 @@ const resource = new ResourceLoader(workerData.wptPath);
 global.self = global;
 global.GLOBAL = {
   isWindow() { return false; },
-  isShadowRealm() { return false; }
+  isShadowRealm() { return false; },
 };
 global.require = require;
 
@@ -25,7 +25,7 @@ if (workerData.initScript) {
 }
 
 runInThisContext(workerData.harness.code, {
-  filename: workerData.harness.filename
+  filename: workerData.harness.filename,
 });
 
 // eslint-disable-next-line no-undef

--- a/test/doctool/test-apilinks.mjs
+++ b/test/doctool/test-apilinks.mjs
@@ -23,7 +23,7 @@ fs.readdirSync(apilinks).forEach((fixture) => {
   execFileSync(
     process.execPath,
     [script, outputPath, input],
-    { encoding: 'utf-8' }
+    { encoding: 'utf-8' },
   );
 
   const expectedLinks = JSON.parse(expectedContent);
@@ -38,6 +38,6 @@ fs.readdirSync(apilinks).forEach((fixture) => {
 
   assert.strictEqual(
     Object.keys(actualLinks).length, 0,
-    `unexpected links returned ${JSON.stringify(actualLinks)}`
+    `unexpected links returned ${JSON.stringify(actualLinks)}`,
   );
 });

--- a/test/doctool/test-deprecation-codes.js
+++ b/test/doctool/test-deprecation-codes.js
@@ -10,7 +10,7 @@ const script = path.join(
   '..',
   'tools',
   'doc',
-  'deprecationCodes.mjs'
+  'deprecationCodes.mjs',
 );
 
 const mdPath = path.join(
@@ -19,7 +19,7 @@ const mdPath = path.join(
   '..',
   'doc',
   'api',
-  'deprecations.md'
+  'deprecations.md',
 );
 
 const cp = spawn(process.execPath, [script, mdPath], { encoding: 'utf-8', stdio: 'inherit' });

--- a/test/doctool/test-doctool-html.mjs
+++ b/test/doctool/test-doctool-html.mjs
@@ -23,8 +23,8 @@ import {
 const testLinksMapper = {
   'foo': {
     'command line options': 'cli.html#cli-options',
-    'web server': 'example.html'
-  }
+    'web server': 'example.html',
+  },
 };
 
 function toHTML({ input, filename, nodeVersion, versions }) {
@@ -58,7 +58,7 @@ const testData = [
       'id="foo_static_method_buffer_from_array"></a></h4>' +
       '<ul><li><code>array</code><a ' +
       'href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/' +
-      'Reference/Global_Objects/Array" class="type">&#x3C;Array></a></li></ul>'
+      'Reference/Global_Objects/Array" class="type">&#x3C;Array></a></li></ul>',
   },
   {
     file: fixtures.path('doc_with_yaml.md'),
@@ -99,7 +99,7 @@ const testData = [
       '" id="something">#</a></span>' +
       '<a aria-hidden="true" class="legacy" id="foo_something"></a></h3>' +
       '<!-- This is not a metadata comment --> ' +
-      '<p>Describe <code>Something</code> in more detail here. </p></section>'
+      '<p>Describe <code>Something</code> in more detail here. </p></section>',
   },
   {
     file: fixtures.path('sample_document.md'),
@@ -129,7 +129,7 @@ const testData = [
     '<h3>See also<span><a class="mark"' +
     'href="#see-also" id="see-also">#</a></span><a aria-hidden="true"' +
     'class="legacy" id="foo_see_also"></a></h3><p>Check' +
-    'out also<a href="https://nodejs.org/">this guide</a></p></section>'
+    'out also<a href="https://nodejs.org/">this guide</a></p></section>',
   },
   {
     file: fixtures.path('document_with_special_heading.md'),

--- a/test/doctool/test-doctool-json.mjs
+++ b/test/doctool/test-doctool-json.mjs
@@ -41,12 +41,12 @@ const testData = [
           desc: '<ol>\n<li>fish</li>\n<li>fish</li>\n</ol>\n' +
                   '<ul>\n<li>Red fish</li>\n<li>Blue fish</li>\n</ul>',
           type: 'module',
-          displayName: 'Seussian Rhymes'
+          displayName: 'Seussian Rhymes',
         }],
         type: 'module',
-        displayName: 'Sample Markdown'
-      }]
-    }
+        displayName: 'Sample Markdown',
+      }],
+    },
   },
   {
     file: fixtures.path('order_of_end_tags_5873.md'),
@@ -68,18 +68,18 @@ const testData = [
                 params: [{
                   textRaw: '`array` {Array}',
                   name: 'array',
-                  type: 'Array'
-                }]
+                  type: 'Array',
+                }],
               },
-            ]
+            ],
           }],
           type: 'module',
-          displayName: 'Subsection'
+          displayName: 'Subsection',
         }],
         type: 'module',
-        displayName: 'Title'
-      }]
-    }
+        displayName: 'Title',
+      }],
+    },
   },
   {
     file: fixtures.path('doc_with_yaml.md'),
@@ -96,12 +96,12 @@ const testData = [
               name: 'foobar',
               meta: {
                 added: ['v1.0.0'],
-                changes: []
+                changes: [],
               },
               desc: '<p>Describe <code>Foobar</code> in more detail ' +
                 'here.</p>',
               type: 'module',
-              displayName: 'Foobar'
+              displayName: 'Foobar',
             },
             {
               textRaw: 'Foobar II',
@@ -113,12 +113,12 @@ const testData = [
                     'pr-url': 'https://github.com/nodejs/node/pull/3276',
                     'description': 'The `error` parameter can now be ' +
                       'an arrow function.' },
-                ]
+                ],
               },
               desc: '<p>Describe <code>Foobar II</code> in more detail ' +
                 'here. fg(1)</p>',
               type: 'module',
-              displayName: 'Foobar II'
+              displayName: 'Foobar II',
             },
             {
               textRaw: 'Deprecated thingy',
@@ -126,12 +126,12 @@ const testData = [
               meta: {
                 added: ['v1.0.0'],
                 deprecated: ['v2.0.0'],
-                changes: []
+                changes: [],
               },
               desc: '<p>Describe <code>Deprecated thingy</code> in more ' +
                 'detail here. fg(1p)</p>',
               type: 'module',
-              displayName: 'Deprecated thingy'
+              displayName: 'Deprecated thingy',
             },
             {
               textRaw: 'Something',
@@ -139,14 +139,14 @@ const testData = [
               desc: '<!-- This is not a metadata comment -->\n<p>' +
                 'Describe <code>Something</code> in more detail here.</p>',
               type: 'module',
-              displayName: 'Something'
+              displayName: 'Something',
             },
           ],
           type: 'module',
-          displayName: 'Sample Markdown with YAML info'
+          displayName: 'Sample Markdown with YAML info',
         },
-      ]
-    }
+      ],
+    },
   },
   {
     file: fixtures.path('doc_with_backticks_in_headings.md'),
@@ -160,7 +160,7 @@ const testData = [
           properties: [
             {
               name: 'fullName',
-              textRaw: '`Fqhqwhgads.fullName`'
+              textRaw: '`Fqhqwhgads.fullName`',
             },
           ],
           classMethods: [
@@ -168,18 +168,18 @@ const testData = [
               name: 'again',
               signatures: [
                 {
-                  params: []
+                  params: [],
                 },
               ],
               textRaw: 'Static method: `Fhqwhgads.again()`',
-              type: 'classMethod'
+              type: 'classMethod',
             },
           ],
           classes: [
             {
               textRaw: 'Class: `ComeOn`',
               type: 'class',
-              name: 'ComeOn'
+              name: 'ComeOn',
             },
           ],
           ctors: [
@@ -187,11 +187,11 @@ const testData = [
               name: 'Fhqwhgads',
               signatures: [
                 {
-                  params: []
+                  params: [],
                 },
               ],
               textRaw: 'Constructor: `new Fhqwhgads()`',
-              type: 'ctor'
+              type: 'ctor',
             },
           ],
           methods: [
@@ -199,7 +199,7 @@ const testData = [
               textRaw: '`everybody.to(limit)`',
               type: 'method',
               name: 'to',
-              signatures: [{ params: [] }]
+              signatures: [{ params: [] }],
             },
           ],
           events: [
@@ -207,14 +207,14 @@ const testData = [
               textRaw: "Event: `'FHQWHfest'`",
               type: 'event',
               name: 'FHQWHfest',
-              params: []
+              params: [],
             },
           ],
           type: 'module',
-          displayName: 'Fhqwhgads'
+          displayName: 'Fhqwhgads',
         },
-      ]
-    }
+      ],
+    },
   },
 ];
 

--- a/test/doctool/test-make-doc.mjs
+++ b/test/doctool/test-make-doc.mjs
@@ -21,7 +21,7 @@ const actualDocs = allDocs.filter(
   (name) => {
     const extension = path.extname(name);
     return extension === '.html' || extension === '.json';
-  }
+  },
 );
 
 for (const name of actualDocs) {
@@ -29,7 +29,7 @@ for (const name of actualDocs) {
 
   assert.ok(
     allMD.includes(name.replace(/\.\w+$/, '.md')),
-    `Unexpected output: out/doc/api/${name}, remove and rerun.`
+    `Unexpected output: out/doc/api/${name}, remove and rerun.`,
   );
 }
 
@@ -66,6 +66,6 @@ for (const actualDoc of actualDocs) {
   assert.notStrictEqual(
     fs.statSync(new URL(`./${actualDoc}`, apiURL)).size,
     0,
-    `${actualDoc} is empty`
+    `${actualDoc} is empty`,
   );
 }

--- a/test/report/test-report-config.js
+++ b/test/report/test-report-config.js
@@ -76,13 +76,13 @@ if (!common.isWindows) {
     process.report.signal = 'foo';
   }, {
     code: 'ERR_UNKNOWN_SIGNAL',
-    message: 'Unknown signal: foo'
+    message: 'Unknown signal: foo',
   });
   assert.throws(() => {
     process.report.signal = 'sigusr1';
   }, {
     code: 'ERR_UNKNOWN_SIGNAL',
-    message: 'Unknown signal: sigusr1 (signals must use all capital letters)'
+    message: 'Unknown signal: sigusr1 (signals must use all capital letters)',
   });
   assert.strictEqual(process.report.signal, 'SIGUSR2');
   process.report.signal = 'SIGUSR1';

--- a/test/report/test-report-uncaught-exception-compat.js
+++ b/test/report/test-report-uncaught-exception-compat.js
@@ -17,7 +17,7 @@ const child = childProcess.spawn(process.execPath, [
   __filename,
   'child',
 ], {
-  cwd: tmpdir.path
+  cwd: tmpdir.path,
 });
 child.on('exit', common.mustCall((code) => {
   assert.strictEqual(code, 1);

--- a/test/tick-processor/test-tick-processor-builtin.js
+++ b/test/tick-processor/test-tick-processor-builtin.js
@@ -14,5 +14,5 @@ base.runTest({
            this.ts = Date.now();
            setImmediate(function() { new f(); });
          };
-         f();`
+         f();`,
 });

--- a/test/tick-processor/test-tick-processor-cpp-core.js
+++ b/test/tick-processor/test-tick-processor-cpp-core.js
@@ -14,5 +14,5 @@ base.runTest({
            require('vm').createContext({});
            setImmediate(function() { f(); });
          };
-         f();`
+         f();`,
 });

--- a/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
+++ b/test/tick-processor/test-tick-processor-polyfill-brokenfile.js
@@ -36,7 +36,7 @@ const proc = spawn(process.execPath, [
   '--prof',
   '-pe', code,
 ], {
-  stdio: ['ignore', 'pipe', 'inherit']
+  stdio: ['ignore', 'pipe', 'inherit'],
 });
 
 let ticks = '';

--- a/test/tick-processor/test-tick-processor-preprocess-flag.js
+++ b/test/tick-processor/test-tick-processor-preprocess-flag.js
@@ -15,5 +15,5 @@ base.runTest({
            setImmediate(function() { f(); });
          };
          f();`,
-  profProcessFlags: ['--preprocess']
+  profProcessFlags: ['--preprocess'],
 });

--- a/test/tick-processor/test-tick-processor-unknown.js
+++ b/test/tick-processor/test-tick-processor-unknown.js
@@ -21,5 +21,5 @@ base.runTest({
            }
            setImmediate(function() { f(); });
          };
-         f();`
+         f();`,
 });

--- a/test/tick-processor/tick-processor-base.js
+++ b/test/tick-processor/tick-processor-base.js
@@ -17,7 +17,7 @@ function runTest(test) {
     '--prof',
     '-pe', test.code,
   ], {
-    stdio: [ 'ignore', 'pipe', 'inherit' ]
+    stdio: [ 'ignore', 'pipe', 'inherit' ],
   });
 
   let ticks = '';
@@ -39,7 +39,7 @@ function match(pattern, parent, ticks, flags = []) {
     ...flags,
     LOG_FILE,
   ], {
-    stdio: [ 'ignore', 'pipe', 'inherit' ]
+    stdio: [ 'ignore', 'pipe', 'inherit' ],
   });
 
   let out = '';

--- a/test/tick-processor/util.js
+++ b/test/tick-processor/util.js
@@ -6,7 +6,7 @@ const {
   isSunOS,
   isAIX,
   isLinuxPPCBE,
-  isFreeBSD
+  isFreeBSD,
 } = require('../common');
 
 module.exports = {
@@ -14,5 +14,5 @@ module.exports = {
                          isSunOS ||
                          isAIX ||
                          isLinuxPPCBE ||
-                         isFreeBSD
+                         isFreeBSD,
 };

--- a/test/wasi/test-wasi-initialize-validation.js
+++ b/test/wasi/test-wasi-initialize-validation.js
@@ -18,8 +18,8 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.initialize(); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance" argument must be of type object/
-      }
+        message: /"instance" argument must be of type object/,
+      },
     );
   }
 
@@ -34,8 +34,8 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.initialize(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports" property must be of type object/
-      }
+        message: /"instance\.exports" property must be of type object/,
+      },
     );
   }
 
@@ -57,8 +57,8 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.initialize(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\._initialize" property must be of type function/
-      }
+        message: /"instance\.exports\._initialize" property must be of type function/,
+      },
     );
   }
 
@@ -75,7 +75,7 @@ const bufferSource = fixtures.readSync('simple.wasm');
           _initialize() {},
           memory: new WebAssembly.Memory({ initial: 1 }),
         };
-      }
+      },
     });
     assert.throws(
       () => { wasi.initialize(instance); },
@@ -83,7 +83,7 @@ const bufferSource = fixtures.readSync('simple.wasm');
         code: 'ERR_INVALID_ARG_TYPE',
         message: 'The "instance.exports._start" property must be' +
           ' undefined. Received function _start',
-      }
+      },
     );
   }
 
@@ -94,14 +94,14 @@ const bufferSource = fixtures.readSync('simple.wasm');
     const instance = await WebAssembly.instantiate(wasm);
 
     Object.defineProperty(instance, 'exports', {
-      get() { return { _initialize() {} }; }
+      get() { return { _initialize() {} }; },
     });
     assert.throws(
       () => { wasi.initialize(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\.memory" property must be a WebAssembly\.Memory object/
-      }
+        message: /"instance\.exports\.memory" property must be a WebAssembly\.Memory object/,
+      },
     );
   }
 
@@ -139,17 +139,17 @@ const bufferSource = fixtures.readSync('simple.wasm');
       get() {
         return {
           _initialize() {},
-          memory: new WebAssembly.Memory({ initial: 1 })
+          memory: new WebAssembly.Memory({ initial: 1 }),
         };
-      }
+      },
     });
     wasi.initialize(instance);
     assert.throws(
       () => { wasi.initialize(instance); },
       {
         code: 'ERR_WASI_ALREADY_STARTED',
-        message: /^WASI instance has already started$/
-      }
+        message: /^WASI instance has already started$/,
+      },
     );
   }
 })().then(common.mustCall());

--- a/test/wasi/test-wasi-not-started.js
+++ b/test/wasi/test-wasi-not-started.js
@@ -8,7 +8,7 @@ if (process.argv[2] === 'wasi-child') {
 
   const { WASI } = require('wasi');
   const wasi = new WASI({
-    args: ['foo', '-bar', '--baz=value']
+    args: ['foo', '-bar', '--baz=value'],
   });
   const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
@@ -21,7 +21,7 @@ if (process.argv[2] === 'wasi-child') {
   }, {
     name: 'Error',
     code: 'ERR_WASI_NOT_STARTED',
-    message: 'wasi.start() has not been called'
+    message: 'wasi.start() has not been called',
   });
 } else {
   const assert = require('assert');
@@ -32,7 +32,7 @@ if (process.argv[2] === 'wasi-child') {
     __filename,
     'wasi-child',
   ], {
-    env: { ...process.env, NODE_DEBUG_NATIVE: 'wasi' }
+    env: { ...process.env, NODE_DEBUG_NATIVE: 'wasi' },
   });
   assert.strictEqual(child.signal, null);
   assert.strictEqual(child.status, 0);

--- a/test/wasi/test-wasi-start-validation.js
+++ b/test/wasi/test-wasi-start-validation.js
@@ -18,8 +18,8 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance" argument must be of type object/
-      }
+        message: /"instance" argument must be of type object/,
+      },
     );
   }
 
@@ -34,8 +34,8 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports" property must be of type object/
-      }
+        message: /"instance\.exports" property must be of type object/,
+      },
     );
   }
 
@@ -54,8 +54,8 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\._start" property must be of type function/
-      }
+        message: /"instance\.exports\._start" property must be of type function/,
+      },
     );
   }
 
@@ -72,7 +72,7 @@ const bufferSource = fixtures.readSync('simple.wasm');
           _initialize() {},
           memory: new WebAssembly.Memory({ initial: 1 }),
         };
-      }
+      },
     });
     assert.throws(
       () => { wasi.start(instance); },
@@ -80,7 +80,7 @@ const bufferSource = fixtures.readSync('simple.wasm');
         code: 'ERR_INVALID_ARG_TYPE',
         message: 'The "instance.exports._initialize" property must be' +
           ' undefined. Received function _initialize',
-      }
+      },
     );
   }
 
@@ -91,14 +91,14 @@ const bufferSource = fixtures.readSync('simple.wasm');
     const instance = await WebAssembly.instantiate(wasm);
 
     Object.defineProperty(instance, 'exports', {
-      get() { return { _start() {} }; }
+      get() { return { _start() {} }; },
     });
     assert.throws(
       () => { wasi.start(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\.memory" property must be a WebAssembly\.Memory object/
-      }
+        message: /"instance\.exports\.memory" property must be a WebAssembly\.Memory object/,
+      },
     );
   }
 
@@ -136,17 +136,17 @@ const bufferSource = fixtures.readSync('simple.wasm');
       get() {
         return {
           _start() {},
-          memory: new WebAssembly.Memory({ initial: 1 })
+          memory: new WebAssembly.Memory({ initial: 1 }),
         };
-      }
+      },
     });
     wasi.start(instance);
     assert.throws(
       () => { wasi.start(instance); },
       {
         code: 'ERR_WASI_ALREADY_STARTED',
-        message: /^WASI instance has already started$/
-      }
+        message: /^WASI instance has already started$/,
+      },
     );
   }
 })().then(common.mustCall());

--- a/test/wasi/test-wasi-symlinks.js
+++ b/test/wasi/test-wasi-symlinks.js
@@ -14,8 +14,8 @@ if (process.argv[2] === 'wasi-child') {
     env: process.env,
     preopens: {
       '/sandbox': process.argv[4],
-      '/tmp': process.argv[5]
-    }
+      '/tmp': process.argv[5],
+    },
   });
   const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
   const modulePath = path.join(wasmDir, `${process.argv[3]}.wasm`);

--- a/test/wasi/test-wasi.js
+++ b/test/wasi/test-wasi.js
@@ -18,8 +18,8 @@ if (process.argv[2] === 'wasi-child') {
     env: process.env,
     preopens: {
       '/sandbox': fixtures.path('wasi'),
-      '/tmp': tmpdir.path
-    }
+      '/tmp': tmpdir.path,
+    },
   });
   const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
   const modulePath = path.join(wasmDir, `${process.argv[3]}.wasm`);
@@ -41,8 +41,8 @@ if (process.argv[2] === 'wasi-child') {
       env: {
         ...process.env,
         NODE_DEBUG_NATIVE: 'wasi',
-        NODE_PLATFORM: process.platform
-      }
+        NODE_PLATFORM: process.platform,
+      },
     };
 
     if (options.stdin !== undefined)
@@ -89,7 +89,7 @@ if (process.argv[2] === 'wasi-child') {
   runWASI({ test: 'read_file', stdout: `hello from input.txt${checkoutEOL}` });
   runWASI({
     test: 'read_file_twice',
-    stdout: `hello from input.txt${checkoutEOL}hello from input.txt${checkoutEOL}`
+    stdout: `hello from input.txt${checkoutEOL}hello from input.txt${checkoutEOL}`,
   });
   runWASI({ test: 'stat' });
   runWASI({ test: 'write_file' });


### PR DESCRIPTION
Only activated on some subfolders to minimize the diff, ideally this rule would be applied gradually to the entire codebase in follow-up commits.

There have been previous attempts at imposing trailing commas via a lint rule that failed because the diff it produces it simply to large to be reviewed before git conflicts arise, let's try a more gradual approach and split the effort in separate PRs that apply only on a subset of the codebase at a time.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
