### PR TITLE
deps: V8: backport 8ca9f77d0f7c

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.6',
+    'v8_embedder_string': '-node.7',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-internal.h
+++ b/deps/v8/include/v8-internal.h
@@ -398,7 +398,8 @@ constexpr uint64_t kAllExternalPointerTypeTags[] = {
   V(kWasmInternalFunctionCallTargetTag,     sandboxed, TAG(17)) \
   V(kWasmTypeInfoNativeTypeTag,             sandboxed, TAG(18)) \
   V(kWasmExportedFunctionDataSignatureTag,  sandboxed, TAG(19)) \
-  V(kWasmContinuationJmpbufTag,             sandboxed, TAG(20))
+  V(kWasmContinuationJmpbufTag,             sandboxed, TAG(20)) \
+  V(kArrayBufferExtensionTag,               sandboxed, TAG(21))
 
 // All external pointer tags.
 #define ALL_EXTERNAL_POINTER_TAGS(V) \

--- a/deps/v8/src/builtins/builtins-typed-array-gen.cc
+++ b/deps/v8/src/builtins/builtins-typed-array-gen.cc
@@ -70,8 +70,15 @@ TNode<JSArrayBuffer> TypedArrayBuiltinsAssembler::AllocateEmptyOnHeapBuffer(
                            UintPtrConstant(0));
   StoreSandboxedPointerToObject(buffer, JSArrayBuffer::kBackingStoreOffset,
                                 EmptyBackingStoreBufferConstant());
+#ifdef V8_COMPRESS_POINTERS
+  // When pointer compression is enabled, the extension slot contains a
+  // (lazily-initialized) external pointer handle.
+  StoreObjectFieldNoWriteBarrier(buffer, JSArrayBuffer::kExtensionOffset,
+                                 ExternalPointerHandleNullConstant());
+#else
   StoreObjectFieldNoWriteBarrier(buffer, JSArrayBuffer::kExtensionOffset,
                                  IntPtrConstant(0));
+#endif
   for (int offset = JSArrayBuffer::kHeaderSize;
        offset < JSArrayBuffer::kSizeWithEmbedderFields; offset += kTaggedSize) {
     // TODO(v8:10391, saelo): Handle external pointers in EmbedderDataSlot

--- a/deps/v8/src/compiler/code-assembler.h
+++ b/deps/v8/src/compiler/code-assembler.h
@@ -553,6 +553,9 @@ class V8_EXPORT_PRIVATE CodeAssembler {
   TNode<BoolT> BoolConstant(bool value) {
     return value ? Int32TrueConstant() : Int32FalseConstant();
   }
+  TNode<ExternalPointerHandleT> ExternalPointerHandleNullConstant() {
+    return ReinterpretCast<ExternalPointerHandleT>(Uint32Constant(0));
+  }
 
   bool IsMapOffsetConstant(Node* node);
 

--- a/deps/v8/src/objects/js-array-buffer.h
+++ b/deps/v8/src/objects/js-array-buffer.h
@@ -168,14 +168,15 @@ class JSArrayBuffer
  private:
   void DetachInternal(bool force_for_wasm_memory, Isolate* isolate);
 
-  inline ArrayBufferExtension** extension_location() const;
-
 #if V8_COMPRESS_POINTERS
-  static const int kUninitializedTagMask = 1;
-
-  inline uint32_t* extension_lo() const;
-  inline uint32_t* extension_hi() const;
-#endif
+  // When pointer compression is enabled, the pointer to the extension is
+  // stored in the external pointer table and the object itself only contains a
+  // 32-bit external pointer handles. This simplifies alignment requirements
+  // and is also necessary for the sandbox.
+  inline ExternalPointerHandle* extension_handle_location() const;
+#else
+  inline ArrayBufferExtension** extension_location() const;
+#endif  // V8_COMPRESS_POINTERS
 
   TQ_OBJECT_CONSTRUCTORS(JSArrayBuffer)
 };

--- a/deps/v8/src/objects/js-array-buffer.tq
+++ b/deps/v8/src/objects/js-array-buffer.tq
@@ -19,7 +19,7 @@ extern class JSArrayBuffer extends JSObjectWithEmbedderSlots {
   raw_max_byte_length: uintptr;
   // A SandboxedPtr if the sandbox is enabled
   backing_store: RawPtr;
-  extension: RawPtr;
+  extension: ExternalPointer;
   bit_field: JSArrayBufferFlags;
   // Pads header size to be a multiple of kTaggedSize.
   @if(TAGGED_SIZE_8_BYTES) optional_padding: uint32;

--- a/deps/v8/src/objects/objects-body-descriptors-inl.h
+++ b/deps/v8/src/objects/objects-body-descriptors-inl.h
@@ -387,6 +387,8 @@ class JSArrayBuffer::BodyDescriptor final : public BodyDescriptorBase {
     // JSArrayBuffer instances contain raw data that the GC does not know about.
     IteratePointers(obj, kPropertiesOrHashOffset, kEndOfTaggedFieldsOffset, v);
     IterateJSObjectBodyImpl(map, obj, kHeaderSize, object_size, v);
+    v->VisitExternalPointer(map, obj.RawExternalPointerField(kExtensionOffset),
+                            kArrayBufferExtensionTag);
   }
 
   static inline int SizeOf(Map map, HeapObject object) {

--- a/deps/v8/src/sandbox/external-pointer-table.h
+++ b/deps/v8/src/sandbox/external-pointer-table.h
@@ -98,7 +98,7 @@ class V8_EXPORT_PRIVATE ExternalPointerTable {
   // returning the previous value. The same tag is applied both to decode the
   // previous value and encode the given value.
   //
-  // This method is atomic and can call be called from background threads.
+  // This method is atomic and can be called from background threads.
   inline Address Exchange(ExternalPointerHandle handle, Address value,
                           ExternalPointerTag tag);
 

--- a/deps/v8/src/snapshot/deserializer.cc
+++ b/deps/v8/src/snapshot/deserializer.cc
@@ -399,6 +399,7 @@ void Deserializer<Isolate>::PostProcessNewJSReceiver(Map map,
     auto buffer = JSArrayBuffer::cast(*obj);
     uint32_t store_index = buffer.GetBackingStoreRefForDeserialization();
     if (store_index == kEmptyBackingStoreRefSentinel) {
+      buffer.set_extension(nullptr);
       buffer.set_backing_store(main_thread_isolate(),
                                EmptyBackingStoreBuffer());
     } else {

--- a/deps/v8/test/cctest/heap/test-array-buffer-tracker.cc
+++ b/deps/v8/test/cctest/heap/test-array-buffer-tracker.cc
@@ -218,7 +218,6 @@ TEST(ArrayBuffer_NonLivePromotion) {
   v8::Isolate* isolate = env->GetIsolate();
   Heap* heap = reinterpret_cast<Isolate*>(isolate)->heap();
 
-  JSArrayBuffer raw_ab;
   {
     v8::HandleScope handle_scope(isolate);
     Handle<FixedArray> root =
@@ -235,13 +234,12 @@ TEST(ArrayBuffer_NonLivePromotion) {
     CHECK(IsTracked(heap, JSArrayBuffer::cast(root->get(0))));
     heap::GcAndSweep(heap, NEW_SPACE);
     CHECK(IsTracked(heap, JSArrayBuffer::cast(root->get(0))));
-    raw_ab = JSArrayBuffer::cast(root->get(0));
+    ArrayBufferExtension* extension =
+        JSArrayBuffer::cast(root->get(0)).extension();
     root->set(0, ReadOnlyRoots(heap).undefined_value());
     heap::SimulateIncrementalMarking(heap, true);
-    // Prohibit page from being released.
-    Page::FromHeapObject(raw_ab)->MarkNeverEvacuate();
     heap::GcAndSweep(heap, OLD_SPACE);
-    CHECK(!IsTracked(heap, raw_ab));
+    CHECK(!IsTracked(heap, extension));
   }
 }
 


### PR DESCRIPTION
This fixes a crash when loading snapshots that contain empty ArrayBuffer instances:

```js
const X = [];
X.push(new ArrayBuffer());
v8.startupSnapshot.setDeserializeMainFunction(() => {
  for (let i = 0; i < 1000000; i++) { // trigger GC
    X.push(new ArrayBuffer());
  }
})
```

Original commit message:

    [sandbox] Sandboxify JSArrayBuffer::extension external pointer

    Bug: chromium:1335043
    Change-Id: Id8e6883fc652b144f6380ff09b1c18e777e041c2
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3706626
    Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
    Reviewed-by: Igor Sheludko <ishell@chromium.org>
    Commit-Queue: Samuel Groß <saelo@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#84544}

Refs: https://github.com/v8/v8/commit/8ca9f77d0f7c2d5ec5ef8255b9689f5ac1c547a3

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
