### PR TITLE
esm: rewrite loader hooks test

### DIFF
--- a/test/fixtures/es-module-loaders/hooks-input.mjs
+++ b/test/fixtures/es-module-loaders/hooks-input.mjs
@@ -1,0 +1,92 @@
+// This is expected to be used by test-esm-loader-hooks.mjs via:
+// node --loader ./test/fixtures/es-module-loaders/hooks-input.mjs ./test/fixtures/es-modules/json-modules.mjs
+
+import assert from 'assert';
+import { write } from 'fs';
+import { readFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+
+
+let resolveCalls = 0;
+let loadCalls = 0;
+
+export async function resolve(specifier, context, next) {
+  resolveCalls++;
+  let url;
+
+  if (resolveCalls === 1) {
+    url = new URL(specifier).href;
+    assert.match(specifier, /json-modules\.mjs$/);
+    assert.deepStrictEqual(context.parentURL, undefined);
+    assert.deepStrictEqual(context.importAssertions, {
+      __proto__: null,
+    });
+  } else if (resolveCalls === 2) {
+    url = new URL(specifier, context.parentURL).href;
+    assert.match(specifier, /experimental\.json$/);
+    assert.match(context.parentURL, /json-modules\.mjs$/);
+    assert.deepStrictEqual(context.importAssertions, {
+      __proto__: null,
+      type: 'json',
+    });
+  }
+
+  // Ensure `context` has all and only the properties it's supposed to
+  assert.deepStrictEqual(Object.keys(context), [
+    'conditions',
+    'importAssertions',
+    'parentURL',
+  ]);
+  assert.ok(Array.isArray(context.conditions));
+  assert.deepStrictEqual(typeof next, 'function');
+
+  const returnValue = {
+    url,
+    format: 'test',
+    shortCircuit: true,
+  }
+
+  await new Promise(resolve => write(1, `${JSON.stringify(returnValue)}\n`, resolve)); // For the test to read
+
+  return returnValue;
+}
+
+export async function load(url, context, next) {
+  loadCalls++;
+  const source = await readFile(fileURLToPath(url));
+  let format;
+
+  if (loadCalls === 1) {
+    assert.match(url, /json-modules\.mjs$/);
+    assert.deepStrictEqual(context.importAssertions, {
+      __proto__: null,
+    });
+    format = 'module';
+  } else if (loadCalls === 2) {
+    assert.match(url, /experimental\.json$/);
+    assert.deepStrictEqual(context.importAssertions, {
+      __proto__: null,
+      type: 'json',
+    });
+    format = 'json';
+  }
+
+  assert.ok(new URL(url));
+  // Ensure `context` has all and only the properties it's supposed to
+  assert.deepStrictEqual(Object.keys(context), [
+    'format',
+    'importAssertions',
+  ]);
+  assert.deepStrictEqual(context.format, 'test');
+  assert.deepStrictEqual(typeof next, 'function');
+
+  const returnValue = {
+    source,
+    format,
+    shortCircuit: true,
+  };
+
+  await new Promise(resolve => write(1, `${JSON.stringify(returnValue)}\n`, resolve)); // For the test to read
+
+  return returnValue;
+}

--- a/test/fixtures/es-module-loaders/hooks-input.mjs
+++ b/test/fixtures/es-module-loaders/hooks-input.mjs
@@ -2,7 +2,6 @@
 // node --loader ./test/fixtures/es-module-loaders/hooks-input.mjs ./test/fixtures/es-modules/json-modules.mjs
 
 import assert from 'assert';
-import { write } from 'fs';
 import { readFile } from 'fs/promises';
 import { fileURLToPath } from 'url';
 
@@ -46,7 +45,7 @@ export async function resolve(specifier, context, next) {
     shortCircuit: true,
   }
 
-  await new Promise(resolve => write(1, `${JSON.stringify(returnValue)}\n`, resolve)); // For the test to read
+  console.log(JSON.stringify(returnValue)); // For the test to validate when it parses stdout
 
   return returnValue;
 }
@@ -86,7 +85,7 @@ export async function load(url, context, next) {
     shortCircuit: true,
   };
 
-  await new Promise(resolve => write(1, `${JSON.stringify(returnValue)}\n`, resolve)); // For the test to read
+  console.log(JSON.stringify(returnValue)); // For the test to validate when it parses stdout
 
   return returnValue;
 }

--- a/test/fixtures/es-module-loaders/hooks-input.mjs
+++ b/test/fixtures/es-module-loaders/hooks-input.mjs
@@ -17,7 +17,7 @@ export async function resolve(specifier, context, next) {
   if (resolveCalls === 1) {
     url = new URL(specifier).href;
     assert.match(specifier, /json-modules\.mjs$/);
-    assert.deepStrictEqual(context.parentURL, undefined);
+    assert.strictEqual(context.parentURL, undefined);
     assert.deepStrictEqual(context.importAssertions, {
       __proto__: null,
     });
@@ -32,13 +32,13 @@ export async function resolve(specifier, context, next) {
   }
 
   // Ensure `context` has all and only the properties it's supposed to
-  assert.deepStrictEqual(Object.keys(context), [
+  assert.deepStrictEqual(Reflect.ownKeys(context), [
     'conditions',
     'importAssertions',
     'parentURL',
   ]);
   assert.ok(Array.isArray(context.conditions));
-  assert.deepStrictEqual(typeof next, 'function');
+  assert.strictEqual(typeof next, 'function');
 
   const returnValue = {
     url,
@@ -77,8 +77,8 @@ export async function load(url, context, next) {
     'format',
     'importAssertions',
   ]);
-  assert.deepStrictEqual(context.format, 'test');
-  assert.deepStrictEqual(typeof next, 'function');
+  assert.strictEqual(context.format, 'test');
+  assert.strictEqual(typeof next, 'function');
 
   const returnValue = {
     source,


### PR DESCRIPTION
This is a spinoff from #44710. As part of that work, I needed to rewrite this test to no longer depend on internals and invoke `ESMLoader` directly; instead it spawns a `node` child process like most of the other loaders tests. The same result is confirmed, and this version of the test is less coupled to internal implementation details. I’m opening this as a standalone PR to confirm that this test passes for pre-refactor loaders code too, and to reduce the diff in the off-thread PR.

@nodejs/loaders @nodejs/modules @nodejs/testing 