### PR TITLE
src,lib: add constrainedMemory API for process

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1103,6 +1103,23 @@ and [Cluster][] documentation), the `process.connected` property will return
 Once `process.connected` is `false`, it is no longer possible to send messages
 over the IPC channel using `process.send()`.
 
+## `process.constrainedMemory()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* {number|undefined}
+
+Gets the amount of memory available to the process (in bytes) based on
+limits imposed by the OS. If there is no such constraint, or the constraint
+is unknown, `undefined` is returned.
+
+See [`uv_get_constrained_memory`][uv_get_constrained_memory] for more
+information.
+
 ## `process.cpuUsage([previousValue])`
 
 <!-- YAML
@@ -3901,6 +3918,7 @@ cases:
 [process_warning]: #event-warning
 [report documentation]: report.md
 [terminal raw mode]: tty.md#readstreamsetrawmodemode
+[uv_get_constrained_memory]: https://docs.libuv.org/en/v1.x/misc.html#c.uv_get_constrained_memory
 [uv_rusage_t]: https://docs.libuv.org/en/v1.x/misc.html#c.uv_rusage_t
 [wikipedia_major_fault]: https://en.wikipedia.org/wiki/Page_fault#Major
 [wikipedia_minor_fault]: https://en.wikipedia.org/wiki/Page_fault#Minor

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -179,6 +179,7 @@ const rawMethods = internalBinding('process_methods');
   process.cpuUsage = wrapped.cpuUsage;
   process.resourceUsage = wrapped.resourceUsage;
   process.memoryUsage = wrapped.memoryUsage;
+  process.constrainedMemory = rawMethods.constrainedMemory;
   process.kill = wrapped.kill;
   process.exit = wrapped.exit;
 

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -207,6 +207,13 @@ static void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
           : static_cast<double>(array_buffer_allocator->total_mem_usage());
 }
 
+static void GetConstrainedMemory(const FunctionCallbackInfo<Value>& args) {
+  uint64_t value = uv_get_constrained_memory();
+  if (value != 0) {
+    args.GetReturnValue().Set(static_cast<double>(value));
+  }
+}
+
 void RawDebug(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
         "must be called with a single string");
@@ -582,6 +589,7 @@ static void Initialize(Local<Object> target,
 
   SetMethod(context, target, "umask", Umask);
   SetMethod(context, target, "memoryUsage", MemoryUsage);
+  SetMethod(context, target, "constrainedMemory", GetConstrainedMemory);
   SetMethod(context, target, "rss", Rss);
   SetMethod(context, target, "cpuUsage", CPUUsage);
   SetMethod(context, target, "resourceUsage", ResourceUsage);
@@ -612,6 +620,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(Umask);
   registry->Register(RawDebug);
   registry->Register(MemoryUsage);
+  registry->Register(GetConstrainedMemory);
   registry->Register(Rss);
   registry->Register(CPUUsage);
   registry->Register(ResourceUsage);

--- a/test/parallel/test-process-constrained-memory.js
+++ b/test/parallel/test-process-constrained-memory.js
@@ -1,0 +1,12 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+const constrainedMemory = process.constrainedMemory();
+if (constrainedMemory !== undefined) {
+  assert(constrainedMemory > 0);
+}
+if (!process.env.isWorker) {
+  process.env.isWorker = true;
+  new Worker(__filename);
+}


### PR DESCRIPTION
add `constrainedMemory` API for process.
cc @anonrig 

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
