### PR TITLE
src: rename internal module declaration as internal bindings

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -419,9 +419,9 @@ void Initialize(Local<Object> target,
   SetConstructorFunction(context, target, "ChannelWrap", channel_wrap);
 }
 
-// Run the `Initialize` function when loading this module through
+// Run the `Initialize` function when loading this binding through
 // `internalBinding('cares_wrap')` in Node.js's built-in JavaScript code:
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(cares_wrap, Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(cares_wrap, Initialize)
 ```
 
 If the C++ binding is loaded during bootstrap, it needs to be registered
@@ -438,10 +438,10 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace util
 }  // namespace node
 
-// The first argument passed to `NODE_MODULE_EXTERNAL_REFERENCE`,
+// The first argument passed to `NODE_BINDING_EXTERNAL_REFERENCE`,
 // which is `util` here, needs to be added to the
 // `EXTERNAL_REFERENCE_BINDING_LIST_BASE` list in node_external_reference.h
-NODE_MODULE_EXTERNAL_REFERENCE(util, node::util::RegisterExternalReferences)
+NODE_BINDING_EXTERNAL_REFERENCE(util, node::util::RegisterExternalReferences)
 ```
 
 Otherwise, you might see an error message like this when building the

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -703,6 +703,6 @@ Local<Object> AsyncWrap::GetOwner(Environment* env, Local<Object> obj) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(async_wrap, node::AsyncWrap::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(async_wrap,
-                               node::AsyncWrap::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(async_wrap, node::AsyncWrap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(async_wrap,
+                                node::AsyncWrap::RegisterExternalReferences)

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1976,6 +1976,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace cares_wrap
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(cares_wrap, node::cares_wrap::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(cares_wrap,
-                               node::cares_wrap::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(cares_wrap, node::cares_wrap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(cares_wrap,
+                                node::cares_wrap::RegisterExternalReferences)

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -2155,6 +2155,6 @@ void TLSWrap::RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace crypto
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(tls_wrap, node::crypto::TLSWrap::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(tls_wrap, node::crypto::TLSWrap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(
     tls_wrap, node::crypto::TLSWrap::RegisterExternalReferences)

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -237,6 +237,7 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
 }  // anonymous namespace
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(fs_event_wrap, node::FSEventWrap::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(fs_event_wrap,
-                               node::FSEventWrap::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(fs_event_wrap,
+                                    node::FSEventWrap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(fs_event_wrap,
+                                node::FSEventWrap::RegisterExternalReferences)

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -181,5 +181,5 @@ void HandleWrap::RegisterExternalReferences(
 
 }  // namespace node
 
-NODE_MODULE_EXTERNAL_REFERENCE(handle_wrap,
-                               node::HandleWrap::RegisterExternalReferences)
+NODE_BINDING_EXTERNAL_REFERENCE(handle_wrap,
+                                node::HandleWrap::RegisterExternalReferences)

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -486,6 +486,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace heap
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(heap_utils, node::heap::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(heap_utils,
-                               node::heap::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(heap_utils, node::heap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(heap_utils,
+                                node::heap::RegisterExternalReferences)

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -399,7 +399,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace inspector
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(inspector,
-                                  node::inspector::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(inspector,
-                               node::inspector::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(inspector, node::inspector::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(inspector,
+                                node::inspector::RegisterExternalReferences)

--- a/src/inspector_profiler.cc
+++ b/src/inspector_profiler.cc
@@ -524,6 +524,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace profiler
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(profiler, node::profiler::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(profiler,
-                               node::profiler::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(profiler, node::profiler::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(profiler,
+                                node::profiler::RegisterExternalReferences)

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -216,4 +216,4 @@ void JSStream::Initialize(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(js_stream, node::JSStream::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(js_stream, node::JSStream::Initialize)

--- a/src/js_udp_wrap.cc
+++ b/src/js_udp_wrap.cc
@@ -217,4 +217,4 @@ void JSUDPWrap::Initialize(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(js_udp_wrap, node::JSUDPWrap::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(js_udp_wrap, node::JSUDPWrap::Initialize)

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -814,5 +814,5 @@ void ModuleWrap::Initialize(Local<Object> target,
 }  // namespace loader
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(module_wrap,
-                                   node::loader::ModuleWrap::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(module_wrap,
+                                    node::loader::ModuleWrap::Initialize)

--- a/src/node.cc
+++ b/src/node.cc
@@ -749,7 +749,7 @@ static ExitCode InitializeNodeWithArgsInternal(
   // Initialize node_start_time to get relative uptime.
   per_process::node_start_time = uv_hrtime();
 
-  // Register built-in modules
+  // Register built-in bindings
   binding::RegisterBuiltinBindings();
 
   // Make inherited handles noninheritable.

--- a/src/node.cc
+++ b/src/node.cc
@@ -750,7 +750,7 @@ static ExitCode InitializeNodeWithArgsInternal(
   per_process::node_start_time = uv_hrtime();
 
   // Register built-in modules
-  binding::RegisterBuiltinModules();
+  binding::RegisterBuiltinBindings();
 
   // Make inherited handles noninheritable.
   if (!(flags & ProcessInitializationFlags::kEnableStdioInheritance) &&
@@ -1250,5 +1250,5 @@ int Stop(Environment* env) {
 #if !HAVE_INSPECTOR
 void Initialize() {}
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(inspector, Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(inspector, Initialize)
 #endif  // !HAVE_INSPECTOR

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -652,7 +652,7 @@ void GetLinkedBinding(const FunctionCallbackInfo<Value>& args) {
 }
 
 // Call built-in bindings' _register_<module name> function to
-// do module registration explicitly.
+// do binding registration explicitly.
 void RegisterBuiltinBindings() {
 #define V(modname) _register_##modname();
   NODE_BUILTIN_BINDINGS(V)

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -9,30 +9,30 @@
 #include <string>
 
 #if HAVE_OPENSSL
-#define NODE_BUILTIN_OPENSSL_MODULES(V) V(crypto) V(tls_wrap)
+#define NODE_BUILTIN_OPENSSL_BINDINGS(V) V(crypto) V(tls_wrap)
 #else
-#define NODE_BUILTIN_OPENSSL_MODULES(V)
+#define NODE_BUILTIN_OPENSSL_BINDINGS(V)
 #endif
 
 #if NODE_HAVE_I18N_SUPPORT
-#define NODE_BUILTIN_ICU_MODULES(V) V(icu)
+#define NODE_BUILTIN_ICU_BINDINGS(V) V(icu)
 #else
-#define NODE_BUILTIN_ICU_MODULES(V)
+#define NODE_BUILTIN_ICU_BINDINGS(V)
 #endif
 
 #if HAVE_INSPECTOR
-#define NODE_BUILTIN_PROFILER_MODULES(V) V(profiler)
+#define NODE_BUILTIN_PROFILER_BINDINGS(V) V(profiler)
 #else
-#define NODE_BUILTIN_PROFILER_MODULES(V)
+#define NODE_BUILTIN_PROFILER_BINDINGS(V)
 #endif
 
-// A list of built-in modules. In order to do module registration
-// in node::Init(), need to add built-in modules in the following list.
-// Then in binding::RegisterBuiltinModules(), it calls modules' registration
-// function. This helps the built-in modules are loaded properly when
+// A list of built-in bindings. In order to do binding registration
+// in node::Init(), need to add built-in bindings in the following list.
+// Then in binding::RegisterBuiltinBindings(), it calls bindings' registration
+// function. This helps the built-in bindings are loaded properly when
 // node is built as static library. No need to depend on the
 // __attribute__((constructor)) like mechanism in GCC.
-#define NODE_BUILTIN_STANDARD_MODULES(V)                                       \
+#define NODE_BUILTIN_STANDARD_BINDINGS(V)                                      \
   V(async_wrap)                                                                \
   V(blob)                                                                      \
   V(block_list)                                                                \
@@ -86,20 +86,20 @@
   V(worker)                                                                    \
   V(zlib)
 
-#define NODE_BUILTIN_MODULES(V)                                                \
-  NODE_BUILTIN_STANDARD_MODULES(V)                                             \
-  NODE_BUILTIN_OPENSSL_MODULES(V)                                              \
-  NODE_BUILTIN_ICU_MODULES(V)                                                  \
-  NODE_BUILTIN_PROFILER_MODULES(V)
+#define NODE_BUILTIN_BINDINGS(V)                                               \
+  NODE_BUILTIN_STANDARD_BINDINGS(V)                                            \
+  NODE_BUILTIN_OPENSSL_BINDINGS(V)                                             \
+  NODE_BUILTIN_ICU_BINDINGS(V)                                                 \
+  NODE_BUILTIN_PROFILER_BINDINGS(V)
 
-// This is used to load built-in modules. Instead of using
+// This is used to load built-in bindings. Instead of using
 // __attribute__((constructor)), we call the _register_<modname>
-// function for each built-in modules explicitly in
-// binding::RegisterBuiltinModules(). This is only forward declaration.
-// The definitions are in each module's implementation when calling
-// the NODE_MODULE_CONTEXT_AWARE_INTERNAL.
+// function for each built-in bindings explicitly in
+// binding::RegisterBuiltinBindings(). This is only forward declaration.
+// The definitions are in each binding's implementation when calling
+// the NODE_BINDING_CONTEXT_AWARE_INTERNAL.
 #define V(modname) void _register_##modname();
-NODE_BUILTIN_MODULES(V)
+NODE_BUILTIN_BINDINGS(V)
 #undef V
 
 #ifdef _AIX
@@ -552,9 +552,9 @@ inline struct node_module* FindModule(struct node_module* list,
   return mp;
 }
 
-static Local<Object> InitModule(Environment* env,
-                                node_module* mod,
-                                Local<String> module) {
+static Local<Object> InitInternalBinding(Environment* env,
+                                         node_module* mod,
+                                         Local<String> module) {
   // Internal bindings don't have a "module" object, only exports.
   Local<Function> ctor = env->binding_data_ctor_template()
                              ->GetFunction(env->context())
@@ -578,7 +578,7 @@ void GetInternalBinding(const FunctionCallbackInfo<Value>& args) {
 
   node_module* mod = FindModule(modlist_internal, *module_v, NM_F_INTERNAL);
   if (mod != nullptr) {
-    exports = InitModule(env, mod, module);
+    exports = InitInternalBinding(env, mod, module);
     env->internal_bindings.insert(mod);
   } else if (!strcmp(*module_v, "constants")) {
     exports = Object::New(env->isolate());
@@ -595,7 +595,7 @@ void GetInternalBinding(const FunctionCallbackInfo<Value>& args) {
                     builtins::BuiltinLoader::GetConfigString(env->isolate()))
               .FromJust());
   } else {
-    return THROW_ERR_INVALID_MODULE(env, "No such module: %s", *module_v);
+    return THROW_ERR_INVALID_MODULE(env, "No such binding: %s", *module_v);
   }
 
   args.GetReturnValue().Set(exports);
@@ -626,7 +626,7 @@ void GetLinkedBinding(const FunctionCallbackInfo<Value>& args) {
 
   if (mod == nullptr) {
     return THROW_ERR_INVALID_MODULE(
-        env, "No such module was linked: %s", *module_name_v);
+        env, "No such binding was linked: %s", *module_name_v);
   }
 
   Local<Object> module = Object::New(env->isolate());
@@ -642,8 +642,7 @@ void GetLinkedBinding(const FunctionCallbackInfo<Value>& args) {
     mod->nm_register_func(exports, module, mod->nm_priv);
   } else {
     return THROW_ERR_INVALID_MODULE(
-        env,
-        "Linked moduled has no declared entry point.");
+        env, "Linked binding has no declared entry point.");
   }
 
   auto effective_exports =
@@ -652,11 +651,11 @@ void GetLinkedBinding(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(effective_exports);
 }
 
-// Call built-in modules' _register_<module name> function to
+// Call built-in bindings' _register_<module name> function to
 // do module registration explicitly.
-void RegisterBuiltinModules() {
+void RegisterBuiltinBindings() {
 #define V(modname) _register_##modname();
-  NODE_BUILTIN_MODULES(V)
+  NODE_BUILTIN_BINDINGS(V)
 #undef V
 }
 
@@ -668,5 +667,5 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace binding
 }  // namespace node
 
-NODE_MODULE_EXTERNAL_REFERENCE(binding,
-                               node::binding::RegisterExternalReferences)
+NODE_BINDING_EXTERNAL_REFERENCE(binding,
+                                node::binding::RegisterExternalReferences)

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -24,7 +24,7 @@ static_assert(static_cast<int>(NM_F_LINKED) ==
               static_cast<int>(node::ModuleFlags::kLinked),
               "NM_F_LINKED != node::ModuleFlags::kLinked");
 
-#define NODE_MODULE_CONTEXT_AWARE_CPP(modname, regfunc, priv, flags)           \
+#define NODE_BINDING_CONTEXT_AWARE_CPP(modname, regfunc, priv, flags)          \
   static node::node_module _module = {                                         \
       NODE_MODULE_VERSION,                                                     \
       flags,                                                                   \
@@ -44,8 +44,8 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
 
 namespace node {
 
-#define NODE_MODULE_CONTEXT_AWARE_INTERNAL(modname, regfunc)                   \
-  NODE_MODULE_CONTEXT_AWARE_CPP(modname, regfunc, nullptr, NM_F_INTERNAL)
+#define NODE_BINDING_CONTEXT_AWARE_INTERNAL(modname, regfunc)                  \
+  NODE_BINDING_CONTEXT_AWARE_CPP(modname, regfunc, nullptr, NM_F_INTERNAL)
 
 // Globals per process
 // This is set by node::Init() which is used by embedders
@@ -83,10 +83,10 @@ class DLib {
 };
 
 // Call _register<module_name> functions for all of
-// the built-in modules. Because built-in modules don't
+// the built-in bindings. Because built-in bindings don't
 // use the __attribute__((constructor)). Need to
 // explicitly call the _register* functions.
-void RegisterBuiltinModules();
+void RegisterBuiltinBindings();
 void GetInternalBinding(const v8::FunctionCallbackInfo<v8::Value>& args);
 void GetLinkedBinding(const v8::FunctionCallbackInfo<v8::Value>& args);
 void DLOpen(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -499,5 +499,5 @@ void Blob::RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(blob, node::Blob::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(blob, node::Blob::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(blob, node::Blob::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(blob, node::Blob::RegisterExternalReferences)

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1425,5 +1425,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace Buffer
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(buffer, node::Buffer::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(buffer, node::Buffer::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(buffer, node::Buffer::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(buffer,
+                                node::Buffer::RegisterExternalReferences)

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -747,7 +747,7 @@ void BuiltinLoader::RegisterExternalReferences(
 }  // namespace builtins
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(builtins,
-                                   node::builtins::BuiltinLoader::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(builtins,
+                                    node::builtins::BuiltinLoader::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(
     builtins, node::builtins::BuiltinLoader::RegisterExternalReferences)

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -80,4 +80,4 @@ static void Initialize(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(config, node::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(config, node::Initialize)

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1425,6 +1425,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace contextify
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(contextify, node::contextify::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(contextify,
-                               node::contextify::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(contextify, node::contextify::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(contextify,
+                                node::contextify::RegisterExternalReferences)

--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -483,6 +483,6 @@ static void Initialize(Local<Object> target,
 }  // namespace credentials
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(credentials, node::credentials::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(credentials,
-                               node::credentials::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(credentials, node::credentials::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(credentials,
+                                node::credentials::RegisterExternalReferences)

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -92,5 +92,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace crypto
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(crypto, node::crypto::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(crypto, node::crypto::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(crypto, node::crypto::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(crypto,
+                                node::crypto::RegisterExternalReferences)

--- a/src/node_dir.cc
+++ b/src/node_dir.cc
@@ -425,5 +425,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 
 }  // end namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(fs_dir, node::fs_dir::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(fs_dir, node::fs_dir::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(fs_dir, node::fs_dir::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(fs_dir,
+                                node::fs_dir::RegisterExternalReferences)

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -462,4 +462,4 @@ void RegisterEnvVarExternalReferences(ExternalReferenceRegistry* registry) {
 }
 }  // namespace node
 
-NODE_MODULE_EXTERNAL_REFERENCE(env_var, node::RegisterEnvVarExternalReferences)
+NODE_BINDING_EXTERNAL_REFERENCE(env_var, node::RegisterEnvVarExternalReferences)

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -1180,5 +1180,6 @@ void TriggerUncaughtException(Isolate* isolate, const v8::TryCatch& try_catch) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(errors, node::errors::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(errors, node::errors::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(errors, node::errors::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(errors,
+                                node::errors::RegisterExternalReferences)

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -128,14 +128,14 @@ class ExternalReferenceRegistry {
 }  // namespace node
 
 // Declare all the external reference registration functions here,
-// and define them later with #NODE_MODULE_EXTERNAL_REFERENCE(modname, func);
+// and define them later with #NODE_BINDING_EXTERNAL_REFERENCE(modname, func);
 #define V(modname)                                                             \
   void _register_external_reference_##modname(                                 \
       node::ExternalReferenceRegistry* registry);
 EXTERNAL_REFERENCE_BINDING_LIST(V)
 #undef V
 
-#define NODE_MODULE_EXTERNAL_REFERENCE(modname, func)                          \
+#define NODE_BINDING_EXTERNAL_REFERENCE(modname, func)                         \
   void _register_external_reference_##modname(                                 \
       node::ExternalReferenceRegistry* registry) {                             \
     func(registry);                                                            \

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2784,5 +2784,5 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 
 }  // end namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(fs, node::fs::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(fs, node::fs::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(fs, node::fs::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(fs, node::fs::RegisterExternalReferences)

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -3358,4 +3358,4 @@ void Initialize(Local<Object> target,
 }  // namespace http2
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(http2, node::http2::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(http2, node::http2::Initialize)

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -1277,4 +1277,4 @@ void InitializeHttpParser(Local<Object> target,
 }  // anonymous namespace
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(http_parser, node::InitializeHttpParser)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(http_parser, node::InitializeHttpParser)

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -903,7 +903,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace i18n
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(icu, node::i18n::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(icu, node::i18n::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(icu, node::i18n::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(icu, node::i18n::RegisterExternalReferences)
 
 #endif  // NODE_HAVE_I18N_SUPPORT

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -1520,6 +1520,6 @@ static void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace worker
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(messaging, node::worker::InitMessaging)
-NODE_MODULE_EXTERNAL_REFERENCE(messaging,
-                               node::worker::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(messaging, node::worker::InitMessaging)
+NODE_BINDING_EXTERNAL_REFERENCE(messaging,
+                                node::worker::RegisterExternalReferences)

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1291,6 +1291,6 @@ std::vector<std::string> ParseNodeOptionsEnvVar(
 }
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(options, node::options_parser::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(options,
-                               node::options_parser::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(options, node::options_parser::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(
+    options, node::options_parser::RegisterExternalReferences)

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -423,5 +423,5 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace os
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(os, node::os::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(os, node::os::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(os, node::os::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(os, node::os::RegisterExternalReferences)

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -387,6 +387,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace performance
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(performance, node::performance::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(performance,
-                               node::performance::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(performance, node::performance::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(performance,
+                                node::performance::RegisterExternalReferences)

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -629,6 +629,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace process
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(process_methods, node::process::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(process_methods,
-                               node::process::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(process_methods, node::process::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(process_methods,
+                                node::process::RegisterExternalReferences)

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -229,5 +229,5 @@ void RegisterProcessExternalReferences(ExternalReferenceRegistry* registry) {
 
 }  // namespace node
 
-NODE_MODULE_EXTERNAL_REFERENCE(process_object,
-                               node::RegisterProcessExternalReferences)
+NODE_BINDING_EXTERNAL_REFERENCE(process_object,
+                                node::RegisterProcessExternalReferences)

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -217,5 +217,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace report
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(report, node::report::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(report, node::report::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(report, node::report::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(report,
+                                node::report::RegisterExternalReferences)

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -540,5 +540,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace serdes
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(serdes, node::serdes::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(serdes, node::serdes::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(serdes, node::serdes::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(serdes,
+                                node::serdes::RegisterExternalReferences)

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1503,6 +1503,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace mksnapshot
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(mksnapshot, node::mksnapshot::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(mksnapshot,
-                               node::mksnapshot::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(mksnapshot, node::mksnapshot::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(mksnapshot,
+                                node::mksnapshot::RegisterExternalReferences)

--- a/src/node_sockaddr.cc
+++ b/src/node_sockaddr.cc
@@ -886,6 +886,5 @@ BaseObjectPtr<BaseObject> SocketAddressBase::TransferData::Deserialize(
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(
-    block_list,
-    node::SocketAddressBlockListWrap::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(
+    block_list, node::SocketAddressBlockListWrap::Initialize)

--- a/src/node_symbols.cc
+++ b/src/node_symbols.cc
@@ -29,4 +29,4 @@ static void Initialize(Local<Object> target,
 }  // namespace symbols
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(symbols, node::symbols::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(symbols, node::symbols::Initialize)

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -226,6 +226,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace task_queue
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(task_queue, node::task_queue::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(task_queue,
-                               node::task_queue::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(task_queue, node::task_queue::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(task_queue,
+                                node::task_queue::RegisterExternalReferences)

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -168,7 +168,7 @@ void NodeCategorySet::RegisterExternalReferences(
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(trace_events,
-                                   node::NodeCategorySet::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(trace_events,
+                                    node::NodeCategorySet::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(
     trace_events, node::NodeCategorySet::RegisterExternalReferences)

--- a/src/node_types.cc
+++ b/src/node_types.cc
@@ -85,5 +85,5 @@ void RegisterTypesExternalReferences(ExternalReferenceRegistry* registry) {
 }
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(types, node::InitializeTypes)
-NODE_MODULE_EXTERNAL_REFERENCE(types, node::RegisterTypesExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(types, node::InitializeTypes)
+NODE_BINDING_EXTERNAL_REFERENCE(types, node::RegisterTypesExternalReferences)

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1943,5 +1943,5 @@ MaybeLocal<Value> URL::ToObject(Environment* env) const {
 }  // namespace url
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(url, node::url::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(url, node::url::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(url, node::url::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(url, node::url::RegisterExternalReferences)

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -450,5 +450,5 @@ void Initialize(Local<Object> target,
 }  // namespace util
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(util, node::util::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(util, node::util::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(util, node::util::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(util, node::util::RegisterExternalReferences)

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -286,5 +286,5 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace v8_utils
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(v8, node::v8_utils::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(v8, node::v8_utils::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(v8, node::v8_utils::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(v8, node::v8_utils::RegisterExternalReferences)

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -1733,4 +1733,4 @@ static void Initialize(Local<Object> target,
 }  // namespace wasi
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(wasi, node::wasi::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(wasi, node::wasi::Initialize)

--- a/src/node_wasm_web_api.cc
+++ b/src/node_wasm_web_api.cc
@@ -208,6 +208,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace wasm_web_api
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(wasm_web_api, node::wasm_web_api::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(wasm_web_api,
-                               node::wasm_web_api::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(wasm_web_api,
+                                    node::wasm_web_api::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(wasm_web_api,
+                                node::wasm_web_api::RegisterExternalReferences)

--- a/src/node_watchdog.cc
+++ b/src/node_watchdog.cc
@@ -435,4 +435,4 @@ static void Initialize(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(watchdog, node::watchdog::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(watchdog, node::watchdog::Initialize)

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -975,5 +975,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace worker
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(worker, node::worker::InitWorker)
-NODE_MODULE_EXTERNAL_REFERENCE(worker, node::worker::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(worker, node::worker::InitWorker)
+NODE_BINDING_EXTERNAL_REFERENCE(worker,
+                                node::worker::RegisterExternalReferences)

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -1430,5 +1430,5 @@ void DefineZlibConstants(Local<Object> target) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(zlib, node::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(zlib, node::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(zlib, node::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(zlib, node::RegisterExternalReferences)

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -255,6 +255,6 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(pipe_wrap, node::PipeWrap::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(pipe_wrap,
-                               node::PipeWrap::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(pipe_wrap, node::PipeWrap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(pipe_wrap,
+                                node::PipeWrap::RegisterExternalReferences)

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -320,4 +320,4 @@ class ProcessWrap : public HandleWrap {
 }  // anonymous namespace
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(process_wrap, node::ProcessWrap::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(process_wrap, node::ProcessWrap::Initialize)

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -174,7 +174,6 @@ bool HasSignalJSHandler(int signum) {
 }
 }  // namespace node
 
-
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(signal_wrap, node::SignalWrap::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(signal_wrap,
-                               node::SignalWrap::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(signal_wrap, node::SignalWrap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(signal_wrap,
+                                node::SignalWrap::RegisterExternalReferences)

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -1104,5 +1104,5 @@ void SyncProcessRunner::KillTimerCloseCallback(uv_handle_t* handle) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(spawn_sync,
-  node::SyncProcessRunner::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(spawn_sync,
+                                    node::SyncProcessRunner::Initialize)

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -332,5 +332,4 @@ void InitializeStreamPipe(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(stream_pipe,
-                                   node::InitializeStreamPipe)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(stream_pipe, node::InitializeStreamPipe)

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -415,7 +415,7 @@ void LibuvStreamWrap::AfterUvWrite(uv_write_t* req, int status) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(stream_wrap,
-                                   node::LibuvStreamWrap::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(stream_wrap,
+                                    node::LibuvStreamWrap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(
     stream_wrap, node::LibuvStreamWrap::RegisterExternalReferences)

--- a/src/string_decoder.cc
+++ b/src/string_decoder.cc
@@ -342,7 +342,7 @@ void RegisterStringDecoderExternalReferences(
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(string_decoder,
-                                   node::InitializeStringDecoder)
-NODE_MODULE_EXTERNAL_REFERENCE(string_decoder,
-                               node::RegisterStringDecoderExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(string_decoder,
+                                    node::InitializeStringDecoder)
+NODE_BINDING_EXTERNAL_REFERENCE(string_decoder,
+                                node::RegisterStringDecoderExternalReferences)

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -450,6 +450,6 @@ MaybeLocal<Object> AddressToJS(Environment* env,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(tcp_wrap, node::TCPWrap::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(tcp_wrap,
-                               node::TCPWrap::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(tcp_wrap, node::TCPWrap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(tcp_wrap,
+                                node::TCPWrap::RegisterExternalReferences)

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -71,5 +71,5 @@ void RegisterTimerExternalReferences(ExternalReferenceRegistry* registry) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(timers, node::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(timers, node::RegisterTimerExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(timers, node::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(timers, node::RegisterTimerExternalReferences)

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -156,6 +156,6 @@ TTYWrap::TTYWrap(Environment* env,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(tty_wrap, node::TTYWrap::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(tty_wrap,
-                               node::TTYWrap::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(tty_wrap, node::TTYWrap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(tty_wrap,
+                                node::TTYWrap::RegisterExternalReferences)

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -806,4 +806,4 @@ void UDPWrap::GetSendQueueCount(const FunctionCallbackInfo<Value>& args) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(udp_wrap, node::UDPWrap::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(udp_wrap, node::UDPWrap::Initialize)

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -137,5 +137,5 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace uv
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(uv, node::uv::Initialize)
-NODE_MODULE_EXTERNAL_REFERENCE(uv, node::uv::RegisterExternalReferences)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(uv, node::uv::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(uv, node::uv::RegisterExternalReferences)


### PR DESCRIPTION
This is a continuation of the name reification on the internal bindings.
As these bindings are already loaded with the function `internalBinding`
in the JS land, the term "internal binding" can be straightforward to
be adopted.

Renames NODE_MODULE_CONTEXT_AWARE_INTERNAL and
NODE_MODULE_EXTERNAL_REFERENCE to NODE_BINDING_CONTEXT_AWARE_INTERNAL
and NODE_BINDING_EXTERNAL_REFERENCE respectively.

Refs: https://github.com/nodejs/node/issues/44036