### PR TITLE
test: enable idlharness WebCryptoAPI WPTs

### DIFF
--- a/test/wpt/status/WebCryptoAPI.json
+++ b/test/wpt/status/WebCryptoAPI.json
@@ -6,6 +6,18 @@
     "skip": "Not relevant in Node.js context"
   },
   "idlharness.https.any.js": {
-    "skip": "Various non-IDL-compliant things"
+    "fail": {
+      "expected": [
+        "Crypto interface: existence and properties of interface object",
+        "Crypto interface: calling getRandomValues(ArrayBufferView) on crypto with too few arguments must throw TypeError",
+        "CryptoKey interface: existence and properties of interface object",
+        "CryptoKey interface: existence and properties of interface prototype object",
+        "CryptoKey interface: attribute type",
+        "CryptoKey interface: attribute extractable",
+        "CryptoKey interface: attribute algorithm",
+        "CryptoKey interface: attribute usages",
+        "Window interface: attribute crypto"
+      ]
+    }
   }
 }

--- a/test/wpt/test-webcrypto.js
+++ b/test/wpt/test-webcrypto.js
@@ -15,4 +15,6 @@ runner.setInitScript(`
   global.location = {};
 `);
 
+runner.pretendGlobalThisAs('Window');
+
 runner.runJsTests();


### PR DESCRIPTION
Enables the `idlharness.https.any.js` tests from WebCryptoAPI WPT to run, adding 73 new PASS tests and 9 acknowledged failures that I'll be dealing with on an ongoing basis.