### PR TITLE
src: use explicit C++17 fallthrough

### DIFF
--- a/src/crypto/crypto_clienthello.cc
+++ b/src/crypto/crypto_clienthello.cc
@@ -29,7 +29,7 @@ void ClientHelloParser::Parse(const uint8_t* data, size_t avail) {
     case kWaiting:
       if (!ParseRecordHeader(data, avail))
         break;
-      // Fall through
+      [[fallthrough]];
     case kTLSHeader:
       ParseHeader(data, avail);
       break;

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -74,7 +74,7 @@ class RequestToServer {
     switch (action_) {
       case TransportAction::kKill:
         server->TerminateConnections();
-        // Fallthrough
+        [[fallthrough]];
       case TransportAction::kStop:
         server->Stop();
         break;

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -794,12 +794,12 @@ static int GetColumnWidth(UChar32 codepoint,
         return 2;
       }
       // If ambiguous_as_full_width is false:
-      // Fall through
+      [[fallthrough]];
     case U_EA_NEUTRAL:
       if (u_hasBinaryProperty(codepoint, UCHAR_EMOJI_PRESENTATION)) {
         return 2;
       }
-      // Fall through
+      [[fallthrough]];
     case U_EA_HALFWIDTH:
     case U_EA_NARROW:
     default:

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -797,7 +797,7 @@ void ZlibContext::DoThreadPoolWork() {
             break;
           }
 
-          // fallthrough
+          [[fallthrough]];
         case 1:
           if (next_expected_header_byte == nullptr) {
             break;
@@ -817,7 +817,7 @@ void ZlibContext::DoThreadPoolWork() {
           CHECK(0 && "invalid number of gzip magic number bytes read");
       }
 
-      // fallthrough
+      [[fallthrough]];
     case INFLATE:
     case GUNZIP:
     case INFLATERAW:


### PR DESCRIPTION
This passes the strictest `-Wimplicit-fallthrough` setting.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
