### PR TITLE
fs: set fs.watchFile poll interval to 1s

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4448,6 +4448,9 @@ watch('somedir', (eventType, filename) => {
 <!-- YAML
 added: v0.1.31
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/45536
+    description: Changed default interval to 1000.
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: The `bigint` option is now supported.
@@ -4461,7 +4464,7 @@ changes:
 * `options` {Object}
   * `bigint` {boolean} **Default:** `false`
   * `persistent` {boolean} **Default:** `true`
-  * `interval` {integer} **Default:** `5007`
+  * `interval` {integer} **Default:** `1000`
 * `listener` {Function}
   * `current` {fs.Stats}
   * `previous` {fs.Stats}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2359,10 +2359,7 @@ function watchFile(filename, options, listener) {
   }
 
   options = {
-    // Poll interval in milliseconds. 5007 is what libev used to use. It's
-    // a little on the slow side but let's stick with it for now to keep
-    // behavioral changes to a minimum.
-    interval: 5007,
+    interval: 1000,
     persistent: true,
     ...options
   };


### PR DESCRIPTION
I couldn't find any reference in the libuv repo for the reason or usage of 5007ms interval. Hopefully this improves the `test.parallel/test-fs-watch-recursive` tests.

Hopefully, fixes https://github.com/nodejs/node/issues/45535