### PR TITLE
test: print failed JS/parallel tests

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -29,6 +29,7 @@
 
 
 from __future__ import print_function
+from typing import Dict
 import logging
 import optparse
 import os
@@ -147,7 +148,7 @@ class ProgressIndicator(object):
     })
     print("Path: %s" % "/".join(test.path))
 
-  def Run(self, tasks) -> dict:
+  def Run(self, tasks) -> Dict:
     self.Starting()
     threads = []
     # Spawn N-1 threads and then use this thread as the last one.

--- a/tools/test.py
+++ b/tools/test.py
@@ -482,6 +482,7 @@ class CompactProgressIndicator(ProgressIndicator):
         print("--- %s ---" % PrintCrashed(output.output.exit_code))
       if output.HasTimedOut():
         print("--- TIMEOUT ---")
+      print("\n") # Two blank lines between failures, for visual separation
 
   def Truncate(self, str, length):
     if length and (len(str) > (length - 3)):
@@ -1779,9 +1780,9 @@ def Main():
       sys.stderr.write("%4i (%s) %s\n" % (i, t, entry.GetLabel()))
 
   if result['allPassed']:
-    print('All tests passed.')
+    print("\nAll tests passed.")
   else:
-    print('Failed tests:')
+    print("\nFailed tests:")
     for failedTest in result['failed']:
       print(EscapeCommand(failedTest.command))
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -147,7 +147,7 @@ class ProgressIndicator(object):
     })
     print("Path: %s" % "/".join(test.path))
 
-  def Run(self, tasks):
+  def Run(self, tasks) -> dict:
     self.Starting()
     threads = []
     # Spawn N-1 threads and then use this thread as the last one.

--- a/tools/test.py
+++ b/tools/test.py
@@ -1762,7 +1762,7 @@ def Main():
     try:
       start = time.time()
       result = RunTestCases(cases_to_run, options.progress, options.j, options.flaky_tests, options.measure_flakiness)
-      exitCode = 0 if result['allPassed'] else 1
+      exitcode = 0 if result['allPassed'] else 1
       duration = time.time() - start
     except KeyboardInterrupt:
       print("Interrupted")
@@ -1783,10 +1783,10 @@ def Main():
     print("\nAll tests passed.")
   else:
     print("\nFailed tests:")
-    for failedTest in result['failed']:
-      print(EscapeCommand(failedTest.command))
+    for failure in result['failed']:
+      print(EscapeCommand(failure.command))
 
-  return exitCode
+  return exitcode
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a small productivity improvement. When running `make test`, or specifically `make test-parallel` or `make jstest`, if there any failed JavaScript (or parallel-run) tests, the error output is printed but the only summary is a line like this:

```
[02:24|% 100|+ 3110|-   2]: Done
```

With this PR, in addition to the previous output the test runner will also print a list of the failed tests, like so:

```
[02:32|% 100|+ 3110|-   2]: Done
Failed tests:
out/Release/node --experimental-loader ./test/fixtures/es-module-loaders/loader-this-value-inside-hook-functions.mjs /node/test/parallel/test-loaders-this-value-inside-hook-functions.mjs
out/Release/node --experimental-loader ./test/fixtures/es-module-loaders/loader-unknown-builtin-module.mjs node/test/parallel/test-loaders-unknown-builtin-module.mjs
```

Again, this is _in addition_ to the current output; the present full output for each test is preserved.

My reasons for adding this:

- When there are many failing tests, it’s helpful to see a summary of all the failing tests to discern patterns of which groups of tests are failing. This cannot be done in the current output, where each failing test gets something like 10 to 100 lines of output.
- The summary of commands makes it quick to re-run particular failed tests.

cc @nodejs/testing @nodejs/test_runner @nodejs/python 