### PR TITLE
doc: remove exhortation to be conservative with semver

### DIFF
--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -875,8 +875,6 @@ such as if the CI run fails or a new outstanding review comment is posted.
 ***
 
 * `semver-{minor,major}`
-  * be conservative – that is, if a change has the remote _chance_ of breaking
-    something, go for semver-major
   * when adding a semver label, add a comment explaining why you're adding it
   * minor vs. patch: roughly: "does it add a new method / does it add a new
     section to the docs"


### PR DESCRIPTION
The collaborator guide suggests that anything that might be considered a breaking change should be labeled a breaking change. While that is a theoretically excellent attitude to take, Node.js has many times debated internally whether a particular change is breaking or not. Given that we do not automatically assume that it is a breaking change in these cases, let's remove this sentence which tends to get ignored anyway.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
