### PR TITLE
lib: add webstreams to Duplex.from()

### DIFF
--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -20,6 +20,7 @@ const {
 const { destroyer } = require('internal/streams/destroy');
 const Duplex = require('internal/streams/duplex');
 const Readable = require('internal/streams/readable');
+const Writable = require('internal/streams/writable');
 const { createDeferredPromise } = require('internal/util');
 const from = require('internal/streams/from');
 
@@ -31,6 +32,16 @@ const { AbortController } = require('internal/abort_controller');
 const {
   FunctionPrototypeCall
 } = primordials;
+
+
+const {
+  isBrandCheck,
+} = require('internal/webstreams/util');
+
+const isReadableStream =
+  isBrandCheck('ReadableStream');
+const isWritableStream =
+  isBrandCheck('WritableStream');
 
 // This is needed for pre node 17.
 class Duplexify extends Duplex {
@@ -71,15 +82,13 @@ module.exports = function duplexify(body, name) {
     return _duplexify({ writable: false, readable: false });
   }
 
-  // TODO: Webstreams
-  // if (isReadableStream(body)) {
-  //   return _duplexify({ readable: Readable.fromWeb(body) });
-  // }
+  if (isReadableStream(body)) {
+    return _duplexify({ readable: Readable.fromWeb(body) });
+  }
 
-  // TODO: Webstreams
-  // if (isWritableStream(body)) {
-  //   return _duplexify({ writable: Writable.fromWeb(body) });
-  // }
+  if (isWritableStream(body)) {
+    return _duplexify({ writable: Writable.fromWeb(body) });
+  }
 
   if (typeof body === 'function') {
     const { value, write, final, destroy } = fromAsyncGen(body);
@@ -146,13 +155,12 @@ module.exports = function duplexify(body, name) {
     });
   }
 
-  // TODO: Webstreams.
-  // if (
-  //   isReadableStream(body?.readable) &&
-  //   isWritableStream(body?.writable)
-  // ) {
-  //   return Duplexify.fromWeb(body);
-  // }
+  if (
+    isReadableStream(body?.readable) &&
+    isWritableStream(body?.writable)
+  ) {
+    return Duplexify.fromWeb(body);
+  }
 
   if (
     typeof body?.writable === 'object' ||

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const { Duplex, Readable, Writable, pipeline, PassThrough } = require('stream');
+const { ReadableStream, WritableStream } = require('stream/web');
 const { Blob } = require('buffer');
 
 {
@@ -298,4 +299,105 @@ const { Blob } = require('buffer');
   }).on('end', common.mustCall(() => {
     assert.strictEqual(res, 'foobar');
   })).on('close', common.mustCall());
+}
+
+function makeATestReadableStream(value) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(value);
+      controller.close();
+    }
+  });
+}
+
+function makeATestWritableStream(writeFunc) {
+  return new WritableStream({
+    write(chunk) {
+      writeFunc(chunk)
+    }
+  });
+}
+
+{
+  const d = Duplex.from({
+    readable: makeATestReadableStream('foo'),
+  });
+  assert.strictEqual(d.readable, true);
+  assert.strictEqual(d.writable, false);
+
+  d.on('data', common.mustCall((data) => {
+    assert.strictEqual(data.toString(), 'foo');
+  }));
+
+  d.on('end', common.mustCall(() => {
+    assert.strictEqual(d.readable, false);
+  }));
+}
+
+{
+  const d = Duplex.from(makeATestReadableStream('foo'));
+
+  assert.strictEqual(d.readable, true);
+  assert.strictEqual(d.writable, false);
+
+  d.on('data', common.mustCall((data) => {
+    assert.strictEqual(data.toString(), 'foo');
+  }));
+
+  d.on('end', common.mustCall(() => {
+    assert.strictEqual(d.readable, false);
+  }));
+}
+
+{
+  let ret = '';
+  const d = Duplex.from({
+    writable: makeATestWritableStream((chunk) => ret += chunk),
+  });
+
+  assert.strictEqual(d.readable, false);
+  assert.strictEqual(d.writable, true);
+
+  d.end('foo');
+  d.on('finish', common.mustCall(() => {
+    assert.strictEqual(ret, 'foo');
+    assert.strictEqual(d.writable, false);
+  }));
+}
+
+{
+  let ret = '';
+  const d = Duplex.from(makeATestWritableStream((chunk) => ret += chunk));
+
+  assert.strictEqual(d.readable, false);
+  assert.strictEqual(d.writable, true);
+
+  d.end('foo');
+  d.on('finish', common.mustCall(() => {
+    assert.strictEqual(ret, 'foo');
+    assert.strictEqual(d.writable, false);
+  }));
+}
+
+{
+  let ret = '';
+  const d = Duplex.from({
+    readable: makeATestReadableStream('foo'),
+    writable: makeATestWritableStream((chunk) => ret += chunk),
+  });
+
+  d.end('bar')
+
+  d.on('data', common.mustCall((data) => {
+    assert.strictEqual(data.toString(), 'foo');
+  }));
+
+  d.on('end', common.mustCall(() => {
+    assert.strictEqual(d.readable, false);
+  }));
+
+  d.on('finish', common.mustCall(() => {
+    assert.strictEqual(ret, 'bar');
+    assert.strictEqual(d.writable, false);
+  }));
 }

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -313,7 +313,7 @@ function makeATestReadableStream(value) {
 function makeATestWritableStream(writeFunc) {
   return new WritableStream({
     write(chunk) {
-      writeFunc(chunk)
+      writeFunc(chunk);
     }
   });
 }
@@ -386,7 +386,7 @@ function makeATestWritableStream(writeFunc) {
     writable: makeATestWritableStream((chunk) => ret += chunk),
   });
 
-  d.end('bar')
+  d.end('bar');
 
   d.on('data', common.mustCall((data) => {
     assert.strictEqual(data.toString(), 'foo');


### PR DESCRIPTION
Enabled webstreams on Duplex.from() and added tests

Refs: https://github.com/nodejs/node/pull/39519

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
