### PR TITLE
lib: use kEmptyObject and update JSDoc in webstreams

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1105,16 +1105,7 @@ class ReadableByteStreamController {
   enqueue(chunk) {
     if (!isReadableByteStreamController(this))
       throw new ERR_INVALID_THIS('ReadableByteStreamController');
-    if (!isArrayBufferView(chunk)) {
-      throw new ERR_INVALID_ARG_TYPE(
-        'chunk',
-        [
-          'Buffer',
-          'TypedArray',
-          'DataView',
-        ],
-        chunk);
-    }
+    validateBuffer(chunk);
     const chunkByteLength = ArrayBufferViewGetByteLength(chunk);
     const chunkBuffer = ArrayBufferViewGetBuffer(chunk);
     const chunkBufferByteLength = ArrayBufferPrototypeGetByteLength(chunkBuffer);

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -26,6 +26,7 @@ const {
 const {
   createDeferredPromise,
   customInspectSymbol: kInspect,
+  kEmptyObject,
   kEnumerableProperty,
 } = require('internal/util');
 
@@ -117,8 +118,8 @@ class TransformStream {
    */
   constructor(
     transformer = null,
-    writableStrategy = {},
-    readableStrategy = {}) {
+    writableStrategy = kEmptyObject,
+    readableStrategy = kEmptyObject) {
     const readableType = transformer?.readableType;
     const writableType = transformer?.writableType;
     const start = transformer?.start;
@@ -292,7 +293,7 @@ class TransformStreamDefaultController {
   }
 
   /**
-   * @param {any} chunk
+   * @param {any} [chunk]
    */
   enqueue(chunk = undefined) {
     if (!isTransformStreamDefaultController(this))
@@ -301,7 +302,7 @@ class TransformStreamDefaultController {
   }
 
   /**
-   * @param {any} reason
+   * @param {any} [reason]
    */
   error(reason = undefined) {
     if (!isTransformStreamDefaultController(this))

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -33,6 +33,7 @@ const {
 const {
   createDeferredPromise,
   customInspectSymbol: kInspect,
+  kEmptyObject,
   kEnumerableProperty,
 } = require('internal/util');
 
@@ -133,7 +134,7 @@ class WritableStream {
    * @param {UnderlyingSink} [sink]
    * @param {QueuingStrategy} [strategy]
    */
-  constructor(sink = null, strategy = {}) {
+  constructor(sink = null, strategy = kEmptyObject) {
     const type = sink?.type;
     if (type !== undefined)
       throw new ERR_INVALID_ARG_VALUE.RangeError('type', type);
@@ -202,7 +203,7 @@ class WritableStream {
   }
 
   /**
-   * @param {any} reason
+   * @param {any} [reason]
    * @returns {Promise<void>}
    */
   abort(reason = undefined) {
@@ -460,7 +461,7 @@ class WritableStreamDefaultWriter {
   }
 
   /**
-   * @param {any} chunk
+   * @param {any} [chunk]
    * @returns {Promise<void>}
    */
   write(chunk = undefined) {


### PR DESCRIPTION
Use kEmptyObject as default value of strategy.
Plus, make reason and chunk as optional.
And refactor to use validateBuffer.

Refs: https://github.com/nodejs/node/blob/main/doc/api/webstreams.md#transformstreamdefaultcontrollerenqueuechunk
Refs: https://github.com/nodejs/node/blob/main/doc/api/webstreams.md#transformstreamdefaultcontrollererrorreason
Refs: https://github.com/nodejs/node/blob/main/doc/api/webstreams.md#writablestreamdefaultwriterabortreason
Refs: https://github.com/nodejs/node/blob/main/doc/api/webstreams.md#writablestreamdefaultwriterwritechunk

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
