### PR TITLE
lib,src: update exit codes

### DIFF
--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -45,6 +45,7 @@ const {
   exitCodes: {
     kGenericUserError,
     kNoFailure,
+    kInvalidCommandLineArgument,
   },
 } = internalBinding('errors');
 
@@ -340,7 +341,7 @@ function startInspect(argv = ArrayPrototypeSlice(process.argv, 2),
                          `       ${invokedAs} --port=<port>\n` +
                          `       ${invokedAs} -p <pid>\n`);
     // TODO(joyeecheung): should be kInvalidCommandLineArgument.
-    process.exit(kGenericUserError);
+    process.exit(kInvalidCommandLineArgument);
   }
 
   const options = parseArgv(argv);

--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -340,7 +340,6 @@ function startInspect(argv = ArrayPrototypeSlice(process.argv, 2),
                          `       ${invokedAs} <host>:<port>\n` +
                          `       ${invokedAs} --port=<port>\n` +
                          `       ${invokedAs} -p <pid>\n`);
-    // TODO(joyeecheung): should be kInvalidCommandLineArgument.
     process.exit(kInvalidCommandLineArgument);
   }
 

--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -16,7 +16,7 @@ const console = require('internal/console/global');
 
 const { getOptionValue } = require('internal/options');
 
-const { exitCodes: { kGenericUserError } } = internalBinding('errors');
+const { exitCodes: { kInvalidCommandLineArgument } } = internalBinding('errors');
 
 prepareMainThreadExecution();
 
@@ -33,7 +33,7 @@ if (process.env.NODE_REPL_EXTERNAL_MODULE) {
     // so use console.error.
     console.error('Cannot specify --input-type for REPL');
     // TODO(joyeecheung): should be kInvalidCommandLineArgument.
-    process.exit(kGenericUserError);
+    process.exit(kInvalidCommandLineArgument);
   }
 
   const esmLoader = require('internal/process/esm_loader');

--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -32,7 +32,6 @@ if (process.env.NODE_REPL_EXTERNAL_MODULE) {
     // If we can't write to stderr, we'd like to make this a noop,
     // so use console.error.
     console.error('Cannot specify --input-type for REPL');
-    // TODO(joyeecheung): should be kInvalidCommandLineArgument.
     process.exit(kInvalidCommandLineArgument);
   }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1132,7 +1132,6 @@ ExitCode GenerateAndWriteSnapshotData(const SnapshotData** snapshot_data_ptr,
               "node:embedded_snapshot_main was specified as snapshot "
               "entry point but Node.js was built without embedded "
               "snapshot.\n");
-      // TODO(joyeecheung): should be kInvalidCommandLineArgument instead.
       exit_code = ExitCode::kInvalidCommandLineArgument;
       return exit_code;
     }
@@ -1166,7 +1165,6 @@ ExitCode GenerateAndWriteSnapshotData(const SnapshotData** snapshot_data_ptr,
     fprintf(stderr,
             "Cannot open %s for writing a snapshot.\n",
             snapshot_blob_path.c_str());
-    // TODO(joyeecheung): should be kStartupSnapshotFailure.
     exit_code = ExitCode::kStartupSnapshotFailure;
   }
   return exit_code;
@@ -1192,7 +1190,6 @@ ExitCode LoadSnapshotDataAndRun(const SnapshotData** snapshot_data_ptr,
     fclose(fp);
     if (!ok) {
       // If we fail to read the customized snapshot, simply exit with 1.
-      // TODO(joyeecheung): should be kStartupSnapshotFailure.
       exit_code = ExitCode::kStartupSnapshotFailure;
       return exit_code;
     }

--- a/src/node.cc
+++ b/src/node.cc
@@ -1188,7 +1188,8 @@ ExitCode LoadSnapshotDataAndRun(const SnapshotData** snapshot_data_ptr,
     bool ok = SnapshotData::FromFile(read_data.get(), fp);
     fclose(fp);
     if (!ok) {
-      // If we fail to read the customized snapshot, simply exit with kStartupSnapshotFailure.
+      // If we fail to read the customized snapshot, 
+      // simply exit with kStartupSnapshotFailure.
       exit_code = ExitCode::kStartupSnapshotFailure;
       return exit_code;
     }

--- a/src/node.cc
+++ b/src/node.cc
@@ -1181,8 +1181,7 @@ ExitCode LoadSnapshotDataAndRun(const SnapshotData** snapshot_data_ptr,
     FILE* fp = fopen(filename.c_str(), "rb");
     if (fp == nullptr) {
       fprintf(stderr, "Cannot open %s", filename.c_str());
-      // TODO(joyeecheung): should be kStartupSnapshotFailure.
-      exit_code = ExitCode::kGenericUserError;
+      exit_code = ExitCode::kStartupSnapshotFailure;
       return exit_code;
     }
     std::unique_ptr<SnapshotData> read_data = std::make_unique<SnapshotData>();

--- a/src/node.cc
+++ b/src/node.cc
@@ -1188,7 +1188,7 @@ ExitCode LoadSnapshotDataAndRun(const SnapshotData** snapshot_data_ptr,
     bool ok = SnapshotData::FromFile(read_data.get(), fp);
     fclose(fp);
     if (!ok) {
-      // If we fail to read the customized snapshot, 
+      // If we fail to read the customized snapshot,
       // simply exit with kStartupSnapshotFailure.
       exit_code = ExitCode::kStartupSnapshotFailure;
       return exit_code;

--- a/src/node.cc
+++ b/src/node.cc
@@ -1133,7 +1133,7 @@ ExitCode GenerateAndWriteSnapshotData(const SnapshotData** snapshot_data_ptr,
               "entry point but Node.js was built without embedded "
               "snapshot.\n");
       // TODO(joyeecheung): should be kInvalidCommandLineArgument instead.
-      exit_code = ExitCode::kGenericUserError;
+      exit_code = ExitCode::kInvalidCommandLineArgument;
       return exit_code;
     }
   } else {
@@ -1167,7 +1167,7 @@ ExitCode GenerateAndWriteSnapshotData(const SnapshotData** snapshot_data_ptr,
             "Cannot open %s for writing a snapshot.\n",
             snapshot_blob_path.c_str());
     // TODO(joyeecheung): should be kStartupSnapshotFailure.
-    exit_code = ExitCode::kGenericUserError;
+    exit_code = ExitCode::kStartupSnapshotFailure;
   }
   return exit_code;
 }
@@ -1193,7 +1193,7 @@ ExitCode LoadSnapshotDataAndRun(const SnapshotData** snapshot_data_ptr,
     if (!ok) {
       // If we fail to read the customized snapshot, simply exit with 1.
       // TODO(joyeecheung): should be kStartupSnapshotFailure.
-      exit_code = ExitCode::kGenericUserError;
+      exit_code = ExitCode::kStartupSnapshotFailure;
       return exit_code;
     }
     *snapshot_data_ptr = read_data.release();

--- a/src/node.cc
+++ b/src/node.cc
@@ -1189,7 +1189,7 @@ ExitCode LoadSnapshotDataAndRun(const SnapshotData** snapshot_data_ptr,
     bool ok = SnapshotData::FromFile(read_data.get(), fp);
     fclose(fp);
     if (!ok) {
-      // If we fail to read the customized snapshot, simply exit with 1.
+      // If we fail to read the customized snapshot, simply exit with kStartupSnapshotFailure.
       exit_code = ExitCode::kStartupSnapshotFailure;
       return exit_code;
     }

--- a/test/parallel/test-snapshot-basic.js
+++ b/test/parallel/test-snapshot-basic.js
@@ -28,7 +28,7 @@ if (!process.config.variables.node_use_node_snapshot) {
   assert.match(
     child.stderr.toString(),
     /Node\.js was built without embedded snapshot/);
-  assert.strictEqual(child.status, 1);
+  assert.strictEqual(child.status, 9);
 
   snapshotScript = fixtures.path('empty.js');
 }

--- a/test/parallel/test-snapshot-error.js
+++ b/test/parallel/test-snapshot-error.js
@@ -47,7 +47,7 @@ const entry = fixtures.path('snapshot', 'error.js');
   console.log(child.status);
   console.log(stderr);
   console.log(child.stdout.toString());
-  assert.strictEqual(child.status, 1);
+  assert.strictEqual(child.status, 14);
   assert.match(stderr, /Cannot open/);
   assert(!fs.existsSync(path.join(tmpdir.path, 'snapshot.blob')));
 }

--- a/test/parallel/test-snapshot-incompatible.js
+++ b/test/parallel/test-snapshot-incompatible.js
@@ -52,7 +52,7 @@ const entry = fixtures.path('empty.js');
 
   const stderr = child.stderr.toString().trim();
   assert.match(stderr, /Failed to load the startup snapshot/);
-  assert.strictEqual(child.status, 1);
+  assert.strictEqual(child.status, 14);
 }
 
 {

--- a/test/sequential/test-debugger-invalid-args.js
+++ b/test/sequential/test-debugger-invalid-args.js
@@ -11,7 +11,7 @@ const assert = require('assert');
 (async () => {
   const cli = startCLI([]);
   const code = await cli.quit();
-  assert.strictEqual(code, 1);
+  assert.strictEqual(code, 9);
   assert.match(cli.output, /^Usage:/, 'Prints usage info');
 })().then(common.mustCall());
 


### PR DESCRIPTION
Attempted to solve a few TODOs left behind by @joyeecheung on updating exit codes, I assume those TODOs must have been left behind for a reason but have tried my hand at it and would seek some review on if there could be some adverse consequences to these changes and can work on fixing the same

Refs: https://github.com/nodejs/node/pull/44746

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
