### PR TITLE
test: fix test broken under --node-builtin-modules-path

### DIFF
--- a/test/parallel/test-v8-serialize-leak.js
+++ b/test/parallel/test-v8-serialize-leak.js
@@ -22,6 +22,8 @@ const after = process.memoryUsage.rss();
 
 if (process.config.variables.asan) {
   assert(after < before * 10, `asan: before=${before} after=${after}`);
+} else if (process.config.variables.node_builtin_modules_path) {
+  assert(after < before * 4, `node_builtin_modules_path: before=${before} after=${after}`);
 } else {
   assert(after < before * 2, `before=${before} after=${after}`);
 }


### PR DESCRIPTION
When developing using `./configure --node-builtin-modules-path $(pwd)`, the test `test/parallel/test-v8-serialize-leak.js` always fails (at least for me). This update adds a tweak to account for the different memory usage under `--node-builtin-modules-path`, to make the test pass. Alternatively we could have this test be skipped under `--node-builtin-modules-path`.

See also https://openjs-foundation.slack.com/archives/C019Y2T6STH/p1664596265175919