### PR TITLE
[v18.x] deps: V8: cherry-pick 5fe919f78321

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.21',
+    'v8_embedder_string': '-node.22',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/wasm/baseline/ppc/liftoff-assembler-ppc.h
+++ b/deps/v8/src/wasm/baseline/ppc/liftoff-assembler-ppc.h
@@ -1455,6 +1455,7 @@ bool LiftoffAssembler::emit_type_conversion(WasmOpcode opcode,
       fcmpu(src.fp(), kScratchDoubleReg);
       bunordered(trap);
 
+      mtfsb0(VXCVI);  // clear FPSCR:VXCVI bit
       fctiwz(kScratchDoubleReg, src.fp());
       MovDoubleLowToInt(dst.gp(), kScratchDoubleReg);
       mcrfs(cr7, VXCVI);
@@ -1463,6 +1464,7 @@ bool LiftoffAssembler::emit_type_conversion(WasmOpcode opcode,
     }
     case kExprI32UConvertF64:
     case kExprI32UConvertF32: {
+      mtfsb0(VXCVI);  // clear FPSCR:VXCVI bit
       ConvertDoubleToUnsignedInt64(src.fp(), r0, kScratchDoubleReg,
                                    kRoundToZero);
       mcrfs(cr7, VXCVI);  // extract FPSCR field containing VXCVI into cr7
@@ -1478,6 +1480,7 @@ bool LiftoffAssembler::emit_type_conversion(WasmOpcode opcode,
       fcmpu(src.fp(), kScratchDoubleReg);
       bunordered(trap);
 
+      mtfsb0(VXCVI);  // clear FPSCR:VXCVI bit
       fctidz(kScratchDoubleReg, src.fp());
       MovDoubleToInt64(dst.gp(), kScratchDoubleReg);
       mcrfs(cr7, VXCVI);
@@ -1490,6 +1493,7 @@ bool LiftoffAssembler::emit_type_conversion(WasmOpcode opcode,
       fcmpu(src.fp(), kScratchDoubleReg);
       bunordered(trap);
 
+      mtfsb0(VXCVI);  // clear FPSCR:VXCVI bit
       fctiduz(kScratchDoubleReg, src.fp());
       MovDoubleToInt64(dst.gp(), kScratchDoubleReg);
       mcrfs(cr7, VXCVI);


### PR DESCRIPTION
Original commit message:

    PPC: clear VXCVI before doing a conversion

    This bit may not get cleared automatically and could show
    results from older executed instructions.

    Change-Id: I5976f9a6c5bf87b1a63ef0f35493b222729e20f6
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3812037
    Reviewed-by: Junliang Yan <junyan@redhat.com>
    Commit-Queue: Milad Farazmand <mfarazma@redhat.com>
    Cr-Commit-Position: refs/heads/main@{#82237}

Refs: https://github.com/v8/v8/commit/5fe919f783214c978cb174425554ede8fc1eac5f

---

cc @nodejs/platform-aix @nodejs/platform-ppc 

Noticed from the CITGM CI runs for https://github.com/nodejs/citgm/pull/905 that PPC platforms (AIX and Linux) on Node.js 18 were failing (note that the PR marks ppc as flaky so Jenkins marks the run as passing but the yarn tests failed) with:
e.g. https://ci.nodejs.org/job/citgm-smoker-nobuild/1463/nodes=rhel8-ppc64le/console
```
07:09:17 verbose: @yarnpkg/cli npm-test:| RuntimeError: float unrepresentable in integer range                                                                                                                                                         
07:09:17 verbose:                       | at wasm://wasm/02834d3a:wasm-function[1041]:0xe1004                                                                                                                                                          
07:09:17 verbose:                       | at wasm://wasm/02834d3a:wasm-function[1442]:0x1406a3                                                                                                                                                         
07:09:17 verbose:                       | at wasm://wasm/02834d3a:wasm-function[751]:0xa66c9                                                                                                                                                           
07:09:17 verbose:                       | at wasm://wasm/02834d3a:wasm-function[751]:0xa6536                                                                                                                                                           
07:09:17 verbose:                       | at wasm://wasm/02834d3a:wasm-function[751]:0xa6536                                                                                                                                                           
07:09:17 verbose:                       | at wasm://wasm/02834d3a:wasm-function[751]:0xa6536                                                                                                                                                           
07:09:17 verbose:                       | at wasm://wasm/02834d3a:wasm-function[751]:0xa6536                                                                                                                                                           
07:09:17 verbose:                       | at wasm://wasm/02834d3a:wasm-function[1034]:0xe0ed4                                                                                                                                                          
07:09:17 verbose:                       | at wasm://wasm/02834d3a:wasm-function[1032]:0xe0ea7                                                                                                                                                          
07:09:17 verbose:                       | at globalThis.Go.run (/home/iojs/tmp/citgm_tmp/e9a10d7f-d071-4ac5-b4c2-80b8e64ba7dd/@yarnpkg/cli/.yarn/cache/esbuild-wasm-npm-0.15.5-bc4c954bca-149219c551.zip/node_modules/esbuild-wasm/wasm_exec.js:527:23)
```

with this backport Linux PPC is fixed 🎉 : https://ci.nodejs.org/job/citgm-smoker/3049/nodes=rhel8-ppc64le/
Although we now get a different issue on AIX which looks to be a crash of some sort: https://ci.nodejs.org/job/citgm-smoker/3049/nodes=aix72-ppc64/console

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
