### PR TITLE
doc: added information about .toWeb() and .fromWeb() to webstreams

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -161,6 +161,9 @@ added: v17.0.0
   * `objectMode` {boolean}
   * `signal` {AbortSignal}
 * `Returns`: {stream.Readable}
+<!-- YAML
+added: v17.0.0
+-->
 
 #### `readableStream.toWeb(writableStream[,options])`
 
@@ -170,8 +173,8 @@ added: v17.0.0
 
 * `streamReadable` {stream.Readable}
 * `options` {Object}
-  * `strategy` {Object}
   * `highWaterMark` {number}
+  * `strategy` {Object}
   * `size` {Function}
 * Returns: {ReadableStream}
 

--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -148,6 +148,33 @@ The `readableStream.locked` property is `false` by default, and is
 switched to `true` while there is an active reader consuming the
 stream's data.
 
+#### `readableStream.fromWeb(readableStream[,options])`
+
+<!-- YAML
+added: v17.0.0
+-->
+
+* `readableStream` {ReadableStream}
+* `options` {Object}
+  * `encoding` {string}
+  * `highWaterMark` {number}
+  * `objectMode` {boolean}
+  * `signal` {AbortSignal}
+* `Returns`: {stream.Readable}
+
+#### `readableStream.toWeb(writableStream[,options])`
+
+<!-- YAML
+added: v17.0.0
+-->
+
+* `streamReadable` {stream.Readable}
+* `options` {Object}
+  * `strategy` {Object}
+  * `highWaterMark` {number}
+  * `size` {Function}
+* Returns: {ReadableStream}
+
 #### `readableStream.cancel([reason])`
 
 <!-- YAML
@@ -863,6 +890,29 @@ added: v16.5.0
 The `writableStream.locked` property is `false` by default, and is
 switched to `true` while there is an active writer attached to this
 `WritableStream`.
+
+#### `writableStream.fromWeb(writableStream[,options])`
+
+<!-- YAML
+added: v17.0.0
+-->
+
+* `writableStream` {WritableStream}
+* `options` {Object}
+  * `decodeStrings` {boolean}
+  * `highWaterMark` {number}
+  * `objectMode` {boolean}
+  * `signal` {AbortSignal}
+* Returns: {stream.Writable}
+
+#### `writableStream.toWeb(streamWritable)`
+
+<!-- YAML
+added: v17.0.0
+-->
+
+* `streamWritable` {stream.Writable}
+* Returns: {WritableStream}
 
 #### Transferring with postMessage()
 

--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -148,6 +148,16 @@ The `readableStream.locked` property is `false` by default, and is
 switched to `true` while there is an active reader consuming the
 stream's data.
 
+#### `readableStream.cancel([reason])`
+
+<!-- YAML
+added: v16.5.0
+-->
+
+* `reason` {any}
+* Returns: A promise fulfilled with `undefined` once cancelation has
+  been completed.
+
 #### `readableStream.fromWeb(readableStream[,options])`
 
 <!-- YAML
@@ -161,32 +171,6 @@ added: v17.0.0
   * `objectMode` {boolean}
   * `signal` {AbortSignal}
 * `Returns`: {stream.Readable}
-<!-- YAML
-added: v17.0.0
--->
-
-#### `readableStream.toWeb(writableStream[,options])`
-
-<!-- YAML
-added: v17.0.0
--->
-
-* `streamReadable` {stream.Readable}
-* `options` {Object}
-  * `highWaterMark` {number}
-  * `strategy` {Object}
-  * `size` {Function}
-* Returns: {ReadableStream}
-
-#### `readableStream.cancel([reason])`
-
-<!-- YAML
-added: v16.5.0
--->
-
-* `reason` {any}
-* Returns: A promise fulfilled with `undefined` once cancelation has
-  been completed.
 
 #### `readableStream.getReader([options])`
 
@@ -344,6 +328,19 @@ Returns a pair of new {ReadableStream} instances to which this
 same data.
 
 Causes the `readableStream.locked` to be `true`.
+
+#### `readableStream.toWeb(writableStream[,options])`
+
+<!-- YAML
+added: v17.0.0
+-->
+
+* `streamReadable` {stream.Readable}
+* `options` {Object}
+  * `highWaterMark` {number}
+  * `strategy` {Object}
+  * `size` {Function}
+* Returns: {ReadableStream}
 
 #### `readableStream.values([options])`
 
@@ -871,6 +868,20 @@ added: v16.5.0
 
 Closes the `WritableStream` when no additional writes are expected.
 
+#### `writableStream.fromWeb(writableStream[,options])`
+
+<!-- YAML
+added: v17.0.0
+-->
+
+* `writableStream` {WritableStream}
+* `options` {Object}
+  * `decodeStrings` {boolean}
+  * `highWaterMark` {number}
+  * `objectMode` {boolean}
+  * `signal` {AbortSignal}
+* Returns: {stream.Writable}
+
 #### `writableStream.getWriter()`
 
 <!-- YAML
@@ -893,20 +904,6 @@ added: v16.5.0
 The `writableStream.locked` property is `false` by default, and is
 switched to `true` while there is an active writer attached to this
 `WritableStream`.
-
-#### `writableStream.fromWeb(writableStream[,options])`
-
-<!-- YAML
-added: v17.0.0
--->
-
-* `writableStream` {WritableStream}
-* `options` {Object}
-  * `decodeStrings` {boolean}
-  * `highWaterMark` {number}
-  * `objectMode` {boolean}
-  * `signal` {AbortSignal}
-* Returns: {stream.Writable}
 
 #### `writableStream.toWeb(streamWritable)`
 


### PR DESCRIPTION
Added information about .toWeb() and .fromWeb() methods to the Web Streams documentation.
fixes #45381 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
