### PR TITLE
fix(sec): upgrade urllib3 to 1.26.5

### DIFF
--- a/deps/uv/docs/requirements.txt
+++ b/deps/uv/docs/requirements.txt
@@ -38,5 +38,5 @@ sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-urllib3==1.25.8
+urllib3==1.26.5
 webencodings==0.5.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.25.8
- [CVE-2021-33503](https://www.oscs1024.com/hd/CVE-2021-33503)


### What did I do？
Upgrade urllib3 from 1.25.8 to 1.26.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>