### PR TITLE
watch: add CLI flag to preserve output

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1628,7 +1628,7 @@ This option is only supported on macOS and Windows.
 An `ERR_FEATURE_UNAVAILABLE_ON_PLATFORM` exception will be thrown
 when the option is used on a platform that does not support it.
 
-### --watch-preserve-output
+### `--watch-preserve-output`
 
 Option to ensure output of stdout is preserved during --watch on restart.
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1628,6 +1628,14 @@ This option is only supported on macOS and Windows.
 An `ERR_FEATURE_UNAVAILABLE_ON_PLATFORM` exception will be thrown
 when the option is used on a platform that does not support it.
 
+### --watch-preserve-output
+
+Option to ensure output of stdout is preserved during --watch on restart
+
+```console
+$ node --watch --watch-preserve-output test.js
+```
+
 ### `--zero-fill-buffers`
 
 <!-- YAML
@@ -1933,6 +1941,7 @@ Node.js options that are allowed are:
 * `--v8-pool-size`
 * `--watch-path`
 * `--watch`
+* `--watch-preserve-output`
 * `--zero-fill-buffers`
 
 <!-- node-options-node end -->

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1630,7 +1630,7 @@ when the option is used on a platform that does not support it.
 
 ### `--watch-preserve-output`
 
-Option to ensure output of stdout is preserved during --watch on restart.
+Disable the clearing of the console when watch mode restarts the process.
 
 ```console
 $ node --watch --watch-preserve-output test.js

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1630,7 +1630,7 @@ when the option is used on a platform that does not support it.
 
 ### --watch-preserve-output
 
-Option to ensure output of stdout is preserved during --watch on restart
+Option to ensure output of stdout is preserved during --watch on restart.
 
 ```console
 $ node --watch --watch-preserve-output test.js

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1940,8 +1940,8 @@ Node.js options that are allowed are:
 * `--use-openssl-ca`
 * `--v8-pool-size`
 * `--watch-path`
-* `--watch`
 * `--watch-preserve-output`
+* `--watch`
 * `--zero-fill-buffers`
 
 <!-- node-options-node end -->

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -101,8 +101,9 @@ async function stop() {
 }
 
 async function restart() {
+  const clearOutput = kPreserveOutput ? '' : clear;
   process.stdout.write(
-    `${kPreserveOutput ? '' : clear}${green}Restarting ${kCommandStr}${white}\n`
+    `${clearOutput}${green}Restarting ${kCommandStr}${white}\n`
   );
   await stop();
   start();

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -101,10 +101,8 @@ async function stop() {
 }
 
 async function restart() {
-  const clearOutput = kPreserveOutput ? '' : clear;
-  process.stdout.write(
-    `${clearOutput}${green}Restarting ${kCommandStr}${white}\n`
-  );
+  if (!kPreserveOutput) process.stdout.write(clear);
+  process.stdout.write(`${green}Restarting ${kCommandStr}${white}\n`);
   await stop();
   start();
 }

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -34,11 +34,11 @@ markBootstrapComplete();
 const kKillSignal = 'SIGTERM';
 const kShouldFilterModules = getOptionValue('--watch-path').length === 0;
 const kWatchedPaths = ArrayPrototypeMap(getOptionValue('--watch-path'), (path) => resolve(path));
-const kPreserveOutput = getOptionValue('--preserve-output');
+const kPreserveOutput = getOptionValue('--watch-preserve-output');
 const kCommand = ArrayPrototypeSlice(process.argv, 1);
 const kCommandStr = inspect(ArrayPrototypeJoin(kCommand, ' '));
 const args = ArrayPrototypeFilter(process.execArgv, (arg, i, arr) =>
-  arg !== '--watch-path' && arr[i - 1] !== '--watch-path' && arg !== '--watch' && arg !== '--preserve-output');
+  arg !== '--watch-path' && arr[i - 1] !== '--watch-path' && arg !== '--watch' && arg !== '--watch-preserve-output');
 ArrayPrototypePushApply(args, kCommand);
 
 const watcher = new FilesWatcher({ throttle: 500, mode: kShouldFilterModules ? 'filter' : 'all' });

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -34,10 +34,11 @@ markBootstrapComplete();
 const kKillSignal = 'SIGTERM';
 const kShouldFilterModules = getOptionValue('--watch-path').length === 0;
 const kWatchedPaths = ArrayPrototypeMap(getOptionValue('--watch-path'), (path) => resolve(path));
+const kPreserveOutput = getOptionValue('--preserve-output');
 const kCommand = ArrayPrototypeSlice(process.argv, 1);
 const kCommandStr = inspect(ArrayPrototypeJoin(kCommand, ' '));
 const args = ArrayPrototypeFilter(process.execArgv, (arg, i, arr) =>
-  arg !== '--watch-path' && arr[i - 1] !== '--watch-path' && arg !== '--watch');
+  arg !== '--watch-path' && arr[i - 1] !== '--watch-path' && arg !== '--watch' && arg !== '--preserve-output');
 ArrayPrototypePushApply(args, kCommand);
 
 const watcher = new FilesWatcher({ throttle: 500, mode: kShouldFilterModules ? 'filter' : 'all' });
@@ -99,8 +100,8 @@ async function stop() {
   clearGraceReport();
 }
 
-async function restart() {
-  process.stdout.write(`${clear}${green}Restarting ${kCommandStr}${white}\n`);
+async function restart() {;
+  process.stdout.write(`${kPreserveOutput ? '' : clear}${green}Restarting ${kCommandStr}${white}\n`);
   await stop();
   start();
 }

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -100,8 +100,10 @@ async function stop() {
   clearGraceReport();
 }
 
-async function restart() {;
-  process.stdout.write(`${kPreserveOutput ? '' : clear}${green}Restarting ${kCommandStr}${white}\n`);
+async function restart() {
+  process.stdout.write(
+    `${kPreserveOutput ? '' : clear}${green}Restarting ${kCommandStr}${white}\n`
+  );
   await stop();
   start();
 }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -613,9 +613,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "path to watch",
             &EnvironmentOptions::watch_mode_paths,
             kAllowedInEnvvar);
-  AddOption("--preserve-output",
+  AddOption("--watch-preserve-output",
             "preserve outputs on watch mode restart",
-            &EnvironmentOptions::preserve_output,
+            &EnvironmentOptions::watch_mode_preserve_output,
             kAllowedInEnvvar);
   Implies("--watch-path", "--watch");
   AddOption("--check",

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -613,6 +613,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "path to watch",
             &EnvironmentOptions::watch_mode_paths,
             kAllowedInEnvvar);
+  AddOption("--preserve-output", 
+            "preserve outputs on watch mode restart",
+            &EnvironmentOptions::preserve_output,
+            kAllowedInEnvvar);
   Implies("--watch-path", "--watch");
   AddOption("--check",
             "syntax check script without executing",

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -613,7 +613,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "path to watch",
             &EnvironmentOptions::watch_mode_paths,
             kAllowedInEnvvar);
-  AddOption("--preserve-output", 
+  AddOption("--preserve-output",
             "preserve outputs on watch mode restart",
             &EnvironmentOptions::preserve_output,
             kAllowedInEnvvar);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -177,6 +177,7 @@ class EnvironmentOptions : public Options {
 
   bool watch_mode = false;
   bool watch_mode_report_to_parent = false;
+  bool preserve_output = false;
   std::vector<std::string> watch_mode_paths;
 
   bool syntax_check_only = false;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -177,7 +177,7 @@ class EnvironmentOptions : public Options {
 
   bool watch_mode = false;
   bool watch_mode_report_to_parent = false;
-  bool preserve_output = false;
+  bool watch_mode_preserve_output = false;
   std::vector<std::string> watch_mode_paths;
 
   bool syntax_check_only = false;

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -281,12 +281,12 @@ describe('watch mode', { concurrency: false, timeout: 60_000 }, () => {
     await failWriteSucceed({ file: dependant, watchedFile: dependency });
   });
 
-  it('should preserve output when --preserve-output flag is passed', async () => {
+  it('should preserve output when --watch-preserve-output flag is passed', async () => {
     const file = createTmpFile();
     console.log(file);
     const { stderr, stdout } = await spawnWithRestarts({
       file,
-      args: ['--preserve-output', file],
+      args: ['--watch-preserve-output', file],
     });
 
     assert.strictEqual(stderr, '');

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -283,7 +283,6 @@ describe('watch mode', { concurrency: false, timeout: 60_000 }, () => {
 
   it('should preserve output when --watch-preserve-output flag is passed', async () => {
     const file = createTmpFile();
-    console.log(file);
     const { stderr, stdout } = await spawnWithRestarts({
       file,
       args: ['--watch-preserve-output', file],

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -280,4 +280,30 @@ describe('watch mode', { concurrency: false, timeout: 60_000 }, () => {
 
     await failWriteSucceed({ file: dependant, watchedFile: dependency });
   });
+
+  it('should preserve output when --preserve-output flag is passed', async () => {
+    const file = createTmpFile();
+    console.log(file);
+    const { stderr, stdout } = await spawnWithRestarts({
+      file,
+      args: ['--preserve-output', file],
+    });
+
+    assert.strictEqual(stderr, '');
+    // Checks if the existing output is preserved
+    assertRestartedCorrectly({
+      stdout,
+      messages: {
+        inner: 'running',
+        restarted: `Restarting ${inspect(file)}`,
+        completed: `Completed running ${inspect(file)}`,
+      },
+    });
+    // Remove the first 3 lines from stdout
+    const lines = stdout.split(/\r?\n/).filter(Boolean).slice(3);
+    assert.deepStrictEqual(lines, [
+      'running',
+      `Completed running ${inspect(file)}`,
+    ]);
+  });
 });


### PR DESCRIPTION
Added a --preserve-output flag to watch mode
Fixes: https://github.com/nodejs/node/issues/45713

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
