### PR TITLE
test: fix invalid output TAP if there newline in test name

### DIFF
--- a/lib/internal/test_runner/tap_stream.js
+++ b/lib/internal/test_runner/tap_stream.js
@@ -270,4 +270,4 @@ function isAssertionLike(value) {
   return value && typeof value === 'object' && 'expected' in value && 'actual' in value;
 }
 
-module.exports = { TapStream };
+module.exports = { TapStream, tapEscape };

--- a/lib/internal/test_runner/tap_stream.js
+++ b/lib/internal/test_runner/tap_stream.js
@@ -131,9 +131,9 @@ class TapStream extends Readable {
 
 // In certain places, # and \ need to be escaped as \# and \\.
 function tapEscape(input) {
-  return StringPrototypeReplaceAll(
+  return StringPrototypeReplaceAll(StringPrototypeReplaceAll(
     StringPrototypeReplaceAll(input, '\\', '\\\\'), '#', '\\#'
-  );
+  ), '\n', '\\n');
 }
 
 function jsToYaml(indent, name, value) {

--- a/lib/internal/test_runner/tap_stream.js
+++ b/lib/internal/test_runner/tap_stream.js
@@ -131,9 +131,18 @@ class TapStream extends Readable {
 
 // In certain places, # and \ need to be escaped as \# and \\.
 function tapEscape(input) {
-  return StringPrototypeReplaceAll(StringPrototypeReplaceAll(
-    StringPrototypeReplaceAll(input, '\\', '\\\\'), '#', '\\#'
-  ), '\n', '\\n');
+  [{ escapeChar: '\\', tappedEscape: '\\\\' },
+   { escapeChar: '#', tappedEscape: '\\#' },
+   { escapeChar: '\n', tappedEscape: '\\n' },
+   { escapeChar: '\t', tappedEscape: '\\t' },
+   { escapeChar: '\r', tappedEscape: '\\r' },
+   { escapeChar: '\f', tappedEscape: '\\f' },
+   { escapeChar: '\b', tappedEscape: '\\b' },
+   { escapeChar: '\v', tappedEscape: '\\v' },
+  ].forEach(({ escapeChar, tappedEscape }) => {
+    input = StringPrototypeReplaceAll(input, escapeChar, tappedEscape);
+  });
+  return input;
 }
 
 function jsToYaml(indent, name, value) {

--- a/lib/internal/test_runner/tap_stream.js
+++ b/lib/internal/test_runner/tap_stream.js
@@ -131,18 +131,15 @@ class TapStream extends Readable {
 
 // In certain places, # and \ need to be escaped as \# and \\.
 function tapEscape(input) {
-  [{ escapeChar: '\\', tappedEscape: '\\\\' },
-   { escapeChar: '#', tappedEscape: '\\#' },
-   { escapeChar: '\n', tappedEscape: '\\n' },
-   { escapeChar: '\t', tappedEscape: '\\t' },
-   { escapeChar: '\r', tappedEscape: '\\r' },
-   { escapeChar: '\f', tappedEscape: '\\f' },
-   { escapeChar: '\b', tappedEscape: '\\b' },
-   { escapeChar: '\v', tappedEscape: '\\v' },
-  ].forEach(({ escapeChar, tappedEscape }) => {
-    input = StringPrototypeReplaceAll(input, escapeChar, tappedEscape);
-  });
-  return input;
+  let result = StringPrototypeReplaceAll(input, '\\', '\\\\');
+  result = StringPrototypeReplaceAll(result, '#', '\\#');
+  result = StringPrototypeReplaceAll(result,'\b', '\\b');
+  result = StringPrototypeReplaceAll(result,'\f', '\\f');
+  result = StringPrototypeReplaceAll(result,'\t', '\\t');
+  result = StringPrototypeReplaceAll(result,'\n', '\\n');
+  result = StringPrototypeReplaceAll(result,'\r', '\\r');
+  result = StringPrototypeReplaceAll(result,'\v', '\\v');
+  return result;
 }
 
 function jsToYaml(indent, name, value) {
@@ -270,4 +267,4 @@ function isAssertionLike(value) {
   return value && typeof value === 'object' && 'expected' in value && 'actual' in value;
 }
 
-module.exports = { TapStream, tapEscape };
+module.exports = { TapStream };

--- a/lib/internal/test_runner/tap_stream.js
+++ b/lib/internal/test_runner/tap_stream.js
@@ -133,12 +133,12 @@ class TapStream extends Readable {
 function tapEscape(input) {
   let result = StringPrototypeReplaceAll(input, '\\', '\\\\');
   result = StringPrototypeReplaceAll(result, '#', '\\#');
-  result = StringPrototypeReplaceAll(result,'\b', '\\b');
-  result = StringPrototypeReplaceAll(result,'\f', '\\f');
-  result = StringPrototypeReplaceAll(result,'\t', '\\t');
-  result = StringPrototypeReplaceAll(result,'\n', '\\n');
-  result = StringPrototypeReplaceAll(result,'\r', '\\r');
-  result = StringPrototypeReplaceAll(result,'\v', '\\v');
+  result = StringPrototypeReplaceAll(result, '\b', '\\b');
+  result = StringPrototypeReplaceAll(result, '\f', '\\f');
+  result = StringPrototypeReplaceAll(result, '\t', '\\t');
+  result = StringPrototypeReplaceAll(result, '\n', '\\n');
+  result = StringPrototypeReplaceAll(result, '\r', '\\r');
+  result = StringPrototypeReplaceAll(result, '\v', '\\v');
   return result;
 }
 

--- a/test/message/test_runner_output.js
+++ b/test/message/test_runner_output.js
@@ -213,7 +213,7 @@ test('test with a name and options provided', { skip: true });
 test({ skip: true }, function functionAndOptions() {});
 
 // A test whose description needs to be escaped.
-test('escaped description \\ # \\#\\');
+test('escaped description \\ # \\#\\ \n \t \f \v \b \r');
 
 // A test whose skip message needs to be escaped.
 test('escaped skip message', { skip: '#skip' });

--- a/test/message/test_runner_output.out
+++ b/test/message/test_runner_output.out
@@ -127,9 +127,9 @@ not ok 13 - async assertion fail
   failureType: 'testCodeFailure'
   error: |-
     Expected values to be strictly equal:
-    
+
     true !== false
-    
+
   code: 'ERR_ASSERTION'
   expected: false
   actual: true
@@ -353,8 +353,8 @@ ok 36 - functionAndOptions # SKIP
   ---
   duration_ms: *
   ...
-# Subtest: escaped description \\ \# \\\#\\
-ok 37 - escaped description \\ \# \\\#\\
+# Subtest: escaped description \\ \# \\\#\\ \n \t \f \v \b \r
+ok 37 - escaped description \\ \# \\\#\\ \n \t \f \v \b \r
   ---
   duration_ms: *
   ...

--- a/test/parallel/test-runner-tap-parser-stream.js
+++ b/test/parallel/test-runner-tap-parser-stream.js
@@ -4,7 +4,6 @@ const common = require('../common');
 const assert = require('node:assert');
 const { TapParser } = require('internal/test_runner/tap_parser');
 const { TapChecker } = require('internal/test_runner/tap_checker');
-const { tapEscape } = require('internal/test_runner/tap_stream');
 
 const cases = [
   {
@@ -627,18 +626,4 @@ ok 1 - test 1
     actual,
     expected.map((item) => ({ __proto__: null, ...item }))
   );
-})().then(common.mustCall());
-
-(async () => {
-  [{ escapeChar: '\\', tappedEscape: '\\\\' },
-   { escapeChar: '#', tappedEscape: '\\#' },
-   { escapeChar: '\n', tappedEscape: '\\n' },
-   { escapeChar: '\t', tappedEscape: '\\t' },
-   { escapeChar: '\r', tappedEscape: '\\r' },
-   { escapeChar: '\f', tappedEscape: '\\f' },
-   { escapeChar: '\b', tappedEscape: '\\b' },
-   { escapeChar: '\v', tappedEscape: '\\v' },
-  ].forEach(({ escapeChar, tappedEscape }) => {
-    assert.strictEqual(tapEscape(escapeChar), tappedEscape);
-  });
 })().then(common.mustCall());

--- a/test/parallel/test-runner-tap-parser-stream.js
+++ b/test/parallel/test-runner-tap-parser-stream.js
@@ -4,6 +4,7 @@ const common = require('../common');
 const assert = require('node:assert');
 const { TapParser } = require('internal/test_runner/tap_parser');
 const { TapChecker } = require('internal/test_runner/tap_checker');
+const { tapEscape } = require('internal/test_runner/tap_stream');
 
 const cases = [
   {
@@ -626,4 +627,18 @@ ok 1 - test 1
     actual,
     expected.map((item) => ({ __proto__: null, ...item }))
   );
+})().then(common.mustCall());
+
+(async () => {
+  [{ escapeChar: '\\', tappedEscape: '\\\\' },
+   { escapeChar: '#', tappedEscape: '\\#' },
+   { escapeChar: '\n', tappedEscape: '\\n' },
+   { escapeChar: '\t', tappedEscape: '\\t' },
+   { escapeChar: '\r', tappedEscape: '\\r' },
+   { escapeChar: '\f', tappedEscape: '\\f' },
+   { escapeChar: '\b', tappedEscape: '\\b' },
+   { escapeChar: '\v', tappedEscape: '\\v' },
+  ].forEach(({ escapeChar, tappedEscape }) => {
+    assert.strictEqual(tapEscape(escapeChar), tappedEscape);
+  });
 })().then(common.mustCall());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

fixes: #45396 

fix test outputs invalid TAP if there is a newline in the test name


**Fixed Changes**

Test Case:

```js
// test.mjs
import { it } from 'node:test'
it('Hello \n world \t hello \b hello \v hello \f hello \r hello', () => {});

```

Output

```
TAP version 13
# Subtest: Hello \n world \t hello \b hello \v hello \f hello \r hello
ok 1 - Hello \n world \t hello \b hello \v hello \f hello \r hello
  ---
  duration_ms: 1.117041
  ...
1..1
# tests 1
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 6.629375

```





