### PR TITLE
build: disable v8 snapshot compression

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -805,6 +805,12 @@ parser.add_argument('--v8-enable-short-builtin-calls',
     help='Enable V8 short builtin calls support. This feature is enabled '+
          'on x86_64 platform by default.')
 
+parser.add_argument('--v8-enable-snapshot-compression',
+    action='store_true',
+    dest='v8_enable_snapshot_compression',
+    default=None,
+    help='Enable the built-in snapshot compression in V8.')
+
 parser.add_argument('--node-builtin-modules-path',
     action='store',
     dest='node_builtin_modules_path',
@@ -1482,6 +1488,8 @@ def configure_v8(o):
   o['variables']['v8_enable_hugepage'] = 1 if options.v8_enable_hugepage else 0
   if options.v8_enable_short_builtin_calls or o['variables']['target_arch'] == 'x64':
     o['variables']['v8_enable_short_builtin_calls'] = 1
+  if options.v8_enable_snapshot_compression:
+    o['variables']['v8_enable_snapshot_compression'] = 1
   if options.v8_enable_object_print and options.v8_disable_object_print:
     raise Exception(
         'Only one of the --v8-enable-object-print or --v8-disable-object-print options '

--- a/tools/v8_gypfiles/features.gypi
+++ b/tools/v8_gypfiles/features.gypi
@@ -216,7 +216,7 @@
     'v8_enable_regexp_interpreter_threaded_dispatch%': 1,
 
     # Disable all snapshot compression.
-    'v8_enable_snapshot_compression%': 1,
+    'v8_enable_snapshot_compression%': 0,
 
     # Enable control-flow integrity features, such as pointer authentication
     # for ARM64.


### PR DESCRIPTION
Following https://chromium-review.googlesource.com/c/v8/v8/+/3275554. Locally the binary size is increased by ~2.4mb (+2.9%) with a pretty significant speedup in startup:

```
                                                                                     confidence improvement accuracy (*)   (**)  (***)
misc/startup.js count=30 mode='process' script='benchmark/fixtures/require-builtins'        ***     12.28 %       ±1.13% ±1.52% ±2.00%
misc/startup.js count=30 mode='process' script='test/fixtures/semicolon'                    ***     17.39 %       ±1.12% ±1.50% ±1.97%
misc/startup.js count=30 mode='worker' script='benchmark/fixtures/require-builtins'         ***     14.54 %       ±0.77% ±1.03% ±1.35%
misc/startup.js count=30 mode='worker' script='test/fixtures/semicolon'                     ***     18.02 %       ±1.02% ±1.36% ±1.79%
```

I think the increased binary size is worth it, but if we really worry about it, another (perhaps better) option would be to disable the built-in compression of V8 and compress the snapshot + source code + code cache ourselves using a different compression library (e.g. Deno switched to [lz4 and zstd](https://github.com/denoland/deno/pull/13320) and got a pretty significant performance boost). I'd suggest to just disable it for now, regardless of whether we can follow up with a compression strategy that can reduce the binary size significantly without hurting performance, because currently a 2.9% binary size saving is not really worth the performance regression.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
