### PR TITLE
http: headers(Distinct), trailers(Distinct) setters to be no-op

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -122,9 +122,7 @@ ObjectDefineProperty(IncomingMessage.prototype, 'headers', {
     }
     return this[kHeaders];
   },
-  set: function(val) {
-    this[kHeaders] = val;
-  }
+  set: function(val) {}
 });
 
 ObjectDefineProperty(IncomingMessage.prototype, 'headersDistinct', {
@@ -142,9 +140,7 @@ ObjectDefineProperty(IncomingMessage.prototype, 'headersDistinct', {
     }
     return this[kHeadersDistinct];
   },
-  set: function(val) {
-    this[kHeadersDistinct] = val;
-  }
+  set: function(val) {}
 });
 
 ObjectDefineProperty(IncomingMessage.prototype, 'trailers', {
@@ -162,9 +158,7 @@ ObjectDefineProperty(IncomingMessage.prototype, 'trailers', {
     }
     return this[kTrailers];
   },
-  set: function(val) {
-    this[kTrailers] = val;
-  }
+  set: function(val) {}
 });
 
 ObjectDefineProperty(IncomingMessage.prototype, 'trailersDistinct', {
@@ -182,9 +176,7 @@ ObjectDefineProperty(IncomingMessage.prototype, 'trailersDistinct', {
     }
     return this[kTrailersDistinct];
   },
-  set: function(val) {
-    this[kTrailersDistinct] = val;
-  }
+  set: function(val) {}
 });
 
 IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {

--- a/test/parallel/test-http-set-headers-distinct.js
+++ b/test/parallel/test-http-set-headers-distinct.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { createServer, request } = require('http');
+
+const server = createServer(
+  common.mustCall((req, res) => {
+    req.headersDistinct = { 'x-req-a': ['zzz'] };
+
+    // headersDistinct setter should be a No-Op
+    assert.deepStrictEqual(req.headersDistinct, {
+      'transfer-encoding': [
+        'chunked',
+      ],
+      'connection': [
+        'keep-alive',
+      ],
+      'host': [
+        `127.0.0.1:${server.address().port}`,
+      ]
+    });
+
+    req.on('end', function() {
+      res.write('BODY');
+      res.end();
+    });
+
+    req.resume();
+  })
+);
+
+server.listen(
+  0,
+  common.mustCall(() => {
+    const req = request(
+      {
+        host: '127.0.0.1',
+        port: server.address().port,
+        path: '/',
+        method: 'POST',
+      },
+      common.mustCall((res) => {
+        res.on('end', function() {
+          server.close();
+        });
+        res.resume();
+      })
+    );
+
+    req.write('BODY');
+    req.end();
+  })
+);

--- a/test/parallel/test-set-incoming-message-header.js
+++ b/test/parallel/test-set-incoming-message-header.js
@@ -4,24 +4,23 @@ require('../common');
 const { IncomingMessage } = require('http');
 const assert = require('assert');
 
-// Headers setter function set a header correctly
+// Headers setter should be a No-Op
 {
   const im = new IncomingMessage();
   im.headers = { key: 'value' };
-  assert.deepStrictEqual(im.headers, { key: 'value' });
+  assert.deepStrictEqual(im.headers, {});
 }
 
-// Trailers setter function set a header correctly
+// Trailers setter should be a No-Op
 {
   const im = new IncomingMessage();
   im.trailers = { key: 'value' };
-  assert.deepStrictEqual(im.trailers, { key: 'value' });
+  assert.deepStrictEqual(im.trailers, {});
 }
 
 // _addHeaderLines function set a header correctly
 {
   const im = new IncomingMessage();
-  im.headers = { key1: 'value1' };
   im._addHeaderLines(['key2', 'value2'], 2);
-  assert.deepStrictEqual(im.headers, { key1: 'value1', key2: 'value2' });
+  assert.deepStrictEqual(im.headers, { key2: 'value2' });
 }


### PR DESCRIPTION
Re-land this as a breaking change.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
