### PR TITLE
stream: allow transfer of readable byte streams

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -251,16 +251,15 @@ class ReadableStream {
         this,
         source,
         extractHighWaterMark(highWaterMark, 0));
-      return;
+    } else {
+      if (type !== undefined)
+        throw new ERR_INVALID_ARG_VALUE('source.type', type);
+      setupReadableStreamDefaultControllerFromSource(
+        this,
+        source,
+        extractHighWaterMark(highWaterMark, 1),
+        extractSizeAlgorithm(size));
     }
-
-    if (type !== undefined)
-      throw new ERR_INVALID_ARG_VALUE('source.type', type);
-    setupReadableStreamDefaultControllerFromSource(
-      this,
-      source,
-      extractHighWaterMark(highWaterMark, 1),
-      extractSizeAlgorithm(size));
 
     // eslint-disable-next-line no-constructor-return
     return makeTransferable(this);

--- a/test/parallel/test-whatwg-webstreams-transfer.js
+++ b/test/parallel/test-whatwg-webstreams-transfer.js
@@ -125,7 +125,7 @@ const theData = 'hello';
   const theByteData = new Uint8Array([1, 2, 3]);
 
   const readable = new ReadableStream({
-    type: "bytes",
+    type: 'bytes',
     start: common.mustCall((controller) => {
       // `enqueue` will detach its argument's buffer, so clone first
       controller.enqueue(theByteData.slice());

--- a/test/parallel/test-whatwg-webstreams-transfer.js
+++ b/test/parallel/test-whatwg-webstreams-transfer.js
@@ -15,6 +15,7 @@ const {
 
 const {
   isReadableStream,
+  isReadableByteStreamController,
 } = require('internal/webstreams/readablestream');
 
 const {
@@ -24,6 +25,10 @@ const {
 const {
   isTransformStream,
 } = require('internal/webstreams/transformstream');
+
+const {
+  kState,
+} = require('internal/webstreams/util');
 
 const {
   makeTransferable,
@@ -94,6 +99,56 @@ const theData = 'hello';
 
   port1.onmessage = common.mustCall(({ data }) => {
     assert(isReadableStream(data));
+    assert(!data.locked);
+    port1.postMessage(data, [data]);
+    assert(data.locked);
+  });
+
+  assert.throws(() => port2.postMessage(readable), {
+    code: 'ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST',
+  });
+
+  port2.postMessage(readable, [readable]);
+  assert(readable.locked);
+}
+
+{
+  const { port1, port2 } = new MessageChannel();
+  port1.onmessageerror = common.mustNotCall();
+  port2.onmessageerror = common.mustNotCall();
+
+  // This test repeats the test above, but with a readable byte stream.
+  // Note transferring a readable byte stream results in a regular
+  // value-oriented stream on the other side:
+  // https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable
+
+  const theByteData = new Uint8Array([1, 2, 3]);
+
+  const readable = new ReadableStream({
+    type: "bytes",
+    start: common.mustCall((controller) => {
+      // `enqueue` will detach its argument's buffer, so clone first
+      controller.enqueue(theByteData.slice());
+      controller.close();
+    }),
+  });
+  assert(isReadableByteStreamController(readable[kState].controller));
+
+  port2.onmessage = common.mustCall(({ data }) => {
+    assert(isReadableStream(data));
+    assert(!isReadableByteStreamController(data[kState].controller));
+
+    const reader = data.getReader();
+    reader.read().then(common.mustCall((chunk) => {
+      assert.deepStrictEqual(chunk, { done: false, value: theByteData });
+    }));
+
+    port2.close();
+  });
+
+  port1.onmessage = common.mustCall(({ data }) => {
+    assert(isReadableStream(data));
+    assert(!isReadableByteStreamController(data[kState].controller));
     assert(!data.locked);
     port1.postMessage(data, [data]);
     assert(data.locked);


### PR DESCRIPTION
Previosuly, attempting to transfer a `type: "bytes"` `ReadableStream` like so...

```js
const stream = new ReadableStream({
  type: "bytes",
  pull(controller) {
    controller.enqueue(new Uint8Array([1, 2, 3]));
    controller.close();
  },
});
const stream2 = structuredClone(stream, { transfer: [stream] });
```

...would fail with...

```
node:internal/structured_clone:23
  channel.port1.postMessage(value, options?.transfer);
                ^

TypeError: Found invalid object in transferList
    at structuredClone (node:internal/structured_clone:23:17)
    at file:///.../streams.mjs:8:17
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25) {
  code: 'ERR_INVALID_TRANSFER_OBJECT'
}

Node.js v19.3.0
```

This PR updates the `ReadableStream` constructor to mark byte streams as transferable. When transferred, byte streams become regular streams.

```js
const stream = new ReadableStream({
  type: "bytes",
  pull(controller) {
    controller.enqueue(new Uint8Array([1, 2, 3]));
    controller.close();
  },
});

const stream2 = structuredClone(stream, { transfer: [stream] });
const reader = await stream2.getReader(); // `{ mode: "byob" }` would fail here as
                                          // `stream2` is no longer a byte stream
```

_(tested with Chrome 108.0.5359.124)_

Refs: https://github.com/nodejs/node/pull/39062
Refs: https://streams.spec.whatwg.org/#rs-transfer

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
