### PR TITLE
stream: fix `pipeline(readable, Duplex.from(<async-iterator>), cb)` not triggering data or calling the cb

### DIFF
--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -107,6 +107,10 @@ function from(Readable, iterable, opts) {
       break;
     }
   }
+
+  readable.on('pipe', readable.resume.bind(readable));
+  readable.on('unpipe', readable.pause.bind(readable));
+
   return readable;
 }
 

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -301,18 +301,13 @@ const { Blob } = require('buffer');
 }
 
 {
-  // Ensure piping to duplexified async iterator trigger the data call
-  let i = 0;
+  // Ensure piping to duplexified async iterator without calling data does not trigger the data call
 
-  const data = ['a', 'b', 'c', 'd'];
+  const cb = common.mustNotCall();
 
-  const cb = common.mustCall((chunk) => {
-    assert.strictEqual(chunk, data[i++]);
-  }, 4);
-
-  Readable.from(data).pipe(Duplex.from(async function* stopAfterFirst(stream) {
+  Readable.from(['a', 'b', 'c', 'd']).pipe(Duplex.from(async function* stopAfterFirst(stream) {
     for await (const chunk of stream) {
-      cb(chunk);
+      cb();
       yield chunk;
     }
   }));

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -302,10 +302,9 @@ const { Blob } = require('buffer');
 
 {
   // Ensure piping to duplexified async iterator without calling data does not trigger the data call
-
   const cb = common.mustNotCall();
 
-  Readable.from(['a', 'b', 'c', 'd']).pipe(Duplex.from(async function* stopAfterFirst(stream) {
+  Readable.from(['a', 'b', 'c', 'd']).pipe(Duplex.from(async function*(stream) {
     for await (const chunk of stream) {
       cb();
       yield chunk;

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -299,3 +299,21 @@ const { Blob } = require('buffer');
     assert.strictEqual(res, 'foobar');
   })).on('close', common.mustCall());
 }
+
+{
+  // Ensure piping to duplexified async iterator trigger the data call
+  let i = 0;
+
+  const data = ['a', 'b', 'c', 'd'];
+
+  const cb = common.mustCall((chunk) => {
+    assert.strictEqual(chunk, data[i++]);
+  }, 4);
+
+  Readable.from(data).pipe(Duplex.from(async function* stopAfterFirst(stream) {
+    for await (const chunk of stream) {
+      cb(chunk);
+      yield chunk;
+    }
+  }));
+}

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -301,12 +301,17 @@ const { Blob } = require('buffer');
 }
 
 {
-  // Ensure piping to duplexified async iterator without calling data does not trigger the data call
-  const cb = common.mustNotCall();
+  // Ensure piping to duplexified async iterator trigger the data call
 
-  Readable.from(['a', 'b', 'c', 'd']).pipe(Duplex.from(async function*(stream) {
+  const data = ['a', 'b', 'c', 'd'];
+
+  const cb = common.mustCall((chunk) => {
+    assert.strictEqual(chunk, data.shift());
+  }, data.length);
+
+  Readable.from(data.slice(0)).pipe(Duplex.from(async function*(stream) {
     for await (const chunk of stream) {
-      cb();
+      cb(chunk);
       yield chunk;
     }
   }));

--- a/test/parallel/test-stream-pipeline-duplex.js
+++ b/test/parallel/test-stream-pipeline-duplex.js
@@ -29,7 +29,7 @@ const assert = require('assert');
   // Must call when last stream is Duplex from function
   pipeline(
     Readable.from(['a', 'b', 'c', 'd']),
-    Duplex.from(async function* stopAfterFirst(stream) {
+    Duplex.from(async function*(stream) {
       for await (const chunk of stream) {
         yield chunk;
       }

--- a/test/parallel/test-stream-pipeline-duplex.js
+++ b/test/parallel/test-stream-pipeline-duplex.js
@@ -1,21 +1,39 @@
 'use strict';
 
 const common = require('../common');
-const { pipeline, Duplex, PassThrough } = require('stream');
+const { pipeline, Duplex, PassThrough, Readable } = require('stream');
 const assert = require('assert');
 
-const remote = new PassThrough();
-const local = new Duplex({
-  read() {},
-  write(chunk, enc, callback) {
-    callback();
-  }
-});
+{
+  // Call pipeline error function with ERR_STREAM_PREMATURE_CLOSE error if dst close before src
+  const remote = new PassThrough();
+  const local = new Duplex({
+    read() {
+    },
+    write(chunk, enc, callback) {
+      callback();
+    },
+  });
 
-pipeline(remote, local, remote, common.mustCall((err) => {
-  assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
-}));
+  pipeline(remote, local, remote, common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
+  }));
 
-setImmediate(() => {
-  remote.end();
-});
+  setImmediate(() => {
+    remote.end();
+  });
+}
+
+
+{
+  // Must call when last stream is Duplex from function
+  pipeline(
+    Readable.from(['a', 'b', 'c', 'd']),
+    Duplex.from(async function* stopAfterFirst(stream) {
+      for await (const chunk of stream) {
+        yield chunk;
+      }
+    }),
+    common.mustSucceed(),
+  ).on('error', common.mustNotCall());
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


Fix #45533

I think this should be ported to the rest of node versions... 