### PR TITLE
src: speed up `process.getActiveResourcesInfo()`

### DIFF
--- a/benchmark/process/getActiveResourcesInfo.js
+++ b/benchmark/process/getActiveResourcesInfo.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const { createBenchmark } = require('../common.js');
+
+const { connect, createServer } = require('net');
+const { open } = require('fs');
+
+const bench = createBenchmark(main, {
+  handlesCount: [1e4],
+  requestsCount: [1e4],
+  timeoutsCount: [1e4],
+  immediatesCount: [1e4],
+  n: [1e5],
+});
+
+function main({ handlesCount, requestsCount, timeoutsCount, immediatesCount, n }) {
+  const server = createServer().listen();
+  const clients = [];
+  for (let i = 0; i < handlesCount; i++) {
+    clients.push(connect({ port: server.address().port }));
+  }
+
+  for (let i = 0; i < requestsCount; i++) {
+    open(__filename, 'r', () => {});
+  }
+
+  for (let i = 0; i < timeoutsCount; ++i) {
+    setTimeout(() => {}, 1);
+  }
+
+  for (let i = 0; i < immediatesCount; ++i) {
+    setImmediate(() => {});
+  }
+
+  bench.start();
+  for (let i = 0; i < n; ++i) {
+    process.getActiveResourcesInfo();
+  }
+  bench.end(n);
+
+  for (const client of clients) {
+    client.destroy();
+  }
+  server.close();
+}

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -55,9 +55,6 @@
 setupPrepareStackTrace();
 
 const {
-  Array,
-  ArrayPrototypeFill,
-  ArrayPrototypePushApply,
   FunctionPrototypeCall,
   JSONParse,
   Number,
@@ -171,15 +168,7 @@ const rawMethods = internalBinding('process_methods');
   // TODO(joyeecheung): either remove them or make them public
   process._getActiveRequests = rawMethods._getActiveRequests;
   process._getActiveHandles = rawMethods._getActiveHandles;
-
-  process.getActiveResourcesInfo = function() {
-    const timerCounts = internalTimers.getTimerCounts();
-    const info = rawMethods._getActiveRequestsInfo();
-    ArrayPrototypePushApply(info, rawMethods._getActiveHandlesInfo());
-    ArrayPrototypePushApply(info, ArrayPrototypeFill(new Array(timerCounts.timeoutCount), 'Timeout'));
-    ArrayPrototypePushApply(info, ArrayPrototypeFill(new Array(timerCounts.immediateCount), 'Immediate'));
-    return info;
-  };
+  process.getActiveResourcesInfo = rawMethods.getActiveResourcesInfo;
 
   // TODO(joyeecheung): remove these
   process.reallyExit = rawMethods.reallyExit;

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -141,7 +141,7 @@ let nextExpiry = Infinity;
 // timeoutInfo is an Int32Array that contains the reference count of Timeout
 // objects at index 0. This is a TypedArray so that GetActiveResourcesInfo() in
 // `src/node_process_methods.cc` is able to access this value without crossing
-// the JS-C++ boundary, which is currently slow.
+// the JS-C++ boundary, which is slow at the time of writing.
 timeoutInfo[0] = 0;
 
 // This is a priority queue with a custom sorting function that first compares

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -87,6 +87,7 @@ const {
   toggleTimerRef,
   getLibuvNow,
   immediateInfo,
+  timeoutInfo,
   toggleImmediateRef
 } = internalBinding('timers');
 
@@ -137,7 +138,7 @@ let timerListId = NumberMIN_SAFE_INTEGER;
 const kRefed = Symbol('refed');
 
 let nextExpiry = Infinity;
-let refCount = 0;
+timeoutInfo[0] = 0;
 
 // This is a priority queue with a custom sorting function that first compares
 // the expiry times of two lists and if they're the same then compares their
@@ -302,12 +303,12 @@ class ImmediateList {
 const immediateQueue = new ImmediateList();
 
 function incRefCount() {
-  if (refCount++ === 0)
+  if (timeoutInfo[0]++ === 0)
     toggleTimerRef(true);
 }
 
 function decRefCount() {
-  if (--refCount === 0)
+  if (--timeoutInfo[0] === 0)
     toggleTimerRef(false);
 }
 
@@ -498,7 +499,7 @@ function getTimerCallbacks(runNextTicks) {
     while ((list = timerListQueue.peek()) != null) {
       if (list.expiry > now) {
         nextExpiry = list.expiry;
-        return refCount > 0 ? nextExpiry : -nextExpiry;
+        return timeoutInfo[0] > 0 ? nextExpiry : -nextExpiry;
       }
       if (ranAtLeastOneList)
         runNextTicks();
@@ -544,7 +545,7 @@ function getTimerCallbacks(runNextTicks) {
           timer._destroyed = true;
 
           if (timer[kRefed])
-            refCount--;
+            timeoutInfo[0]--;
 
           if (destroyHooksExist())
             emitDestroy(asyncId);
@@ -572,7 +573,7 @@ function getTimerCallbacks(runNextTicks) {
           timer._destroyed = true;
 
           if (timer[kRefed])
-            refCount--;
+            timeoutInfo[0]--;
 
           if (destroyHooksExist())
             emitDestroy(asyncId);
@@ -643,13 +644,6 @@ class Immediate {
   }
 }
 
-function getTimerCounts() {
-  return {
-    timeoutCount: refCount,
-    immediateCount: immediateInfo[kRefCount],
-  };
-}
-
 module.exports = {
   TIMEOUT_MAX,
   kTimeout: Symbol('timeout'), // For hiding Timeouts on other internals.
@@ -676,5 +670,4 @@ module.exports = {
   timerListQueue,
   decRefCount,
   incRefCount,
-  getTimerCounts,
 };

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -138,6 +138,10 @@ let timerListId = NumberMIN_SAFE_INTEGER;
 const kRefed = Symbol('refed');
 
 let nextExpiry = Infinity;
+// timeoutInfo is an Int32Array that contains the reference count of Timeout
+// objects at index 0. This is a TypedArray so that GetActiveResourcesInfo() in
+// `src/node_process_methods.cc` is able to access this value without crossing
+// the JS-C++ boundary, which is currently slow.
 timeoutInfo[0] = 0;
 
 // This is a priority queue with a custom sorting function that first compares

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -323,6 +323,10 @@ inline ImmediateInfo* Environment::immediate_info() {
   return &immediate_info_;
 }
 
+inline AliasedInt32Array& Environment::timeout_info() {
+  return timeout_info_;
+}
+
 inline TickInfo* Environment::tick_info() {
   return &tick_info_;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -650,6 +650,7 @@ Environment::Environment(IsolateData* isolate_data,
       isolate_data_(isolate_data),
       async_hooks_(isolate, MAYBE_FIELD_PTR(env_info, async_hooks)),
       immediate_info_(isolate, MAYBE_FIELD_PTR(env_info, immediate_info)),
+      timeout_info_(isolate_, 1, MAYBE_FIELD_PTR(env_info, timeout_info)),
       tick_info_(isolate, MAYBE_FIELD_PTR(env_info, tick_info)),
       timer_base_(uv_now(isolate_data->event_loop())),
       exec_argv_(exec_args),
@@ -1607,6 +1608,7 @@ EnvSerializeInfo Environment::Serialize(SnapshotCreator* creator) {
 
   info.async_hooks = async_hooks_.Serialize(ctx, creator);
   info.immediate_info = immediate_info_.Serialize(ctx, creator);
+  info.timeout_info = timeout_info_.Serialize(ctx, creator);
   info.tick_info = tick_info_.Serialize(ctx, creator);
   info.performance_state = performance_state_->Serialize(ctx, creator);
   info.exit_info = exit_info_.Serialize(ctx, creator);
@@ -1653,6 +1655,7 @@ void Environment::DeserializeProperties(const EnvSerializeInfo* info) {
   builtins_in_snapshot = info->builtins;
   async_hooks_.Deserialize(ctx);
   immediate_info_.Deserialize(ctx);
+  timeout_info_.Deserialize(ctx);
   tick_info_.Deserialize(ctx);
   performance_state_->Deserialize(ctx);
   exit_info_.Deserialize(ctx);
@@ -1852,6 +1855,7 @@ void Environment::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("cleanup_queue", cleanup_queue_);
   tracker->TrackField("async_hooks", async_hooks_);
   tracker->TrackField("immediate_info", immediate_info_);
+  tracker->TrackField("timeout_info", timeout_info_);
   tracker->TrackField("tick_info", tick_info_);
   tracker->TrackField("principal_realm", principal_realm_);
 

--- a/src/env.h
+++ b/src/env.h
@@ -461,6 +461,7 @@ struct EnvSerializeInfo {
   AsyncHooks::SerializeInfo async_hooks;
   TickInfo::SerializeInfo tick_info;
   ImmediateInfo::SerializeInfo immediate_info;
+  AliasedBufferIndex timeout_info;
   performance::PerformanceState::SerializeInfo performance_state;
   AliasedBufferIndex exit_info;
   AliasedBufferIndex stream_base_state;
@@ -672,6 +673,7 @@ class Environment : public MemoryRetainer {
 
   inline AsyncHooks* async_hooks();
   inline ImmediateInfo* immediate_info();
+  inline AliasedInt32Array& timeout_info();
   inline TickInfo* tick_info();
   inline uint64_t timer_base() const;
   inline std::shared_ptr<KVStore> env_vars();
@@ -1010,6 +1012,7 @@ class Environment : public MemoryRetainer {
 
   AsyncHooks async_hooks_;
   ImmediateInfo immediate_info_;
+  AliasedInt32Array timeout_info_;
   TickInfo tick_info_;
   const uint64_t timer_base_;
   std::shared_ptr<KVStore> env_vars_;

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -120,6 +120,7 @@ std::ostream& operator<<(std::ostream& output, const EnvSerializeInfo& i) {
          << "// -- async_hooks ends --\n"
          << i.tick_info << ",  // tick_info\n"
          << i.immediate_info << ",  // immediate_info\n"
+         << i.timeout_info << ",  // timeout_info\n"
          << "// -- performance_state begins --\n"
          << i.performance_state << ",\n"
          << "// -- performance_state ends --\n"
@@ -734,6 +735,7 @@ EnvSerializeInfo FileReader::Read() {
   result.async_hooks = Read<AsyncHooks::SerializeInfo>();
   result.tick_info = Read<TickInfo::SerializeInfo>();
   result.immediate_info = Read<ImmediateInfo::SerializeInfo>();
+  result.timeout_info = Read<AliasedBufferIndex>();
   result.performance_state =
       Read<performance::PerformanceState::SerializeInfo>();
   result.exit_info = Read<AliasedBufferIndex>();
@@ -755,6 +757,7 @@ size_t FileWriter::Write(const EnvSerializeInfo& data) {
   written_total += Write<AsyncHooks::SerializeInfo>(data.async_hooks);
   written_total += Write<TickInfo::SerializeInfo>(data.tick_info);
   written_total += Write<ImmediateInfo::SerializeInfo>(data.immediate_info);
+  written_total += Write<AliasedBufferIndex>(data.timeout_info);
   written_total += Write<performance::PerformanceState::SerializeInfo>(
       data.performance_state);
   written_total += Write<AliasedBufferIndex>(data.exit_info);

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -59,6 +59,12 @@ void Initialize(Local<Object> target,
             FIXED_ONE_BYTE_STRING(env->isolate(), "immediateInfo"),
             env->immediate_info()->fields().GetJSArray())
       .Check();
+
+  target
+      ->Set(context,
+            FIXED_ONE_BYTE_STRING(env->isolate(), "timeoutInfo"),
+            env->timeout_info().GetJSArray())
+      .Check();
 }
 }  // anonymous namespace
 void RegisterTimerExternalReferences(ExternalReferenceRegistry* registry) {


### PR DESCRIPTION
This change reduces the number of calls that were crossing the JS-C++ boundary to 1 and also removes the need for calling `Array::New()` multiple times internally and `ArrayPrototypeConcat`-ing the results later on, thus improving performance by **75%**!

Refs: https://github.com/nodejs/node/pull/44445#pullrequestreview-1220052837
Signed-off-by: Darshan Sen <raisinten@gmail.com>

---

* [`process.getActiveResourcesInfo()` benchmark result](https://ci.nodejs.org/job/benchmark-node-micro-benchmarks/1280): 75% improvement
* [`timers` benchmark result](https://ci.nodejs.org/job/benchmark-node-micro-benchmarks/1281): no noticeable deterioration

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
