### PR TITLE
src: distinguish env stopping flags

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -424,6 +424,9 @@ void FreeEnvironment(Environment* env) {
     Context::Scope context_scope(env->context());
     SealHandleScope seal_handle_scope(isolate);
 
+    // Set the flag in accordance with the DisallowJavascriptExecutionScope
+    // above.
+    env->set_can_call_into_js(false);
     env->set_stopping(true);
     env->stop_sub_worker_contexts();
     env->RunCleanup();

--- a/src/env.cc
+++ b/src/env.cc
@@ -910,10 +910,13 @@ void Environment::InitializeLibuv() {
 }
 
 void Environment::ExitEnv() {
-  set_can_call_into_js(false);
+  // Should not access non-thread-safe methods here.
   set_stopping(true);
   isolate_->TerminateExecution();
-  SetImmediateThreadsafe([](Environment* env) { uv_stop(env->event_loop()); });
+  SetImmediateThreadsafe([](Environment* env) {
+    env->set_can_call_into_js(false);
+    uv_stop(env->event_loop());
+  });
 }
 
 void Environment::RegisterHandleCleanups() {

--- a/src/env.h
+++ b/src/env.h
@@ -780,6 +780,7 @@ class Environment : public MemoryRetainer {
   void stop_sub_worker_contexts();
   template <typename Fn>
   inline void ForEachWorker(Fn&& iterator);
+  // Determine if the environment is stopping. This getter is thread-safe.
   inline bool is_stopping() const;
   inline void set_stopping(bool value);
   inline std::list<node_module>* extra_linked_bindings();

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1127,7 +1127,7 @@ int Http2Session::OnStreamClose(nghttp2_session* handle,
   // Don't close synchronously in case there's pending data to be written. This
   // may happen when writing trailing headers.
   if (code == NGHTTP2_NO_ERROR && nghttp2_session_want_write(handle) &&
-      !env->is_stopping()) {
+      env->can_call_into_js()) {
     env->SetImmediate([handle, id, code, user_data](Environment* env) {
       OnStreamClose(handle, id, code, user_data);
     });

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -609,7 +609,7 @@ void ReportWritesToJSStreamListener::OnStreamAfterReqFinished(
     StreamReq* req_wrap, int status) {
   StreamBase* stream = static_cast<StreamBase*>(stream_);
   Environment* env = stream->stream_env();
-  if (env->is_stopping()) return;
+  if (!env->can_call_into_js()) return;
   AsyncWrap* async_wrap = req_wrap->GetAsyncWrap();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());


### PR DESCRIPTION
Currently, `!env->can_call_into_js()` and `env->is_stopping()` have different semantics by their names. The `is_stopping()` flag implies `!env->can_call_into_js()`. 

However, this implication is not enforced in `Environment::FreeEnvironment`. `Environment::FreeEnvironment` creates a `DisallowJavascriptExecutionScope`, the flag `Environment::can_call_into_js()` needs to be set as `false`.

As `Environment::can_call_into_js_` is a simple boolean flag, it should not be accessed off-thread. This also fixes an issue that the flag `Environment::can_call_into_js_` is been modified in `Environment::ExitEnv`, which may be called from other threads.