### PR TITLE
lib: add deserialization callbacks for worker threads

### DIFF
--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -126,7 +126,9 @@ port.on('message', (message) => {
       require('internal/process/policy').setup(manifestSrc, manifestURL);
     }
     setupUserModules();
-
+  
+    require('internal/v8/startup_snapshot').runDeserializeCallbacks();
+  
     if (!hasStdin)
       process.stdin.push(null);
 

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -107,7 +107,6 @@ function prepareExecution(options) {
     // (including preload modules).
     initializeClusterIPC();
 
-    // TODO(joyeecheung): do this for worker threads as well.
     require('internal/v8/startup_snapshot').runDeserializeCallbacks();
   } else {
     assert(!internalBinding('worker').isMainThread);


### PR DESCRIPTION
Have attempted to call the `runDeserializeCallbacks()` in reference to `// TODO(joyeecheung): do this for worker threads as well.` 

cc @joyeecheung 

(I have a feeling there might be more work to this if yes any guidance would be appreciated)

Refs: https://github.com/nodejs/node/pull/44869

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
