### PR TITLE
http: refactor to use min of validateNumber for maxTotalSockets

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -30,7 +30,6 @@ const {
   ArrayPrototypeSome,
   ArrayPrototypeSplice,
   FunctionPrototypeCall,
-  NumberIsNaN,
   NumberParseInt,
   ObjectCreate,
   ObjectKeys,
@@ -51,11 +50,6 @@ let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
 });
 const { AsyncResource } = require('async_hooks');
 const { async_id_symbol } = require('internal/async_hooks').symbols;
-const {
-  codes: {
-    ERR_OUT_OF_RANGE,
-  },
-} = require('internal/errors');
 const {
   kEmptyObject,
   once,
@@ -125,10 +119,7 @@ function Agent(options) {
   validateOneOf(this.scheduling, 'scheduling', ['fifo', 'lifo']);
 
   if (this.maxTotalSockets !== undefined) {
-    validateNumber(this.maxTotalSockets, 'maxTotalSockets');
-    if (this.maxTotalSockets <= 0 || NumberIsNaN(this.maxTotalSockets))
-      throw new ERR_OUT_OF_RANGE('maxTotalSockets', '> 0',
-                                 this.maxTotalSockets);
+    validateNumber(this.maxTotalSockets, 'maxTotalSockets', 1);
   } else {
     this.maxTotalSockets = Infinity;
   }

--- a/test/parallel/test-http-agent-maxtotalsockets.js
+++ b/test/parallel/test-http-agent-maxtotalsockets.js
@@ -20,8 +20,6 @@ assert.throws(() => new http.Agent({
   }), {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "maxTotalSockets" is out of range. ' +
-      `It must be > 0. Received ${item}`,
   });
 });
 


### PR DESCRIPTION
Remove duplicate implementation by using min of validateNumber.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
