### PR TITLE
src: add missing include for `std::all_of`

### DIFF
--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -6,6 +6,7 @@
 
 #include "openssl/sha.h"  // Sha-1 hash
 
+#include <algorithm>
 #include <cstring>
 #include <map>
 


### PR DESCRIPTION
This fixes compilation of src/inspector_socket.cc with clang-cl.
