### PR TITLE
test: avoid left behind child processes

### DIFF
--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -10,9 +10,9 @@ const invalidArgTypeError = {
   name: 'TypeError'
 };
 
-const waitCommand = common.isLinux ?
-  'sleep 2m' :
-  `${process.execPath} -e "setInterval(()=>{}, 99)"`;
+const waitCommand = common.isWindows ?
+  `${process.execPath} -e "setInterval(()=>{}, 99)"` :
+  'sleep 2m';
 
 {
   const ac = new AbortController();


### PR DESCRIPTION
Extend the Linux logic in test-child-process-exec-abortcontroller-promisified to all POSIX platforms.

Fixes: https://github.com/nodejs/build/issues/3154
Refs: https://github.com/nodejs/node/pull/37572#discussion_r585634725
Refs: https://github.com/nodejs/node/issues/37518

---

This unblocks the [SmartOS CI for Node.js 14](https://ci.nodejs.org/job/node-test-commit-smartos/47640/) and 16 that has been failing since we migrated the smartos machines at the end of last year. I'm opening this on main (which hasn't been failing) so I can cherry pick the same fix to both v16.x-staging and v14.x-staging. My main aim here is to unblock the CI.

To clarify, the test itself passes but is leaving behind child processes, which cause the CI run to fail as it checks for left over `node` processes at the end of the test run.

cc @nodejs/releasers @bahamat 
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
