### PR TITLE
lib / src : add undici version to process.versions

### DIFF
--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -38,6 +38,7 @@ namespace node {
   V(nghttp2)                                                                   \
   V(napi)                                                                      \
   V(llhttp)                                                                    \
+  V(undici)                                                                    \
 
 #if HAVE_OPENSSL
 #define NODE_VERSIONS_KEY_CRYPTO(V) V(openssl)
@@ -79,7 +80,7 @@ class Metadata {
 
   struct Versions {
     Versions();
-
+    std::string GetDependencyVersionFromPackageJson(std::string packageName);
 #ifdef NODE_HAVE_I18N_SUPPORT
     // Must be called on the main thread after
     // i18n::InitializeICUDirectory()

--- a/test_node_metadata.cc
+++ b/test_node_metadata.cc
@@ -1,0 +1,19 @@
+#include "node_metadata.h"
+#include <string>
+#include "gtest/gtest.h"
+
+TEST(NodeMetadataTest, Versions) {
+  std::string ver = node::Metadata::Versions().undici;
+  std::stringstream versionstream(ver);
+  std::string segment;
+  std::vector<std::string> seglist;
+  while (std::getline(versionstream, segment, '.')) {
+    seglist.push_back(segment);
+  }
+
+  EXPECT_EQ(seglist.size(), 3);
+  EXPECT_GE(std::stoi(seglist[0]), 5);
+  EXPECT_GE(std::stoi(seglist[1]), 0);
+  EXPECT_GE(std::stoi(seglist[2]), 0);
+  
+}


### PR DESCRIPTION
process.versions is not returning undici version,
this PR will read the version number from undici/src/package.json and add it to result. If this approach is ok then other missing libraries will be added

Refs: https://github.com/nodejs/node/issues/45260