### PR TITLE
net: handle socket.write(cb) edge case

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2573,6 +2573,13 @@ could not be determined.
 
 An attempt was made to operate on an already closed socket.
 
+<a id="ERR_SOCKET_CLOSED_BEFORE_CONNECTION"></a>
+
+### `ERR_SOCKET_CLOSED_BEFORE_CONNECTION`
+
+When calling [`net.Socket.write()`][] on a connecting socket and the socket was
+closed before the connection was established.
+
 <a id="ERR_SOCKET_DGRAM_IS_CONNECTED"></a>
 
 ### `ERR_SOCKET_DGRAM_IS_CONNECTED`
@@ -3586,6 +3593,7 @@ The native call from `process.cpuUsage` could not be processed.
 [`http`]: http.md
 [`https`]: https.md
 [`libuv Error handling`]: https://docs.libuv.org/en/v1.x/errors.html
+[`net.Socket.write()`]: net.md#socketwritedata-encoding-callback
 [`net`]: net.md
 [`new URL(input)`]: url.md#new-urlinput-base
 [`new URLSearchParams(iterable)`]: url.md#new-urlsearchparamsiterable

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1566,6 +1566,9 @@ E('ERR_SOCKET_BUFFER_SIZE',
   'Could not get or set buffer size',
   SystemError);
 E('ERR_SOCKET_CLOSED', 'Socket is closed', Error);
+E('ERR_SOCKET_CLOSED_BEFORE_CONNECTION',
+  'Socket closed before the connection was established',
+  Error);
 E('ERR_SOCKET_DGRAM_IS_CONNECTED', 'Already connected', Error);
 E('ERR_SOCKET_DGRAM_NOT_CONNECTED', 'Not connected', Error);
 E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running', Error);

--- a/lib/net.js
+++ b/lib/net.js
@@ -98,6 +98,7 @@ const {
     ERR_SERVER_ALREADY_LISTEN,
     ERR_SERVER_NOT_RUNNING,
     ERR_SOCKET_CLOSED,
+    ERR_SOCKET_CLOSED_BEFORE_CONNECTION,
     ERR_MISSING_ARGS,
   },
   aggregateErrors,
@@ -896,8 +897,13 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
     this._pendingData = data;
     this._pendingEncoding = encoding;
     this.once('connect', function connect() {
+      this.off('close', onClose);
       this._writeGeneric(writev, data, encoding, cb);
     });
+    function onClose() {
+      cb(new ERR_SOCKET_CLOSED_BEFORE_CONNECTION());
+    }
+    this.once('close', onClose);
     return;
   }
   this._pendingData = null;

--- a/test/parallel/test-net-write-cb-on-destroy-before-connect.js
+++ b/test/parallel/test-net-write-cb-on-destroy-before-connect.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const server = net.createServer();
+server.listen(0, common.mustCall(() => {
+  const socket = new net.Socket();
+
+  socket.on('connect', common.mustNotCall());
+
+  socket.connect({
+    port: server.address().port,
+  });
+
+  assert(socket.connecting);
+
+  socket.write('foo', common.expectsError({
+    code: 'ERR_SOCKET_CLOSED_BEFORE_CONNECTION',
+    name: 'Error'
+  }));
+
+  socket.destroy();
+  server.close();
+}));


### PR DESCRIPTION
Make sure that when calling `write()` on a connecting socket, the callback is called if the socket is destroyed before the connection is established.

Fixes: https://github.com/nodejs/node/issues/30841

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
