### PR TITLE
src: avoid unused variables and functions

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -52,7 +52,9 @@ using v8_inspector::StringView;
 using v8_inspector::V8Inspector;
 using v8_inspector::V8InspectorClient;
 
+#ifdef __POSIX__
 static uv_sem_t start_io_thread_semaphore;
+#endif  // __POSIX__
 static uv_async_t start_io_thread_async;
 // This is just an additional check to make sure start_io_thread_async
 // is not accidentally re-used or used when uninitialized.

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -222,7 +222,7 @@ static bool libc_may_be_musl() {
   has_cached_retval = true;
   return retval;
 }
-#else  // __linux__
+#elif defined(__POSIX__)
 static bool libc_may_be_musl() { return false; }
 #endif  // __linux__
 

--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -456,12 +456,12 @@ static void Initialize(Local<Object> target,
                        Local<Value> unused,
                        Local<Context> context,
                        void* priv) {
-  Environment* env = Environment::GetCurrent(context);
-  Isolate* isolate = env->isolate();
-
   SetMethod(context, target, "safeGetenv", SafeGetenv);
 
 #ifdef NODE_IMPLEMENTS_POSIX_CREDENTIALS
+  Environment* env = Environment::GetCurrent(context);
+  Isolate* isolate = env->isolate();
+
   READONLY_TRUE_PROPERTY(target, "implementsPosixCredentials");
   SetMethodNoSideEffect(context, target, "getuid", GetUid);
   SetMethodNoSideEffect(context, target, "geteuid", GetEUid);


### PR DESCRIPTION
This fixes some warnings I saw with clang-cl on Windows.