### PR TITLE
http: refactor to use `validateHeaderName`

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3672,7 +3672,7 @@ changes:
 -->
 
 * `name` {string}
-* `label` {string} Label for error message. **Default:** `Header name`.
+* `label` {string} Label for error message. **Default:** `'Header name'`.
 
 Performs the low-level validations on the provided `name` that are done when
 `res.setHeader(name, value)` is called.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3661,13 +3661,18 @@ Passing an `AbortSignal` and then calling `abort` on the corresponding
 `AbortController` will behave the same way as calling `.destroy()` on the
 request itself.
 
-## `http.validateHeaderName(name)`
+## `http.validateHeaderName(name[, label])`
 
 <!-- YAML
 added: v14.3.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46143
+    description: The `label` parameter is added.
 -->
 
 * `name` {string}
+* `label` {string} Label for error message. **Default:** `Header name`.
 
 Performs the low-level validations on the provided `name` that are done when
 `res.setHeader(name, value)` is called.

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -933,9 +933,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
       field = key;
       value = headers[key];
     }
-    if (typeof field !== 'string' || !field || !checkIsHttpToken(field)) {
-      throw new ERR_INVALID_HTTP_TOKEN('Trailer name', field);
-    }
+    validateHeaderName(field);
 
     // Check if the field must be sent several times
     const isArrayValue = ArrayIsArray(value);

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -628,9 +628,9 @@ function matchHeader(self, state, field, value) {
   }
 }
 
-const validateHeaderName = hideStackFrames((name) => {
+const validateHeaderName = hideStackFrames((name, label = 'Header name') => {
   if (typeof name !== 'string' || !name || !checkIsHttpToken(name)) {
-    throw new ERR_INVALID_HTTP_TOKEN('Header name', name);
+    throw new ERR_INVALID_HTTP_TOKEN(label, name);
   }
 });
 
@@ -933,7 +933,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
       field = key;
       value = headers[key];
     }
-    validateHeaderName(field);
+    validateHeaderName(field, 'Trailer name');
 
     // Check if the field must be sent several times
     const isArrayValue = ArrayIsArray(value);

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -628,9 +628,9 @@ function matchHeader(self, state, field, value) {
   }
 }
 
-const validateHeaderName = hideStackFrames((name, label = 'Header name') => {
+const validateHeaderName = hideStackFrames((name, label) => {
   if (typeof name !== 'string' || !name || !checkIsHttpToken(name)) {
-    throw new ERR_INVALID_HTTP_TOKEN(label, name);
+    throw new ERR_INVALID_HTTP_TOKEN(label || 'Header name', name);
   }
 });
 

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -117,6 +117,7 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_HTTP_TOKEN',
   name: 'TypeError',
+  message: 'Trailer name must be a valid HTTP token ["あ"]'
 });
 
 assert.throws(() => {

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -117,7 +117,6 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_HTTP_TOKEN',
   name: 'TypeError',
-  message: 'Trailer name must be a valid HTTP token ["あ"]'
 });
 
 assert.throws(() => {


### PR DESCRIPTION
Remove duplicate implementation by using validateHeaderName.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
