### PR TITLE
doc: fix setter of `event.cancelBubble`

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1754,7 +1754,7 @@ This is not used in Node.js and is provided purely for completeness.
 added: v14.5.0
 -->
 
-* {boolean}
+* Type: {boolean}
 
 Alias for `event.stopPropagation()` if set to `true`. This is not used
 in Node.js and is provided purely for completeness.

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1748,15 +1748,15 @@ added: v14.5.0
 
 This is not used in Node.js and is provided purely for completeness.
 
-#### `event.cancelBubble(value)`
+#### `event.cancelBubble`
 
 <!-- YAML
 added: v14.5.0
 -->
 
-* `value` {boolean}
+* {boolean}
 
-Alias for `event.stopPropagation()` if `value` is `true`. This is not used
+Alias for `event.stopPropagation()` if set to `true`. This is not used
 in Node.js and is provided purely for completeness.
 
 #### `event.cancelable`

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1748,14 +1748,16 @@ added: v14.5.0
 
 This is not used in Node.js and is provided purely for completeness.
 
-#### `event.cancelBubble()`
+#### `event.cancelBubble(value)`
 
 <!-- YAML
 added: v14.5.0
 -->
 
-Alias for `event.stopPropagation()`. This is not used in Node.js and is
-provided purely for completeness.
+* `value` {boolean}
+
+Alias for `event.stopPropagation()` if `value` is `true`. This is not used
+in Node.js and is provided purely for completeness.
 
 #### `event.cancelable`
 

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -276,7 +276,7 @@ class Event {
   }
 
   /**
-   * @type {boolean}
+   * @param {boolean} value
    */
   set cancelBubble(value) {
     if (!isEvent(this))

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -276,7 +276,7 @@ class Event {
   }
 
   /**
-   * @param {boolean} value
+   * @type {boolean}
    */
   set cancelBubble(value) {
     if (!isEvent(this))


### PR DESCRIPTION
Setter of `event.cancelBubble` needs 1 argument(value). And event.cancelBubble() is working if value is true. But it's not described properly.

Refs: https://dom.spec.whatwg.org/#interface-event

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
