### PR TITLE
dgram: sync the old handle state to new handle

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -184,7 +184,10 @@ function startListening(socket) {
 function replaceHandle(self, newHandle) {
   const state = self[kStateSymbol];
   const oldHandle = state.handle;
-
+  // Sync the old handle state to new handle
+  if (!oldHandle.hasRef() && typeof newHandle.unref === 'function') {
+    newHandle.unref();
+  }
   // Set up the handle that we got from primary.
   newHandle.lookup = oldHandle.lookup;
   newHandle.bind = oldHandle.bind;

--- a/test/parallel/test-dgram-unref-in-cluster.js
+++ b/test/parallel/test-dgram-unref-in-cluster.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const dgram = require('dgram');
+const cluster = require('cluster');
+const assert = require('assert');
+
+if (common.isWindows)
+  common.skip('dgram clustering is currently not supported on Windows.');
+
+if (cluster.isPrimary) {
+  cluster.fork();
+} else {
+  const socket = dgram.createSocket('udp4');
+  socket.unref();
+  socket.bind();
+  socket.on('listening', common.mustCall(() => {
+    const sockets = process.getActiveResourcesInfo().filter((item) => {
+      return item === 'UDPWrap';
+    });
+    assert.ok(sockets.length === 0);
+    process.disconnect();
+  }));
+}


### PR DESCRIPTION
Sync the old handle state to new handle Or the unref UDP socket will keep the loop alive.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
