### PR TITLE
test,esm: validate more edge cases for dynamic imports

### DIFF
--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
-describe('Loader hooks', () => {
+describe('Loader hooks', { concurrency: true }, () => {
   it('are called with all expected arguments', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
@@ -22,5 +22,89 @@ describe('Loader hooks', () => {
     assert.match(lines[1], /{"source":{"type":"Buffer","data":\[.*\]},"format":"module","shortCircuit":true}/);
     assert.match(lines[2], /{"url":"file:\/\/\/.*\/experimental\.json","format":"test","shortCircuit":true}/);
     assert.match(lines[3], /{"source":{"type":"Buffer","data":\[.*\]},"format":"json","shortCircuit":true}/);
+  });
+
+  it('should be able to handle never resolving dynamic imports (ESM entry point)', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+      fixtures.path('es-module-loaders/never-settling-resolve-step/never-resolve.mjs'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.match(stdout, /^should be output\r?\n$/);
+    assert.strictEqual(code, 13);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should be able to handle never resolving dynamic imports (CJS entry point)', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+      fixtures.path('es-module-loaders/never-settling-resolve-step/never-resolve.cjs'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.match(stdout, /^should be output\r?\n$/);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should be able to handle never loading dynamic imports (ESM entry point)', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+      fixtures.path('es-module-loaders/never-settling-resolve-step/never-load.mjs'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.match(stdout, /^should be output\r?\n$/);
+    assert.strictEqual(code, 13);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should be able to handle never loading dynamic imports (CJS entry point)', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+      fixtures.path('es-module-loaders/never-settling-resolve-step/never-load.cjs'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.match(stdout, /^should be output\r?\n$/);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should be able to handle race of never settling dynamic imports (ESM entry point)', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+      fixtures.path('es-module-loaders/never-settling-resolve-step/race.mjs'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.match(stdout, /^true\r?\n$/);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should be able to handle race of never settling dynamic imports (CJS entry point)', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+      fixtures.path('es-module-loaders/never-settling-resolve-step/race.cjs'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.match(stdout, /^true\r?\n$/);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
   });
 });

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -24,87 +24,93 @@ describe('Loader hooks', { concurrency: true }, () => {
     assert.match(lines[3], /{"source":{"type":"Buffer","data":\[.*\]},"format":"json","shortCircuit":true}/);
   });
 
-  it('should be able to handle never resolving dynamic imports (ESM entry point)', async () => {
-    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      '--experimental-loader',
-      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
-      fixtures.path('es-module-loaders/never-settling-resolve-step/never-resolve.mjs'),
-    ]);
+  describe('should handle never-settling hooks in ESM files', { concurrency: true }, () => {
+    it('top-level await of a never-settling resolve', async () => {
+      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+        '--no-warnings',
+        '--experimental-loader',
+        fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+        fixtures.path('es-module-loaders/never-settling-resolve-step/never-resolve.mjs'),
+      ]);
 
-    assert.strictEqual(stderr, '');
-    assert.match(stdout, /^should be output\r?\n$/);
-    assert.strictEqual(code, 13);
-    assert.strictEqual(signal, null);
+      assert.strictEqual(stderr, '');
+      assert.match(stdout, /^should be output\r?\n$/);
+      assert.strictEqual(code, 13);
+      assert.strictEqual(signal, null);
+    });
+
+    it('top-level await of a never-settling load', async () => {
+      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+        '--no-warnings',
+        '--experimental-loader',
+        fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+        fixtures.path('es-module-loaders/never-settling-resolve-step/never-load.mjs'),
+      ]);
+
+      assert.strictEqual(stderr, '');
+      assert.match(stdout, /^should be output\r?\n$/);
+      assert.strictEqual(code, 13);
+      assert.strictEqual(signal, null);
+    });
+
+
+    it('top-level await of a race of never-settling hooks', async () => {
+      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+        '--no-warnings',
+        '--experimental-loader',
+        fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+        fixtures.path('es-module-loaders/never-settling-resolve-step/race.mjs'),
+      ]);
+
+      assert.strictEqual(stderr, '');
+      assert.match(stdout, /^true\r?\n$/);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(signal, null);
+    });
   });
 
-  it('should be able to handle never resolving dynamic imports (CJS entry point)', async () => {
-    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      '--experimental-loader',
-      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
-      fixtures.path('es-module-loaders/never-settling-resolve-step/never-resolve.cjs'),
-    ]);
+  describe('should handle never-settling hooks in CJS files', { concurrency: true }, () => {
+    it('never-settling resolve', async () => {
+      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+        '--no-warnings',
+        '--experimental-loader',
+        fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+        fixtures.path('es-module-loaders/never-settling-resolve-step/never-resolve.cjs'),
+      ]);
 
-    assert.strictEqual(stderr, '');
-    assert.match(stdout, /^should be output\r?\n$/);
-    assert.strictEqual(code, 0);
-    assert.strictEqual(signal, null);
-  });
+      assert.strictEqual(stderr, '');
+      assert.match(stdout, /^should be output\r?\n$/);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(signal, null);
+    });
 
-  it('should be able to handle never loading dynamic imports (ESM entry point)', async () => {
-    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      '--experimental-loader',
-      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
-      fixtures.path('es-module-loaders/never-settling-resolve-step/never-load.mjs'),
-    ]);
 
-    assert.strictEqual(stderr, '');
-    assert.match(stdout, /^should be output\r?\n$/);
-    assert.strictEqual(code, 13);
-    assert.strictEqual(signal, null);
-  });
+    it('never-settling load', async () => {
+      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+        '--no-warnings',
+        '--experimental-loader',
+        fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+        fixtures.path('es-module-loaders/never-settling-resolve-step/never-load.cjs'),
+      ]);
 
-  it('should be able to handle never loading dynamic imports (CJS entry point)', async () => {
-    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      '--experimental-loader',
-      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
-      fixtures.path('es-module-loaders/never-settling-resolve-step/never-load.cjs'),
-    ]);
+      assert.strictEqual(stderr, '');
+      assert.match(stdout, /^should be output\r?\n$/);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(signal, null);
+    });
 
-    assert.strictEqual(stderr, '');
-    assert.match(stdout, /^should be output\r?\n$/);
-    assert.strictEqual(code, 0);
-    assert.strictEqual(signal, null);
-  });
+    it('race of never-settling hooks', async () => {
+      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+        '--no-warnings',
+        '--experimental-loader',
+        fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+        fixtures.path('es-module-loaders/never-settling-resolve-step/race.cjs'),
+      ]);
 
-  it('should be able to handle race of never settling dynamic imports (ESM entry point)', async () => {
-    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      '--experimental-loader',
-      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
-      fixtures.path('es-module-loaders/never-settling-resolve-step/race.mjs'),
-    ]);
-
-    assert.strictEqual(stderr, '');
-    assert.match(stdout, /^true\r?\n$/);
-    assert.strictEqual(code, 0);
-    assert.strictEqual(signal, null);
-  });
-
-  it('should be able to handle race of never settling dynamic imports (CJS entry point)', async () => {
-    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      '--experimental-loader',
-      fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
-      fixtures.path('es-module-loaders/never-settling-resolve-step/race.cjs'),
-    ]);
-
-    assert.strictEqual(stderr, '');
-    assert.match(stdout, /^true\r?\n$/);
-    assert.strictEqual(code, 0);
-    assert.strictEqual(signal, null);
+      assert.strictEqual(stderr, '');
+      assert.match(stdout, /^true\r?\n$/);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(signal, null);
+    });
   });
 });

--- a/test/fixtures/es-module-loaders/never-settling-resolve-step/loader.mjs
+++ b/test/fixtures/es-module-loaders/never-settling-resolve-step/loader.mjs
@@ -1,0 +1,10 @@
+export function resolve(specifier, context, next) {
+    if (specifier === 'never-settle-resolve') return new Promise(() => {});
+    if (specifier === 'never-settle-load') return { __proto__: null, shortCircuit: true, url: 'never-settle:///' };
+    return next(specifier, context);
+}
+
+export function load(url, context, next) {
+    if (url === 'never-settle:///') return new Promise(() => {});
+    return next(url, context);
+}

--- a/test/fixtures/es-module-loaders/never-settling-resolve-step/never-load.cjs
+++ b/test/fixtures/es-module-loaders/never-settling-resolve-step/never-load.cjs
@@ -1,0 +1,7 @@
+'use strict';
+
+const neverSettlingDynamicImport = import('never-settle-load');
+
+console.log('should be output');
+
+neverSettlingDynamicImport.then(() => process.exit(1));

--- a/test/fixtures/es-module-loaders/never-settling-resolve-step/never-load.mjs
+++ b/test/fixtures/es-module-loaders/never-settling-resolve-step/never-load.mjs
@@ -1,0 +1,5 @@
+const neverSettlingDynamicImport = import('never-settle-load');
+
+console.log('should be output');
+
+await neverSettlingDynamicImport;

--- a/test/fixtures/es-module-loaders/never-settling-resolve-step/never-resolve.cjs
+++ b/test/fixtures/es-module-loaders/never-settling-resolve-step/never-resolve.cjs
@@ -1,0 +1,7 @@
+'use strict';
+
+const neverSettlingDynamicImport = import('never-settle-resolve');
+
+console.log('should be output');
+
+neverSettlingDynamicImport.then(() => process.exit(1));

--- a/test/fixtures/es-module-loaders/never-settling-resolve-step/never-resolve.mjs
+++ b/test/fixtures/es-module-loaders/never-settling-resolve-step/never-resolve.mjs
@@ -1,0 +1,5 @@
+const neverSettlingDynamicImport = import('never-settle-resolve');
+
+console.log('should be output');
+
+await neverSettlingDynamicImport;

--- a/test/fixtures/es-module-loaders/never-settling-resolve-step/race.cjs
+++ b/test/fixtures/es-module-loaders/never-settling-resolve-step/race.cjs
@@ -1,0 +1,7 @@
+'use strict';
+
+Promise.race([
+    import('never-settle-resolve'),
+    import('never-settle-load'),
+    import('node:process'),
+]).then(result => console.log(result.default === process));

--- a/test/fixtures/es-module-loaders/never-settling-resolve-step/race.mjs
+++ b/test/fixtures/es-module-loaders/never-settling-resolve-step/race.mjs
@@ -1,0 +1,7 @@
+const result = await Promise.race([
+    import('never-settle-resolve'),
+    import('never-settle-load'),
+    import('node:process'),
+]);
+
+console.log(result.default === process);


### PR DESCRIPTION
@nodejs/loaders this is relevant to the off-threading discussions, the idea is to make sure that using dynamic import doesn't break the expected order of operations if the main thread is being frozen.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
