### PR TITLE
buffer: faster case for compare two empty buffers

### DIFF
--- a/benchmark/buffers/buffer-compare-zero.js
+++ b/benchmark/buffers/buffer-compare-zero.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  millions: [1]
+});
+
+function main(conf) {
+  const iter = (conf.millions >>> 0) * 1e6;
+  const b0 = Buffer.alloc(0);
+  const b1 = Buffer.alloc(0);
+
+  bench.start();
+  for (let i = 0; i < iter; i++) {
+    Buffer.compare(b0, b1);
+  }
+  bench.end(iter / 1e6);
+}

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -527,6 +527,10 @@ Buffer.compare = function compare(buf1, buf2) {
     return 0;
   }
 
+  if (buf1.length === 0 && buf2.length === 0) {
+    return 0;
+  }
+
   return _compare(buf1, buf2);
 };
 


### PR DESCRIPTION
This patch can improve ~2x speed for the edge case

before:
buffers/buffer-compare-zero.js millions=1: 21.366342109793383

after:
buffers/buffer-compare-zero.js millions=1: 48.002975416428214

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
