### PR TITLE
test: stop requiring URL and URLSearchParams

### DIFF
--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const http = require('http');
 const fixtures = require('../common/fixtures');
 const { spawn } = require('child_process');
-const { URL, pathToFileURL } = require('url');
+const { pathToFileURL } = require('url');
 const { EventEmitter } = require('events');
 
 const _MAINSCRIPT = fixtures.path('loop.js');

--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -27,7 +27,7 @@ tmpdir.refresh();
 
 const assert = require('assert');
 const { spawn } = require('child_process');
-const { pathToFileURL, URL } = require('url');
+const { pathToFileURL } = require('url');
 
 // Spawns 'pwd' with given options, then test
 // - whether the child pid is undefined or number,

--- a/test/parallel/test-whatwg-url-invalidthis.js
+++ b/test/parallel/test-whatwg-url-invalidthis.js
@@ -2,7 +2,6 @@
 
 require('../common');
 
-const { URL } = require('url');
 const assert = require('assert');
 
 [

--- a/test/parallel/test-whatwg-url-properties.js
+++ b/test/parallel/test-whatwg-url-properties.js
@@ -1,7 +1,6 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const { URL, URLSearchParams } = require('url');
 
 [
   { name: 'toString' },


### PR DESCRIPTION
Since the URL and URLSearchParams classes are available in the global object, there is no need to require them from 'url'.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
