### PR TITLE
doc: fix error in Buffer.lastIndexOf

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2219,7 +2219,7 @@ changes:
 * `value` {string|Buffer|Uint8Array|integer} What to search for.
 * `byteOffset` {integer} Where to begin searching in `buf`. If negative, then
   offset is calculated from the end of `buf`. **Default:**
-  `buf.length - 1`.
+  `buf.length`.
 * `encoding` {string} If `value` is a string, this is the encoding used to
   determine the binary representation of the string that will be searched for in
   `buf`. **Default:** `'utf8'`.


### PR DESCRIPTION
For `Buffer.lastIndexOf`, the default value of `byteOffset` parameter is `buf.length`, not `buf.length - 1`.