### PR TITLE
[v18.x] tools: Revert "tools: update V8 gypfiles for RISC-V"

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1646,7 +1646,7 @@
               }],
               ['_toolset == "host" and host_arch == "riscv64" or _toolset == "target" and target_arch=="riscv64"', {
                 'sources': [
-                  '<(V8_ROOT)/src/heap/base/asm/riscv/push_registers_asm.cc',
+                  '<(V8_ROOT)/src/heap/base/asm/riscv64/push_registers_asm.cc',
                 ],
               }],
               ['_toolset == "host" and host_arch == "loong64" or _toolset == "target" and target_arch=="loong64"', {


### PR DESCRIPTION
Fix wrong file path
fix #46154 