### PR TITLE
build: avoid redefined macro

### DIFF
--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -93,7 +93,6 @@
         },
         'defines': [
           'U_ATTRIBUTE_DEPRECATED=',
-          '_CRT_SECURE_NO_DEPRECATE=',
           'U_STATIC_IMPLEMENTATION=1',
         ],
       },


### PR DESCRIPTION
It's already defined in `common.gypi`.
