### PR TITLE
tools: add missing step in update-base64.sh script

### DIFF
--- a/deps/base64/base64/CMakeLists.txt
+++ b/deps/base64/base64/CMakeLists.txt
@@ -17,7 +17,7 @@ if (POLICY CMP0127)
     cmake_policy(SET CMP0127 NEW)
 endif()
 
-project(base64 LANGUAGES C VERSION 0.4.0)
+project(base64 LANGUAGES C VERSION 0.5.0)
 
 include(GNUInstallDirs)
 include(CMakeDependentOption)

--- a/tools/update-base64.sh
+++ b/tools/update-base64.sh
@@ -34,6 +34,10 @@ echo "Replacing existing base64"
 rm -rf "$DEPS_DIR/base64/base64"
 mv "$WORKSPACE/base64" "$DEPS_DIR/base64/"
 
+# Build configuration is handled by `deps/base64/base64.gyp`, but since `config.h` has to be present for the build
+# to work, we create it and leave it empty.
+echo "// Intentionally empty" >> "$DEPS_DIR/base64/base64/lib/config.h"
+
 echo "All done!"
 echo ""
 echo "Please git add base64/base64, commit the new version:"


### PR DESCRIPTION
This PR adds an extra step to the `update-base64.sh` script, which adds an empty `config.h` header after updating `base64`.

The reason for this is that `config.h` needs to exist in order to compile `base64`. In upstream, this header is used to define which processor extensions should be supported (see [here](https://github.com/aklomp/base64/blob/master/Makefile#L71)). Since in Node's build this is handled by the [base64.gyp](https://github.com/nodejs/node/blob/v19.0.0/deps/base64/base64.gyp#L41-L48) file, we leave the `config.h` file empty.