### PR TITLE
lib: refactor to use validators in http2

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -762,27 +762,27 @@ function requestOnConnect(headers, options) {
 const setAndValidatePriorityOptions = hideStackFrames((options) => {
   if (options.weight === undefined) {
     options.weight = NGHTTP2_DEFAULT_WEIGHT;
+  } else {
+    validateNumber(options.weight, 'options.weight');
   }
-
-  validateNumber(options.weight, 'options.weight');
 
   if (options.parent === undefined) {
     options.parent = 0;
+  } else {
+    validateNumber(options.parent, 'options.parent', 0);
   }
-
-  validateNumber(options.parent, 'options.parent', 0);
 
   if (options.exclusive === undefined) {
     options.exclusive = false;
+  } else {
+    validateBoolean(options.exclusive, 'options.exclusive');
   }
-
-  validateBoolean(options.exclusive, 'options.exclusive');
 
   if (options.silent === undefined) {
     options.silent = false;
+  } else {
+    validateBoolean(options.silent, 'options.silent');
   }
-
-  validateBoolean(options.silent, 'options.silent');
 });
 
 // When an error occurs internally at the binding level, immediately
@@ -1785,9 +1785,9 @@ class ClientHttp2Session extends Http2Session {
       // stream by default if the user has not specifically indicated a
       // preference.
       options.endStream = isPayloadMeaningless(headers[HTTP2_HEADER_METHOD]);
+    } else {
+      validateBoolean(options.endStream, 'options.endStream');
     }
-
-    validateBoolean(options.endStream, 'options.endStream');
 
     const headersList = mapToHeaders(headers);
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -126,7 +126,8 @@ const {
   validateNumber,
   validateString,
   validateUint32,
-  validateAbortSignal
+  validateAbortSignal,
+  validateBoolean,
 } = require('internal/validators');
 const fsPromisesInternal = require('internal/fs/promises');
 const { utcDate } = require('internal/http');
@@ -761,27 +762,27 @@ function requestOnConnect(headers, options) {
 const setAndValidatePriorityOptions = hideStackFrames((options) => {
   if (options.weight === undefined) {
     options.weight = NGHTTP2_DEFAULT_WEIGHT;
-  } else if (typeof options.weight !== 'number') {
-    throw new ERR_INVALID_ARG_VALUE('options.weight', options.weight);
-  }
+  } 
+
+  validateNumber(options.weight, 'options.weight');
 
   if (options.parent === undefined) {
     options.parent = 0;
-  } else if (typeof options.parent !== 'number' || options.parent < 0) {
-    throw new ERR_INVALID_ARG_VALUE('options.parent', options.parent);
-  }
+  } 
+
+  validateNumber(options.parent, 'options.parent', 0);
 
   if (options.exclusive === undefined) {
     options.exclusive = false;
-  } else if (typeof options.exclusive !== 'boolean') {
-    throw new ERR_INVALID_ARG_VALUE('options.exclusive', options.exclusive);
   }
+
+  validateBoolean(options.exclusive, 'options.exclusive');
 
   if (options.silent === undefined) {
     options.silent = false;
-  } else if (typeof options.silent !== 'boolean') {
-    throw new ERR_INVALID_ARG_VALUE('options.silent', options.silent);
   }
+
+  validateBoolean(options.silent, 'options.silent');
 });
 
 // When an error occurs internally at the binding level, immediately
@@ -1784,9 +1785,10 @@ class ClientHttp2Session extends Http2Session {
       // stream by default if the user has not specifically indicated a
       // preference.
       options.endStream = isPayloadMeaningless(headers[HTTP2_HEADER_METHOD]);
-    } else if (typeof options.endStream !== 'boolean') {
-      throw new ERR_INVALID_ARG_VALUE('options.endStream', options.endStream);
     }
+
+    validateBoolean(options.endStream, 'options.endStream');
+    
 
     const headersList = mapToHeaders(headers);
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -762,13 +762,13 @@ function requestOnConnect(headers, options) {
 const setAndValidatePriorityOptions = hideStackFrames((options) => {
   if (options.weight === undefined) {
     options.weight = NGHTTP2_DEFAULT_WEIGHT;
-  } 
+  }
 
   validateNumber(options.weight, 'options.weight');
 
   if (options.parent === undefined) {
     options.parent = 0;
-  } 
+  }
 
   validateNumber(options.parent, 'options.parent', 0);
 
@@ -1788,7 +1788,6 @@ class ClientHttp2Session extends Http2Session {
     }
 
     validateBoolean(options.endStream, 'options.endStream');
-    
 
     const headersList = mapToHeaders(headers);
 

--- a/test/parallel/test-http2-client-request-options-errors.js
+++ b/test/parallel/test-http2-client-request-options-errors.js
@@ -42,7 +42,7 @@ function determineSpecificType(value) {
     return `${inspect(value, { depth: -1 })}`;
   }
   let inspected = inspect(value, { colors: false });
-  if (inspected.length > 28) { inspected = `${StringPrototypeSlice(inspected, 0, 25)}...`; }
+  if (inspected.length > 28) { inspected = `${inspected.slice(0, 25)}...`; }
 
   return `type ${typeof value} (${inspected})`;
 }

--- a/test/parallel/test-http2-client-request-options-errors.js
+++ b/test/parallel/test-http2-client-request-options-errors.js
@@ -5,7 +5,6 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
-const { inspect } = require('util');
 
 // Check if correct errors are emitted when wrong type of data is passed
 // to certain options of ClientHttp2Session request method
@@ -28,25 +27,6 @@ const types = {
   symbol: Symbol('test')
 };
 
-function determineSpecificType(value) {
-  if (value == null) {
-    return '' + value;
-  }
-  if (typeof value === 'function' && value.name) {
-    return `function ${value.name}`;
-  }
-  if (typeof value === 'object') {
-    if (value.constructor?.name) {
-      return `an instance of ${value.constructor.name}`;
-    }
-    return `${inspect(value, { depth: -1 })}`;
-  }
-  let inspected = inspect(value, { colors: false });
-  if (inspected.length > 28) { inspected = `${inspected.slice(0, 25)}...`; }
-
-  return `type ${typeof value} (${inspected})`;
-}
-
 const server = http2.createServer(common.mustNotCall());
 
 server.listen(0, common.mustCall(() => {
@@ -68,8 +48,6 @@ server.listen(0, common.mustCall(() => {
           }), {
             name: 'TypeError',
             code: 'ERR_INVALID_ARG_TYPE',
-            message: `The "options.${option}" property must be of type ${optionsToTest[option]}. ` +
-                    `Received ${determineSpecificType(types[type])}`
           });
       });
     });

--- a/test/parallel/test-http2-client-request-options-errors.js
+++ b/test/parallel/test-http2-client-request-options-errors.js
@@ -28,6 +28,25 @@ const types = {
   symbol: Symbol('test')
 };
 
+function determineSpecificType(value) {
+  if (value == null) {
+    return '' + value;
+  }
+  if (typeof value === 'function' && value.name) {
+    return `function ${value.name}`;
+  }
+  if (typeof value === 'object') {
+    if (value.constructor?.name) {
+      return `an instance of ${value.constructor.name}`;
+    }
+    return `${inspect(value, { depth: -1 })}`;
+  }
+  let inspected = inspect(value, { colors: false });
+  if (inspected.length > 28) { inspected = `${StringPrototypeSlice(inspected, 0, 25)}...`; }
+
+  return `type ${typeof value} (${inspected})`;
+}
+
 const server = http2.createServer(common.mustNotCall());
 
 server.listen(0, common.mustCall(() => {
@@ -48,9 +67,9 @@ server.listen(0, common.mustCall(() => {
             [option]: types[type]
           }), {
             name: 'TypeError',
-            code: 'ERR_INVALID_ARG_VALUE',
-            message: `The property 'options.${option}' is invalid. ` +
-                    `Received ${inspect(types[type])}`
+            code: 'ERR_INVALID_ARG_TYPE',
+            message: `The "options.${option}" property must be of type ${optionsToTest[option]}. ` +
+                    `Received ${determineSpecificType(types[type])}`
           });
       });
     });


### PR DESCRIPTION
Attempted to refactor usage of validators similar to the referenced PR

Refs: https://github.com/nodejs/node/pull/46101

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
