### PR TITLE
test: remove use of --experimental-global-webcrypto flag

### DIFF
--- a/test/parallel/test-global-webcrypto.js
+++ b/test/parallel/test-global-webcrypto.js
@@ -1,4 +1,3 @@
-// Flags: --experimental-global-webcrypto
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-webcrypto-constructors.js
+++ b/test/parallel/test-webcrypto-constructors.js
@@ -1,4 +1,3 @@
-// Flags: --experimental-global-webcrypto
 'use strict';
 
 const common = require('../common');

--- a/test/wpt/test-webcrypto.js
+++ b/test/wpt/test-webcrypto.js
@@ -8,9 +8,6 @@ const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('WebCryptoAPI');
 
-// Set Node.js flags required for the tests.
-runner.setFlags(['--experimental-global-webcrypto']);
-
 runner.setInitScript(`
   global.location = {};
 `);


### PR DESCRIPTION
`--experimental-global-webcrypto` is no longer needed to execute these tests