### PR TITLE
process: fix `process.exit()` behavior when passing `null` or `undefined`

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1719,10 +1719,10 @@ changes:
   integer strings (e.g.,'1') are allowed. **Default:** `0`.
 
 The `process.exit()` method instructs Node.js to terminate the process
-synchronously with an exit status of `code`. If `code` is omitted, exit uses
-either the 'success' code `0` or the value of `process.exitCode` if it has been
-set. Node.js will not terminate until all the [`'exit'`][] event listeners are
-called.
+synchronously with an exit status of `code`. If `code` is `null`, `undefined`,
+or omitted, exit uses either the 'success' code `0` or the value of
+`process.exitCode` if it has been set. Node.js will not terminate until all the
+[`'exit'`][] event listeners are called.
 
 To exit with a 'failure' code:
 
@@ -1830,8 +1830,9 @@ A number which will be the process exit code, when the process either
 exits gracefully, or is exited via [`process.exit()`][] without specifying
 a code.
 
-Specifying a code to [`process.exit(code)`][`process.exit()`] will override any
-previous setting of `process.exitCode`.
+Specifying a code (except `null` or `undefined`) to
+[`process.exit(code)`][`process.exit()`] will override any previous setting of
+`process.exitCode`.
 
 ## `process.getActiveResourcesInfo()`
 

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -183,7 +183,7 @@ function wrapProcessMethods(binding) {
   function exit(code) {
     process.off('exit', handleProcessExit);
 
-    if (arguments.length !== 0) {
+    if (code !== undefined && code !== null) {
       process.exitCode = code;
     }
 

--- a/test/parallel/test-process-exit-code-regression.js
+++ b/test/parallel/test-process-exit-code-regression.js
@@ -1,0 +1,42 @@
+'use strict';
+
+require('../common');
+
+const args = [
+  {
+    code1: 2,
+    code2: undefined,
+    expected: 2,
+  },
+  {
+    code1: 2,
+    code2: null,
+    expected: 2,
+  },
+  {
+    code1: 2,
+    code2: 0,
+    expected: 0,
+  },
+];
+
+if (process.argv[2] === undefined) {
+  const { spawnSync } = require('node:child_process');
+  const { strictEqual } = require('node:assert');
+
+  const test = (index) => {
+    const { status } = spawnSync(process.execPath, [__filename, index]);
+    const expectedCode = args[index].expected;
+
+    strictEqual(status, expectedCode, `actual: ${status}, ${expectedCode}`);
+  };
+
+  for (const index of args.keys()) {
+    test(index);
+  }
+} else {
+  const index = parseInt(process.argv[2]);
+
+  process.exitCode = args[index].code1;
+  process.exit(args[index].code2);
+}


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/45683 (This fixes one of the two issues mentioned.)

The process should exit with code 2 in the following examples to fix the breaking.

```js
process.exitCode = 2;
process.exit(undefined);

// $ echo $?
// 2
```

```js
process.exitCode = 2;
process.exit(null);

// $ echo $?
// 2
```

This also updates the descriptions since the following behaviors may confuse users :
 - passing `null` or `undefined` to `'process.exit()'` is not applied to the exit code.
 - setting `null` or `undefined` to `'process.exitCode'` is applied to the exit code.

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
