### PR TITLE
repl: do not define `wasi` on global with no flag

### DIFF
--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -8,7 +8,6 @@ const {
   markBootstrapComplete
 } = require('internal/process/pre_execution');
 
-const esmLoader = require('internal/process/esm_loader');
 const {
   evalScript
 } = require('internal/process/execution');
@@ -37,6 +36,7 @@ if (process.env.NODE_REPL_EXTERNAL_MODULE) {
     process.exit(kGenericUserError);
   }
 
+  const esmLoader = require('internal/process/esm_loader');
   esmLoader.loadESM(() => {
     console.log(`Welcome to Node.js ${process.version}.\n` +
       'Type ".help" for more information.');

--- a/test/parallel/test-repl-built-in-modules.js
+++ b/test/parallel/test-repl-built-in-modules.js
@@ -30,3 +30,19 @@ assert.doesNotMatch(
   stdout,
   /Uncaught Error: Cannot find module 'wasi'[\w\W]+- <repl>\n/);
 assert.match(stdout, /{ WASI: \[class WASI\] }/);
+
+{
+  const res = cp.execFileSync(process.execPath, ['-i'], {
+    input: "'wasi' in global",
+    encoding: 'utf8',
+  });
+  // `wasi` shouldn't be defined on global when the flag is not set
+  assert.match(res, /false\n/);
+}
+{
+  const res = cp.execFileSync(process.execPath, ['-i', '--experimental-wasi-unstable-preview1'], {
+    input: "'wasi' in global",
+    encoding: 'utf8',
+  });
+  assert.match(res, /true\n/);
+}


### PR DESCRIPTION
Fixes #45560 

In the REPL, `prepareMainThreadExecution` that updates the `canBeRequiredByUsers` flag of `wasi` module according to the flag is called **after** the `internal/process/esm_loader.js` load that creates `builtinModules` depending on the `module.canBeRequiredByUsers` flag. In this case, `wasi.canBeRequiredByUsers` is always `true` so `wasi` module always can be required by users even if the flag is not set.

https://github.com/nodejs/node/blob/2a7635feb226f410433d2c6e20699ced7a250be1/lib/internal/modules/cjs/loader.js#L217-L223

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
