### PR TITLE
test_runner: add resetCalls to MockFunctionContext

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -870,6 +870,14 @@ test('changes a mock behavior once', (t) => {
 });
 ```
 
+### `ctx.resetCalls()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Resets the call history of the mock function.
+
 ### `ctx.restore()`
 
 <!-- YAML

--- a/lib/internal/test_runner/mock.js
+++ b/lib/internal/test_runner/mock.js
@@ -77,6 +77,10 @@ class MockFunctionContext {
     }
   }
 
+  resetCalls() {
+    this.#calls = [];
+  }
+
   trackCall(call) {
     ArrayPrototypePush(this.#calls, call);
   }

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -780,6 +780,23 @@ test('local mocks are auto restored after the test finishes', async (t) => {
   assert.strictEqual(originalBar, obj.bar);
 });
 
+test('reset mock calls', (t) => {
+  const sum = (arg1, arg2) => arg1 + arg2;
+  const difference = (arg1, arg2) => arg1 - arg2;
+  const fn = t.mock.fn(sum, difference);
+
+  assert.strictEqual(fn(1, 2), -1);
+  assert.strictEqual(fn(2, 1), 1);
+  assert.strictEqual(fn.mock.calls.length, 2);
+  assert.strictEqual(fn.mock.callCount(), 2);
+
+  fn.mock.resetCalls();
+  assert.strictEqual(fn.mock.calls.length, 0);
+  assert.strictEqual(fn.mock.callCount(), 0);
+
+  assert.strictEqual(fn(3, 2), 1);
+});
+
 test('uses top level mock', () => {
   function sum(a, b) {
     return a + b;


### PR DESCRIPTION
This commit allows tests in test runner to reset the calls of mock function

Refs: https://github.com/nodejs/node/pull/45326#discussion_r1014728750

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
