### PR TITLE
src: lazily initialize global BuiltinLoader

### DIFF
--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -67,8 +67,14 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
   // Returns config.gypi as a JSON string
   static v8::Local<v8::String> GetConfigString(v8::Isolate* isolate);
   static bool Exists(const char* id);
-  static bool Add(const char* id, const UnionBytes& source);
-  static bool Add(const char* id, std::string_view utf8source);
+  // TODO(addaleax): Make BuiltinLoader non-global so that these
+  // methods do not need to be static.
+  static bool Add(const char* id,
+                  const UnionBytes& source,
+                  BuiltinLoader* instance = nullptr);
+  static bool Add(const char* id,
+                  std::string_view utf8source,
+                  BuiltinLoader* instance = nullptr);
 
   static bool CompileAllBuiltins(v8::Local<v8::Context> context);
   static void RefreshCodeCache(const std::vector<CodeCacheInfo>& in);
@@ -134,9 +140,8 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
   static void HasCachedBuiltins(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  static void AddExternalizedBuiltin(const char* id, const char* filename);
+  void AddExternalizedBuiltin(const char* id, const char* filename);
 
-  static BuiltinLoader instance_;
   BuiltinCategories builtin_categories_;
   BuiltinSourceMap source_;
   BuiltinCodeCacheMap code_cache_;

--- a/test/cctest/test_per_process.cc
+++ b/test/cctest/test_per_process.cc
@@ -11,7 +11,7 @@ using node::builtins::BuiltinSourceMap;
 class PerProcessTest : public ::testing::Test {
  protected:
   static const BuiltinSourceMap get_sources_for_test() {
-    return BuiltinLoader::instance_.source_;
+    return BuiltinLoader::GetInstance()->source_;
   }
 };
 


### PR DESCRIPTION
Using simdutf during startup can fail when compilation units are linked in the wrong order by a static initialization order issue.

https://github.com/nodejs/node/pull/45942 would also solve this, but since that is a larger effort, this patch focuses on solving the immediate problem. Alternatively, simdutf should arguably be made usable during static initialization, but that is also not as straightforward as this patch.

Fixes: https://github.com/nodejs/node/issues/46235

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
