### PR TITLE
test: refactor to avoid mutation of global by a loader

### DIFF
--- a/test/es-module/test-esm-loader-resolve-type.mjs
+++ b/test/es-module/test-esm-loader-resolve-type.mjs
@@ -6,6 +6,9 @@ import * as fs from 'fs';
 
 allowGlobals(global.getModuleTypeStats);
 
+const { importedESM: importedESMBefore,
+        importedCJS: importedCJSBefore } = await global.getModuleTypeStats();
+
 const basePath =
   new URL('./node_modules/', import.meta.url);
 
@@ -17,25 +20,24 @@ const createDir = (path) => {
 };
 
 const moduleName = 'module-counter-by-type';
-
 const moduleDir = rel(`${moduleName}`);
-createDir(basePath);
-createDir(moduleDir);
-fs.cpSync(
-  fixtures.path('es-modules', moduleName),
-  moduleDir,
-  { recursive: true }
-);
+try {
+  createDir(basePath);
+  createDir(moduleDir);
+  fs.cpSync(
+    fixtures.path('es-modules', moduleName),
+    moduleDir,
+    { recursive: true }
+  );
 
-const { importedESM: importedESMBefore,
-        importedCJS: importedCJSBefore } = global.getModuleTypeStats();
 
-await import(`${moduleName}`).finally(() => {
+  await import(`${moduleName}`);
+} finally {
   fs.rmSync(basePath, { recursive: true, force: true });
-});
+}
 
 const { importedESM: importedESMAfter,
-        importedCJS: importedCJSAfter } = global.getModuleTypeStats();
+        importedCJS: importedCJSAfter } = await global.getModuleTypeStats();
 
 // Dynamic import above should increment ESM counter but not CJS counter
 assert.strictEqual(importedESMBefore + 1, importedESMAfter);

--- a/test/fixtures/es-module-loaders/hook-resolve-type.mjs
+++ b/test/fixtures/es-module-loaders/hook-resolve-type.mjs
@@ -1,6 +1,29 @@
 let importedESM = 0;
 let importedCJS = 0;
-global.getModuleTypeStats = () => { return {importedESM, importedCJS} };
+
+export function globalPreload({ port }) {
+  port.on('message', (int32) => {
+    port.postMessage({ importedESM, importedCJS });
+    Atomics.store(int32, 0, 1);
+    Atomics.notify(int32, 0);
+  });
+  port.unref();
+  return `
+    const { receiveMessageOnPort } = getBuiltin('worker_threads');
+    global.getModuleTypeStats = async function getModuleTypeStats() {
+      const sab = new SharedArrayBuffer(4);
+      const int32 = new Int32Array(sab);
+      port.postMessage(int32);
+      // Artificial timeout to keep the event loop alive.
+      // https://bugs.chromium.org/p/v8/issues/detail?id=13238
+      // TODO(targos) Remove when V8 issue is resolved.
+      const timeout = setTimeout(() => {}, 1_000);
+      await Atomics.waitAsync(int32, 0, 0).value;
+      clearTimeout(timeout);
+      return receiveMessageOnPort(port).message;
+    };
+  `;
+}
 
 export async function load(url, context, next) {
   return next(url);

--- a/test/fixtures/es-module-loaders/hook-resolve-type.mjs
+++ b/test/fixtures/es-module-loaders/hook-resolve-type.mjs
@@ -17,7 +17,7 @@ export function globalPreload({ port }) {
       // Artificial timeout to keep the event loop alive.
       // https://bugs.chromium.org/p/v8/issues/detail?id=13238
       // TODO(targos) Remove when V8 issue is resolved.
-      const timeout = setTimeout(() => {}, 1_000);
+      const timeout = setTimeout(() => { throw new Error('timeout'); }, 1_000);
       await Atomics.waitAsync(int32, 0, 0).value;
       clearTimeout(timeout);
       return receiveMessageOnPort(port).message;


### PR DESCRIPTION
This makes the test compatible with off-thread loaders.

/cc @GeoffreyBooth @aduh95 

