### PR TITLE
events: refactor to use `validateNumber`

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -33,7 +33,6 @@ const {
   ErrorCaptureStackTrace,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
-  NumberIsNaN,
   NumberMAX_SAFE_INTEGER,
   ObjectCreate,
   ObjectDefineProperty,
@@ -70,7 +69,6 @@ const {
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_THIS,
-    ERR_OUT_OF_RANGE,
     ERR_UNHANDLED_ERROR
   },
   genericNodeError,
@@ -82,6 +80,7 @@ const {
   validateBoolean,
   validateFunction,
   validateString,
+  validateNumber,
 } = require('internal/validators');
 
 const kCapture = Symbol('kCapture');
@@ -279,11 +278,7 @@ ObjectDefineProperty(EventEmitter, 'defaultMaxListeners', {
     return defaultMaxListeners;
   },
   set: function(arg) {
-    if (typeof arg !== 'number' || arg < 0 || NumberIsNaN(arg)) {
-      throw new ERR_OUT_OF_RANGE('defaultMaxListeners',
-                                 'a non-negative number',
-                                 arg);
-    }
+    validateNumber(arg, 'defaultMaxListeners', 0);
     defaultMaxListeners = arg;
   }
 });
@@ -313,8 +308,7 @@ ObjectDefineProperties(EventEmitter, {
  */
 EventEmitter.setMaxListeners =
   function(n = defaultMaxListeners, ...eventTargets) {
-    if (typeof n !== 'number' || n < 0 || NumberIsNaN(n))
-      throw new ERR_OUT_OF_RANGE('n', 'a non-negative number', n);
+    validateNumber(n, 'setMaxListeners', 0);
     if (eventTargets.length === 0) {
       defaultMaxListeners = n;
     } else {
@@ -410,9 +404,7 @@ function emitUnhandledRejectionOrErr(ee, err, type, args) {
  * @returns {EventEmitter}
  */
 EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
-  if (typeof n !== 'number' || n < 0 || NumberIsNaN(n)) {
-    throw new ERR_OUT_OF_RANGE('n', 'a non-negative number', n);
-  }
+  validateNumber(n, 'setMaxListeners', 0);
   this._maxListeners = n;
   return this;
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -79,8 +79,8 @@ const {
   validateAbortSignal,
   validateBoolean,
   validateFunction,
-  validateString,
   validateNumber,
+  validateString,
 } = require('internal/validators');
 
 const kCapture = Symbol('kCapture');


### PR DESCRIPTION
Need to use validateNumber for checking `TypeError`

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
