### PR TITLE
build: add vtune profiling enabling flag in default Linux buiding CI

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Build
-        run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn"
+        run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn --enable-vtune-profiling"
       - name: Test
         run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9"


### PR DESCRIPTION
Added --enable-vtune-profiling into test-linux.yml to avoid building broken when users enable vtune profiling. This check is done in CI and for Linux only so as to make the CI change minimal but effective.
