### PR TITLE
lib: cache parsed source maps to reduce memory footprint

### DIFF
--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -14,6 +14,9 @@ const {
 
 function ObjectGetValueSafe(obj, key) {
   const desc = ObjectGetOwnPropertyDescriptor(obj, key);
+  if (desc === undefined) {
+    return undefined;
+  }
   return ObjectPrototypeHasOwnProperty(desc, 'value') ? desc.value : undefined;
 }
 
@@ -141,6 +144,7 @@ function maybeCacheSourceMap(filename, content, cjsModuleInstance, isGeneratedSo
   const url = data ? null : sourceMapURL;
   if (cjsModuleInstance) {
     getCjsSourceMapCache().set(cjsModuleInstance, {
+      __proto__: null,
       filename,
       lineLengths: lineLengths(content),
       data,
@@ -149,6 +153,7 @@ function maybeCacheSourceMap(filename, content, cjsModuleInstance, isGeneratedSo
     });
   } else if (isGeneratedSource) {
     const entry = {
+      __proto__: null,
       lineLengths: lineLengths(content),
       data,
       url,
@@ -162,6 +167,7 @@ function maybeCacheSourceMap(filename, content, cjsModuleInstance, isGeneratedSo
     // If there is no cjsModuleInstance and is not generated source assume we are in a
     // "modules/esm" context.
     const entry = {
+      __proto__: null,
       lineLengths: lineLengths(content),
       data,
       url,
@@ -296,6 +302,7 @@ function sourceMapCacheToObject() {
 function appendCJSCache(obj) {
   for (const value of getCjsSourceMapCache()) {
     obj[ObjectGetValueSafe(value, 'filename')] = {
+      __proto__: null,
       lineLengths: ObjectGetValueSafe(value, 'lineLengths'),
       data: ObjectGetValueSafe(value, 'data'),
       url: ObjectGetValueSafe(value, 'url')
@@ -310,22 +317,25 @@ function findSourceMap(sourceURL) {
   if (!SourceMap) {
     SourceMap = require('internal/source_map/source_map').SourceMap;
   }
-  let sourceMap = esmSourceMapCache.get(sourceURL) ?? generatedSourceMapCache.get(sourceURL);
-  if (sourceMap === undefined) {
+  let entry = esmSourceMapCache.get(sourceURL) ?? generatedSourceMapCache.get(sourceURL);
+  if (entry === undefined) {
     for (const value of getCjsSourceMapCache()) {
       const filename = ObjectGetValueSafe(value, 'filename');
       const cachedSourceURL = ObjectGetValueSafe(value, 'sourceURL');
       if (sourceURL === filename || sourceURL === cachedSourceURL) {
-        sourceMap = {
-          data: ObjectGetValueSafe(value, 'data')
-        };
+        entry = value;
       }
     }
   }
-  if (sourceMap && sourceMap.data) {
-    return new SourceMap(sourceMap.data);
+  if (entry === undefined) {
+    return undefined;
   }
-  return undefined;
+  let sourceMap = ObjectGetValueSafe(entry, 'sourceMap');
+  if (sourceMap === undefined) {
+    sourceMap = new SourceMap(ObjectGetValueSafe(entry, 'data'));
+    entry.sourceMap = sourceMap;
+  }
+  return sourceMap;
 }
 
 module.exports = {


### PR DESCRIPTION
This also improves performance to map the stack trace when the `Error.stack` is accessed.

```
                                                      confidence improvement accuracy (*)   (**)  (***)
es/error-stack.js n=100000 method='sourcemap'                ***     18.90 %       ±1.54% ±2.06% ±2.68%
es/error-stack.js n=100000 method='without-sourcemap'                -0.24 %       ±1.40% ±1.86% ±2.43%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 2 comparisons, you can thus expect the following amount of false-positive results:
  0.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.02 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

Fixes https://github.com/nodejs/node/issues/46140.
