### PR TITLE
v8: support gc profile

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -1051,6 +1051,112 @@ added:
 
 Returns true if the Node.js instance is run to build a snapshot.
 
+## Class: `v8.GCProfiler`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+This API collects GC data in current thread.
+
+### `new v8.GCProfiler()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Create a new instance of the `v8.GCProfiler` class.
+
+### `profiler.start()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Start collecting GC data.
+
+### `profiler.stop()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Stop collecting GC data and return a object.The content of object
+is as follows.
+
+```json
+{
+  "version": 1,
+  "startTime": 1674059033862,
+  "statistics": [
+    {
+      "gcType": "Scavenge",
+      "beforeGC": {
+        "heapStatistics": {
+          "totalHeapSize": 5005312,
+          "totalHeapSizeExecutable": 524288,
+          "totalPhysicalSize": 5226496,
+          "totalAvailableSize": 4341325216,
+          "totalGlobalHandlesSize": 8192,
+          "usedGlobalHandlesSize": 2112,
+          "usedHeapSize": 4883840,
+          "heapSizeLimit": 4345298944,
+          "mallocedMemory": 254128,
+          "externalMemory": 225138,
+          "peakMallocedMemory": 181760
+        },
+        "heapSpaceStatistics": [
+          {
+            "spaceName": "read_only_space",
+            "spaceSize": 0,
+            "spaceUsedSize": 0,
+            "spaceAvailableSize": 0,
+            "physicalSpaceSize": 0
+          }
+        ]
+      },
+      "cost": 1574.14,
+      "afterGC": {
+        "heapStatistics": {
+          "totalHeapSize": 6053888,
+          "totalHeapSizeExecutable": 524288,
+          "totalPhysicalSize": 5500928,
+          "totalAvailableSize": 4341101384,
+          "totalGlobalHandlesSize": 8192,
+          "usedGlobalHandlesSize": 2112,
+          "usedHeapSize": 4059096,
+          "heapSizeLimit": 4345298944,
+          "mallocedMemory": 254128,
+          "externalMemory": 225138,
+          "peakMallocedMemory": 181760
+        },
+        "heapSpaceStatistics": [
+          {
+            "spaceName": "read_only_space",
+            "spaceSize": 0,
+            "spaceUsedSize": 0,
+            "spaceAvailableSize": 0,
+            "physicalSpaceSize": 0
+          }
+        ]
+      }
+    }
+  ],
+  "endTime": 1674059036865
+}
+```
+
+Here's an example.
+
+```js
+const { GCProfiler } = require('v8');
+const profiler = new GCProfiler();
+profiler.start();
+setTimeout(() => {
+  console.log(profiler.stop());
+}, 1000);
+```
+
 [HTML structured clone algorithm]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 [Hook Callbacks]: #hook-callbacks
 [V8]: https://developers.google.com/v8/

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -63,7 +63,7 @@ const {
 } = require('internal/heap_utils');
 const promiseHooks = require('internal/promise_hooks');
 const { getOptionValue } = require('internal/options');
-
+const { JSONParse } = primordials;
 /**
  * Generates a snapshot of the current V8 heap
  * and writes it to a JSON file.
@@ -397,6 +397,25 @@ function deserialize(buffer) {
   return der.readValue();
 }
 
+class GCProfiler {
+  #profiler = null;
+
+  start() {
+    if (!this.#profiler) {
+      this.#profiler = new binding.GCProfiler();
+      this.#profiler.start();
+    }
+  }
+
+  stop() {
+    if (this.#profiler) {
+      const data = this.#profiler.stop();
+      this.#profiler = null;
+      return JSONParse(data);
+    }
+  }
+}
+
 module.exports = {
   cachedDataVersionTag,
   getHeapSnapshot,
@@ -416,4 +435,5 @@ module.exports = {
   promiseHooks,
   startupSnapshot,
   setHeapSnapshotNearHeapLimit,
+  GCProfiler,
 };

--- a/src/node_v8.h
+++ b/src/node_v8.h
@@ -3,8 +3,10 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include <sstream>
 #include "aliased_buffer.h"
 #include "base_object.h"
+#include "json_utils.h"
 #include "node_snapshotable.h"
 #include "util.h"
 #include "v8.h"
@@ -32,6 +34,32 @@ class BindingData : public SnapshotableObject {
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_SELF_SIZE(BindingData)
   SET_MEMORY_INFO_NAME(BindingData)
+};
+
+class GCProfiler : public BaseObject {
+ public:
+  enum class GCProfilerState { kInitialized, kStarted, kStopped };
+  GCProfiler(Environment* env, v8::Local<v8::Object> object);
+  inline ~GCProfiler() override;
+  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Stop(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  JSONWriter* writer();
+
+  std::ostringstream* out_stream();
+
+  SET_NO_MEMORY_INFO()
+  SET_MEMORY_INFO_NAME(GCProfiler)
+  SET_SELF_SIZE(GCProfiler)
+
+  uint64_t start_time;
+  uint8_t current_gc_type;
+  GCProfilerState state;
+
+ private:
+  std::ostringstream out_stream_;
+  JSONWriter writer_;
 };
 
 }  // namespace v8_utils

--- a/test/common/v8.js
+++ b/test/common/v8.js
@@ -1,0 +1,70 @@
+'use strict';
+const assert = require('assert');
+const { GCProfiler } = require('v8');
+
+function collectGCProfile({ duration }) {
+  return new Promise((resolve) => {
+    const profiler = new GCProfiler();
+    profiler.start();
+    setTimeout(() => {
+      resolve(profiler.stop());
+    }, duration);
+  });
+}
+
+function checkGCProfile(data) {
+  assert.ok(data.version > 0);
+  assert.ok(data.startTime >= 0);
+  assert.ok(data.endTime >= 0);
+  assert.ok(Array.isArray(data.statistics));
+  // If the array is not empty, check it
+  if (data.statistics.length) {
+    // Just check the first one
+    const item = data.statistics[0];
+    assert.ok(typeof item.gcType === 'string');
+    assert.ok(item.cost >= 0);
+    assert.ok(typeof item.beforeGC === 'object');
+    assert.ok(typeof item.afterGC === 'object');
+    // The content of beforeGC and afterGC is same, so we just check afterGC
+    assert.ok(typeof item.afterGC.heapStatistics === 'object');
+    const heapStatisticsKeys = [
+      'externalMemory',
+      'heapSizeLimit',
+      'mallocedMemory',
+      'peakMallocedMemory',
+      'totalAvailableSize',
+      'totalGlobalHandlesSize',
+      'totalHeapSize',
+      'totalHeapSizeExecutable',
+      'totalPhysicalSize',
+      'usedGlobalHandlesSize',
+      'usedHeapSize',
+    ];
+    heapStatisticsKeys.forEach((key) => {
+      assert.ok(item.afterGC.heapStatistics[key] >= 0);
+    });
+    assert.ok(typeof item.afterGC.heapSpaceStatistics === 'object');
+    const heapSpaceStatisticsKeys = [
+      'physicalSpaceSize',
+      'spaceAvailableSize',
+      'spaceName',
+      'spaceSize',
+      'spaceUsedSize',
+    ];
+    heapSpaceStatisticsKeys.forEach((key) => {
+      const value = item.afterGC.heapSpaceStatistics[0][key];
+      assert.ok(key === 'spaceName' ? typeof value === 'string' : value >= 0);
+    });
+  }
+}
+
+async function testGCProfiler() {
+  const data = await collectGCProfile({ duration: 5000 });
+  checkGCProfile(data);
+}
+
+module.exports = {
+  collectGCProfile,
+  checkGCProfile,
+  testGCProfiler,
+};

--- a/test/parallel/test-v8-collect-gc-profile-exit-before-stop.js
+++ b/test/parallel/test-v8-collect-gc-profile-exit-before-stop.js
@@ -1,0 +1,17 @@
+'use strict';
+require('../common');
+const { GCProfiler } = require('v8');
+
+// Test if it makes the process crash.
+{
+  const profiler = new GCProfiler();
+  profiler.start();
+  profiler.stop();
+  profiler.start();
+  profiler.stop();
+}
+{
+  const profiler = new GCProfiler();
+  profiler.start();
+  profiler.stop();
+}

--- a/test/parallel/test-v8-collect-gc-profile-in-worker.js
+++ b/test/parallel/test-v8-collect-gc-profile-in-worker.js
@@ -1,0 +1,16 @@
+// Flags: --expose-gc
+'use strict';
+require('../common');
+const { Worker } = require('worker_threads');
+const { testGCProfiler } = require('../common/v8');
+
+if (process.env.isWorker) {
+  process.env.isWorker = 1;
+  new Worker(__filename);
+} else {
+  testGCProfiler();
+  for (let i = 0; i < 100; i++) {
+    new Array(100);
+  }
+  global?.gc();
+}

--- a/test/parallel/test-v8-collect-gc-profile.js
+++ b/test/parallel/test-v8-collect-gc-profile.js
@@ -1,0 +1,12 @@
+// Flags: --expose-gc
+'use strict';
+require('../common');
+const { testGCProfiler } = require('../common/v8');
+
+testGCProfiler();
+
+for (let i = 0; i < 100; i++) {
+  new Array(100);
+}
+
+global?.gc();


### PR DESCRIPTION
support gc profile. the content is as follows.
```json
{
  "version": 1,
  "startTime": 1674059033862,
  "statistics": [
    {
      "gcType": "Scavenge",
      "beforeGC": {
        "heapStatistics": {
          "totalHeapSize": 5005312,
          "totalHeapSizeExecutable": 524288,
          "totalPhysicalSize": 5226496,
          "totalAvailableSize": 4341325216,
          "totalGlobalHandlesSize": 8192,
          "usedGlobalHandlesSize": 2112,
          "usedHeapSize": 4883840,
          "heapSizeLimit": 4345298944,
          "mallocedMemory": 254128,
          "externalMemory": 225138,
          "peakMallocedMemory": 181760
        },
        "heapSpaceStatistics": [
          {
            "spaceName": "read_only_space",
            "spaceSize": 0,
            "spaceUsedSize": 0,
            "spaceAvailableSize": 0,
            "physicalSpaceSize": 0
          }
        ]
      },
      "cost": 1574.14,
      "afterGC": {
        "heapStatistics": {
          "totalHeapSize": 6053888,
          "totalHeapSizeExecutable": 524288,
          "totalPhysicalSize": 5500928,
          "totalAvailableSize": 4341101384,
          "totalGlobalHandlesSize": 8192,
          "usedGlobalHandlesSize": 2112,
          "usedHeapSize": 4059096,
          "heapSizeLimit": 4345298944,
          "mallocedMemory": 254128,
          "externalMemory": 225138,
          "peakMallocedMemory": 181760
        },
        "heapSpaceStatistics": [
          {
            "spaceName": "read_only_space",
            "spaceSize": 0,
            "spaceUsedSize": 0,
            "spaceAvailableSize": 0,
            "physicalSpaceSize": 0
          }
        ]
      }
    }
  ],
  "endtTime": 1674059036865
}
```


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
