### PR TITLE
test: enable more case of bad buffer in `fs.write`

### DIFF
--- a/test/parallel/test-fs-write-optional-params.js
+++ b/test/parallel/test-fs-write-optional-params.js
@@ -68,9 +68,7 @@ async function runTests(fd) {
     new Date(),
     new String('notPrimitive'),
     { [Symbol.toPrimitive]: (hint) => 'amObject' },
-
-    // TODO(LiviaMedeiros): add the following after DEP0162 EOL
-    // { toString() { return 'amObject'; } },
+    { toString() { return 'amObject'; } },
   ]) {
     await testInvalid(fd, 'ERR_INVALID_ARG_TYPE', badBuffer, {});
   }


### PR DESCRIPTION
Passing to the `string` parameter an object with an own `toString` function is no longer supported.(DEP0162)
So use such case as bad buffer in test.

Refs: https://github.com/nodejs/node/blob/main/doc/api/deprecations.md#dep0162-fswrite-fswritefilesync-coercion-to-string

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
