### PR TITLE
buffer: use min/max of `validateNumber`

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -106,9 +106,9 @@ const {
 const {
   validateArray,
   validateBuffer,
-  validateNumber,
   validateInteger,
-  validateString
+  validateNumber,
+  validateString,
 } = require('internal/validators');
 // Provide validateInteger() but with kMaxLength as the default maximum value.
 const validateOffset = (value, name, min = 0, max = kMaxLength) =>
@@ -356,10 +356,7 @@ ObjectSetPrototypeOf(Buffer, Uint8Array);
 // occurs. This is done simply to keep the internal details of the
 // implementation from bleeding out to users.
 const assertSize = hideStackFrames((size) => {
-  validateNumber(size, 'size');
-  if (!(size >= 0 && size <= kMaxLength)) {
-    throw new ERR_INVALID_ARG_VALUE.RangeError('size', size);
-  }
+  validateNumber(size, 'size', 0, kMaxLength);
 });
 
 /**

--- a/test/parallel/test-buffer-no-negative-allocation.js
+++ b/test/parallel/test-buffer-no-negative-allocation.js
@@ -5,9 +5,8 @@ const assert = require('assert');
 const { SlowBuffer } = require('buffer');
 
 const msg = {
-  code: 'ERR_INVALID_ARG_VALUE',
+  code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 
 // Test that negative Buffer length inputs throw errors.

--- a/test/parallel/test-buffer-over-max-length.js
+++ b/test/parallel/test-buffer-over-max-length.js
@@ -8,9 +8,8 @@ const SlowBuffer = buffer.SlowBuffer;
 
 const kMaxLength = buffer.kMaxLength;
 const bufferMaxSizeMsg = {
-  code: 'ERR_INVALID_ARG_VALUE',
+  code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 
 assert.throws(() => Buffer((-1 >>> 0) + 2), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -52,9 +52,8 @@ assert.throws(() => SlowBuffer(true), bufferInvalidTypeMsg);
 
 // Should throw with invalid length value
 const bufferMaxSizeMsg = {
-  code: 'ERR_INVALID_ARG_VALUE',
+  code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 assert.throws(() => SlowBuffer(NaN), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer(Infinity), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-tostring-rangeerror.js
+++ b/test/parallel/test-buffer-tostring-rangeerror.js
@@ -10,9 +10,8 @@ const SlowBuffer = require('buffer').SlowBuffer;
 
 const len = 1422561062959;
 const message = {
-  code: 'ERR_INVALID_ARG_VALUE',
+  code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
-  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 assert.throws(() => Buffer(len).toString('utf8'), message);
 assert.throws(() => SlowBuffer(len).toString('utf8'), message);


### PR DESCRIPTION
Instead of additional `if` statement, use min/max
of `validateNumber`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
