### PR TITLE
src,node-api: update `napi_is_detached_arraybuffer` using `ArrayBuffer::WasDetached`

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -3254,7 +3254,7 @@ napi_status NAPI_CDECL napi_is_detached_arraybuffer(napi_env env,
   v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(arraybuffer);
 
   *result =
-      value->IsArrayBuffer() && value.As<v8::ArrayBuffer>()->Data() == nullptr;
+      value->IsArrayBuffer() && value.As<v8::ArrayBuffer>()->WasDetached();
 
   return napi_clear_last_error(env);
 }


### PR DESCRIPTION
This updates `napi_is_detached_arraybuffer(...)` using the new API below which looks more straightforward.

https://github.com/nodejs/node/blob/db88483354cb364da9d81ffb75cd527beeac20aa/deps/v8/include/v8-array-buffer.h#L243-L246

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
