### PR TITLE
stream: add fast path for utf8

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -8,6 +8,8 @@ const {
   Uint8Array,
 } = primordials;
 
+const { TextEncoder } = require('internal/encoding');
+
 const {
   ReadableStream,
   isReadableStream,
@@ -54,6 +56,7 @@ const {
 const {
   createDeferredPromise,
   kEmptyObject,
+  normalizeEncoding,
 } = require('internal/util');
 
 const {
@@ -72,6 +75,8 @@ const {
 const finished = require('internal/streams/end-of-stream');
 
 const { UV_EOF } = internalBinding('uv');
+
+const encoder = new TextEncoder();
 
 /**
  * @typedef {import('../../stream').Writable} Writable
@@ -255,11 +260,17 @@ function newStreamWritableFromWritableStream(writableStream, options = kEmptyObj
 
     write(chunk, encoding, callback) {
       if (typeof chunk === 'string' && decodeStrings && !objectMode) {
-        chunk = Buffer.from(chunk, encoding);
-        chunk = new Uint8Array(
-          chunk.buffer,
-          chunk.byteOffset,
-          chunk.byteLength);
+        const enc = normalizeEncoding(encoding);
+
+        if (enc === 'utf8') {
+          chunk = encoder.encode(chunk);
+        } else {
+          chunk = Buffer.from(chunk, encoding);
+          chunk = new Uint8Array(
+            chunk.buffer,
+            chunk.byteOffset,
+            chunk.byteLength);
+        }
       }
 
       function done(error) {
@@ -674,11 +685,17 @@ function newStreamDuplexFromReadableWritablePair(pair = kEmptyObject, options = 
 
     write(chunk, encoding, callback) {
       if (typeof chunk === 'string' && decodeStrings && !objectMode) {
-        chunk = Buffer.from(chunk, encoding);
-        chunk = new Uint8Array(
-          chunk.buffer,
-          chunk.byteOffset,
-          chunk.byteLength);
+        const enc = normalizeEncoding(encoding);
+
+        if (enc === 'utf8') {
+          chunk = encoder.encode(chunk);
+        } else {
+          chunk = Buffer.from(chunk, encoding);
+          chunk = new Uint8Array(
+            chunk.buffer,
+            chunk.byteOffset,
+            chunk.byteLength);
+        }
       }
 
       function done(error) {


### PR DESCRIPTION
TextEncoder is now faster than `Buffer.from` for UTF8.