### PR TITLE
crypto: use globalThis.crypto over require('crypto').webcrypto

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -239,6 +239,12 @@ module.exports = {
         selector: "CallExpression[callee.name='isNaN']",
         message: 'Use Number.isNaN() instead of the global isNaN() function.',
       },
+      {
+        // TODO(@panva): move this to no-restricted-properties
+        // when https://github.com/eslint/eslint/issues/16412 is fixed
+        selector: "Identifier[name='webcrypto']",
+        message: 'Use `globalThis.crypto`.',
+      },
     ],
     'no-return-await': 'error',
     'no-self-compare': 'error',

--- a/benchmark/crypto/webcrypto-digest.js
+++ b/benchmark/crypto/webcrypto-digest.js
@@ -1,11 +1,8 @@
 'use strict';
 
 const common = require('../common.js');
-const {
-  createHash,
-  webcrypto,
-} = require('crypto');
-const { subtle } = webcrypto;
+const { createHash } = require('crypto');
+const { subtle } = globalThis.crypto;
 
 const bench = common.createBenchmark(main, {
   sync: ['createHash', 'subtle'],
@@ -48,7 +45,7 @@ function measureSubtle(n, data, method) {
 }
 
 function main({ n, sync, data, method }) {
-  data = webcrypto.getRandomValues(Buffer.alloc(data));
+  data = globalThis.crypto.getRandomValues(Buffer.alloc(data));
   switch (sync) {
     case 'createHash': return measureLegacy(n, data, method);
     case 'subtle': return measureSubtle(n, data, method);

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1930,8 +1930,8 @@ added: v15.0.0
 Example: Converting a `CryptoKey` instance to a `KeyObject`:
 
 ```mjs
-const { webcrypto, KeyObject } = await import('node:crypto');
-const { subtle } = webcrypto;
+const { KeyObject } = await import('node:crypto');
+const { subtle } = globalThis.crypto;
 
 const key = await subtle.generateKey({
   name: 'HMAC',
@@ -1945,12 +1945,8 @@ console.log(keyObject.symmetricKeySize);
 ```
 
 ```cjs
-const {
-  webcrypto: {
-    subtle,
-  },
-  KeyObject,
-} = require('node:crypto');
+const { KeyObject } = require('node:crypto');
+const { subtle } = globalThis.crypto;
 
 (async function() {
   const key = await subtle.generateKey({

--- a/src/crypto/README.md
+++ b/src/crypto/README.md
@@ -310,12 +310,12 @@ crypto.randomFill(buf, (err, buf) => {
 For the legacy Node.js crypto API, asynchronous single-call
 operations use the traditional Node.js callback pattern, as
 illustrated in the previous `randomFill()` example. In the
-Web Crypto API (accessible via `require('node:crypto').webcrypto`),
+Web Crypto API (accessible via `globalThis.crypto`),
 all asynchronous single-call operations are Promise-based.
 
 ```js
 // Example Web Crypto API asynchronous single-call operation
-const { subtle } = require('node:crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 subtle.generateKeys({ name: 'HMAC', length: 256 }, true, ['sign'])
   .then((key) => {

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -49,6 +49,8 @@ rules:
       message: Use 'test' as debuglog value in tests.
     - selector: CallExpression:matches([callee.object.name="common"][callee.property.name=/^mustCall/],[callee.name="mustCall"],[callee.name="mustCallAtLeast"])>:first-child[type=/FunctionExpression$/][body.body.length=0]
       message: Do not use an empty function, omit the parameter altogether.
+    - selector: Identifier[name='webcrypto']
+      message: Use `globalThis.crypto`.
 
   # Custom rules in tools/eslint-rules
   node-core/prefer-assert-iferror: error

--- a/test/parallel/test-crypto-psychic-signatures.js
+++ b/test/parallel/test-crypto-psychic-signatures.js
@@ -80,14 +80,14 @@ for (const [encoding, signatures] of Object.entries(vectors)) {
     );
 
     // webcrypto
-    crypto.webcrypto.subtle.importKey(
+    globalThis.crypto.subtle.importKey(
       'spki',
       keyPair.publicKey,
       { name: 'ECDSA', namedCurve: 'P-256' },
       false,
       ['verify'],
     ).then((publicKey) => {
-      return crypto.webcrypto.subtle.verify(
+      return globalThis.crypto.subtle.verify(
         { name: 'ECDSA', hash: 'SHA-256' },
         publicKey,
         signature,

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -28,7 +28,6 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const crypto = require('crypto');
-const cryptop = require('crypto').webcrypto;
 const { kMaxLength } = require('buffer');
 
 const kMaxInt32 = 2 ** 31 - 1;
@@ -107,7 +106,7 @@ common.expectWarning('DeprecationWarning',
     new Uint32Array(10),
   ].forEach((buf) => {
     const before = Buffer.from(buf.buffer).toString('hex');
-    cryptop.getRandomValues(buf);
+    globalThis.crypto.getRandomValues(buf);
     const after = Buffer.from(buf.buffer).toString('hex');
     assert.notStrictEqual(before, after);
   });

--- a/test/parallel/test-crypto-subtle-zero-length.js
+++ b/test/parallel/test-crypto-subtle-zero-length.js
@@ -6,10 +6,10 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const crypto = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 (async () => {
-  const k = await crypto.subtle.importKey(
+  const k = await subtle.importKey(
     'raw',
     new Uint8Array(32),
     { name: 'AES-GCM' },
@@ -17,7 +17,7 @@ const crypto = require('crypto').webcrypto;
     [ 'encrypt', 'decrypt' ]);
   assert(k instanceof CryptoKey);
 
-  const e = await crypto.subtle.encrypt({
+  const e = await subtle.encrypt({
     name: 'AES-GCM',
     iv: new Uint8Array(12),
   }, k, new Uint8Array(0));
@@ -28,7 +28,7 @@ const crypto = require('crypto').webcrypto;
       0x53, 0x0f, 0x8a, 0xfb, 0xc7, 0x45, 0x36, 0xb9,
       0xa9, 0x63, 0xb4, 0xf1, 0xc4, 0xcb, 0x73, 0x8b ]));
 
-  const v = await crypto.subtle.decrypt({
+  const v = await subtle.decrypt({
     name: 'AES-GCM',
     iv: new Uint8Array(12),
   }, k, e);

--- a/test/parallel/test-crypto-webcrypto-aes-decrypt-tag-too-small.js
+++ b/test/parallel/test-crypto-webcrypto-aes-decrypt-tag-too-small.js
@@ -6,9 +6,9 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const crypto = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
-crypto.subtle.importKey(
+subtle.importKey(
   'raw',
   new Uint8Array(32),
   {
@@ -18,7 +18,7 @@ crypto.subtle.importKey(
   [ 'encrypt', 'decrypt' ])
   .then((k) => {
     assert.rejects(() => {
-      return crypto.subtle.decrypt({
+      return subtle.decrypt({
         name: 'AES-GCM',
         iv: new Uint8Array(12),
       }, k, new Uint8Array(0));

--- a/test/parallel/test-global-webcrypto-classes.js
+++ b/test/parallel/test-global-webcrypto-classes.js
@@ -6,8 +6,9 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const webcrypto = require('internal/crypto/webcrypto');
 
+/* eslint-disable no-restricted-syntax */
+const webcrypto = require('internal/crypto/webcrypto');
 assert.strictEqual(Crypto, webcrypto.Crypto);
 assert.strictEqual(CryptoKey, webcrypto.CryptoKey);
 assert.strictEqual(SubtleCrypto, webcrypto.SubtleCrypto);

--- a/test/parallel/test-global-webcrypto.js
+++ b/test/parallel/test-global-webcrypto.js
@@ -8,6 +8,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
+/* eslint-disable no-restricted-syntax */
 assert.strictEqual(globalThis.crypto, crypto.webcrypto);
 assert.strictEqual(Crypto, crypto.webcrypto.constructor);
 assert.strictEqual(SubtleCrypto, crypto.webcrypto.subtle.constructor);

--- a/test/parallel/test-webcrypto-constructors.js
+++ b/test/parallel/test-webcrypto-constructors.js
@@ -7,6 +7,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
+const { subtle } = globalThis.crypto;
 
 // Test CryptoKey constructor
 {
@@ -138,15 +139,15 @@ const notSubtle = Reflect.construct(function() {}, [], SubtleCrypto);
 }
 
 {
-  globalThis.crypto.subtle.importKey(
+  subtle.importKey(
     'raw',
     globalThis.crypto.getRandomValues(new Uint8Array(4)),
     'PBKDF2',
     false,
     ['deriveKey'],
   ).then((key) => {
-    globalThis.crypto.subtle.importKey = common.mustNotCall();
-    return globalThis.crypto.subtle.deriveKey({
+    subtle.importKey = common.mustNotCall();
+    return subtle.deriveKey({
       name: 'PBKDF2',
       hash: 'SHA-512',
       salt: globalThis.crypto.getRandomValues(new Uint8Array()),

--- a/test/parallel/test-webcrypto-cryptokey-workers.js
+++ b/test/parallel/test-webcrypto-cryptokey-workers.js
@@ -8,7 +8,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 const { once } = require('events');
 
 const {

--- a/test/parallel/test-webcrypto-derivebits-cfrg.js
+++ b/test/parallel/test-webcrypto-derivebits-cfrg.js
@@ -6,8 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { webcrypto } = require('crypto');
-const { subtle } = webcrypto;
+const { subtle } = globalThis.crypto;
 
 const kTests = [
   {
@@ -196,7 +195,7 @@ async function prepareKeys() {
 
   {
     // Public is a secret key
-    const keyData = webcrypto.getRandomValues(new Uint8Array(32));
+    const keyData = globalThis.crypto.getRandomValues(new Uint8Array(32));
     const key = await subtle.importKey(
       'raw',
       keyData,

--- a/test/parallel/test-webcrypto-derivebits-ecdh.js
+++ b/test/parallel/test-webcrypto-derivebits-ecdh.js
@@ -6,8 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { webcrypto } = require('crypto');
-const { subtle } = webcrypto;
+const { subtle } = globalThis.crypto;
 
 const kTests = [
   {
@@ -251,7 +250,7 @@ async function prepareKeys() {
 
   {
     // Public is a secret key
-    const keyData = webcrypto.getRandomValues(new Uint8Array(32));
+    const keyData = globalThis.crypto.getRandomValues(new Uint8Array(32));
     const key = await subtle.importKey(
       'raw',
       keyData,

--- a/test/parallel/test-webcrypto-derivebits-hkdf.js
+++ b/test/parallel/test-webcrypto-derivebits-hkdf.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 function getDeriveKeyInfo(name, length, hash, ...usages) {
   return [{ name, length, hash }, usages];

--- a/test/parallel/test-webcrypto-derivebits.js
+++ b/test/parallel/test-webcrypto-derivebits.js
@@ -7,7 +7,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 // This is only a partial test. The WebCrypto Web Platform Tests
 // will provide much greater coverage.

--- a/test/parallel/test-webcrypto-derivekey-cfrg.js
+++ b/test/parallel/test-webcrypto-derivekey-cfrg.js
@@ -6,8 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { webcrypto } = require('crypto');
-const { subtle } = webcrypto;
+const { subtle } = globalThis.crypto;
 
 const kTests = [
   {
@@ -168,7 +167,7 @@ async function prepareKeys() {
 
   {
     // Public is a secret key
-    const keyData = webcrypto.getRandomValues(new Uint8Array(32));
+    const keyData = globalThis.crypto.getRandomValues(new Uint8Array(32));
     const key = await subtle.importKey(
       'raw',
       keyData,

--- a/test/parallel/test-webcrypto-derivekey-ecdh.js
+++ b/test/parallel/test-webcrypto-derivekey-ecdh.js
@@ -6,8 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { webcrypto } = require('crypto');
-const { subtle } = webcrypto;
+const { subtle } = globalThis.crypto;
 
 const kTests = [
   {
@@ -227,7 +226,7 @@ async function prepareKeys() {
 
   {
     // Public is a secret key
-    const keyData = webcrypto.getRandomValues(new Uint8Array(32));
+    const keyData = globalThis.crypto.getRandomValues(new Uint8Array(32));
     const key = await subtle.importKey(
       'raw',
       keyData,

--- a/test/parallel/test-webcrypto-derivekey.js
+++ b/test/parallel/test-webcrypto-derivekey.js
@@ -7,7 +7,8 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { webcrypto: { subtle }, KeyObject } = require('crypto');
+const { subtle } = globalThis.crypto;
+const { KeyObject } = require('crypto');
 
 // This is only a partial test. The WebCrypto Web Platform Tests
 // will provide much greater coverage.

--- a/test/parallel/test-webcrypto-digest.js
+++ b/test/parallel/test-webcrypto-digest.js
@@ -7,7 +7,7 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const { Buffer } = require('buffer');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 const { createHash } = require('crypto');
 
 const kTests = [

--- a/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
@@ -6,8 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { webcrypto } = require('crypto');
-const { subtle } = webcrypto;
+const { subtle } = globalThis.crypto;
 
 async function testEncrypt({ keyBuffer, algorithm, plaintext, result }) {
   // Using a copy of plaintext to prevent tampering of the original
@@ -214,8 +213,8 @@ async function testDecrypt({ keyBuffer, algorithm, result }) {
       ['encrypt', 'decrypt'],
     );
 
-    const iv = webcrypto.getRandomValues(new Uint8Array(12));
-    const aad = webcrypto.getRandomValues(new Uint8Array(32));
+    const iv = globalThis.crypto.getRandomValues(new Uint8Array(12));
+    const aad = globalThis.crypto.getRandomValues(new Uint8Array(32));
 
     const encrypted = await subtle.encrypt(
       {
@@ -225,7 +224,7 @@ async function testDecrypt({ keyBuffer, algorithm, result }) {
         tagLength: 128
       },
       secretKey,
-      webcrypto.getRandomValues(new Uint8Array(32))
+      globalThis.crypto.getRandomValues(new Uint8Array(32))
     );
 
     await subtle.decrypt(

--- a/test/parallel/test-webcrypto-encrypt-decrypt-rsa.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt-rsa.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 const {
   passing

--- a/test/parallel/test-webcrypto-encrypt-decrypt.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt.js
@@ -6,15 +6,14 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { webcrypto } = require('crypto');
-const { subtle } = webcrypto;
+const { subtle } = globalThis.crypto;
 
 // This is only a partial test. The WebCrypto Web Platform Tests
 // will provide much greater coverage.
 
 // Test Encrypt/Decrypt RSA-OAEP
 {
-  const buf = webcrypto.getRandomValues(new Uint8Array(50));
+  const buf = globalThis.crypto.getRandomValues(new Uint8Array(50));
 
   async function test() {
     const ec = new TextEncoder();
@@ -45,8 +44,8 @@ const { subtle } = webcrypto;
 
 // Test Encrypt/Decrypt AES-CTR
 {
-  const buf = webcrypto.getRandomValues(new Uint8Array(50));
-  const counter = webcrypto.getRandomValues(new Uint8Array(16));
+  const buf = globalThis.crypto.getRandomValues(new Uint8Array(50));
+  const counter = globalThis.crypto.getRandomValues(new Uint8Array(16));
 
   async function test() {
     const key = await subtle.generateKey({
@@ -72,8 +71,8 @@ const { subtle } = webcrypto;
 
 // Test Encrypt/Decrypt AES-CBC
 {
-  const buf = webcrypto.getRandomValues(new Uint8Array(50));
-  const iv = webcrypto.getRandomValues(new Uint8Array(16));
+  const buf = globalThis.crypto.getRandomValues(new Uint8Array(50));
+  const iv = globalThis.crypto.getRandomValues(new Uint8Array(16));
 
   async function test() {
     const key = await subtle.generateKey({
@@ -99,8 +98,8 @@ const { subtle } = webcrypto;
 
 // Test Encrypt/Decrypt AES-GCM
 {
-  const buf = webcrypto.getRandomValues(new Uint8Array(50));
-  const iv = webcrypto.getRandomValues(new Uint8Array(12));
+  const buf = globalThis.crypto.getRandomValues(new Uint8Array(50));
+  const iv = globalThis.crypto.getRandomValues(new Uint8Array(12));
 
   async function test() {
     const key = await subtle.generateKey({

--- a/test/parallel/test-webcrypto-export-import-cfrg.js
+++ b/test/parallel/test-webcrypto-export-import-cfrg.js
@@ -8,7 +8,7 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const crypto = require('crypto');
-const { subtle } = crypto.webcrypto;
+const { subtle } = globalThis.crypto;
 
 const keyData = {
   'Ed25519': {

--- a/test/parallel/test-webcrypto-export-import-ec.js
+++ b/test/parallel/test-webcrypto-export-import-ec.js
@@ -8,7 +8,7 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const crypto = require('crypto');
-const { subtle } = crypto.webcrypto;
+const { subtle } = globalThis.crypto;
 
 const curves = ['P-256', 'P-384', 'P-521'];
 

--- a/test/parallel/test-webcrypto-export-import-rsa.js
+++ b/test/parallel/test-webcrypto-export-import-rsa.js
@@ -8,7 +8,7 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const crypto = require('crypto');
-const { subtle } = crypto.webcrypto;
+const { subtle } = globalThis.crypto;
 
 const sizes = [1024, 2048, 4096];
 

--- a/test/parallel/test-webcrypto-export-import.js
+++ b/test/parallel/test-webcrypto-export-import.js
@@ -6,12 +6,11 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { webcrypto } = require('crypto');
-const { subtle } = webcrypto;
+const { subtle } = globalThis.crypto;
 
 {
   async function test() {
-    const keyData = webcrypto.getRandomValues(new Uint8Array(32));
+    const keyData = globalThis.crypto.getRandomValues(new Uint8Array(32));
     await Promise.all([1, null, undefined, {}, []].map((format) =>
       assert.rejects(
         subtle.importKey(format, keyData, {}, false, ['wrapKey']), {
@@ -76,7 +75,7 @@ const { subtle } = webcrypto;
 // Import/Export HMAC Secret Key
 {
   async function test() {
-    const keyData = webcrypto.getRandomValues(new Uint8Array(32));
+    const keyData = globalThis.crypto.getRandomValues(new Uint8Array(32));
     const key = await subtle.importKey(
       'raw',
       keyData, {
@@ -106,7 +105,7 @@ const { subtle } = webcrypto;
 // Import/Export AES Secret Key
 {
   async function test() {
-    const keyData = webcrypto.getRandomValues(new Uint8Array(32));
+    const keyData = globalThis.crypto.getRandomValues(new Uint8Array(32));
     const key = await subtle.importKey(
       'raw',
       keyData, {

--- a/test/parallel/test-webcrypto-getRandomValues.js
+++ b/test/parallel/test-webcrypto-getRandomValues.js
@@ -6,6 +6,6 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { getRandomValues } = require('crypto').webcrypto;
+const { getRandomValues } = globalThis.crypto;
 
 assert.throws(() => getRandomValues(new Uint8Array()), { code: 'ERR_INVALID_THIS' });

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -9,10 +9,10 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const { types: { isCryptoKey } } = require('util');
 const {
-  webcrypto: { subtle },
   createSecretKey,
   KeyObject,
 } = require('crypto');
+const { subtle } = globalThis.crypto;
 
 const { bigIntArrayToUnsignedBigInt } = require('internal/crypto/util');
 

--- a/test/parallel/test-webcrypto-random.js
+++ b/test/parallel/test-webcrypto-random.js
@@ -7,7 +7,7 @@ if (!common.hasCrypto)
 
 const { Buffer } = require('buffer');
 const assert = require('assert');
-const { webcrypto } = require('crypto');
+const { crypto } = globalThis;
 
 [
   undefined, null, '', 1, {}, [],
@@ -16,14 +16,14 @@ const { webcrypto } = require('crypto');
   new DataView(new ArrayBuffer(1)),
 ].forEach((i) => {
   assert.throws(
-    () => webcrypto.getRandomValues(i),
+    () => crypto.getRandomValues(i),
     { name: 'TypeMismatchError', code: 17 },
   );
 });
 
 {
   const buf = new Uint8Array(0);
-  webcrypto.getRandomValues(buf);
+  crypto.getRandomValues(buf);
 }
 
 const intTypedConstructors = [
@@ -41,7 +41,7 @@ const intTypedConstructors = [
 for (const ctor of intTypedConstructors) {
   const buf = new ctor(10);
   const before = Buffer.from(buf.buffer).toString('hex');
-  webcrypto.getRandomValues(buf);
+  crypto.getRandomValues(buf);
   const after = Buffer.from(buf.buffer).toString('hex');
   assert.notStrictEqual(before, after);
 }
@@ -49,7 +49,7 @@ for (const ctor of intTypedConstructors) {
 {
   const buf = Buffer.alloc(10);
   const before = buf.toString('hex');
-  webcrypto.getRandomValues(buf);
+  crypto.getRandomValues(buf);
   const after = buf.toString('hex');
   assert.notStrictEqual(before, after);
 }
@@ -64,7 +64,7 @@ for (const ctor of intTypedConstructors) {
 
   if (kData !== undefined) {
     assert.throws(
-      () => webcrypto.getRandomValues(kData),
+      () => crypto.getRandomValues(kData),
       { name: 'QuotaExceededError', code: 22 },
     );
   }

--- a/test/parallel/test-webcrypto-sign-verify-ecdsa.js
+++ b/test/parallel/test-webcrypto-sign-verify-ecdsa.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 const vectors = require('../fixtures/crypto/ecdsa')();
 

--- a/test/parallel/test-webcrypto-sign-verify-eddsa.js
+++ b/test/parallel/test-webcrypto-sign-verify-eddsa.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 const vectors = require('../fixtures/crypto/eddsa')();
 

--- a/test/parallel/test-webcrypto-sign-verify-hmac.js
+++ b/test/parallel/test-webcrypto-sign-verify-hmac.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 const vectors = require('../fixtures/crypto/hmac')();
 

--- a/test/parallel/test-webcrypto-sign-verify-rsa.js
+++ b/test/parallel/test-webcrypto-sign-verify-rsa.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 const rsa_pkcs = require('../fixtures/crypto/rsa_pkcs');
 const rsa_pss = require('../fixtures/crypto/rsa_pss');

--- a/test/parallel/test-webcrypto-sign-verify.js
+++ b/test/parallel/test-webcrypto-sign-verify.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 // This is only a partial test. The WebCrypto Web Platform Tests
 // will provide much greater coverage.

--- a/test/parallel/test-webcrypto-wrap-unwrap.js
+++ b/test/parallel/test-webcrypto-wrap-unwrap.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 const kWrappingData = {
   'RSA-OAEP': {

--- a/test/pummel/test-webcrypto-derivebits-pbkdf2.js
+++ b/test/pummel/test-webcrypto-derivebits-pbkdf2.js
@@ -11,7 +11,7 @@ if (common.isPi) {
 }
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const { subtle } = globalThis.crypto;
 
 function getDeriveKeyInfo(name, length, hash, ...usages) {
   return [{ name, length, hash }, usages];


### PR DESCRIPTION
Updates tests and some remaining documentation to use `globalThis.crypto` instead of `require('crypto').webcrypto`.

@aduh95 it would be great if we could make this into a lint rule but unfortunately the existing options I tried to do this with fall short:

- `no-restricted-modules` cannot restrict an exported property from the crypto module.
- `no-restricted-properties` does not catch use of `const { webcrypto } = require('crypto')`.