### PR TITLE
doc,crypto: fix WebCryptoAPI import keyData and export return

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -710,7 +710,7 @@ changes:
 
 * `format`: {string} Must be one of `'raw'`, `'pkcs8'`, `'spki'`, or `'jwk'`.
 * `key`: {CryptoKey}
-* Returns: {Promise} containing {ArrayBuffer}.
+* Returns: {Promise} containing {ArrayBuffer|Object}.
 
 Exports the given key into the specified format, if supported.
 
@@ -799,7 +799,7 @@ changes:
 -->
 
 * `format`: {string} Must be one of `'raw'`, `'pkcs8'`, `'spki'`, or `'jwk'`.
-* `keyData`: {ArrayBuffer|TypedArray|DataView|Buffer|KeyObject}
+* `keyData`: {ArrayBuffer|TypedArray|DataView|Buffer|Object}
 
 <!--lint disable maximum-line-length remark-lint-->
 


### PR DESCRIPTION
On the `exportKey` function an `Object` resolve is possible when `keyFormat` is `jwk`.

On the `importKey` function the `KeyObject` option was removed in #43310 and the `Object` option is missing and possible when the `keyFormat` is `jwk`.