### PR TITLE
doc: fix mismatched arguments of `NodeEventTarget`

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1645,9 +1645,8 @@ and cannot be used in place of an `EventEmitter` in most cases.
    ignored.
 2. The `NodeEventTarget` does not emulate the full `EventEmitter` API.
    Specifically the `prependListener()`, `prependOnceListener()`,
-   `rawListeners()`, `setMaxListeners()`, `getMaxListeners()`, and
-   `errorMonitor` APIs are not emulated. The `'newListener'` and
-   `'removeListener'` events will also not be emitted.
+   `rawListeners()`, and `errorMonitor` APIs are not emulated.
+   The `'newListener'` and `'removeListener'` events will also not be emitted.
 3. The `NodeEventTarget` does not implement any special default behavior
    for events with type `'error'`.
 4. The `NodeEventTarget` supports `EventListener` objects as well as

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -2027,7 +2027,7 @@ added: v14.5.0
 The `NodeEventTarget` is a Node.js-specific extension to `EventTarget`
 that emulates a subset of the `EventEmitter` API.
 
-#### `nodeEventTarget.addListener(type, listener[, options])`
+#### `nodeEventTarget.addListener(type, listener)`
 
 <!-- YAML
 added: v14.5.0
@@ -2036,9 +2036,6 @@ added: v14.5.0
 * `type` {string}
 
 * `listener` {Function|EventListener}
-
-* `options` {Object}
-  * `once` {boolean}
 
 * Returns: {EventTarget} this
 
@@ -2071,7 +2068,29 @@ added: v14.5.0
 Node.js-specific extension to the `EventTarget` class that returns the number
 of event listeners registered for the `type`.
 
-#### `nodeEventTarget.off(type, listener)`
+#### `nodeEventTarget.setMaxListeners(n)`
+
+<!-- YAML
+added: v14.5.0
+-->
+
+* `n` {number}
+
+Node.js-specific extension to the `EventTarget` class that sets the number
+of max event listeners as `n`.
+
+#### `nodeEventTarget.getMaxListeners()`
+
+<!-- YAML
+added: v14.5.0
+-->
+
+* Returns: {number}
+
+Node.js-specific extension to the `EventTarget` class that returns the number
+of max event listeners.
+
+#### `nodeEventTarget.off(type, listener[, options])`
 
 <!-- YAML
 added: v14.5.0
@@ -2080,12 +2099,15 @@ added: v14.5.0
 * `type` {string}
 
 * `listener` {Function|EventListener}
+
+* `options` {Object}
+  * `capture` {boolean}
 
 * Returns: {EventTarget} this
 
 Node.js-specific alias for `eventTarget.removeListener()`.
 
-#### `nodeEventTarget.on(type, listener[, options])`
+#### `nodeEventTarget.on(type, listener)`
 
 <!-- YAML
 added: v14.5.0
@@ -2094,15 +2116,12 @@ added: v14.5.0
 * `type` {string}
 
 * `listener` {Function|EventListener}
-
-* `options` {Object}
-  * `once` {boolean}
 
 * Returns: {EventTarget} this
 
 Node.js-specific alias for `eventTarget.addListener()`.
 
-#### `nodeEventTarget.once(type, listener[, options])`
+#### `nodeEventTarget.once(type, listener)`
 
 <!-- YAML
 added: v14.5.0
@@ -2111,8 +2130,6 @@ added: v14.5.0
 * `type` {string}
 
 * `listener` {Function|EventListener}
-
-* `options` {Object}
 
 * Returns: {EventTarget} this
 
@@ -2134,7 +2151,7 @@ Node.js-specific extension to the `EventTarget` class. If `type` is specified,
 removes all registered listeners for `type`, otherwise removes all registered
 listeners.
 
-#### `nodeEventTarget.removeListener(type, listener)`
+#### `nodeEventTarget.removeListener(type, listener[, options])`
 
 <!-- YAML
 added: v14.5.0
@@ -2143,6 +2160,9 @@ added: v14.5.0
 * `type` {string}
 
 * `listener` {Function|EventListener}
+
+* `options` {Object}
+  * `capture` {boolean}
 
 * Returns: {EventTarget} this
 

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -821,7 +821,7 @@ class NodeEventTarget extends EventTarget {
   }
 
   /**
-   * @param {string} [type]
+   * @param {string} type
    * @returns {number}
    */
   listenerCount(type) {


### PR DESCRIPTION
Arguments of some APIs are mismatched and 2 APIs are not described.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
