### PR TITLE
doc: add tips for NODE_MODULE

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -107,6 +107,9 @@ When building addons with `node-gyp`, using the macro `NODE_GYP_MODULE_NAME` as
 the first parameter of `NODE_MODULE()` will ensure that the name of the final
 binary will be passed to `NODE_MODULE()`.
 
+Addons defined with `NODE_MODULE()` can not be loaded in multiple contexts or
+multiple threads at the same time.
+
 ### Context-aware addons
 
 There are environments in which Node.js addons may need to be loaded multiple


### PR DESCRIPTION
If we define an addon with `NODE_MODULE`, we can not loaded it both in the
main and worker thread.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
