### PR TITLE
Revert "deps: disable avx512 for simutf on benchmark ci"

### DIFF
--- a/deps/simdutf/simdutf.gyp
+++ b/deps/simdutf/simdutf.gyp
@@ -1,9 +1,4 @@
 {
-  'variables': {
-    'gas_version%': '0.0',
-    'nasm_version%': '0.0',
-    'llvm_version%': '0.0',
-  },
   'targets': [
     {
       'target_name': 'simdutf',
@@ -13,16 +8,6 @@
         'include_dirs': ['.'],
       },
       'sources': ['simdutf.cpp'],
-      'conditions': [
-        ['OS=="linux"', {
-          'conditions': [
-            # TODO(anonrig): Remove this validation when benchmark CI has binutils >= 2.30
-            ['v(gas_version) < v("2.30") and v(nasm_version) < v("2.14") and v(llvm_version) < v("6.0")', {
-              'defines': ['SIMDUTF_IMPLEMENTATION_ICELAKE=0'],
-            }],
-          ],
-        }],
-      ],
     },
   ]
 }


### PR DESCRIPTION
This is no longer needed. Benchmark CI is now running Ubuntu 18.04. Referencing https://github.com/nodejs/build/pull/3122

CC @nodejs/build 