### PR TITLE
src: set an appropriate thread pool size if given `--v8-pool-size=0`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1573,6 +1573,10 @@ Set V8's thread pool size which will be used to allocate background jobs.
 If set to `0` then Node.js will choose an appropriate size of the thread pool
 based on an estimate of the amount of parallelism.
 
+The amount of parallelism refers to the number of computations that can be
+carried out simultaneously in a given machine. In general, it's the same as the
+amount of CPUs, but it may diverge in environments such as VMs or containers.
+
 ### `--watch`
 
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1570,11 +1570,8 @@ added: v5.10.0
 
 Set V8's thread pool size which will be used to allocate background jobs.
 
-If set to `0` then V8 will choose an appropriate size of the thread pool based
-on the number of online processors.
-
-If the value provided is larger than V8's maximum, then the largest value
-will be chosen.
+If set to `0` then Node.js will choose an appropriate size of the thread pool
+based on an estimate of the amount of parallelism.
 
 ### `--watch`
 

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -45,6 +45,13 @@ static void PlatformWorkerThread(void* data) {
   }
 }
 
+static int GetActualThreadPoolSize(int thread_pool_size) {
+  if (thread_pool_size < 1) {
+    thread_pool_size = uv_available_parallelism() - 1;
+  }
+  return std::max(thread_pool_size, 1);
+}
+
 }  // namespace
 
 class WorkerThreadsTaskRunner::DelayedTaskScheduler {
@@ -340,6 +347,8 @@ NodePlatform::NodePlatform(int thread_pool_size,
   // current v8::Platform instance.
   SetTracingController(tracing_controller_);
   DCHECK_EQ(GetTracingController(), tracing_controller_);
+
+  thread_pool_size = GetActualThreadPoolSize(thread_pool_size);
   worker_thread_task_runner_ =
       std::make_shared<WorkerThreadsTaskRunner>(thread_pool_size);
 }

--- a/test/parallel/test-v8-flag-pool-size-0.js
+++ b/test/parallel/test-v8-flag-pool-size-0.js
@@ -1,0 +1,10 @@
+// Flags: --v8-pool-size=0 --expose-gc
+
+'use strict';
+
+require('../common');
+
+// This verifies that V8 tasks scheduled by GC are handled on worker threads if
+// `--v8-pool-size=0` is given. The worker threads are managed by Node.js'
+// `v8::Platform` implementation.
+globalThis.gc();


### PR DESCRIPTION
Node.js doesn't terminate when any pending V8 tasks exist if no thread is in the pool.

This allocates one thread at least for the tasks if `--v8-pool-size=0` is given as a CLI option.

Fixes: https://github.com/nodejs/node/issues/42523
Alternative to https://github.com/nodejs/node/pull/42524

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
