### PR TITLE
src,lib: add constrainedMemory API for process

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1103,6 +1103,21 @@ and [Cluster][] documentation), the `process.connected` property will return
 Once `process.connected` is `false`, it is no longer possible to send messages
 over the IPC channel using `process.send()`.
 
+## `process.constrainedMemory()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+Gets the amount of memory available to the process (in bytes) based on
+limits imposed by the OS. If there is no such constraint, or the constraint
+is unknown, `0` is returned. It is not unusual for this value to
+be less than or greater than `os.totalmem()`. This function currently only
+returns a non-zero value on Linux, based on cgroups if it is present, and
+on z/OS based on `RLIMIT_MEMLIMIT`.
+
 ## `process.cpuUsage([previousValue])`
 
 <!-- YAML

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -184,6 +184,7 @@ const rawMethods = internalBinding('process_methods');
 
   process.hrtime = perThreadSetup.hrtime;
   process.hrtime.bigint = perThreadSetup.hrtimeBigInt;
+  process.constrainedMemory = perThreadSetup.constrainedMemory;
 
   process.openStdin = function() {
     process.stdin.resume();

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -60,6 +60,7 @@ const binding = internalBinding('process_methods');
 
 let hrValues;
 let hrBigintValues;
+let constrainedMemoryValus;
 
 function refreshHrtimeBuffer() {
   // The 3 entries filled in by the original process.hrtime contains
@@ -69,6 +70,7 @@ function refreshHrtimeBuffer() {
   // Use a BigUint64Array in the closure because this is actually a bit
   // faster than simply returning a BigInt from C++ in V8 7.1.
   hrBigintValues = new BigUint64Array(binding.hrtimeBuffer, 0, 1);
+  constrainedMemoryValus = new BigUint64Array(binding.hrtimeBuffer, 0, 1);
 }
 
 // Create the buffers.
@@ -98,6 +100,11 @@ function hrtime(time) {
 function hrtimeBigInt() {
   binding.hrtimeBigInt();
   return hrBigintValues[0];
+}
+
+function constrainedMemory() {
+  binding.constrainedMemory();
+  return constrainedMemoryValus[0];
 }
 
 function nop() {}
@@ -427,4 +434,5 @@ module.exports = {
   hrtime,
   hrtimeBigInt,
   refreshHrtimeBuffer,
+  constrainedMemory,
 };

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -81,6 +81,11 @@ class BindingData : public SnapshotableObject {
 
   static void SlowBigInt(const v8::FunctionCallbackInfo<v8::Value>& args);
 
+  static void ConstrainedMemoryImpl(BindingData* receiver);
+  static void SlowGetConstrainedMemory(
+    const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void FastGetConstrainedMemory(v8::Local<v8::Value> receiver);
+
  private:
   static constexpr size_t kBufferSize =
       std::max(sizeof(uint64_t), sizeof(uint32_t) * 3);
@@ -92,6 +97,7 @@ class BindingData : public SnapshotableObject {
   // time.
   static v8::CFunction fast_number_;
   static v8::CFunction fast_bigint_;
+  static v8::CFunction fast_get_constrained_memory_;
 };
 
 }  // namespace process

--- a/test/parallel/test-process-constrained-memory.js
+++ b/test/parallel/test-process-constrained-memory.js
@@ -1,0 +1,13 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+
+if (!process.env.isWorker) {
+  process.env.isWorker = true;
+  new Worker(__filename);
+  assert(process.constrainedMemory() >= 0);
+} else {
+  assert(process.constrainedMemory() >= 0);
+}


### PR DESCRIPTION
add `constrainedMemory` API for process.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
