### PR TITLE
stream: add fast-path for readable streams

### DIFF
--- a/benchmark/streams/readable-encoding.js
+++ b/benchmark/streams/readable-encoding.js
@@ -17,6 +17,8 @@ function main({ n, encoding, len, op }) {
   const s = new Readable({
     objectMode: false,
   });
+  function noop() {}
+  s._read = noop;
 
   bench.start();
   switch (op) {

--- a/benchmark/streams/readable-encoding.js
+++ b/benchmark/streams/readable-encoding.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common');
+const Readable = require('stream').Readable;
+
+const BASE = 'hello world\n\n';
+
+const bench = common.createBenchmark(main, {
+  encoding: ['utf-8', 'latin1'],
+  len: [256, 512, 1024 * 16],
+  op: ['unshift', 'push'],
+  n: [1e3]
+});
+
+function main({ n, encoding, len, op }) {
+  const b = BASE.repeat(len);
+  const s = new Readable({
+    objectMode: false,
+  });
+
+  bench.start();
+  switch (op) {
+    case 'unshift': {
+      for (let i = 0; i < n; i++)
+        s.unshift(b, encoding);
+      break;
+    }
+    case 'push': {
+      for (let i = 0; i < n; i++)
+        s.push(b, encoding);
+      break;
+    }
+  }
+  bench.end(n);
+}

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -32,7 +32,7 @@ const {
   Promise,
   SafeSet,
   SymbolAsyncIterator,
-  Symbol
+  Symbol,
 } = primordials;
 
 module.exports = Readable;
@@ -73,6 +73,7 @@ const kPaused = Symbol('kPaused');
 
 const { StringDecoder } = require('string_decoder');
 const from = require('internal/streams/from');
+const { encodeWithFastPath } = require('internal/streams/utils');
 
 ObjectSetPrototypeOf(Readable.prototype, Stream.prototype);
 ObjectSetPrototypeOf(Readable, Stream);
@@ -251,9 +252,10 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
         if (addToFront && state.encoding) {
           // When unshifting, if state.encoding is set, we have to save
           // the string in the BufferList with the state encoding.
+
           chunk = Buffer.from(chunk, encoding).toString(state.encoding);
         } else {
-          chunk = Buffer.from(chunk, encoding);
+          chunk = encodeWithFastPath(chunk, encoding);
           encoding = '';
         }
       }

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -12,6 +12,7 @@ const {
 const { normalizeEncoding } = require('internal/util');
 const { FastBuffer } = require('internal/buffer');
 const { TextEncoder } = require('internal/encoding');
+const { isTypedArray } = require('internal/util/types');
 
 let buffer;
 function lazyLoadBuffer() {
@@ -277,13 +278,14 @@ function isErrored(stream) {
 
 function encodeWithFastPath(input, encoding) {
   const enc = normalizeEncoding(encoding);
+  const byteLength = enc === 'utf8' && isTypedArray(input) && TypedArrayPrototypeGetByteLength(input);
 
-  if (enc === 'utf8') {
+  if (byteLength > 512) {
     const buf = encoder.encode(input);
     return new FastBuffer(
       TypedArrayPrototypeGetBuffer(buf),
       TypedArrayPrototypeGetByteOffset(buf),
-      TypedArrayPrototypeGetByteLength(buf),
+      byteLength,
     );
   }
 

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -4,7 +4,21 @@ const {
   Symbol,
   SymbolAsyncIterator,
   SymbolIterator,
+  TypedArrayPrototypeGetBuffer,
+  TypedArrayPrototypeGetByteOffset,
+  TypedArrayPrototypeGetByteLength,
 } = primordials;
+
+const { normalizeEncoding } = require('internal/util');
+const { FastBuffer } = require('internal/buffer');
+const { TextEncoder } = require('internal/encoding');
+
+let buffer;
+function lazyLoadBuffer() {
+  buffer ??= require('buffer').Buffer;
+  return buffer;
+}
+const encoder = new TextEncoder();
 
 const kDestroyed = Symbol('kDestroyed');
 const kIsErrored = Symbol('kIsErrored');
@@ -261,7 +275,23 @@ function isErrored(stream) {
   ));
 }
 
+function encodeWithFastPath(input, encoding) {
+  const enc = normalizeEncoding(encoding);
+
+  if (enc === 'utf8') {
+    const buf = encoder.encode(input);
+    return new FastBuffer(
+      TypedArrayPrototypeGetBuffer(buf),
+      TypedArrayPrototypeGetByteOffset(buf),
+      TypedArrayPrototypeGetByteLength(buf),
+    );
+  }
+
+  return lazyLoadBuffer().from(input, enc);
+}
+
 module.exports = {
+  encodeWithFastPath,
   kDestroyed,
   isDisturbed,
   kIsDisturbed,


### PR DESCRIPTION
Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1225/

<details><summary>Results</summary>

```
                                                                             confidence improvement accuracy (*)    (**)   (***)
streams/readable-encoding.js n=1000 op='push' len=16384 encoding='latin1'                    1.29 %       ±2.75%  ±3.66%  ±4.77%
streams/readable-encoding.js n=1000 op='push' len=16384 encoding='utf-8'            ***     15.70 %       ±4.21%  ±5.61%  ±7.34%
streams/readable-encoding.js n=1000 op='push' len=256 encoding='latin1'                     -5.85 %       ±7.27%  ±9.68% ±12.60%
streams/readable-encoding.js n=1000 op='push' len=256 encoding='utf-8'                      -0.91 %       ±7.21%  ±9.61% ±12.53%
streams/readable-encoding.js n=1000 op='push' len=512 encoding='latin1'              **     -9.23 %       ±6.72%  ±8.94% ±11.64%
streams/readable-encoding.js n=1000 op='push' len=512 encoding='utf-8'                       3.36 %       ±8.07% ±10.74% ±13.98%
streams/readable-encoding.js n=1000 op='unshift' len=16384 encoding='latin1'                 1.49 %       ±4.27%  ±5.68%  ±7.40%
streams/readable-encoding.js n=1000 op='unshift' len=16384 encoding='utf-8'         ***     15.10 %       ±4.09%  ±5.45%  ±7.11%
streams/readable-encoding.js n=1000 op='unshift' len=256 encoding='latin1'           **     -8.54 %       ±5.66%  ±7.55%  ±9.85%
streams/readable-encoding.js n=1000 op='unshift' len=256 encoding='utf-8'                   -6.27 %       ±7.00%  ±9.32% ±12.14%
streams/readable-encoding.js n=1000 op='unshift' len=512 encoding='latin1'                  -0.28 %       ±6.23%  ±8.30% ±10.85%
streams/readable-encoding.js n=1000 op='unshift' len=512 encoding='utf-8'                   -1.42 %       ±7.15%  ±9.51% ±12.39%
```

</details>