### PR TITLE
trace_events: refactor to use `validateStringArray`

### DIFF
--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const {
-  ArrayIsArray,
   ArrayPrototypeJoin,
   SafeSet,
   Symbol,
@@ -17,7 +16,6 @@ const kMaxTracingCount = 10;
 const {
   ERR_TRACE_EVENTS_CATEGORY_REQUIRED,
   ERR_TRACE_EVENTS_UNAVAILABLE,
-  ERR_INVALID_ARG_TYPE
 } = require('internal/errors').codes;
 
 const { ownsProcessState } = require('internal/worker');
@@ -29,6 +27,7 @@ const { customInspectSymbol } = require('internal/util');
 const { format } = require('internal/util/inspect');
 const {
   validateObject,
+  validateStringArray,
 } = require('internal/validators');
 
 const enabledTracingObjects = new SafeSet();
@@ -84,11 +83,7 @@ class Tracing {
 
 function createTracing(options) {
   validateObject(options, 'options');
-
-  if (!ArrayIsArray(options.categories)) {
-    throw new ERR_INVALID_ARG_TYPE('options.categories', 'string[]',
-                                   options.categories);
-  }
+  validateStringArray(options.categories, 'options.categories');
 
   if (options.categories.length <= 0)
     throw new ERR_TRACE_EVENTS_CATEGORY_REQUIRED();


### PR DESCRIPTION
`options.categories` is string[]. So used `validateStringArray`
    
Refs: https://nodejs.org/dist/latest-v19.x/docs/api/tracing.html#trace_eventscreatetracingoptions

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
