### PR TITLE
src: update src/crypto/* in preparation for quic

### DIFF
--- a/src/crypto/crypto_common.cc
+++ b/src/crypto/crypto_common.cc
@@ -545,6 +545,16 @@ MaybeLocal<Value> GetKeyUsage(Environment* env, X509* cert) {
   return Undefined(env->isolate());
 }
 
+MaybeLocal<Value> GetCurrentCipherName(Environment* env,
+                                       const SSLPointer& ssl) {
+  return GetCipherName(env, SSL_get_current_cipher(ssl.get()));
+}
+
+MaybeLocal<Value> GetCurrentCipherVersion(Environment* env,
+                                          const SSLPointer& ssl) {
+  return GetCipherVersion(env, SSL_get_current_cipher(ssl.get()));
+}
+
 MaybeLocal<Value> GetFingerprintDigest(
     Environment* env,
     const EVP_MD* method,

--- a/src/crypto/crypto_common.h
+++ b/src/crypto/crypto_common.h
@@ -111,6 +111,10 @@ v8::MaybeLocal<v8::Value> GetFingerprintDigest(
     X509* cert);
 
 v8::MaybeLocal<v8::Value> GetKeyUsage(Environment* env, X509* cert);
+v8::MaybeLocal<v8::Value> GetCurrentCipherName(Environment* env,
+                                               const SSLPointer& ssl);
+v8::MaybeLocal<v8::Value> GetCurrentCipherVersion(Environment* env,
+                                                  const SSLPointer& ssl);
 
 v8::MaybeLocal<v8::Value> GetSerialNumber(Environment* env, X509* cert);
 

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -32,7 +32,10 @@ using v8::HandleScope;
 using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
+using v8::Just;
 using v8::Local;
+using v8::Maybe;
+using v8::Nothing;
 using v8::Object;
 using v8::PropertyAttribute;
 using v8::ReadOnly;
@@ -574,6 +577,22 @@ void SecureContext::SetKeylogCallback(KeylogCb cb) {
   SSL_CTX_set_keylog_callback(ctx_.get(), cb);
 }
 
+Maybe<bool> SecureContext::UseKey(Environment* env,
+                                  std::shared_ptr<KeyObjectData> key) {
+  if (key->GetKeyType() != KeyType::kKeyTypePrivate) {
+    THROW_ERR_CRYPTO_INVALID_KEYTYPE(env);
+    return Nothing<bool>();
+  }
+
+  ClearErrorOnReturn clear_error_on_return;
+  if (!SSL_CTX_use_PrivateKey(ctx_.get(), key->GetAsymmetricKey().get())) {
+    ThrowCryptoError(env, ERR_get_error(), "SSL_CTX_use_PrivateKey");
+    return Nothing<bool>();
+  }
+
+  return Just(true);
+}
+
 void SecureContext::SetKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -662,30 +681,47 @@ void SecureContext::SetEngineKey(const FunctionCallbackInfo<Value>& args) {
 }
 #endif  // !OPENSSL_NO_ENGINE
 
+Maybe<bool> SecureContext::AddCert(Environment* env, BIOPointer&& bio) {
+  ClearErrorOnReturn clear_error_on_return;
+  if (!bio) return Just(false);
+  cert_.reset();
+  issuer_.reset();
+
+  // The SSL_CTX_use_certificate_chain call here is not from openssl, this is
+  // the method implemented elsewhere in this file. The naming is a bit
+  // confusing, unfortunately.
+  if (SSL_CTX_use_certificate_chain(
+          ctx_.get(), std::move(bio), &cert_, &issuer_) == 0) {
+    ThrowCryptoError(env, ERR_get_error(), "SSL_CTX_use_certificate_chain");
+    return Nothing<bool>();
+  }
+  return Just(true);
+}
+
 void SecureContext::SetCert(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
 
-  CHECK_GE(args.Length(), 1);  // Certificate argument is mandator
+  CHECK_GE(args.Length(), 1);  // Certificate argument is mandatory
 
   BIOPointer bio(LoadBIO(env, args[0]));
-  if (!bio)
-    return;
+  USE(sc->AddCert(env, std::move(bio)));
+}
 
-  sc->cert_.reset();
-  sc->issuer_.reset();
-
-  if (!SSL_CTX_use_certificate_chain(
-          sc->ctx_.get(),
-          std::move(bio),
-          &sc->cert_,
-          &sc->issuer_)) {
-    return ThrowCryptoError(
-        env,
-        ERR_get_error(),
-        "SSL_CTX_use_certificate_chain");
+void SecureContext::SetCACert(const BIOPointer& bio) {
+  ClearErrorOnReturn clear_error_on_return;
+  if (!bio) return;
+  X509_STORE* cert_store = SSL_CTX_get_cert_store(ctx_.get());
+  while (X509Pointer x509 = X509Pointer(PEM_read_bio_X509_AUX(
+             bio.get(), nullptr, NoPasswordCallback, nullptr))) {
+    if (cert_store == GetOrCreateRootCertStore()) {
+      cert_store = NewRootCertStore();
+      SSL_CTX_set_cert_store(ctx_.get(), cert_store);
+    }
+    CHECK_EQ(1, X509_STORE_add_cert(cert_store, x509.get()));
+    CHECK_EQ(1, SSL_CTX_add_client_CA(ctx_.get(), x509.get()));
   }
 }
 
@@ -694,24 +730,36 @@ void SecureContext::AddCACert(const FunctionCallbackInfo<Value>& args) {
 
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
-  ClearErrorOnReturn clear_error_on_return;
 
   CHECK_GE(args.Length(), 1);  // CA certificate argument is mandatory
 
   BIOPointer bio(LoadBIO(env, args[0]));
-  if (!bio)
-    return;
+  sc->SetCACert(bio);
+}
 
-  X509_STORE* cert_store = SSL_CTX_get_cert_store(sc->ctx_.get());
-  while (X509Pointer x509 = X509Pointer(PEM_read_bio_X509_AUX(
-             bio.get(), nullptr, NoPasswordCallback, nullptr))) {
-    if (cert_store == GetOrCreateRootCertStore()) {
-      cert_store = NewRootCertStore();
-      SSL_CTX_set_cert_store(sc->ctx_.get(), cert_store);
-    }
-    X509_STORE_add_cert(cert_store, x509.get());
-    SSL_CTX_add_client_CA(sc->ctx_.get(), x509.get());
+Maybe<bool> SecureContext::SetCRL(Environment* env, const BIOPointer& bio) {
+  ClearErrorOnReturn clear_error_on_return;
+  if (!bio) return Just(false);
+
+  DeleteFnPtr<X509_CRL, X509_CRL_free> crl(
+      PEM_read_bio_X509_CRL(bio.get(), nullptr, NoPasswordCallback, nullptr));
+
+  if (!crl) {
+    THROW_ERR_CRYPTO_OPERATION_FAILED(env, "Failed to parse CRL");
+    return Nothing<bool>();
   }
+
+  X509_STORE* cert_store = SSL_CTX_get_cert_store(ctx_.get());
+  if (cert_store == GetOrCreateRootCertStore()) {
+    cert_store = NewRootCertStore();
+    SSL_CTX_set_cert_store(ctx_.get(), cert_store);
+  }
+
+  CHECK_EQ(1, X509_STORE_add_crl(cert_store, crl.get()));
+  CHECK_EQ(1,
+           X509_STORE_set_flags(
+               cert_store, X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL));
+  return Just(true);
 }
 
 void SecureContext::AddCRL(const FunctionCallbackInfo<Value>& args) {
@@ -722,37 +770,23 @@ void SecureContext::AddCRL(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_GE(args.Length(), 1);  // CRL argument is mandatory
 
-  ClearErrorOnReturn clear_error_on_return;
-
   BIOPointer bio(LoadBIO(env, args[0]));
-  if (!bio)
-    return;
+  USE(sc->SetCRL(env, bio));
+}
 
-  DeleteFnPtr<X509_CRL, X509_CRL_free> crl(
-      PEM_read_bio_X509_CRL(bio.get(), nullptr, NoPasswordCallback, nullptr));
+void SecureContext::SetRootCerts() {
+  ClearErrorOnReturn clear_error_on_return;
+  auto store = GetOrCreateRootCertStore();
 
-  if (!crl)
-    return THROW_ERR_CRYPTO_OPERATION_FAILED(env, "Failed to parse CRL");
-
-  X509_STORE* cert_store = SSL_CTX_get_cert_store(sc->ctx_.get());
-  if (cert_store == GetOrCreateRootCertStore()) {
-    cert_store = NewRootCertStore();
-    SSL_CTX_set_cert_store(sc->ctx_.get(), cert_store);
-  }
-
-  X509_STORE_add_crl(cert_store, crl.get());
-  X509_STORE_set_flags(cert_store,
-                       X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL);
+  // Increment reference count so global store is not deleted along with CTX.
+  X509_STORE_up_ref(store);
+  SSL_CTX_set_cert_store(ctx_.get(), store);
 }
 
 void SecureContext::AddRootCerts(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
-  ClearErrorOnReturn clear_error_on_return;
-  X509_STORE* store = GetOrCreateRootCertStore();
-  // Increment reference count so global store is not deleted along with CTX.
-  X509_STORE_up_ref(store);
-  SSL_CTX_set_cert_store(sc->ctx_.get(), store);
+  sc->SetRootCerts();
 }
 
 void SecureContext::SetCipherSuites(const FunctionCallbackInfo<Value>& args) {

--- a/src/crypto/crypto_context.h
+++ b/src/crypto/crypto_context.h
@@ -3,8 +3,9 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "crypto/crypto_util.h"
 #include "base_object.h"
+#include "crypto/crypto_keys.h"
+#include "crypto/crypto_util.h"
 #include "env.h"
 #include "memory_tracker.h"
 #include "v8.h"
@@ -43,12 +44,26 @@ class SecureContext final : public BaseObject {
 
   const SSLCtxPointer& ctx() const { return ctx_; }
 
+  // Non-const ctx() that allows for non-default initialization of
+  // the SecureContext.
+  SSLCtxPointer& ctx() { return ctx_; }
+
   SSLPointer CreateSSL();
 
   void SetGetSessionCallback(GetSessionCb cb);
   void SetKeylogCallback(KeylogCb cb);
   void SetNewSessionCallback(NewSessionCb cb);
   void SetSelectSNIContextCallback(SelectSNIContextCb cb);
+
+  inline const X509Pointer& issuer() const { return issuer_; }
+  inline const X509Pointer& cert() const { return cert_; }
+
+  v8::Maybe<bool> AddCert(Environment* env, BIOPointer&& bio);
+  v8::Maybe<bool> SetCRL(Environment* env, const BIOPointer& bio);
+  v8::Maybe<bool> UseKey(Environment* env, std::shared_ptr<KeyObjectData> key);
+
+  void SetCACert(const BIOPointer& bio);
+  void SetRootCerts();
 
   // TODO(joyeecheung): track the memory used by OpenSSL types
   SET_NO_MEMORY_INFO()

--- a/src/crypto/crypto_keys.h
+++ b/src/crypto/crypto_keys.h
@@ -163,6 +163,7 @@ class KeyObjectData : public MemoryRetainer {
 
 class KeyObjectHandle : public BaseObject {
  public:
+  static bool HasInstance(Environment* env, v8::Local<v8::Value> value);
   static v8::Local<v8::Function> Initialize(Environment* env);
   static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
 

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -332,6 +332,7 @@
   V(contextify_global_template, v8::ObjectTemplate)                            \
   V(contextify_wrapper_template, v8::ObjectTemplate)                           \
   V(compiled_fn_entry_template, v8::ObjectTemplate)                            \
+  V(crypto_key_object_handle_constructor, v8::FunctionTemplate)                \
   V(env_proxy_template, v8::ObjectTemplate)                                    \
   V(env_proxy_ctor_template, v8::FunctionTemplate)                             \
   V(dir_instance_template, v8::ObjectTemplate)                                 \
@@ -374,7 +375,6 @@
   V(async_hooks_promise_resolve_function, v8::Function)                        \
   V(buffer_prototype_object, v8::Object)                                       \
   V(crypto_key_object_constructor, v8::Function)                               \
-  V(crypto_key_object_handle_constructor, v8::Function)                        \
   V(crypto_key_object_private_constructor, v8::Function)                       \
   V(crypto_key_object_public_constructor, v8::Function)                        \
   V(crypto_key_object_secret_constructor, v8::Function)                        \


### PR DESCRIPTION
In preparation for use by the QUIC implementation, updates some pieces of `src/crypto`. These changes have been separated out of the larger quic PR (#44325) to make incremental review easier / possible.

/cc @bnoordhuis ... I've addressed the comments you had in #44325 here.