### PR TITLE
crypto: fix remaining WebCryptoAPI idlharness WPTs

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -56,7 +56,7 @@ const {
 } = require('internal/util/types');
 
 const {
-  JSTransferable,
+  makeTransferable,
   kClone,
   kDeserialize,
 } = require('internal/worker/js_transferable');
@@ -630,14 +630,12 @@ function isKeyObject(obj) {
 }
 
 // Our implementation of CryptoKey is a simple wrapper around a KeyObject
-// that adapts it to the standard interface. This implementation also
-// extends the JSTransferable class, allowing the CryptoKey to be cloned
-// to Workers.
+// that adapts it to the standard interface.
 // TODO(@jasnell): Embedder environments like electron may have issues
 // here similar to other things like URL. A chromium provided CryptoKey
 // will not be recognized as a Node.js CryptoKey, and vice versa. It
 // would be fantastic if we could find a way of making those interop.
-class CryptoKey extends JSTransferable {
+class CryptoKey {
   constructor() {
     throw new ERR_ILLEGAL_CONSTRUCTOR();
   }
@@ -682,6 +680,37 @@ class CryptoKey extends JSTransferable {
       throw new ERR_INVALID_THIS('CryptoKey');
     return ArrayFrom(this[kKeyUsages]);
   }
+}
+
+ObjectDefineProperties(CryptoKey.prototype, {
+  type: kEnumerableProperty,
+  extractable: kEnumerableProperty,
+  algorithm: kEnumerableProperty,
+  usages: kEnumerableProperty,
+});
+
+// All internal code must use new InternalCryptoKey to create
+// CryptoKey instances. The CryptoKey class is exposed to end
+// user code but is not permitted to be constructed directly.
+// Using makeTransferable also allows the CryptoKey to be
+// cloned to Workers.
+class InternalCryptoKey {
+  constructor(
+    keyObject,
+    algorithm,
+    keyUsages,
+    extractable) {
+    // Using symbol properties here currently instead of private
+    // properties because (for now) the performance penalty of
+    // private fields is still too high.
+    this[kKeyObject] = keyObject;
+    this[kAlgorithm] = algorithm;
+    this[kExtractable] = extractable;
+    this[kKeyUsages] = keyUsages;
+
+    // eslint-disable-next-line no-constructor-return
+    return makeTransferable(this);
+  }
 
   [kClone]() {
     const keyObject = this[kKeyObject];
@@ -707,34 +736,6 @@ class CryptoKey extends JSTransferable {
     this[kExtractable] = extractable;
   }
 }
-
-ObjectDefineProperties(CryptoKey.prototype, {
-  type: kEnumerableProperty,
-  extractable: kEnumerableProperty,
-  algorithm: kEnumerableProperty,
-  usages: kEnumerableProperty,
-});
-
-// All internal code must use new InternalCryptoKey to create
-// CryptoKey instances. The CryptoKey class is exposed to end
-// user code but is not permitted to be constructed directly.
-class InternalCryptoKey extends JSTransferable {
-  constructor(
-    keyObject,
-    algorithm,
-    keyUsages,
-    extractable) {
-    super();
-    // Using symbol properties here currently instead of private
-    // properties because (for now) the performance penalty of
-    // private fields is still too high.
-    this[kKeyObject] = keyObject;
-    this[kAlgorithm] = algorithm;
-    this[kExtractable] = extractable;
-    this[kKeyUsages] = keyUsages;
-  }
-}
-
 InternalCryptoKey.prototype.constructor = CryptoKey;
 ObjectSetPrototypeOf(InternalCryptoKey.prototype, CryptoKey.prototype);
 

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -23,6 +23,7 @@ const {
 } = require('internal/util');
 
 const {
+  ERR_INVALID_THIS,
   ERR_MANIFEST_ASSERT_INTEGRITY,
   ERR_NO_CRYPTO,
 } = require('internal/errors').codes;
@@ -278,7 +279,15 @@ function setupWebCrypto() {
 
   if (internalBinding('config').hasOpenSSL) {
     defineReplaceableLazyAttribute(
-      globalThis, 'internal/crypto/webcrypto', ['crypto'], false
+      globalThis,
+      'internal/crypto/webcrypto',
+      ['crypto'],
+      false,
+      function cryptoThisCheck() {
+        if (this !== globalThis && this != null)
+          throw new ERR_INVALID_THIS(
+            'nullish or must be the global object');
+      }
     );
     exposeLazyInterfaces(
       globalThis, 'internal/crypto/webcrypto',

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -552,7 +552,7 @@ function defineLazyProperties(target, id, keys, enumerable = true) {
   ObjectDefineProperties(target, descriptors);
 }
 
-function defineReplaceableLazyAttribute(target, id, keys, writable = true) {
+function defineReplaceableLazyAttribute(target, id, keys, writable = true, check) {
   let mod;
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
@@ -560,6 +560,9 @@ function defineReplaceableLazyAttribute(target, id, keys, writable = true) {
     let setterCalled = false;
 
     function get() {
+      if (check !== undefined) {
+        FunctionPrototypeCall(check, this);
+      }
       if (setterCalled) {
         return value;
       }

--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -397,7 +397,7 @@ class WPTRunner {
       'CompressionStream', 'DecompressionStream',
     ];
     if (Boolean(process.versions.openssl) && !process.env.NODE_SKIP_CRYPTO) {
-      lazyProperties.push('crypto');
+      lazyProperties.push('crypto', 'Crypto', 'CryptoKey', 'SubtleCrypto');
     }
     const script = lazyProperties.map((name) => `globalThis.${name};`).join('\n');
     this.globalThisInitScripts.push(script);

--- a/test/wpt/status/WebCryptoAPI.json
+++ b/test/wpt/status/WebCryptoAPI.json
@@ -17,13 +17,5 @@
   },
   "historical.any.js": {
     "skip": "Not relevant in Node.js context"
-  },
-  "idlharness.https.any.js": {
-    "fail": {
-      "expected": [
-        "CryptoKey interface: existence and properties of interface object",
-        "Window interface: attribute crypto"
-      ]
-    }
   }
 }

--- a/test/wpt/status/WebCryptoAPI.json
+++ b/test/wpt/status/WebCryptoAPI.json
@@ -23,7 +23,6 @@
       "expected": [
         "Crypto interface: existence and properties of interface object",
         "CryptoKey interface: existence and properties of interface object",
-        "CryptoKey interface: existence and properties of interface prototype object",
         "Window interface: attribute crypto"
       ]
     }

--- a/test/wpt/status/WebCryptoAPI.json
+++ b/test/wpt/status/WebCryptoAPI.json
@@ -21,7 +21,6 @@
   "idlharness.https.any.js": {
     "fail": {
       "expected": [
-        "Crypto interface: existence and properties of interface object",
         "CryptoKey interface: existence and properties of interface object",
         "Window interface: attribute crypto"
       ]


### PR DESCRIPTION
Refactor `Cryptokey` to be just a non-constructable wrapper, not having any of the transferable related getters, moving those to `InternalCryptoKey`.

JSTransferable remains in effect, but will rebase and run ci after #45811 lands to reconfirm (done).

Also fixes (adds) `globalThis.crypto` `this` check.