### PR TITLE
stream: expose stream symbols

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -11,7 +11,7 @@ const {
   Symbol,
 } = primordials;
 const {
-  kDestroyed,
+  kIsDestroyed,
   isDestroyed,
   isFinished,
   isServerRequest,
@@ -327,7 +327,7 @@ function destroyer(stream, err) {
   }
 
   if (!stream.destroyed) {
-    stream[kDestroyed] = true;
+    stream[kIsDestroyed] = true;
   }
 }
 

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -1,16 +1,20 @@
 'use strict';
 
 const {
-  Symbol,
   SymbolAsyncIterator,
   SymbolIterator,
   SymbolFor,
 } = primordials;
 
-const kDestroyed = Symbol('kDestroyed');
-const kIsErrored = Symbol('kIsErrored');
-const kIsReadable = Symbol('kIsReadable');
-const kIsDisturbed = Symbol('kIsDisturbed');
+// We need to use SymbolFor to make these globally available
+// for interopt with readable-stream, i.e. readable-stream
+// and node core needs to be able to read/write private state
+// from each other for proper interoperability.
+const kIsDestroyed = SymbolFor('nodejs.stream.destroyed');
+const kIsErrored = SymbolFor('nodejs.stream.errored');
+const kIsReadable = SymbolFor('nodejs.stream.readable');
+const kIsWritable = SymbolFor('nodejs.stream.writable');
+const kIsDisturbed = SymbolFor('nodejs.stream.disturbed');
 
 const kIsClosedPromise = SymbolFor('nodejs.webstream.isClosedPromise');
 const kControllerErrorFunction = SymbolFor('nodejs.webstream.controllerErrorFunction');
@@ -104,7 +108,7 @@ function isDestroyed(stream) {
   const wState = stream._writableState;
   const rState = stream._readableState;
   const state = wState || rState;
-  return !!(stream.destroyed || stream[kDestroyed] || state?.destroyed);
+  return !!(stream.destroyed || stream[kIsDestroyed] || state?.destroyed);
 }
 
 // Have been end():d.
@@ -162,6 +166,7 @@ function isReadable(stream) {
 }
 
 function isWritable(stream) {
+  if (stream && stream[kIsWritable] != null) return stream[kIsWritable];
   if (typeof stream?.writable !== 'boolean') return null;
   if (isDestroyed(stream)) return false;
   return isWritableNodeStream(stream) &&
@@ -298,7 +303,8 @@ function isErrored(stream) {
 }
 
 module.exports = {
-  kDestroyed,
+  isDestroyed,
+  kIsDestroyed,
   isDisturbed,
   kIsDisturbed,
   isErrored,
@@ -307,8 +313,8 @@ module.exports = {
   kIsReadable,
   kIsClosedPromise,
   kControllerErrorFunction,
+  kIsWritable,
   isClosed,
-  isDestroyed,
   isDuplexNodeStream,
   isFinished,
   isIterable,

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -51,9 +51,13 @@ const promises = require('stream/promises');
 const utils = require('internal/streams/utils');
 
 const Stream = module.exports = require('internal/streams/legacy').Stream;
+
+Stream.isDestroyed = utils.isDestroyed;
 Stream.isDisturbed = utils.isDisturbed;
 Stream.isErrored = utils.isErrored;
 Stream.isReadable = utils.isReadable;
+Stream.isWritable = utils.isWritable;
+
 Stream.Readable = require('internal/streams/readable');
 for (const key of ObjectKeys(streamReturningOperators)) {
   const op = streamReturningOperators[key];


### PR DESCRIPTION
This is required for streams interop with e.g. readable-stream. Currently readable-stream helpers will not work with normal node streams which is confusing and bad for the ecosystem.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
