### PR TITLE
crypto: add CryptoKey Symbol.toStringTag

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -7,6 +7,7 @@ const {
   ObjectDefineProperties,
   ObjectSetPrototypeOf,
   Symbol,
+  SymbolToStringTag,
   Uint8Array,
 } = primordials;
 
@@ -687,6 +688,11 @@ ObjectDefineProperties(CryptoKey.prototype, {
   extractable: kEnumerableProperty,
   algorithm: kEnumerableProperty,
   usages: kEnumerableProperty,
+  [SymbolToStringTag]: {
+    __proto__: null,
+    configurable: true,
+    value: 'CryptoKey',
+  },
 });
 
 // All internal code must use new InternalCryptoKey to create

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -277,6 +277,8 @@ const vectors = {
 
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(privateKey.type, 'private');
+    assert.strictEqual(publicKey.toString(), '[object CryptoKey]');
+    assert.strictEqual(privateKey.toString(), '[object CryptoKey]');
     assert.strictEqual(publicKey.extractable, true);
     assert.strictEqual(privateKey.extractable, true);
     assert.deepStrictEqual(publicKey.usages, publicUsages);
@@ -439,6 +441,8 @@ const vectors = {
 
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(privateKey.type, 'private');
+    assert.strictEqual(publicKey.toString(), '[object CryptoKey]');
+    assert.strictEqual(privateKey.toString(), '[object CryptoKey]');
     assert.strictEqual(publicKey.extractable, true);
     assert.strictEqual(privateKey.extractable, true);
     assert.deepStrictEqual(publicKey.usages, publicUsages);
@@ -503,6 +507,7 @@ const vectors = {
     assert(isCryptoKey(key));
 
     assert.strictEqual(key.type, 'secret');
+    assert.strictEqual(key.toString(), '[object CryptoKey]');
     assert.strictEqual(key.extractable, true);
     assert.deepStrictEqual(key.usages, usages);
     assert.strictEqual(key.algorithm.name, name);
@@ -562,6 +567,7 @@ const vectors = {
     assert(isCryptoKey(key));
 
     assert.strictEqual(key.type, 'secret');
+    assert.strictEqual(key.toString(), '[object CryptoKey]');
     assert.strictEqual(key.extractable, true);
     assert.deepStrictEqual(key.usages, usages);
     assert.strictEqual(key.algorithm.name, 'HMAC');
@@ -629,6 +635,8 @@ assert.throws(() => new CryptoKey(), { code: 'ERR_ILLEGAL_CONSTRUCTOR' });
 
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(privateKey.type, 'private');
+    assert.strictEqual(publicKey.toString(), '[object CryptoKey]');
+    assert.strictEqual(privateKey.toString(), '[object CryptoKey]');
     assert.strictEqual(publicKey.extractable, true);
     assert.strictEqual(privateKey.extractable, true);
     assert.deepStrictEqual(publicKey.usages, publicUsages);


### PR DESCRIPTION
Adds `Symbol.toStringTag` getter to CryptoKey to match other implementations behaviour.

Fixes: https://github.com/nodejs/node/issues/45987