### PR TITLE
tools: removed multiple import statements

### DIFF
--- a/tools/inspector_protocol/jinja2/_compat.py
+++ b/tools/inspector_protocol/jinja2/_compat.py
@@ -58,7 +58,6 @@ else:
     iteritems = lambda d: d.iteritems()
 
     import cPickle as pickle
-    from cStringIO import StringIO as BytesIO, StringIO
     NativeStringIO = BytesIO
 
     exec('def reraise(tp, value, tb=None):\n raise tp, value, tb')

--- a/tools/inspector_protocol/jinja2/debug.py
+++ b/tools/inspector_protocol/jinja2/debug.py
@@ -302,7 +302,6 @@ def _init_ugly_crap():
     interpreters
     """
     import ctypes
-    from types import TracebackType
 
     if PY2:
         # figure out size of _Py_ssize_t for Python 2:


### PR DESCRIPTION
removed unnecessary multiple import statements
in [_compat.py](https://github.com/nodejs/node/blob/main/tools/inspector_protocol/jinja2/_compat.py)

https://github.com/nodejs/node/blob/cd4f4b4dfac4d96316058e12aafdc2737ed43f72/tools/inspector_protocol/jinja2/_compat.py#L61

and in [debug.py](https://github.com/nodejs/node/blob/main/tools/inspector_protocol/jinja2/debug.py)

https://github.com/nodejs/node/blob/cd4f4b4dfac4d96316058e12aafdc2737ed43f72/tools/inspector_protocol/jinja2/debug.py#L305


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
