### PR TITLE
src,lib: group properties used as constants from `util` binding

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -67,11 +67,11 @@ const {
   kStringMaxLength
 } = internalBinding('buffer');
 const {
-  getOwnNonIndexProperties,
-  propertyFilter: {
+  constants: {
     ALL_PROPERTIES,
-    ONLY_ENUMERABLE
+    ONLY_ENUMERABLE,
   },
+  getOwnNonIndexProperties,
 } = internalBinding('util');
 const {
   customInspectSymbol,

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -80,12 +80,14 @@ const {
   validateInteger,
 } = require('internal/validators');
 const {
+  constants: {
+    kExitCode,
+    kExiting,
+    kHasExitCode,
+  },
   privateSymbols: {
     exit_info_private_symbol,
   },
-  kExitCode,
-  kExiting,
-  kHasExitCode,
 } = internalBinding('util');
 
 setupProcessObject();

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -46,11 +46,11 @@ const {
   isFloat64Array,
 } = types;
 const {
-  getOwnNonIndexProperties,
-  propertyFilter: {
+  constants: {
     ONLY_ENUMERABLE,
-    SKIP_SYMBOLS
-  }
+    SKIP_SYMBOLS,
+  },
+  getOwnNonIndexProperties,
 } = internalBinding('util');
 
 const kStrict = true;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -97,18 +97,18 @@ const {
 } = primordials;
 
 const {
+  constants: {
+    ALL_PROPERTIES,
+    ONLY_ENUMERABLE,
+    kPending,
+    kRejected,
+  },
   getOwnNonIndexProperties,
   getPromiseDetails,
   getProxyDetails,
-  kPending,
-  kRejected,
   previewEntries,
   getConstructorName: internalGetConstructorName,
   getExternalValue,
-  propertyFilter: {
-    ALL_PROPERTIES,
-    ONLY_ENUMERABLE
-  }
 } = internalBinding('util');
 
 const {

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -40,8 +40,10 @@ const {
 } = require('util');
 
 const {
+  constants: {
+    kPending,
+  },
   getPromiseDetails,
-  kPending,
 } = internalBinding('util');
 
 const assert = require('internal/assert');

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -166,11 +166,11 @@ const {
   setupReverseSearch,
 } = require('internal/repl/utils');
 const {
-  getOwnNonIndexProperties,
-  propertyFilter: {
+  constants: {
     ALL_PROPERTIES,
-    SKIP_SYMBOLS
-  }
+    SKIP_SYMBOLS,
+  },
+  getOwnNonIndexProperties,
 } = internalBinding('util');
 const {
   startSigintWatchdog,

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -365,7 +365,7 @@ void Initialize(Local<Object> target,
   Isolate* isolate = env->isolate();
 
   {
-    Local<v8::ObjectTemplate> tmpl = v8::ObjectTemplate::New(isolate);
+    Local<ObjectTemplate> tmpl = ObjectTemplate::New(isolate);
 #define V(PropertyName, _)                                                     \
   tmpl->Set(FIXED_ONE_BYTE_STRING(env->isolate(), #PropertyName),              \
             env->PropertyName());
@@ -381,7 +381,7 @@ void Initialize(Local<Object> target,
   }
 
   {
-    Local<Object> constants = Object::New(env->isolate());
+    Local<Object> constants = Object::New(isolate);
 #define V(name)                                                                \
   constants                                                                    \
       ->Set(context,                                                           \

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -381,10 +381,13 @@ void Initialize(Local<Object> target,
   }
 
   {
-    Local<ObjectTemplate> tmpl = ObjectTemplate::New(isolate);
+    Local<Object> constants = Object::New(env->isolate());
 #define V(name)                                                                \
-  tmpl->Set(FIXED_ONE_BYTE_STRING(isolate, #name),                             \
-            Integer::New(isolate, Promise::PromiseState::name));
+  constants                                                                    \
+      ->Set(context,                                                           \
+            FIXED_ONE_BYTE_STRING(isolate, #name),                             \
+            Integer::New(isolate, Promise::PromiseState::name))                \
+      .Check();
 
     V(kPending);
     V(kFulfilled);
@@ -392,8 +395,11 @@ void Initialize(Local<Object> target,
 #undef V
 
 #define V(name)                                                                \
-  tmpl->Set(FIXED_ONE_BYTE_STRING(isolate, #name),                             \
-            Integer::New(isolate, Environment::ExitInfoField::name));
+  constants                                                                    \
+      ->Set(context,                                                           \
+            FIXED_ONE_BYTE_STRING(isolate, #name),                             \
+            Integer::New(isolate, Environment::ExitInfoField::name))           \
+      .Check();
 
     V(kExiting);
     V(kExitCode);
@@ -401,8 +407,11 @@ void Initialize(Local<Object> target,
 #undef V
 
 #define V(name)                                                                \
-  tmpl->Set(FIXED_ONE_BYTE_STRING(isolate, #name),                             \
-            Integer::New(isolate, PropertyFilter::name));
+  constants                                                                    \
+      ->Set(context,                                                           \
+            FIXED_ONE_BYTE_STRING(isolate, #name),                             \
+            Integer::New(isolate, PropertyFilter::name))                       \
+      .Check();
 
     V(ALL_PROPERTIES);
     V(ONLY_WRITABLE);
@@ -412,11 +421,7 @@ void Initialize(Local<Object> target,
     V(SKIP_SYMBOLS);
 #undef V
 
-    target
-        ->Set(context,
-              env->constants_string(),
-              tmpl->NewInstance(context).ToLocalChecked())
-        .Check();
+    target->Set(context, env->constants_string(), constants).Check();
   }
 
   SetMethodNoSideEffect(


### PR DESCRIPTION
The ways to create properties used as constants are scattered in `util` internal binding. 
This PR gets them created in one code block and creates an object holding all of them.

Similar object patterns can be found in other bindings.

https://github.com/nodejs/node/blob/db88483354cb364da9d81ffb75cd527beeac20aa/lib/dgram.js#L71-L75
https://github.com/nodejs/node/blob/db88483354cb364da9d81ffb75cd527beeac20aa/lib/internal/perf/nodetiming.js#L21-L31

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
