### PR TITLE
tools: allow icutrim.py to run on python2

### DIFF
--- a/tools/icu/icutrim.py
+++ b/tools/icu/icutrim.py
@@ -316,10 +316,7 @@ def removeList(count=0):
             erritems = fi.readlines()
             fi.close()
             #Item zone/zh_Hant_TW.res depends on missing item zone/zh_Hant.res
-            if (sys.version_info.major < 3):
-              pat = re.compile(bytes(r"^Item ([^ ]+) depends on missing item ([^ ]+).*").encode('utf-8'))
-            else:
-              pat = re.compile(bytes(r"^Item ([^ ]+) depends on missing item ([^ ]+).*", 'utf-8'))
+            pat = re.compile(br"^Item ([^ ]+) depends on missing item ([^ ]+).*")
             for i in range(len(erritems)):
                 line = erritems[i].strip()
                 m = pat.match(line)

--- a/tools/icu/icutrim.py
+++ b/tools/icu/icutrim.py
@@ -316,7 +316,10 @@ def removeList(count=0):
             erritems = fi.readlines()
             fi.close()
             #Item zone/zh_Hant_TW.res depends on missing item zone/zh_Hant.res
-            pat = re.compile(bytes(r"^Item ([^ ]+) depends on missing item ([^ ]+).*", 'utf-8'))
+            if (sys.version_info.major < 3):
+              pat = re.compile(bytes(r"^Item ([^ ]+) depends on missing item ([^ ]+).*").encode('utf-8'))
+            else:
+              pat = re.compile(bytes(r"^Item ([^ ]+) depends on missing item ([^ ]+).*", 'utf-8'))
             for i in range(len(erritems)):
                 line = erritems[i].strip()
                 m = pat.match(line)


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/2998

Small icu seems broken from 14.x since it uses
python2. Although main no longer supports python2
landing and backporting this change to the 14.x line would allow us to simplify future backports as currently the files are the same across lines.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
