### PR TITLE
tools: add release host var to promotion script

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -827,6 +827,14 @@ or at runtime with:
 $ ./tools/release.sh -i ~/.ssh/node_id_rsa
 ```
 
+You can also specify a different ssh server address to connect to by defining
+a `NODEJS_RELEASE_HOST` environment variable:
+
+```console
+# Substitute proxy.xyz with whatever address you intend to use
+$ NODEJS_RELEASE_HOST=proxy.xyz ./tools/release.sh
+```
+
 `tools/release.sh` will perform the following actions when run:
 
 <details>

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -8,7 +8,9 @@
 
 set -e
 
-webhost=direct.nodejs.org
+[ -z "$NODEJS_RELEASE_HOST" ] && NODEJS_RELEASE_HOST=direct.nodejs.org
+
+webhost=$NODEJS_RELEASE_HOST
 webuser=dist
 promotablecmd=dist-promotable
 promotecmd=dist-promote


### PR DESCRIPTION
Adds a `NODEJS_RELEASE_HOST` environment variable that enable releasers to provide a custom proxy host to connect to when performing the promotion steps of a given release.

cc @nodejs/releasers 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
