### PR TITLE
lib: improve performance of readable webstreams

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -260,7 +260,9 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
     } else if (chunk instanceof Buffer) {
       encoding = '';
     } else if (Stream._isUint8Array(chunk)) {
-      chunk = Stream._uint8ArrayToBuffer(chunk);
+      if (!state.decoder) {
+        chunk = Stream._uint8ArrayToBuffer(chunk);
+      }
       encoding = '';
     } else if (chunk != null) {
       err = new ERR_INVALID_ARG_TYPE(


### PR DESCRIPTION
I couldn't verify this with the existing `webstreams` benchmarks. Opening in case somebody points me to the exact benchmark and/or provides one.

Referencing: https://github.com/oven-sh/bun/pull/1708