### PR TITLE
child_process: add `subprocess.readLines` method

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1470,7 +1470,7 @@ for await (const fileInfo of spawn('ls', ['-a']).readLines()) {
 ```
 
 ```cjs
-const { spawn } = require('node:child_process')
+const { spawn } = require('node:child_process');
 
 (async () => {
   for await (const fileInfo of spawn('ls', ['-a']).readLines()) {

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1454,12 +1454,13 @@ added: REPLACEME
 -->
 
 * `options` {Object}
-  * `shouldIgnoreErrors` {boolean} **Default:** `false`
-  * `useStdErr` {boolean} **Default:** `false`
+  * `rejectIfNonZeroExitCode` {boolean} **Default:** `false`
+  * `listenTo` {string} Can be one of `'stdout'`, or `'stderr'`.
+    **Default:** `'stdout'`
 * Returns: {readline.InterfaceConstructor}
 
-Convenience method to create a `readline` interface and stream over the stdout
-(or stderr if `useStdErr` is `true`) of the process.
+Convenience method to create a `node:readline` interface and stream over the
+output of the child process.
 
 ```mjs
 import { spawn } from 'node:child_process';

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1447,6 +1447,38 @@ console.log(`Spawned child pid: ${grep.pid}`);
 grep.stdin.end();
 ```
 
+### `subprocess.readLines([options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {Object}
+  * `shouldIgnoreErrors` {boolean} **Default:** `false`
+  * `useStdErr` {boolean} **Default:** `false`
+* Returns: {readline.InterfaceConstructor}
+
+Convenience method to create a `readline` interface and stream over the stdout
+(or stderr if `useStdErr` is `true`) of the process.
+
+```mjs
+import { spawn } from 'node:child_process';
+
+for await (const fileInfo of spawn('ls', ['-a']).readLines()) {
+  console.log(fileInfo);
+}
+```
+
+```cjs
+const { spawn } = require('node:child_process')
+
+(async () => {
+  for await (const fileInfo of spawn('ls', ['-a']).readLines()) {
+    console.log(fileInfo);
+  }
+})();
+```
+
 ### `subprocess.ref()`
 
 <!-- YAML

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -87,9 +87,10 @@ const {
 } = require('internal/validators');
 const child_process = require('internal/child_process');
 const {
-  getValidStdio,
-  setupChannel,
   ChildProcess,
+  getValidStdio,
+  kSignal,
+  setupChannel,
   stdioStringToArray,
 } = child_process;
 
@@ -782,6 +783,7 @@ function spawn(file, args, options) {
 
   if (options.signal) {
     const signal = options.signal;
+    child[kSignal] = signal;
     if (signal.aborted) {
       process.nextTick(onAbortListener);
     } else {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -7,11 +7,15 @@ const {
   ArrayPrototypeSlice,
   FunctionPrototype,
   FunctionPrototypeCall,
+  ObjectAssign,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Promise,
   ReflectApply,
+  SafePromiseRace,
   StringPrototypeSlice,
   Symbol,
+  SymbolAsyncIterator,
   SymbolDispose,
   Uint8Array,
 } = primordials;
@@ -29,18 +33,21 @@ const {
     ERR_IPC_SYNC_FORK,
     ERR_MISSING_ARGS,
   },
+  genericNodeError,
 } = require('internal/errors');
 const {
   validateArray,
   validateObject,
   validateOneOf,
   validateString,
+  validateBoolean,
 } = require('internal/validators');
 const EventEmitter = require('events');
 const net = require('net');
 const dgram = require('dgram');
 const inspect = require('internal/util/inspect').inspect;
 const assert = require('internal/assert');
+const { Interface } = require('internal/readline/interface');
 
 const { Process } = internalBinding('process_wrap');
 const {
@@ -56,7 +63,7 @@ const { TTY } = internalBinding('tty_wrap');
 const { UDP } = internalBinding('udp_wrap');
 const SocketList = require('internal/socket_list');
 const { owner_symbol } = require('internal/async_hooks').symbols;
-const { convertToValidSignal, deprecate } = require('internal/util');
+const { convertToValidSignal, deprecate, kEmptyObject } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 const spawn_sync = internalBinding('spawn_sync');
 const { kStateSymbol } = require('internal/dgram');
@@ -85,6 +92,7 @@ const MAX_HANDLE_RETRANSMISSIONS = 3;
 const kChannelHandle = Symbol('kChannelHandle');
 const kIsUsedAsStdio = Symbol('kIsUsedAsStdio');
 const kPendingMessages = Symbol('kPendingMessages');
+const kSignal = Symbol('kSignal');
 
 // This object contain function to convert TCP objects to native handle objects
 // and back again.
@@ -531,6 +539,37 @@ ChildProcess.prototype.ref = function() {
 
 ChildProcess.prototype.unref = function() {
   if (this._handle) this._handle.unref();
+};
+
+ChildProcess.prototype.readLines = function readLines(options = undefined) {
+  const { useStdErr = false, ignoreErrors = false } = options ?? kEmptyObject;
+  if (options != null) {
+    validateBoolean(useStdErr, 'options.useStdErr');
+    validateBoolean(ignoreErrors, 'options.ignoreErrors');
+  }
+  const rlInterface = new Interface({
+    __proto__: null,
+    signal: this[kSignal],
+    input: useStdErr ? this.stderr : this.stdout,
+  });
+  if (ignoreErrors) {
+    this.on('error', () => {});
+  } else {
+    const errorPromise = new Promise((_, reject) => this.once('error', reject));
+    const exitPromise = new Promise((resolve, reject) => this.once('exit', (code) => {
+      if (code === 0) resolve({ done: true, value: undefined });
+      else reject(genericNodeError('Command failed', { pid: this.pid, signal: this.signalCode, status: code }));
+    }));
+    rlInterface[SymbolAsyncIterator] = function() {
+      return { __proto__: null,
+               next: () => SafePromiseRace([
+                 errorPromise,
+                 new Promise((resolve) => this.on('line', (value) => resolve({ done: false, value }))),
+                 exitPromise]),
+               [SymbolAsyncIterator]() { return this; } };
+    };
+  }
+  return rlInterface;
 };
 
 class Control extends EventEmitter {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -555,7 +555,7 @@ ChildProcess.prototype.readLines = function readLines(options = undefined) {
     this.on('error', () => {});
   } else {
     const errorPromise = new Promise((_, reject) => this.once('error', reject));
-    const exitPromise = new Promise((resolve, reject) => this.once('exit', (code) => {
+    const exitPromise = new Promise((resolve, reject) => this.once('close', (code) => {
       if (code === 0) resolve({ done: true, value: undefined });
       else reject(genericNodeError('Command failed', { pid: this.pid, signal: this.signalCode, status: code }));
     }));

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -4,12 +4,15 @@ const {
   ArrayIsArray,
   ArrayPrototypePush,
   ArrayPrototypeReduce,
+  ArrayPrototypeShift,
   ArrayPrototypeSlice,
   FunctionPrototype,
   FunctionPrototypeCall,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Promise,
+  PromiseResolve,
+  PromisePrototypeThen,
   ReflectApply,
   SafePromiseRace,
   StringPrototypeSlice,
@@ -541,33 +544,71 @@ ChildProcess.prototype.unref = function() {
 };
 
 ChildProcess.prototype.readLines = function readLines(options = undefined) {
-  const { useStdErr = false, ignoreErrors = false } = options ?? kEmptyObject;
+  const { listenTo, rejectIfNonZeroExitCode = false } = options ?? kEmptyObject;
   if (options != null) {
-    validateBoolean(useStdErr, 'options.useStdErr');
-    validateBoolean(ignoreErrors, 'options.ignoreErrors');
+    if (listenTo != null) validateOneOf(listenTo, 'options.listenTo', ['stdout', 'stderr']);
+    validateBoolean(rejectIfNonZeroExitCode, 'options.rejectIfNonZeroExitCode');
+  }
+  let input;
+  switch (listenTo) {
+    // TODO(aduh95): add case 'both'
+
+    case 'stderr':
+      input = this.stderr;
+      break;
+
+    default:
+      input = this.stdout;
   }
   const rlInterface = new Interface({
     __proto__: null,
     signal: this[kSignal],
-    input: useStdErr ? this.stderr : this.stdout,
+    input,
   });
-  if (ignoreErrors) {
-    this.on('error', () => {});
-  } else {
-    const errorPromise = new Promise((_, reject) => this.once('error', reject));
-    const exitPromise = new Promise((resolve, reject) => this.once('close', (code) => {
-      if (code === 0) resolve({ done: true, value: undefined });
-      else reject(genericNodeError('Command failed', { pid: this.pid, signal: this.signalCode, status: code }));
-    }));
-    rlInterface[SymbolAsyncIterator] = function() {
-      return { __proto__: null,
-               next: () => SafePromiseRace([
-                 errorPromise,
-                 new Promise((resolve) => this.on('line', (value) => resolve({ done: false, value }))),
-                 exitPromise]),
-               [SymbolAsyncIterator]() { return this; } };
-    };
-  }
+  const errorPromise = new Promise((_, reject) => this.once('error', reject));
+  const exitPromise = new Promise((resolve, reject) => this.once('close', rejectIfNonZeroExitCode ? (code) => {
+    if (code === 0) resolve({ done: true, value: undefined });
+    else reject(genericNodeError('Command failed', { pid: this.pid, signal: this.signalCode, status: code }));
+  } : () => resolve({ done: true, value: undefined })));
+  rlInterface[SymbolAsyncIterator] = function() {
+    let resolveNext;
+    let nextPromise = new Promise((resolve) => {
+      resolveNext = resolve;
+    });
+    const buffer = ObjectSetPrototypeOf([], null);
+    this.on('line', (value) => {
+      if (resolveNext != null) {
+        resolveNext(value);
+        resolveNext = null;
+      } else {
+        ArrayPrototypePush(buffer, value);
+      }
+    },
+    );
+    return { __proto__: null,
+             next: () => SafePromiseRace([
+               errorPromise,
+               (() => {
+                 if (nextPromise != null) {
+                   const p = nextPromise;
+                   nextPromise = buffer.length === 0 ? new Promise((resolve) => {
+                     PromisePrototypeThen(p, () => {
+                       resolveNext = resolve;
+                     });
+                   }) : null;
+                   return p;
+                 }
+                 const iteratorObject = { value: ArrayPrototypeShift(buffer), done: false };
+                 if (buffer.length === 0) {
+                   nextPromise = new Promise((resolve) => {
+                     resolveNext = resolve;
+                   });
+                 }
+                 return PromiseResolve(iteratorObject);
+               })(),
+               exitPromise]),
+             [SymbolAsyncIterator]() { return this; } };
+  };
   return rlInterface;
 };
 

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -36,10 +36,10 @@ const {
 } = require('internal/errors');
 const {
   validateArray,
+  validateBoolean,
   validateObject,
   validateOneOf,
   validateString,
-  validateBoolean,
 } = require('internal/validators');
 const EventEmitter = require('events');
 const net = require('net');

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -7,7 +7,6 @@ const {
   ArrayPrototypeSlice,
   FunctionPrototype,
   FunctionPrototypeCall,
-  ObjectAssign,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Promise,
@@ -1171,6 +1170,7 @@ function spawnSync(options) {
 module.exports = {
   ChildProcess,
   kChannelHandle,
+  kSignal,
   setupChannel,
   getValidStdio,
   stdioStringToArray,

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -117,6 +117,7 @@ const kRefreshLine = Symbol('_refreshLine');
 const kSawKeyPress = Symbol('_sawKeyPress');
 const kSawReturnAt = Symbol('_sawReturnAt');
 const kSetRawMode = Symbol('_setRawMode');
+const kSignal = Symbol('kSignal');
 const kTabComplete = Symbol('_tabComplete');
 const kTabCompleter = Symbol('_tabCompleter');
 const kTtyWrite = Symbol('_ttyWrite');
@@ -322,6 +323,7 @@ function InterfaceConstructor(input, output, completer, terminal) {
   }
 
   if (signal) {
+    this[kSignal] = signal;
     const onAborted = () => self.close();
     if (signal.aborted) {
       process.nextTick(onAborted);
@@ -329,6 +331,8 @@ function InterfaceConstructor(input, output, completer, terminal) {
       const disposable = EventEmitter.addAbortListener(signal, onAborted);
       self.once('close', disposable[SymbolDispose]);
     }
+  } else {
+    this[kSignal] = undefined;
   }
 
   // Current line
@@ -1357,6 +1361,8 @@ class Interface extends InterfaceConstructor {
       kFirstEventParam ??= require('internal/events/symbols').kFirstEventParam;
       this[kLineObjectStream] = EventEmitter.on(
         this, 'line', {
+          __proto__: null,
+          signal: this[kSignal],
           close: ['close'],
           highWatermark: 1024,
           [kFirstEventParam]: true,

--- a/test/parallel/test-child-process-readLines.mjs
+++ b/test/parallel/test-child-process-readLines.mjs
@@ -1,0 +1,65 @@
+import * as common from '../common/index.mjs';
+
+import assert from 'node:assert';
+import { spawn, exec, execSync } from 'node:child_process';
+
+
+{
+  const lines = exec(`${process.execPath} -p 42`).readLines();
+
+  lines.on('line', common.mustCall((result) => assert.strictEqual(result, '42')));
+}
+
+for await (const line of spawn(process.execPath, ['-p', 42]).readLines()) {
+  assert.strictEqual(line, '42');
+}
+
+{
+  const cp = spawn(process.execPath, ['-p', 42]);
+
+  [0, 1, '', 'a', 0n, 1n, Symbol(), () => {}, {}, []].forEach((useStdErr) => assert.throws(
+    () => cp.readLines({ useStdErr }),
+    { code: 'ERR_INVALID_ARG_TYPE' }));
+
+  [0, 1, '', 'a', 0n, 1n, Symbol(), () => {}, {}, []].forEach((ignoreErrors) => assert.throws(
+    () => cp.readLines({ ignoreErrors }),
+    { code: 'ERR_INVALID_ARG_TYPE' }));
+}
+
+await assert.rejects(async () => {
+  for await (const line of spawn(process.execPath, ['-p', 42], { signal: AbortSignal.abort() }).readLines()) {
+    assert.strictEqual(line, '42');
+  }
+}, { name: 'AbortError' });
+
+
+await assert.rejects(async () => {
+  // eslint-disable-next-line no-unused-vars
+  for await (const _ of spawn(process.execPath, { signal: AbortSignal.abort() }).readLines({ ignoreErrors: true }));
+}, { name: 'AbortError' });
+
+{
+  const cp = spawn(process.execPath, ['-e', 'throw null']);
+  await assert.rejects(async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of cp.readLines());
+  }, { pid: cp.pid, status: 1, signal: null });
+}
+
+for await (const line of spawn(process.execPath, ['-e', 'console.error(42)']).readLines({ useStdErr: true })) {
+  assert.strictEqual(line, '42');
+}
+
+{
+  let stderr;
+  try {
+    execSync(`${process.execPath} -e 'throw new Error'`, { encoding: 'utf-8' });
+  } catch (err) {
+    if (!Array.isArray(err?.output)) throw err;
+    stderr = err.output[2].split(/\r?\n/);
+  }
+  const cp = spawn(process.execPath, ['-e', 'throw new Error']);
+  for await (const line of cp.readLines({ useStdErr: true, ignoreErrors: true })) {
+    assert.strictEqual(line, stderr.shift());
+  }
+}


### PR DESCRIPTION
Similarly to `fileHandle.readLines()`, iterating line by line over the output of a command is a somewhat regular thing when writing scripts. This PR adds a util method to cover this use case.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
