### PR TITLE
test: fix `test-net-happy-eyeballs` without IPv6 support

### DIFF
--- a/test/parallel/test-net-autoselectfamily.js
+++ b/test/parallel/test-net-autoselectfamily.js
@@ -215,6 +215,8 @@ if (common.hasIPv6) {
         if (common.hasIPv6) {
           assert.strictEqual(error.code, 'ECONNREFUSED');
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
+        } else if (error.code === 'EAFNOSUPPORT') {
+          assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
         } else {
           assert.strictEqual(error.code, 'EADDRNOTAVAIL');
           assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);

--- a/test/parallel/test-net-autoselectfamilydefault.js
+++ b/test/parallel/test-net-autoselectfamilydefault.js
@@ -127,6 +127,8 @@ function createDnsServer(ipv6Addr, ipv4Addr, cb) {
         if (common.hasIPv6) {
           assert.strictEqual(error.code, 'ECONNREFUSED');
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
+        } else if (error.code === 'EAFNOSUPPORT') {
+          assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
         } else {
           assert.strictEqual(error.code, 'EADDRNOTAVAIL');
           assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);


### PR DESCRIPTION
The error observed on linux-6.1.0 with disabled `CONFIG_IPV6` is `EAFNOSUPPORT`.

cc @ShogunPanda in case of any of:
- ~`EADDRNOTAVAIL` is confirmed to be thrown on any other platform: in this case, it would make sense to simply leave the error unchecked.~ Confirmed, checking both errors.
- `undefined:undefined` is not what should appear in error message: in this case, we probably need a fallback to `DEFAULT_IPV4_ADDR`/`DEFAULT_IPV6_ADDR` at https://github.com/nodejs/node/blob/cf0a42cf11a55aee04b7319dc2236aa0431ef405/lib/net.js#L1040