### PR TITLE
test_runner: add getter and setter to MockTracker

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -941,6 +941,15 @@ test('mocks a counting function', (t) => {
 });
 ```
 
+### `mock.getter(object, methodName[, implementation][, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+This function is syntax sugar for [`MockTracker.method`][] with `options.getter`
+set to `true`.
+
 ### `mock.method(object, methodName[, implementation][, options])`
 
 <!-- YAML
@@ -1020,6 +1029,15 @@ added: v19.1.0
 This function restores the default behavior of all mocks that were previously
 created by this `MockTracker`. Unlike `mock.reset()`, `mock.restoreAll()` does
 not disassociate the mocks from the `MockTracker` instance.
+
+### `mock.setter(object, methodName[, implementation][, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+This function is syntax sugar for [`MockTracker.method`][] with `options.setter`
+set to `true`.
 
 ## Class: `TapStream`
 
@@ -1357,6 +1375,7 @@ added:
 [`--test-only`]: cli.md#--test-only
 [`--test`]: cli.md#--test
 [`MockFunctionContext`]: #class-mockfunctioncontext
+[`MockTracker.method`]: #mockmethodobject-methodname-implementation-options
 [`MockTracker`]: #class-mocktracker
 [`SuiteContext`]: #class-suitecontext
 [`TestContext`]: #class-testcontext

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -202,6 +202,60 @@ class MockTracker {
     return mock;
   }
 
+  getter(
+    object,
+    methodName,
+    implementation = kDefaultFunction,
+    options = kEmptyObject
+  ) {
+    if (implementation !== null && typeof implementation === 'object') {
+      options = implementation;
+      implementation = kDefaultFunction;
+    } else {
+      validateObject(options, 'options');
+    }
+
+    const { getter = true } = options;
+
+    if (getter === false) {
+      throw new ERR_INVALID_ARG_VALUE(
+        'options.getter', getter, 'cannot be false'
+      );
+    }
+
+    return this.method(object, methodName, implementation, {
+      ...options,
+      getter,
+    });
+  }
+
+  setter(
+    object,
+    methodName,
+    implementation = kDefaultFunction,
+    options = kEmptyObject
+  ) {
+    if (implementation !== null && typeof implementation === 'object') {
+      options = implementation;
+      implementation = kDefaultFunction;
+    } else {
+      validateObject(options, 'options');
+    }
+
+    const { setter = true } = options;
+
+    if (setter === false) {
+      throw new ERR_INVALID_ARG_VALUE(
+        'options.setter', setter, 'cannot be false'
+      );
+    }
+
+    return this.method(object, methodName, implementation, {
+      ...options,
+      setter,
+    });
+  }
+
   reset() {
     this.restoreAll();
     this.#mocks = [];


### PR DESCRIPTION
This commit allows tests in test runner to use the `getter` and `setter` methods as "syntax sugar" for `MockTracker.method` with the `options.getter` or `options.setter` set to true in the options.

Refs: https://github.com/nodejs/node/pull/45326#discussion_r1014727289

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
