### PR TITLE
[v18.x] perf_hooks: convert maxSize to IDL value in setResourceTimingBufferSize

### DIFF
--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -66,6 +66,7 @@ const {
 const { inspect } = require('util');
 
 const { now } = require('internal/perf/utils');
+const { convertToInt } = require('internal/webidl');
 
 const kDispatch = Symbol('kDispatch');
 const kMaybeBuffer = Symbol('kMaybeBuffer');
@@ -430,6 +431,8 @@ function bufferResourceTiming(entry) {
 
 // https://w3c.github.io/resource-timing/#dom-performance-setresourcetimingbuffersize
 function setResourceTimingBufferSize(maxSize) {
+  // unsigned long
+  maxSize = convertToInt('maxSize', maxSize, 32);
   // If the maxSize parameter is less than resource timing buffer current
   // size, no PerformanceResourceTiming objects are to be removed from the
   // performance entry buffer.

--- a/test/parallel/test-internal-webidl-converttoint.js
+++ b/test/parallel/test-internal-webidl-converttoint.js
@@ -1,0 +1,58 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { convertToInt, evenRound } = require('internal/webidl');
+
+assert.strictEqual(evenRound(-0.5), 0);
+assert.strictEqual(evenRound(0.5), 0);
+assert.strictEqual(evenRound(-1.5), -2);
+assert.strictEqual(evenRound(1.5), 2);
+assert.strictEqual(evenRound(3.4), 3);
+assert.strictEqual(evenRound(4.6), 5);
+assert.strictEqual(evenRound(5), 5);
+assert.strictEqual(evenRound(6), 6);
+
+// https://webidl.spec.whatwg.org/#abstract-opdef-converttoint
+assert.strictEqual(convertToInt('x', 0, 64), 0);
+assert.strictEqual(convertToInt('x', 1, 64), 1);
+assert.strictEqual(convertToInt('x', -0.5, 64), 0);
+assert.strictEqual(convertToInt('x', -0.5, 64, { signed: true }), 0);
+assert.strictEqual(convertToInt('x', -1.5, 64, { signed: true }), -1);
+
+// EnforceRange
+const OutOfRangeValues = [ NaN, Infinity, -Infinity, 2 ** 53, -(2 ** 53) ];
+for (const value of OutOfRangeValues) {
+  assert.throws(() => convertToInt('x', value, 64, { enforceRange: true }), {
+    name: 'TypeError',
+    code: 'ERR_INVALID_ARG_VALUE',
+  });
+}
+
+// Out of range: clamp
+assert.strictEqual(convertToInt('x', NaN, 64, { clamp: true }), 0);
+assert.strictEqual(convertToInt('x', Infinity, 64, { clamp: true }), Number.MAX_SAFE_INTEGER);
+assert.strictEqual(convertToInt('x', -Infinity, 64, { clamp: true }), 0);
+assert.strictEqual(convertToInt('x', -Infinity, 64, { signed: true, clamp: true }), Number.MIN_SAFE_INTEGER);
+assert.strictEqual(convertToInt('x', 0x1_0000_0000, 32, { clamp: true }), 0xFFFF_FFFF);
+assert.strictEqual(convertToInt('x', 0xFFFF_FFFF, 32, { clamp: true }), 0xFFFF_FFFF);
+assert.strictEqual(convertToInt('x', 0x8000_0000, 32, { clamp: true, signed: true }), 0x7FFF_FFFF);
+assert.strictEqual(convertToInt('x', 0xFFFF_FFFF, 32, { clamp: true, signed: true }), 0x7FFF_FFFF);
+assert.strictEqual(convertToInt('x', 0.5, 64, { clamp: true }), 0);
+assert.strictEqual(convertToInt('x', 1.5, 64, { clamp: true }), 2);
+assert.strictEqual(convertToInt('x', -0.5, 64, { clamp: true }), 0);
+assert.strictEqual(convertToInt('x', -0.5, 64, { signed: true, clamp: true }), 0);
+assert.strictEqual(convertToInt('x', -1.5, 64, { signed: true, clamp: true }), -2);
+
+// Out of range, step 8.
+assert.strictEqual(convertToInt('x', NaN, 64), 0);
+assert.strictEqual(convertToInt('x', Infinity, 64), 0);
+assert.strictEqual(convertToInt('x', -Infinity, 64), 0);
+assert.strictEqual(convertToInt('x', 0x1_0000_0000, 32), 0);
+assert.strictEqual(convertToInt('x', 0x1_0000_0001, 32), 1);
+assert.strictEqual(convertToInt('x', 0xFFFF_FFFF, 32), 0xFFFF_FFFF);
+
+// Out of range, step 11.
+assert.strictEqual(convertToInt('x', 0x8000_0000, 32, { signed: true }), -0x8000_0000);
+assert.strictEqual(convertToInt('x', 0xFFF_FFFF, 32, { signed: true }), 0xFFF_FFFF);

--- a/test/parallel/test-performance-resourcetimingbuffersize.js
+++ b/test/parallel/test-performance-resourcetimingbuffersize.js
@@ -30,6 +30,17 @@ const initiatorType = '';
 const cacheMode = '';
 
 async function main() {
+  // Invalid buffer size values are converted to 0.
+  const invalidValues = [ null, undefined, true, false, -1, 0.5, Infinity, NaN, '', 'foo', {}, [], () => {} ];
+  for (const value of invalidValues) {
+    performance.setResourceTimingBufferSize(value);
+    performance.markResourceTiming(timingInfo, requestedUrl, initiatorType, globalThis, cacheMode);
+    assert.strictEqual(performance.getEntriesByType('resource').length, 0);
+    performance.clearResourceTimings();
+  }
+  // Wait for the buffer full event to be cleared.
+  await waitBufferFullEvent();
+
   performance.setResourceTimingBufferSize(1);
   performance.markResourceTiming(timingInfo, requestedUrl, initiatorType, globalThis, cacheMode);
   // Trigger a resourcetimingbufferfull event.


### PR DESCRIPTION
ECMAScript values of WebIDL interface parameters should be converted to IDL representatives before the actual implementation, as defined in step 11.5 of the WebIDL Overload resolution algorithm.

Refs: https://webidl.spec.whatwg.org/#dfn-create-operation-function
Refs: https://webidl.spec.whatwg.org/#es-overloads
PR-URL: https://github.com/nodejs/node/pull/44902
Reviewed-By: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
