### PR TITLE
benchmark: add variety of inputs to text-encoder

### DIFF
--- a/benchmark/util/text-encoder.js
+++ b/benchmark/util/text-encoder.js
@@ -2,17 +2,30 @@
 
 const common = require('../common.js');
 
-const BASE = 'string\ud801';
-
 const bench = common.createBenchmark(main, {
-  len: [256, 1024, 1024 * 32],
+  len: [0, 256, 1024, 1024 * 32],
   n: [1e4],
+  type: ['one-byte-string', 'two-byte-string', 'ascii'],
   op: ['encode', 'encodeInto']
 });
 
-function main({ n, op, len }) {
+function main({ n, op, len, type }) {
   const encoder = new TextEncoder();
-  const input = BASE.repeat(len);
+  let base = '';
+
+  switch (type) {
+    case 'ascii':
+      base = 'a';
+      break;
+    case 'one-byte-string':
+      base = '\xff';
+      break;
+    case 'two-byte-string':
+      base = 'ğ';
+      break;
+  }
+
+  const input = base.repeat(len);
   const subarray = new Uint8Array(len);
 
   bench.start();

--- a/benchmark/util/text-encoder.js
+++ b/benchmark/util/text-encoder.js
@@ -3,7 +3,7 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  len: [0, 256, 1024, 1024 * 32],
+  len: [16, 32, 256, 1024, 1024 * 32],
   n: [1e4],
   type: ['one-byte-string', 'two-byte-string', 'ascii'],
   op: ['encode', 'encodeInto']


### PR DESCRIPTION
This pull request is taking from my previous pull request, and updates the text-encoder types to include ascii, latin and utf8 characters to have a much more broad benchmarking for text-encoder.

Referencing https://github.com/nodejs/node/pull/45701