### PR TITLE
stream: use structuredClone instead of v8

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1470,7 +1470,7 @@ function readableStreamDefaultTee(stream, cloneForBranch2) {
           let value2 = value;
           if (!canceled2 && cloneForBranch2) {
             // Structured Clone
-            value2 = structuredClone((value2));
+            value2 = structuredClone(value2);
           }
           if (!canceled1) {
             readableStreamDefaultControllerEnqueue(

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -56,11 +56,6 @@ const {
 } = require('internal/util');
 
 const {
-  serialize,
-  deserialize,
-} = require('v8');
-
-const {
   validateBuffer,
   validateObject,
 } = require('internal/validators');
@@ -89,6 +84,10 @@ const {
   kIsErrored,
   kIsReadable,
 } = require('internal/streams/utils');
+
+const {
+  structuredClone,
+} = require('internal/structured_clone');
 
 const {
   ArrayBufferViewGetBuffer,
@@ -1471,7 +1470,7 @@ function readableStreamDefaultTee(stream, cloneForBranch2) {
           let value2 = value;
           if (!canceled2 && cloneForBranch2) {
             // Structured Clone
-            value2 = deserialize(serialize(value2));
+            value2 = structuredClone((value2));
           }
           if (!canceled1) {
             readableStreamDefaultControllerEnqueue(

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1469,7 +1469,6 @@ function readableStreamDefaultTee(stream, cloneForBranch2) {
           const value1 = value;
           let value2 = value;
           if (!canceled2 && cloneForBranch2) {
-            // Structured Clone
             value2 = structuredClone(value2);
           }
           if (!canceled1) {


### PR DESCRIPTION
This pull request replaces `deserialize(serialize(value))` with `structuredClone(value)` due to performance.