### PR TITLE
src: use constant strings for memory info names

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -673,13 +673,14 @@ MaybeLocal<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   return ret;
 }
 
-std::string AsyncWrap::MemoryInfoName() const {
+const char* AsyncWrap::MemoryInfoName() const {
   return provider_names[provider_type()];
 }
 
 std::string AsyncWrap::diagnostic_name() const {
-  return MemoryInfoName() + " (" + std::to_string(env()->thread_id()) + ":" +
-      std::to_string(static_cast<int64_t>(async_id_)) + ")";
+  return std::string(MemoryInfoName()) + " (" +
+         std::to_string(env()->thread_id()) + ":" +
+         std::to_string(static_cast<int64_t>(async_id_)) + ")";
 }
 
 Local<Object> AsyncWrap::GetOwner() {

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -209,7 +209,7 @@ class AsyncWrap : public BaseObject {
       v8::Local<v8::Value>* argv);
 
   virtual std::string diagnostic_name() const;
-  std::string MemoryInfoName() const override;
+  const char* MemoryInfoName() const override;
 
   static void WeakCallback(const v8::WeakCallbackInfo<DestroyParam> &info);
 

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -398,7 +398,7 @@ class CryptoJob : public AsyncWrap, public ThreadPoolWork {
 
   AdditionalParams* params() { return &params_; }
 
-  std::string MemoryInfoName() const override {
+  const char* MemoryInfoName() const override {
     return CryptoJobTraits::JobName;
   }
 

--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -44,7 +44,7 @@ class MemoryRetainerNode : public v8::EmbedderGraph::Node {
     is_root_node_ = is_root_node;
   }
 
-  const char* Name() override { return name_.c_str(); }
+  const char* Name() override { return name_; }
   const char* NamePrefix() override { return "Node /"; }
   size_t SizeInBytes() override { return size_; }
   // TODO(addaleax): Merging this with the "official" WrapperNode() method
@@ -75,7 +75,7 @@ class MemoryRetainerNode : public v8::EmbedderGraph::Node {
 
   // Otherwise (retainer == nullptr), we set these fields in an ad-hoc way
   bool is_root_node_ = false;
-  std::string name_;
+  const char* name_;
   size_t size_ = 0;
   v8::EmbedderGraph::Node::Detachedness detachedness_ =
       v8::EmbedderGraph::Node::Detachedness::kUnknown;

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -17,7 +17,7 @@ namespace node {
 
 // Set the node name of a MemoryRetainer to klass
 #define SET_MEMORY_INFO_NAME(Klass)                                            \
-  inline std::string MemoryInfoName() const override { return #Klass; }
+  inline const char* MemoryInfoName() const override { return #Klass; }
 
 // Set the self size of a MemoryRetainer to the stack-allocated size of a
 // certain class
@@ -68,7 +68,7 @@ class CleanupHookCallback;
  *     }
  *
  *     // Or use SET_MEMORY_INFO_NAME(ExampleRetainer)
- *     std::string MemoryInfoName() const override {
+ *     const char* MemoryInfoName() const override {
  *       return "ExampleRetainer";
  *     }
  *
@@ -119,7 +119,7 @@ class MemoryRetainer {
   // where all the edges start from the node of the current retainer,
   // and point to the nodes as specified by tracker->Track* calls.
   virtual void MemoryInfo(MemoryTracker* tracker) const = 0;
-  virtual std::string MemoryInfoName() const = 0;
+  virtual const char* MemoryInfoName() const = 0;
   virtual size_t SelfSize() const = 0;
 
   virtual v8::Local<v8::Object> WrappedObject() const {

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -283,14 +283,14 @@ static void GetActiveResourcesInfo(const FunctionCallbackInfo<Value>& args) {
     AsyncWrap* w = req_wrap->GetAsyncWrap();
     if (w->persistent().IsEmpty()) continue;
     resources_info.emplace_back(
-        OneByteString(env->isolate(), w->MemoryInfoName().c_str()));
+        OneByteString(env->isolate(), w->MemoryInfoName()));
   }
 
   // Active handles
   for (HandleWrap* w : *env->handle_wrap_queue()) {
     if (w->persistent().IsEmpty() || !HandleWrap::HasRef(w)) continue;
     resources_info.emplace_back(
-        OneByteString(env->isolate(), w->MemoryInfoName().c_str()));
+        OneByteString(env->isolate(), w->MemoryInfoName()));
   }
 
   // Active timeouts

--- a/src/node_realm.cc
+++ b/src/node_realm.cc
@@ -357,7 +357,7 @@ void Realm::VerifyNoStrongBaseObjects() {
     if (obj->IsNotIndicativeOfMemoryLeakAtExit()) return;
     fprintf(stderr,
             "Found bad BaseObject during clean exit: %s\n",
-            obj->MemoryInfoName().c_str());
+            obj->MemoryInfoName());
     fflush(stderr);
     ABORT();
   });

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -50,7 +50,7 @@ class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
 
   SET_NO_MEMORY_INFO()
   SET_SELF_SIZE(TCPWrap)
-  std::string MemoryInfoName() const override {
+  const char* MemoryInfoName() const override {
     switch (provider_type()) {
       case ProviderType::PROVIDER_TCPWRAP:
         return "TCPSocketWrap";


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

`v8::EmbedderGraph::Node::Name()` expects constant strings. There is no need for `node::MemoryRetainer::MemoryInfoName()` to return a copy of the name string when building an embedder graph for heap snapshots.