### PR TITLE
src: hide kMaxDigestMultiplier outside HKDF impl

### DIFF
--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -87,6 +87,10 @@ Maybe<bool> HKDFTraits::AdditionalConfig(
       : info.ToByteSource();
 
   params->length = args[offset + 4].As<Uint32>()->Value();
+  // HKDF-Expand computes up to 255 HMAC blocks, each having as many bits as the
+  // output of the hash function. 255 is a hard limit because HKDF appends an
+  // 8-bit counter to each HMAC'd message, starting at 1.
+  constexpr size_t kMaxDigestMultiplier = 255;
   size_t max_length = EVP_MD_size(params->digest) * kMaxDigestMultiplier;
   if (params->length > max_length) {
     THROW_ERR_CRYPTO_INVALID_KEYLEN(env);

--- a/src/crypto/crypto_hkdf.h
+++ b/src/crypto/crypto_hkdf.h
@@ -11,8 +11,6 @@
 
 namespace node {
 namespace crypto {
-static constexpr size_t kMaxDigestMultiplier = 255;
-
 struct HKDFConfig final : public MemoryRetainer {
   CryptoJobMode mode;
   size_t length;


### PR DESCRIPTION
There is no reason to expose this constant outside of the HKDF implementation, especially with such a generic name.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
