### PR TITLE
url: remove unnecessary object call to kFormat

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -748,13 +748,13 @@ class URL {
   toString() {
     if (!isURLThis(this))
       throw new ERR_INVALID_THIS('URL');
-    return this[kFormat]({});
+    return this[kFormat]();
   }
 
   get href() {
     if (!isURLThis(this))
       throw new ERR_INVALID_THIS('URL');
-    return this[kFormat]({});
+    return this[kFormat]();
   }
 
   set href(input) {
@@ -1011,7 +1011,7 @@ class URL {
   toJSON() {
     if (!isURLThis(this))
       throw new ERR_INVALID_THIS('URL');
-    return this[kFormat]({});
+    return this[kFormat]();
   }
 
   static createObjectURL(obj) {


### PR DESCRIPTION
Unnecessary call to `{}` triggers `validateObject` which effects the performance. Found it while working on https://github.com/nodejs/undici/pull/1774