### PR TITLE
Revert "src: let http2 streams end after session close"

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1124,17 +1124,6 @@ int Http2Session::OnStreamClose(nghttp2_session* handle,
   if (!stream || stream->is_destroyed())
     return 0;
 
-  // Don't close synchronously in case there's pending data to be written. This
-  // may happen when writing trailing headers.
-  if (code == NGHTTP2_NO_ERROR && nghttp2_session_want_write(handle) &&
-      env->can_call_into_js()) {
-    env->SetImmediate([handle, id, code, user_data](Environment* env) {
-      OnStreamClose(handle, id, code, user_data);
-    });
-
-    return 0;
-  }
-
   stream->Close(code);
 
   // It is possible for the stream close to occur before the stream is

--- a/test/known_issues/test-http2-trailers-after-session-close.js
+++ b/test/known_issues/test-http2-trailers-after-session-close.js
@@ -8,9 +8,6 @@ if (!common.hasCrypto) {
   require('assert').fail('missing crypto');
   common.skip('missing crypto');
 }
-  // Change require('assert').fail to common.skip when issue is fixed and test
-  // is moved out of the known_issues directory
-  require('assert').fail('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/known_issues/test-http2-trailers-after-session-close.js
+++ b/test/known_issues/test-http2-trailers-after-session-close.js
@@ -3,7 +3,9 @@
 // Fixes: https://github.com/nodejs/node/issues/42713
 const common = require('../common');
 if (!common.hasCrypto)
-  common.skip('missing crypto');
+  // Change require('assert').fail to common.skip when issue is fixed and test
+  // is moved out of the known_issues directory
+  require('assert').fail('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/known_issues/test-http2-trailers-after-session-close.js
+++ b/test/known_issues/test-http2-trailers-after-session-close.js
@@ -2,7 +2,12 @@
 
 // Fixes: https://github.com/nodejs/node/issues/42713
 const common = require('../common');
-if (!common.hasCrypto)
+if (!common.hasCrypto) {
+  // Remove require('assert').fail when issue is fixed and test
+  // is moved out of the known_issues directory.
+  require('assert').fail('missing crypto');
+  common.skip('missing crypto');
+}
   // Change require('assert').fail to common.skip when issue is fixed and test
   // is moved out of the known_issues directory
   require('assert').fail('missing crypto');

--- a/test/known_issues/test-http2-trailers-after-session-close.js
+++ b/test/known_issues/test-http2-trailers-after-session-close.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// Fixes: https://github.com/nodejs/node/issues/42713
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');


### PR DESCRIPTION
This reverts commit dee882e94f4caa4e1cd608013f90f6a14629403f. Moved the test that demonstrated what this commit was fixing to the `known_issues` folder.

Fixes: https://github.com/nodejs/node/issues/46234