### PR TITLE
src: fix crash on OnStreamRead on Windows

### DIFF
--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -583,9 +583,10 @@ void CustomBufferJSListener::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
 
-  // To deal with the case where POLLHUP is received and UV_EOF is returned, as
-  // libuv returns an empty buffer (on unices only).
-  if (nread == UV_EOF && buf.base == nullptr) {
+  // In the case that there's an error and buf is null, return immediately.
+  // This can happen on unices when POLLHUP is received and UV_EOF is returned
+  // or when getting an error while performing a UV_HANDLE_ZERO_READ on Windows.
+  if (buf.base == nullptr && nread < 0) {
     stream->CallJSOnreadMethod(nread, Local<ArrayBuffer>());
     return;
   }

--- a/test/parallel/test-net-child-process-connect-reset.js
+++ b/test/parallel/test-net-child-process-connect-reset.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { spawn } = require('child_process');
+const net = require('net');
+
+if (process.argv[2] === 'child') {
+  const server = net.createServer(common.mustCall());
+  server.listen(0, common.mustCall(() => {
+    process.send({ type: 'ready', data: { port: server.address().port } });
+  }));
+} else {
+  const cp = spawn(process.execPath,
+                   [__filename, 'child'],
+                   {
+                     stdio: ['ipc', 'inherit', 'inherit']
+                   });
+
+  cp.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, null);
+    assert.strictEqual(signal, 'SIGKILL');
+  }));
+
+  cp.on('message', common.mustCall((msg) => {
+    const { type, data } = msg;
+    assert.strictEqual(type, 'ready');
+    const port = data.port;
+
+    const conn = net.createConnection({
+      port,
+      onread: {
+        buffer: Buffer.alloc(65536),
+        callback: () => {},
+      }
+    });
+
+    conn.on('error', (err) => {
+      // Error emitted on Windows.
+      assert.strictEqual(err.code, 'ECONNRESET');
+    });
+
+    conn.on('connect', common.mustCall(() => {
+      cp.kill('SIGKILL');
+    }));
+  }));
+}


### PR DESCRIPTION
On Windows [it's perfectly possible that the `uv_tcp_t` `read_cb` is called with an error and a null `uv_buf_t` if it corresponds to a `UV_HANDLE_ZERO_READ` read](https://github.com/nodejs/node/blob/4166d40d0873b6d8a0c7291872c8d20dc680b1d7/deps/uv/src/win/tcp.c#L1012-L1030). Handle this case without crashing.

Fixes: https://github.com/nodejs/node/issues/40764

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
