### PR TITLE
lib: improve AbortController creation duration

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -309,12 +309,13 @@ function abortSignal(signal, reason) {
 }
 
 class AbortController {
-  #signal = createAbortSignal();
+  #signal;
 
   /**
    * @type {AbortSignal}
    */
   get signal() {
+    this.#signal ??= createAbortSignal();
     return this.#signal;
   }
 
@@ -322,7 +323,7 @@ class AbortController {
    * @param {any} reason
    */
   abort(reason = new DOMException('This operation was aborted', 'AbortError')) {
-    abortSignal(this.#signal, reason);
+    abortSignal(this.#signal ??= createAbortSignal(), reason);
   }
 
   [customInspectSymbol](depth, options) {

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -334,7 +334,7 @@ class AbortController {
 
   static [kMakeTransferable]() {
     const controller = new AbortController();
-    controller.#signal = transferableAbortSignal(controller.#signal);
+    controller.#signal = createAbortSignal({ transferable: true });
     return controller;
   }
 }


### PR DESCRIPTION
1. Remove `createAbortSignal()` call unless `signal` getter is called.
2. Improve `kMakeTransferable` abort signal creation.