### PR TITLE
test_runner: add t.after() hook

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1125,6 +1125,33 @@ test('top level test', async (t) => {
 });
 ```
 
+### `context.after([fn][, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function|AsyncFunction} The hook function. The first argument
+  to this function is a [`TestContext`][] object. If the hook uses callbacks,
+  the callback function is passed as the second argument. **Default:** A no-op
+  function.
+* `options` {Object} Configuration options for the hook. The following
+  properties are supported:
+  * `signal` {AbortSignal} Allows aborting an in-progress hook.
+  * `timeout` {number} A number of milliseconds the hook will fail after.
+    If unspecified, subtests inherit this value from their parent.
+    **Default:** `Infinity`.
+
+This function is used to create a hook that runs after the current test
+finishes.
+
+```js
+test('top level test', async (t) => {
+  t.after((t) => t.diagnostic(`finished running ${t.name}`));
+  assert.ok('some relevant assertion here');
+});
+```
+
 ### `context.afterEach([fn][, options])`
 
 <!-- YAML

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -136,6 +136,10 @@ class TestContext {
     return subtest.start();
   }
 
+  after(fn, options) {
+    this.#test.createHook('after', fn, options);
+  }
+
   beforeEach(fn, options) {
     this.#test.createHook('beforeEach', fn, options);
   }
@@ -545,6 +549,7 @@ class Test extends AsyncResource {
         return;
       }
 
+      await this.runHook('after', { args, ctx });
       await afterEach();
       this.pass();
     } catch (err) {

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -75,7 +75,6 @@ const testNamePatterns = testNamePatternFlag?.length > 0 ?
     (re) => convertStringToRegExp(re, '--test-name-pattern')
   ) : null;
 const kShouldAbort = Symbol('kShouldAbort');
-const kRunHook = Symbol('kRunHook');
 const kHookNames = ObjectSeal(['before', 'after', 'beforeEach', 'afterEach']);
 const kUnwrapErrors = new SafeSet()
   .add(kTestCodeFailure).add(kHookFailure)
@@ -476,7 +475,7 @@ class Test extends AsyncResource {
     return { ctx, args: [ctx] };
   }
 
-  async [kRunHook](hook, args) {
+  async runHook(hook, args) {
     validateOneOf(hook, 'hook name', kHookNames);
     try {
       await ArrayPrototypeReduce(this.hooks[hook], async (prev, hook) => {
@@ -507,13 +506,13 @@ class Test extends AsyncResource {
     const { args, ctx } = this.getRunArgs();
     const afterEach = runOnce(async () => {
       if (this.parent?.hooks.afterEach.length > 0) {
-        await this.parent[kRunHook]('afterEach', { args, ctx });
+        await this.parent.runHook('afterEach', { args, ctx });
       }
     });
 
     try {
       if (this.parent?.hooks.beforeEach.length > 0) {
-        await this.parent[kRunHook]('beforeEach', { args, ctx });
+        await this.parent.runHook('beforeEach', { args, ctx });
       }
       const stopPromise = stopTest(this.timeout, this.signal);
       const runArgs = ArrayPrototypeSlice(args);
@@ -761,9 +760,10 @@ class Suite extends Test {
     const hookArgs = this.getRunArgs();
     const afterEach = runOnce(async () => {
       if (this.parent?.hooks.afterEach.length > 0) {
-        await this.parent[kRunHook]('afterEach', hookArgs);
+        await this.parent.runHook('afterEach', hookArgs);
       }
     });
+
     try {
       this.parent.activeSubtests++;
       await this.buildSuite;
@@ -775,19 +775,18 @@ class Suite extends Test {
         return;
       }
 
-
       if (this.parent?.hooks.beforeEach.length > 0) {
-        await this.parent[kRunHook]('beforeEach', hookArgs);
+        await this.parent.runHook('beforeEach', hookArgs);
       }
 
-      await this[kRunHook]('before', hookArgs);
+      await this.runHook('before', hookArgs);
 
       const stopPromise = stopTest(this.timeout, this.signal);
       const subtests = this.skipped || this.error ? [] : this.subtests;
       const promise = SafePromiseAll(subtests, (subtests) => subtests.start());
 
       await SafePromiseRace([promise, stopPromise]);
-      await this[kRunHook]('after', hookArgs);
+      await this.runHook('after', hookArgs);
       await afterEach();
 
       this.pass();

--- a/test/message/test_runner_hooks.js
+++ b/test/message/test_runner_hooks.js
@@ -90,6 +90,8 @@ describe('afterEach throws and test fails', () => {
 
 test('test hooks', async (t) => {
   const testArr = [];
+
+  t.after(common.mustCall((t) => testArr.push('after ' + t.name)));
   t.beforeEach((t) => testArr.push('beforeEach ' + t.name));
   t.afterEach((t) => testArr.push('afterEach ' + t.name));
   await t.test('1', () => testArr.push('1'));
@@ -113,12 +115,14 @@ test('test hooks', async (t) => {
 });
 
 test('t.beforeEach throws', async (t) => {
+  t.after(common.mustCall());
   t.beforeEach(() => { throw new Error('beforeEach'); });
   await t.test('1', () => {});
   await t.test('2', () => {});
 });
 
 test('t.afterEach throws', async (t) => {
+  t.after(common.mustCall());
   t.afterEach(() => { throw new Error('afterEach'); });
   await t.test('1', () => {});
   await t.test('2', () => {});
@@ -126,13 +130,15 @@ test('t.afterEach throws', async (t) => {
 
 
 test('afterEach when test fails', async (t) => {
+  t.after(common.mustCall());
   t.afterEach(common.mustCall(2));
   await t.test('1', () => { throw new Error('test'); });
   await t.test('2', () => {});
 });
 
 test('afterEach throws and test fails', async (t) => {
-  afterEach(() => { throw new Error('afterEach'); });
+  t.after(common.mustCall());
+  t.afterEach(() => { throw new Error('afterEach'); });
   await t.test('1', () => { throw new Error('test'); });
   await t.test('2', () => {});
 });


### PR DESCRIPTION
##### test_runner: don't use a symbol for runHook()

This is not exposed to userland, so there is no need to put it
behind a symbol.

##### test_runner: add t.after() hook

This commit adds an after() hook to the TestContext class. This
hook can be used to clean up after a test finishes.