### PR TITLE
lib: support --watch use with --watch-path

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1623,7 +1623,7 @@ When in watch mode, changes in the watched files cause the Node.js process to
 restart.
 By default, watch mode will watch the entry point
 and any required or imported module.
-Use `--watch-path` to specify what paths to watch.
+Use `--watch-path` to specify extra paths to watch.
 
 This flag cannot be combined with
 `--check`, `--eval`, `--interactive`, or the REPL.
@@ -1645,8 +1645,6 @@ added:
 Starts Node.js in watch mode and specifies what paths to watch.
 When in watch mode, changes in the watched paths cause the Node.js process to
 restart.
-This will turn off watching of required or imported modules, even when used in
-combination with `--watch`.
 
 This flag cannot be combined with
 `--check`, `--eval`, `--interactive`, `--test`, or the REPL.

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -34,11 +34,11 @@ markBootstrapComplete();
 const kKillSignal = 'SIGTERM';
 const kWatchedPaths = ArrayPrototypeMap(getOptionValue('--watch-path'), (path) => resolve(path));
 const kPreserveOutput = getOptionValue('--watch-preserve-output');
-const kWatch = process.execArgv.some((arg) => arg === '--watch');
+const kWatch = ArrayPrototypeIncludes(process.execArgv, '--watch');
 const kCommand = ArrayPrototypeSlice(process.argv, 1);
 const kCommandStr = inspect(ArrayPrototypeJoin(kCommand, ' '));
 const args = ArrayPrototypeFilter(process.execArgv, (arg, i, arr) =>
-  !arg.startsWith('--watch-path') &&
+  !StringPrototypeStartsWith(arg, '--watch-path') &&
   arr[i - 1] !== '--watch-path' &&
   arg !== '--watch' &&
   arg !== '--watch-preserve-output'

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -32,9 +32,9 @@ markBootstrapComplete();
 
 // TODO(MoLow): Make kill signal configurable
 const kKillSignal = 'SIGTERM';
-const kShouldFilterModules = getOptionValue('--watch-path').length === 0;
 const kWatchedPaths = ArrayPrototypeMap(getOptionValue('--watch-path'), (path) => resolve(path));
 const kPreserveOutput = getOptionValue('--watch-preserve-output');
+const kWatch = process.execArgv.some((arg) => arg === '--watch');
 const kCommand = ArrayPrototypeSlice(process.argv, 1);
 const kCommandStr = inspect(ArrayPrototypeJoin(kCommand, ' '));
 const args = ArrayPrototypeFilter(process.execArgv, (arg, i, arr) =>
@@ -45,8 +45,8 @@ const args = ArrayPrototypeFilter(process.execArgv, (arg, i, arr) =>
 );
 ArrayPrototypePushApply(args, kCommand);
 
-const watcher = new FilesWatcher({ throttle: 500, mode: kShouldFilterModules ? 'filter' : 'all' });
-ArrayPrototypeForEach(kWatchedPaths, (p) => watcher.watchPath(p));
+const watcher = new FilesWatcher({ throttle: 500, mode: kWatch ? 'filter' : 'all' });
+ArrayPrototypeForEach(kWatchedPaths, (p) => watcher.filterFile(p, false));
 
 let graceTimer;
 let child;
@@ -54,7 +54,7 @@ let exited;
 
 function start() {
   exited = false;
-  const stdio = kShouldFilterModules ? ['inherit', 'inherit', 'inherit', 'ipc'] : undefined;
+  const stdio = kWatch ? ['inherit', 'inherit', 'inherit', 'ipc'] : undefined;
   child = spawn(process.execPath, args, { stdio, env: { ...process.env, WATCH_REPORT_DEPENDENCIES: '1' } });
   watcher.watchChildProcessModules(child);
   child.once('exit', (code) => {

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -38,7 +38,11 @@ const kPreserveOutput = getOptionValue('--watch-preserve-output');
 const kCommand = ArrayPrototypeSlice(process.argv, 1);
 const kCommandStr = inspect(ArrayPrototypeJoin(kCommand, ' '));
 const args = ArrayPrototypeFilter(process.execArgv, (arg, i, arr) =>
-  arg !== '--watch-path' && arr[i - 1] !== '--watch-path' && arg !== '--watch' && arg !== '--watch-preserve-output');
+  !arg.startsWith('--watch-path') &&
+  arr[i - 1] !== '--watch-path' &&
+  arg !== '--watch' &&
+  arg !== '--watch-preserve-output'
+);
 ArrayPrototypePushApply(args, kCommand);
 
 const watcher = new FilesWatcher({ throttle: 500, mode: kShouldFilterModules ? 'filter' : 'all' });

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -92,7 +92,8 @@ function reportGracefulTermination() {
   return () => {
     clearTimeout(graceTimer);
     if (reported) {
-      process.stdout.write(`${clear}${green}Gracefully restarted ${kCommandStr}${white}\n`);
+      if (!kPreserveOutput) process.stdout.write(clear);
+      process.stdout.write(`${green}Gracefully restarted ${kCommandStr}${white}\n`);
     }
   };
 }

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -123,6 +123,27 @@ describe('watch mode', { concurrency: false, timeout: 60_000 }, () => {
     });
   });
 
+  it('should watch change to entry point and the path in --watch-path', async () => {
+    const file = createTmpFile();
+    const otherFile = createTmpFile('console.log("Execution...")');
+
+    const { stderr, stdout } = await spawnWithRestarts({ file, args: ['--watch-path', otherFile, file] });
+
+    assert.strictEqual(stderr, '');
+    assertRestartedCorrectly({
+      stdout,
+      messages: { inner: 'running', restarted: `Restarting ${inspect(file)}`, completed: `Completed running ${inspect(file)}` },
+    });
+
+    const out = await spawnWithRestarts({ file, watchedfile: otherFile, args: ['--watch-path', otherFile, file] });
+
+    assert.strictEqual(out.stderr, '');
+    assertRestartedCorrectly({
+      stdout: out.stdout,
+      messages: { inner: 'running', restarted: `Restarting ${inspect(file)}`, completed: `Completed running ${inspect(file)}` },
+    });
+  });
+
   it('should watch changes to a failing file', async () => {
     const file = fixtures.path('watch-mode/failing.js');
     const { stderr, stdout } = await spawnWithRestarts({ file });


### PR DESCRIPTION
This patch is adding support for --watch-path when using --watch by adding the path passed to --watch-path in the filtered files instead of calling watchPath directly. 
So now the app will reload if the entry point or one of the dependency change, but also if one of the  --watch-path change.
The aim was to keep the current behavior of --watch-path when used alone.

It is also fixing the child arguments, now removing the  --watch-path=xxx from it.
It is also fixing a hardcoded clear that did not account for --watch-preserve-output.

Fixes: https://github.com/nodejs/node/issues/45467
