### PR TITLE
url: emit warning in url.parse() for URLs with invalid ports

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3303,12 +3303,16 @@ issued for `url.parse()` vulnerabilities.
 <!-- YAML
 changes:
   - version:
+    - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/45526
+    description: Runtime deprecation.
+  - version:
     - v19.2.0
     pr-url: https://github.com/nodejs/node/pull/45576
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 [`url.parse()`][] accepts URLs with ports that are not numbers. This behavior
 might result in host name spoofing with unexpected input. These URLs will throw

--- a/lib/url.js
+++ b/lib/url.js
@@ -387,7 +387,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
 
     // validate a little.
     if (!ipv6Hostname) {
-      rest = getHostname(this, rest, hostname);
+      rest = getHostname(this, rest, hostname, url);
     }
 
     if (this.hostname.length > hostnameMaxLen) {
@@ -506,7 +506,8 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
   return this;
 };
 
-function getHostname(self, rest, hostname) {
+let warnInvalidPort = true;
+function getHostname(self, rest, hostname, url) {
   for (let i = 0; i < hostname.length; ++i) {
     const code = hostname.charCodeAt(i);
     const isValid = (code !== CHAR_FORWARD_SLASH &&
@@ -516,6 +517,14 @@ function getHostname(self, rest, hostname) {
                      code !== CHAR_COLON);
 
     if (!isValid) {
+      // If leftover starts with :, then it represents an invalid port.
+      // But url.parse() is lenient about it for now.
+      // Issue a warning and continue.
+      if (warnInvalidPort && code === CHAR_COLON) {
+        const detail = `The URL ${url} is invalid. Future versions of Node.js will throw an error.`;
+        process.emitWarning(detail, 'DeprecationWarning', 'DEP0170');
+        warnInvalidPort = false;
+      }
       self.hostname = hostname.slice(0, i);
       return `/${hostname.slice(i)}${rest}`;
     }

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -1,6 +1,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const childProcess = require('child_process');
 const url = require('url');
 
 // https://github.com/joyent/node/issues/568
@@ -73,4 +74,32 @@ if (common.hasIntl) {
   assert.throws(() => { url.parse('http://\u00AD/bad.com/'); },
                 (e) => e.code === 'ERR_INVALID_URL',
                 'parsing http://\u00AD/bad.com/');
+}
+
+{
+  const badURLs = [
+    'https://evil.com:.example.com',
+    'git+ssh://git@github.com:npm/npm',
+  ];
+  badURLs.forEach((badURL) => {
+    childProcess.exec(`${process.execPath} -e "url.parse('${badURL}')"`,
+                      common.mustCall((err, stdout, stderr) => {
+                        assert.strictEqual(err, null);
+                        assert.strictEqual(stdout, '');
+                        assert.match(stderr, /\[DEP0170\] DeprecationWarning:/);
+                      })
+    );
+  });
+
+  // Warning should only happen once per process.
+  const expectedWarning = [
+    `The URL ${badURLs[0]} is invalid. Future versions of Node.js will throw an error.`,
+    'DEP0170',
+  ];
+  common.expectWarning({
+    DeprecationWarning: expectedWarning,
+  });
+  badURLs.forEach((badURL) => {
+    url.parse(badURL);
+  });
 }


### PR DESCRIPTION
These URLs throw with WHATWG URL. They are permitted with url.parse() but that allows potential host spoofing by sending a domain name as the port. This warning can be changed to an error as a breaking change in a major release.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
