### PR TITLE
net: check `autoSelectFamilyAttemptTimeout` is positive

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1210,7 +1210,7 @@ function lookupAndConnect(self, options) {
   }
 
   if (autoSelectFamilyAttemptTimeout !== undefined) {
-    validateInt32(autoSelectFamilyAttemptTimeout);
+    validateInt32(autoSelectFamilyAttemptTimeout, 'options.autoSelectFamilyAttemptTimeout', 1);
 
     if (autoSelectFamilyAttemptTimeout < 10) {
       autoSelectFamilyAttemptTimeout = 10;

--- a/test/parallel/test-net-socket-connect-invalid-autoselectfamilyattempttimeout.js
+++ b/test/parallel/test-net-socket-connect-invalid-autoselectfamilyattempttimeout.js
@@ -1,0 +1,14 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const autoSelectFamilyAttemptTimeout = common.platformTimeout(-10);
+
+assert.throws(() => {
+  net.connect({
+    port: 8080,
+    autoSelectFamily: true,
+    autoSelectFamilyAttemptTimeout,
+  });
+}, { code: 'ERR_OUT_OF_RANGE' });

--- a/test/parallel/test-net-socket-connect-invalid-autoselectfamilyattempttimeout.js
+++ b/test/parallel/test-net-socket-connect-invalid-autoselectfamilyattempttimeout.js
@@ -1,14 +1,14 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const autoSelectFamilyAttemptTimeout = common.platformTimeout(-10);
-
-assert.throws(() => {
-  net.connect({
-    port: 8080,
-    autoSelectFamily: true,
-    autoSelectFamilyAttemptTimeout,
-  });
-}, { code: 'ERR_OUT_OF_RANGE' });
+for (const autoSelectFamilyAttemptTimeout of [-10, 0]) {
+  assert.throws(() => {
+    net.connect({
+      port: 8080,
+      autoSelectFamily: true,
+      autoSelectFamilyAttemptTimeout,
+    });
+  }, { code: 'ERR_OUT_OF_RANGE' });
+}


### PR DESCRIPTION
In document, `autoSelectFamilyAttemptTimeout` is described as positive integer because it's time unit. But there is no checking whether it's positive integer.

Refs: https://github.com/nodejs/node/blob/main/doc/api/net.md#socketconnectoptions-connectlistener

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
