### PR TITLE
[v18.x backport] backport utf8 performance improvements

### DIFF
--- a/benchmark/util/text-decoder.js
+++ b/benchmark/util/text-decoder.js
@@ -14,6 +14,8 @@ function main({ encoding, len, n, ignoreBOM }) {
   const decoder = new TextDecoder(encoding, { ignoreBOM });
 
   bench.start();
-  decoder.decode(buf);
+  for (let i = 0; i < n; i++) {
+    decoder.decode(buf);
+  }
   bench.end(n);
 }

--- a/benchmark/util/text-decoder.js
+++ b/benchmark/util/text-decoder.js
@@ -6,12 +6,28 @@ const bench = common.createBenchmark(main, {
   encoding: ['utf-8', 'latin1', 'iso-8859-3'],
   ignoreBOM: [0, 1],
   len: [256, 1024 * 16, 1024 * 512],
-  n: [1e6]
+  n: [1e2],
+  type: ['SharedArrayBuffer', 'ArrayBuffer', 'Buffer']
 });
 
-function main({ encoding, len, n, ignoreBOM }) {
-  const buf = Buffer.allocUnsafe(len);
+function main({ encoding, len, n, ignoreBOM, type }) {
   const decoder = new TextDecoder(encoding, { ignoreBOM });
+  let buf;
+
+  switch (type) {
+    case 'SharedArrayBuffer': {
+      buf = new SharedArrayBuffer(len);
+      break;
+    }
+    case 'ArrayBuffer': {
+      buf = new ArrayBuffer(len);
+      break;
+    }
+    case 'Buffer': {
+      buf = Buffer.allocUnsafe(len);
+      break;
+    }
+  }
 
   bench.start();
   for (let i = 0; i < n; i++) {

--- a/benchmark/util/text-decoder.js
+++ b/benchmark/util/text-decoder.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  encoding: ['utf-8', 'latin1', 'iso-8859-3'],
+  ignoreBOM: [0, 1],
+  len: [256, 1024 * 16, 1024 * 512],
+  n: [1e6]
+});
+
+function main({ encoding, len, n, ignoreBOM }) {
+  const buf = Buffer.allocUnsafe(len);
+  const decoder = new TextDecoder(encoding, { ignoreBOM });
+
+  bench.start();
+  decoder.decode(buf);
+  bench.end(n);
+}

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -4,6 +4,7 @@
 // https://encoding.spec.whatwg.org
 
 const {
+  Boolean,
   ObjectCreate,
   ObjectDefineProperties,
   ObjectGetOwnPropertyDescriptors,
@@ -28,6 +29,8 @@ const kFlags = Symbol('flags');
 const kEncoding = Symbol('encoding');
 const kDecoder = Symbol('decoder');
 const kEncoder = Symbol('encoder');
+const kUTF8FastPath = Symbol('kUTF8FastPath');
+const kIgnoreBOM = Symbol('kIgnoreBOM');
 
 const {
   getConstructorOf,
@@ -49,7 +52,8 @@ const {
 
 const {
   encodeInto,
-  encodeUtf8String
+  encodeUtf8String,
+  decodeUTF8,
 } = internalBinding('buffer');
 
 let Buffer;
@@ -397,19 +401,40 @@ function makeTextDecoderICU() {
         flags |= options.ignoreBOM ? CONVERTER_FLAGS_IGNORE_BOM : 0;
       }
 
-      const handle = getConverter(enc, flags);
-      if (handle === undefined)
-        throw new ERR_ENCODING_NOT_SUPPORTED(encoding);
+      // Only support fast path for UTF-8 without FATAL flag
+      const fastPathAvailable = enc === 'utf-8' && !(options?.fatal);
 
       this[kDecoder] = true;
-      this[kHandle] = handle;
       this[kFlags] = flags;
       this[kEncoding] = enc;
+      this[kIgnoreBOM] = Boolean(options?.ignoreBOM);
+      this[kUTF8FastPath] = fastPathAvailable;
+      this[kHandle] = undefined;
+
+      if (!fastPathAvailable) {
+        this.#prepareConverter();
+      }
     }
 
+    #prepareConverter() {
+      if (this[kHandle] !== undefined) return;
+      const handle = getConverter(this[kEncoding], this[kFlags]);
+      if (handle === undefined)
+        throw new ERR_ENCODING_NOT_SUPPORTED(this[kEncoding]);
+      this[kHandle] = handle;
+    }
 
     decode(input = empty, options = kEmptyObject) {
       validateDecoder(this);
+
+      this[kUTF8FastPath] &&= !(options?.stream);
+
+      if (this[kUTF8FastPath]) {
+        return decodeUTF8(input, this[kIgnoreBOM]);
+      }
+
+      this.#prepareConverter();
+
       validateObject(options, 'options', {
         nullable: true,
         allowArray: true,

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -18,7 +18,6 @@ const {
 } = primordials;
 
 const {
-  ERR_ENCODING_INVALID_ENCODED_DATA,
   ERR_ENCODING_NOT_SUPPORTED,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_THIS,
@@ -411,11 +410,6 @@ function makeTextDecoderICU() {
 
     decode(input = empty, options = kEmptyObject) {
       validateDecoder(this);
-      if (!isAnyArrayBuffer(input) && !isArrayBufferView(input)) {
-        throw new ERR_INVALID_ARG_TYPE('input',
-                                       ['ArrayBuffer', 'ArrayBufferView'],
-                                       input);
-      }
       validateObject(options, 'options', {
         nullable: true,
         allowArray: true,
@@ -426,11 +420,7 @@ function makeTextDecoderICU() {
       if (options !== null)
         flags |= options.stream ? 0 : CONVERTER_FLAGS_FLUSH;
 
-      const ret = _decode(this[kHandle], input, flags);
-      if (typeof ret === 'number') {
-        throw new ERR_ENCODING_INVALID_ENCODED_DATA(this.encoding, ret);
-      }
-      return ret;
+      return _decode(this[kHandle], input, flags, this.encoding);
     }
   }
 

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -432,7 +432,7 @@ function makeTextDecoderICU() {
       if (typeof ret === 'number') {
         throw new ERR_ENCODING_INVALID_ENCODED_DATA(this.encoding, ret);
       }
-      return ret.toString('ucs2');
+      return ret;
     }
   }
 

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -411,9 +411,7 @@ function makeTextDecoderICU() {
 
     decode(input = empty, options = kEmptyObject) {
       validateDecoder(this);
-      if (isAnyArrayBuffer(input)) {
-        input = lazyBuffer().from(input);
-      } else if (!isArrayBufferView(input)) {
+      if (!isAnyArrayBuffer(input) && !isArrayBufferView(input)) {
         throw new ERR_INVALID_ARG_TYPE('input',
                                        ['ArrayBuffer', 'ArrayBufferView'],
                                        input);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -24,6 +24,7 @@
 #include "node_blob.h"
 #include "node_errors.h"
 #include "node_external_reference.h"
+#include "node_i18n.h"
 #include "node_internals.h"
 
 #include "env-inl.h"
@@ -565,6 +566,48 @@ void StringSlice(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(ret);
 }
 
+// Convert the input into an encoded string
+void DecodeUTF8(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);  // list, flags
+
+  if (!(args[0]->IsArrayBuffer() || args[0]->IsSharedArrayBuffer() ||
+        args[0]->IsArrayBufferView())) {
+    return node::THROW_ERR_INVALID_ARG_TYPE(
+        env->isolate(),
+        "The \"list\" argument must be an instance of SharedArrayBuffer, "
+        "ArrayBuffer or ArrayBufferView.");
+  }
+
+  ArrayBufferViewContents<char> buffer(args[0]);
+
+  CHECK(args[1]->IsBoolean());
+  bool ignore_bom = args[1]->IsTrue();
+
+  const char* data = buffer.data();
+  size_t length = buffer.length();
+
+  if (!ignore_bom && length >= 3) {
+    if (memcmp(data, "\xEF\xBB\xBF", 3) == 0) {
+      data += 3;
+      length -= 3;
+    }
+  }
+
+  if (length == 0) return args.GetReturnValue().SetEmptyString();
+
+  Local<Value> error;
+  MaybeLocal<Value> maybe_ret =
+      StringBytes::Encode(env->isolate(), data, length, UTF8, &error);
+  Local<Value> ret;
+
+  if (!maybe_ret.ToLocal(&ret)) {
+    CHECK(!error.IsEmpty());
+    env->isolate()->ThrowException(error);
+    return;
+  }
+
+  args.GetReturnValue().Set(ret);
+}
 
 // bytesCopied = copy(buffer, target[, targetStart][, sourceStart][, sourceEnd])
 void Copy(const FunctionCallbackInfo<Value> &args) {
@@ -1282,6 +1325,7 @@ void Initialize(Local<Object> target,
 
   SetMethod(context, target, "setBufferPrototype", SetBufferPrototype);
   SetMethodNoSideEffect(context, target, "createFromString", CreateFromString);
+  SetMethodNoSideEffect(context, target, "decodeUTF8", DecodeUTF8);
 
   SetMethodNoSideEffect(context, target, "byteLengthUtf8", ByteLengthUtf8);
   SetMethod(context, target, "copy", Copy);
@@ -1339,6 +1383,7 @@ void Initialize(Local<Object> target,
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(SetBufferPrototype);
   registry->Register(CreateFromString);
+  registry->Register(DecodeUTF8);
 
   registry->Register(ByteLengthUtf8);
   registry->Register(Copy);

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -60,6 +60,7 @@ void OOMErrorHandler(const char* location, bool is_heap_oom);
   V(ERR_CRYPTO_JOB_INIT_FAILED, Error)                                         \
   V(ERR_DLOPEN_DISABLED, Error)                                                \
   V(ERR_DLOPEN_FAILED, Error)                                                  \
+  V(ERR_ENCODING_INVALID_ENCODED_DATA, TypeError)                              \
   V(ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE, Error)                            \
   V(ERR_INVALID_ADDRESS, Error)                                                \
   V(ERR_INVALID_ARG_VALUE, TypeError)                                          \

--- a/src/util.h
+++ b/src/util.h
@@ -505,6 +505,7 @@ class ArrayBufferViewContents {
   explicit inline ArrayBufferViewContents(v8::Local<v8::Object> value);
   explicit inline ArrayBufferViewContents(v8::Local<v8::ArrayBufferView> abv);
   inline void Read(v8::Local<v8::ArrayBufferView> abv);
+  inline void ReadValue(v8::Local<v8::Value> buf);
 
   inline const T* data() const { return data_; }
   inline size_t length() const { return length_; }

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -113,7 +113,7 @@ if (common.hasIntl) {
       '  fatal: false,\n' +
       '  ignoreBOM: true,\n' +
       '  [Symbol(flags)]: 4,\n' +
-      '  [Symbol(handle)]: Converter {}\n' +
+      '  [Symbol(handle)]: undefined\n' +
       '}'
     );
   } else {


### PR DESCRIPTION
This is my first backport. If the time is right, I'd like to backport UTF8 encoding performance improvements, so that LTS users can access to the performance boosts. 

I'm trying to backport the following changes to the v18 release line:

- https://github.com/nodejs/node/pull/45294
- https://github.com/nodejs/node/pull/45363
- https://github.com/nodejs/node/pull/45388
- https://github.com/nodejs/node/pull/45412