### PR TITLE
buffer: remove unnecessary lazy loading

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -30,6 +30,7 @@ const {
   TextDecoder,
   TextEncoder,
 } = require('internal/encoding');
+const { URL } = require('internal/url');
 
 const {
   makeTransferable,
@@ -77,7 +78,6 @@ const kMaxChunkSize = 65536;
 const disallowedTypeCharacters = /[^\u{0020}-\u{007E}]/u;
 
 let ReadableStream;
-let URL;
 
 const enc = new TextEncoder();
 let dec;
@@ -85,11 +85,6 @@ let dec;
 // Yes, lazy loading is annoying but because of circular
 // references between the url, internal/blob, and buffer
 // modules, lazy loading here makes sure that things work.
-
-function lazyURL(id) {
-  URL ??= require('internal/url').URL;
-  return new URL(id);
-}
 
 function lazyReadableStream(options) {
   // eslint-disable-next-line no-global-assign
@@ -378,7 +373,7 @@ ObjectDefineProperties(Blob.prototype, {
 function resolveObjectURL(url) {
   url = `${url}`;
   try {
-    const parsed = new lazyURL(url);
+    const parsed = new URL(url);
 
     const split = StringPrototypeSplit(parsed.pathname, ':');
 


### PR DESCRIPTION
`internal/url` is snapshotted, so there's no benefit in lazy loading it. The comment above says something about circular dependency, but that doesn't seem to apply anymore.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
