### PR TITLE
doc: allow strings in StringDecoder methods

### DIFF
--- a/doc/api/string_decoder.md
+++ b/doc/api/string_decoder.md
@@ -63,8 +63,8 @@ Creates a new `StringDecoder` instance.
 added: v0.9.3
 -->
 
-* `buffer` {Buffer|TypedArray|DataView} A `Buffer`, or `TypedArray`, or
-  `DataView` containing the bytes to decode.
+* `buffer` {string|Buffer|TypedArray|DataView} A `string`, `Buffer`,
+  `TypedArray`, or `DataView` containing the bytes to decode.
 * Returns: {string}
 
 Returns any remaining input stored in the internal buffer as a string. Bytes
@@ -86,8 +86,8 @@ changes:
                  character instead of one for each individual byte.
 -->
 
-* `buffer` {Buffer|TypedArray|DataView} A `Buffer`, or `TypedArray`, or
-  `DataView` containing the bytes to decode.
+* `buffer` {string|Buffer|TypedArray|DataView} A `string`, `Buffer`,
+  `TypedArray`, or `DataView` containing the bytes to decode.
 * Returns: {string}
 
 Returns a decoded string, ensuring that any incomplete multibyte characters at

--- a/doc/api/string_decoder.md
+++ b/doc/api/string_decoder.md
@@ -63,8 +63,8 @@ Creates a new `StringDecoder` instance.
 added: v0.9.3
 -->
 
-* `buffer` {string|Buffer|TypedArray|DataView} A `string`, `Buffer`,
-  `TypedArray`, or `DataView` containing the bytes to decode.
+* `buffer` {Buffer|TypedArray|DataView} A `Buffer`, `TypedArray`,
+  or `DataView` containing the bytes to decode.
 * Returns: {string}
 
 Returns any remaining input stored in the internal buffer as a string. Bytes
@@ -72,8 +72,9 @@ representing incomplete UTF-8 and UTF-16 characters will be replaced with
 substitution characters appropriate for the character encoding.
 
 If the `buffer` argument is provided, one final call to `stringDecoder.write()`
-is performed before returning the remaining input.
-After `end()` is called, the `stringDecoder` object can be reused for new input.
+is performed before returning the remaining input. If the `buffer` is a
+`string`, then the `string` is returned as-is. After `end()` is called, the
+`stringDecoder` object can be reused for new input.
 
 ### `stringDecoder.write(buffer)`
 
@@ -86,13 +87,15 @@ changes:
                  character instead of one for each individual byte.
 -->
 
-* `buffer` {string|Buffer|TypedArray|DataView} A `string`, `Buffer`,
-  `TypedArray`, or `DataView` containing the bytes to decode.
+* `buffer` {Buffer|TypedArray|DataView} A `Buffer`, `TypedArray`, or `DataView`
+  containing the bytes to decode.
 * Returns: {string}
 
 Returns a decoded string, ensuring that any incomplete multibyte characters at
 the end of the `Buffer`, or `TypedArray`, or `DataView` are omitted from the
 returned string and stored in an internal buffer for the next call to
-`stringDecoder.write()` or `stringDecoder.end()`.
+`stringDecoder.write()` or `stringDecoder.end()`. When a `string` buffer is
+passed into the function, the string is returned as-is without any special
+logic.
 
 [encoding]: buffer.md#buffers-and-character-encodings


### PR DESCRIPTION
The `StringDecoder#end()` and `StringDecoder#write()` functions did not include the `string` type as one of the acceptable types for the buffer argument. However, the JSDoc in the codebase states that `string` is allowed. Found by @ThatOneBro

See the following lines of code to validate the JSDoc in the codebase:

- https://github.com/nodejs/node/blob/main/lib/string_decoder.js#L94
- https://github.com/nodejs/node/blob/main/lib/string_decoder.js#L116

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
