### PR TITLE
deps: update to uvwasi 0.0.14

### DIFF
--- a/deps/uvwasi/include/uvwasi.h
+++ b/deps/uvwasi/include/uvwasi.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #define UVWASI_VERSION_MAJOR 0
 #define UVWASI_VERSION_MINOR 0
-#define UVWASI_VERSION_PATCH 13
+#define UVWASI_VERSION_PATCH 14
 #define UVWASI_VERSION_HEX ((UVWASI_VERSION_MAJOR << 16) | \
                             (UVWASI_VERSION_MINOR <<  8) | \
                             (UVWASI_VERSION_PATCH))

--- a/deps/uvwasi/src/debug.h
+++ b/deps/uvwasi/src/debug.h
@@ -6,8 +6,8 @@
 # define __STDC_FORMAT_MACROS
 #endif
 # include <inttypes.h>
-# define UVWASI_DEBUG(fmt, ...)                                                      \
-    do { fprintf(stderr, fmt, __VA_ARGS__); } while (0)
+# define UVWASI_DEBUG(...)                                                    \
+    do { fprintf(stderr, __VA_ARGS__); } while (0)
 #else
 # define UVWASI_DEBUG(fmt, ...)
 #endif

--- a/deps/uvwasi/src/uv_mapping.c
+++ b/deps/uvwasi/src/uv_mapping.c
@@ -251,8 +251,13 @@ uvwasi_errno_t uvwasi__get_filetype_by_fd(uv_file fd, uvwasi_filetype_t* type) {
   if (r != 0) {
     uv_fs_req_cleanup(&req);
 
-    /* Windows can't stat a TTY. */
-    if (uv_guess_handle(fd) == UV_TTY) {
+    uv_handle_type guess;
+    /*
+      Windows can't stat a FILE_TYPE_CHAR, which is guessed
+      as UV_TTY in "ConsoleMode" or UV_FILE otherwise.
+    */
+    guess = uv_guess_handle(fd);
+    if (guess == UV_TTY || guess == UV_FILE) {
       *type = UVWASI_FILETYPE_CHARACTER_DEVICE;
       return UVWASI_ESUCCESS;
     }


### PR DESCRIPTION
Notable changes:

- Windows applications not in ConsoleMode now properly guess handle types for `FILE_TYPE_CHAR` file types which cannot be stat'ed.
- The `UVWASI_DEBUG` macro can now be used without a format string.