### PR TITLE
src: use simdutf for converting externalized builtins to UTF-16

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2024,11 +2024,7 @@ output['variables']['node_builtin_shareable_builtins'] = []
 for builtin in shareable_builtins:
   builtin_id = 'node_shared_builtin_' + builtin.replace('/', '_') + '_path'
   if getattr(options, builtin_id):
-    if options.with_intl == 'none':
-      option_name = '--shared-builtin-' + builtin + '-path'
-      error(option_name + ' is incompatible with --with-intl=none' )
-    else:
-      output['defines'] += [builtin_id.upper() + '=' + getattr(options, builtin_id)]
+    output['defines'] += [builtin_id.upper() + '=' + getattr(options, builtin_id)]
   else:
     output['variables']['node_builtin_shareable_builtins'] += [shareable_builtins[builtin]]
 

--- a/node.gyp
+++ b/node.gyp
@@ -973,6 +973,7 @@
         'deps/googletest/googletest.gyp:gtest_main',
         'deps/histogram/histogram.gyp:histogram',
         'deps/uvwasi/uvwasi.gyp:uvwasi',
+        'deps/simdutf/simdutf.gyp:simdutf',
       ],
 
       'includes': [

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -805,11 +805,6 @@ void Environment::RemoveCleanupHook(CleanupQueue::Callback fn, void* arg) {
   cleanup_queue_.Remove(fn, arg);
 }
 
-void Environment::set_main_utf16(std::unique_ptr<v8::String::Value> str) {
-  CHECK(!main_utf16_);
-  main_utf16_ = std::move(str);
-}
-
 void Environment::set_process_exit_handler(
     std::function<void(Environment*, ExitCode)>&& handler) {
   process_exit_handler_ = std::move(handler);

--- a/src/env.h
+++ b/src/env.h
@@ -961,7 +961,6 @@ class Environment : public MemoryRetainer {
 
 #endif  // HAVE_INSPECTOR
 
-  inline void set_main_utf16(std::unique_ptr<v8::String::Value>);
   inline void set_process_exit_handler(
       std::function<void(Environment*, ExitCode)>&& handler);
 
@@ -1143,11 +1142,6 @@ class Environment : public MemoryRetainer {
       DefaultProcessExitHandlerInternal};
 
   std::unique_ptr<Realm> principal_realm_ = nullptr;
-
-  // Keeps the main script source alive is one was passed to LoadEnvironment().
-  // We should probably find a way to just use plain `v8::String`s created from
-  // the source passed to LoadEnvironment() directly instead.
-  std::unique_ptr<v8::String::Value> main_utf16_;
 
   // Used by allocate_managed_buffer() and release_managed_buffer() to keep
   // track of the BackingStore for a given pointer.

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -3,6 +3,7 @@
 #include "env-inl.h"
 #include "node_external_reference.h"
 #include "node_internals.h"
+#include "simdutf.h"
 #include "util-inl.h"
 
 namespace node {
@@ -35,7 +36,6 @@ BuiltinLoader BuiltinLoader::instance_;
 
 BuiltinLoader::BuiltinLoader() : config_(GetConfig()), has_code_cache_(false) {
   LoadJavaScriptSource();
-#if defined(NODE_HAVE_I18N_SUPPORT)
 #ifdef NODE_SHARED_BUILTIN_CJS_MODULE_LEXER_LEXER_PATH
   AddExternalizedBuiltin(
       "internal/deps/cjs-module-lexer/lexer",
@@ -52,7 +52,6 @@ BuiltinLoader::BuiltinLoader() : config_(GetConfig()), has_code_cache_(false) {
   AddExternalizedBuiltin("internal/deps/undici/undici",
                          STRINGIFY(NODE_SHARED_BUILTIN_UNDICI_UNDICI_PATH));
 #endif  // NODE_SHARED_BUILTIN_UNDICI_UNDICI_PATH
-#endif  // NODE_HAVE_I18N_SUPPORT
 }
 
 BuiltinLoader* BuiltinLoader::GetInstance() {
@@ -240,7 +239,6 @@ MaybeLocal<String> BuiltinLoader::LoadBuiltinSource(Isolate* isolate,
 #endif  // NODE_BUILTIN_MODULES_PATH
 }
 
-#if defined(NODE_HAVE_I18N_SUPPORT)
 void BuiltinLoader::AddExternalizedBuiltin(const char* id,
                                            const char* filename) {
   std::string source;
@@ -252,16 +250,19 @@ void BuiltinLoader::AddExternalizedBuiltin(const char* id,
     return;
   }
 
-  icu::UnicodeString utf16 = icu::UnicodeString::fromUTF8(
-      icu::StringPiece(source.data(), source.length()));
-  auto source_utf16 = std::make_unique<icu::UnicodeString>(utf16);
-  Add(id,
-      UnionBytes(reinterpret_cast<const uint16_t*>((*source_utf16).getBuffer()),
-                 utf16.length()));
-  // keep source bytes for builtin alive while BuiltinLoader exists
-  GetInstance()->externalized_source_bytes_.push_back(std::move(source_utf16));
+  Add(id, source);
 }
-#endif  // NODE_HAVE_I18N_SUPPORT
+
+bool BuiltinLoader::Add(const char* id, std::string_view utf8source) {
+  size_t expected_u16_length =
+      simdutf::utf16_length_from_utf8(utf8source.data(), utf8source.length());
+  std::shared_ptr<uint16_t[]> out{new uint16_t[expected_u16_length]};
+  size_t u16_length =
+      simdutf::convert_utf8_to_utf16le(utf8source.data(),
+                                       utf8source.length(),
+                                       reinterpret_cast<char16_t*>(out.get()));
+  return Add(id, UnionBytes(out, u16_length));
+}
 
 // Returns Local<Function> of the compiled module if return_code_cache
 // is false (we are only compiling the function).

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -256,12 +256,13 @@ void BuiltinLoader::AddExternalizedBuiltin(const char* id,
 bool BuiltinLoader::Add(const char* id, std::string_view utf8source) {
   size_t expected_u16_length =
       simdutf::utf16_length_from_utf8(utf8source.data(), utf8source.length());
-  std::shared_ptr<uint16_t[]> out{new uint16_t[expected_u16_length]};
-  size_t u16_length =
-      simdutf::convert_utf8_to_utf16le(utf8source.data(),
-                                       utf8source.length(),
-                                       reinterpret_cast<char16_t*>(out.get()));
-  return Add(id, UnionBytes(out, u16_length));
+  auto out = std::make_shared<std::vector<uint16_t>>(expected_u16_length);
+  size_t u16_length = simdutf::convert_utf8_to_utf16le(
+      utf8source.data(),
+      utf8source.length(),
+      reinterpret_cast<char16_t*>(out->data()));
+  out->resize(u16_length);
+  return Add(id, UnionBytes(out));
 }
 
 // Returns Local<Function> of the compiled module if return_code_cache

--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -8,9 +8,6 @@
 #include <memory>
 #include <set>
 #include <string>
-#if defined(NODE_HAVE_I18N_SUPPORT)
-#include <unicode/unistr.h>
-#endif  // NODE_HAVE_I18N_SUPPORT
 #include <vector>
 #include "node_mutex.h"
 #include "node_union_bytes.h"
@@ -71,6 +68,7 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
   static v8::Local<v8::String> GetConfigString(v8::Isolate* isolate);
   static bool Exists(const char* id);
   static bool Add(const char* id, const UnionBytes& source);
+  static bool Add(const char* id, std::string_view utf8source);
 
   static bool CompileAllBuiltins(v8::Local<v8::Context> context);
   static void RefreshCodeCache(const std::vector<CodeCacheInfo>& in);
@@ -136,18 +134,13 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
   static void HasCachedBuiltins(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
-#if defined(NODE_HAVE_I18N_SUPPORT)
   static void AddExternalizedBuiltin(const char* id, const char* filename);
-#endif  // NODE_HAVE_I18N_SUPPORT
 
   static BuiltinLoader instance_;
   BuiltinCategories builtin_categories_;
   BuiltinSourceMap source_;
   BuiltinCodeCacheMap code_cache_;
   UnionBytes config_;
-#if defined(NODE_HAVE_I18N_SUPPORT)
-  std::list<std::unique_ptr<icu::UnicodeString>> externalized_source_bytes_;
-#endif  // NODE_HAVE_I18N_SUPPORT
 
   // Used to synchronize access to the code cache map
   Mutex code_cache_mutex_;

--- a/src/node_union_bytes.h
+++ b/src/node_union_bytes.h
@@ -11,48 +11,6 @@
 
 namespace node {
 
-class NonOwningExternalOneByteResource
-    : public v8::String::ExternalOneByteStringResource {
- public:
-  explicit NonOwningExternalOneByteResource(const uint8_t* data, size_t length)
-      : data_(data), length_(length) {}
-  ~NonOwningExternalOneByteResource() override = default;
-
-  const char* data() const override {
-    return reinterpret_cast<const char*>(data_);
-  }
-  size_t length() const override { return length_; }
-
-  NonOwningExternalOneByteResource(const NonOwningExternalOneByteResource&) =
-      delete;
-  NonOwningExternalOneByteResource& operator=(
-      const NonOwningExternalOneByteResource&) = delete;
-
- private:
-  const uint8_t* data_;
-  size_t length_;
-};
-
-class NonOwningExternalTwoByteResource
-    : public v8::String::ExternalStringResource {
- public:
-  explicit NonOwningExternalTwoByteResource(const uint16_t* data, size_t length)
-      : data_(data), length_(length) {}
-  ~NonOwningExternalTwoByteResource() override = default;
-
-  const uint16_t* data() const override { return data_; }
-  size_t length() const override { return length_; }
-
-  NonOwningExternalTwoByteResource(const NonOwningExternalTwoByteResource&) =
-      delete;
-  NonOwningExternalTwoByteResource& operator=(
-      const NonOwningExternalTwoByteResource&) = delete;
-
- private:
-  const uint16_t* data_;
-  size_t length_;
-};
-
 // Similar to a v8::String, but it's independent from Isolates
 // and can be materialized in Isolates as external Strings
 // via ToStringChecked.
@@ -63,7 +21,7 @@ class UnionBytes {
   UnionBytes(const uint8_t* data, size_t length)
       : one_bytes_(data), two_bytes_(nullptr), length_(length) {}
   template <typename T>  // T = uint8_t or uint16_t
-  explicit UnionBytes(std::shared_ptr<std::vector<T>> data)
+  explicit UnionBytes(std::shared_ptr<std::vector</*const*/ T>> data)
       : UnionBytes(data->data(), data->size()) {
     owning_ptr_ = data;
   }
@@ -82,18 +40,8 @@ class UnionBytes {
     CHECK_NOT_NULL(one_bytes_);
     return one_bytes_;
   }
-  v8::Local<v8::String> ToStringChecked(v8::Isolate* isolate) const {
-    if (is_one_byte()) {
-      NonOwningExternalOneByteResource* source =
-          new NonOwningExternalOneByteResource(one_bytes_data(), length_);
-      return v8::String::NewExternalOneByte(isolate, source).ToLocalChecked();
-    } else {
-      NonOwningExternalTwoByteResource* source =
-          new NonOwningExternalTwoByteResource(two_bytes_data(), length_);
-      return v8::String::NewExternalTwoByte(isolate, source).ToLocalChecked();
-    }
-  }
-  size_t length() { return length_; }
+  v8::Local<v8::String> ToStringChecked(v8::Isolate* isolate) const;
+  size_t length() const { return length_; }
 
  private:
   const uint8_t* one_bytes_;

--- a/src/node_union_bytes.h
+++ b/src/node_union_bytes.h
@@ -55,13 +55,18 @@ class NonOwningExternalTwoByteResource
 
 // Similar to a v8::String, but it's independent from Isolates
 // and can be materialized in Isolates as external Strings
-// via ToStringChecked. The data pointers are owned by the caller.
+// via ToStringChecked.
 class UnionBytes {
  public:
   UnionBytes(const uint16_t* data, size_t length)
       : one_bytes_(nullptr), two_bytes_(data), length_(length) {}
   UnionBytes(const uint8_t* data, size_t length)
       : one_bytes_(data), two_bytes_(nullptr), length_(length) {}
+  template <typename T>  // T = uint8_t or uint16_t
+  UnionBytes(std::shared_ptr<T[]> data, size_t length)
+      : UnionBytes(data.get(), length) {
+    owning_ptr_ = data;
+  }
 
   UnionBytes(const UnionBytes&) = default;
   UnionBytes& operator=(const UnionBytes&) = default;
@@ -94,6 +99,7 @@ class UnionBytes {
   const uint8_t* one_bytes_;
   const uint16_t* two_bytes_;
   size_t length_;
+  std::shared_ptr<void> owning_ptr_;
 };
 
 }  // namespace node

--- a/src/node_union_bytes.h
+++ b/src/node_union_bytes.h
@@ -63,8 +63,8 @@ class UnionBytes {
   UnionBytes(const uint8_t* data, size_t length)
       : one_bytes_(data), two_bytes_(nullptr), length_(length) {}
   template <typename T>  // T = uint8_t or uint16_t
-  UnionBytes(std::shared_ptr<T[]> data, size_t length)
-      : UnionBytes(data.get(), length) {
+  explicit UnionBytes(std::shared_ptr<std::vector<T>> data)
+      : UnionBytes(data->data(), data->size()) {
     owning_ptr_ = data;
   }
 

--- a/test/cctest/test_util.cc
+++ b/test/cctest/test_util.cc
@@ -1,7 +1,8 @@
-#include "util-inl.h"
 #include "debug_utils-inl.h"
 #include "env-inl.h"
 #include "gtest/gtest.h"
+#include "simdutf.h"
+#include "util-inl.h"
 
 using node::Calloc;
 using node::Malloc;
@@ -297,4 +298,18 @@ TEST(UtilTest, SPrintF) {
 
   const std::string with_zero = std::string("a") + '\0' + 'b';
   EXPECT_EQ(SPrintF("%s", with_zero), with_zero);
+}
+
+TEST(UtilTest, SimdutfEndiannessDoesNotMeanEndianness) {
+  // In simdutf, "LE" does *not* refer to Little Endian, it refers
+  // to 16-byte code units that are stored using *host* endianness.
+  // This is weird and confusing naming, and so we add this assertion
+  // here to verify that this is actually the case (so that CI tells
+  // us if it changed, because for most people Little Endian is
+  // host endianness, so locally everything would work fine).
+  const char utf8source[] = "\xe7\x8c\xab";
+  char16_t u16output;
+  size_t u16len = simdutf::convert_utf8_to_utf16le(utf8source, 3, &u16output);
+  EXPECT_EQ(u16len, 1u);
+  EXPECT_EQ(u16output, 0x732B);
 }


### PR DESCRIPTION
Remove the dependency on ICU for this part, as well as the hacky way of converting embedder main sources to UTF-8 via V8 APIs. Allow `UnionBytes` to own the memory its pointing to in order to simplify the code on the `BuiltinLoader` side.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
