### PR TITLE
src: define per-isolate internal bindings registration callback

### DIFF
--- a/src/async_wrap-inl.h
+++ b/src/async_wrap-inl.h
@@ -80,6 +80,12 @@ inline v8::MaybeLocal<v8::Value> AsyncWrap::MakeCallback(
   return MakeCallback(cb_v.As<v8::Function>(), argc, argv);
 }
 
+// static
+inline v8::Local<v8::FunctionTemplate> AsyncWrap::GetConstructorTemplate(
+    Environment* env) {
+  return GetConstructorTemplate(env->isolate_data());
+}
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -334,18 +334,20 @@ void AsyncWrap::SetCallbackTrampoline(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-Local<FunctionTemplate> AsyncWrap::GetConstructorTemplate(Environment* env) {
-  Local<FunctionTemplate> tmpl = env->async_wrap_ctor_template();
+Local<FunctionTemplate> AsyncWrap::GetConstructorTemplate(
+    IsolateData* isolate_data) {
+  Local<FunctionTemplate> tmpl = isolate_data->async_wrap_ctor_template();
   if (tmpl.IsEmpty()) {
-    Isolate* isolate = env->isolate();
+    Isolate* isolate = isolate_data->isolate();
     tmpl = NewFunctionTemplate(isolate, nullptr);
-    tmpl->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "AsyncWrap"));
-    tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
+    tmpl->SetClassName(
+        FIXED_ONE_BYTE_STRING(isolate_data->isolate(), "AsyncWrap"));
+    tmpl->Inherit(BaseObject::GetConstructorTemplate(isolate_data));
     SetProtoMethod(isolate, tmpl, "getAsyncId", AsyncWrap::GetAsyncId);
     SetProtoMethod(isolate, tmpl, "asyncReset", AsyncWrap::AsyncReset);
     SetProtoMethod(
         isolate, tmpl, "getProviderType", AsyncWrap::GetProviderType);
-    env->set_async_wrap_ctor_template(tmpl);
+    isolate_data->set_async_wrap_ctor_template(tmpl);
   }
   return tmpl;
 }

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -138,6 +138,8 @@ class AsyncWrap : public BaseObject {
   static constexpr double kInvalidAsyncId = -1;
 
   static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
+      IsolateData* isolate_data);
+  inline static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
       Environment* env);
 
   static void RegisterExternalReferences(ExternalReferenceRegistry* registry);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -827,6 +827,7 @@ void Environment::set_process_exit_handler(
 #undef VY
 #undef VP
 
+#define VM(PropertyName) V(PropertyName##_binding, v8::FunctionTemplate)
 #define V(PropertyName, TypeName)                                              \
   inline v8::Local<TypeName> IsolateData::PropertyName() const {               \
     return PropertyName##_.Get(isolate_);                                      \
@@ -835,7 +836,9 @@ void Environment::set_process_exit_handler(
     PropertyName##_.Set(isolate_, value);                                      \
   }
   PER_ISOLATE_TEMPLATE_PROPERTIES(V)
+  NODE_BINDINGS_WITH_PER_ISOLATE_INIT(VM)
 #undef V
+#undef VM
 
 #define VP(PropertyName, StringValue) V(v8::Private, PropertyName)
 #define VY(PropertyName, StringValue) V(v8::Symbol, PropertyName)

--- a/src/env.h
+++ b/src/env.h
@@ -155,11 +155,14 @@ class NODE_EXTERN_PRIVATE IsolateData : public MemoryRetainer {
 #undef VS
 #undef VP
 
+#define VM(PropertyName) V(PropertyName##_binding, v8::FunctionTemplate)
 #define V(PropertyName, TypeName)                                              \
   inline v8::Local<TypeName> PropertyName() const;                             \
   inline void set_##PropertyName(v8::Local<TypeName> value);
   PER_ISOLATE_TEMPLATE_PROPERTIES(V)
+  NODE_BINDINGS_WITH_PER_ISOLATE_INIT(VM)
 #undef V
+#undef VM
 
   inline v8::Local<v8::String> async_wrap_provider(int index) const;
 
@@ -179,6 +182,7 @@ class NODE_EXTERN_PRIVATE IsolateData : public MemoryRetainer {
 #define VP(PropertyName, StringValue) V(v8::Private, PropertyName)
 #define VY(PropertyName, StringValue) V(v8::Symbol, PropertyName)
 #define VS(PropertyName, StringValue) V(v8::String, PropertyName)
+#define VM(PropertyName) V(v8::FunctionTemplate, PropertyName##_binding)
 #define VT(PropertyName, TypeName) V(TypeName, PropertyName)
 #define V(TypeName, PropertyName)                                             \
   v8::Eternal<TypeName> PropertyName ## _;
@@ -186,8 +190,9 @@ class NODE_EXTERN_PRIVATE IsolateData : public MemoryRetainer {
   PER_ISOLATE_SYMBOL_PROPERTIES(VY)
   PER_ISOLATE_STRING_PROPERTIES(VS)
   PER_ISOLATE_TEMPLATE_PROPERTIES(VT)
+  NODE_BINDINGS_WITH_PER_ISOLATE_INIT(VM)
 #undef V
-#undef V
+#undef VM
 #undef VT
 #undef VS
 #undef VY
@@ -457,7 +462,6 @@ struct DeserializeRequest {
 };
 
 struct EnvSerializeInfo {
-  std::vector<std::string> builtins;
   AsyncHooks::SerializeInfo async_hooks;
   TickInfo::SerializeInfo tick_info;
   ImmediateInfo::SerializeInfo immediate_info;
@@ -714,13 +718,6 @@ class Environment : public MemoryRetainer {
 
   // List of id's that have been destroyed and need the destroy() cb called.
   inline std::vector<double>* destroy_async_id_list();
-
-  std::set<struct node_module*> internal_bindings;
-  std::set<std::string> builtins_with_cache;
-  std::set<std::string> builtins_without_cache;
-  // This is only filled during deserialization. We use a vector since
-  // it's only used for tests.
-  std::vector<std::string> builtins_in_snapshot;
 
   std::unordered_multimap<int, loader::ModuleWrap*> hash_to_module_map;
   std::unordered_map<uint32_t, loader::ModuleWrap*> id_to_module_map;

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -1,3 +1,4 @@
+#include "async_wrap-inl.h"
 #include "base_object-inl.h"
 #include "inspector_agent.h"
 #include "inspector_io.h"

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -102,6 +102,12 @@
 NODE_BUILTIN_BINDINGS(V)
 #undef V
 
+#define V(modname)                                                             \
+  void _register_isolate_##modname(node::IsolateData* isolate_data,            \
+                                   v8::Local<v8::FunctionTemplate> target);
+NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V)
+#undef V
+
 #ifdef _AIX
 // On AIX, dlopen() behaves differently from other operating systems, in that
 // it returns unique values from each call, rather than identical values, when
@@ -229,9 +235,12 @@ static bool libc_may_be_musl() { return false; }
 namespace node {
 
 using v8::Context;
+using v8::EscapableHandleScope;
 using v8::Exception;
-using v8::Function;
 using v8::FunctionCallbackInfo;
+using v8::FunctionTemplate;
+using v8::HandleScope;
+using v8::Isolate;
 using v8::Local;
 using v8::Object;
 using v8::String;
@@ -552,50 +561,86 @@ inline struct node_module* FindModule(struct node_module* list,
   return mp;
 }
 
-static Local<Object> InitInternalBinding(Environment* env,
-                                         node_module* mod,
-                                         Local<String> module) {
-  // Internal bindings don't have a "module" object, only exports.
-  Local<Function> ctor = env->binding_data_ctor_template()
-                             ->GetFunction(env->context())
-                             .ToLocalChecked();
-  Local<Object> exports = ctor->NewInstance(env->context()).ToLocalChecked();
+void CreateInternalBindingTemplates(IsolateData* isolate_data) {
+#define V(modname)                                                             \
+  do {                                                                         \
+    Local<FunctionTemplate> templ =                                            \
+        FunctionTemplate::New(isolate_data->isolate());                        \
+    templ->InstanceTemplate()->SetInternalFieldCount(                          \
+        BaseObject::kInternalFieldCount);                                      \
+    templ->Inherit(BaseObject::GetConstructorTemplate(isolate_data));          \
+    _register_isolate_##modname(isolate_data, templ);                          \
+    isolate_data->set_##modname##_binding(templ);                              \
+  } while (0);
+  NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V)
+#undef V
+}
+
+static Local<Object> GetInternalBindingExportObject(IsolateData* isolate_data,
+                                                    const char* mod_name,
+                                                    Local<Context> context) {
+  Local<FunctionTemplate> ctor;
+#define V(name)                                                                \
+  if (strcmp(mod_name, #name) == 0) {                                          \
+    ctor = isolate_data->name##_binding();                                     \
+  } else  // NOLINT(readability/braces)
+  NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V)
+#undef V
+  {
+    ctor = isolate_data->binding_data_ctor_template();
+  }
+
+  Local<Object> obj = ctor->GetFunction(context)
+                          .ToLocalChecked()
+                          ->NewInstance(context)
+                          .ToLocalChecked();
+  return obj;
+}
+
+static Local<Object> InitInternalBinding(Realm* realm, node_module* mod) {
+  EscapableHandleScope scope(realm->isolate());
+  Local<Context> context = realm->context();
+  Local<Object> exports = GetInternalBindingExportObject(
+      realm->isolate_data(), mod->nm_modname, context);
   CHECK_NULL(mod->nm_register_func);
   CHECK_NOT_NULL(mod->nm_context_register_func);
-  Local<Value> unused = Undefined(env->isolate());
-  mod->nm_context_register_func(exports, unused, env->context(), mod->nm_priv);
-  return exports;
+  Local<Value> unused = Undefined(realm->isolate());
+  // Internal bindings don't have a "module" object, only exports.
+  mod->nm_context_register_func(exports, unused, context, mod->nm_priv);
+  return scope.Escape(exports);
 }
 
 void GetInternalBinding(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  Realm* realm = Realm::GetCurrent(args);
+  Isolate* isolate = realm->isolate();
+  HandleScope scope(isolate);
+  Local<Context> context = realm->context();
 
   CHECK(args[0]->IsString());
 
   Local<String> module = args[0].As<String>();
-  node::Utf8Value module_v(env->isolate(), module);
+  node::Utf8Value module_v(isolate, module);
   Local<Object> exports;
 
   node_module* mod = FindModule(modlist_internal, *module_v, NM_F_INTERNAL);
   if (mod != nullptr) {
-    exports = InitInternalBinding(env, mod, module);
-    env->internal_bindings.insert(mod);
+    exports = InitInternalBinding(realm, mod);
+    realm->internal_bindings.insert(mod);
   } else if (!strcmp(*module_v, "constants")) {
-    exports = Object::New(env->isolate());
-    CHECK(
-        exports->SetPrototype(env->context(), Null(env->isolate())).FromJust());
-    DefineConstants(env->isolate(), exports);
+    exports = Object::New(isolate);
+    CHECK(exports->SetPrototype(context, Null(isolate)).FromJust());
+    DefineConstants(isolate, exports);
   } else if (!strcmp(*module_v, "natives")) {
-    exports = builtins::BuiltinLoader::GetSourceObject(env->context());
+    exports = builtins::BuiltinLoader::GetSourceObject(context);
     // Legacy feature: process.binding('natives').config contains stringified
     // config.gypi
     CHECK(exports
-              ->Set(env->context(),
-                    env->config_string(),
-                    builtins::BuiltinLoader::GetConfigString(env->isolate()))
+              ->Set(context,
+                    realm->isolate_data()->config_string(),
+                    builtins::BuiltinLoader::GetConfigString(isolate))
               .FromJust());
   } else {
-    return THROW_ERR_INVALID_MODULE(env, "No such binding: %s", *module_v);
+    return THROW_ERR_INVALID_MODULE(isolate, "No such binding: %s", *module_v);
   }
 
   args.GetReturnValue().Set(exports);

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -24,6 +24,8 @@ static_assert(static_cast<int>(NM_F_LINKED) ==
               static_cast<int>(node::ModuleFlags::kLinked),
               "NM_F_LINKED != node::ModuleFlags::kLinked");
 
+#define NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V) V(builtins)
+
 #define NODE_BINDING_CONTEXT_AWARE_CPP(modname, regfunc, priv, flags)          \
   static node::node_module _module = {                                         \
       NODE_MODULE_VERSION,                                                     \
@@ -44,8 +46,19 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
 
 namespace node {
 
+// Define a node internal binding that may be loaded in a context of
+// a node::Environment.
+// If an internal binding needs initializing per-isolate templates, define
+// with NODE_BINDING_PER_ISOLATE_INIT too.
 #define NODE_BINDING_CONTEXT_AWARE_INTERNAL(modname, regfunc)                  \
   NODE_BINDING_CONTEXT_AWARE_CPP(modname, regfunc, nullptr, NM_F_INTERNAL)
+
+// Define a per-isolate initialization function for a node internal binding.
+#define NODE_BINDING_PER_ISOLATE_INIT(modname, per_isolate_func)               \
+  void _register_isolate_##modname(node::IsolateData* isolate_data,            \
+                                   v8::Local<v8::FunctionTemplate> target) {   \
+    per_isolate_func(isolate_data, target);                                    \
+  }
 
 // Globals per process
 // This is set by node::Init() which is used by embedders
@@ -87,6 +100,8 @@ class DLib {
 // use the __attribute__((constructor)). Need to
 // explicitly call the _register* functions.
 void RegisterBuiltinBindings();
+// Create per-isolate templates for the internal bindings.
+void CreateInternalBindingTemplates(IsolateData* isolate_data);
 void GetInternalBinding(const v8::FunctionCallbackInfo<v8::Value>& args);
 void GetLinkedBinding(const v8::FunctionCallbackInfo<v8::Value>& args);
 void DLOpen(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -24,7 +24,9 @@ static_assert(static_cast<int>(NM_F_LINKED) ==
               static_cast<int>(node::ModuleFlags::kLinked),
               "NM_F_LINKED != node::ModuleFlags::kLinked");
 
-#define NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V) V(builtins)
+#define NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V)                                 \
+  V(builtins)                                                                  \
+  V(worker)
 
 #define NODE_BINDING_CONTEXT_AWARE_CPP(modname, regfunc, priv, flags)          \
   static node::node_module _module = {                                         \

--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -44,24 +44,24 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
   BuiltinLoader& operator=(const BuiltinLoader&) = delete;
 
   static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
-  static void Initialize(v8::Local<v8::Object> target,
-                         v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context,
-                         void* priv);
+  static void CreatePerIsolateProperties(
+      IsolateData* isolate_data, v8::Local<v8::FunctionTemplate> target);
+  static void CreatePerContextProperties(v8::Local<v8::Object> target,
+                                         v8::Local<v8::Value> unused,
+                                         v8::Local<v8::Context> context,
+                                         void* priv);
 
   // The parameters used to compile the scripts are detected based on
   // the pattern of the id.
   static v8::MaybeLocal<v8::Function> LookupAndCompile(
-      v8::Local<v8::Context> context,
-      const char* id,
-      Environment* optional_env);
+      v8::Local<v8::Context> context, const char* id, Realm* optional_realm);
 
   static v8::MaybeLocal<v8::Value> CompileAndCall(
       v8::Local<v8::Context> context,
       const char* id,
       int argc,
       v8::Local<v8::Value> argv[],
-      Environment* optional_env);
+      Realm* optional_realm);
 
   static v8::MaybeLocal<v8::Value> CompileAndCall(
       v8::Local<v8::Context> context, const char* id, Realm* realm);
@@ -118,7 +118,7 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
 
   static void RecordResult(const char* id,
                            BuiltinLoader::Result result,
-                           Environment* env);
+                           Realm* realm);
   static void GetBuiltinCategories(
       v8::Local<v8::Name> property,
       const v8::PropertyCallbackInfo<v8::Value>& info);

--- a/src/node_realm-inl.h
+++ b/src/node_realm-inl.h
@@ -30,6 +30,10 @@ inline Realm* Realm::GetCurrent(const v8::PropertyCallbackInfo<T>& info) {
   return GetCurrent(info.GetIsolate()->GetCurrentContext());
 }
 
+inline IsolateData* Realm::isolate_data() const {
+  return env_->isolate_data();
+}
+
 inline Environment* Realm::env() const {
   return env_;
 }

--- a/src/node_realm.h
+++ b/src/node_realm.h
@@ -12,6 +12,7 @@
 namespace node {
 
 struct RealmSerializeInfo {
+  std::vector<std::string> builtins;
   std::vector<PropInfo> persistent_values;
   std::vector<PropInfo> native_objects;
 
@@ -98,6 +99,13 @@ class Realm : public MemoryRetainer {
   inline void set_##PropertyName(v8::Local<TypeName> value);
   PER_REALM_STRONG_PERSISTENT_VALUES(V)
 #undef V
+
+  std::set<struct node_module*> internal_bindings;
+  std::set<std::string> builtins_with_cache;
+  std::set<std::string> builtins_without_cache;
+  // This is only filled during deserialization. We use a vector since
+  // it's only used for tests.
+  std::vector<std::string> builtins_in_snapshot;
 
  private:
   void InitializeContext(v8::Local<v8::Context> context,

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -99,6 +99,9 @@ std::ostream& operator<<(std::ostream& output,
 
 std::ostream& operator<<(std::ostream& output, const RealmSerializeInfo& i) {
   output << "{\n"
+         << "// -- builtins begins --\n"
+         << i.builtins << ",\n"
+         << "// -- builtins ends --\n"
          << "// -- persistent_values begins --\n"
          << i.persistent_values << ",\n"
          << "// -- persistent_values ends --\n"
@@ -112,9 +115,6 @@ std::ostream& operator<<(std::ostream& output, const RealmSerializeInfo& i) {
 
 std::ostream& operator<<(std::ostream& output, const EnvSerializeInfo& i) {
   output << "{\n"
-         << "// -- builtins begins --\n"
-         << i.builtins << ",\n"
-         << "// -- builtins ends --\n"
          << "// -- async_hooks begins --\n"
          << i.async_hooks << ",\n"
          << "// -- async_hooks ends --\n"
@@ -704,6 +704,7 @@ template <>
 RealmSerializeInfo FileReader::Read() {
   per_process::Debug(DebugCategory::MKSNAPSHOT, "Read<RealmSerializeInfo>()\n");
   RealmSerializeInfo result;
+  result.builtins = ReadVector<std::string>();
   result.persistent_values = ReadVector<PropInfo>();
   result.native_objects = ReadVector<PropInfo>();
   result.context = Read<SnapshotIndex>();
@@ -718,7 +719,8 @@ size_t FileWriter::Write(const RealmSerializeInfo& data) {
   }
 
   // Use += here to ensure order of evaluation.
-  size_t written_total = WriteVector<PropInfo>(data.persistent_values);
+  size_t written_total = WriteVector<std::string>(data.builtins);
+  written_total += WriteVector<PropInfo>(data.persistent_values);
   written_total += WriteVector<PropInfo>(data.native_objects);
   written_total += Write<SnapshotIndex>(data.context);
 
@@ -730,7 +732,6 @@ template <>
 EnvSerializeInfo FileReader::Read() {
   per_process::Debug(DebugCategory::MKSNAPSHOT, "Read<EnvSerializeInfo>()\n");
   EnvSerializeInfo result;
-  result.builtins = ReadVector<std::string>();
   result.async_hooks = Read<AsyncHooks::SerializeInfo>();
   result.tick_info = Read<TickInfo::SerializeInfo>();
   result.immediate_info = Read<ImmediateInfo::SerializeInfo>();
@@ -751,8 +752,7 @@ size_t FileWriter::Write(const EnvSerializeInfo& data) {
   }
 
   // Use += here to ensure order of evaluation.
-  size_t written_total = WriteVector<std::string>(data.builtins);
-  written_total += Write<AsyncHooks::SerializeInfo>(data.async_hooks);
+  size_t written_total = Write<AsyncHooks::SerializeInfo>(data.async_hooks);
   written_total += Write<TickInfo::SerializeInfo>(data.tick_info);
   written_total += Write<ImmediateInfo::SerializeInfo>(data.immediate_info);
   written_total += Write<performance::PerformanceState::SerializeInfo>(

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -34,6 +34,7 @@ using v8::MaybeLocal;
 using v8::Null;
 using v8::Number;
 using v8::Object;
+using v8::ObjectTemplate;
 using v8::ResourceConstraints;
 using v8::SealHandleScope;
 using v8::String;
@@ -882,19 +883,17 @@ void GetEnvMessagePort(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-void InitWorker(Local<Object> target,
-                Local<Value> unused,
-                Local<Context> context,
-                void* priv) {
-  Environment* env = Environment::GetCurrent(context);
-  Isolate* isolate = env->isolate();
+void CreateWorkerPerIsolateProperties(IsolateData* isolate_data,
+                                      Local<FunctionTemplate> target) {
+  Isolate* isolate = isolate_data->isolate();
+  Local<ObjectTemplate> proto = target->PrototypeTemplate();
 
   {
     Local<FunctionTemplate> w = NewFunctionTemplate(isolate, Worker::New);
 
     w->InstanceTemplate()->SetInternalFieldCount(
         Worker::kInternalFieldCount);
-    w->Inherit(AsyncWrap::GetConstructorTemplate(env));
+    w->Inherit(AsyncWrap::GetConstructorTemplate(isolate_data));
 
     SetProtoMethod(isolate, w, "startThread", Worker::StartThread);
     SetProtoMethod(isolate, w, "stopThread", Worker::StopThread);
@@ -906,7 +905,7 @@ void InitWorker(Local<Object> target,
     SetProtoMethod(isolate, w, "loopIdleTime", Worker::LoopIdleTime);
     SetProtoMethod(isolate, w, "loopStartTime", Worker::LoopStartTime);
 
-    SetConstructorFunction(context, target, "Worker", w);
+    SetConstructorFunction(isolate, proto, "Worker", w);
   }
 
   {
@@ -914,15 +913,24 @@ void InitWorker(Local<Object> target,
 
     wst->InstanceTemplate()->SetInternalFieldCount(
         WorkerHeapSnapshotTaker::kInternalFieldCount);
-    wst->Inherit(AsyncWrap::GetConstructorTemplate(env));
+    wst->Inherit(AsyncWrap::GetConstructorTemplate(isolate_data));
 
     Local<String> wst_string =
         FIXED_ONE_BYTE_STRING(isolate, "WorkerHeapSnapshotTaker");
     wst->SetClassName(wst_string);
-    env->set_worker_heap_snapshot_taker_template(wst->InstanceTemplate());
+    isolate_data->set_worker_heap_snapshot_taker_template(
+        wst->InstanceTemplate());
   }
 
-  SetMethod(context, target, "getEnvMessagePort", GetEnvMessagePort);
+  SetMethod(isolate, proto, "getEnvMessagePort", GetEnvMessagePort);
+}
+
+void CreateWorkerPerContextProperties(Local<Object> target,
+                                      Local<Value> unused,
+                                      Local<Context> context,
+                                      void* priv) {
+  Environment* env = Environment::GetCurrent(context);
+  Isolate* isolate = env->isolate();
 
   target
       ->Set(env->context(),
@@ -975,6 +983,9 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace worker
 }  // namespace node
 
-NODE_BINDING_CONTEXT_AWARE_INTERNAL(worker, node::worker::InitWorker)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(
+    worker, node::worker::CreateWorkerPerContextProperties)
+NODE_BINDING_PER_ISOLATE_INIT(worker,
+                              node::worker::CreateWorkerPerIsolateProperties)
 NODE_BINDING_EXTERNAL_REFERENCE(worker,
                                 node::worker::RegisterExternalReferences)

--- a/src/util.cc
+++ b/src/util.cc
@@ -56,9 +56,13 @@ static std::atomic_int seq = {0};  // Sequence number for diagnostic filenames.
 namespace node {
 
 using v8::ArrayBufferView;
+using v8::Context;
+using v8::FunctionTemplate;
 using v8::Isolate;
 using v8::Local;
+using v8::Object;
 using v8::String;
+using v8::Template;
 using v8::Value;
 
 template <typename T>
@@ -482,14 +486,33 @@ void SetConstructorFunction(Local<v8::Context> context,
       context, that, OneByteString(isolate, name), tmpl, flag);
 }
 
-void SetConstructorFunction(Local<v8::Context> context,
-                            Local<v8::Object> that,
-                            Local<v8::String> name,
-                            Local<v8::FunctionTemplate> tmpl,
+void SetConstructorFunction(Local<Context> context,
+                            Local<Object> that,
+                            Local<String> name,
+                            Local<FunctionTemplate> tmpl,
                             SetConstructorFunctionFlag flag) {
   if (LIKELY(flag == SetConstructorFunctionFlag::SET_CLASS_NAME))
     tmpl->SetClassName(name);
   that->Set(context, name, tmpl->GetFunction(context).ToLocalChecked()).Check();
+}
+
+void SetConstructorFunction(Isolate* isolate,
+                            Local<Template> that,
+                            const char* name,
+                            Local<FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag) {
+  SetConstructorFunction(
+      isolate, that, OneByteString(isolate, name), tmpl, flag);
+}
+
+void SetConstructorFunction(Isolate* isolate,
+                            Local<Template> that,
+                            Local<String> name,
+                            Local<FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag) {
+  if (LIKELY(flag == SetConstructorFunctionFlag::SET_CLASS_NAME))
+    tmpl->SetClassName(name);
+  that->Set(name, tmpl);
 }
 
 }  // namespace node

--- a/src/util.cc
+++ b/src/util.cc
@@ -356,6 +356,23 @@ void SetMethod(Local<v8::Context> context,
   function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
 }
 
+void SetMethod(v8::Isolate* isolate,
+               v8::Local<v8::Template> that,
+               const char* name,
+               v8::FunctionCallback callback) {
+  Local<v8::FunctionTemplate> t =
+      NewFunctionTemplate(isolate,
+                          callback,
+                          Local<v8::Signature>(),
+                          v8::ConstructorBehavior::kThrow,
+                          v8::SideEffectType::kHasSideEffect);
+  // kInternalized strings are created in the old space.
+  const v8::NewStringType type = v8::NewStringType::kInternalized;
+  Local<v8::String> name_string =
+      v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+  that->Set(name_string, t);
+}
+
 void SetFastMethod(Local<v8::Context> context,
                    Local<v8::Object> that,
                    const char* name,

--- a/src/util.h
+++ b/src/util.h
@@ -930,6 +930,20 @@ void SetConstructorFunction(v8::Local<v8::Context> context,
                             SetConstructorFunctionFlag flag =
                                 SetConstructorFunctionFlag::SET_CLASS_NAME);
 
+void SetConstructorFunction(v8::Isolate* isolate,
+                            v8::Local<v8::Template> that,
+                            const char* name,
+                            v8::Local<v8::FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag =
+                                SetConstructorFunctionFlag::SET_CLASS_NAME);
+
+void SetConstructorFunction(v8::Isolate* isolate,
+                            v8::Local<v8::Template> that,
+                            v8::Local<v8::String> name,
+                            v8::Local<v8::FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag =
+                                SetConstructorFunctionFlag::SET_CLASS_NAME);
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/util.h
+++ b/src/util.h
@@ -879,6 +879,11 @@ void SetMethod(v8::Local<v8::Context> context,
                v8::Local<v8::Object> that,
                const char* name,
                v8::FunctionCallback callback);
+// Similar to SetProtoMethod but without receiver signature checks.
+void SetMethod(v8::Isolate* isolate,
+               v8::Local<v8::Template> that,
+               const char* name,
+               v8::FunctionCallback callback);
 
 void SetFastMethod(v8::Local<v8::Context> context,
                    v8::Local<v8::Object> that,


### PR DESCRIPTION
Bindings that need to be loaded in distinct contexts of node::Realm in
the same node::Environment instance needs to share the per-isolate
templates.

Add a new binding registration callback, which is called with
per-IsolateData. This allows bindings to define templates and
share them across realms eagerly, and avoid accidental modification on
the templates when the per-context callback is called multiple times.

This also tracks loaded bindings and built-in modules with node::Realm.

Refs: https://github.com/nodejs/node/issues/42528