### PR TITLE
[v14.x] deps: V8: cherry-pick d2db7fa7f786

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.87',
+    'v8_embedder_string': '-node.88',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/objects/intl-objects.cc
+++ b/deps/v8/src/objects/intl-objects.cc
@@ -569,7 +569,14 @@ std::set<std::string> Intl::BuildLocaleSet(
   for (const std::string& locale : icu_available_locales) {
     if (path != nullptr || validate_key != nullptr) {
       if (!ValidateResource(icu::Locale(locale.c_str()), path, validate_key)) {
-        continue;
+        // FIXME(chromium:1215606) Find a beter fix for nb->no fallback
+        if (locale != "nb") {
+          continue;
+        }
+        // Try no for nb
+        if (!ValidateResource(icu::Locale("no"), path, validate_key)) {
+          continue;
+        }
       }
     }
     locales.insert(locale);


### PR DESCRIPTION
Original commit message:

    [Intl] Fix nb / no fallback

    ICU 69 moved content of nb resources to no and let
    nb fallback to no. This break our original design of checking
    locale availability. Hard wire to check on no if nb fail for now
    until we come out with a better fix.

    Bug: chromium:1215606
    Change-Id: I831529d29590cc643ee0109fb2ce8948dac75613
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3068010
    Commit-Queue: Frank Tang <ftang@chromium.org>
    Reviewed-by: Shu-yu Guo <syg@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#76044}

Refs: https://github.com/v8/v8/commit/d2db7fa7f786f7f5cf76b86fc4178ccc4a1f5624

Fixes: https://github.com/nodejs/node/issues/45784
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
