### PR TITLE
test_runner: use os.availableParallelism()

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -53,7 +53,7 @@ const {
 } = require('internal/validators');
 const { setTimeout } = require('timers/promises');
 const { TIMEOUT_MAX } = require('internal/timers');
-const { cpus } = require('os');
+const { availableParallelism } = require('os');
 const { bigint: hrtime } = process.hrtime;
 const kCallbackAndPromisePresent = 'callbackAndPromisePresent';
 const kCancelledByParent = 'cancelledByParent';
@@ -216,8 +216,8 @@ class Test extends AsyncResource {
 
       case 'boolean':
         if (concurrency) {
-          // TODO(cjihrig): Use uv_available_parallelism() once it lands.
-          this.concurrency = parent === null ? MathMax(cpus().length - 1, 1) : Infinity;
+          this.concurrency = parent === null ?
+            MathMax(availableParallelism() - 1, 1) : Infinity;
         } else {
           this.concurrency = 1;
         }


### PR DESCRIPTION
This commit addresses an existing TODO in the code by moving to the new `os.availableParallelism()` instead of `os.cpus().length`.