### PR TITLE
deps: V8: cherry-pick bc831f8ba33b

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.5',
+    'v8_embedder_string': '-node.6',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-fast-api-calls.h
+++ b/deps/v8/include/v8-fast-api-calls.h
@@ -248,6 +248,7 @@ class CTypeInfo {
     kFloat32,
     kFloat64,
     kV8Value,
+    kSeqOneByteString,
     kApiObject,  // This will be deprecated once all users have
                  // migrated from v8::ApiObject to v8::Local<v8::Value>.
     kAny,        // This is added to enable untyped representation of fast
@@ -379,6 +380,11 @@ struct FastApiArrayBuffer {
   size_t byte_length;
 };
 
+struct FastOneByteString {
+  const char* data;
+  uint32_t length;
+};
+
 class V8_EXPORT CFunctionInfo {
  public:
   // Construct a struct to hold a CFunction's type information.
@@ -438,6 +444,7 @@ struct AnyCType {
     const FastApiTypedArray<uint64_t>* uint64_ta_value;
     const FastApiTypedArray<float>* float_ta_value;
     const FastApiTypedArray<double>* double_ta_value;
+    const FastOneByteString* string_value;
     FastApiCallbackOptions* options_value;
   };
 };
@@ -614,7 +621,7 @@ class CFunctionInfoImpl : public CFunctionInfo {
                       kReturnType == CTypeInfo::Type::kFloat32 ||
                       kReturnType == CTypeInfo::Type::kFloat64 ||
                       kReturnType == CTypeInfo::Type::kAny,
-                  "64-bit int and api object values are not currently "
+                  "64-bit int, string and api object values are not currently "
                   "supported return types.");
   }
 
@@ -729,6 +736,18 @@ struct TypeInfoHelper<FastApiCallbackOptions&> {
 
   static constexpr CTypeInfo::Type Type() {
     return CTypeInfo::kCallbackOptionsType;
+  }
+  static constexpr CTypeInfo::SequenceType SequenceType() {
+    return CTypeInfo::SequenceType::kScalar;
+  }
+};
+
+template <>
+struct TypeInfoHelper<const FastOneByteString&> {
+  static constexpr CTypeInfo::Flags Flags() { return CTypeInfo::Flags::kNone; }
+
+  static constexpr CTypeInfo::Type Type() {
+    return CTypeInfo::Type::kSeqOneByteString;
   }
   static constexpr CTypeInfo::SequenceType SequenceType() {
     return CTypeInfo::SequenceType::kScalar;

--- a/deps/v8/src/codegen/machine-type.h
+++ b/deps/v8/src/codegen/machine-type.h
@@ -315,6 +315,7 @@ class MachineType {
       case CTypeInfo::Type::kFloat64:
         return MachineType::Float64();
       case CTypeInfo::Type::kV8Value:
+      case CTypeInfo::Type::kSeqOneByteString:
       case CTypeInfo::Type::kApiObject:
         return MachineType::AnyTagged();
     }

--- a/deps/v8/src/compiler/fast-api-calls.cc
+++ b/deps/v8/src/compiler/fast-api-calls.cc
@@ -29,6 +29,7 @@ ElementsKind GetTypedArrayElementsKind(CTypeInfo::Type type) {
     case CTypeInfo::Type::kFloat64:
       return FLOAT64_ELEMENTS;
     case CTypeInfo::Type::kVoid:
+    case CTypeInfo::Type::kSeqOneByteString:
     case CTypeInfo::Type::kBool:
     case CTypeInfo::Type::kV8Value:
     case CTypeInfo::Type::kApiObject:

--- a/deps/v8/src/compiler/simplified-lowering.cc
+++ b/deps/v8/src/compiler/simplified-lowering.cc
@@ -1961,6 +1961,7 @@ class RepresentationSelector {
           case CTypeInfo::Type::kFloat64:
             return UseInfo::CheckedNumberAsFloat64(kDistinguishZeros, feedback);
           case CTypeInfo::Type::kV8Value:
+          case CTypeInfo::Type::kSeqOneByteString:
           case CTypeInfo::Type::kApiObject:
             return UseInfo::AnyTagged();
         }

--- a/deps/v8/test/mjsunit/compiler/fast-api-calls-string.js
+++ b/deps/v8/test/mjsunit/compiler/fast-api-calls-string.js
@@ -1,0 +1,84 @@
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file excercises one byte string support for fast API calls.
+
+// Flags: --turbo-fast-api-calls --expose-fast-api --allow-natives-syntax --turbofan
+// --always-turbofan is disabled because we rely on particular feedback for
+// optimizing to the fastest path.
+// Flags: --no-always-turbofan
+// The test relies on optimizing/deoptimizing at predictable moments, so
+// it's not suitable for deoptimization fuzzing.
+// Flags: --deopt-every-n-times=0
+
+assertThrows(() => d8.test.FastCAPI());
+const fast_c_api = new d8.test.FastCAPI();
+
+function assertSlowCall(input) {
+  assertEquals(new Uint8Array(input.length), copy_string(false, input));
+}
+
+function assertFastCall(input) {
+  const bytes = Uint8Array.from(input, c => c.charCodeAt(0));
+  assertEquals(bytes, copy_string(false, input));
+}
+
+function copy_string(should_fallback = false, input) {
+  const buffer = new Uint8Array(input.length);
+  fast_c_api.copy_string(should_fallback, input, buffer);
+  return buffer;
+}
+
+%PrepareFunctionForOptimization(copy_string);
+assertSlowCall('Hello');
+%OptimizeFunctionOnNextCall(copy_string);
+
+fast_c_api.reset_counts();
+assertFastCall('Hello');
+assertFastCall('');
+assertFastCall(['Hello', 'World'].join(''));
+assertOptimized(copy_string);
+assertEquals(3, fast_c_api.fast_call_count());
+assertEquals(0, fast_c_api.slow_call_count());
+
+// Fall back for twobyte strings.
+fast_c_api.reset_counts();
+assertSlowCall('Hello\u{10000}');
+assertSlowCall('नमस्ते');
+assertSlowCall(['नमस्ते', 'World'].join(''));
+assertOptimized(copy_string);
+assertEquals(0, fast_c_api.fast_call_count());
+assertEquals(3, fast_c_api.slow_call_count());
+
+// Fall back for cons strings.
+function getTwoByteString() {
+  return '\u1234t';
+}
+function getCons() {
+  return 'hello' + getTwoByteString()
+}
+
+fast_c_api.reset_counts();
+assertSlowCall(getCons());
+assertOptimized(copy_string);
+assertEquals(0, fast_c_api.fast_call_count());
+assertEquals(1, fast_c_api.slow_call_count());
+
+// Fall back for sliced strings.
+fast_c_api.reset_counts();
+function getSliced() {
+  return getCons().slice(1);
+}
+assertSlowCall(getSliced());
+assertOptimized(copy_string);
+assertEquals(0, fast_c_api.fast_call_count());
+assertEquals(1, fast_c_api.slow_call_count());
+
+// Fall back for SMI and non-string inputs.
+fast_c_api.reset_counts();
+assertSlowCall(1);
+assertSlowCall({});
+assertSlowCall(new Uint8Array(1));
+assertEquals(0, fast_c_api.fast_call_count());
+assertEquals(3, fast_c_api.slow_call_count());


### PR DESCRIPTION
Referencing https://github.com/nodejs/node/pull/45701, this commit from v8 can leverage different use cases (for example wasm), and I believe it shouldn't be blocked with my `encodeInto` experiment.

Original commit message:

    [fastcall] Implement support for onebyte string arguments

    This CL adds one byte string specialization support for fast API call arguments.
    It introduces a kOneByteString variant to CTypeInfo.

    We see a ~6x improvement in Deno's TextEncoder#encode microbenchmark.
    Rendered results: https://divy-v8-patches.deno.dev/

    Bug: chromium:1052746
    Change-Id: I47c3a9e101cd18ddc6ad58f627db3a34231b60f7
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4036884
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Reviewed-by: Maya Lekova <mslekova@chromium.org>
    Commit-Queue: Maya Lekova <mslekova@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#84552}

Refs: https://github.com/v8/v8/commit/bc831f8ba33b79e2eb670faf1f84c4e39aeb0f9f

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
