### PR TITLE
fix: tap parser fails when test name includes non ASCII characters

### DIFF
--- a/lib/internal/test_runner/tap_lexer.js
+++ b/lib/internal/test_runner/tap_lexer.js
@@ -471,7 +471,8 @@ class TapLexer {
     return (
       (char >= 'a' && char <= 'z') ||
       (char >= 'A' && char <= 'Z') ||
-      this.#isSpecialCharacterSymbol(char)
+      this.#isSpecialCharacterSymbol(char) ||
+      this.#isNonASCIISymbol(char)
     );
   }
 
@@ -480,6 +481,11 @@ class TapLexer {
     // these are used for comments/reasons explanations, pragma and escape characters
     // whitespace is not included because it is handled separately
     return '!"$%&\'()*,./:;<=>?@[]^_`{|}~'.indexOf(char) > -1;
+  }
+
+  #isNonASCIISymbol(char) {
+    const ascii = /^[ -~]+$/;
+    return !ascii.test(char);
   }
 
   #isWhitespaceSymbol(char) {

--- a/lib/internal/test_runner/tap_lexer.js
+++ b/lib/internal/test_runner/tap_lexer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { SafeSet, MathMax, StringPrototypeIncludes } = primordials;
+const { SafeSet, MathMax, StringPrototypeIncludes, RegExpPrototypeExec } = primordials;
 const {
   codes: { ERR_TAP_LEXER_ERROR },
 } = require('internal/errors');
@@ -485,7 +485,7 @@ class TapLexer {
 
   #isNonASCIISymbol(char) {
     const ascii = /^[ -~]+$/;
-    return !ascii.test(char);
+    return RegExpPrototypeExec(ascii, char) === null;
   }
 
   #isWhitespaceSymbol(char) {


### PR DESCRIPTION
fixes: #45706 

fix: tap parser fails when test name includes non ASCII characters

check for non-ascii characters and return `true` if it is not.

function to check for non-ASCII characters:

```js

  #isNonASCIISymbol(char) {
    const ascii = /^[ -~]+$/;
    return !ascii.test(char);
  }

```

Example:


Testing:

```
// test.mjs
import { it } from 'node:test'
it('नमस्ते', () => {});

```

Output:
```
TAP version 13
# Subtest: /Users/pulkitgupta/Desktop/node/test.mjs
    # Subtest: नमस्ते
ok 1 - नमस्ते
    # duration_ms:
ok 1 - /Users/pulkitgupta/Desktop/node/test.mjs
  ---
  duration_ms: 59.161084
  ...
1..1
# tests 1
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 61.073625
pulkitgupta@Pulkits-MacBook-Air node % 

```