### PR TITLE
events: change status of `event.returnvalue` to legacy

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1846,8 +1846,11 @@ Sets the `defaultPrevented` property to `true` if `cancelable` is `true`.
 added: v14.5.0
 -->
 
+> Stability: 3 - Legacy: Use [`event.defaultPrevented`][] instead.
+
 * Type: {boolean} True if the event has not been canceled.
 
+Returns a value which is opposite of the value returned by `defaultPrevented`.
 This is not used in Node.js and is provided purely for completeness.
 
 #### `event.srcElement`
@@ -2168,6 +2171,7 @@ to the `EventTarget`.
 [`emitter.listenerCount()`]: #emitterlistenercounteventname
 [`emitter.removeListener()`]: #emitterremovelistenereventname-listener
 [`emitter.setMaxListeners(n)`]: #emittersetmaxlistenersn
+[`event.defaultPrevented`]: #eventdefaultprevented
 [`event.stopPropagation()`]: #eventstoppropagation
 [`event.target`]: #eventtarget
 [`events.defaultMaxListeners`]: #eventsdefaultmaxlisteners

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1850,7 +1850,7 @@ added: v14.5.0
 
 * Type: {boolean} True if the event has not been canceled.
 
-Returns a value which is opposite of the value returned by `defaultPrevented`.
+The value of `event.returnValue` is always the opposite of `event.defaultPrevented`.
 This is not used in Node.js and is provided purely for completeness.
 
 #### `event.srcElement`

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -236,7 +236,7 @@ class Event {
   get returnValue() {
     if (!isEvent(this))
       throw new ERR_INVALID_THIS('Event');
-    return !this.defaultPrevented;
+    return !this.#defaultPrevented;
   }
 
   /**

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -236,7 +236,7 @@ class Event {
   get returnValue() {
     if (!isEvent(this))
       throw new ERR_INVALID_THIS('Event');
-    return !this.#defaultPrevented;
+    return !this.#cancelable || !this.#defaultPrevented;
   }
 
   /**


### PR DESCRIPTION
`event.returnvalue` is described as legacy in spec. Plus, add missed '#'(private member) of defaultPrevented in implementation.

Refs: https://dom.spec.whatwg.org/#interface-event
Refs: https://developer.mozilla.org/en-US/docs/Web/API/Event/returnValue

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
