### PR TITLE
crypto: fix CryptoKey WebIDL conformance

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -4,6 +4,7 @@ const {
   ArrayFrom,
   ArrayPrototypeSlice,
   ObjectDefineProperty,
+  ObjectDefineProperties,
   ObjectSetPrototypeOf,
   Symbol,
   Uint8Array,
@@ -38,6 +39,7 @@ const {
     ERR_ILLEGAL_CONSTRUCTOR,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
+    ERR_INVALID_THIS,
   }
 } = require('internal/errors');
 
@@ -61,6 +63,7 @@ const {
 
 const {
   customInspectSymbol: kInspect,
+  kEnumerableProperty,
 } = require('internal/util');
 
 const { inspect } = require('internal/util/inspect');
@@ -657,18 +660,26 @@ class CryptoKey extends JSTransferable {
   }
 
   get type() {
+    if (!(this instanceof CryptoKey))
+      throw new ERR_INVALID_THIS('CryptoKey');
     return this[kKeyObject].type;
   }
 
   get extractable() {
+    if (!(this instanceof CryptoKey))
+      throw new ERR_INVALID_THIS('CryptoKey');
     return this[kExtractable];
   }
 
   get algorithm() {
+    if (!(this instanceof CryptoKey))
+      throw new ERR_INVALID_THIS('CryptoKey');
     return this[kAlgorithm];
   }
 
   get usages() {
+    if (!(this instanceof CryptoKey))
+      throw new ERR_INVALID_THIS('CryptoKey');
     return ArrayFrom(this[kKeyUsages]);
   }
 
@@ -696,6 +707,13 @@ class CryptoKey extends JSTransferable {
     this[kExtractable] = extractable;
   }
 }
+
+ObjectDefineProperties(CryptoKey.prototype, {
+  type: kEnumerableProperty,
+  extractable: kEnumerableProperty,
+  algorithm: kEnumerableProperty,
+  usages: kEnumerableProperty,
+});
 
 // All internal code must use new InternalCryptoKey to create
 // CryptoKey instances. The CryptoKey class is exposed to end

--- a/test/wpt/status/WebCryptoAPI.json
+++ b/test/wpt/status/WebCryptoAPI.json
@@ -12,10 +12,6 @@
         "Crypto interface: calling getRandomValues(ArrayBufferView) on crypto with too few arguments must throw TypeError",
         "CryptoKey interface: existence and properties of interface object",
         "CryptoKey interface: existence and properties of interface prototype object",
-        "CryptoKey interface: attribute type",
-        "CryptoKey interface: attribute extractable",
-        "CryptoKey interface: attribute algorithm",
-        "CryptoKey interface: attribute usages",
         "Window interface: attribute crypto"
       ]
     }


### PR DESCRIPTION
CryptoKey getters need to check `this` and be enumerable.