### PR TITLE
test: add CryptoKey transferring tests

### DIFF
--- a/test/parallel/test-crypto-key-objects-messageport.js
+++ b/test/parallel/test-crypto-key-objects-messageport.js
@@ -4,7 +4,12 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { createSecretKey, generateKeyPairSync, randomBytes } = require('crypto');
+const {
+  generateKeySync,
+  generateKeyPairSync,
+  KeyObject,
+} = require('crypto');
+const { subtle } = globalThis.crypto;
 const { createContext } = require('vm');
 const {
   MessageChannel,
@@ -15,6 +20,9 @@ const {
 
 function keyToString(key) {
   let ret;
+  if (key instanceof CryptoKey) {
+    key = KeyObject.from(key);
+  }
   if (key.type === 'secret') {
     ret = key.export().toString('hex');
   } else {
@@ -33,55 +41,59 @@ if (process.env.HAS_STARTED_WORKER) {
 // Don't use isMainThread to allow running this test inside a worker.
 process.env.HAS_STARTED_WORKER = 1;
 
-// The main thread generates keys and passes them to worker threads.
-const secretKey = createSecretKey(randomBytes(32));
-const { publicKey, privateKey } = generateKeyPairSync('rsa', {
-  modulusLength: 1024
-});
+(async () => {
+  // The main thread generates keys and passes them to worker threads.
+  const secretKey = generateKeySync('aes', { length: 128 });
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 1024
+  });
+  const cryptoKey = await subtle.generateKey(
+    { name: 'AES-CBC', length: 128 }, false, ['encrypt']);
 
-// Get immutable representations of all keys.
-const keys = [secretKey, publicKey, privateKey]
+  // Get immutable representations of all keys.
+  const keys = [secretKey, publicKey, privateKey, cryptoKey]
              .map((key) => [key, keyToString(key)]);
 
-for (const [key, repr] of keys) {
-  {
+  for (const [key, repr] of keys) {
+    {
     // Test 1: No context change.
-    const { port1, port2 } = new MessageChannel();
+      const { port1, port2 } = new MessageChannel();
 
-    port1.postMessage({ key });
-    assert.strictEqual(keyToString(key), repr);
-
-    port2.once('message', common.mustCall(({ key }) => {
+      port1.postMessage({ key });
       assert.strictEqual(keyToString(key), repr);
-    }));
-  }
 
-  {
+      port2.once('message', common.mustCall(({ key }) => {
+        assert.strictEqual(keyToString(key), repr);
+      }));
+    }
+
+    {
     // Test 2: Across threads.
-    const worker = new Worker(__filename);
-    worker.once('message', common.mustCall((receivedRepresentation) => {
-      assert.strictEqual(receivedRepresentation, repr);
-    }));
-    worker.on('disconnect', () => console.log('disconnect'));
-    worker.postMessage({ key });
-  }
+      const worker = new Worker(__filename);
+      worker.once('message', common.mustCall((receivedRepresentation) => {
+        assert.strictEqual(receivedRepresentation, repr);
+      }));
+      worker.on('disconnect', () => console.log('disconnect'));
+      worker.postMessage({ key });
+    }
 
-  {
+    {
     // Test 3: Across contexts (should not work).
-    const { port1, port2 } = new MessageChannel();
-    const context = createContext();
-    const port2moved = moveMessagePortToContext(port2, context);
-    assert(!(port2moved instanceof Object));
+      const { port1, port2 } = new MessageChannel();
+      const context = createContext();
+      const port2moved = moveMessagePortToContext(port2, context);
+      assert(!(port2moved instanceof Object));
 
-    // TODO(addaleax): Switch this to a 'messageerror' event once MessagePort
-    // implements EventTarget fully and in a cross-context manner.
-    port2moved.onmessageerror = common.mustCall((event) => {
-      assert.strictEqual(event.data.code,
-                         'ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE');
-    });
+      // TODO(addaleax): Switch this to a 'messageerror' event once MessagePort
+      // implements EventTarget fully and in a cross-context manner.
+      port2moved.onmessageerror = common.mustCall((event) => {
+        assert.strictEqual(event.data.code,
+                           'ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE');
+      });
 
-    port2moved.start();
-    port1.postMessage({ key });
-    port1.close();
+      port2moved.start();
+      port1.postMessage({ key });
+      port1.close();
+    }
   }
-}
+})().then(common.mustCall());

--- a/test/parallel/test-crypto-worker-thread.js
+++ b/test/parallel/test-crypto-worker-thread.js
@@ -5,13 +5,30 @@ if (!common.hasCrypto)
 
 // Issue https://github.com/nodejs/node/issues/35263
 // Description: Test that passing keyobject to worker thread does not crash.
-const { createSecretKey } = require('crypto');
+const {
+  generateKeySync,
+  generateKeyPairSync,
+} = require('crypto');
+const { subtle } = globalThis.crypto;
+
+const assert = require('assert');
 
 const { Worker, isMainThread, workerData } = require('worker_threads');
 
 if (isMainThread) {
-  const key = createSecretKey(Buffer.from('hello'));
-  new Worker(__filename, { workerData: key });
+  (async () => {
+    const secretKey = generateKeySync('aes', { length: 128 });
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 1024
+    });
+    const cryptoKey = await subtle.generateKey(
+      { name: 'AES-CBC', length: 128 }, false, ['encrypt']);
+
+    for (const key of [secretKey, publicKey, privateKey, cryptoKey]) {
+      new Worker(__filename, { workerData: key });
+    }
+  })().then(common.mustCall());
 } else {
   console.log(workerData);
+  assert.notDeepStrictEqual(workerData, {});
 }


### PR DESCRIPTION
Extends the worker thread, message port, postMessage KeyObject tests to also cover CryptoKey instances.