### PR TITLE
src: mark generated `snapshot_data` as `const`

### DIFF
--- a/src/node_snapshot_builder.h
+++ b/src/node_snapshot_builder.h
@@ -32,8 +32,6 @@ class NODE_EXTERN_PRIVATE SnapshotBuilder {
                                       v8::Isolate::CreateParams* params);
 
  private:
-  // Used to synchronize access to the snapshot data
-  static Mutex snapshot_data_mutex_;
   static const std::vector<intptr_t>& CollectExternalReferences();
 
   static std::unique_ptr<ExternalReferenceRegistry> registry_;

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -978,7 +978,7 @@ static void WriteCodeCacheInitializer(std::ostream* ss, const std::string& id) {
   *ss << "    },\n";
 }
 
-void FormatBlob(std::ostream& ss, SnapshotData* data) {
+void FormatBlob(std::ostream& ss, const SnapshotData* data) {
   ss << R"(#include <cstddef>
 #include "env.h"
 #include "node_snapshot_builder.h"
@@ -1004,7 +1004,7 @@ static const int v8_snapshot_blob_size = )"
     WriteStaticCodeCacheData(&ss, item);
   }
 
-  ss << R"(SnapshotData snapshot_data {
+  ss << R"(const SnapshotData snapshot_data {
   // -- data_ownership begins --
   SnapshotData::DataOwnership::kNotOwned,
   // -- data_ownership ends --
@@ -1036,7 +1036,6 @@ static const int v8_snapshot_blob_size = )"
 };
 
 const SnapshotData* SnapshotBuilder::GetEmbeddedSnapshotData() {
-  Mutex::ScopedLock lock(snapshot_data_mutex_);
   return &snapshot_data;
 }
 }  // namespace node
@@ -1052,8 +1051,6 @@ static void ResetContextSettingsBeforeSnapshot(Local<Context> context) {
   // node::InitializeContextRuntime.
   context->AllowCodeGenerationFromStrings(true);
 }
-
-Mutex SnapshotBuilder::snapshot_data_mutex_;
 
 const std::vector<intptr_t>& SnapshotBuilder::CollectExternalReferences() {
   static auto registry = std::make_unique<ExternalReferenceRegistry>();


### PR DESCRIPTION
This renders the mutex protecting it unnecessary, since mutexes only need to protect concurrent accesses to mutable data.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
