### PR TITLE
events: check signal before listener

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -561,6 +561,8 @@ class EventTarget {
       weak,
     } = validateEventListenerOptions(options);
 
+    validateAbortSignal(signal, 'options.signal');
+
     if (!validateEventListener(listener)) {
       // The DOM silently allows passing undefined as a second argument
       // No error code for this since it is a Warning
@@ -574,8 +576,6 @@ class EventTarget {
       return;
     }
     type = String(type);
-
-    validateAbortSignal(signal, 'options.signal');
 
     if (signal) {
       if (signal.aborted) {

--- a/test/wpt/status/dom/events.json
+++ b/test/wpt/status/dom/events.json
@@ -8,13 +8,6 @@
       ]
     }
   },
-  "AddEventListenerOptions-signal.any.js": {
-    "fail": {
-      "expected": [
-        "Passing null as the signal should throw (listener is also null)"
-      ]
-    }
-  },
   "Event-constructors.any.js": {
     "fail": {
       "expected": [


### PR DESCRIPTION
In WPT Events, TypeError is expected if both listener and signal are null. But checking listener doesn't throw TypeError. So check signal before listener because checking signal throws TypeError if signal is null.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
