### PR TITLE
benchmark: add default value for settings param

### DIFF
--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -42,7 +42,7 @@ function CLI(usage, settings = kEmptyObject) {
     } else if (mode === 'both' && arg[0] === '-') {
       // Optional arguments declaration
 
-      currentOptional = arg.split('-').pop();
+      currentOptional = arg.slice(arg[1] === '-' ? 2 : 1);
 
       if (settings.boolArgs?.includes(currentOptional)) {
         this.optional[currentOptional] = true;

--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 
+const kEmptyObject = Object.freeze(Object.create(null));
 // Create an object of all benchmark scripts
 const benchmarks = {};
 fs.readdirSync(__dirname)
@@ -15,7 +16,7 @@ fs.readdirSync(__dirname)
       .filter((filename) => filename[0] !== '.' && filename[0] !== '_');
   });
 
-function CLI(usage, settings) {
+function CLI(usage, settings = kEmptyObject) {
   if (process.argv.length < 3) {
     this.abort(usage); // Abort will exit the process
   }
@@ -25,8 +26,10 @@ function CLI(usage, settings) {
   this.items = [];
   this.test = false;
 
-  for (const argName of settings.arrayArgs) {
-    this.optional[argName] = [];
+  if (settings.arrayArgs) {
+    for (const argName of settings.arrayArgs) {
+      this.optional[argName] = [];
+    }
   }
 
   let currentOptional = null;
@@ -39,13 +42,9 @@ function CLI(usage, settings) {
     } else if (mode === 'both' && arg[0] === '-') {
       // Optional arguments declaration
 
-      if (arg[1] === '-') {
-        currentOptional = arg.slice(2);
-      } else {
-        currentOptional = arg.slice(1);
-      }
+      currentOptional = arg.split('-').pop();
 
-      if (settings.boolArgs && settings.boolArgs.includes(currentOptional)) {
+      if (settings.boolArgs?.includes(currentOptional)) {
         this.optional[currentOptional] = true;
         mode = 'both';
       } else {
@@ -55,7 +54,7 @@ function CLI(usage, settings) {
     } else if (mode === 'option') {
       // Optional arguments value
 
-      if (settings.arrayArgs.includes(currentOptional)) {
+      if (settings.arrayArgs?.includes(currentOptional)) {
         this.optional[currentOptional].push(arg);
       } else {
         this.optional[currentOptional] = arg;
@@ -107,8 +106,8 @@ CLI.prototype.benchmarks = function() {
 };
 
 CLI.prototype.shouldSkip = function(scripts) {
-  const filters = this.optional.filter || [];
-  const excludes = this.optional.exclude || [];
+  const filters = this.optional.filter ? [...this.optional.filter] : [];
+  const excludes = this.optional.exclude ? [...this.optional.exclude] : [];
   let skip = filters.length > 0;
 
   for (const filter of filters) {

--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const kEmptyObject = Object.freeze(Object.create(null));
+const kEmptyObject = Object.freeze({__proto__: null});
 // Create an object of all benchmark scripts
 const benchmarks = {};
 fs.readdirSync(__dirname)
@@ -106,8 +106,8 @@ CLI.prototype.benchmarks = function() {
 };
 
 CLI.prototype.shouldSkip = function(scripts) {
-  const filters = this.optional.filter ? [...this.optional.filter] : [];
-  const excludes = this.optional.exclude ? [...this.optional.exclude] : [];
+  const filters = this.optional.filter || [];
+  const excludes = this.optional.exclude || [];
   let skip = filters.length > 0;
 
   for (const filter of filters) {

--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const kEmptyObject = Object.freeze({__proto__: null});
+const kEmptyObject = Object.freeze({ __proto__: null });
 // Create an object of all benchmark scripts
 const benchmarks = {};
 fs.readdirSync(__dirname)

--- a/test/parallel/test-benchmark-cli.js
+++ b/test/parallel/test-benchmark-cli.js
@@ -38,9 +38,11 @@ testFilterPattern(['foo'], ['bar'], 'foo', false);
 testFilterPattern(['foo'], ['bar'], 'foo-bar', true);
 
 function testNoSettingsPattern(filters, excludes, filename, expectedResult) {
-  process.argv = process.argv.concat(...filters.map((p) => ['--filter', p]));
-  process.argv = process.argv.concat(...excludes.map((p) => ['--exclude', p]));
-  process.argv = process.argv.concat(['bench']);
+  process.argv = process.argv.concat(
+    filters.flatMap((p) => ['--filter', p]),
+    excludes.flatMap((p) => ['--exclude', p]),
+    ['bench'],
+  );
   try {
     const cli = new CLI('');
     assert.deepStrictEqual(cli.shouldSkip(filename), expectedResult);

--- a/test/parallel/test-benchmark-cli.js
+++ b/test/parallel/test-benchmark-cli.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 
 // This tests the CLI parser for our benchmark suite.
 
@@ -36,3 +36,32 @@ testFilterPattern([], ['foo', 'bar'], 'bar', true);
 
 testFilterPattern(['foo'], ['bar'], 'foo', false);
 testFilterPattern(['foo'], ['bar'], 'foo-bar', true);
+
+function testNoSettingsPattern(filters, excludes, filename, expectedResult) {
+  process.argv = process.argv.concat(...filters.map((p) => ['--filter', p]));
+  process.argv = process.argv.concat(...excludes.map((p) => ['--exclude', p]));
+  process.argv = process.argv.concat(['bench']);
+  try {
+    const cli = new CLI('');
+    assert.deepStrictEqual(cli.shouldSkip(filename), expectedResult);
+  } catch {
+    common.mustNotCall('If settings param is null, shouldn\'t throw an error');
+  }
+  process.argv = originalArgv;
+}
+
+testNoSettingsPattern([], []);
+testNoSettingsPattern([], [], 'foo', false);
+
+testNoSettingsPattern(['foo'], [], 'foo', false);
+testNoSettingsPattern(['foo'], [], 'bar', true);
+testNoSettingsPattern(['foo', 'bar'], [], 'foo', false);
+testNoSettingsPattern(['foo', 'bar'], [], 'bar', false);
+
+testNoSettingsPattern([], ['foo'], 'foo', true);
+testNoSettingsPattern([], ['foo'], 'bar', false);
+testNoSettingsPattern([], ['foo', 'bar'], 'foo', true);
+testNoSettingsPattern([], ['foo', 'bar'], 'bar', true);
+
+testNoSettingsPattern(['foo'], ['bar'], 'foo', false);
+testNoSettingsPattern(['foo'], ['bar'], 'foo-bar', true);

--- a/test/parallel/test-benchmark-cli.js
+++ b/test/parallel/test-benchmark-cli.js
@@ -12,9 +12,9 @@ const originalArgv = process.argv;
 
 function testFilterPattern(filters, excludes, filename, expectedResult) {
   process.argv = process.argv.concat(
-      filters.flatMap((p) => ['--filter', p]),
-      excludes.flatMap((p) => ['--exclude', p]),
-      ['bench'],
+    filters.flatMap((p) => ['--filter', p]),
+    excludes.flatMap((p) => ['--exclude', p]),
+    ['bench'],
   );
 
   const cli = new CLI('', { 'arrayArgs': ['filter', 'exclude'] });
@@ -74,10 +74,10 @@ function testNormalOption(options = [], expectedResult = []) {
   process.argv = process.argv.concat(options);
   const cli = new CLI('', { boolArgs: ['foo', 'bar', 'foo-bar'] });
   const optional = Object.keys(cli.optional);
-  assert.deepEqual(optional, expectedResult);
+  assert.deepStrictEqual(optional, expectedResult);
   process.argv = originalArgv;
 }
 
-testNormalOption(['--foo'], ['foo'])
-testNormalOption(['--foo', '--bar'], ['foo', 'bar'])
-testNormalOption(['--foo-bar'], ['foo-bar'])
+testNormalOption(['--foo'], ['foo']);
+testNormalOption(['--foo', '--bar'], ['foo', 'bar']);
+testNormalOption(['--foo-bar'], ['foo-bar']);


### PR DESCRIPTION
It will cause an error when I try to import `_cli.js`:
```shell
const CLI = require('./benchmark/_cli.js');
const cli = new CLI('');

TypeError: Cannot read properties of undefined (reading 'arrayArgs')
    at new CLI (/Users/didi/Desktop/node/benchmark/_cli.js:28:34)
    at Object.<anonymous> (/Users/didi/Desktop/node/benchmark/test-cli.js:2:13)
    at Module._compile (node:internal/modules/cjs/loader:1120:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1174:10)
    at Module.load (node:internal/modules/cjs/loader:998:32)
    at Module._load (node:internal/modules/cjs/loader:839:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```
So I try to use `kEmptyObject` as default settings value for benchmark CLI.