### PR TITLE
lib: use `kEmptyObject` as default value for options

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1013,7 +1013,7 @@ function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
  *   }} [options]
  * @returns {AsyncIterator}
  */
-function on(emitter, event, options = {}) {
+function on(emitter, event, options = kEmptyObject) {
   // Parameters validation
   const signal = options.signal;
   validateAbortSignal(signal, 'options.signal');

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -14,7 +14,10 @@ const {
     ERR_INVALID_ARG_VALUE,
   },
 } = require('internal/errors');
-const { createDeferredPromise } = require('internal/util');
+const {
+  createDeferredPromise,
+  kEmptyObject,
+} = require('internal/util');
 
 const {
   kFsStatsFieldsNumber,
@@ -296,7 +299,7 @@ ObjectDefineProperty(FSEvent.prototype, 'owner', {
   set(v) { return this[owner_symbol] = v; }
 });
 
-async function* watch(filename, options = {}) {
+async function* watch(filename, options = kEmptyObject) {
   const path = toNamespacedPath(getValidatedPath(filename));
   validateObject(options, 'options');
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3326,7 +3326,7 @@ function createSecureServer(options, handler) {
 function createServer(options, handler) {
   if (typeof options === 'function') {
     handler = options;
-    options = {};
+    options = kEmptyObject;
   }
   return new Http2Server(options, handler);
 }

--- a/lib/internal/socketaddress.js
+++ b/lib/internal/socketaddress.js
@@ -26,6 +26,7 @@ const {
 
 const {
   customInspectSymbol: kInspect,
+  kEmptyObject,
 } = require('internal/util');
 
 const { inspect } = require('internal/util/inspect');
@@ -44,7 +45,7 @@ class SocketAddress extends JSTransferable {
     return value?.[kHandle] !== undefined;
   }
 
-  constructor(options = {}) {
+  constructor(options = kEmptyObject) {
     super();
     validateObject(options, 'options');
     let { family = 'ipv4' } = options;

--- a/lib/net.js
+++ b/lib/net.js
@@ -108,6 +108,7 @@ const {
 } = require('internal/errors');
 const { isUint8Array } = require('internal/util/types');
 const { queueMicrotask } = require('internal/process/task_queues');
+const { kEmptyObject } = require('internal/util');
 const {
   validateAbortSignal,
   validateBoolean,
@@ -1584,7 +1585,7 @@ function Server(options, connectionListener) {
 
   if (typeof options === 'function') {
     connectionListener = options;
-    options = {};
+    options = kEmptyObject;
     this.on('connection', connectionListener);
   } else if (options == null || typeof options === 'object') {
     options = { ...options };


### PR DESCRIPTION
`kEmptyObject` is more suitable than {} if options don't need mutation.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
