### PR TITLE
test_runner: fix mock.method to support class instances

### DIFF
--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -6,6 +6,7 @@ const {
   FunctionPrototypeCall,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
+  ObjectGetPrototypeOf,
   Proxy,
   ReflectApply,
   ReflectConstruct,
@@ -131,8 +132,13 @@ class MockTracker {
     implementation = kDefaultFunction,
     options = kEmptyObject,
   ) {
-    validateObject(object, 'object');
     validateStringOrSymbol(methodName, 'methodName');
+    // In case object is a static class
+    if (typeof object === 'function') {
+      validateFunction(object, methodName);
+    } else {
+      validateObject(object, 'object');
+    }
 
     if (implementation !== null && typeof implementation === 'object') {
       options = implementation;
@@ -157,16 +163,30 @@ class MockTracker {
         'options.setter', setter, "cannot be used with 'options.getter'"
       );
     }
+    const getOriginalObject = (descriptor) => {
+      let original;
 
-    const descriptor = ObjectGetOwnPropertyDescriptor(object, methodName);
-    let original;
+      if (getter) {
+        original = descriptor?.get;
+      } else if (setter) {
+        original = descriptor?.set;
+      } else {
+        original = descriptor?.value;
+      }
 
-    if (getter) {
-      original = descriptor?.get;
-    } else if (setter) {
-      original = descriptor?.set;
-    } else {
-      original = descriptor?.value;
+      return original;
+    };
+    let descriptor = ObjectGetOwnPropertyDescriptor(object, methodName);
+    let original = getOriginalObject(descriptor);
+
+    // classes instances
+    if (typeof original !== 'function') {
+      descriptor = ObjectGetOwnPropertyDescriptor(
+        ObjectGetPrototypeOf(object),
+        methodName
+      );
+
+      original = getOriginalObject(descriptor);
     }
 
     if (typeof original !== 'function') {

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -127,14 +127,14 @@ class MockTracker {
   }
 
   method(
-    object,
+    objectOrFunction,
     methodName,
     implementation = kDefaultFunction,
     options = kEmptyObject,
   ) {
     validateStringOrSymbol(methodName, 'methodName');
-    if (typeof object !== 'function') {
-      validateObject(object, 'object');
+    if (typeof objectOrFunction !== 'function') {
+      validateObject(objectOrFunction, 'object');
     }
 
     if (implementation !== null && typeof implementation === 'object') {
@@ -160,7 +160,7 @@ class MockTracker {
         'options.setter', setter, "cannot be used with 'options.getter'"
       );
     }
-    const descriptor = findMethodOnPrototypeChain(object, methodName);
+    const descriptor = findMethodOnPrototypeChain(objectOrFunction, methodName);
 
     let original;
 
@@ -178,7 +178,7 @@ class MockTracker {
       );
     }
 
-    const restore = { descriptor, object, methodName };
+    const restore = { descriptor, object: objectOrFunction, methodName };
     const impl = implementation === kDefaultFunction ?
       original : implementation;
     const ctx = new MockFunctionContext(impl, restore, times);
@@ -200,7 +200,7 @@ class MockTracker {
       mockDescriptor.value = mock;
     }
 
-    ObjectDefineProperty(object, methodName, mockDescriptor);
+    ObjectDefineProperty(objectOrFunction, methodName, mockDescriptor);
 
     return mock;
   }

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -23,7 +23,6 @@ const { kEmptyObject } = require('internal/util');
 const {
   validateBoolean,
   validateFunction,
-  validateField,
   validateInteger,
   validateObject,
 } = require('internal/validators');
@@ -161,8 +160,6 @@ class MockTracker {
         'options.setter', setter, "cannot be used with 'options.getter'"
       );
     }
-    validateField(object, methodName);
-
     const descriptor = findMethodOnPrototypeChain(object, methodName);
 
     let original;

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -186,7 +186,8 @@ class MockTracker {
 
       const proto = ObjectGetPrototypeOf(instance);
       const desc = ObjectGetOwnPropertyDescriptor(proto, method);
-      if (!desc && proto.name) {
+
+      if (!desc) {
         return findMethodOnPrototypeChain(proto, method, true);
       }
       return desc;

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -23,6 +23,7 @@ const { kEmptyObject } = require('internal/util');
 const {
   validateBoolean,
   validateFunction,
+  validateField,
   validateInteger,
   validateObject,
 } = require('internal/validators');
@@ -133,7 +134,6 @@ class MockTracker {
     options = kEmptyObject,
   ) {
     validateStringOrSymbol(methodName, 'methodName');
-
     if (typeof object !== 'function') {
       validateObject(object, 'object');
     }
@@ -161,6 +161,7 @@ class MockTracker {
         'options.setter', setter, "cannot be used with 'options.getter'"
       );
     }
+    validateField(object, methodName);
 
     const descriptor = this.#findMethodOnPrototypeChain(object, methodName);
     const original = this.#getOriginalObject({ descriptor, getter, setter });

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -161,40 +161,9 @@ class MockTracker {
         'options.setter', setter, "cannot be used with 'options.getter'"
       );
     }
-    function getOriginalObject(descriptor) {
-      let original;
 
-      if (getter) {
-        original = descriptor?.get;
-      } else if (setter) {
-        original = descriptor?.set;
-      } else {
-        original = descriptor?.value;
-      }
-
-      return original;
-    }
-
-    function findMethodOnPrototypeChain(instance, method, isDescriptor = false) {
-      const original = isDescriptor ?
-        instance :
-        ObjectGetOwnPropertyDescriptor(instance, method);
-
-      if (original && !isDescriptor) {
-        return original;
-      }
-
-      const proto = ObjectGetPrototypeOf(instance);
-      const desc = ObjectGetOwnPropertyDescriptor(proto, method);
-
-      if (!desc) {
-        return findMethodOnPrototypeChain(proto, method, true);
-      }
-      return desc;
-    }
-
-    const descriptor = findMethodOnPrototypeChain(object, methodName);
-    const original = getOriginalObject(descriptor);
+    const descriptor = this.#findMethodOnPrototypeChain(object, methodName);
+    const original = this.#getOriginalObject({ descriptor, getter, setter });
 
     if (typeof original !== 'function') {
       throw new ERR_INVALID_ARG_VALUE(
@@ -292,6 +261,38 @@ class MockTracker {
     for (let i = 0; i < this.#mocks.length; i++) {
       FunctionPrototypeCall(restore, this.#mocks[i]);
     }
+  }
+
+  #getOriginalObject({ descriptor, getter, setter }) {
+    let original;
+
+    if (getter) {
+      original = descriptor?.get;
+    } else if (setter) {
+      original = descriptor?.set;
+    } else {
+      original = descriptor?.value;
+    }
+
+    return original;
+  }
+
+  #findMethodOnPrototypeChain(instance, method, isDescriptor = false) {
+    const original = isDescriptor ?
+      instance :
+      ObjectGetOwnPropertyDescriptor(instance, method);
+
+    if (original && !isDescriptor) {
+      return original;
+    }
+
+    const proto = ObjectGetPrototypeOf(instance);
+    const desc = ObjectGetOwnPropertyDescriptor(proto, method);
+
+    if (!desc) {
+      return this.#findMethodOnPrototypeChain(proto, method, true);
+    }
+    return desc;
   }
 
   #setupMock(ctx, fnToMatch) {

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -163,7 +163,7 @@ class MockTracker {
         'options.setter', setter, "cannot be used with 'options.getter'"
       );
     }
-    const getOriginalObject = (descriptor) => {
+    function getOriginalObject(descriptor) {
       let original;
 
       if (getter) {

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -133,7 +133,7 @@ class MockTracker {
     options = kEmptyObject,
   ) {
     validateStringOrSymbol(methodName, 'methodName');
-    // In case object is a static class
+
     if (typeof object !== 'function') {
       validateObject(object, 'object');
     }

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -163,8 +163,8 @@ class MockTracker {
     }
     validateField(object, methodName);
 
-    const descriptor = this.#findMethodOnPrototypeChain(object, methodName);
-    const original = this.#getOriginalObject({ descriptor, getter, setter });
+    const descriptor = findMethodOnPrototypeChain(object, methodName);
+    const original = getOriginalObject({ descriptor, getter, setter });
 
     if (typeof original !== 'function') {
       throw new ERR_INVALID_ARG_VALUE(
@@ -264,38 +264,6 @@ class MockTracker {
     }
   }
 
-  #getOriginalObject({ descriptor, getter, setter }) {
-    let original;
-
-    if (getter) {
-      original = descriptor?.get;
-    } else if (setter) {
-      original = descriptor?.set;
-    } else {
-      original = descriptor?.value;
-    }
-
-    return original;
-  }
-
-  #findMethodOnPrototypeChain(instance, method, isDescriptor = false) {
-    const original = isDescriptor ?
-      instance :
-      ObjectGetOwnPropertyDescriptor(instance, method);
-
-    if (original && !isDescriptor) {
-      return original;
-    }
-
-    const proto = ObjectGetPrototypeOf(instance);
-    const desc = ObjectGetOwnPropertyDescriptor(proto, method);
-
-    if (!desc) {
-      return this.#findMethodOnPrototypeChain(proto, method, true);
-    }
-    return desc;
-  }
-
   #setupMock(ctx, fnToMatch) {
     const mock = new Proxy(fnToMatch, {
       __proto__: null,
@@ -373,6 +341,37 @@ function validateTimes(value, name) {
   }
 
   validateInteger(value, name, 1);
+}
+
+function getOriginalObject({ descriptor, getter, setter }) {
+  let original;
+
+  if (getter) {
+    original = descriptor?.get;
+  } else if (setter) {
+    original = descriptor?.set;
+  } else {
+    original = descriptor?.value;
+  }
+
+  return original;
+}
+
+function findMethodOnPrototypeChain(instance, methodName) {
+  let host = instance;
+  let descriptor;
+
+  while (host !== null) {
+    descriptor = ObjectGetOwnPropertyDescriptor(host, methodName);
+
+    if (descriptor) {
+      break;
+    }
+
+    host = ObjectGetPrototypeOf(host);
+  }
+
+  return descriptor;
 }
 
 module.exports = { MockTracker };

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -134,9 +134,7 @@ class MockTracker {
   ) {
     validateStringOrSymbol(methodName, 'methodName');
     // In case object is a static class
-    if (typeof object === 'function') {
-      validateFunction(object, methodName);
-    } else {
+    if (typeof object !== 'function') {
       validateObject(object, 'object');
     }
 
@@ -175,7 +173,7 @@ class MockTracker {
       }
 
       return original;
-    };
+    }
     let descriptor = ObjectGetOwnPropertyDescriptor(object, methodName);
     let original = getOriginalObject(descriptor);
 

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -174,18 +174,26 @@ class MockTracker {
 
       return original;
     }
-    let descriptor = ObjectGetOwnPropertyDescriptor(object, methodName);
-    let original = getOriginalObject(descriptor);
 
-    // classes instances
-    if (typeof original !== 'function') {
-      descriptor = ObjectGetOwnPropertyDescriptor(
-        ObjectGetPrototypeOf(object),
-        methodName
-      );
+    function findMethodOnPrototypeChain(instance, method, isDescriptor = false) {
+      const original = isDescriptor ?
+        instance :
+        ObjectGetOwnPropertyDescriptor(instance, method);
 
-      original = getOriginalObject(descriptor);
+      if (original && !isDescriptor) {
+        return original;
+      }
+
+      const proto = ObjectGetPrototypeOf(instance);
+      const desc = ObjectGetOwnPropertyDescriptor(proto, method);
+      if (!desc && proto.name) {
+        return findMethodOnPrototypeChain(proto, method, true);
+      }
+      return desc;
     }
+
+    const descriptor = findMethodOnPrototypeChain(object, methodName);
+    const original = getOriginalObject(descriptor);
 
     if (typeof original !== 'function') {
       throw new ERR_INVALID_ARG_VALUE(

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -164,7 +164,16 @@ class MockTracker {
     validateField(object, methodName);
 
     const descriptor = findMethodOnPrototypeChain(object, methodName);
-    const original = getOriginalObject({ descriptor, getter, setter });
+
+    let original;
+
+    if (getter) {
+      original = descriptor?.get;
+    } else if (setter) {
+      original = descriptor?.set;
+    } else {
+      original = descriptor?.value;
+    }
 
     if (typeof original !== 'function') {
       throw new ERR_INVALID_ARG_VALUE(
@@ -341,20 +350,6 @@ function validateTimes(value, name) {
   }
 
   validateInteger(value, name, 1);
-}
-
-function getOriginalObject({ descriptor, getter, setter }) {
-  let original;
-
-  if (getter) {
-    original = descriptor?.get;
-  } else if (setter) {
-    original = descriptor?.set;
-  } else {
-    original = descriptor?.value;
-  }
-
-  return original;
 }
 
 function findMethodOnPrototypeChain(instance, methodName) {

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -478,6 +478,20 @@ function validateLinkHeaderFormat(value, name) {
   }
 }
 
+/**
+ * @param {any} object
+ * @param {string} name
+ */
+const validateField = hideStackFrames((object, name) => {
+  if (object === null || !(name in object)) {
+    throw new ERR_INVALID_ARG_VALUE(
+      name,
+      object,
+      `the property ${name} does not exists in the object instance`
+    );
+  }
+});
+
 const validateInternalField = hideStackFrames((object, fieldKey, className) => {
   if (typeof object !== 'object' || object === null || !ObjectPrototypeHasOwnProperty(object, fieldKey)) {
     throw new ERR_INVALID_ARG_TYPE('this', className, object);
@@ -547,4 +561,5 @@ module.exports = {
   validateAbortSignal,
   validateLinkHeaderValue,
   validateInternalField,
+  validateField,
 };

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -478,20 +478,6 @@ function validateLinkHeaderFormat(value, name) {
   }
 }
 
-/**
- * @param {any} object
- * @param {string} name
- */
-const validateField = hideStackFrames((object, name) => {
-  if (object === null || !(name in object)) {
-    throw new ERR_INVALID_ARG_VALUE(
-      name,
-      object,
-      `the property ${name} does not exists in the object instance`
-    );
-  }
-});
-
 const validateInternalField = hideStackFrames((object, fieldKey, className) => {
   if (typeof object !== 'object' || object === null || !ObjectPrototypeHasOwnProperty(object, fieldKey)) {
     throw new ERR_INVALID_ARG_TYPE('this', className, object);
@@ -561,5 +547,4 @@ module.exports = {
   validateAbortSignal,
   validateLinkHeaderValue,
   validateInternalField,
-  validateField,
 };

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -398,10 +398,7 @@ test('given null to a mock.method it throws a invalid argument error', (t) => {
 
 test('it should throw given an inexistent property on a object instance', (t) => {
   const expectedMessage = [
-    'The argument \'non-existent\'',
-    ' the property non-existent',
-    ' does not exists in the object instance.',
-    ' Received { abc: 0 }',
+    'The argument \'methodName\' must be a method. Received undefined',
   ].join('');
   assert.throws(() => t.mock.method({ abc: 0 }, 'non-existent'), {
     message: expectedMessage

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -2,7 +2,6 @@
 const common = require('../common');
 const assert = require('node:assert');
 const { mock, test } = require('node:test');
-
 test('spies on a function', (t) => {
   const sum = t.mock.fn((arg1, arg2) => {
     return arg1 + arg2;
@@ -397,11 +396,8 @@ test('given null to a mock.method it throws a invalid argument error', (t) => {
 });
 
 test('it should throw given an inexistent property on a object instance', (t) => {
-  const expectedMessage = [
-    'The argument \'methodName\' must be a method. Received undefined',
-  ].join('');
   assert.throws(() => t.mock.method({ abc: 0 }, 'non-existent'), {
-    message: expectedMessage
+    code: 'ERR_INVALID_ARG_VALUE'
   });
 });
 

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -393,7 +393,7 @@ test('spies on async static class methods', async (t) => {
 });
 
 test('given null to a mock.method it throws a invalid argument error', (t) => {
-  assert.throws(() => t.mock.method(null, {}), /ERR_INVALID_ARG_TYPE/);
+  assert.throws(() => t.mock.method(null, {}), { code: 'ERR_INVALID_ARG_TYPE' });
 });
 
 test('it should throw given an inexistent property on a object instance', (t) => {

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -318,7 +318,7 @@ test('spy functions can be bound', (t) => {
   assert.strictEqual(sum.mock.restore(), undefined);
   assert.strictEqual(sum.bind(0)(2, 11), 13);
 });
-test('spies on async class functions', async (t) => {
+test('mocks prototype methods on an instance', async (t) => {
   class Runner {
     async someTask(msg) {
       return Promise.resolve(msg);
@@ -350,7 +350,7 @@ test('spies on async class functions', async (t) => {
   assert.strictEqual(obj.someTask.mock, undefined);
 });
 
-test('spies on async class static functions', async (t) => {
+test('spies on async static class methods', async (t) => {
   class Runner {
     static async someTask(msg) {
       return Promise.resolve(msg);

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -397,7 +397,9 @@ test('given null to a mock.method it throws a invalid argument error', (t) => {
 });
 
 test('spy functions can be used on classes inheritance', (t) => {
-  class A {
+  
+  // make sure that having a null-prototype doesn't throw our system off
+  class A extends null {
     static someTask(msg) {
       return msg;
     }

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -356,6 +356,7 @@ test('mocks prototype methods on an instance', async (t) => {
   assert.strictEqual(obj.someTask.mock.restore(), undefined);
   assert.strictEqual(await obj.method(msg), msg);
   assert.strictEqual(obj.someTask.mock, undefined);
+  assert.strictEqual(Runner.prototype.someTask.mock, undefined);
 });
 
 test('spies on async static class methods', async (t) => {
@@ -387,6 +388,8 @@ test('spies on async static class methods', async (t) => {
   assert.strictEqual(Runner.someTask.mock.restore(), undefined);
   assert.strictEqual(await Runner.method(msg), msg);
   assert.strictEqual(Runner.someTask.mock, undefined);
+  assert.strictEqual(Runner.prototype.someTask, undefined);
+
 });
 
 test('given null to a mock.method it throws a invalid argument error', (t) => {

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -396,6 +396,18 @@ test('given null to a mock.method it throws a invalid argument error', (t) => {
   assert.throws(() => t.mock.method(null, {}), /ERR_INVALID_ARG_TYPE/);
 });
 
+test('it should throw given an inexistent property on a object instance', (t) => {
+  const expectedMessage = [
+    'The argument \'non-existent\'',
+    ' the property non-existent',
+    ' does not exists in the object instance.',
+    ' Received { abc: 0 }',
+  ].join('');
+  assert.throws(() => t.mock.method({ abc: 0 }, 'non-existent'), {
+    message: expectedMessage
+  });
+});
+
 test('spy functions can be used on classes inheritance', (t) => {
   // Makes sure that having a null-prototype doesn't throw our system off
   class A extends null {

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -434,6 +434,31 @@ test('spy functions can be used on classes inheritance', (t) => {
   assert.strictEqual(C.someTask.mock, undefined);
 });
 
+test('spy functions don\'t affect the prototype chain', (t) => {
+
+  class A {
+    static someTask(msg) {
+      return msg;
+    }
+  }
+  class B extends A {}
+  class C extends B {}
+
+  const msg = 'ok';
+
+  t.mock.method(C, C.someTask.name);
+  C.someTask(msg);
+
+  assert.strictEqual(B.someTask.mock, undefined);
+  assert.strictEqual(A.someTask.mock, undefined);
+
+  assert.strictEqual(C.someTask.mock.restore(), undefined);
+  C.someTask(msg);
+  assert.strictEqual(C.someTask.mock, undefined);
+  assert.strictEqual(B.someTask.mock, undefined);
+  assert.strictEqual(A.someTask.mock, undefined);
+});
+
 test('mocked functions report thrown errors', (t) => {
   const testError = new Error('test error');
   const fn = t.mock.fn(() => {

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -397,8 +397,7 @@ test('given null to a mock.method it throws a invalid argument error', (t) => {
 });
 
 test('spy functions can be used on classes inheritance', (t) => {
-  
-  // make sure that having a null-prototype doesn't throw our system off
+  // Makes sure that having a null-prototype doesn't throw our system off
   class A extends null {
     static someTask(msg) {
       return msg;

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -446,17 +446,27 @@ test('spy functions don\'t affect the prototype chain', (t) => {
 
   const msg = 'ok';
 
+  const ABeforeMockIsUnchanged = Object.getOwnPropertyDescriptor(A, A.someTask.name);
+  const BBeforeMockIsUnchanged = Object.getOwnPropertyDescriptor(B, B.someTask.name);
+  const CBeforeMockShouldNotHaveDesc = Object.getOwnPropertyDescriptor(C, C.someTask.name);
+
   t.mock.method(C, C.someTask.name);
   C.someTask(msg);
+  const BAfterMockIsUnchanged = Object.getOwnPropertyDescriptor(B, B.someTask.name);
 
-  assert.strictEqual(B.someTask.mock, undefined);
-  assert.strictEqual(A.someTask.mock, undefined);
+  const AAfterMockIsUnchanged = Object.getOwnPropertyDescriptor(A, A.someTask.name);
+  const CAfterMockHasDescriptor = Object.getOwnPropertyDescriptor(C, C.someTask.name);
+
+  assert.strictEqual(CBeforeMockShouldNotHaveDesc, undefined);
+  assert.ok(CAfterMockHasDescriptor);
+
+  assert.deepStrictEqual(ABeforeMockIsUnchanged, AAfterMockIsUnchanged);
+  assert.strictEqual(BBeforeMockIsUnchanged, BAfterMockIsUnchanged);
+  assert.strictEqual(BBeforeMockIsUnchanged, undefined);
 
   assert.strictEqual(C.someTask.mock.restore(), undefined);
-  C.someTask(msg);
-  assert.strictEqual(C.someTask.mock, undefined);
-  assert.strictEqual(B.someTask.mock, undefined);
-  assert.strictEqual(A.someTask.mock, undefined);
+  const CAfterRestoreKeepsDescriptor = Object.getOwnPropertyDescriptor(C, C.someTask.name);
+  assert.ok(CAfterRestoreKeepsDescriptor);
 });
 
 test('mocked functions report thrown errors', (t) => {


### PR DESCRIPTION
It fixes a problem when trying to spy a method from a class instance or static functions on a class instance.

Working example:

```mjs
import { mock } from 'node:test'
class Runner {
  static async someTask(msg) {
    return Promise.resolve(msg);
  }

  static async method(msg) {
    await this.someTask(msg);
    return msg;
  }
}
mock.method(Runner, Runner.someTask.name);
await Runner.method('ok')
console.log('calls', {
  length: Runner.someTask.mock.calls.length,
  result: await Runner.someTask.mock.calls[0].result,
  arguments: Runner.someTask.mock.calls[0].arguments
});
// calls { length: 1, result: 'ok', arguments: [ 'ok' ] }
```
and 
```mjs
import { mock } from 'node:test'
class Runner {
  async someTask(msg) {
    return Promise.resolve(msg);
  }

  async method(msg) {
    await this.someTask(msg);
    return msg;
  }
}
const runner = new Runner()
mock.method(runner, runner.someTask.name);
await runner.method('ok')
console.log('calls', {
  length: runner.someTask.mock.calls.length,
  result: await runner.someTask.mock.calls[0].result,
  arguments: runner.someTask.mock.calls[0].arguments
});
// calls { length: 1, result: 'ok', arguments: [ 'ok' ] }
```
This also makes sure that null Objects and inexisting methods are verified

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
