### PR TITLE
buffer: attempt to use `Uint8Array` for `Buffer.indexof` (fast path)

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -941,6 +941,12 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   }
   dir = !!dir;  // Cast to bool.
 
+  const isUtf8 = encoding === 'utf8' || encoding === 'utf-8' || encoding === undefined;
+  if (isUtf8 && typeof val === 'string') {
+    const method = dir ? 'indexOf' : 'lastIndexOf';
+    return Uint8ArrayPrototype[method].call(buffer, val, byteOffset);
+  }
+
   if (typeof val === 'number')
     return indexOfNumber(buffer, val >>> 0, byteOffset, dir);
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -944,7 +944,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   const isUtf8 = encoding === 'utf8' || encoding === 'utf-8' || encoding === undefined;
   if (isUtf8 && typeof val === 'number') {
     const method = dir ? 'indexOf' : 'lastIndexOf';
-    let value = (val > 128 || val < -128) ? new Uint8Array([val])[0] : val;
+    let value = (val > 255 || val < 0) ? val & 0b11111111 : val;
 
     return Uint8ArrayPrototype[method].call(buffer, value, byteOffset);
   }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -944,7 +944,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   const isUtf8 = encoding === 'utf8' || encoding === 'utf-8' || encoding === undefined;
   if (isUtf8 && typeof val === 'number') {
     const method = dir ? 'indexOf' : 'lastIndexOf';
-    let value = value % 256;
+    let value = (val > 128 || val < -128) ? new Uint8Array([val])[0] : val;
 
     return Uint8ArrayPrototype[method].call(buffer, value, byteOffset);
   }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -941,12 +941,11 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   }
   dir = !!dir;  // Cast to bool.
 
-  const isUtf8 = encoding === 'utf8' || encoding === 'utf-8' || encoding === undefined;
+  const isUtf8 = encoding === undefined || encoding === 'utf8' || encoding === 'utf-8';
   if (isUtf8 && typeof val === 'number') {
     const method = dir ? 'indexOf' : 'lastIndexOf';
-    let value = (val > 255 || val < 0) ? val & 0b11111111 : val;
 
-    return Uint8ArrayPrototype[method].call(buffer, value, byteOffset);
+    return Uint8ArrayPrototype[method].call(buffer, val & 0b1111_1111, byteOffset);
   }
 
   if (typeof val === 'number')

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -942,9 +942,11 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   dir = !!dir;  // Cast to bool.
 
   const isUtf8 = encoding === 'utf8' || encoding === 'utf-8' || encoding === undefined;
-  if (isUtf8 && typeof val === 'string') {
+  if (isUtf8 && typeof val === 'number') {
     const method = dir ? 'indexOf' : 'lastIndexOf';
-    return Uint8ArrayPrototype[method].call(buffer, val, byteOffset);
+    let value = value % 256;
+
+    return Uint8ArrayPrototype[method].call(buffer, value, byteOffset);
   }
 
   if (typeof val === 'number')

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -602,7 +602,6 @@ assert.strictEqual(reallyLong.lastIndexOf(pattern), 0);
   assert.strictEqual(buf.indexOf(0x697374657374), 0);
   assert.strictEqual(buf.indexOf(0x69737374), 0);
   assert.strictEqual(buf.indexOf(0x69737465), 11);
-  assert.strictEqual(buf.indexOf(0x69737465), 11);
   assert.strictEqual(buf.indexOf(-140), 0);
   assert.strictEqual(buf.indexOf(-152), 1);
   assert.strictEqual(buf.indexOf(0xff), -1);


### PR DESCRIPTION
Ref: https://github.com/nodejs/performance/issues/4