### PR TITLE
deps: V8: cherry-pick 30861a39323d

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.6',
+    'v8_embedder_string': '-node.7',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/flags/flag-definitions.h
+++ b/deps/v8/src/flags/flag-definitions.h
@@ -1715,7 +1715,7 @@ DEFINE_BOOL(experimental_value_unavailable, false,
 DEFINE_BOOL(experimental_reuse_locals_blocklists, true,
             "enable reuse of local blocklists across multiple debug-evaluates")
 
-DEFINE_BOOL(experimental_remove_internal_scopes_property, true,
+DEFINE_BOOL(experimental_remove_internal_scopes_property, false,
             "don't report the artificial [[Scopes]] property for functions")
 
 // disassembler


### PR DESCRIPTION
Original commit message:

    [debug] Re-enable internal [[Scopes]] property

    We received feedback that the [[Scopes]] property has some legitimate
    use-cases not covered by the Scopes View during pause.

    We re-enable the feature for now and will remove the flag in a
    follow-up.

    R=bmeurer@chromium.org

    Bug: chromium:1365858
    Change-Id: Ibf279ae6c4f5ae492d03e9b4ee7316f6500508d9
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4099385
    Auto-Submit: Simon Zünd <szuend@chromium.org>
    Commit-Queue: Benedikt Meurer <bmeurer@chromium.org>
    Commit-Queue: Simon Zünd <szuend@chromium.org>
    Reviewed-by: Benedikt Meurer <bmeurer@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#84800}

Refs: https://github.com/v8/v8/commit/30861a39323d2d4263b2b9f5d9740134d4104cd3

See also: #45845