### PR TITLE
tools: fix macro name in update-undici

### DIFF
--- a/tools/update-undici.sh
+++ b/tools/update-undici.sh
@@ -32,10 +32,10 @@ rm -f deps/undici/undici.js
     FILE_PATH="$ROOT/src/undici_version.h"
     echo "// This is an auto generated file, please do not edit." > "$FILE_PATH"
     echo "// Refer to tools/update-undici.sh" >> "$FILE_PATH"
-    echo "#ifndef SRC_ACORN_VERSION_H_" >> "$FILE_PATH"
-    echo "#define SRC_ACORN_VERSION_H_" >> "$FILE_PATH"
+    echo "#ifndef SRC_UNDICI_VERSION_H_" >> "$FILE_PATH"
+    echo "#define SRC_UNDICI_VERSION_H_" >> "$FILE_PATH"
     echo "#define UNDICI_VERSION \"$UNDICI_VERSION\"" >> "$FILE_PATH"
-    echo "#endif  // SRC_ACORN_VERSION_H_" >> "$FILE_PATH"
+    echo "#endif  // SRC_UNDICI_VERSION_H_" >> "$FILE_PATH"
 )
 
 mv undici-tmp/node_modules/undici deps/undici/src


### PR DESCRIPTION
The `tools/update-undici.sh` script was using the same macro name as `tools/update-acorn.sh`
https://github.com/nodejs/node/blob/67a9ed3f7f3c02cd908f98ac375bf1041a64ec70/tools/update-acorn.sh#L33-L36

The generated file, however, has the correct macro name
https://github.com/nodejs/node/blob/67a9ed3f7f3c02cd908f98ac375bf1041a64ec70/src/undici_version.h#L3-L6

This seems to be an oversight from #45621

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


