### PR TITLE
src: use `enum class` instead of `enum` in node_i18n

### DIFF
--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -648,7 +648,7 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
     UIDNA_CHECK_BIDI |                // CheckBidi = true
     UIDNA_CHECK_CONTEXTJ |            // CheckJoiners = true
     UIDNA_NONTRANSITIONAL_TO_ASCII;   // Nontransitional_Processing
-  if (mode == idna_mode::kSTRICT) {
+  if (mode == idna_mode::kStrict) {
     options |= UIDNA_USE_STD3_RULES;  // UseSTD3ASCIIRules = beStrict
                                       // VerifyDnsLength = beStrict;
                                       //   handled later
@@ -696,14 +696,14 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
   info.errors &= ~UIDNA_ERROR_LEADING_HYPHEN;
   info.errors &= ~UIDNA_ERROR_TRAILING_HYPHEN;
 
-  if (mode != idna_mode::kSTRICT) {
+  if (mode != idna_mode::kStrict) {
     // VerifyDnsLength = beStrict
     info.errors &= ~UIDNA_ERROR_EMPTY_LABEL;
     info.errors &= ~UIDNA_ERROR_LABEL_TOO_LONG;
     info.errors &= ~UIDNA_ERROR_DOMAIN_NAME_TOO_LONG;
   }
 
-  if (U_FAILURE(status) || (mode != idna_mode::kLENIENT && info.errors != 0)) {
+  if (U_FAILURE(status) || (mode != idna_mode::kLenient && info.errors != 0)) {
     len = -1;
     buf->SetLength(0);
   } else {
@@ -741,7 +741,7 @@ static void ToASCII(const FunctionCallbackInfo<Value>& args) {
   Utf8Value val(env->isolate(), args[0]);
   // optional arg
   bool lenient = args[1]->BooleanValue(env->isolate());
-  idna_mode mode = lenient ? idna_mode::kLENIENT : idna_mode::kDEFAULT;
+  idna_mode mode = lenient ? idna_mode::kLenient : idna_mode::kDefault;
 
   MaybeStackBuffer<char> buf;
   int32_t len = ToASCII(&buf, *val, val.length(), mode);

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -648,7 +648,7 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
     UIDNA_CHECK_BIDI |                // CheckBidi = true
     UIDNA_CHECK_CONTEXTJ |            // CheckJoiners = true
     UIDNA_NONTRANSITIONAL_TO_ASCII;   // Nontransitional_Processing
-  if (mode == idna_mode::STRICT) {
+  if (mode == idna_mode::kSTRICT) {
     options |= UIDNA_USE_STD3_RULES;  // UseSTD3ASCIIRules = beStrict
                                       // VerifyDnsLength = beStrict;
                                       //   handled later
@@ -696,14 +696,14 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
   info.errors &= ~UIDNA_ERROR_LEADING_HYPHEN;
   info.errors &= ~UIDNA_ERROR_TRAILING_HYPHEN;
 
-  if (mode != idna_mode::STRICT) {
+  if (mode != idna_mode::kSTRICT) {
     // VerifyDnsLength = beStrict
     info.errors &= ~UIDNA_ERROR_EMPTY_LABEL;
     info.errors &= ~UIDNA_ERROR_LABEL_TOO_LONG;
     info.errors &= ~UIDNA_ERROR_DOMAIN_NAME_TOO_LONG;
   }
 
-  if (U_FAILURE(status) || (mode != idna_mode::LENIENT && info.errors != 0)) {
+  if (U_FAILURE(status) || (mode != idna_mode::kLENIENT && info.errors != 0)) {
     len = -1;
     buf->SetLength(0);
   } else {
@@ -741,7 +741,7 @@ static void ToASCII(const FunctionCallbackInfo<Value>& args) {
   Utf8Value val(env->isolate(), args[0]);
   // optional arg
   bool lenient = args[1]->BooleanValue(env->isolate());
-  idna_mode mode = lenient ? idna_mode::LENIENT : idna_mode::DEFAULT;
+  idna_mode mode = lenient ? idna_mode::kLENIENT : idna_mode::kDEFAULT;
 
   MaybeStackBuffer<char> buf;
   int32_t len = ToASCII(&buf, *val, val.length(), mode);

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -642,13 +642,13 @@ int32_t ToUnicode(MaybeStackBuffer<char>* buf,
 int32_t ToASCII(MaybeStackBuffer<char>* buf,
                 const char* input,
                 size_t length,
-                enum idna_mode mode) {
+                idna_mode mode) {
   UErrorCode status = U_ZERO_ERROR;
   uint32_t options =                  // CheckHyphens = false; handled later
     UIDNA_CHECK_BIDI |                // CheckBidi = true
     UIDNA_CHECK_CONTEXTJ |            // CheckJoiners = true
     UIDNA_NONTRANSITIONAL_TO_ASCII;   // Nontransitional_Processing
-  if (mode == IDNA_STRICT) {
+  if (mode == idna_mode::IDNA_STRICT) {
     options |= UIDNA_USE_STD3_RULES;  // UseSTD3ASCIIRules = beStrict
                                       // VerifyDnsLength = beStrict;
                                       //   handled later
@@ -696,14 +696,15 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
   info.errors &= ~UIDNA_ERROR_LEADING_HYPHEN;
   info.errors &= ~UIDNA_ERROR_TRAILING_HYPHEN;
 
-  if (mode != IDNA_STRICT) {
+  if (mode != idna_mode::IDNA_STRICT) {
     // VerifyDnsLength = beStrict
     info.errors &= ~UIDNA_ERROR_EMPTY_LABEL;
     info.errors &= ~UIDNA_ERROR_LABEL_TOO_LONG;
     info.errors &= ~UIDNA_ERROR_DOMAIN_NAME_TOO_LONG;
   }
 
-  if (U_FAILURE(status) || (mode != IDNA_LENIENT && info.errors != 0)) {
+  if (U_FAILURE(status) ||
+      (mode != idna_mode::IDNA_LENIENT && info.errors != 0)) {
     len = -1;
     buf->SetLength(0);
   } else {
@@ -741,7 +742,7 @@ static void ToASCII(const FunctionCallbackInfo<Value>& args) {
   Utf8Value val(env->isolate(), args[0]);
   // optional arg
   bool lenient = args[1]->BooleanValue(env->isolate());
-  enum idna_mode mode = lenient ? IDNA_LENIENT : IDNA_DEFAULT;
+  idna_mode mode = lenient ? idna_mode::IDNA_LENIENT : idna_mode::IDNA_DEFAULT;
 
   MaybeStackBuffer<char> buf;
   int32_t len = ToASCII(&buf, *val, val.length(), mode);

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -648,7 +648,7 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
     UIDNA_CHECK_BIDI |                // CheckBidi = true
     UIDNA_CHECK_CONTEXTJ |            // CheckJoiners = true
     UIDNA_NONTRANSITIONAL_TO_ASCII;   // Nontransitional_Processing
-  if (mode == idna_mode::IDNA_STRICT) {
+  if (mode == idna_mode::STRICT) {
     options |= UIDNA_USE_STD3_RULES;  // UseSTD3ASCIIRules = beStrict
                                       // VerifyDnsLength = beStrict;
                                       //   handled later
@@ -696,15 +696,14 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
   info.errors &= ~UIDNA_ERROR_LEADING_HYPHEN;
   info.errors &= ~UIDNA_ERROR_TRAILING_HYPHEN;
 
-  if (mode != idna_mode::IDNA_STRICT) {
+  if (mode != idna_mode::STRICT) {
     // VerifyDnsLength = beStrict
     info.errors &= ~UIDNA_ERROR_EMPTY_LABEL;
     info.errors &= ~UIDNA_ERROR_LABEL_TOO_LONG;
     info.errors &= ~UIDNA_ERROR_DOMAIN_NAME_TOO_LONG;
   }
 
-  if (U_FAILURE(status) ||
-      (mode != idna_mode::IDNA_LENIENT && info.errors != 0)) {
+  if (U_FAILURE(status) || (mode != idna_mode::LENIENT && info.errors != 0)) {
     len = -1;
     buf->SetLength(0);
   } else {
@@ -742,7 +741,7 @@ static void ToASCII(const FunctionCallbackInfo<Value>& args) {
   Utf8Value val(env->isolate(), args[0]);
   // optional arg
   bool lenient = args[1]->BooleanValue(env->isolate());
-  idna_mode mode = lenient ? idna_mode::IDNA_LENIENT : idna_mode::IDNA_DEFAULT;
+  idna_mode mode = lenient ? idna_mode::LENIENT : idna_mode::DEFAULT;
 
   MaybeStackBuffer<char> buf;
   int32_t len = ToASCII(&buf, *val, val.length(), mode);

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -44,13 +44,13 @@ void SetDefaultTimeZone(const char* tzid);
 
 enum class idna_mode {
   // Default mode for maximum compatibility.
-  DEFAULT,
+  kDEFAULT,
   // Ignore all errors in IDNA conversion, if possible.
-  LENIENT,
+  kLENIENT,
   // Enforce STD3 rules (UseSTD3ASCIIRules) and DNS length restrictions
   // (VerifyDnsLength). Corresponds to `beStrict` flag in the "domain to ASCII"
   // algorithm.
-  STRICT
+  kSTRICT
 };
 
 // Implements the WHATWG URL Standard "domain to ASCII" algorithm.
@@ -58,7 +58,7 @@ enum class idna_mode {
 int32_t ToASCII(MaybeStackBuffer<char>* buf,
                 const char* input,
                 size_t length,
-                idna_mode mode = idna_mode::DEFAULT);
+                idna_mode mode = idna_mode::kDEFAULT);
 
 // Implements the WHATWG URL Standard "domain to Unicode" algorithm.
 // https://url.spec.whatwg.org/#concept-domain-to-unicode

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -42,7 +42,7 @@ bool InitializeICUDirectory(const std::string& path);
 
 void SetDefaultTimeZone(const char* tzid);
 
-enum idna_mode {
+enum class idna_mode {
   // Default mode for maximum compatibility.
   IDNA_DEFAULT,
   // Ignore all errors in IDNA conversion, if possible.
@@ -58,7 +58,7 @@ enum idna_mode {
 int32_t ToASCII(MaybeStackBuffer<char>* buf,
                 const char* input,
                 size_t length,
-                enum idna_mode mode = IDNA_DEFAULT);
+                idna_mode mode = idna_mode::IDNA_DEFAULT);
 
 // Implements the WHATWG URL Standard "domain to Unicode" algorithm.
 // https://url.spec.whatwg.org/#concept-domain-to-unicode

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -44,13 +44,13 @@ void SetDefaultTimeZone(const char* tzid);
 
 enum class idna_mode {
   // Default mode for maximum compatibility.
-  kDEFAULT,
+  kDefault,
   // Ignore all errors in IDNA conversion, if possible.
-  kLENIENT,
+  kLenient,
   // Enforce STD3 rules (UseSTD3ASCIIRules) and DNS length restrictions
   // (VerifyDnsLength). Corresponds to `beStrict` flag in the "domain to ASCII"
   // algorithm.
-  kSTRICT
+  kStrict
 };
 
 // Implements the WHATWG URL Standard "domain to ASCII" algorithm.
@@ -58,7 +58,7 @@ enum class idna_mode {
 int32_t ToASCII(MaybeStackBuffer<char>* buf,
                 const char* input,
                 size_t length,
-                idna_mode mode = idna_mode::kDEFAULT);
+                idna_mode mode = idna_mode::kDefault);
 
 // Implements the WHATWG URL Standard "domain to Unicode" algorithm.
 // https://url.spec.whatwg.org/#concept-domain-to-unicode

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -44,13 +44,13 @@ void SetDefaultTimeZone(const char* tzid);
 
 enum class idna_mode {
   // Default mode for maximum compatibility.
-  IDNA_DEFAULT,
+  DEFAULT,
   // Ignore all errors in IDNA conversion, if possible.
-  IDNA_LENIENT,
+  LENIENT,
   // Enforce STD3 rules (UseSTD3ASCIIRules) and DNS length restrictions
   // (VerifyDnsLength). Corresponds to `beStrict` flag in the "domain to ASCII"
   // algorithm.
-  IDNA_STRICT
+  STRICT
 };
 
 // Implements the WHATWG URL Standard "domain to ASCII" algorithm.
@@ -58,7 +58,7 @@ enum class idna_mode {
 int32_t ToASCII(MaybeStackBuffer<char>* buf,
                 const char* input,
                 size_t length,
-                idna_mode mode = idna_mode::IDNA_DEFAULT);
+                idna_mode mode = idna_mode::DEFAULT);
 
 // Implements the WHATWG URL Standard "domain to Unicode" algorithm.
 // https://url.spec.whatwg.org/#concept-domain-to-unicode


### PR DESCRIPTION
"enum class" has more advantages than "enum" because it's strongly typed and scoped.

Refs: https://isocpp.org/wiki/faq/cpp11-language-types#enum-class

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
