### PR TITLE
doc: move os.machine() docs to sorted position

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -220,6 +220,24 @@ system and expressed as a fractional number.
 The load average is a Unix-specific concept. On Windows, the return value is
 always `[0, 0, 0]`.
 
+## `os.machine()`
+
+<!-- YAML
+added:
+  - v18.9.0
+  - v16.18.0
+-->
+
+* Returns {string}
+
+Returns the machine type as a string, such as `arm`, `arm64`, `aarch64`,
+`mips`, `mips64`, `ppc64`, `ppc64le`, `s390`, `s390x`, `i386`, `i686`, `x86_64`.
+
+On POSIX systems, the machine type is determined by calling
+[`uname(3)`][]. On Windows, `RtlGetVersion()` is used, and if it is not
+available, `GetVersionExW()` will be used. See
+<https://en.wikipedia.org/wiki/Uname#Examples> for more information.
+
 ## `os.networkInterfaces()`
 
 <!-- YAML
@@ -448,24 +466,6 @@ added:
 Returns a string identifying the kernel version.
 
 On POSIX systems, the operating system release is determined by calling
-[`uname(3)`][]. On Windows, `RtlGetVersion()` is used, and if it is not
-available, `GetVersionExW()` will be used. See
-<https://en.wikipedia.org/wiki/Uname#Examples> for more information.
-
-## `os.machine()`
-
-<!-- YAML
-added:
-  - v18.9.0
-  - v16.18.0
--->
-
-* Returns {string}
-
-Returns the machine type as a string, such as `arm`, `arm64`, `aarch64`,
-`mips`, `mips64`, `ppc64`, `ppc64le`, `s390`, `s390x`, `i386`, `i686`, `x86_64`.
-
-On POSIX systems, the machine type is determined by calling
 [`uname(3)`][]. On Windows, `RtlGetVersion()` is used, and if it is not
 available, `GetVersionExW()` will be used. See
 <https://en.wikipedia.org/wiki/Uname#Examples> for more information.


### PR DESCRIPTION
This commit moves the os.machine() docs so that the API list is sorted.