### PR TITLE
tools, lib: fix console intrinsic freezing

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -153,7 +153,7 @@ rules:
     - name: clearTimeout
       message: Use `const { clearTimeout } = require('timers');` instead of the global.
     - name: console
-      message: Use `const { console } = require('internal/console/global');` instead of the global.
+      message: Use `const console = require('internal/console/global');` instead of the global.
     - name: crypto
       message: Use `const { crypto } = require('internal/crypto/webcrypto');` instead of the global.
     - name: Crypto

--- a/lib/internal/freeze_intrinsics.js
+++ b/lib/internal/freeze_intrinsics.js
@@ -135,7 +135,7 @@ const {
 
 module.exports = function() {
   const { Console } = require('internal/console/constructor');
-  const { console } = require('internal/console/global');
+  const console = require('internal/console/global');
   const {
     clearImmediate,
     clearInterval,

--- a/test/parallel/test-freeze-intrinsics.js
+++ b/test/parallel/test-freeze-intrinsics.js
@@ -37,3 +37,12 @@ assert.throws(
                 { name: 'TypeError' });
   assert.strictEqual(globalThis.globalThis, globalThis);
 }
+
+// Ensure that we cannot override console properties.
+{
+  const { log } = console;
+
+  assert.throws(() => { console.log = null; },
+                { name: 'TypeError' });
+  assert.strictEqual(console.log, log);
+}


### PR DESCRIPTION
##### tools: fix lint rule recommendation

The lint rule recommends destructuring `console` out of the
`internal/console/global.js` export. However, that does not
exist. The top level export is actually the `console` object.

##### lib: fix incorrect use of `console` intrinsic

The `console` object was not being frozen because the intrinsic
freezing code was accessing `undefined` instead of the `console`
object.