### PR TITLE
stream: add fast-path for readable streams

### DIFF
--- a/benchmark/streams/readable-encoding.js
+++ b/benchmark/streams/readable-encoding.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+const Readable = require('stream').Readable;
+
+const BASE = 'hello world\n\n';
+
+const bench = common.createBenchmark(main, {
+  encoding: ['utf-8', 'latin1'],
+  len: [256, 512, 1024 * 16],
+  op: ['unshift', 'push'],
+  n: [1e3]
+});
+
+function main({ n, encoding, len, op }) {
+  const b = BASE.repeat(len);
+  const s = new Readable({
+    objectMode: false,
+    encoding: 'utf8'
+  });
+
+  bench.start();
+  switch (op) {
+    case 'unshift': {
+      for (let i = 0; i < n; i++)
+        s.unshift(b, encoding);
+      break;
+    }
+    case 'push': {
+      for (let i = 0; i < n; i++)
+        s.push(b, encoding);
+      break;
+    }
+  }
+  bench.end(n);
+}

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -42,6 +42,8 @@ const EE = require('events');
 const { Stream, prependListener } = require('internal/streams/legacy');
 const { Buffer } = require('buffer');
 
+const { TextEncoder } = require('internal/encoding');
+
 const {
   addAbortSignal,
 } = require('internal/streams/add-abort-signal');
@@ -73,6 +75,8 @@ const kPaused = Symbol('kPaused');
 
 const { StringDecoder } = require('string_decoder');
 const from = require('internal/streams/from');
+const { normalizeEncoding } = require("internal/util");
+const encoder = new TextEncoder();
 
 ObjectSetPrototypeOf(Readable.prototype, Stream.prototype);
 ObjectSetPrototypeOf(Readable, Stream);
@@ -251,7 +255,13 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
         if (addToFront && state.encoding) {
           // When unshifting, if state.encoding is set, we have to save
           // the string in the BufferList with the state encoding.
-          chunk = Buffer.from(chunk, encoding).toString(state.encoding);
+          const enc = normalizeEncoding(encoding);
+
+          if (enc === 'utf8') {
+            chunk = encoder.encode(chunk);
+          } else {
+            chunk = Buffer.from(chunk, encoding).toString(state.encoding);
+          }
         } else {
           chunk = Buffer.from(chunk, encoding);
           encoding = '';


### PR DESCRIPTION
I'll update benchmarks after CI machine is completed. Until then, here's my benchmark results:

```
                                                                                  confidence improvement accuracy (*)   (**)   (***)
streams/readable-push-encoding.js n=1000 op='push' len=16384 encoding='latin1'                   -1.42 %       ±2.07% ±2.76%  ±3.61%
streams/readable-push-encoding.js n=1000 op='push' len=16384 encoding='utf-8'                     1.28 %       ±1.77% ±2.36%  ±3.08%
streams/readable-push-encoding.js n=1000 op='push' len=256 encoding='latin1'                      1.42 %       ±2.36% ±3.15%  ±4.11%
streams/readable-push-encoding.js n=1000 op='push' len=256 encoding='utf-8'                       1.16 %       ±2.51% ±3.34%  ±4.35%
streams/readable-push-encoding.js n=1000 op='push' len=512 encoding='latin1'                     -0.67 %       ±2.03% ±2.71%  ±3.54%
streams/readable-push-encoding.js n=1000 op='push' len=512 encoding='utf-8'                      -0.30 %       ±2.69% ±3.58%  ±4.66%
streams/readable-push-encoding.js n=1000 op='unshift' len=16384 encoding='latin1'                -0.63 %       ±1.62% ±2.16%  ±2.82%
streams/readable-push-encoding.js n=1000 op='unshift' len=16384 encoding='utf-8'         ***    127.33 %       ±1.33% ±1.77%  ±2.31%
streams/readable-push-encoding.js n=1000 op='unshift' len=256 encoding='latin1'          ***     -5.89 %       ±2.30% ±3.06%  ±3.98%
streams/readable-push-encoding.js n=1000 op='unshift' len=256 encoding='utf-8'           ***    178.86 %       ±4.23% ±5.64%  ±7.36%
streams/readable-push-encoding.js n=1000 op='unshift' len=512 encoding='latin1'            *     -2.42 %       ±2.27% ±3.02%  ±3.94%
streams/readable-push-encoding.js n=1000 op='unshift' len=512 encoding='utf-8'           ***    183.72 %       ±6.54% ±8.76% ±11.51%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 12 comparisons, you can thus expect the following amount of false-positive results:
  0.60 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.12 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```