### PR TITLE
events: validate options of `on` and `once`

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -81,6 +81,7 @@ const {
   validateBoolean,
   validateFunction,
   validateNumber,
+  validateObject,
   validateString,
 } = require('internal/validators');
 
@@ -960,6 +961,7 @@ function getMaxListeners(emitterOrTarget) {
  * @returns {Promise}
  */
 async function once(emitter, name, options = kEmptyObject) {
+  validateObject(options, 'options');
   const signal = options?.signal;
   validateAbortSignal(signal, 'options.signal');
   if (signal?.aborted)
@@ -1047,6 +1049,7 @@ function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
  */
 function on(emitter, event, options = kEmptyObject) {
   // Parameters validation
+  validateObject(options, 'options');
   const signal = options.signal;
   validateAbortSignal(signal, 'options.signal');
   if (signal?.aborted)

--- a/test/parallel/test-events-on-async-iterator.js
+++ b/test/parallel/test-events-on-async-iterator.js
@@ -43,7 +43,7 @@ async function invalidArgType() {
 
   const ee = new EventEmitter();
 
-  [1, 'hi', null, false].map((options) => {
+  [1, 'hi', null, false, () => {}, Symbol(), 1n].map((options) => {
     return assert.throws(() => on(ee, 'foo', options), common.expectsError({
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',

--- a/test/parallel/test-events-on-async-iterator.js
+++ b/test/parallel/test-events-on-async-iterator.js
@@ -40,6 +40,15 @@ async function invalidArgType() {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
   }));
+
+  const ee = new EventEmitter();
+
+  [1, 'hi', null, false].map((options) => {
+    return assert.throws(() => on(ee, 'foo', options), common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+    }));
+  });
 }
 
 async function error() {

--- a/test/parallel/test-events-once.js
+++ b/test/parallel/test-events-once.js
@@ -4,10 +4,10 @@
 const common = require('../common');
 const { once, EventEmitter } = require('events');
 const {
-  strictEqual,
   deepStrictEqual,
   fail,
   rejects,
+  strictEqual,
 } = require('assert');
 const { kEvents } = require('internal/event_target');
 
@@ -24,17 +24,15 @@ async function onceAnEvent() {
   strictEqual(ee.listenerCount('myevent'), 0);
 }
 
-async function onceAnEventWithNullOptions() {
+async function onceAnEventWithInvalidOptions() {
   const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
-
-  const [value] = await once(ee, 'myevent', null);
-  strictEqual(value, 42);
+  await Promise.all([1, 'hi', null, false].map((options) => {
+    return rejects(once(ee, 'myevent', options), {
+      code: 'ERR_INVALID_ARG_TYPE',
+    });
+  }));
 }
-
 
 async function onceAnEventWithTwoArgs() {
   const ee = new EventEmitter();
@@ -267,7 +265,7 @@ async function eventTargetAbortSignalAfterEvent() {
 
 Promise.all([
   onceAnEvent(),
-  onceAnEventWithNullOptions(),
+  onceAnEventWithInvalidOptions(),
   onceAnEventWithTwoArgs(),
   catchesErrors(),
   catchesErrorsWithAbortSignal(),

--- a/test/parallel/test-events-once.js
+++ b/test/parallel/test-events-once.js
@@ -27,7 +27,7 @@ async function onceAnEvent() {
 async function onceAnEventWithInvalidOptions() {
   const ee = new EventEmitter();
 
-  await Promise.all([1, 'hi', null, false].map((options) => {
+  await Promise.all([1, 'hi', null, false, () => {}, Symbol(), 1n].map((options) => {
     return rejects(once(ee, 'myevent', options), {
       code: 'ERR_INVALID_ARG_TYPE',
     });


### PR DESCRIPTION
Check whether options is object or not to avoid passing invalid type as options to `on` and `once`.

Refs: https://nodejs.org/dist/latest-v19.x/docs/api/events.html#eventsonceemitter-name-options

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
