### PR TITLE
src: fix creating `Isolate`s from addons

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -96,6 +96,9 @@
         'NODE_USE_V8_PLATFORM=0',
       ],
     }],
+    [ 'v8_enable_shared_ro_heap==1', {
+      'defines': ['NODE_V8_SHARED_RO_HEAP',],
+    }],
     [ 'node_tag!=""', {
       'defines': [ 'NODE_TAG="<(node_tag)"' ],
     }],

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -303,7 +303,8 @@ bool SafeGetenv(const char* key,
 void DefineZlibConstants(v8::Local<v8::Object> target);
 v8::Isolate* NewIsolate(v8::Isolate::CreateParams* params,
                         uv_loop_t* event_loop,
-                        MultiIsolatePlatform* platform);
+                        MultiIsolatePlatform* platform,
+                        bool has_snapshot_data = false);
 // This overload automatically picks the right 'main_script_id' if no callback
 // was provided by the embedder.
 v8::MaybeLocal<v8::Value> StartExecution(Environment* env,

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -76,13 +76,9 @@ NodeMainInstance::NodeMainInstance(const SnapshotData* snapshot_data,
                                              isolate_params_.get());
   }
 
-  isolate_ = Isolate::Allocate();
+  isolate_ = NewIsolate(
+      isolate_params_.get(), event_loop, platform, snapshot_data != nullptr);
   CHECK_NOT_NULL(isolate_);
-  // Register the isolate on the platform before the isolate gets initialized,
-  // so that the isolate can access the platform during initialization.
-  platform->RegisterIsolate(isolate_, event_loop);
-  SetIsolateCreateParamsForNode(isolate_params_.get());
-  Isolate::Initialize(isolate_, *isolate_params_);
 
   // If the indexes are not nullptr, we are not deserializing
   isolate_data_ = std::make_unique<IsolateData>(
@@ -91,13 +87,7 @@ NodeMainInstance::NodeMainInstance(const SnapshotData* snapshot_data,
       platform,
       array_buffer_allocator_.get(),
       snapshot_data == nullptr ? nullptr : &(snapshot_data->isolate_data_info));
-  IsolateSettings s;
-  SetIsolateMiscHandlers(isolate_, s);
-  if (snapshot_data == nullptr) {
-    // If in deserialize mode, delay until after the deserialization is
-    // complete.
-    SetIsolateErrorHandlers(isolate_, s);
-  }
+
   isolate_data_->max_young_gen_size =
       isolate_params_->constraints.max_young_generation_size_in_bytes();
 }

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -148,14 +148,10 @@ class WorkerThreadData {
         ArrayBufferAllocator::Create();
     Isolate::CreateParams params;
     SetIsolateCreateParamsForNode(&params);
-    params.array_buffer_allocator_shared = allocator;
-
-    if (w->snapshot_data() != nullptr) {
-      SnapshotBuilder::InitializeIsolateParams(w->snapshot_data(), &params);
-    }
     w->UpdateResourceConstraints(&params.constraints);
-
-    Isolate* isolate = Isolate::Allocate();
+    params.array_buffer_allocator_shared = allocator;
+    Isolate* isolate =
+        NewIsolate(&params, &loop_, w->platform_, w->snapshot_data());
     if (isolate == nullptr) {
       // TODO(joyeecheung): maybe this should be kBootstrapFailure instead?
       w->Exit(ExitCode::kGenericUserError,
@@ -164,8 +160,6 @@ class WorkerThreadData {
       return;
     }
 
-    w->platform_->RegisterIsolate(isolate, &loop_);
-    Isolate::Initialize(isolate, params);
     SetIsolateUpForNode(isolate);
 
     // Be sure it's called before Environment::InitializeDiagnostics()

--- a/test/addons/new-isolate-addon/binding.cc
+++ b/test/addons/new-isolate-addon/binding.cc
@@ -1,0 +1,76 @@
+#include <assert.h>
+#include <node.h>
+
+using node::Environment;
+using node::MultiIsolatePlatform;
+using v8::Context;
+using v8::FunctionCallbackInfo;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Local;
+using v8::Locker;
+using v8::MaybeLocal;
+using v8::Object;
+using v8::SharedArrayBuffer;
+using v8::String;
+using v8::Unlocker;
+using v8::Value;
+
+void RunInSeparateIsolate(const FunctionCallbackInfo<Value>& args) {
+  Isolate* parent_isolate = args.GetIsolate();
+
+  assert(args[0]->IsString());
+  String::Utf8Value code(parent_isolate, args[0]);
+  assert(*code != nullptr);
+  assert(args[1]->IsSharedArrayBuffer());
+  auto arg_bs = args[1].As<SharedArrayBuffer>()->GetBackingStore();
+
+  Environment* parent_env =
+      node::GetCurrentEnvironment(parent_isolate->GetCurrentContext());
+  assert(parent_env != nullptr);
+  MultiIsolatePlatform* platform = node::GetMultiIsolatePlatform(parent_env);
+  assert(parent_env != nullptr);
+
+  {
+    Unlocker unlocker(parent_isolate);
+
+    std::vector<std::string> errors;
+    const std::vector<std::string> empty_args;
+    auto setup =
+        node::CommonEnvironmentSetup::Create(platform,
+                                             &errors,
+                                             empty_args,
+                                             empty_args,
+                                             node::EnvironmentFlags::kNoFlags);
+    assert(setup);
+
+    {
+      Locker locker(setup->isolate());
+      Isolate::Scope isolate_scope(setup->isolate());
+      HandleScope handle_scope(setup->isolate());
+      Context::Scope context_scope(setup->context());
+      auto arg = SharedArrayBuffer::New(setup->isolate(), arg_bs);
+      auto result = setup->context()->Global()->Set(
+          setup->context(),
+          v8::String::NewFromUtf8Literal(setup->isolate(), "arg"),
+          arg);
+      assert(!result.IsNothing());
+
+      MaybeLocal<Value> loadenv_ret =
+          node::LoadEnvironment(setup->env(), *code);
+      assert(!loadenv_ret.IsEmpty());
+
+      (void)node::SpinEventLoop(setup->env());
+
+      node::Stop(setup->env());
+    }
+  }
+}
+
+void Initialize(Local<Object> exports,
+                Local<Value> module,
+                Local<Context> context) {
+  NODE_SET_METHOD(exports, "runInSeparateIsolate", RunInSeparateIsolate);
+}
+
+NODE_MODULE_CONTEXT_AWARE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/new-isolate-addon/binding.gyp
+++ b/test/addons/new-isolate-addon/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'includes': ['../common.gypi'],
+    }
+  ]
+}

--- a/test/addons/new-isolate-addon/test-nonodesnapshot.js
+++ b/test/addons/new-isolate-addon/test-nonodesnapshot.js
@@ -1,0 +1,6 @@
+// Flags: --no-node-snapshot
+'use strict';
+require('../../common');
+
+// Just re-execute the main test.
+require('./test');

--- a/test/addons/new-isolate-addon/test.js
+++ b/test/addons/new-isolate-addon/test.js
@@ -1,0 +1,8 @@
+'use strict';
+const common = require('../../common');
+const binding = require(`./build/${common.buildType}/binding`);
+const assert = require('assert');
+
+const arg = new SharedArrayBuffer(1);
+binding.runInSeparateIsolate('const arr = new Uint8Array(arg); arr[0] = 0x42;', arg);
+assert.deepStrictEqual(new Uint8Array(arg), new Uint8Array([0x42]));


### PR DESCRIPTION
daae938f32f2660 broke addons which create their own `Isolate` instances, because enabling the shared-readonly-heap feature of V8 requires all snapshots used for different `Isolate`s to be identical. Usage of addons that do this has probably decreased quite a bit since Worker threads were introduced in Node.js, but it’s still a valid use case, and in any case the breakage was probably not intentional (although the referenced commit did require test changes because of this issue).

This commit addresses this issue partially by caching the V8 snapshot parameters and ignoring ones passed in from users in `NewIsolate()` when this feature is enabled, and makes the `NodeMainInstance` snapshot-based isolate creation also re-use this code.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
