### PR TITLE
crypto: simplify lazy loading of internal modules

### DIFF
--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -62,15 +62,6 @@ const {
 const kHandle = Symbol('kHandle');
 const kKeyObject = Symbol('kKeyObject');
 
-const lazyRequireCache = {};
-
-function lazyRequire(name) {
-  let ret = lazyRequireCache[name];
-  if (ret === undefined)
-    ret = lazyRequireCache[name] = require(name);
-  return ret;
-}
-
 let defaultEncoding = 'buffer';
 
 function setDefaultEncoding(val) {
@@ -431,7 +422,6 @@ module.exports = {
   validateByteSource,
   validateKeyOps,
   jobPromise,
-  lazyRequire,
   validateMaxBufferLength,
   bigIntArrayToUnsignedBigInt,
   bigIntArrayToUnsignedInt,

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -58,7 +58,6 @@ const {
   getArrayBufferOrView,
   getBlockSize,
   hasAnyNotIn,
-  lazyRequire,
   normalizeAlgorithm,
   normalizeHashName,
   validateMaxBufferLength,
@@ -104,7 +103,7 @@ async function generateKey(
       // Fall through
     case 'RSA-OAEP':
       resultType = 'CryptoKeyPair';
-      result = await lazyRequire('internal/crypto/rsa')
+      result = await require('internal/crypto/rsa')
         .rsaKeyGenerate(algorithm, extractable, keyUsages);
       break;
     case 'Ed25519':
@@ -115,19 +114,19 @@ async function generateKey(
       // Fall through
     case 'X448':
       resultType = 'CryptoKeyPair';
-      result = await lazyRequire('internal/crypto/cfrg')
+      result = await require('internal/crypto/cfrg')
         .cfrgGenerateKey(algorithm, extractable, keyUsages);
       break;
     case 'ECDSA':
       // Fall through
     case 'ECDH':
       resultType = 'CryptoKeyPair';
-      result = await lazyRequire('internal/crypto/ec')
+      result = await require('internal/crypto/ec')
         .ecGenerateKey(algorithm, extractable, keyUsages);
       break;
     case 'HMAC':
       resultType = 'CryptoKey';
-      result = await lazyRequire('internal/crypto/mac')
+      result = await require('internal/crypto/mac')
         .hmacGenerateKey(algorithm, extractable, keyUsages);
       break;
     case 'AES-CTR':
@@ -138,7 +137,7 @@ async function generateKey(
       // Fall through
     case 'AES-KW':
       resultType = 'CryptoKey';
-      result = await lazyRequire('internal/crypto/aes')
+      result = await require('internal/crypto/aes')
         .aesGenerateKey(algorithm, extractable, keyUsages);
       break;
     default:
@@ -177,13 +176,13 @@ async function deriveBits(algorithm, baseKey, length) {
     case 'X448':
       // Fall through
     case 'ECDH':
-      return lazyRequire('internal/crypto/diffiehellman')
+      return require('internal/crypto/diffiehellman')
         .ecdhDeriveBits(algorithm, baseKey, length);
     case 'HKDF':
-      return lazyRequire('internal/crypto/hkdf')
+      return require('internal/crypto/hkdf')
         .hkdfDeriveBits(algorithm, baseKey, length);
     case 'PBKDF2':
-      return lazyRequire('internal/crypto/pbkdf2')
+      return require('internal/crypto/pbkdf2')
         .pbkdf2DeriveBits(algorithm, baseKey, length);
   }
   throw lazyDOMException('Unrecognized name.');
@@ -247,15 +246,15 @@ async function deriveKey(
     case 'X448':
       // Fall through
     case 'ECDH':
-      bits = await lazyRequire('internal/crypto/diffiehellman')
+      bits = await require('internal/crypto/diffiehellman')
         .ecdhDeriveBits(algorithm, baseKey, length);
       break;
     case 'HKDF':
-      bits = await lazyRequire('internal/crypto/hkdf')
+      bits = await require('internal/crypto/hkdf')
         .hkdfDeriveBits(algorithm, baseKey, length);
       break;
     case 'PBKDF2':
-      bits = await lazyRequire('internal/crypto/pbkdf2')
+      bits = await require('internal/crypto/pbkdf2')
         .pbkdf2DeriveBits(algorithm, baseKey, length);
       break;
     default:
@@ -277,7 +276,7 @@ async function exportKeySpki(key) {
       // Fall through
     case 'RSA-OAEP':
       if (key.type === 'public') {
-        return lazyRequire('internal/crypto/rsa')
+        return require('internal/crypto/rsa')
           .rsaExportKey(key, kWebCryptoKeyFormatSPKI);
       }
       break;
@@ -285,7 +284,7 @@ async function exportKeySpki(key) {
       // Fall through
     case 'ECDH':
       if (key.type === 'public') {
-        return lazyRequire('internal/crypto/ec')
+        return require('internal/crypto/ec')
           .ecExportKey(key, kWebCryptoKeyFormatSPKI);
       }
       break;
@@ -297,7 +296,7 @@ async function exportKeySpki(key) {
       // Fall through
     case 'X448':
       if (key.type === 'public') {
-        return lazyRequire('internal/crypto/cfrg')
+        return require('internal/crypto/cfrg')
           .cfrgExportKey(key, kWebCryptoKeyFormatSPKI);
       }
       break;
@@ -316,7 +315,7 @@ async function exportKeyPkcs8(key) {
       // Fall through
     case 'RSA-OAEP':
       if (key.type === 'private') {
-        return lazyRequire('internal/crypto/rsa')
+        return require('internal/crypto/rsa')
           .rsaExportKey(key, kWebCryptoKeyFormatPKCS8);
       }
       break;
@@ -324,7 +323,7 @@ async function exportKeyPkcs8(key) {
       // Fall through
     case 'ECDH':
       if (key.type === 'private') {
-        return lazyRequire('internal/crypto/ec')
+        return require('internal/crypto/ec')
           .ecExportKey(key, kWebCryptoKeyFormatPKCS8);
       }
       break;
@@ -336,7 +335,7 @@ async function exportKeyPkcs8(key) {
       // Fall through
     case 'X448':
       if (key.type === 'private') {
-        return lazyRequire('internal/crypto/cfrg')
+        return require('internal/crypto/cfrg')
           .cfrgExportKey(key, kWebCryptoKeyFormatPKCS8);
       }
       break;
@@ -353,7 +352,7 @@ async function exportKeyRaw(key) {
       // Fall through
     case 'ECDH':
       if (key.type === 'public') {
-        return lazyRequire('internal/crypto/ec')
+        return require('internal/crypto/ec')
           .ecExportKey(key, kWebCryptoKeyFormatRaw);
       }
       break;
@@ -365,7 +364,7 @@ async function exportKeyRaw(key) {
       // Fall through
     case 'X448':
       if (key.type === 'public') {
-        return lazyRequire('internal/crypto/cfrg')
+        return require('internal/crypto/cfrg')
           .cfrgExportKey(key, kWebCryptoKeyFormatRaw);
       }
       break;
@@ -430,7 +429,7 @@ async function exportKeyJWK(key) {
     case 'AES-GCM':
       // Fall through
     case 'AES-KW':
-      jwk.alg = lazyRequire('internal/crypto/aes')
+      jwk.alg = require('internal/crypto/aes')
         .getAlgorithmName(key.algorithm.name, key.algorithm.length);
       return jwk;
     case 'HMAC':
@@ -529,12 +528,12 @@ async function importKey(
     case 'RSA-PSS':
       // Fall through
     case 'RSA-OAEP':
-      return lazyRequire('internal/crypto/rsa')
+      return require('internal/crypto/rsa')
         .rsaImportKey(format, keyData, algorithm, extractable, keyUsages);
     case 'ECDSA':
       // Fall through
     case 'ECDH':
-      return lazyRequire('internal/crypto/ec')
+      return require('internal/crypto/ec')
         .ecImportKey(format, keyData, algorithm, extractable, keyUsages);
     case 'Ed25519':
       // Fall through
@@ -543,10 +542,10 @@ async function importKey(
     case 'X25519':
       // Fall through
     case 'X448':
-      return lazyRequire('internal/crypto/cfrg')
+      return require('internal/crypto/cfrg')
         .cfrgImportKey(format, keyData, algorithm, extractable, keyUsages);
     case 'HMAC':
-      return lazyRequire('internal/crypto/mac')
+      return require('internal/crypto/mac')
         .hmacImportKey(format, keyData, algorithm, extractable, keyUsages);
     case 'AES-CTR':
       // Fall through
@@ -555,7 +554,7 @@ async function importKey(
     case 'AES-GCM':
       // Fall through
     case 'AES-KW':
-      return lazyRequire('internal/crypto/aes')
+      return require('internal/crypto/aes')
         .aesImportKey(algorithm, format, keyData, extractable, keyUsages);
     case 'HKDF':
       // Fall through
@@ -655,19 +654,19 @@ function signVerify(algorithm, key, data, signature) {
     case 'RSA-PSS':
       // Fall through
     case 'RSASSA-PKCS1-v1_5':
-      return lazyRequire('internal/crypto/rsa')
+      return require('internal/crypto/rsa')
         .rsaSignVerify(key, data, algorithm, signature);
     case 'ECDSA':
-      return lazyRequire('internal/crypto/ec')
+      return require('internal/crypto/ec')
         .ecdsaSignVerify(key, data, algorithm, signature);
     case 'Ed25519':
       // Fall through
     case 'Ed448':
       // Fall through
-      return lazyRequire('internal/crypto/cfrg')
+      return require('internal/crypto/cfrg')
         .eddsaSignVerify(key, data, algorithm, signature);
     case 'HMAC':
-      return lazyRequire('internal/crypto/mac')
+      return require('internal/crypto/mac')
         .hmacSignVerify(key, data, algorithm, signature);
   }
   throw lazyDOMException('Unrecognized named.', 'NotSupportedError');
@@ -710,18 +709,18 @@ async function cipherOrWrap(mode, algorithm, key, data, op) {
 
   switch (algorithm.name) {
     case 'RSA-OAEP':
-      return lazyRequire('internal/crypto/rsa')
+      return require('internal/crypto/rsa')
         .rsaCipher(mode, key, data, algorithm);
     case 'AES-CTR':
       // Fall through
     case 'AES-CBC':
       // Fall through
     case 'AES-GCM':
-      return lazyRequire('internal/crypto/aes')
+      return require('internal/crypto/aes')
         .aesCipher(mode, key, data, algorithm);
     case 'AES-KW':
       if (op === 'wrapKey' || op === 'unwrapKey') {
-        return lazyRequire('internal/crypto/aes')
+        return require('internal/crypto/aes')
           .aesCipher(mode, key, data, algorithm);
       }
   }


### PR DESCRIPTION
The internal `require()` is actually just one map load (to see if the module is already loaded) + one property load (state check for circular dependencies) for modules that are already loaded.

Refs: https://github.com/nodejs/node/pull/45659#discussion_r1033762328

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
