### PR TITLE
doc: add  pipeline and finished to stream/promises doc

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -124,7 +124,7 @@ async function run() {
   const ac = new AbortController();
   const signal = ac.signal;
 
-  setTimeout(() => ac.abort(), 1);
+  setImmediate(() => ac.abort());
   await pipeline(
     fs.createReadStream('archive.tar'),
     zlib.createGzip(),

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2749,6 +2749,7 @@ pipeline(
 ```
 
 The `pipeline` API provides a [promise version][stream-pipeline-promise].
+
 `stream.pipeline()` will call `stream.destroy(err)` on all streams except:
 
 * `Readable` streams which have emitted `'end'` or `'close'`.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2668,7 +2668,7 @@ Especially useful in error handling scenarios where a stream is destroyed
 prematurely (like an aborted HTTP request), and will not emit `'end'`
 or `'finish'`.
 
-The `finished` API provides [promise version][stream-finished-promise]:
+The `finished` API provides [promise version][stream-finished-promise].
 
 `stream.finished()` leaves dangling event listeners (in particular
 `'error'`, `'end'`, `'finish'` and `'close'`) after `callback` has been

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -59,25 +59,183 @@ functions for streams that return `Promise` objects rather than using
 callbacks. The API is accessible via `require('node:stream/promises')`
 or `require('node:stream').promises`.
 
-### `stream.pipeline(source[, ...transforms], destination, options)`
+### `stream.pipeline(source[, ...transforms], destination[, options])`
 
-### `stream.pipeline(streams, options)`
+### `stream.pipeline(streams[, options])`
+
+<!-- YAML
+added: v15.0.0
+-->
 
 * `streams` {Stream\[]|Iterable\[]|AsyncIterable\[]|Function\[]}
 * `source` {Stream|Iterable|AsyncIterable|Function}
-  * Returns: {Promise<AsyncIterable>}
+  * Returns: {Promise|AsyncIterable}
 * `...transforms` {Stream|Function}
   * `source` {AsyncIterable}
-  * Returns: {Promise<AsyncIterable>}
+  * Returns: {Promise|AsyncIterable>}
 * `destination` {Stream|Function}
   * `source` {AsyncIterable}
-  * Returns: {Promise<AsyncIterable>}
+  * Returns: {Promise|AsyncIterable}
 * `options` {Object}
   * `signal` {AbortSignal}
   * `end` {boolean}
-* Returns: {Promise<void>}
+* Returns: {Promise} Fulfills when the pipeline is complete.
 
-### `stream.finished(stream, options)`
+```cjs
+const { pipeline } = require('node:stream/promises');
+const fs = require('node:fs');
+const zlib = require('node:zlib');
+
+async function run() {
+  await pipeline(
+    fs.createReadStream('archive.tar'),
+    zlib.createGzip(),
+    fs.createWriteStream('archive.tar.gz'),
+  );
+  console.log('Pipeline succeeded.');
+}
+
+run().catch(console.error);
+```
+
+```mjs
+import { pipeline } from 'node:stream/promises';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { createGzip } from 'node:zlib';
+
+async function run() {
+  await pipeline(
+    createReadStream('archive.tar'),
+    createGzip(),
+    createWriteStream('archive.tar.gz'),
+  );
+  console.log('Pipeline succeeded.');
+}
+
+run().catch(console.error);
+```
+
+To use an `AbortSignal`, pass it inside an options object,
+as the last argument.
+When the signal is aborted,
+`destroy` will be called on the underlying pipeline, with an
+`AbortError`.
+
+```cjs
+const { pipeline } = require('node:stream/promises');
+const fs = require('node:fs');
+const zlib = require('node:zlib');
+
+async function run() {
+  const ac = new AbortController();
+  const signal = ac.signal;
+
+  setTimeout(() => ac.abort(), 1);
+  await pipeline(
+    fs.createReadStream('archive.tar'),
+    zlib.createGzip(),
+    fs.createWriteStream('archive.tar.gz'),
+    { signal },
+  );
+}
+
+run().catch(console.error); // AbortError
+```
+
+```mjs
+import { pipeline } from 'node:stream/promises';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { createGzip } from 'node:zlib';
+
+async function run() {
+  const ac = new AbortController();
+  const signal = ac.signal;
+
+  setTimeout(() => ac.abort(), 1);
+  await pipeline(
+    createReadStream('archive.tar'),
+    createGzip(),
+    createWriteStream('archive.tar.gz'),
+    { signal },
+  );
+}
+
+run().catch(console.error); // AbortError
+```
+
+The `pipeline` API also supports async generators:
+
+```cjs
+const { pipeline } = require('node:stream/promises');
+const fs = require('node:fs');
+
+async function run() {
+  await pipeline(
+    fs.createReadStream('lowercase.txt'),
+    async function* (source, { signal }) {
+      source.setEncoding('utf8');  // Work with strings rather than `Buffer`s.
+      for await (const chunk of source) {
+        yield await processChunk(chunk, { signal });
+      }
+    },
+    fs.createWriteStream('uppercase.txt'),
+  );
+  console.log('Pipeline succeeded.');
+}
+
+run().catch(console.error);
+```
+
+```mjs
+import { pipeline } from 'node:stream/promises';
+import { createReadStream, createWriteStream } from 'node:fs';
+
+async function run() {
+  await pipeline(
+    createReadStream('lowercase.txt'),
+    async function* (source, { signal }) {
+      source.setEncoding('utf8');  // Work with strings rather than `Buffer`s.
+      for await (const chunk of source) {
+        yield await processChunk(chunk, { signal });
+      }
+    },
+    createWriteStream('uppercase.txt'),
+  );
+  console.log('Pipeline succeeded.');
+}
+
+run().catch(console.error);
+```
+
+Remember to handle the `signal` argument passed into the async generator.
+Especially in the case where the async generator is the source for the
+pipeline (i.e. first argument) or the pipeline will never complete.
+
+```js
+const { pipeline } = require('node:stream/promises');
+const fs = require('node:fs');
+
+async function run() {
+  await pipeline(
+    async function* ({ signal }) {
+      await someLongRunningfn({ signal });
+      yield 'asd';
+    },
+    fs.createWriteStream('uppercase.txt'),
+  );
+  console.log('Pipeline succeeded.');
+}
+
+run().catch(console.error);
+```
+
+The `pipeline` API provides [callback version][stream-pipeline]:
+
+### `stream.finished(stream[, options])`
+
+<!-- YAML
+added: v15.0.0
+-->
 
 * `stream` {Stream}
 * `options` {Object}
@@ -85,7 +243,40 @@ or `require('node:stream').promises`.
   * `readable` {boolean|undefined}
   * `writable` {boolean|undefined}
   * `signal`: {AbortSignal|undefined}
-* Returns: {Promise<void>}
+* Returns: {Promise}  Fulfills when the stream is no
+  longer readable or writable.
+
+```cjs
+const { finished } = require('node:stream/promises');
+const fs = require('node:fs');
+
+const rs = fs.createReadStream('archive.tar');
+
+async function run() {
+  await finished(rs);
+  console.log('Stream is done reading.');
+}
+
+run().catch(console.error);
+rs.resume(); // Drain the stream.
+```
+
+```mjs
+import { finished } from 'node:stream/promises';
+import { createReadStream } from 'node:fs';
+
+const rs = createReadStream('archive.tar');
+
+async function run() {
+  await finished(rs);
+  console.log('Stream is done reading.');
+}
+
+run().catch(console.error);
+rs.resume(); // Drain the stream.
+```
+
+The `finished` API provides [callback version][stream-finished]:
 
 ### Object mode
 
@@ -2475,22 +2666,7 @@ Especially useful in error handling scenarios where a stream is destroyed
 prematurely (like an aborted HTTP request), and will not emit `'end'`
 or `'finish'`.
 
-The `finished` API provides promise version:
-
-```js
-const { finished } = require('node:stream/promises');
-const fs = require('node:fs');
-
-const rs = fs.createReadStream('archive.tar');
-
-async function run() {
-  await finished(rs);
-  console.log('Stream is done reading.');
-}
-
-run().catch(console.error);
-rs.resume(); // Drain the stream.
-```
+The `finished` API provides [promise version][stream-finished-promise]:
 
 `stream.finished()` leaves dangling event listeners (in particular
 `'error'`, `'end'`, `'finish'` and `'close'`) after `callback` has been
@@ -2570,98 +2746,7 @@ pipeline(
 );
 ```
 
-The `pipeline` API provides a promise version, which can also
-receive an options argument as the last parameter with a
-`signal` {AbortSignal} property. When the signal is aborted,
-`destroy` will be called on the underlying pipeline, with an
-`AbortError`.
-
-```js
-const { pipeline } = require('node:stream/promises');
-const fs = require('node:fs');
-const zlib = require('node:zlib');
-
-async function run() {
-  await pipeline(
-    fs.createReadStream('archive.tar'),
-    zlib.createGzip(),
-    fs.createWriteStream('archive.tar.gz'),
-  );
-  console.log('Pipeline succeeded.');
-}
-
-run().catch(console.error);
-```
-
-To use an `AbortSignal`, pass it inside an options object,
-as the last argument:
-
-```js
-const { pipeline } = require('node:stream/promises');
-const fs = require('node:fs');
-const zlib = require('node:zlib');
-
-async function run() {
-  const ac = new AbortController();
-  const signal = ac.signal;
-
-  setTimeout(() => ac.abort(), 1);
-  await pipeline(
-    fs.createReadStream('archive.tar'),
-    zlib.createGzip(),
-    fs.createWriteStream('archive.tar.gz'),
-    { signal },
-  );
-}
-
-run().catch(console.error); // AbortError
-```
-
-The `pipeline` API also supports async generators:
-
-```js
-const { pipeline } = require('node:stream/promises');
-const fs = require('node:fs');
-
-async function run() {
-  await pipeline(
-    fs.createReadStream('lowercase.txt'),
-    async function* (source, { signal }) {
-      source.setEncoding('utf8');  // Work with strings rather than `Buffer`s.
-      for await (const chunk of source) {
-        yield await processChunk(chunk, { signal });
-      }
-    },
-    fs.createWriteStream('uppercase.txt'),
-  );
-  console.log('Pipeline succeeded.');
-}
-
-run().catch(console.error);
-```
-
-Remember to handle the `signal` argument passed into the async generator.
-Especially in the case where the async generator is the source for the
-pipeline (i.e. first argument) or the pipeline will never complete.
-
-```js
-const { pipeline } = require('node:stream/promises');
-const fs = require('node:fs');
-
-async function run() {
-  await pipeline(
-    async function* ({ signal }) {
-      await someLongRunningfn({ signal });
-      yield 'asd';
-    },
-    fs.createWriteStream('uppercase.txt'),
-  );
-  console.log('Pipeline succeeded.');
-}
-
-run().catch(console.error);
-```
-
+The `pipeline` API provides a [promise version][stream-pipeline-promise].
 `stream.pipeline()` will call `stream.destroy(err)` on all streams except:
 
 * `Readable` streams which have emitted `'end'` or `'close'`.
@@ -4594,7 +4679,11 @@ contain multi-byte characters.
 [stream-_write]: #writable_writechunk-encoding-callback
 [stream-_writev]: #writable_writevchunks-callback
 [stream-end]: #writableendchunk-encoding-callback
+[stream-finished]: #streamfinishedstream-options-callback
+[stream-finished-promise]: #streamfinishedstream-options
 [stream-pause]: #readablepause
+[stream-pipeline]: #streampipelinesource-transforms-destination-callback
+[stream-pipeline-promise]: #streampipelinesource-transforms-destination-options
 [stream-push]: #readablepushchunk-encoding
 [stream-read]: #readablereadsize
 [stream-resume]: #readableresume

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -59,6 +59,34 @@ functions for streams that return `Promise` objects rather than using
 callbacks. The API is accessible via `require('node:stream/promises')`
 or `require('node:stream').promises`.
 
+### `stream.pipeline(source[, ...transforms], destination, options)`
+
+### `stream.pipeline(streams, options)`
+
+* `streams` {Stream\[]|Iterable\[]|AsyncIterable\[]|Function\[]}
+* `source` {Stream|Iterable|AsyncIterable|Function}
+  * Returns: {Promise\<Iterable|AsyncIterable>}
+* `...transforms` {Stream|Function}
+  * `source` {AsyncIterable}
+  * Returns: {Promise<AsyncIterable>}
+* `destination` {Stream|Function}
+  * `source` {AsyncIterable}
+  * Returns: {Promise<AsyncIterable>}
+* `options` {Object}
+  * `signal` {AbortSignal}
+  * `end` {boolean}
+* Returns: {Promise<void>}
+
+### `stream.finished(stream, options)`
+
+* `stream` {Stream}
+* `options` {Object}
+  * `error` {boolean|undefined}
+  * `readable` {boolean|undefined}
+  * `writable` {boolean|undefined}
+  * `signal`: {AbortSignal|undefined}
+* Returns: {Promise<void>}
+
 ### Object mode
 
 All streams created by Node.js APIs operate exclusively on strings and `Buffer`

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -72,7 +72,7 @@ added: v15.0.0
   * Returns: {Promise|AsyncIterable}
 * `...transforms` {Stream|Function}
   * `source` {AsyncIterable}
-  * Returns: {Promise|AsyncIterable>}
+  * Returns: {Promise|AsyncIterable}
 * `destination` {Stream|Function}
   * `source` {AsyncIterable}
   * Returns: {Promise|AsyncIterable}

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -65,7 +65,7 @@ or `require('node:stream').promises`.
 
 * `streams` {Stream\[]|Iterable\[]|AsyncIterable\[]|Function\[]}
 * `source` {Stream|Iterable|AsyncIterable|Function}
-  * Returns: {Promise\<Iterable|AsyncIterable>}
+  * Returns: {Promise<AsyncIterable>}
 * `...transforms` {Stream|Function}
   * `source` {AsyncIterable}
   * Returns: {Promise<AsyncIterable>}


### PR DESCRIPTION

I've added to the doc the signature of `pipeline` and `finished` which was missing.
@ronag I've also added the `end` field which was mentioned here https://github.com/nodejs/node/issues/34805#issuecomment-1009739825  but I'm not sure if that's all right.

Fixes: https://github.com/nodejs/node/issues/45821


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
