### PR TITLE
src: add fast path to TextEncoder.encodeInto

### DIFF
--- a/benchmark/util/text-encoder.js
+++ b/benchmark/util/text-encoder.js
@@ -2,17 +2,27 @@
 
 const common = require('../common.js');
 
-const BASE = 'string\ud801';
-
 const bench = common.createBenchmark(main, {
-  len: [256, 1024, 1024 * 32],
+  len: [0, 256, 1024, 1024 * 32],
   n: [1e4],
+  type: ['v8-one-byte-string', 'v8-two-byte-string'],
   op: ['encode', 'encodeInto']
 });
 
-function main({ n, op, len }) {
+function main({ n, op, len, type }) {
   const encoder = new TextEncoder();
-  const input = BASE.repeat(len);
+  let base = '';
+
+  switch (type) {
+    case 'v8-one-byte-string':
+      base = 'a';
+      break;
+    case 'v8-two-byte-string':
+      base = 'ğ';
+      break;
+  }
+
+  const input = base.repeat(len);
   const subarray = new Uint8Array(len);
 
   bench.start();

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.5',
+    'v8_embedder_string': '-node.6',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-fast-api-calls.h
+++ b/deps/v8/include/v8-fast-api-calls.h
@@ -248,6 +248,7 @@ class CTypeInfo {
     kFloat32,
     kFloat64,
     kV8Value,
+    kSeqOneByteString,
     kApiObject,  // This will be deprecated once all users have
                  // migrated from v8::ApiObject to v8::Local<v8::Value>.
     kAny,        // This is added to enable untyped representation of fast
@@ -379,6 +380,11 @@ struct FastApiArrayBuffer {
   size_t byte_length;
 };
 
+struct FastOneByteString {
+  const char* data;
+  uint32_t length;
+};
+
 class V8_EXPORT CFunctionInfo {
  public:
   // Construct a struct to hold a CFunction's type information.
@@ -438,6 +444,7 @@ struct AnyCType {
     const FastApiTypedArray<uint64_t>* uint64_ta_value;
     const FastApiTypedArray<float>* float_ta_value;
     const FastApiTypedArray<double>* double_ta_value;
+    const FastOneByteString* string_value;
     FastApiCallbackOptions* options_value;
   };
 };
@@ -614,7 +621,7 @@ class CFunctionInfoImpl : public CFunctionInfo {
                       kReturnType == CTypeInfo::Type::kFloat32 ||
                       kReturnType == CTypeInfo::Type::kFloat64 ||
                       kReturnType == CTypeInfo::Type::kAny,
-                  "64-bit int and api object values are not currently "
+                  "64-bit int, string and api object values are not currently "
                   "supported return types.");
   }
 
@@ -729,6 +736,18 @@ struct TypeInfoHelper<FastApiCallbackOptions&> {
 
   static constexpr CTypeInfo::Type Type() {
     return CTypeInfo::kCallbackOptionsType;
+  }
+  static constexpr CTypeInfo::SequenceType SequenceType() {
+    return CTypeInfo::SequenceType::kScalar;
+  }
+};
+
+template <>
+struct TypeInfoHelper<const FastOneByteString&> {
+  static constexpr CTypeInfo::Flags Flags() { return CTypeInfo::Flags::kNone; }
+
+  static constexpr CTypeInfo::Type Type() {
+    return CTypeInfo::Type::kSeqOneByteString;
   }
   static constexpr CTypeInfo::SequenceType SequenceType() {
     return CTypeInfo::SequenceType::kScalar;

--- a/deps/v8/src/codegen/machine-type.h
+++ b/deps/v8/src/codegen/machine-type.h
@@ -315,6 +315,7 @@ class MachineType {
       case CTypeInfo::Type::kFloat64:
         return MachineType::Float64();
       case CTypeInfo::Type::kV8Value:
+      case CTypeInfo::Type::kSeqOneByteString:
       case CTypeInfo::Type::kApiObject:
         return MachineType::AnyTagged();
     }

--- a/deps/v8/src/compiler/fast-api-calls.cc
+++ b/deps/v8/src/compiler/fast-api-calls.cc
@@ -29,6 +29,7 @@ ElementsKind GetTypedArrayElementsKind(CTypeInfo::Type type) {
     case CTypeInfo::Type::kFloat64:
       return FLOAT64_ELEMENTS;
     case CTypeInfo::Type::kVoid:
+    case CTypeInfo::Type::kSeqOneByteString:
     case CTypeInfo::Type::kBool:
     case CTypeInfo::Type::kV8Value:
     case CTypeInfo::Type::kApiObject:

--- a/deps/v8/src/compiler/simplified-lowering.cc
+++ b/deps/v8/src/compiler/simplified-lowering.cc
@@ -1961,6 +1961,7 @@ class RepresentationSelector {
           case CTypeInfo::Type::kFloat64:
             return UseInfo::CheckedNumberAsFloat64(kDistinguishZeros, feedback);
           case CTypeInfo::Type::kV8Value:
+          case CTypeInfo::Type::kSeqOneByteString:
           case CTypeInfo::Type::kApiObject:
             return UseInfo::AnyTagged();
         }

--- a/deps/v8/test/mjsunit/compiler/fast-api-calls-string.js
+++ b/deps/v8/test/mjsunit/compiler/fast-api-calls-string.js
@@ -1,0 +1,84 @@
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file excercises one byte string support for fast API calls.
+
+// Flags: --turbo-fast-api-calls --expose-fast-api --allow-natives-syntax --turbofan
+// --always-turbofan is disabled because we rely on particular feedback for
+// optimizing to the fastest path.
+// Flags: --no-always-turbofan
+// The test relies on optimizing/deoptimizing at predictable moments, so
+// it's not suitable for deoptimization fuzzing.
+// Flags: --deopt-every-n-times=0
+
+assertThrows(() => d8.test.FastCAPI());
+const fast_c_api = new d8.test.FastCAPI();
+
+function assertSlowCall(input) {
+  assertEquals(new Uint8Array(input.length), copy_string(false, input));
+}
+
+function assertFastCall(input) {
+  const bytes = Uint8Array.from(input, c => c.charCodeAt(0));
+  assertEquals(bytes, copy_string(false, input));
+}
+
+function copy_string(should_fallback = false, input) {
+  const buffer = new Uint8Array(input.length);
+  fast_c_api.copy_string(should_fallback, input, buffer);
+  return buffer;
+}
+
+%PrepareFunctionForOptimization(copy_string);
+assertSlowCall('Hello');
+%OptimizeFunctionOnNextCall(copy_string);
+
+fast_c_api.reset_counts();
+assertFastCall('Hello');
+assertFastCall('');
+assertFastCall(['Hello', 'World'].join(''));
+assertOptimized(copy_string);
+assertEquals(3, fast_c_api.fast_call_count());
+assertEquals(0, fast_c_api.slow_call_count());
+
+// Fall back for twobyte strings.
+fast_c_api.reset_counts();
+assertSlowCall('Hello\u{10000}');
+assertSlowCall('नमस्ते');
+assertSlowCall(['नमस्ते', 'World'].join(''));
+assertOptimized(copy_string);
+assertEquals(0, fast_c_api.fast_call_count());
+assertEquals(3, fast_c_api.slow_call_count());
+
+// Fall back for cons strings.
+function getTwoByteString() {
+  return '\u1234t';
+}
+function getCons() {
+  return 'hello' + getTwoByteString()
+}
+
+fast_c_api.reset_counts();
+assertSlowCall(getCons());
+assertOptimized(copy_string);
+assertEquals(0, fast_c_api.fast_call_count());
+assertEquals(1, fast_c_api.slow_call_count());
+
+// Fall back for sliced strings.
+fast_c_api.reset_counts();
+function getSliced() {
+  return getCons().slice(1);
+}
+assertSlowCall(getSliced());
+assertOptimized(copy_string);
+assertEquals(0, fast_c_api.fast_call_count());
+assertEquals(1, fast_c_api.slow_call_count());
+
+// Fall back for SMI and non-string inputs.
+fast_c_api.reset_counts();
+assertSlowCall(1);
+assertSlowCall({});
+assertSlowCall(new Uint8Array(1));
+assertEquals(0, fast_c_api.fast_call_count());
+assertEquals(3, fast_c_api.slow_call_count());

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -85,6 +85,7 @@ const internalBindingAllowlist = new SafeSet([
   'constants',
   'contextify',
   'crypto',
+  'encoding_methods',
   'fs',
   'fs_event_wrap',
   'http_parser',

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -51,10 +51,7 @@ const {
 } = require('internal/validators');
 
 const {
-  decodeUTF8,
-} = internalBinding('buffer');
-
-const {
+  decodeUtf8,
   encodeUtf8,
   encodeIntoUtf8,
 } = internalBinding('encoding_methods');
@@ -433,7 +430,7 @@ function makeTextDecoderICU() {
       this[kUTF8FastPath] &&= !(options?.stream);
 
       if (this[kUTF8FastPath]) {
-        return decodeUTF8(input, this[kIgnoreBOM]);
+        return decodeUtf8(input, this[kIgnoreBOM]);
       }
 
       this.#prepareConverter();

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -51,10 +51,13 @@ const {
 } = require('internal/validators');
 
 const {
-  encodeInto,
-  encodeUtf8String,
   decodeUTF8,
 } = internalBinding('buffer');
+
+const {
+  encodeUtf8,
+  encodeIntoUtf8,
+} = internalBinding('encoding_methods');
 
 let Buffer;
 function lazyBuffer() {
@@ -337,7 +340,7 @@ class TextEncoder {
 
   encode(input = '') {
     validateEncoder(this);
-    return encodeUtf8String(`${input}`);
+    return encodeUtf8(`${input}`);
   }
 
   encodeInto(src, dest) {
@@ -345,7 +348,7 @@ class TextEncoder {
     validateString(src, 'src');
     if (!dest || !isUint8Array(dest))
       throw new ERR_INVALID_ARG_TYPE('dest', 'Uint8Array', dest);
-    encodeInto(src, dest, encodeIntoResults);
+    encodeIntoUtf8(src, dest, encodeIntoResults);
     return { read: encodeIntoResults[0], written: encodeIntoResults[1] };
   }
 

--- a/node.gyp
+++ b/node.gyp
@@ -498,6 +498,7 @@
         'src/node_contextify.cc',
         'src/node_credentials.cc',
         'src/node_dir.cc',
+        'src/node_encoding.cc',
         'src/node_env_var.cc',
         'src/node_errors.cc',
         'src/node_external_reference.cc',

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -43,6 +43,7 @@
   V(contextify)                                                                \
   V(credentials)                                                               \
   V(errors)                                                                    \
+  V(encoding_methods)                                                          \
   V(fs)                                                                        \
   V(fs_dir)                                                                    \
   V(fs_event_wrap)                                                             \

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -566,50 +566,6 @@ void StringSlice(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(ret);
 }
 
-// Convert the input into an encoded string
-void DecodeUTF8(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);  // list, flags
-
-  CHECK_GE(args.Length(), 1);
-
-  if (!(args[0]->IsArrayBuffer() || args[0]->IsSharedArrayBuffer() ||
-        args[0]->IsArrayBufferView())) {
-    return node::THROW_ERR_INVALID_ARG_TYPE(
-        env->isolate(),
-        "The \"list\" argument must be an instance of SharedArrayBuffer, "
-        "ArrayBuffer or ArrayBufferView.");
-  }
-
-  ArrayBufferViewContents<char> buffer(args[0]);
-
-  bool ignore_bom = args[1]->IsTrue();
-
-  const char* data = buffer.data();
-  size_t length = buffer.length();
-
-  if (!ignore_bom && length >= 3) {
-    if (memcmp(data, "\xEF\xBB\xBF", 3) == 0) {
-      data += 3;
-      length -= 3;
-    }
-  }
-
-  if (length == 0) return args.GetReturnValue().SetEmptyString();
-
-  Local<Value> error;
-  MaybeLocal<Value> maybe_ret =
-      StringBytes::Encode(env->isolate(), data, length, UTF8, &error);
-  Local<Value> ret;
-
-  if (!maybe_ret.ToLocal(&ret)) {
-    CHECK(!error.IsEmpty());
-    env->isolate()->ThrowException(error);
-    return;
-  }
-
-  args.GetReturnValue().Set(ret);
-}
-
 // bytesCopied = copy(buffer, target[, targetStart][, sourceStart][, sourceEnd])
 void Copy(const FunctionCallbackInfo<Value> &args) {
   Environment* env = Environment::GetCurrent(args);
@@ -1259,7 +1215,6 @@ void Initialize(Local<Object> target,
 
   SetMethod(context, target, "setBufferPrototype", SetBufferPrototype);
   SetMethodNoSideEffect(context, target, "createFromString", CreateFromString);
-  SetMethodNoSideEffect(context, target, "decodeUTF8", DecodeUTF8);
 
   SetMethodNoSideEffect(context, target, "byteLengthUtf8", ByteLengthUtf8);
   SetMethod(context, target, "copy", Copy);
@@ -1314,7 +1269,6 @@ void Initialize(Local<Object> target,
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(SetBufferPrototype);
   registry->Register(CreateFromString);
-  registry->Register(DecodeUTF8);
 
   registry->Register(ByteLengthUtf8);
   registry->Register(Copy);

--- a/src/node_encoding.cc
+++ b/src/node_encoding.cc
@@ -1,0 +1,150 @@
+#include "env-inl.h"
+#include "node.h"
+#include "node_external_reference.h"
+#include "node_internals.h"
+#include "util-inl.h"
+#include "v8-fast-api-calls.h"
+#include "v8.h"
+
+#if defined(NODE_HAVE_I18N_SUPPORT)
+#include <unicode/utf8.h>
+#endif  // NODE_HAVE_I18N_SUPPORT
+
+namespace node {
+
+using v8::ArrayBuffer;
+using v8::BackingStore;
+using v8::CFunction;
+using v8::Context;
+using v8::FastApiTypedArray;
+using v8::FastOneByteString;
+using v8::FunctionCallbackInfo;
+using v8::Isolate;
+using v8::Local;
+using v8::Object;
+using v8::String;
+using v8::Uint32Array;
+using v8::Uint8Array;
+using v8::Value;
+
+namespace encoding_methods {
+
+static void EncodeUtf8(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = env->isolate();
+  CHECK_GE(args.Length(), 1);
+  CHECK(args[0]->IsString());
+
+  Local<String> str = args[0].As<String>();
+  size_t length = str->Utf8Length(isolate);
+
+  Local<ArrayBuffer> ab;
+  {
+    NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
+    std::unique_ptr<BackingStore> bs =
+        ArrayBuffer::NewBackingStore(isolate, length);
+
+    CHECK(bs);
+
+    str->WriteUtf8(isolate,
+                   static_cast<char*>(bs->Data()),
+                   -1,  // We are certain that `data` is sufficiently large
+                   nullptr,
+                   String::NO_NULL_TERMINATION | String::REPLACE_INVALID_UTF8);
+
+    ab = ArrayBuffer::New(isolate, std::move(bs));
+  }
+
+  args.GetReturnValue().Set(Uint8Array::New(ab, 0, length));
+}
+
+static void EncodeIntoUtf8(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = env->isolate();
+  CHECK_GE(args.Length(), 3);
+  CHECK(args[0]->IsString());
+  CHECK(args[1]->IsUint8Array());
+  CHECK(args[2]->IsUint32Array());
+
+  Local<String> source = args[0].As<String>();
+
+  Local<Uint8Array> dest = args[1].As<Uint8Array>();
+  Local<ArrayBuffer> buf = dest->Buffer();
+  char* write_result = static_cast<char*>(buf->Data()) + dest->ByteOffset();
+  size_t dest_length = dest->ByteLength();
+
+  // results = [ read, written ]
+  Local<Uint32Array> result_arr = args[2].As<Uint32Array>();
+  uint32_t* results = reinterpret_cast<uint32_t*>(
+      static_cast<char*>(result_arr->Buffer()->Data()) +
+      result_arr->ByteOffset());
+
+  int nchars;
+  int written = source->WriteUtf8(
+      isolate,
+      write_result,
+      dest_length,
+      &nchars,
+      String::NO_NULL_TERMINATION | String::REPLACE_INVALID_UTF8);
+  results[0] = nchars;
+  results[1] = written;
+}
+
+#if defined(NODE_HAVE_I18N_SUPPORT)
+static void FastEncodeIntoUtf8(Local<Value> receiver,
+                               const FastOneByteString& source,
+                               const FastApiTypedArray<uint8_t>& destination,
+                               const FastApiTypedArray<uint32_t>& result) {
+  uint8_t* destination_data;
+  CHECK(destination.getStorageIfAligned(&destination_data));
+
+  uint32_t* results;
+  CHECK(result.getStorageIfAligned(&results));
+
+  size_t source_length = source.length;
+  size_t destination_length = destination.length();
+  size_t min_length = std::min(source_length, destination_length);
+
+  memcpy(destination_data, source.data, min_length);
+
+  results[0] = min_length;
+  results[1] = min_length;
+}
+
+CFunction fast_encode_into_utf8_(CFunction::Make(FastEncodeIntoUtf8));
+#endif  // NODE_HAVE_I18N_SUPPORT
+
+static void Initialize(Local<Object> target,
+                       Local<Value> unused,
+                       Local<Context> context,
+                       void* priv) {
+  SetMethodNoSideEffect(context, target, "encodeUtf8", EncodeUtf8);
+#if defined(NODE_HAVE_I18N_SUPPORT)
+  SetFastMethod(context,
+                target,
+                "encodeIntoUtf8",
+                EncodeIntoUtf8,
+                &fast_encode_into_utf8_);
+#else
+  SetMethodNoSideEffect(context, target, "encodeIntoUtf8", EncodeIntoUtf8);
+#endif  // NODE_HAVE_I18N_SUPPORT
+}
+
+void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  registry->Register(EncodeUtf8);
+
+  registry->Register(EncodeIntoUtf8);
+
+#if defined(NODE_HAVE_I18N_SUPPORT)
+  registry->Register(FastEncodeIntoUtf8);
+  registry->Register(fast_encode_into_utf8_.GetTypeInfo());
+#endif  // NODE_HAVE_I18N_SUPPORT
+}
+
+}  // namespace encoding_methods
+}  // namespace node
+
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(encoding_methods,
+                                    node::encoding_methods::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(
+    encoding_methods, node::encoding_methods::RegisterExternalReferences)

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -10,7 +10,13 @@
 
 namespace node {
 
+// TODO(anonrig): Find a good way of reusing existing types for fast api usages.
 using CFunctionCallback = void (*)(v8::Local<v8::Value> receiver);
+using CFunctionCallbackWithInput =
+    void (*)(v8::Local<v8::Value> receiver,
+             const v8::FastOneByteString& source,
+             const v8::FastApiTypedArray<uint8_t>& destination,
+             const v8::FastApiTypedArray<uint32_t>& result);
 
 // This class manages the external references from the V8 heap
 // to the C++ addresses in Node.js.
@@ -20,6 +26,7 @@ class ExternalReferenceRegistry {
 
 #define ALLOWED_EXTERNAL_REFERENCE_TYPES(V)                                    \
   V(CFunctionCallback)                                                         \
+  V(CFunctionCallbackWithInput)                                                \
   V(const v8::CFunctionInfo*)                                                  \
   V(v8::FunctionCallback)                                                      \
   V(v8::AccessorGetterCallback)                                                \
@@ -67,6 +74,7 @@ class ExternalReferenceRegistry {
   V(credentials)                                                               \
   V(env_var)                                                                   \
   V(errors)                                                                    \
+  V(encoding_methods)                                                          \
   V(fs)                                                                        \
   V(fs_dir)                                                                    \
   V(fs_event_wrap)                                                             \

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -18,6 +18,7 @@ const expectedModules = new Set([
   'Internal Binding contextify',
   'Internal Binding credentials',
   'Internal Binding errors',
+  'Internal Binding encoding_methods',
   'Internal Binding fs_dir',
   'Internal Binding fs_event_wrap',
   'Internal Binding fs',

--- a/test/parallel/test-util-text-encoder.js
+++ b/test/parallel/test-util-text-encoder.js
@@ -1,0 +1,50 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { TextEncoder, TextDecoder } = require('util');
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+assert.strictEqual(decoder.decode(encoder.encode('')), '');
+assert.strictEqual(decoder.decode(encoder.encode('latin1')), 'latin1');
+assert.strictEqual(decoder.decode(encoder.encode('Yağız')), 'Yağız');
+
+// For loop is required to trigger the fast path for encodeInto
+// Since v8 fast path is only triggered when v8 optimization starts.
+for (let i = 0; i < 1e4; i++) {
+  {
+    const dest = new Uint8Array(10).fill(0);
+    const encoded = encoder.encodeInto('Yağız', dest);
+    assert.strictEqual(encoded.read, 5);
+    assert.strictEqual(encoded.written, 7);
+    assert.strictEqual(decoder.decode(dest), 'Yağız\x00\x00\x00');
+  }
+
+  {
+    const dest = new Uint8Array(1024).fill(0);
+    const encoded = encoder.encodeInto('latin', dest);
+    assert.strictEqual(encoded.read, 5);
+    assert.strictEqual(encoded.written, 5);
+    assert.strictEqual(decoder.decode(dest.slice(0, 5)), 'latin');
+  }
+
+  {
+    const input = 'latin';
+    const dest = new Uint8Array(10).fill(0);
+    const encoded = encoder.encodeInto(input, dest);
+    assert.strictEqual(encoded.read, input.length);
+    assert.strictEqual(encoded.written, input.length);
+    assert.strictEqual(decoder.decode(dest.slice(0, 5)), 'latin');
+  }
+
+  {
+    const input = 'latin';
+    const dest = new Uint8Array(1).fill(0);
+    const encoded = encoder.encodeInto(input, dest);
+    assert.strictEqual(encoded.read, 1);
+    assert.strictEqual(encoded.written, 1);
+    assert.strictEqual(decoder.decode(dest), 'l');
+  }
+}


### PR DESCRIPTION
Original commit message:

    [fastcall] Implement support for onebyte string arguments

Refs: https://github.com/v8/v8/commit/bc831f8ba33b79e2eb670faf1f84c4e39aeb0f9f

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1259/

```
                                                                                 confidence improvement accuracy (*)    (**)   (***)
util/text-encoder.js op='encodeInto' type='v8-one-byte-string' n=10000 len=0                     1.99 %       ±4.94%  ±6.58%  ±8.57%
util/text-encoder.js op='encodeInto' type='v8-one-byte-string' n=10000 len=1024         ***     13.53 %       ±6.84%  ±9.10% ±11.86%
util/text-encoder.js op='encodeInto' type='v8-one-byte-string' n=10000 len=256                   5.36 %       ±6.97%  ±9.29% ±12.12%
util/text-encoder.js op='encodeInto' type='v8-one-byte-string' n=10000 len=32768        ***     15.07 %       ±7.99% ±10.63% ±13.84%
util/text-encoder.js op='encodeInto' type='v8-two-byte-string' n=10000 len=0                    -5.38 %       ±6.23%  ±8.31% ±10.85%
util/text-encoder.js op='encodeInto' type='v8-two-byte-string' n=10000 len=1024                  1.45 %       ±6.77%  ±9.01% ±11.74%
util/text-encoder.js op='encodeInto' type='v8-two-byte-string' n=10000 len=256                  -2.36 %       ±7.55% ±10.05% ±13.08%
util/text-encoder.js op='encodeInto' type='v8-two-byte-string' n=10000 len=32768                -0.49 %       ±2.34%  ±3.11%  ±4.06%
util/text-encoder.js op='encode' type='v8-one-byte-string' n=10000 len=0                         1.62 %       ±6.95%  ±9.25% ±12.07%
util/text-encoder.js op='encode' type='v8-one-byte-string' n=10000 len=1024                     -2.32 %       ±5.28%  ±7.03%  ±9.17%
util/text-encoder.js op='encode' type='v8-one-byte-string' n=10000 len=256                      -4.58 %       ±6.07%  ±8.08% ±10.54%
util/text-encoder.js op='encode' type='v8-one-byte-string' n=10000 len=32768                     4.25 %      ±11.64% ±15.49% ±20.16%
util/text-encoder.js op='encode' type='v8-two-byte-string' n=10000 len=0                        -6.16 %       ±6.84%  ±9.11% ±11.86%
util/text-encoder.js op='encode' type='v8-two-byte-string' n=10000 len=1024                     -6.52 %       ±7.40%  ±9.85% ±12.83%
util/text-encoder.js op='encode' type='v8-two-byte-string' n=10000 len=256                      -6.35 %       ±6.74%  ±8.97% ±11.68%
util/text-encoder.js op='encode' type='v8-two-byte-string' n=10000 len=32768                    -5.08 %       ±7.21%  ±9.60% ±12.50%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 16 comparisons, you can thus
expect the following amount of false-positive results:
  0.80 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.16 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```