### PR TITLE
fs: fix `nonNativeWatcher` watching folder with existing files

### DIFF
--- a/lib/internal/fs/recursive_watch.js
+++ b/lib/internal/fs/recursive_watch.js
@@ -203,7 +203,7 @@ class FSWatcher extends EventEmitter {
       } else if (currentStats.isDirectory()) {
         this.#watchFolder(file);
       } else {
-        // Watching a dircetory will trigger a change event for child files
+        // Watching a directory will trigger a change event for child files
         this.emit('change', 'change', pathRelative(this.#rootPath, file));
       }
     });

--- a/lib/internal/fs/recursive_watch.js
+++ b/lib/internal/fs/recursive_watch.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayPrototypePush,
+  DateNow,
   SafePromiseAllReturnVoid,
   Promise,
   PromisePrototypeThen,
@@ -206,7 +207,7 @@ class FSWatcher extends EventEmitter {
         this.#watchFolder(file);
       } else {
         // Watching a directory will trigger a change event for child files)
-        const event = Date.now() - currentStats.birthtimeMs < NEW_FILES_AGE ? 'rename' : 'change';
+        const event = DateNow() - currentStats.birthtimeMs < NEW_FILES_AGE ? 'rename' : 'change';
         this.emit('change', event, pathRelative(this.#rootPath, file));
       }
     });

--- a/lib/internal/fs/recursive_watch.js
+++ b/lib/internal/fs/recursive_watch.js
@@ -33,6 +33,8 @@ const {
 let internalSync;
 let internalPromises;
 
+const NEW_FILES_AGE = 20_000;
+
 function lazyLoadFsPromises() {
   internalPromises ??= require('fs/promises');
   return internalPromises;
@@ -203,8 +205,9 @@ class FSWatcher extends EventEmitter {
       } else if (currentStats.isDirectory()) {
         this.#watchFolder(file);
       } else {
-        // Watching a directory will trigger a change event for child files
-        this.emit('change', 'change', pathRelative(this.#rootPath, file));
+        // Watching a directory will trigger a change event for child files)
+        const event = Date.now() - currentStats.birthtimeMs < NEW_FILES_AGE ? 'rename' : 'change';
+        this.emit('change', event, pathRelative(this.#rootPath, file));
       }
     });
   }

--- a/lib/internal/fs/recursive_watch.js
+++ b/lib/internal/fs/recursive_watch.js
@@ -2,7 +2,6 @@
 
 const {
   ArrayPrototypePush,
-  DateNow,
   SafePromiseAllReturnVoid,
   Promise,
   PromisePrototypeThen,
@@ -33,8 +32,6 @@ const {
 
 let internalSync;
 let internalPromises;
-
-const NEW_FILES_AGE = 20_000;
 
 function lazyLoadFsPromises() {
   internalPromises ??= require('fs/promises');
@@ -207,8 +204,7 @@ class FSWatcher extends EventEmitter {
         this.#watchFolder(file);
       } else {
         // Watching a directory will trigger a change event for child files)
-        const event = DateNow() - currentStats.birthtimeMs < NEW_FILES_AGE ? 'rename' : 'change';
-        this.emit('change', event, pathRelative(this.#rootPath, file));
+        this.emit('change', 'change', pathRelative(this.#rootPath, file));
       }
     });
   }

--- a/lib/internal/fs/recursive_watch.js
+++ b/lib/internal/fs/recursive_watch.js
@@ -202,6 +202,9 @@ class FSWatcher extends EventEmitter {
         this.emit('change', 'rename', pathRelative(this.#rootPath, file));
       } else if (currentStats.isDirectory()) {
         this.#watchFolder(file);
+      } else {
+        // Watching a dircetory will trigger a change event for child files
+        this.emit('change', 'change', pathRelative(this.#rootPath, file));
       }
     });
   }

--- a/test/parallel/test-fs-watch-recursive.js
+++ b/test/parallel/test-fs-watch-recursive.js
@@ -23,6 +23,37 @@ const testDir = tmpdir.path;
 tmpdir.refresh();
 
 (async () => {
+  // Watch a folder and update an already existing file in it.
+
+  const rootDirectory = fs.mkdtempSync(testDir + path.sep);
+  const testDirectory = path.join(rootDirectory, 'test-0');
+  fs.mkdirSync(testDirectory);
+
+  const testFile = path.join(testDirectory, 'file-1.txt');
+  fs.writeFileSync(testFile, 'hello');
+
+  const watcher = fs.watch(testDirectory, { recursive: true });
+  let watcherClosed = false;
+  watcher.on('change', common.mustCallAtLeast(function(event, filename) {
+    // Libuv inconsistenly emits a rename event for the file we are watching
+    assert.ok(event === 'change' || event === 'rename');
+
+    if (filename === path.basename(testFile)) {
+      watcher.close();
+      watcherClosed = true;
+    }
+  }));
+
+  await setTimeout(common.platformTimeout(100));
+  fs.writeFileSync(testFile, 'hello');
+
+  process.once('exit', function() {
+    assert(watcherClosed, 'watcher Object was not closed');
+  });
+})().then(common.mustCall());
+
+
+(async () => {
   // Add a file to already watching folder
 
   const rootDirectory = fs.mkdtempSync(testDir + path.sep);


### PR DESCRIPTION
a simple case that has not worked before this fix:
```js
const fs = require('fs');
const watcher = fs.watch(__dirname, { recursive: true });
watcher.on('change', (event, filename) => {
  console.log(event, filename);
});

setTimeout(() => fs.writeFileSync(__filename, fs.readFileSync(__filename)), 1000);
```