### PR TITLE
doc: add experimental stages

### DIFF
--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -38,11 +38,12 @@ The stability indices are as follows:
 > * 1.0 - Early development. Experimental features at this stage are unfinished
 >   and subject to substantial change.
 > * 1.1 - Active development. Experimental features at this stage are nearing
->   potential stability but breaking changes are likely.
+>   minimum viability.
 > * 1.2 - Release candidate. Experimental features at this stage are hopefully
->   ready to become stable. No further breaking changes are anticipated and we
->   encourage user testing and feedback so that we can know that this feature is
->   ready to be marked as stable.
+>   ready to become stable. No further breaking changes are anticipated but may
+>   still occur in response to user feedback. We encourage user testing and
+>   feedback so that we can know that this feature is ready to be marked as
+>   stable.
 
 <!-- separator -->
 

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -32,6 +32,17 @@ The stability indices are as follows:
 > [semantic versioning][] rules. Non-backward compatible changes or removal may
 > occur in any future release. Use of the feature is not recommended in
 > production environments.
+>
+> Experimental features are subdivided into stages:
+>
+> * 1.0 - Early development. Experimental features at this stage are unfinished
+>   and subject to substantial change. They are not yet ready for user testing.
+> * 1.1 - Active development. Experimental features at this stage are nearing
+>   potential stability, with only minor changes expected.
+> * 1.2 - Release candidate. Experimental features at this stage are hopefully
+>   ready to become stable. No further breaking changes are anticipated and we
+>   welcome user testing and feedback so that we can know that this feature is
+>   ready to be marked as stable.
 
 <!-- separator -->
 
@@ -48,9 +59,9 @@ Features are marked as legacy rather than being deprecated if their use does no
 harm, and they are widely relied upon within the npm ecosystem. Bugs found in
 legacy features are unlikely to be fixed.
 
-Use caution when making use of Experimental features, particularly within
-modules. Users may not be aware that experimental features are being used.
-Bugs or behavior changes may surprise users when Experimental API
+Use caution when making use of Experimental features, particularly when
+authoring libraries. Users may not be aware that experimental features are being
+used. Bugs or behavior changes may surprise users when Experimental API
 modifications occur. To avoid surprises, use of an Experimental feature may need
 a command-line flag. Experimental features may also emit a [warning][].
 

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -36,12 +36,12 @@ The stability indices are as follows:
 > Experimental features are subdivided into stages:
 >
 > * 1.0 - Early development. Experimental features at this stage are unfinished
->   and subject to substantial change. They are not yet ready for user testing.
+>   and subject to substantial change.
 > * 1.1 - Active development. Experimental features at this stage are nearing
->   potential stability, with only minor changes expected.
+>   potential stability but breaking changes are likely.
 > * 1.2 - Release candidate. Experimental features at this stage are hopefully
 >   ready to become stable. No further breaking changes are anticipated and we
->   welcome user testing and feedback so that we can know that this feature is
+>   encourage user testing and feedback so that we can know that this feature is
 >   ready to be marked as stable.
 
 <!-- separator -->


### PR DESCRIPTION
Implements the first PR per https://github.com/nodejs/node/discussions/45900#discussioncomment-4593878. This only defines the stages; follow-up PRs will classify all currently experimental features accordingly and add any stage requirements such as flags or warnings that we decide are appropriate. We could potentially land this PR at the same time as the one that updates the statuses for all experimental features, but I don’t want to start work on that one without reaching consensus on this one first.

Even just on its own, this PR solves a few problems:

- It encourages more use and testing of experimental features that we’ve been referring to as in the “baking” phase, where we think they’re ready to be marked as stable. This should hopefully catch more bugs before features become stable.

- It clarifies the refactoring risk that various experimental features have; “release candidate” ones should hopefully require no refactoring due to breaking changes, but “active development” ones very well might; and “early development” ones almost certainly will. Users therefore have a better idea of how much maintenance work they’re signing up for by choosing to use a subject-to-change feature.

Per https://github.com/nodejs/node/discussions/45900#discussioncomment-4593876 I tried to come up with better names for the stages. Please let me know if there are better ideas for names that can reach consensus. 🚲

cc @nodejs/tsc @nodejs/documentation