### PR TITLE
deps: V8: cherry-pick e39af94dd18e

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.5',
+    'v8_embedder_string': '-node.6',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/codegen/riscv/assembler-riscv.cc
+++ b/deps/v8/src/codegen/riscv/assembler-riscv.cc
@@ -501,7 +501,7 @@ void Assembler::target_at_put(int pos, int target_pos, bool is_internal,
     *reinterpret_cast<uintptr_t*>(buffer_start_ + pos) = imm;
     return;
   }
-  DEBUG_PRINTF("target_at_put: %p (%d) to %p (%d)\n",
+  DEBUG_PRINTF("\ttarget_at_put: %p (%d) to %p (%d)\n",
                reinterpret_cast<Instr*>(buffer_start_ + pos), pos,
                reinterpret_cast<Instr*>(buffer_start_ + target_pos),
                target_pos);
@@ -597,7 +597,7 @@ void Assembler::print(const Label* L) {
 
 void Assembler::bind_to(Label* L, int pos) {
   DCHECK(0 <= pos && pos <= pc_offset());  // Must have valid binding position.
-  DEBUG_PRINTF("binding %d to label %p\n", pos, L);
+  DEBUG_PRINTF("\tbinding %d to label %p\n", pos, L);
   int trampoline_pos = kInvalidSlotPos;
   bool is_internal = false;
   if (L->is_linked() && !trampoline_emitted_) {
@@ -666,7 +666,7 @@ void Assembler::next(Label* L, bool is_internal) {
     L->Unuse();
   } else {
     DCHECK_GE(link, 0);
-    DEBUG_PRINTF("next: %p to %p (%d)\n", L,
+    DEBUG_PRINTF("\tnext: %p to %p (%d)\n", L,
                  reinterpret_cast<Instr*>(buffer_start_ + link), link);
     L->link_to(link);
   }
@@ -740,7 +740,7 @@ int32_t Assembler::get_trampoline_entry(int32_t pos) {
 
 uintptr_t Assembler::jump_address(Label* L) {
   intptr_t target_pos;
-  DEBUG_PRINTF("jump_address: %p to %p (%d)\n", L,
+  DEBUG_PRINTF("\tjump_address: %p to %p (%d)\n", L,
                reinterpret_cast<Instr*>(buffer_start_ + pc_offset()),
                pc_offset());
   if (L->is_bound()) {
@@ -771,7 +771,7 @@ uintptr_t Assembler::jump_address(Label* L) {
 int32_t Assembler::branch_long_offset(Label* L) {
   intptr_t target_pos;
 
-  DEBUG_PRINTF("branch_long_offset: %p to %p (%d)\n", L,
+  DEBUG_PRINTF("\tbranch_long_offset: %p to %p (%d)\n", L,
                reinterpret_cast<Instr*>(buffer_start_ + pc_offset()),
                pc_offset());
   if (L->is_bound()) {
@@ -803,7 +803,7 @@ int32_t Assembler::branch_long_offset(Label* L) {
 int32_t Assembler::branch_offset_helper(Label* L, OffsetSize bits) {
   int32_t target_pos;
 
-  DEBUG_PRINTF("branch_offset_helper: %p to %p (%d)\n", L,
+  DEBUG_PRINTF("\tbranch_offset_helper: %p to %p (%d)\n", L,
                reinterpret_cast<Instr*>(buffer_start_ + pc_offset()),
                pc_offset());
   if (L->is_bound()) {
@@ -835,7 +835,7 @@ int32_t Assembler::branch_offset_helper(Label* L, OffsetSize bits) {
 
 void Assembler::label_at_put(Label* L, int at_offset) {
   int target_pos;
-  DEBUG_PRINTF("label_at_put: %p @ %p (%d)\n", L,
+  DEBUG_PRINTF("\tlabel_at_put: %p @ %p (%d)\n", L,
                reinterpret_cast<Instr*>(buffer_start_ + at_offset), at_offset);
   if (L->is_bound()) {
     target_pos = L->pos();
@@ -1179,7 +1179,7 @@ void Assembler::li_ptr(Register rd, int64_t imm) {
 }
 
 void Assembler::li_constant(Register rd, int64_t imm) {
-  DEBUG_PRINTF("li_constant(%d, %lx <%ld>)\n", ToNumber(rd), imm, imm);
+  DEBUG_PRINTF("\tli_constant(%d, %lx <%ld>)\n", ToNumber(rd), imm, imm);
   lui(rd, (imm + (1LL << 47) + (1LL << 35) + (1LL << 23) + (1LL << 11)) >>
               48);  // Bits 63:48
   addiw(rd, rd,
@@ -1236,7 +1236,7 @@ void Assembler::li_ptr(Register rd, int32_t imm) {
 }
 
 void Assembler::li_constant(Register rd, int32_t imm) {
-  DEBUG_PRINTF("li_constant(%d, %x <%d>)\n", ToNumber(rd), imm, imm);
+  DEBUG_PRINTF("\tli_constant(%d, %x <%d>)\n", ToNumber(rd), imm, imm);
   int32_t high_20 = ((imm + 0x800) >> 12);  // bits31:12
   int32_t low_12 = imm & 0xfff;             // bits11:0
   lui(rd, high_20);
@@ -1335,7 +1335,7 @@ int Assembler::RelocateInternalReference(RelocInfo::Mode rmode, Address pc,
   DCHECK(RelocInfo::IsInternalReferenceEncoded(rmode));
   if (IsLui(instr)) {
     uintptr_t target_address = target_address_at(pc) + pc_delta;
-    DEBUG_PRINTF("target_address 0x%" PRIxPTR "\n", target_address);
+    DEBUG_PRINTF("\ttarget_address 0x%" PRIxPTR "\n", target_address);
     set_target_value_at(pc, target_address);
 #if V8_TARGET_ARCH_RISCV64
     return 8;  // Number of instructions patched.

--- a/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
+++ b/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
@@ -4475,6 +4475,7 @@ MemOperand TurboAssembler::EntryFromBuiltinAsOperand(Builtin builtin) {
 }
 
 void TurboAssembler::PatchAndJump(Address target) {
+  BlockTrampolinePoolScope block_trampoline_pool(this);
   UseScratchRegisterScope temps(this);
   Register scratch = temps.Acquire();
   auipc(scratch, 0);  // Load PC into scratch

--- a/deps/v8/src/codegen/riscv/macro-assembler-riscv.h
+++ b/deps/v8/src/codegen/riscv/macro-assembler-riscv.h
@@ -212,6 +212,7 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   void LoadRootRelative(Register destination, int32_t offset) final;
 
   inline void GenPCRelativeJump(Register rd, int32_t imm32) {
+    BlockTrampolinePoolScope block_trampoline_pool(this);
     DCHECK(is_int32(imm32 + 0x800));
     int32_t Hi20 = ((imm32 + 0x800) >> 12);
     int32_t Lo12 = imm32 << 20 >> 20;
@@ -220,6 +221,7 @@ class V8_EXPORT_PRIVATE TurboAssembler : public TurboAssemblerBase {
   }
 
   inline void GenPCRelativeJumpAndLink(Register rd, int32_t imm32) {
+    BlockTrampolinePoolScope block_trampoline_pool(this);
     DCHECK(is_int32(imm32 + 0x800));
     int32_t Hi20 = ((imm32 + 0x800) >> 12);
     int32_t Lo12 = imm32 << 20 >> 20;


### PR DESCRIPTION
Original commit message:

    [riscv64] Fix failed: vector[] index out of

    GenPCRelativeJumpAndLink doesn't use BlockTrampolinePoolScope.
    It inserts a BlockTrampolinePool which causes this error.

    And also alter debug info format.

    Change-Id: I160f13f4261fdcf1f7978bfce9b5169d363e6a10
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4032016
    Commit-Queue: Yahan Lu <yahan@iscas.ac.cn>
    Reviewed-by: ji qiu <qiuji@iscas.ac.cn>
    Commit-Queue: ji qiu <qiuji@iscas.ac.cn>
    Auto-Submit: Yahan Lu <yahan@iscas.ac.cn>
    Cr-Commit-Position: refs/heads/main@{#84316}

Refs: https://github.com/v8/v8/commit/e39af94dd18e6079cfd91d4d1751c3c21c723230

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
