### PR TITLE
lib: refactor to use `validateInteger`

### DIFF
--- a/lib/internal/histogram.js
+++ b/lib/internal/histogram.js
@@ -2,7 +2,6 @@
 
 const {
   MapPrototypeEntries,
-  NumberIsNaN,
   NumberIsInteger,
   NumberMAX_SAFE_INTEGER,
   ObjectFromEntries,
@@ -186,10 +185,7 @@ class Histogram {
   percentile(percentile) {
     if (!isHistogram(this))
       throw new ERR_INVALID_THIS('Histogram');
-    validateNumber(percentile, 'percentile');
-
-    if (NumberIsNaN(percentile) || percentile <= 0 || percentile > 100)
-      throw new ERR_INVALID_ARG_VALUE.RangeError('percentile', percentile);
+    validateNumber(percentile, 'percentile', 1, 100);
 
     return this[kHandle]?.percentile(percentile);
   }
@@ -201,10 +197,7 @@ class Histogram {
   percentileBigInt(percentile) {
     if (!isHistogram(this))
       throw new ERR_INVALID_THIS('Histogram');
-    validateNumber(percentile, 'percentile');
-
-    if (NumberIsNaN(percentile) || percentile <= 0 || percentile > 100)
-      throw new ERR_INVALID_ARG_VALUE.RangeError('percentile', percentile);
+    validateNumber(percentile, 'percentile', 1, 100);
 
     return this[kHandle]?.percentileBigInt(percentile);
   }

--- a/lib/internal/histogram.js
+++ b/lib/internal/histogram.js
@@ -2,7 +2,7 @@
 
 const {
   MapPrototypeEntries,
-  NumberIsInteger,
+  NumberIsNaN,
   NumberMAX_SAFE_INTEGER,
   ObjectFromEntries,
   ReflectConstruct,
@@ -185,7 +185,9 @@ class Histogram {
   percentile(percentile) {
     if (!isHistogram(this))
       throw new ERR_INVALID_THIS('Histogram');
-    validateNumber(percentile, 'percentile', 1, 100);
+    validateNumber(percentile, 'percentile');
+    if (NumberIsNaN(percentile) || percentile <= 0 || percentile > 100)
+      throw new ERR_OUT_OF_RANGE('percentile', '> 0 && <= 100', percentile);
 
     return this[kHandle]?.percentile(percentile);
   }
@@ -197,7 +199,9 @@ class Histogram {
   percentileBigInt(percentile) {
     if (!isHistogram(this))
       throw new ERR_INVALID_THIS('Histogram');
-    validateNumber(percentile, 'percentile', 1, 100);
+    validateNumber(percentile, 'percentile');
+    if (NumberIsNaN(percentile) || percentile <= 0 || percentile > 100)
+      throw new ERR_OUT_OF_RANGE('percentile', '> 0 && <= 100', percentile);
 
     return this[kHandle]?.percentileBigInt(percentile);
   }
@@ -277,11 +281,7 @@ class RecordableHistogram extends Histogram {
       return;
     }
 
-    if (!NumberIsInteger(val))
-      throw new ERR_INVALID_ARG_TYPE('val', ['integer', 'bigint'], val);
-
-    if (val < 1 || val > NumberMAX_SAFE_INTEGER)
-      throw new ERR_OUT_OF_RANGE('val', 'a safe integer greater than 0', val);
+    validateInteger(val, 'val', 1);
 
     this[kHandle]?.record(val);
   }

--- a/test/sequential/test-performance-eventloopdelay.js
+++ b/test/sequential/test-performance-eventloopdelay.js
@@ -91,7 +91,7 @@ const { sleep } = require('internal/util');
           () => histogram.percentile(i),
           {
             name: 'RangeError',
-            code: 'ERR_INVALID_ARG_VALUE'
+            code: 'ERR_OUT_OF_RANGE'
           }
         );
       });


### PR DESCRIPTION
Use validateInteger for record and revise error code of percentile.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
