### PR TITLE
os: add availableParallelism()

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -140,6 +140,10 @@ The properties included on each object include:
 `nice` values are POSIX-only. On Windows, the `nice` values of all processors
 are always 0.
 
+`os.cpus().length` should not be used to calculate the amount of parallelism
+available to an application. Use
+[`os.availableParallelism()`](#osavailableparallelism) for this purpose.
+
 ## `os.devNull`
 
 <!-- YAML

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -26,6 +26,19 @@ The operating system-specific end-of-line marker.
 * `\n` on POSIX
 * `\r\n` on Windows
 
+## `os.availableParallelism()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {integer}
+
+Returns an estimate of the default amount of parallelism a program should use.
+Always returns a value greater than zero.
+
+This function is a small wrapper about libuv's [`uv_available_parallelism()`][].
+
 ## `os.arch()`
 
 <!-- YAML
@@ -1340,3 +1353,4 @@ The following process scheduling constants are exported by
 [`process.arch`]: process.md#processarch
 [`process.platform`]: process.md#processplatform
 [`uname(3)`]: https://linux.die.net/man/3/uname
+[`uv_available_parallelism()`]: https://docs.libuv.org/en/v1.x/misc.html#c.uv_available_parallelism

--- a/lib/os.js
+++ b/lib/os.js
@@ -45,6 +45,7 @@ const {
 const { validateInt32 } = require('internal/validators');
 
 const {
+  getAvailableParallelism,
   getCPUs,
   getFreeMem,
   getHomeDirectory: _getHomeDirectory,
@@ -100,6 +101,7 @@ const getOSVersion = () => version;
  */
 const getMachine = () => machine;
 
+getAvailableParallelism[SymbolToPrimitive] = () => getAvailableParallelism();
 getFreeMem[SymbolToPrimitive] = () => getFreeMem();
 getHostname[SymbolToPrimitive] = () => getHostname();
 getOSVersion[SymbolToPrimitive] = () => getOSVersion();
@@ -364,6 +366,7 @@ function userInfo(options) {
 
 module.exports = {
   arch,
+  availableParallelism: getAvailableParallelism,
   cpus,
   endianness,
   freemem: getFreeMem,

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -380,6 +380,10 @@ static void GetPriority(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(priority);
 }
 
+static void GetAvailableParallelism(const FunctionCallbackInfo<Value>& args) {
+  unsigned int parallelism = uv_available_parallelism();
+  args.GetReturnValue().Set(parallelism);
+}
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,
@@ -397,6 +401,8 @@ void Initialize(Local<Object> target,
   SetMethod(context, target, "getUserInfo", GetUserInfo);
   SetMethod(context, target, "setPriority", SetPriority);
   SetMethod(context, target, "getPriority", GetPriority);
+  SetMethod(
+      context, target, "getAvailableParallelism", GetAvailableParallelism);
   SetMethod(context, target, "getOSInformation", GetOSInformation);
   target
       ->Set(context,
@@ -417,6 +423,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(GetUserInfo);
   registry->Register(SetPriority);
   registry->Register(GetPriority);
+  registry->Register(GetAvailableParallelism);
   registry->Register(GetOSInformation);
 }
 

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -255,6 +255,8 @@ if (!common.isIBMi) {
   is.number(os.uptime(), 'uptime');
 }
 
+is.number(+os.availableParallelism, 'availableParallelism');
+is.number(os.availableParallelism(), 'availableParallelism');
 is.number(+os.freemem, 'freemem');
 is.number(os.freemem(), 'freemem');
 
@@ -264,3 +266,5 @@ if (common.isWindows) {
 } else {
   assert.strictEqual(devNull, '/dev/null');
 }
+
+assert.ok(os.availableParallelism() > 0);


### PR DESCRIPTION
This commit exposes `uv_available_parallelism()` as an alternative to `cpus().length`. `uv_available_parallelism()` is inspired by Rust's `available_parallelism()`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
