### PR TITLE
http: writeHead if statusmessage is undefined dont override headers

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -352,9 +352,7 @@ function writeHead(statusCode, reason, obj) {
     // writeHead(statusCode[, headers])
     if (!this.statusMessage)
       this.statusMessage = STATUS_CODES[statusCode] || 'unknown';
-    if (!obj) {
-      obj = reason;
-    }
+    obj ??= reason;
   }
   this.statusCode = statusCode;
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -352,7 +352,9 @@ function writeHead(statusCode, reason, obj) {
     // writeHead(statusCode[, headers])
     if (!this.statusMessage)
       this.statusMessage = STATUS_CODES[statusCode] || 'unknown';
-    obj = reason;
+    if (!obj) {
+      obj = reason;
+    }
   }
   this.statusCode = statusCode;
 

--- a/test/parallel/test-http-write-head-2.js
+++ b/test/parallel/test-http-write-head-2.js
@@ -59,3 +59,21 @@ const http = require('http');
     }));
   }));
 }
+
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.writeHead(200, undefined, [ 'foo', 'bar' ]);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.statusMessage, 'OK');
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers.foo, 'bar');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}


### PR DESCRIPTION
fix: https://github.com/nodejs/node/issues/32395
this PR avoids that when calling `res.writeHead(200, undefined, { 'x-foo': 'bar' });` the headers are ignored.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
