### PR TITLE
doc: buffer.fill empty value

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1885,7 +1885,7 @@ changes:
 
 * `value` {string|Buffer|Uint8Array|integer} The value with which to fill `buf`.
   Empty value (string, Uint8Array, Buffer) is coerced to `0`.
-* `offset` {integer} Number of bytes to skip before starting to fill `buf`
+* `offset` {integer} Number of bytes to skip before starting to fill `buf`.
   **Default:** `0`.
 * `end` {integer} Where to stop filling `buf` (not inclusive). **Default:**
   [`buf.length`][].

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1884,7 +1884,8 @@ changes:
 -->
 
 * `value` {string|Buffer|Uint8Array|integer} The value with which to fill `buf`.
-* `offset` {integer} Number of bytes to skip before starting to fill `buf`.
+  Empty value (string, Uint8Array, Buffer) is coerced to `0`.
+* `offset` {integer} Number of bytes to skip before starting to fill `buf`
   **Default:** `0`.
 * `end` {integer} Where to stop filling `buf` (not inclusive). **Default:**
   [`buf.length`][].
@@ -1904,6 +1905,12 @@ const b = Buffer.allocUnsafe(50).fill('h');
 
 console.log(b.toString());
 // Prints: hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
+
+// Fill a buffer with empty string
+const c = Buffer.allocUnsafe(5).fill('');
+
+console.log(c.fill(''));
+// Prints: <Buffer 00 00 00 00 00>
 ```
 
 ```cjs
@@ -1915,6 +1922,12 @@ const b = Buffer.allocUnsafe(50).fill('h');
 
 console.log(b.toString());
 // Prints: hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
+
+// Fill a buffer with empty string
+const c = Buffer.allocUnsafe(5).fill('');
+
+console.log(c.fill(''));
+// Prints: <Buffer 00 00 00 00 00>
 ```
 
 `value` is coerced to a `uint32` value if it is not a string, `Buffer`, or

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -429,3 +429,18 @@ assert.throws(() => {
   code: 'ERR_INVALID_ARG_VALUE',
   name: 'TypeError'
 });
+
+
+{
+  const bufEmptyString = Buffer.alloc(5, '');
+  assert.strictEqual(bufEmptyString.toString(), '\x00\x00\x00\x00\x00');
+
+  const bufEmptyArray = Buffer.alloc(5, []);
+  assert.strictEqual(bufEmptyArray.toString(), '\x00\x00\x00\x00\x00');
+
+  const bufEmptyBuffer = Buffer.alloc(5, Buffer.alloc(5));
+  assert.strictEqual(bufEmptyBuffer.toString(), '\x00\x00\x00\x00\x00');
+
+  const bufZero = Buffer.alloc(5, 0);
+  assert.strictEqual(bufZero.toString(), '\x00\x00\x00\x00\x00');
+}


### PR DESCRIPTION
Resolves: https://github.com/nodejs/node/issues/45727
The  doc is missing the case where the `Buffer.fill` value is empty.
I've created a test (not sure if necessary) and added the behaviour to the doc
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
