### PR TITLE
stream: add primordials to adapters

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -5,6 +5,9 @@ const {
   PromiseResolve,
   SafePromiseAll,
   SafePromisePrototypeFinally,
+  TypedArrayPrototypeGetBuffer,
+  TypedArrayPrototypeGetByteOffset,
+  TypedArrayPrototypeGetByteLength,
   Uint8Array,
 } = primordials;
 
@@ -267,9 +270,10 @@ function newStreamWritableFromWritableStream(writableStream, options = kEmptyObj
         } else {
           chunk = Buffer.from(chunk, encoding);
           chunk = new Uint8Array(
-            chunk.buffer,
-            chunk.byteOffset,
-            chunk.byteLength);
+            TypedArrayPrototypeGetBuffer(chunk),
+            TypedArrayPrototypeGetByteOffset(chunk),
+            TypedArrayPrototypeGetByteLength(chunk),
+          );
         }
       }
 
@@ -692,9 +696,10 @@ function newStreamDuplexFromReadableWritablePair(pair = kEmptyObject, options = 
         } else {
           chunk = Buffer.from(chunk, encoding);
           chunk = new Uint8Array(
-            chunk.buffer,
-            chunk.byteOffset,
-            chunk.byteLength);
+            TypedArrayPrototypeGetBuffer(chunk),
+            TypedArrayPrototypeGetByteOffset(chunk),
+            TypedArrayPrototypeGetByteLength(chunk),
+          );
         }
       }
 


### PR DESCRIPTION
Fixes the lack of primordials from my previous commit (https://github.com/nodejs/node/commit/770efeab6db5d78199d3b5bbc1bfb44a21637dc0)