### PR TITLE
doc,lib: disambiguate the old term, `NativeModule`

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -486,9 +486,9 @@ These CommonJS variables are not available in ES modules.
 `__filename` and `__dirname` use cases can be replicated via
 [`import.meta.url`][].
 
-#### No Native Module Loading
+#### No Addon Loading
 
-Native modules are not currently supported with ES module imports.
+[Addons][] are not currently supported with ES module imports.
 
 They can instead be loaded with [`module.createRequire()`][] or
 [`process.dlopen`][].
@@ -1525,6 +1525,7 @@ for ESM specifiers is [commonjs-extension-resolution-loader][].
 <!-- Note: The cjs-module-lexer link should be kept in-sync with the deps version -->
 
 [6.1.7 Array Index]: https://tc39.es/ecma262/#integer-index
+[Addons]: addons.md
 [CommonJS]: modules.md
 [Conditional exports]: packages.md#conditional-exports
 [Core modules]: modules.md#core-modules

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -144,7 +144,7 @@ const schemelessBlockList = new SafeSet([
           'DEP0111');
       }
       if (legacyWrapperList.has(module)) {
-        return nativeModuleRequire('internal/legacy/processbinding')[module]();
+        return requireBuiltin('internal/legacy/processbinding')[module]();
       }
       return internalBinding(module);
     }
@@ -285,14 +285,14 @@ class BuiltinModule {
     // TODO(aduh95): move this to C++, alongside the initialization of the class.
     ObjectSetPrototypeOf(ModuleWrap.prototype, null);
     const url = `node:${this.id}`;
-    const nativeModule = this;
+    const builtin = this;
     const exportsKeys = ArrayPrototypeSlice(this.exportKeys);
     ArrayPrototypePush(exportsKeys, 'default');
     this.module = new ModuleWrap(
       url, undefined, exportsKeys,
       function() {
-        nativeModule.syncExports();
-        this.setExport('default', nativeModule.exports);
+        builtin.syncExports();
+        this.setExport('default', builtin.exports);
       });
     // Ensure immediate sync execution to capture exports now
     this.module.instantiate();
@@ -326,7 +326,7 @@ class BuiltinModule {
 
     try {
       const requireFn = StringPrototypeStartsWith(this.id, 'internal/deps/') ?
-        requireWithFallbackInDeps : nativeModuleRequire;
+        requireWithFallbackInDeps : requireBuiltin;
 
       const fn = compileFunction(id);
       // Arguments must match the parameters specified in
@@ -350,10 +350,10 @@ class BuiltinModule {
 const loaderExports = {
   internalBinding,
   BuiltinModule,
-  require: nativeModuleRequire
+  require: requireBuiltin
 };
 
-function nativeModuleRequire(id) {
+function requireBuiltin(id) {
   if (id === loaderId) {
     return loaderExports;
   }
@@ -371,7 +371,7 @@ function requireWithFallbackInDeps(request) {
   if (!BuiltinModule.map.has(request)) {
     request = `internal/deps/${request}`;
   }
-  return nativeModuleRequire(request);
+  return requireBuiltin(request);
 }
 
 // Pass the exports back to C++ land for C++ internals to use.

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -140,9 +140,9 @@ process.domain = null;
 process._exiting = false;
 
 // process.config is serialized config.gypi
-const nativeModule = internalBinding('builtins');
+const binding = internalBinding('builtins');
 
-const processConfig = JSONParse(nativeModule.config, (_key, value) => {
+const processConfig = JSONParse(binding.config, (_key, value) => {
   // The `reviver` argument of the JSONParse method will visit all the values of
   // the parsed config, including the "root" object, so there is no need to
   // explicitly freeze the config outside of this method
@@ -288,7 +288,7 @@ const features = {
   // This needs to be dynamic because --no-node-snapshot disables the
   // code cache even if the binary is built with embedded code cache.
   get cached_builtins() {
-    return nativeModule.hasCachedBuiltins();
+    return binding.hasCachedBuiltins();
   }
 };
 


### PR DESCRIPTION
This disambiguates cases where `NativeModule` is used with different meanings. 
Please review also whether it's better to use `commit-queue-rebase` for backporting.

Refs: https://github.com/nodejs/node/pull/44135

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
