### PR TITLE
src: replace unreachable code with static_assert

### DIFF
--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -479,12 +479,8 @@ std::shared_ptr<KeyObjectData> ImportJWKSecretKey(
     return std::shared_ptr<KeyObjectData>();
   }
 
+  static_assert(String::kMaxLength <= INT_MAX);
   ByteSource key_data = ByteSource::FromEncodedString(env, key.As<String>());
-  if (key_data.size() > INT_MAX) {
-    THROW_ERR_CRYPTO_INVALID_KEYLEN(env);
-    return std::shared_ptr<KeyObjectData>();
-  }
-
   return KeyObjectData::CreateSecret(std::move(key_data));
 }
 


### PR DESCRIPTION
This function base64-decodes a given JavaScript string to obtain the secret key, whose length must not exceed `INT_MAX`. However, because JavaScript strings are limited to `v8::String::kMaxLength` chars and because base64 decoding never yields more bytes than input chars, the size of the decoded key must be strictly less than `v8::String::kMaxLength` bytes. Therefore, it is sufficient to statically assert that `String::kMaxLength <= INT_MAX` (which is always true because `String::kMaxLength` itself is an int).

Aside from being unreachable, Coverity considers the current code "suspicious" because it indicates that buffers larger than `INT_MAX` might actually be allocated.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
