### PR TITLE
benchmark: introduce benchmark combination filtering

### DIFF
--- a/benchmark/buffers/buffer-copy.js
+++ b/benchmark/buffers/buffer-copy.js
@@ -5,6 +5,12 @@ const bench = common.createBenchmark(main, {
   bytes: [0, 8, 128, 32 * 1024],
   partial: ['true', 'false'],
   n: [6e6]
+}, {
+  combinationFilter: (p) => {
+    return (p.partial === 'false' && p.bytes === 0) ||
+           (p.partial !== 'false' && p.bytes !== 0);
+  },
+  test: { partial: 'false', bytes: 0 },
 });
 
 function main({ n, bytes, partial }) {

--- a/benchmark/buffers/buffer-indexof.js
+++ b/benchmark/buffers/buffer-indexof.js
@@ -19,9 +19,14 @@ const searchStrings = [
 
 const bench = common.createBenchmark(main, {
   search: searchStrings,
-  encoding: ['utf8', 'ucs2'],
+  encoding: ['undefined', 'utf8', 'ucs2'],
   type: ['buffer', 'string'],
   n: [5e4]
+}, {
+  combinationFilter: (p) => {
+    return (p.type === 'buffer' && p.encoding === 'undefined') ||
+           (p.type !== 'buffer' && p.encoding !== 'undefined');
+  },
 });
 
 function main({ n, search, encoding, type }) {

--- a/benchmark/buffers/buffer-tostring.js
+++ b/benchmark/buffers/buffer-tostring.js
@@ -3,10 +3,15 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  encoding: ['utf8', 'ascii', 'latin1', 'hex', 'UCS-2'],
+  encoding: ['', 'utf8', 'ascii', 'latin1', 'hex', 'UCS-2'],
   args: [0, 1, 3],
   len: [1, 64, 1024],
   n: [1e6]
+}, {
+  combinationFilter: (p) => {
+    return (p.args === 0 && p.encoding === '') ||
+           (p.args !== 0 && p.encoding !== '');
+  },
 });
 
 function main({ encoding, args, len, n }) {

--- a/doc/contributing/writing-and-running-benchmarks.md
+++ b/doc/contributing/writing-and-running-benchmarks.md
@@ -450,8 +450,12 @@ The arguments of `createBenchmark` are:
   possible combinations of these parameters, unless specified otherwise.
   Each configuration is a property with an array of possible values.
   The configuration values can only be strings or numbers.
-* `options` {Object} The benchmark options. At the moment only the `flags`
-  option for specifying command line flags is supported.
+* `options` {Object} The benchmark options. Supported options:
+  * `flags` {Array} Contains node-specific command line flags to pass to
+    the child process.
+  * `combinationFilter` {Function} Has a single parameter which is an object
+    containing a combination of benchmark parameters. It should return `true`
+    or `false` to indicate whether the combination should be included or not.
 
 `createBenchmark` returns a `bench` object, which is used for timing
 the runtime of the benchmark. Run `bench.start()` after the initialization


### PR DESCRIPTION
This should help avoid redundant/unnecessary benchmark runs. For this PR, I've only included changes for Buffer benchmarks that would benefit from this.

If this is acceptable, the other benchmark categories would need to be reviewed and modified where appropriate as well, probably in additional PRs?