### PR TITLE
lib: check number of arguments in `EventTarget`'s function

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -636,6 +636,8 @@ class EventTarget {
   removeEventListener(type, listener, options = kEmptyObject) {
     if (!isEventTarget(this))
       throw new ERR_INVALID_THIS('EventTarget');
+    if (arguments.length < 2)
+      throw new ERR_MISSING_ARGS('type', 'listener');
     if (!validateEventListener(listener))
       return;
 
@@ -666,6 +668,8 @@ class EventTarget {
   dispatchEvent(event) {
     if (!isEventTarget(this))
       throw new ERR_INVALID_THIS('EventTarget');
+    if (arguments.length < 1)
+      throw new ERR_MISSING_ARGS('event');
 
     if (!(event instanceof Event))
       throw new ERR_INVALID_ARG_TYPE('event', 'Event', event);

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -691,31 +691,26 @@ let asyncTest = Promise.resolve();
 
   throws(() => et.addEventListener(), {
     code: 'ERR_MISSING_ARGS',
-    name: 'TypeError',
-    message: 'The "type" and "listener" arguments must be specified'
+    name: 'TypeError'
   });
 
   throws(() => et.addEventListener('foo'), {
     code: 'ERR_MISSING_ARGS',
-    name: 'TypeError',
-    message: 'The "type" and "listener" arguments must be specified'
+    name: 'TypeError'
   });
 
   throws(() => et.removeEventListener(), {
     code: 'ERR_MISSING_ARGS',
-    name: 'TypeError',
-    message: 'The "type" and "listener" arguments must be specified'
+    name: 'TypeError'
   });
 
   throws(() => et.removeEventListener('foo'), {
     code: 'ERR_MISSING_ARGS',
-    name: 'TypeError',
-    message: 'The "type" and "listener" arguments must be specified'
+    name: 'TypeError'
   });
 
   throws(() => et.dispatchEvent(), {
     code: 'ERR_MISSING_ARGS',
-    name: 'TypeError',
-    message: 'The "event" argument must be specified'
+    name: 'TypeError'
   });
 }

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -685,3 +685,37 @@ let asyncTest = Promise.resolve();
     et.dispatchEvent(new Event('foo'));
   });
 }
+
+{
+  const et = new EventTarget();
+
+  throws(() => et.addEventListener(), {
+    code: 'ERR_MISSING_ARGS',
+    name: 'TypeError',
+    message: 'The "type" and "listener" arguments must be specified'
+  });
+
+  throws(() => et.addEventListener('foo'), {
+    code: 'ERR_MISSING_ARGS',
+    name: 'TypeError',
+    message: 'The "type" and "listener" arguments must be specified'
+  });
+
+  throws(() => et.removeEventListener(), {
+    code: 'ERR_MISSING_ARGS',
+    name: 'TypeError',
+    message: 'The "type" and "listener" arguments must be specified'
+  });
+
+  throws(() => et.removeEventListener('foo'), {
+    code: 'ERR_MISSING_ARGS',
+    name: 'TypeError',
+    message: 'The "type" and "listener" arguments must be specified'
+  });
+
+  throws(() => et.dispatchEvent(), {
+    code: 'ERR_MISSING_ARGS',
+    name: 'TypeError',
+    message: 'The "event" argument must be specified'
+  });
+}

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -696,21 +696,21 @@ let asyncTest = Promise.resolve();
 
   throws(() => et.addEventListener('foo'), {
     code: 'ERR_MISSING_ARGS',
-    name: 'TypeError'
+    name: 'TypeError',
   });
 
   throws(() => et.removeEventListener(), {
     code: 'ERR_MISSING_ARGS',
-    name: 'TypeError'
+    name: 'TypeError',
   });
 
   throws(() => et.removeEventListener('foo'), {
     code: 'ERR_MISSING_ARGS',
-    name: 'TypeError'
+    name: 'TypeError',
   });
 
   throws(() => et.dispatchEvent(), {
     code: 'ERR_MISSING_ARGS',
-    name: 'TypeError'
+    name: 'TypeError',
   });
 }

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -691,7 +691,7 @@ let asyncTest = Promise.resolve();
 
   throws(() => et.addEventListener(), {
     code: 'ERR_MISSING_ARGS',
-    name: 'TypeError'
+    name: 'TypeError',
   });
 
   throws(() => et.addEventListener('foo'), {


### PR DESCRIPTION
For now, addEventListener() only checks number of arguments.
removeEventListener() and dispatchEvent() also need checking number of arguments.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
