### PR TITLE
src: Keep `PipeWrap::Open` function consistent with TCPWrap

### DIFF
--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -217,10 +217,9 @@ void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
   if (!args[0]->Int32Value(env->context()).To(&fd)) return;
 
   int err = uv_pipe_open(&wrap->handle_, fd);
-  wrap->set_fd(fd);
+  if (err == 0) wrap->set_fd(fd);
 
-  if (err != 0)
-    env->ThrowUVException(err, "uv_pipe_open");
+  args.GetReturnValue().Set(err);
 }
 
 


### PR DESCRIPTION
Keep `PipeWrap::Open` function consistent with TCPWrap.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
