### PR TITLE
buffer: make decodeUTF8 params loose

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -570,6 +570,8 @@ void StringSlice(const FunctionCallbackInfo<Value>& args) {
 void DecodeUTF8(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);  // list, flags
 
+  CHECK_GE(args.Length(), 1);
+
   if (!(args[0]->IsArrayBuffer() || args[0]->IsSharedArrayBuffer() ||
         args[0]->IsArrayBufferView())) {
     return node::THROW_ERR_INVALID_ARG_TYPE(
@@ -580,7 +582,6 @@ void DecodeUTF8(const FunctionCallbackInfo<Value>& args) {
 
   ArrayBufferViewContents<char> buffer(args[0]);
 
-  CHECK(args[1]->IsBoolean());
   bool ignore_bom = args[1]->IsTrue();
 
   const char* data = buffer.data();


### PR DESCRIPTION
This pull request removes the IsBoolean check for the second parameter of `decodeUTF8` in order to make the parameter optional.