### PR TITLE
debugger: refactor console in lib/internal/debugger/inspect.js

### DIFF
--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -336,10 +336,10 @@ function startInspect(argv = ArrayPrototypeSlice(process.argv, 2),
   if (argv.length < 1) {
     const invokedAs = `${process.argv0} ${process.argv[1]}`;
 
-    process.stderr.write(`Usage: ${invokedAs} script.js\n`);
-    process.stderr.write(`       ${invokedAs} <host>:<port>\n`);
-    process.stderr.write(`       ${invokedAs} --port=<port>\n`);
-    process.stderr.write(`       ${invokedAs} -p <pid>\n`);
+    process.stderr.write(`Usage: ${invokedAs} script.js\n` +
+                         `       ${invokedAs} <host>:<port>\n` +
+                         `       ${invokedAs} --port=<port>\n` +
+                         `       ${invokedAs} -p <pid>\n`);
     // TODO(joyeecheung): should be kInvalidCommandLineArgument.
     process.exit(kGenericUserError);
   }

--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -352,11 +352,8 @@ function startInspect(argv = ArrayPrototypeSlice(process.argv, 2),
   function handleUnexpectedError(e) {
     if (e.code !== 'ERR_DEBUGGER_STARTUP_ERROR') {
       process.stderr.write('There was an internal error in Node.js. ' +
-                    'Please report this bug.\n');
-      process.stderr.write(e.message);
-      process.stderr.write('\n');
-      process.stderr.write(e.stack);
-      process.stderr.write('\n');
+                           'Please report this bug.\n' +
+                           `${e.message}\n${e.stack}\n`);
     } else {
       process.stderr.write(e.message);
       process.stderr.write('\n');

--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -32,9 +32,6 @@ const {
   AbortController,
 } = require('internal/abort_controller');
 
-// TODO(aduh95): remove console calls
-const console = require('internal/console/global');
-
 const { 0: InspectClient, 1: createRepl } =
     [
       require('internal/debugger/inspect_client'),
@@ -319,7 +316,7 @@ function parseArgv(args) {
       process._debugProcess(pid);
     } catch (e) {
       if (e.code === 'ESRCH') {
-        console.error(`Target process: ${pid} doesn't exist.`);
+        process.stderr.write(`Target process: ${pid} doesn't exist.\n`);
         process.exit(kGenericUserError);
       }
       throw e;
@@ -339,10 +336,10 @@ function startInspect(argv = ArrayPrototypeSlice(process.argv, 2),
   if (argv.length < 1) {
     const invokedAs = `${process.argv0} ${process.argv[1]}`;
 
-    console.error(`Usage: ${invokedAs} script.js`);
-    console.error(`       ${invokedAs} <host>:<port>`);
-    console.error(`       ${invokedAs} --port=<port>`);
-    console.error(`       ${invokedAs} -p <pid>`);
+    process.stderr.write(`Usage: ${invokedAs} script.js\n`);
+    process.stderr.write(`       ${invokedAs} <host>:<port>\n`);
+    process.stderr.write(`       ${invokedAs} --port=<port>\n`);
+    process.stderr.write(`       ${invokedAs} -p <pid>\n`);
     // TODO(joyeecheung): should be kInvalidCommandLineArgument.
     process.exit(kGenericUserError);
   }
@@ -354,12 +351,15 @@ function startInspect(argv = ArrayPrototypeSlice(process.argv, 2),
 
   function handleUnexpectedError(e) {
     if (e.code !== 'ERR_DEBUGGER_STARTUP_ERROR') {
-      console.error('There was an internal error in Node.js. ' +
-                    'Please report this bug.');
-      console.error(e.message);
-      console.error(e.stack);
+      process.stderr.write('There was an internal error in Node.js. ' +
+                    'Please report this bug.\n');
+      process.stderr.write(e.message);
+      process.stderr.write('\n');
+      process.stderr.write(e.stack);
+      process.stderr.write('\n');
     } else {
-      console.error(e.message);
+      process.stderr.write(e.message);
+      process.stderr.write('\n');
     }
     if (inspector.child) inspector.child.kill();
     process.exit(kGenericUserError);


### PR DESCRIPTION
Came across TODO by @aduh95 in https://github.com/nodejs/node/blob/0665fa4009e2aa26adb95c27a363cc7ff0686d41/lib/internal/debugger/inspect.js to remove usage of console in the file, have attempted to do that by replacing console with process.stderr.write(). 

Refs: https://github.com/nodejs/node/pull/38406/

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
