### PR TITLE
doc: duplex and readable `from`  uncaught exception

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2915,8 +2915,7 @@ the strings or buffers be iterated to match the other streams semantics
 for performance reasons.
 
 If an `Iterable` object containing promises is passed as an argument,
-it could result in uncaught exceptions.
-See the example below:
+it might result in uncaught exceptions.
 
 ```js
 const { Readable } = require('node:stream');
@@ -3058,8 +3057,7 @@ A utility method for creating duplex streams.
 * Returns: {stream.Duplex}
 
 If an `Iterable` object containing promises is passed as an argument,
-it could result in uncaught exceptions.
-See the example below:
+it might result in uncaught exceptions.
 
 ```js
 const { Duplex } = require('node:stream');

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2915,14 +2915,14 @@ the strings or buffers be iterated to match the other streams semantics
 for performance reasons.
 
 If an `Iterable` object containing promises is passed as an argument,
-it might result in uncaught exceptions.
+it might result in uncaught rejections.
 
 ```js
 const { Readable } = require('node:stream');
 
 Readable.from([
   new Promise((resolve) => setTimeout(resolve('1'), 1500)),
-  new Promise((_, reject) => setTimeout(reject(new Error('2')), 1000)), // Uncaught exception
+  new Promise((_, reject) => setTimeout(reject(new Error('2')), 1000)), // Uncaught rejection
 ]);
 ```
 
@@ -3057,14 +3057,14 @@ A utility method for creating duplex streams.
 * Returns: {stream.Duplex}
 
 If an `Iterable` object containing promises is passed as an argument,
-it might result in uncaught exceptions.
+it might result in uncaught rejections.
 
 ```js
 const { Duplex } = require('node:stream');
 
 Duplex.from([
   new Promise((resolve) => setTimeout(resolve('1'), 1500)),
-  new Promise((_, reject) => setTimeout(reject(new Error('2')), 1000)), // Uncaught exception
+  new Promise((_, reject) => setTimeout(reject(new Error('2')), 1000)), // Uncaught rejection
 ]);
 ```
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2914,6 +2914,19 @@ Calling `Readable.from(string)` or `Readable.from(buffer)` will not have
 the strings or buffers be iterated to match the other streams semantics
 for performance reasons.
 
+If an `Iterable` object containing promises is passed as an argument,
+it could result in uncaught exceptions.
+See the example below:
+
+```js
+const { Readable } = require('node:stream');
+
+Readable.from([
+  new Promise((resolve) => setTimeout(resolve('1'), 1500)),
+  new Promise((_, reject) => setTimeout(reject(new Error('2')), 1000)), // Uncaught exception
+]);
+```
+
 ### `stream.Readable.fromWeb(readableStream[, options])`
 
 <!-- YAML
@@ -3043,6 +3056,19 @@ A utility method for creating duplex streams.
   `Duplex` will write to the `writable` and read from the `readable`.
 * `Promise` converts into readable `Duplex`. Value `null` is ignored.
 * Returns: {stream.Duplex}
+
+If an `Iterable` object containing promises is passed as an argument,
+it could result in uncaught exceptions.
+See the example below:
+
+```js
+const { Duplex } = require('node:stream');
+
+Duplex.from([
+  new Promise((resolve) => setTimeout(resolve('1'), 1500)),
+  new Promise((_, reject) => setTimeout(reject(new Error('2')), 1000)), // Uncaught exception
+]);
+```
 
 ### `stream.Duplex.fromWeb(pair[, options])`
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2915,14 +2915,14 @@ the strings or buffers be iterated to match the other streams semantics
 for performance reasons.
 
 If an `Iterable` object containing promises is passed as an argument,
-it might result in uncaught rejections.
+it might result in unhandled rejection.
 
 ```js
 const { Readable } = require('node:stream');
 
 Readable.from([
   new Promise((resolve) => setTimeout(resolve('1'), 1500)),
-  new Promise((_, reject) => setTimeout(reject(new Error('2')), 1000)), // Uncaught rejection
+  new Promise((_, reject) => setTimeout(reject(new Error('2')), 1000)), // Unhandled rejection
 ]);
 ```
 
@@ -3057,14 +3057,14 @@ A utility method for creating duplex streams.
 * Returns: {stream.Duplex}
 
 If an `Iterable` object containing promises is passed as an argument,
-it might result in uncaught rejections.
+it might result in unhandled rejection.
 
 ```js
 const { Duplex } = require('node:stream');
 
 Duplex.from([
   new Promise((resolve) => setTimeout(resolve('1'), 1500)),
-  new Promise((_, reject) => setTimeout(reject(new Error('2')), 1000)), // Uncaught rejection
+  new Promise((_, reject) => setTimeout(reject(new Error('2')), 1000)), // Unhandled rejection
 ]);
 ```
 


### PR DESCRIPTION
resolves: https://github.com/nodejs/node/issues/46071
Warning the user that using `Duplex.from` or `Readable.from` passing an iterable with promises as argument, could lead to uncaught exceptions
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
