### PR TITLE
lib: allow http.OutgoingMessage to be used in Writable.toWeb()

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -101,12 +101,12 @@ function newWritableStreamFromStreamWritable(streamWritable) {
   // here because it will return false if streamWritable is a Duplex
   // whose writable option is false. For a Duplex that is not writable,
   // we want it to pass this check but return a closed WritableStream.
-  const checkIfWritable =
+  // We check if the given stream is a stream.Writable or http.OutgoingMessage
+  const checkIfWritableOrOutgoingMessage =
     streamWritable &&
     typeof streamWritable?.write === 'function' &&
-    typeof streamWritable?.on === 'function' &&
-    !streamWritable?._readableState;
-  if (!checkIfWritable) {
+    typeof streamWritable?.on === 'function';
+  if (!checkIfWritableOrOutgoingMessage) {
     throw new ERR_INVALID_ARG_TYPE(
       'streamWritable',
       'stream.Writable',

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -101,11 +101,17 @@ function newWritableStreamFromStreamWritable(streamWritable) {
   // here because it will return false if streamWritable is a Duplex
   // whose writable option is false. For a Duplex that is not writable,
   // we want it to pass this check but return a closed WritableStream.
-  if (typeof streamWritable?._writableState !== 'object') {
+  const checkIfWritable =
+    streamWritable &&
+    typeof streamWritable?.write === 'function' &&
+    typeof streamWritable?.on === 'function' &&
+    !streamWritable?._readableState;
+  if (!checkIfWritable) {
     throw new ERR_INVALID_ARG_TYPE(
       'streamWritable',
       'stream.Writable',
-      streamWritable);
+      streamWritable
+    );
   }
 
   if (isDestroyed(streamWritable) || !isWritable(streamWritable)) {

--- a/test/parallel/test-stream-toWeb-allows-server-response.js
+++ b/test/parallel/test-stream-toWeb-allows-server-response.js
@@ -6,14 +6,24 @@ const assert = require('assert');
 const http = require('http');
 
 // Check if Writable.toWeb works on the response object after creating a server.
-const server = http.createServer((req, res) => {
-  const webStreamResponse = Writable.toWeb(res);
-  assert.strictEqual(webStreamResponse instanceof Writable, true);
-});
+const server = http.createServer(
+  common.mustCall((req, res) => {
+    const webStreamResponse = Writable.toWeb(res);
+    assert.strictEqual(webStreamResponse instanceof WritableStream, true);
+    res.end();
+  })
+);
 
 server.listen(
   0,
   common.mustCall(() => {
-    server.close();
+    http.get(
+      {
+        port: server.address().port,
+      },
+      common.mustCall(() => {
+        server.close();
+      })
+    );
   })
 );

--- a/test/parallel/test-stream-toWeb-allows-server-response.js
+++ b/test/parallel/test-stream-toWeb-allows-server-response.js
@@ -2,19 +2,18 @@
 const common = require('../common');
 const { Writable } = require('stream');
 
-// test the change i made
 const assert = require('assert');
 const http = require('http');
 
-// check if writeable.toWeb successfully works on the response object after creating a server
+// Check if Writable.toWeb works on the response object after creating a server.
 const server = http.createServer((req, res) => {
-    const webStreamResponse = Writable.toWeb(res);
-    // check instance of webStreamResponse
-    assert.strictEqual(webStreamResponse instanceof Writable, true);
+  const webStreamResponse = Writable.toWeb(res);
+  assert.strictEqual(webStreamResponse instanceof Writable, true);
 });
 
-server.listen(0, common.mustCall(() => {
+server.listen(
+  0,
+  common.mustCall(() => {
     server.close();
-}));
-
-
+  })
+);

--- a/test/parallel/test-stream-toWeb-allows-server-response.js
+++ b/test/parallel/test-stream-toWeb-allows-server-response.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const { Writable } = require('stream');
+
+// test the change i made
+const assert = require('assert');
+const http = require('http');
+
+// check if writeable.toWeb successfully works on the response object after creating a server
+const server = http.createServer((req, res) => {
+    const webStreamResponse = Writable.toWeb(res);
+    // check instance of webStreamResponse
+    assert.strictEqual(webStreamResponse instanceof Writable, true);
+});
+
+server.listen(0, common.mustCall(() => {
+    server.close();
+}));
+
+


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Attempted to fix the issue by watering down the condition being checked in lib/internal/webstreams/adapters.js similar to
isWritableNodeStream utility being used in internal/streams/utils

Fixes: https://github.com/nodejs/node/issues/44188
