### PR TITLE
http: response.setHeaders()

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1995,36 +1995,18 @@ is desired with potential future retrieval and modification, use
 added: REPLACEME
 -->
 
-* `headers` {Headers|Object|Array}
+* `headers` {Headers}
 * Returns: {http.ServerResponse}
 
 Returns the response object.
 
 Sets multiple header values for implicit headers.
-`headers` may be an instance of [`Headers`][] or `Array` where the keys
-and values are in the same list.
-It is _not_ a list of tuples. So, the even-numbered offsets are key values,
-and the odd-numbered offsets are the associated values. The array is in the same
-format as `request.rawHeaders`.
+`headers` must be an instance of [`Headers`][], if header already exists
+in the to-be-sent headers, its value will be replaced.
 
 ```js
 const headers = new Headers({ foo: 'bar' });
 response.setHeaders(headers);
-```
-
-or
-
-```js
-response.setHeaders(['foo', 'bar', 'fizz', 'buzz']);
-```
-
-or
-
-```js
-response.setHeaders({
-  foo: 'bar',
-  fizz: 'buzz',
-});
 ```
 
 When headers have been set with [`response.setHeaders()`][], they will be merged
@@ -2034,7 +2016,8 @@ to [`response.writeHead()`][] given precedence.
 ```js
 // Returns content-type = text/plain
 const server = http.createServer((req, res) => {
-  res.setHeaders(['Content-Type', 'text/html', 'X-Foo', 'bar']);
+  const headers = new Headers({ 'Content-Type': 'text/html' });
+  res.setHeaders(headers);
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('ok');
 });
@@ -2256,10 +2239,6 @@ response.writeEarlyHints({
 <!-- YAML
 added: v0.1.30
 changes:
-  - version:
-    - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/46109
-    description: Allow passing headers as Headers object.
   - version: v14.14.0
     pr-url: https://github.com/nodejs/node/pull/35274
     description: Allow passing headers as an array.
@@ -2279,7 +2258,7 @@ changes:
 
 * `statusCode` {number}
 * `statusMessage` {string}
-* `headers` {Headers|Object|Array}
+* `headers` {Object|Array}
 * Returns: {http.ServerResponse}
 
 Sends a response header to the request. The status code is a 3-digit HTTP
@@ -2301,15 +2280,6 @@ response
     'Content-Length': Buffer.byteLength(body),
     'Content-Type': 'text/plain',
   })
-  .end(body);
-```
-
-`headers` may also be an instance of the [`Headers`][].
-
-```js
-const body = 'hello world';
-response
-  .writeHead(200, new Headers({ foo: 'bar' }))
   .end(body);
 ```
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1995,7 +1995,7 @@ is desired with potential future retrieval and modification, use
 added: REPLACEME
 -->
 
-* `headers` {Object|Array}
+* `headers` {Headers|Object|Array}
 * Returns: {http.ServerResponse}
 
 Returns the response object.
@@ -2005,6 +2005,13 @@ Sets multiple header values for implicit headers.
 It is _not_ a list of tuples. So, the even-numbered offsets are key values,
 and the odd-numbered offsets are the associated values. The array is in the same
 format as `request.rawHeaders`.
+
+```js
+const headers = new Headers({ foo: 'bar' });
+response.setHeaders(headers);
+```
+
+or
 
 ```js
 response.setHeaders(['foo', 'bar', 'fizz', 'buzz']);

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2001,7 +2001,8 @@ added: REPLACEME
 Returns the response object.
 
 Sets multiple header values for implicit headers.
-`headers` may be an `Array` where the keys and values are in the same list.
+`headers` may be an instance of [`Headers`][] or `Array` where the keys
+and values are in the same list.
 It is _not_ a list of tuples. So, the even-numbered offsets are key values,
 and the odd-numbered offsets are the associated values. The array is in the same
 format as `request.rawHeaders`.
@@ -2255,6 +2256,10 @@ response.writeEarlyHints({
 <!-- YAML
 added: v0.1.30
 changes:
+  - version:
+    - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46109
+    description: Allow passing headers as Headers object.
   - version: v14.14.0
     pr-url: https://github.com/nodejs/node/pull/35274
     description: Allow passing headers as an array.
@@ -2274,7 +2279,7 @@ changes:
 
 * `statusCode` {number}
 * `statusMessage` {string}
-* `headers` {Object|Array}
+* `headers` {Headers|Object|Array}
 * Returns: {http.ServerResponse}
 
 Sends a response header to the request. The status code is a 3-digit HTTP
@@ -2296,6 +2301,15 @@ response
     'Content-Length': Buffer.byteLength(body),
     'Content-Type': 'text/plain',
   })
+  .end(body);
+```
+
+`headers` may also be an instance of the [`Headers`][].
+
+```js
+const body = 'hello world';
+response
+  .writeHead(200, new Headers({ foo: 'bar' }))
   .end(body);
 ```
 
@@ -3812,6 +3826,7 @@ Set the maximum number of idle HTTP parsers. **Default:** `1000`.
 [`Buffer.byteLength()`]: buffer.md#static-method-bufferbytelengthstring-encoding
 [`Duplex`]: stream.md#class-streamduplex
 [`HPE_HEADER_OVERFLOW`]: errors.md#hpe_header_overflow
+[`Headers`]: globals.md#class-headers
 [`TypeError`]: errors.md#class-typeerror
 [`URL`]: url.md#the-whatwg-url-api
 [`agent.createConnection()`]: #agentcreateconnectionoptions-callback

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2981,8 +2981,9 @@ added: REPLACEME
 Returns the response object.
 
 Sets multiple header values for implicit headers.
-`headers` must be an instance of [`Headers`][] or `Map`, if a header already exists
-in the to-be-sent headers, its value will be replaced.
+`headers` must be an instance of [`Headers`][] or `Map`,
+if a header already exists in the to-be-sent headers,
+its value will be replaced.
 
 ```js
 const headers = new Headers({ foo: 'bar' });

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1953,8 +1953,6 @@ non-string values. However, the non-string values will be converted to strings
 for network transmission. The same response object is returned to the caller,
 to enable call chaining.
 
-> To set multiple header values at once see [`response.setHeaders()`][].
-
 ```js
 response.setHeader('Content-Type', 'text/html');
 ```
@@ -1988,40 +1986,6 @@ channel without caching internally, and the [`response.getHeader()`][] on the
 header will not yield the expected result. If progressive population of headers
 is desired with potential future retrieval and modification, use
 [`response.setHeader()`][] instead of [`response.writeHead()`][].
-
-### `response.setHeaders(headers)`
-
-<!-- YAML
-added: REPLACEME
--->
-
-* `headers` {Headers}
-* Returns: {http.ServerResponse}
-
-Returns the response object.
-
-Sets multiple header values for implicit headers.
-`headers` must be an instance of [`Headers`][], if header already exists
-in the to-be-sent headers, its value will be replaced.
-
-```js
-const headers = new Headers({ foo: 'bar' });
-response.setHeaders(headers);
-```
-
-When headers have been set with [`response.setHeaders()`][], they will be merged
-with any headers passed to [`response.writeHead()`][], with the headers passed
-to [`response.writeHead()`][] given precedence.
-
-```js
-// Returns content-type = text/plain
-const server = http.createServer((req, res) => {
-  const headers = new Headers({ 'Content-Type': 'text/html' });
-  res.setHeaders(headers);
-  res.writeHead(200, { 'Content-Type': 'text/plain' });
-  res.end('ok');
-});
-```
 
 ### `response.setTimeout(msecs[, callback])`
 
@@ -3005,6 +2969,47 @@ Sets a single header value. If the header already exists in the to-be-sent
 headers, its value will be replaced. Use an array of strings to send multiple
 headers with the same name.
 
+### `outgoingMessage.setHeaders(headers)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `headers` {Headers|Map}
+* Returns: {http.ServerResponse}
+
+Returns the response object.
+
+Sets multiple header values for implicit headers.
+`headers` must be an instance of [`Headers`][], if header already exists
+in the to-be-sent headers, its value will be replaced.
+
+```js
+const headers = new Headers({ foo: 'bar' });
+response.setHeaders(headers);
+```
+
+or
+
+```js
+const headers = new Map([['foo', 'bar']]);
+res.setHeaders(headers);
+```
+
+When headers have been set with [`outgoingMessage.setHeaders()`][],
+they will be merged with any headers passed to [`response.writeHead()`][],
+with the headers passed to [`response.writeHead()`][] given precedence.
+
+```js
+// Returns content-type = text/plain
+const server = http.createServer((req, res) => {
+  const headers = new Headers({ 'Content-Type': 'text/html' });
+  res.setHeaders(headers);
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('ok');
+});
+```
+
 ### `outgoingMessage.setTimeout(msesc[, callback])`
 
 <!-- YAML
@@ -3823,6 +3828,7 @@ Set the maximum number of idle HTTP parsers. **Default:** `1000`.
 [`net.createConnection()`]: net.md#netcreateconnectionoptions-connectlistener
 [`new URL()`]: url.md#new-urlinput-base
 [`outgoingMessage.setHeader(name, value)`]: #outgoingmessagesetheadername-value
+[`outgoingMessage.setHeaders()`]: #outgoingmessagesetheadersheaders
 [`outgoingMessage.socket`]: #outgoingmessagesocket
 [`removeHeader(name)`]: #requestremoveheadername
 [`request.destroy()`]: #requestdestroyerror
@@ -3840,7 +3846,6 @@ Set the maximum number of idle HTTP parsers. **Default:** `1000`.
 [`response.end()`]: #responseenddata-encoding-callback
 [`response.getHeader()`]: #responsegetheadername
 [`response.setHeader()`]: #responsesetheadername-value
-[`response.setHeaders()`]: #responsesetheadersheaders
 [`response.socket`]: #responsesocket
 [`response.writableEnded`]: #responsewritableended
 [`response.writableFinished`]: #responsewritablefinished

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1953,6 +1953,8 @@ non-string values. However, the non-string values will be converted to strings
 for network transmission. The same response object is returned to the caller,
 to enable call chaining.
 
+> To set multiple header values at once see [`response.setHeaders()`][].
+
 ```js
 response.setHeader('Content-Type', 'text/html');
 ```
@@ -1986,6 +1988,49 @@ channel without caching internally, and the [`response.getHeader()`][] on the
 header will not yield the expected result. If progressive population of headers
 is desired with potential future retrieval and modification, use
 [`response.setHeader()`][] instead of [`response.writeHead()`][].
+
+### `response.setHeaders(headers)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `headers` {Object|Array}
+* Returns: {http.ServerResponse}
+
+Returns the response object.
+
+Sets multiple header values for implicit headers.
+`headers` may be an `Array` where the keys and values are in the same list.
+It is _not_ a list of tuples. So, the even-numbered offsets are key values,
+and the odd-numbered offsets are the associated values. The array is in the same
+format as `request.rawHeaders`.
+
+```js
+response.setHeaders(['foo', 'bar', 'fizz', 'buzz']);
+```
+
+or
+
+```js
+response.setHeaders({
+  foo: 'bar',
+  fizz: 'buzz',
+});
+```
+
+When headers have been set with [`response.setHeaders()`][], they will be merged
+with any headers passed to [`response.writeHead()`][], with the headers passed
+to [`response.writeHead()`][] given precedence.
+
+```js
+// Returns content-type = text/plain
+const server = http.createServer((req, res) => {
+  res.setHeaders(['Content-Type', 'text/html', 'X-Foo', 'bar']);
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('ok');
+});
+```
 
 ### `response.setTimeout(msecs[, callback])`
 
@@ -3803,6 +3848,7 @@ Set the maximum number of idle HTTP parsers. **Default:** `1000`.
 [`response.end()`]: #responseenddata-encoding-callback
 [`response.getHeader()`]: #responsegetheadername
 [`response.setHeader()`]: #responsesetheadername-value
+[`response.setHeaders()`]: #responsesetheadersheaders
 [`response.socket`]: #responsesocket
 [`response.writableEnded`]: #responsewritableended
 [`response.writableFinished`]: #responsewritablefinished

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2981,7 +2981,7 @@ added: REPLACEME
 Returns the response object.
 
 Sets multiple header values for implicit headers.
-`headers` must be an instance of [`Headers`][], if header already exists
+`headers` must be an instance of [`Headers`][] or `Map`, if a header already exists
 in the to-be-sent headers, its value will be replaced.
 
 ```js

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -673,6 +673,34 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
   return this;
 };
 
+OutgoingMessage.prototype.setHeaders = function setHeaders(obj) {
+  if (this._header) {
+    throw new ERR_HTTP_HEADERS_SENT('set');
+  }
+  
+  let k;
+  if (ArrayIsArray(obj)) {
+    if (obj.length % 2 !== 0) {
+      throw new ERR_INVALID_ARG_VALUE('headers', obj);
+    }
+
+    for (let n = 0; n < obj.length; n += 2) {
+      k = obj[n + 0];
+      if (k) this.setHeader(k, obj[n + 1]);
+    }
+  } else if (obj) {
+    const keys = ObjectKeys(obj);
+    // Retain for(;;) loop for performance reasons
+    // Refs: https://github.com/nodejs/node/pull/30958
+    for (let i = 0; i < keys.length; i++) {
+      k = keys[i];
+      if (k) this.setHeader(k, obj[k]);
+    }
+  }
+
+  return this;
+};
+
 OutgoingMessage.prototype.appendHeader = function appendHeader(name, value) {
   if (this._header) {
     throw new ERR_HTTP_HEADERS_SENT('append');

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -682,8 +682,9 @@ OutgoingMessage.prototype.setHeaders = function setHeaders(headers) {
 
   if (
     !headers ||
-    !typeof headers.keys === 'function' ||
-    !typeof headers.get === 'function'
+    ArrayIsArray(headers) ||
+    typeof headers.keys !== 'function' ||
+    typeof headers.get !== 'function'
   ) {
     throw new ERR_INVALID_ARG_TYPE('headers', ['Headers', 'Map'], headers);
   }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -679,31 +679,13 @@ OutgoingMessage.prototype.setHeaders = function setHeaders(headers) {
   if (this._header) {
     throw new ERR_HTTP_HEADERS_SENT('set');
   }
-  let k;
 
-  if (headers instanceof Headers) {
-    const keys = [...headers.keys()];
-    for (let i = 0; i < keys.length; i++) {
-      k = keys[i];
-      if (k) this.setHeader(k, headers.get(k));
-    }
-  } else if (ArrayIsArray(headers)) {
-    if (headers.length % 2 !== 0) {
-      throw new ERR_INVALID_ARG_VALUE('headers', headers);
-    }
+  if (headers instanceof Headers === false) {
+    throw new ERR_INVALID_ARG_TYPE('headers', 'Headers', headers);
+  }
 
-    for (let n = 0; n < headers.length; n += 2) {
-      k = headers[n + 0];
-      if (k) this.setHeader(k, headers[n + 1]);
-    }
-  } else if (headers) {
-    const keys = ObjectKeys(headers);
-    // Retain for(;;) loop for performance reasons
-    // Refs: https://github.com/nodejs/node/pull/30958
-    for (let i = 0; i < keys.length; i++) {
-      k = keys[i];
-      if (k) this.setHeader(k, headers[k]);
-    }
+  for (const key of headers.keys()) {
+    this.setHeader(key, headers.get(key));
   }
 
   return this;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -82,7 +82,6 @@ let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
   debug = fn;
 });
 
-
 const HIGH_WATER_MARK = getDefaultHighWaterMark();
 
 const kCorked = Symbol('corked');

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -677,7 +677,7 @@ OutgoingMessage.prototype.setHeaders = function setHeaders(obj) {
   if (this._header) {
     throw new ERR_HTTP_HEADERS_SENT('set');
   }
-  
+
   let k;
   if (ArrayIsArray(obj)) {
     if (obj.length % 2 !== 0) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -82,6 +82,8 @@ let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
   debug = fn;
 });
 
+const { Headers } = require('internal/deps/undici/undici');
+
 const HIGH_WATER_MARK = getDefaultHighWaterMark();
 
 const kCorked = Symbol('corked');
@@ -673,28 +675,34 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
   return this;
 };
 
-OutgoingMessage.prototype.setHeaders = function setHeaders(obj) {
+OutgoingMessage.prototype.setHeaders = function setHeaders(headers) {
   if (this._header) {
     throw new ERR_HTTP_HEADERS_SENT('set');
   }
-
   let k;
-  if (ArrayIsArray(obj)) {
-    if (obj.length % 2 !== 0) {
-      throw new ERR_INVALID_ARG_VALUE('headers', obj);
+
+  if (headers instanceof Headers) {
+    const keys = [...headers.keys()];
+    for (let i = 0; i < keys.length; i++) {
+      k = keys[i];
+      if (k) this.setHeader(k, headers.get(k));
+    }
+  } else if (ArrayIsArray(headers)) {
+    if (headers.length % 2 !== 0) {
+      throw new ERR_INVALID_ARG_VALUE('headers', headers);
     }
 
-    for (let n = 0; n < obj.length; n += 2) {
-      k = obj[n + 0];
-      if (k) this.setHeader(k, obj[n + 1]);
+    for (let n = 0; n < headers.length; n += 2) {
+      k = headers[n + 0];
+      if (k) this.setHeader(k, headers[n + 1]);
     }
-  } else if (obj) {
-    const keys = ObjectKeys(obj);
+  } else if (headers) {
+    const keys = ObjectKeys(headers);
     // Retain for(;;) loop for performance reasons
     // Refs: https://github.com/nodejs/node/pull/30958
     for (let i = 0; i < keys.length; i++) {
       k = keys[i];
-      if (k) this.setHeader(k, obj[k]);
+      if (k) this.setHeader(k, headers[k]);
     }
   }
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -82,7 +82,6 @@ let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
   debug = fn;
 });
 
-const { Headers } = require('internal/deps/undici/undici');
 
 const HIGH_WATER_MARK = getDefaultHighWaterMark();
 
@@ -680,8 +679,13 @@ OutgoingMessage.prototype.setHeaders = function setHeaders(headers) {
     throw new ERR_HTTP_HEADERS_SENT('set');
   }
 
-  if (headers instanceof Headers === false) {
-    throw new ERR_INVALID_ARG_TYPE('headers', 'Headers', headers);
+
+  if (
+    !headers ||
+    !typeof headers.keys === 'function' ||
+    !typeof headers.get === 'function'
+  ) {
+    throw new ERR_INVALID_ARG_TYPE('headers', ['Headers', 'Map'], headers);
   }
 
   for (const key of headers.keys()) {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -22,10 +22,10 @@
 'use strict';
 
 const {
+  ArrayIsArray,
   Error,
   MathMin,
   ObjectKeys,
-  ObjectFromEntries,
   ObjectSetPrototypeOf,
   RegExpPrototypeExec,
   ReflectApply,
@@ -76,6 +76,7 @@ const {
   ERR_HTTP_INVALID_STATUS_CODE,
   ERR_HTTP_SOCKET_ENCODING,
   ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CHAR
 } = codes;
 const {
@@ -89,7 +90,6 @@ const { setInterval, clearInterval } = require('timers');
 let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
   debug = fn;
 });
-const { Headers } = require('internal/deps/undici/undici');
 
 const dc = require('diagnostics_channel');
 const onRequestStartChannel = dc.channel('http.server.request.start');
@@ -359,11 +359,27 @@ function writeHead(statusCode, reason, obj) {
   let headers;
   if (this[kOutHeaders]) {
     // Slow-case: when progressive API and header fields are passed.
-    this.setHeaders(obj);
+    let k;
+    if (ArrayIsArray(obj)) {
+      if (obj.length % 2 !== 0) {
+        throw new ERR_INVALID_ARG_VALUE('headers', obj);
+      }
+
+      for (let n = 0; n < obj.length; n += 2) {
+        k = obj[n + 0];
+        if (k) this.setHeader(k, obj[n + 1]);
+      }
+    } else if (obj) {
+      const keys = ObjectKeys(obj);
+      // Retain for(;;) loop for performance reasons
+      // Refs: https://github.com/nodejs/node/pull/30958
+      for (let i = 0; i < keys.length; i++) {
+        k = keys[i];
+        if (k) this.setHeader(k, obj[k]);
+      }
+    }
     // Only progressive api is used
     headers = this[kOutHeaders];
-  } else if (obj instanceof Headers) {
-    headers = ObjectFromEntries(obj.entries());
   } else {
     // Only writeHead() called
     headers = obj;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -359,28 +359,7 @@ function writeHead(statusCode, reason, obj) {
   let headers;
   if (this[kOutHeaders]) {
     // Slow-case: when progressive API and header fields are passed.
-    let k;
-    if (ArrayIsArray(obj)) {
-      if (obj.length % 2 !== 0) {
-        throw new ERR_INVALID_ARG_VALUE('headers', obj);
-      }
-
-      for (let n = 0; n < obj.length; n += 2) {
-        k = obj[n + 0];
-        if (k) this.setHeader(k, obj[n + 1]);
-      }
-    } else if (obj) {
-      const keys = ObjectKeys(obj);
-      // Retain for(;;) loop for performance reasons
-      // Refs: https://github.com/nodejs/node/pull/30958
-      for (let i = 0; i < keys.length; i++) {
-        k = keys[i];
-        if (k) this.setHeader(k, obj[k]);
-      }
-    }
-    if (k === undefined && this._header) {
-      throw new ERR_HTTP_HEADERS_SENT('render');
-    }
+    this.setHeaders(obj);
     // Only progressive api is used
     headers = this[kOutHeaders];
   } else {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -25,6 +25,7 @@ const {
   Error,
   MathMin,
   ObjectKeys,
+  ObjectFromEntries,
   ObjectSetPrototypeOf,
   RegExpPrototypeExec,
   ReflectApply,
@@ -88,6 +89,7 @@ const { setInterval, clearInterval } = require('timers');
 let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
   debug = fn;
 });
+const { Headers } = require('internal/deps/undici/undici');
 
 const dc = require('diagnostics_channel');
 const onRequestStartChannel = dc.channel('http.server.request.start');
@@ -360,6 +362,8 @@ function writeHead(statusCode, reason, obj) {
     this.setHeaders(obj);
     // Only progressive api is used
     headers = this[kOutHeaders];
+  } else if (obj instanceof Headers) {
+    headers = ObjectFromEntries(obj.entries());
   } else {
     // Only writeHead() called
     headers = obj;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -22,7 +22,6 @@
 'use strict';
 
 const {
-  ArrayIsArray,
   Error,
   MathMin,
   ObjectKeys,
@@ -76,7 +75,6 @@ const {
   ERR_HTTP_INVALID_STATUS_CODE,
   ERR_HTTP_SOCKET_ENCODING,
   ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CHAR
 } = codes;
 const {

--- a/test/parallel/test-http-response-setheaders.js
+++ b/test/parallel/test-http-response-setheaders.js
@@ -1,0 +1,69 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    res.setHeaders(['foo', '1', 'bar', '2' ]);
+    res.writeHead(200);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port, headers: [] }, (res) => {
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers.foo, '1');
+      assert.strictEqual(res.headers.bar, '2');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    res.setHeaders({
+      foo: '1',
+      bar: '2'
+    });
+    res.writeHead(200);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers.foo, '1');
+      assert.strictEqual(res.headers.bar, '2');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    res.writeHead(200); // headers already sent
+    assert.throws(() => { 
+      res.setHeaders({
+        foo: 'bar',
+      }); 
+    }, {
+      code: 'ERR_HTTP_HEADERS_SENT'
+    });
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert.strictEqual(res.headers.foo, undefined)
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}

--- a/test/parallel/test-http-response-setheaders.js
+++ b/test/parallel/test-http-response-setheaders.js
@@ -67,3 +67,23 @@ const assert = require('assert');
     });
   }));
 }
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    const headers = new globalThis.Headers({ foo: '1', bar: '2' });
+    res.setHeaders(headers);
+    res.writeHead(200);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers.foo, '1');
+      assert.strictEqual(res.headers.bar, '2');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}

--- a/test/parallel/test-http-response-setheaders.js
+++ b/test/parallel/test-http-response-setheaders.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 {
   const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
-    res.writeHead(200); // headers already sent
+    res.writeHead(200); // Headers already sent
     const headers = new globalThis.Headers({ foo: '1' });
     assert.throws(() => {
       res.setHeaders(headers);
@@ -101,7 +101,7 @@ const assert = require('assert');
   server.listen(0, common.mustCall(() => {
     http.get({ port: server.address().port }, (res) => {
       assert.strictEqual(res.statusCode, 200);
-      assert.strictEqual(res.headers.foo, '3'); // ovverride by writeHead
+      assert.strictEqual(res.headers.foo, '3'); // Ovverride by writeHead
       assert.strictEqual(res.headers.bar, '2');
       res.resume().on('end', common.mustCall(() => {
         server.close();

--- a/test/parallel/test-http-response-setheaders.js
+++ b/test/parallel/test-http-response-setheaders.js
@@ -101,7 +101,7 @@ const assert = require('assert');
   server.listen(0, common.mustCall(() => {
     http.get({ port: server.address().port }, (res) => {
       assert.strictEqual(res.statusCode, 200);
-      assert.strictEqual(res.headers.foo, '3'); // Ovverride by writeHead
+      assert.strictEqual(res.headers.foo, '3'); // Override by writeHead
       assert.strictEqual(res.headers.bar, '2');
       res.resume().on('end', common.mustCall(() => {
         server.close();

--- a/test/parallel/test-http-response-setheaders.js
+++ b/test/parallel/test-http-response-setheaders.js
@@ -48,10 +48,10 @@ const assert = require('assert');
 {
   const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
     res.writeHead(200); // headers already sent
-    assert.throws(() => { 
+    assert.throws(() => {
       res.setHeaders({
         foo: 'bar',
-      }); 
+      });
     }, {
       code: 'ERR_HTTP_HEADERS_SENT'
     });
@@ -60,7 +60,7 @@ const assert = require('assert');
 
   server.listen(0, common.mustCall(() => {
     http.get({ port: server.address().port }, (res) => {
-      assert.strictEqual(res.headers.foo, undefined)
+      assert.strictEqual(res.headers.foo, undefined);
       res.resume().on('end', common.mustCall(() => {
         server.close();
       }));

--- a/test/parallel/test-http-response-setheaders.js
+++ b/test/parallel/test-http-response-setheaders.js
@@ -109,3 +109,23 @@ const assert = require('assert');
     });
   }));
 }
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    const headers = new Map([['foo', '1'], ['bar', '2']]);
+    res.setHeaders(headers);
+    res.writeHead(200);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers.foo, '1');
+      assert.strictEqual(res.headers.bar, '2');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}

--- a/test/parallel/test-http-write-head-2.js
+++ b/test/parallel/test-http-write-head-2.js
@@ -59,38 +59,3 @@ const http = require('http');
     }));
   }));
 }
-
-{
-  const server = http.createServer(common.mustCall((req, res) => {
-    res.writeHead(200, new globalThis.Headers({ foo: 'bar' }));
-    res.end();
-  }));
-
-  server.listen(0, common.mustCall(() => {
-    http.get({ port: server.address().port }, common.mustCall((res) => {
-      assert.strictEqual(res.headers.foo, 'bar');
-      assert.strictEqual(res.statusCode, 200);
-      res.resume().on('end', common.mustCall(() => {
-        server.close();
-      }));
-    }));
-  }));
-}
-
-{
-  const server = http.createServer(common.mustCall((req, res) => {
-    res.setHeader('test', '1');
-    res.writeHead(200, new globalThis.Headers({ test: '2', test2: '2' }));
-    res.end();
-  }));
-
-  server.listen(0, common.mustCall(() => {
-    http.get({ port: server.address().port }, common.mustCall((res) => {
-      assert.strictEqual(res.headers.test, '2');
-      assert.strictEqual(res.headers.test2, '2');
-      res.resume().on('end', common.mustCall(() => {
-        server.close();
-      }));
-    }));
-  }));
-}

--- a/test/parallel/test-http-write-head-2.js
+++ b/test/parallel/test-http-write-head-2.js
@@ -59,3 +59,38 @@ const http = require('http');
     }));
   }));
 }
+
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.writeHead(200, new globalThis.Headers({ foo: 'bar' }));
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.headers.foo, 'bar');
+      assert.strictEqual(res.statusCode, 200);
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}
+
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.setHeader('test', '1');
+    res.writeHead(200, new globalThis.Headers({ test: '2', test2: '2' }));
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.headers.test, '2');
+      assert.strictEqual(res.headers.test2, '2');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}


### PR DESCRIPTION
from: https://github.com/nodejs/node/issues/46082
I've extracted from `res.writeHead` the part where it sets multiple headers into `res.setHeaders`.
I've removed this part in `writeHead`:
` if (k === undefined && this._header) {
      throw new ERR_HTTP_HEADERS_SENT('render');
}`
because since https://github.com/nodejs/node/pull/45508 it never enters that condition.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
