### PR TITLE
benchmark: add v8 serialize benchmark

### DIFF
--- a/benchmark/v8/serialize.js
+++ b/benchmark/v8/serialize.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common.js');
+const v8 = require('v8');
+
+const bench = common.createBenchmark(main, {
+  len: [256, 1024 * 16, 1024 * 512],
+  n: [1e6]
+});
+
+function main({ n, len }) {
+  const typedArray = new BigUint64Array(len);
+  bench.start();
+  for (let i = 0; i < n; i++)
+    v8.serialize({ a: 1, b: typedArray });
+  bench.end(n);
+}


### PR DESCRIPTION
Taken from one of my old pull requests: https://github.com/nodejs/node/pull/43937/files#diff-522a7e332d08116adcf9089cadcf3e161099f99cf877d76a701ce55fe4f4d398