### PR TITLE
doc: add detail on how api docs are published

### DIFF
--- a/doc/contributing/api-documentation.md
+++ b/doc/contributing/api-documentation.md
@@ -11,13 +11,21 @@ generate the following:
 1. Human-readable HTML in `out/doc/api/*.html`
 2. A JSON representation in `out/doc/api/*.json`
 
-These are published to nodejs.org for multiple versions of Node.js. As an
+These artifacts published to nodejs.org for multiple versions of Node.js. As an
 example the latest version of the human-readable HTML is published to
 [nodejs.org/en/doc](https://nodejs.org/en/docs/), and the latest version
 of the json documentation is published to
 [nodejs.org/api/all.json](https://nodejs.org/api/all.json)
 
-<!-- TODO: Add docs about how the publishing process happens -->
+The artifacts are built as part of release builds by running the doc-upload
+Makefile target as part of the release-sources part of the
+[iojs+release job](https://github.com/nodejs/node/blob/1a83ad6a693f851199608ae957ac5d4f76871485/Makefile#L1218-L1224).
+This target runs the doc target to build the docs and then uses
+scp to copy them onto the staging/www server into a directory of the form
+`/home/staging/nodejs/<type>/<full_version>/docs` where <type> is e.g.
+release, nightly, etc. The promotion step (either automatic for
+nightlies or manual for releases) then moves the docs to
+/home/dist/nodejs/docs/\<full\_version> where they are served by node.org.
 
 **The key things to know about the tooling include:**
 

--- a/doc/contributing/api-documentation.md
+++ b/doc/contributing/api-documentation.md
@@ -25,7 +25,7 @@ scp to copy them onto the staging/www server into a directory of the form
 `/home/staging/nodejs/<type>/<full_version>/docs` where <type> is e.g.
 release, nightly, etc. The promotion step (either automatic for
 nightlies or manual for releases) then moves the docs to
-/home/dist/nodejs/docs/\<full\_version> where they are served by node.org.
+`/home/dist/nodejs/docs/\<full\_version>` where they are served by node.org.
 
 **The key things to know about the tooling include:**
 

--- a/doc/contributing/api-documentation.md
+++ b/doc/contributing/api-documentation.md
@@ -21,7 +21,7 @@ The artifacts are built as part of release builds by running the [doc-upload](ht
 Makefile target as part of the release-sources part of the
 iojs+release job.
 This target runs the doc target to build the docs and then uses
-scp to copy them onto the staging/www server into a directory of the form
+`scp` to copy them onto the staging/www server into a directory of the form
 `/home/staging/nodejs/<type>/<full_version>/docs` where <type> is e.g.
 release, nightly, etc. The promotion step (either automatic for
 nightlies or manual for releases) then moves the docs to

--- a/doc/contributing/api-documentation.md
+++ b/doc/contributing/api-documentation.md
@@ -11,10 +11,10 @@ generate the following:
 1. Human-readable HTML in `out/doc/api/*.html`
 2. A JSON representation in `out/doc/api/*.json`
 
-These artifacts are published to nodejs.org for multiple versions of Node.js. As an
-example the latest version of the human-readable HTML is published to
-[nodejs.org/en/doc](https://nodejs.org/en/docs/), and the latest version
-of the json documentation is published to
+These artifacts are published to nodejs.org for multiple versions of
+Node.js. As an example the latest version of the human-readable HTML
+is published to [nodejs.org/en/doc](https://nodejs.org/en/docs/),
+and the latest version of the json documentation is published to
 [nodejs.org/api/all.json](https://nodejs.org/api/all.json)
 
 The artifacts are built as part of release builds by running the [doc-upload](https://github.com/nodejs/node/blob/1a83ad6a693f851199608ae957ac5d4f76871485/Makefile#L1218-L1224)

--- a/doc/contributing/api-documentation.md
+++ b/doc/contributing/api-documentation.md
@@ -11,7 +11,7 @@ generate the following:
 1. Human-readable HTML in `out/doc/api/*.html`
 2. A JSON representation in `out/doc/api/*.json`
 
-These artifacts published to nodejs.org for multiple versions of Node.js. As an
+These artifacts are published to nodejs.org for multiple versions of Node.js. As an
 example the latest version of the human-readable HTML is published to
 [nodejs.org/en/doc](https://nodejs.org/en/docs/), and the latest version
 of the json documentation is published to

--- a/doc/contributing/api-documentation.md
+++ b/doc/contributing/api-documentation.md
@@ -17,9 +17,9 @@ example the latest version of the human-readable HTML is published to
 of the json documentation is published to
 [nodejs.org/api/all.json](https://nodejs.org/api/all.json)
 
-The artifacts are built as part of release builds by running the doc-upload
+The artifacts are built as part of release builds by running the [doc-upload](https://github.com/nodejs/node/blob/1a83ad6a693f851199608ae957ac5d4f76871485/Makefile#L1218-L1224)
 Makefile target as part of the release-sources part of the
-[iojs+release job](https://github.com/nodejs/node/blob/1a83ad6a693f851199608ae957ac5d4f76871485/Makefile#L1218-L1224).
+iojs+release job.
 This target runs the doc target to build the docs and then uses
 scp to copy them onto the staging/www server into a directory of the form
 `/home/staging/nodejs/<type>/<full_version>/docs` where <type> is e.g.

--- a/doc/contributing/api-documentation.md
+++ b/doc/contributing/api-documentation.md
@@ -20,7 +20,7 @@ of the json documentation is published to
 The artifacts are built as part of release builds by running the [doc-upload](https://github.com/nodejs/node/blob/1a83ad6a693f851199608ae957ac5d4f76871485/Makefile#L1218-L1224)
 Makefile target as part of the release-sources part of the
 iojs+release job.
-This target runs the doc target to build the docs and then uses
+This target runs the `doc` target to build the docs and then uses
 `scp` to copy them onto the staging/www server into a directory of the form
 `/home/staging/nodejs/<type>/<full_version>/docs` where <type> is e.g.
 release, nightly, etc. The promotion step (either automatic for


### PR DESCRIPTION
Add some details that Richard shared with me on
how the docs are published to the website.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
