### PR TITLE
lib: implement finished for webstreams

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -38,6 +38,18 @@ const {
   willEmitClose: _willEmitClose,
 } = require('internal/streams/utils');
 
+const Readable = require('internal/streams/readable');
+const Writable = require('internal/streams/writable');
+
+const {
+  isBrandCheck,
+} = require('internal/webstreams/util');
+
+const isReadableStream =
+  isBrandCheck('ReadableStream');
+const isWritableStream =
+  isBrandCheck('WritableStream');
+
 function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === 'function';
 }
@@ -58,13 +70,16 @@ function eos(stream, options, callback) {
 
   callback = once(callback);
 
+  if (!isNodeStream(stream)) {
+    if (isReadableStream(stream)) {
+      stream = Readable.fromWeb(stream);
+    } else if (isWritableStream(stream)) {
+      stream = Writable.fromWeb(stream);
+    }
+  }
+
   const readable = options.readable ?? isReadableNodeStream(stream);
   const writable = options.writable ?? isWritableNodeStream(stream);
-
-  if (!isNodeStream(stream)) {
-    // TODO: Webstreams.
-    throw new ERR_INVALID_ARG_TYPE('stream', 'Stream', stream);
-  }
 
   const wState = stream._writableState;
   const rState = stream._readableState;

--- a/test/parallel/test-webstreams-finished.js
+++ b/test/parallel/test-webstreams-finished.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { ReadableStream, WritableStream } = require('stream/web');
+const { finished } = require('stream');
+
+{
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue('asd');
+    },
+  });
+  finished(rs, common.mustCall(() => {
+    
+  }));
+}


### PR DESCRIPTION
[Opening this PR as a draft to know if am on the right path and to get some comments]

I have been trying to implement the finished function to work on webstreams so far I am trying to use the adapters to convert the webstreams to streams but when trying to test it seems like 'end' event is not triggered for the readable stream that is created by the adapter function? could this be bug or am I doing something wrong?

Any help would be greatly appreciated and I will try to finish the full issue if get some clarity

Thank You in advance!

Refs: https://github.com/nodejs/node/issues/39316

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
