### PR TITLE
doc: add version description about fsPromise.constants

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1734,6 +1734,12 @@ system requests but rather the internal buffering `fs.writeFile` performs.
 
 ### `fsPromises.constants`
 
+<!-- YAML
+added:
+  - v18.4.0
+  - v16.17.0
+-->
+
 * {Object}
 
 Returns an object containing commonly used constants for file system


### PR DESCRIPTION
Add version description about fsPromise.constants in doc.

Refs: https://github.com/nodejs/node/pull/43177