### PR TITLE
fs: allow FileHandle to outlive ReadableStream

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -119,6 +119,13 @@ function close(stream, err, cb) {
   }
 }
 
+function closeWeakRef(ref) {
+  const stream = ref.deref();
+  if (stream) {
+    stream.close();
+  }
+}
+
 function importFd(stream, options) {
   if (typeof options.fd === 'number') {
     // When fd is a raw descriptor, we must keep our fingers crossed
@@ -137,7 +144,7 @@ function importFd(stream, options) {
     stream[kHandle] = options.fd;
     stream[kFs] = FileHandleOperations(stream[kHandle]);
     stream[kHandle][kRef]();
-    options.fd.on('close', FunctionPrototypeBind(stream.close, stream));
+    stream[kHandle].on('close', FunctionPrototypeBind(closeWeakRef, null, new WeakRef(stream)));
     return options.fd.fd;
   }
 

--- a/test/fixtures/stream-readable-leak.js
+++ b/test/fixtures/stream-readable-leak.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const { mustCall, mustNotCall } = require('../common');
+const { open } = require('node:fs/promises');
+const { setImmediate } = require('node:timers/promises');
+
+function getHugeVector() {
+  return new Array(1e5).fill(0).map((e, i) => i);
+}
+
+const registry = new FinalizationRegistry(() => {
+  process.exitCode = 0;
+  process.send(`success`);
+});
+
+async function run() {
+  process.exitCode = 1;
+
+  // Long-lived file handle. Ensure we keep a reference to it.
+  const fh = await open(__filename)
+  fh.on('close', mustNotCall())
+
+  const stream = fh.createReadStream({ autoClose: false })
+  // Keeping the file handle open shouldn't prevent the stream from being GCed.
+  registry.register(stream, `[GC] Collected readable ${fh.fd}`);
+
+  for await (const chunk of stream.iterator({ destroyOnReturn: false })) {
+    break
+  }
+
+  // Keep a reference to the file handle
+  return { fh };
+}
+
+async function forceGC() {
+  gc();
+  const hugeMatrix = [];
+  for (let i = 0; i < 0x40; i++) {
+    hugeMatrix.push(getHugeVector());
+    gc();
+    await setImmediate();
+  }
+}
+
+run().then(async function (result) {
+  await forceGC();
+});

--- a/test/fixtures/stream-readable-leak.js
+++ b/test/fixtures/stream-readable-leak.js
@@ -17,15 +17,15 @@ async function run() {
   process.exitCode = 1;
 
   // Long-lived file handle. Ensure we keep a reference to it.
-  const fh = await open(__filename)
-  fh.on('close', mustNotCall())
+  const fh = await open(__filename);
+  fh.on('close', mustNotCall());
 
-  const stream = fh.createReadStream({ autoClose: false })
+  const stream = fh.createReadStream({ autoClose: false });
   // Keeping the file handle open shouldn't prevent the stream from being GCed.
   registry.register(stream, `[GC] Collected readable ${fh.fd}`);
 
   for await (const chunk of stream.iterator({ destroyOnReturn: false })) {
-    break
+    break;
   }
 
   // Keep a reference to the file handle

--- a/test/parallel/test-stream-readable-fh-hold.js
+++ b/test/parallel/test-stream-readable-fh-hold.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { mustCall, mustNotCall } = require('../common');
+const { strictEqual, notStrictEqual } = require('assert');
+const fixtures = require('../common/fixtures');
+const { fork } = require('child_process');
+
+{
+  const cp = fork(fixtures.path('stream-readable-leak.js'), {
+    execArgv: ['--expose-gc', '--max-old-space-size=16', '--max-semi-space-size=2'],
+    silent: true,
+  });
+  cp.on('exit', mustCall((code, killSignal) => {
+    notStrictEqual(code, 1);
+    strictEqual(killSignal, null);
+  }));
+  cp.on('error', mustNotCall());
+  cp.on('message', mustCall(message => {
+    strictEqual(message, `success`);
+  }));
+}


### PR DESCRIPTION
Quoting @wolfgang42 at #45721 : 

> there's no way to only partially consume an fs.ReadStream created from a file handle without either closing the handle or leaking the stream.