### PR TITLE
meta: update comment in `CODEOWNERS` to better reflect current policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,8 @@
 
 # 1. Codeowners must always be teams, never individuals
 # 2. Each codeowner team should contain at least one TSC member
-# 3. PRs touching any code with a codeowner must be signed off by at least one
-#    person on the code owner team.
+# 3. PRs touching any code with a codeowner must tag said owners and wait for an
+#    appropriate time to let them time to review the changes.
 
 # tsc
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Node.js Project Codeowners
 
-# 1. Codeowners must always be teams, never individuals
-# 2. Each codeowner team should contain at least one TSC member
-# 3. This file does not define any requirements for landing PRs.
-#    Its purpose is to allow automation of courtesy pings to the
-#    relevant team(s) when any of the paths listed here are modified.
-#    Criteria for landing PRs are defined in
-#    https://github.com/nodejs/node/blob/main/doc/contributing/collaborator-guide.md#code-reviews.
+# This file does not define any requirements for landing PRs.
+# Its purpose is to allow automation of courtesy pings to the
+# relevant team(s) when any of the paths listed here are modified.
+# Criteria for landing PRs are defined in
+# https://github.com/nodejs/node/blob/main/doc/contributing/collaborator-guide.md#code-reviews.
+#
+# Codeowners must always be teams, never individuals.
 
 # tsc
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,11 @@
 
 # 1. Codeowners must always be teams, never individuals
 # 2. Each codeowner team should contain at least one TSC member
-# 3. PRs touching any code with a codeowner must tag said owners and wait for an
-#    appropriate time to let them time to review the changes.
+# 3. This file does not define any requirements for landing PRs.
+#    Its purpose is to allow automation of courtesy pings to the
+#    relevant team(s) when any of the paths listed here are modified.
+#    Criteria for landing PRs are defined in
+#    https://github.com/nodejs/node/blob/main/doc/contributing/collaborator-guide.md#code-reviews.
 
 # tsc
 


### PR DESCRIPTION
We do not enforce signing off by any code owners when landing PRs.

We may want to take the opportunity to refine our policy regarding CODEOWNERS and what are the criteria to consider a PR ready to land. Currently, here are the criteria listed in the Collaborator Guide:

https://github.com/nodejs/node/blob/6831e2fb8814b3c1d7430471fc08dcb8543d4509/doc/contributing/collaborator-guide.md#L139-L147
https://github.com/nodejs/node/blob/6831e2fb8814b3c1d7430471fc08dcb8543d4509/doc/contributing/collaborator-guide.md#L122-L129

/cc @GeoffreyBooth @nodejs/tsc

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
