### PR TITLE
src: check size of args before using for exec_path

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -619,7 +619,7 @@ std::string GetExecPath(const std::vector<std::string>& argv) {
   std::string exec_path;
   if (uv_exepath(exec_path_buf, &exec_path_len) == 0) {
     exec_path = std::string(exec_path_buf, exec_path_len);
-  } else {
+  } else if (argv.size() > 0) {
     exec_path = argv[0];
   }
 


### PR DESCRIPTION
If we are in an artifically created Environment that has no args set, and uv_exepath returns an error (for instance, if /proc is not mounted on a Linux system), then we crash with a nullptr deref attempting to use argv[0].

Fixes: https://github.com/nodejs/node/issues/45901

This is already covered by multiple `cctest`s as noted in the above issue, so I wasn't sure if an explicit test was needed.  If so, I can add one.