### PR TITLE
lib: reuse invalid state errors on webstreams

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -54,6 +54,7 @@ const {
   isArrayBufferDetached,
   kEmptyObject,
   kEnumerableProperty,
+  SideEffectFreeRegExpPrototypeSymbolReplace,
 } = require('internal/util');
 
 const {
@@ -139,6 +140,32 @@ const kChunk = Symbol('kChunk');
 const kError = Symbol('kError');
 const kPull = Symbol('kPull');
 const kRelease = Symbol('kRelease');
+
+let releasedError;
+let releasingError;
+
+const userModuleRegExp = /^ {4}at (?:[^/\\(]+ \()(?!node:(.+):\d+:\d+\)$).*/gm;
+
+function lazyReadableReleasedError() {
+  if (releasedError) {
+    return releasedError;
+  }
+
+  releasedError = new ERR_INVALID_STATE.TypeError('Reader released');
+  // Avoid V8 leak and remove userland stackstrace
+  releasedError.stack = SideEffectFreeRegExpPrototypeSymbolReplace(userModuleRegExp, releasedError.stack, '');
+  return releasedError;
+}
+
+function lazyReadableReleasingError() {
+  if (releasingError) {
+    return releasingError;
+  }
+  releasingError = new ERR_INVALID_STATE.TypeError('Releasing reader');
+  // Avoid V8 leak and remove userland stackstrace
+  releasingError.stack = SideEffectFreeRegExpPrototypeSymbolReplace(userModuleRegExp, releasingError.stack, '');
+  return releasingError;
+}
 
 const getNonWritablePropertyDescriptor = (value) => {
   return {
@@ -2029,7 +2056,7 @@ function readableStreamDefaultReaderRelease(reader) {
   readableStreamReaderGenericRelease(reader);
   readableStreamDefaultReaderErrorReadRequests(
     reader,
-    new ERR_INVALID_STATE.TypeError('Releasing reader')
+    lazyReadableReleasingError(),
   );
 }
 
@@ -2044,7 +2071,7 @@ function readableStreamBYOBReaderRelease(reader) {
   readableStreamReaderGenericRelease(reader);
   readableStreamBYOBReaderErrorReadIntoRequests(
     reader,
-    new ERR_INVALID_STATE.TypeError('Releasing reader')
+    lazyReadableReleasingError(),
   );
 }
 
@@ -2062,13 +2089,12 @@ function readableStreamReaderGenericRelease(reader) {
   assert(stream !== undefined);
   assert(stream[kState].reader === reader);
 
+  const releasedStateError = lazyReadableReleasedError();
   if (stream[kState].state === 'readable') {
-    reader[kState].close.reject?.(
-      new ERR_INVALID_STATE.TypeError('Reader released'));
+    reader[kState].close.reject?.(releasedStateError);
   } else {
     reader[kState].close = {
-      promise: PromiseReject(
-        new ERR_INVALID_STATE.TypeError('Reader released')),
+      promise: PromiseReject(releasedStateError),
       resolve: undefined,
       reject: undefined,
     };

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -34,6 +34,7 @@ const {
   createDeferredPromise,
   customInspectSymbol: kInspect,
   kEnumerableProperty,
+  SideEffectFreeRegExpPrototypeSymbolReplace,
 } = require('internal/util');
 
 const {
@@ -76,6 +77,20 @@ const assert = require('internal/assert');
 const kAbort = Symbol('kAbort');
 const kCloseSentinel = Symbol('kCloseSentinel');
 const kError = Symbol('kError');
+
+let releasedError;
+
+function lazyWritableReleasedError() {
+  if (releasedError) {
+    return releasedError;
+  }
+  const userModuleRegExp = /^ {4}at (?:[^/\\(]+ \()(?!node:(.+):\d+:\d+\)$).*/gm;
+
+  releasedError = new ERR_INVALID_STATE.TypeError('Writer has been released');
+  // Avoid V8 leak and remove userland stackstrace
+  releasedError.stack = SideEffectFreeRegExpPrototypeSymbolReplace(userModuleRegExp, releasedError.stack, '');
+  return releasedError;
+}
 
 const getNonWritablePropertyDescriptor = (value) => {
   return {
@@ -970,10 +985,9 @@ function writableStreamDefaultWriterRelease(writer) {
   } = writer[kState];
   assert(stream !== undefined);
   assert(stream[kState].writer === writer);
-  const releasedError =
-    new ERR_INVALID_STATE.TypeError('Writer has been released');
-  writableStreamDefaultWriterEnsureReadyPromiseRejected(writer, releasedError);
-  writableStreamDefaultWriterEnsureClosedPromiseRejected(writer, releasedError);
+  const releasedStateError = lazyWritableReleasedError();
+  writableStreamDefaultWriterEnsureReadyPromiseRejected(writer, releasedStateError);
+  writableStreamDefaultWriterEnsureClosedPromiseRejected(writer, releasedStateError);
   stream[kState].writer = undefined;
   writer[kState].stream = undefined;
 }


### PR DESCRIPTION
We are tracking internally the webstreams performance and after some investigation (https://github.com/nodejs/undici/issues/1203, https://github.com/nodejs/performance/issues/9#issuecomment-1370136019), we found that one of the bottlenecks is the `NodeError` creation. 

- I'm using `undici.fetch` as a real use case of web streams, the benchmark files are available at https://github.com/RafaelGSS/nodejs-webstreams-perf/blob/main/bench/fetch.js
- This patch improves the `undici.fetch` performance by approximately 23%.
  - Important: I'm considering only the benchmark above.
- I did all the tests on my developer machine and on a dedicated server, and the results seem consistent.

I'm not quite sure about the security impacts of this change, considering we're going to use the same object for all release calls. 

More information on this performance work can be found at https://github.com/nodejs/performance/issues/9.