### PR TITLE
test_runner: remove stdout and stderr from error

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -234,16 +234,11 @@ function runTestFile(path, root, inspectPort, filesWatcher) {
     runningProcesses.set(path, child);
 
     let err;
-    let stderr = '';
 
     filesWatcher?.watchChildProcessModules(child, path);
 
     child.on('error', (error) => {
       err = error;
-    });
-
-    child.stderr.on('data', (data) => {
-      stderr += data;
     });
 
     if (isUsingInspector()) {
@@ -266,7 +261,7 @@ function runTestFile(path, root, inspectPort, filesWatcher) {
       subtest.addToReport(ast);
     });
 
-    const { 0: { 0: code, 1: signal }, 1: stdout } = await SafePromiseAll([
+    const { 0: { 0: code, 1: signal } } = await SafePromiseAll([
       once(child, 'exit', { signal: t.signal }),
       child.stdout.toArray({ signal: t.signal }),
     ]);
@@ -279,8 +274,6 @@ function runTestFile(path, root, inspectPort, filesWatcher) {
           __proto__: null,
           exitCode: code,
           signal: signal,
-          stdout: ArrayPrototypeJoin(stdout, ''),
-          stderr,
           // The stack will not be useful since the failures came from tests
           // in a child process.
           stack: undefined,


### PR DESCRIPTION
The CLI test runner parses the TAP output from child processes now and displays it. This commit removes a previous workaround for displaying child process stdout and stderr when tests failures occurred.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
