### PR TITLE
build: fix MSVC 2022 Release compilation

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        windows: [windows-2019]
+        windows: [windows-2019, windows-2022]
       fail-fast: false
     runs-on: ${{ matrix.windows }}
     steps:

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   coverage-windows:
     if: github.event.pull_request.draft == false
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
         with:

--- a/tools/v8_gypfiles/directory.build.props
+++ b/tools/v8_gypfiles/directory.build.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemDefinitionGroup>
+    <MARMASM>
+      <!-- Works around a situation when we preprocess file in $(IntDir). In such case the output file is the same as input file
+      and we get access violation. Appending '.pp' file extension to the output file name resolves this issue. -->
+      <PreprocessedFileName Condition="'%(PreprocessedFileName)' == ''">$(IntDir)%(FileName)%(Extension).pp</PreprocessedFileName>
+    </MARMASM>
+  </ItemDefinitionGroup>
+</Project>

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1433,6 +1433,14 @@
         ['want_separate_host_toolset', {
           'toolsets': ['host'],
         }],
+        ['OS=="win"', {
+          'msvs_precompiled_header': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.h',
+          'msvs_precompiled_source': '<(V8_ROOT)/../../tools/msvs/pch/v8_pch.cc',
+          'sources': [
+            '<(_msvs_precompiled_header)',
+            '<(_msvs_precompiled_source)',
+          ],
+        }],
       ],
     },  # mksnapshot
     {


### PR DESCRIPTION
This PR targets to address the [Linker errors](https://github.com/nodejs/node/issues/43092#issuecomment-1214132498) mentioned in Issue #43092 when we build Node.JS main branch in MSVC 2022 (Version 17.4.4).
Then, it fixes the VS2022 ARM64 build issue with file access violation originally fixed by PR #46231.

The fix adds PCH file to `mksnapshot` project in the `v8.gyp` file to solve #43092.
`directory.build.props` is added to override `PreprocessedFileName` output path to address the file access violation issue.

### Details

When we build Node.JS Release in MSVC 2022 we see linker errors that `mksnapshot` cannot find `FixedArray::get` method. This is an example of the linker error from issue #43092:
```
platform-embedded-file-writer-aix.obj : error LNK2001: unresolved external symbol "public: class v8::internal::Object __cdecl v8::internal::FixedArray::get(int)const " (?get@FixedArray@internal@v8@@QEBA?AVObject@23@H@Z) [F:\node\tools\v8_gypfiles\mksna
pshot.vcxproj]
```
It seemed that the inlined method `FixedArray::get` is optimized out.
We can either change V8 files and explicitly include `fixed-array-inl.h` file as in PR #46231, or we can use the forced file inclusion used by PCH files. Adding the MSVC specific PCH for `mksnapshot` project addresses the issue.

The root cause of the access violation issue is that the `embedded.S` file is generated in the `$(IntDir)` folder while the preprocessed file name uses exactly the same path: `<PreprocessedFileName Condition="'%(PreprocessedFileName)' == ''">$(IntDir)%(FileName)%(Extension)</PreprocessedFileName>` from `"c:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\BuildCustomizations\marmasm.props"`. Thus, we are getting error because we try to change the `embedded.S` file while reading it.

In this PR we add new `directory.build.props` file that locally overrides the `marmasm.props` definition by adding `.pp` extension to the file name. It generates output file name that is different in from the input file name and addresses the file access violation issue.
