### PR TITLE
performance: changed ArrayPrototypeJoin with custom join implementation

### DIFF
--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -710,5 +710,22 @@ primordials.SafeStringPrototypeSearch = (str, regexp) => {
   return match ? match.index : -1;
 };
 
+// The built-in Array#join is slower in v8 6.0
+function join(output, separator) {
+  let str = '';
+  if (output.length !== 0) {
+    const lastIndex = output.length - 1;
+    for (let i = 0; i < lastIndex; i++) {
+      // It is faster not to use a template string here
+      str += output[i];
+      str += separator;
+    }
+    str += output[lastIndex];
+  }
+  return str;
+}
+
+primordials.ArrayPrototypeJoin = join;
+
 ObjectSetPrototypeOf(primordials, null);
 ObjectFreeze(primordials);

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -717,10 +717,10 @@ function join(output, separator = ',') {
     const lastIndex = output.length - 1;
     for (let i = 0; i < lastIndex; i++) {
       // It is faster not to use a template string here
-      str += output[i];
+      str += output[i] ?? '';
       str += separator;
     }
-    str += output[lastIndex];
+    str += output[lastIndex] ?? '';
   }
   return str;
 }

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -711,7 +711,7 @@ primordials.SafeStringPrototypeSearch = (str, regexp) => {
 };
 
 // The built-in Array#join is slower in v8 6.0
-function join(output, separator) {
+function join(output, separator = ',') {
   let str = '';
   if (output.length !== 0) {
     const lastIndex = output.length - 1;

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -387,21 +387,6 @@ function promisify(original) {
 
 promisify.custom = kCustomPromisifiedSymbol;
 
-// The built-in Array#join is slower in v8 6.0
-function join(output, separator) {
-  let str = '';
-  if (output.length !== 0) {
-    const lastIndex = output.length - 1;
-    for (let i = 0; i < lastIndex; i++) {
-      // It is faster not to use a template string here
-      str += output[i];
-      str += separator;
-    }
-    str += output[lastIndex];
-  }
-  return str;
-}
-
 // As of V8 6.6, depending on the size of the array, this is anywhere
 // between 1.5-10x faster than the two-arg version of Array#splice()
 function spliceOne(list, index) {
@@ -590,7 +575,6 @@ module.exports = {
   isArrayBufferDetached,
   isError,
   isInsideNodeModules,
-  join,
   lazyDOMException,
   lazyDOMExceptionClass,
   normalizeEncoding,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -114,7 +114,6 @@ const {
 const {
   customInspectSymbol,
   isError,
-  join,
   removeColors
 } = require('internal/util');
 
@@ -2057,7 +2056,7 @@ function reduceToSingleString(
         const start = output.length + ctx.indentationLvl +
                       braces[0].length + base.length + 10;
         if (isBelowBreakLength(ctx, output, start, base)) {
-          const joinedOutput = join(output, ', ');
+          const joinedOutput = ArrayPrototypeJoin(output, ', ');
           if (!StringPrototypeIncludes(joinedOutput, '\n')) {
             return `${base ? `${base} ` : ''}${braces[0]} ${joinedOutput}` +
               ` ${braces[1]}`;
@@ -2068,12 +2067,12 @@ function reduceToSingleString(
     // Line up each entry on an individual line.
     const indentation = `\n${StringPrototypeRepeat(' ', ctx.indentationLvl)}`;
     return `${base ? `${base} ` : ''}${braces[0]}${indentation}  ` +
-      `${join(output, `,${indentation}  `)}${indentation}${braces[1]}`;
+      `${ArrayPrototypeJoin(output, `,${indentation}  `)}${indentation}${braces[1]}`;
   }
   // Line up all entries on a single line in case the entries do not exceed
   // `breakLength`.
   if (isBelowBreakLength(ctx, output, 0, base)) {
-    return `${braces[0]}${base ? ` ${base}` : ''} ${join(output, ', ')} ` +
+    return `${braces[0]}${base ? ` ${base}` : ''} ${ArrayPrototypeJoin(output, ', ')} ` +
       braces[1];
   }
   const indentation = StringPrototypeRepeat(' ', ctx.indentationLvl);
@@ -2083,7 +2082,7 @@ function reduceToSingleString(
   const ln = base === '' && braces[0].length === 1 ?
     ' ' : `${base ? ` ${base}` : ''}\n${indentation}  `;
   // Line up each entry on an individual line.
-  return `${braces[0]}${ln}${join(output, `,\n${indentation}  `)} ${braces[1]}`;
+  return `${braces[0]}${ln}${ArrayPrototypeJoin(output, `,\n${indentation}  `)} ${braces[1]}`;
 }
 
 function hasBuiltInToString(value) {


### PR DESCRIPTION
As discussed in the last performance team meeting led by @anonrig, I've updated the primordial ArrayPrototypeJoin with a custom implementation because it is faster than the built-in  in v8 6.0
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
