### PR TITLE
crypto: return correct bit length in KeyObject's asymmetricKeyDetails

### DIFF
--- a/src/crypto/crypto_dsa.cc
+++ b/src/crypto/crypto_dsa.cc
@@ -147,8 +147,8 @@ Maybe<bool> GetDsaKeyDetail(
 
   DSA_get0_pqg(dsa, &p, &q, nullptr);
 
-  size_t modulus_length = BN_num_bytes(p) * CHAR_BIT;
-  size_t divisor_length = BN_num_bytes(q) * CHAR_BIT;
+  size_t modulus_length = BN_num_bits(p);
+  size_t divisor_length = BN_num_bits(q);
 
   if (target
           ->Set(

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -529,7 +529,7 @@ Maybe<bool> GetRsaKeyDetail(
 
   RSA_get0_key(rsa, &n, &e, nullptr);
 
-  size_t modulus_length = BN_num_bytes(n) * CHAR_BIT;
+  size_t modulus_length = BN_num_bits(n);
 
   if (target
           ->Set(

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -1817,3 +1817,31 @@ generateKeyPair('rsa', {
     hashAlgorithm: 'sha1'
   }, common.mustNotCall()), { code: 'ERR_INVALID_ARG_VALUE' });
 }
+
+{
+  // https://github.com/nodejs/node/issues/46102#issuecomment-1372153541
+
+  generateKeyPair('rsa', {
+    modulusLength: 513,
+  }, common.mustSucceed((publicKey, privateKey) => {
+    assert.strictEqual(privateKey.asymmetricKeyDetails.modulusLength, 513);
+    assert.strictEqual(publicKey.asymmetricKeyDetails.modulusLength, 513);
+  }));
+
+  generateKeyPair('rsa-pss', {
+    modulusLength: 513,
+  }, common.mustSucceed((publicKey, privateKey) => {
+    assert.strictEqual(privateKey.asymmetricKeyDetails.modulusLength, 513);
+    assert.strictEqual(publicKey.asymmetricKeyDetails.modulusLength, 513);
+  }));
+
+  if (common.hasOpenSSL3) {
+    generateKeyPair('dsa', {
+      modulusLength: 2049,
+      divisorLength: 256,
+    }, common.mustSucceed((publicKey, privateKey) => {
+      assert.strictEqual(privateKey.asymmetricKeyDetails.modulusLength, 2049);
+      assert.strictEqual(publicKey.asymmetricKeyDetails.modulusLength, 2049);
+    }));
+  }
+}


### PR DESCRIPTION
Our KeyObject details incorrectly ceil bit lengths to the nearest multiple of 8.