### PR TITLE
deps: add simdutf version to metadata

### DIFF
--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -5,6 +5,7 @@
 #include "llhttp.h"
 #include "nghttp2/nghttp2ver.h"
 #include "node.h"
+#include "simdutf.h"
 #include "undici_version.h"
 #include "util.h"
 #include "uv.h"
@@ -112,6 +113,8 @@ Metadata::Versions::Versions() {
   ngtcp2 = NGTCP2_VERSION;
   nghttp3 = NGHTTP3_VERSION;
 #endif
+
+  simdutf = SIMDUTF_VERSION;
 }
 
 Metadata::Release::Release() : name(NODE_RELEASE) {

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -46,6 +46,7 @@ namespace node {
   V(llhttp)                                                                    \
   V(uvwasi)                                                                    \
   V(acorn)                                                                     \
+  V(simdutf)                                                                   \
   NODE_VERSIONS_KEY_UNDICI(V)
 
 #if HAVE_OPENSSL

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -18,6 +18,7 @@ const expected_keys = [
   'llhttp',
   'uvwasi',
   'acorn',
+  'simdutf',
 ];
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');


### PR DESCRIPTION
I saw that simdutf version was missing from process.versions. This pull request adds the version.