### PR TITLE
test: use `process.hrtime.bigint` instead of `process.hrtime`

### DIFF
--- a/test/parallel/test-http2-session-timeout.js
+++ b/test/parallel/test-http2-session-timeout.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const http2 = require('http2');
 const hrtime = process.hrtime.bigint;
-const NS_PER_MS = 1000000n;
+const NS_PER_MS = 1_000_000n;
 
 let requests = 0;
 const mustNotCall = () => {

--- a/test/parallel/test-http2-session-timeout.js
+++ b/test/parallel/test-http2-session-timeout.js
@@ -5,6 +5,8 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
+const hrtime = process.hrtime.bigint;
+const NS_PER_MS = 1000000n;
 
 let requests = 0;
 const mustNotCall = () => {
@@ -14,7 +16,7 @@ const mustNotCall = () => {
 const server = http2.createServer();
 // Disable server timeout until first request. We will set the timeout based on
 // how long the first request takes.
-server.timeout = 0;
+server.timeout = 0n;
 
 server.on('request', (req, res) => res.end());
 server.on('timeout', mustNotCall);
@@ -24,7 +26,7 @@ server.listen(0, common.mustCall(() => {
 
   const url = `http://localhost:${port}`;
   const client = http2.connect(url);
-  let startTime = process.hrtime();
+  let startTime = hrtime();
   makeReq();
 
   function makeReq() {
@@ -40,17 +42,17 @@ server.listen(0, common.mustCall(() => {
     requests += 1;
 
     request.on('end', () => {
-      const diff = process.hrtime(startTime);
-      const milliseconds = (diff[0] * 1e3 + diff[1] / 1e6);
-      if (server.timeout === 0) {
+      const diff = hrtime() - startTime;
+      const milliseconds = diff / NS_PER_MS;
+      if (server.timeout === 0n) {
         // Set the timeout now. First connection will take significantly longer
         // than subsequent connections, so using the duration of the first
         // connection as the timeout should be robust. Double it anyway for good
         // measure.
-        server.timeout = milliseconds * 2;
-        startTime = process.hrtime();
+        server.timeout = milliseconds * 2n;
+        startTime = hrtime();
         makeReq();
-      } else if (milliseconds < server.timeout * 2) {
+      } else if (milliseconds < server.timeout * 2n) {
         makeReq();
       } else {
         server.removeListener('timeout', mustNotCall);


### PR DESCRIPTION
`process.hrtime` is legacy. So replace `process.hrtime` with `process.hrtime.bigint` in test.

Refs: https://github.com/nodejs/node/blob/main/doc/api/process.md#processhrtimetime
Refs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt

Signed-off-by: Deokjin Kim <deokjin81.kim@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
