### PR TITLE
src: use CreateEnvironment instead of inlining its code where possible

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -375,22 +375,32 @@ Environment* CreateEnvironment(
   // options than the global parse call.
   Environment* env = new Environment(
       isolate_data, context, args, exec_args, nullptr, flags, thread_id);
+
+  auto initialize_inspector = [&]() {
 #if HAVE_INSPECTOR
-  if (env->should_create_inspector()) {
-    if (inspector_parent_handle) {
-      env->InitializeInspector(
-          std::move(static_cast<InspectorParentHandleImpl*>(
-              inspector_parent_handle.get())->impl));
-    } else {
-      env->InitializeInspector({});
+    if (env->should_create_inspector()) {
+      if (inspector_parent_handle) {
+        env->InitializeInspector(
+            std::move(static_cast<InspectorParentHandleImpl*>(
+                          inspector_parent_handle.get())
+                          ->impl));
+      } else {
+        env->InitializeInspector({});
+      }
     }
-  }
 #endif
+  };
+
+  if (!(flags & EnvironmentFlags::kInspectorOnlyAfterBootstrap))
+    initialize_inspector();
 
   if (env->principal_realm()->RunBootstrapping().IsEmpty()) {
     FreeEnvironment(env);
     return nullptr;
   }
+
+  if (flags & EnvironmentFlags::kInspectorOnlyAfterBootstrap)
+    initialize_inspector();
 
   return env;
 }

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -376,31 +376,22 @@ Environment* CreateEnvironment(
   Environment* env = new Environment(
       isolate_data, context, args, exec_args, nullptr, flags, thread_id);
 
-  auto initialize_inspector = [&]() {
 #if HAVE_INSPECTOR
-    if (env->should_create_inspector()) {
-      if (inspector_parent_handle) {
-        env->InitializeInspector(
-            std::move(static_cast<InspectorParentHandleImpl*>(
-                          inspector_parent_handle.get())
-                          ->impl));
-      } else {
-        env->InitializeInspector({});
-      }
+  if (env->should_create_inspector()) {
+    if (inspector_parent_handle) {
+      env->InitializeInspector(std::move(
+          static_cast<InspectorParentHandleImpl*>(inspector_parent_handle.get())
+              ->impl));
+    } else {
+      env->InitializeInspector({});
     }
+  }
 #endif
-  };
-
-  if (!(flags & EnvironmentFlags::kInspectorOnlyAfterBootstrap))
-    initialize_inspector();
 
   if (env->principal_realm()->RunBootstrapping().IsEmpty()) {
     FreeEnvironment(env);
     return nullptr;
   }
-
-  if (flags & EnvironmentFlags::kInspectorOnlyAfterBootstrap)
-    initialize_inspector();
 
   return env;
 }

--- a/src/node.h
+++ b/src/node.h
@@ -560,7 +560,10 @@ enum Flags : uint64_t {
   // This control is needed by embedders who may not want to initialize the V8
   // inspector in situations where one has already been created,
   // e.g. Blink's in Chromium.
-  kNoCreateInspector = 1 << 9
+  kNoCreateInspector = 1 << 9,
+  // Whether to enable the V8 inspector during Node.js bootstrap or not.
+  // This has no effect if kNoCreateInspector is set.
+  kInspectorOnlyAfterBootstrap = 1 << 10
 };
 }  // namespace EnvironmentFlags
 

--- a/src/node.h
+++ b/src/node.h
@@ -560,10 +560,7 @@ enum Flags : uint64_t {
   // This control is needed by embedders who may not want to initialize the V8
   // inspector in situations where one has already been created,
   // e.g. Blink's in Chromium.
-  kNoCreateInspector = 1 << 9,
-  // Whether to enable the V8 inspector during Node.js bootstrap or not.
-  // This has no effect if kNoCreateInspector is set.
-  kInspectorOnlyAfterBootstrap = 1 << 10
+  kNoCreateInspector = 1 << 9
 };
 }  // namespace EnvironmentFlags
 

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -191,19 +191,8 @@ NodeMainInstance::CreateMainEnvironment(ExitCode* exit_code) {
     context = NewContext(isolate_);
     CHECK(!context.IsEmpty());
     Context::Scope context_scope(context);
-    env.reset(new Environment(isolate_data_.get(),
-                              context,
-                              args_,
-                              exec_args_,
-                              nullptr,
-                              EnvironmentFlags::kDefaultFlags,
-                              {}));
-#if HAVE_INSPECTOR
-    env->InitializeInspector({});
-#endif
-    if (env->principal_realm()->RunBootstrapping().IsEmpty()) {
-      return nullptr;
-    }
+    env.reset(
+        CreateEnvironment(isolate_data_.get(), context, args_, exec_args_));
   }
 
   return env;

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1151,6 +1151,10 @@ ExitCode SnapshotBuilder::Generate(SnapshotData* out,
       Context::Scope context_scope(main_context);
 
       // Create the environment.
+      // It's not guaranteed that a context that goes through
+      // v8_inspector::V8Inspector::contextCreated() is runtime-independent,
+      // so do not start the inspector on the main context when building
+      // the default snapshot.
       uint64_t env_flags = EnvironmentFlags::kDefaultFlags |
                            EnvironmentFlags::kNoCreateInspector;
 

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1152,10 +1152,7 @@ ExitCode SnapshotBuilder::Generate(SnapshotData* out,
 
       // Create the environment.
       uint64_t env_flags = EnvironmentFlags::kDefaultFlags |
-                           EnvironmentFlags::kInspectorOnlyAfterBootstrap;
-      if (snapshot_type != SnapshotMetadata::Type::kFullyCustomized) {
-        env_flags |= EnvironmentFlags::kNoCreateInspector;
-      }
+                           EnvironmentFlags::kNoCreateInspector;
 
       env = CreateEnvironment(main_instance->isolate_data(),
                               main_context,
@@ -1173,6 +1170,9 @@ ExitCode SnapshotBuilder::Generate(SnapshotData* out,
       // could also explore snapshotting other kinds of execution modes
       // in the future).
       if (snapshot_type == SnapshotMetadata::Type::kFullyCustomized) {
+#if HAVE_INSPECTOR
+        env->InitializeInspector({});
+#endif
         if (LoadEnvironment(env, StartExecutionCallback{}).IsEmpty()) {
           return ExitCode::kGenericUserError;
         }


### PR DESCRIPTION
We had a number of places in which we created an `Environment` instance by performing each step in `CreateEnvironment` manually. Instead, just call the function itself.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
