### PR TITLE
deps: V8: cherry-pick 9df5ef70ff18

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.19',
+    'v8_embedder_string': '-node.20',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -60,6 +60,7 @@ Allan Sandfeld Jensen <allan.jensen@qt.io>
 Amos Lim <eui-sang.lim@samsung.com>
 Andreas Anyuru <andreas.anyuru@gmail.com>
 Andrei Kashcha <anvaka@gmail.com>
+Andreu Botella <andreu@andreubotella.com>
 Andrew Paprocki <andrew@ishiboo.com>
 Anna Henningsen <anna@addaleax.net>
 Antoine du Hamel <duhamelantoine1995@gmail.com>

--- a/deps/v8/include/v8-array-buffer.h
+++ b/deps/v8/include/v8-array-buffer.h
@@ -241,6 +241,11 @@ class V8_EXPORT ArrayBuffer : public Object {
   bool IsDetachable() const;
 
   /**
+   * Returns true if this ArrayBuffer has been detached.
+   */
+  bool WasDetached() const;
+
+  /**
    * Detaches this ArrayBuffer and all its views (typed arrays).
    * Detaching sets the byte length of the buffer and all typed arrays to zero,
    * preventing JavaScript from ever accessing underlying backing store.
@@ -253,6 +258,9 @@ class V8_EXPORT ArrayBuffer : public Object {
    * pointer coordinates the lifetime management of the internal storage
    * with any live ArrayBuffers on the heap, even across isolates. The embedder
    * should not attempt to manage lifetime of the storage through other means.
+   *
+   * The returned shared pointer will not be empty, even if the ArrayBuffer has
+   * been detached. Use |WasDetached| to tell if it has been detached instead.
    */
   std::shared_ptr<BackingStore> GetBackingStore();
 

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -8064,6 +8064,10 @@ bool v8::ArrayBuffer::IsDetachable() const {
   return Utils::OpenHandle(this)->is_detachable();
 }
 
+bool v8::ArrayBuffer::WasDetached() const {
+  return Utils::OpenHandle(this)->was_detached();
+}
+
 namespace {
 std::shared_ptr<i::BackingStore> ToInternal(
     std::shared_ptr<i::BackingStoreBase> backing_store) {

--- a/deps/v8/test/cctest/cctest.status
+++ b/deps/v8/test/cctest/cctest.status
@@ -516,6 +516,7 @@
   'test-api/WasmI32AtomicWaitCallback': [SKIP],
   'test-api/WasmI64AtomicWaitCallback': [SKIP],
   'test-api/WasmSetJitCodeEventHandler': [SKIP],
+  'test-api-array-buffer/ArrayBuffer_NonDetachableWasDetached': [SKIP],
   'test-backing-store/Run_WasmModule_Buffer_Externalized_Regression_UseAfterFree': [SKIP],
   'test-c-wasm-entry/*': [SKIP],
   'test-compilation-cache/*': [SKIP],

--- a/deps/v8/test/cctest/test-api-array-buffer.cc
+++ b/deps/v8/test/cctest/test-api-array-buffer.cc
@@ -245,6 +245,37 @@ THREADED_TEST(ArrayBuffer_DetachingScript) {
   CheckDataViewIsDetached(dv);
 }
 
+THREADED_TEST(ArrayBuffer_WasDetached) {
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+
+  Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(isolate, 0);
+  CHECK(!ab->WasDetached());
+
+  ab->Detach(v8::Local<v8::Value>()).Check();
+  CHECK(ab->WasDetached());
+}
+
+THREADED_TEST(ArrayBuffer_NonDetachableWasDetached) {
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+
+  CompileRun(R"JS(
+    var wasmMemory = new WebAssembly.Memory({initial: 1, maximum: 2});
+  )JS");
+
+  Local<v8::ArrayBuffer> non_detachable =
+      CompileRun("wasmMemory.buffer").As<v8::ArrayBuffer>();
+  CHECK(!non_detachable->IsDetachable());
+  CHECK(!non_detachable->WasDetached());
+
+  CompileRun("wasmMemory.grow(1)");
+  CHECK(!non_detachable->IsDetachable());
+  CHECK(non_detachable->WasDetached());
+}
+
 THREADED_TEST(ArrayBuffer_ExternalizeEmpty) {
   LocalContext env;
   v8::Isolate* isolate = env->GetIsolate();

--- a/deps/v8/test/cctest/test-api-array-buffer.cc
+++ b/deps/v8/test/cctest/test-api-array-buffer.cc
@@ -253,7 +253,7 @@ THREADED_TEST(ArrayBuffer_WasDetached) {
   Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(isolate, 0);
   CHECK(!ab->WasDetached());
 
-  ab->Detach(v8::Local<v8::Value>()).Check();
+  ab->Detach();
   CHECK(ab->WasDetached());
 }
 


### PR DESCRIPTION
Original commit message:

    Add an `v8::ArrayBuffer::WasDetached` method to the C++ API

    V8's C++ API does not give a way to tell whether an ArrayBuffer has
    been detached from the `v8::ArrayBuffer` class. In fact, as far as can
    be told from the C++ API without running JS code, detached
    ArrayBuffers behave the same as zero-sized ArrayBuffers and there is
    no way to observe the difference. However, this difference can be
    observed in JS because constructing a TypedArray from a detached
    ArrayBuffer will throw.

    This change adds a `WasDetached` method to the `v8::ArrayBuffer` class
    to give embedders access to this information without having to run JS
    code.

    Bug: v8:13159
    Change-Id: I2bb1e380cee1cecd31f6d48ec3d9f28c03a8a673
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3810345
    Commit-Queue: Toon Verwaest <verwaest@chromium.org>
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#83963}

Refs: https://github.com/v8/v8/commit/9df5ef70ff18977b157028fc55ced5af4bcee535

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
