### PR TITLE
doc: add PerformanceObserver.supportedEntryTypes to doc

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -1179,6 +1179,20 @@ Returns a `object` that is the JSON representation of the
 
 ## Class: `PerformanceObserver`
 
+<!-- YAML
+added: v8.5.0
+-->
+
+### `PerformanceObserver.supportedEntryTypes`
+
+<!-- YAML
+added: v16.0.0
+-->
+
+* {string\[]}
+
+Get supported types.
+
 ### `new PerformanceObserver(callback)`
 
 <!-- YAML


### PR DESCRIPTION
add `PerformanceObserver.supportedEntryTypes` to doc.
cc @jasnell 

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
