### PR TITLE
http: throw error if options of http.Server is array

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -79,6 +79,9 @@ const {
   ERR_INVALID_CHAR
 } = codes;
 const {
+  kEmptyObject,
+} = require('internal/util');
+const {
   validateInteger,
   validateBoolean,
   validateLinkHeaderValue,
@@ -432,9 +435,6 @@ function storeHTTPOptions(options) {
     validateBoolean(insecureHTTPParser, 'options.insecureHTTPParser');
   this.insecureHTTPParser = insecureHTTPParser;
 
-  if (options.noDelay === undefined)
-    options.noDelay = true;
-
   const requestTimeout = options.requestTimeout;
   if (requestTimeout !== undefined) {
     validateInteger(requestTimeout, 'requestTimeout', 0);
@@ -501,9 +501,9 @@ function Server(options, requestListener) {
 
   if (typeof options === 'function') {
     requestListener = options;
-    options = {};
+    options = kEmptyObject;
   } else if (options == null) {
-    options = {};
+    options = kEmptyObject;
   } else {
     validateObject(options, 'options');
   }
@@ -511,7 +511,7 @@ function Server(options, requestListener) {
   storeHTTPOptions.call(this, options);
   net.Server.call(
     this,
-    { allowHalfOpen: true, noDelay: options.noDelay,
+    { allowHalfOpen: true, noDelay: options.noDelay || true,
       keepAlive: options.keepAlive,
       keepAliveInitialDelay: options.keepAliveInitialDelay });
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -75,7 +75,6 @@ const {
   ERR_HTTP_HEADERS_SENT,
   ERR_HTTP_INVALID_STATUS_CODE,
   ERR_HTTP_SOCKET_ENCODING,
-  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CHAR
 } = codes;
@@ -503,10 +502,10 @@ function Server(options, requestListener) {
   if (typeof options === 'function') {
     requestListener = options;
     options = {};
-  } else if (options == null || (typeof options === 'object' && !ArrayIsArray(options))) {
-    options = { ...options };
+  } else if (options == null) {
+    options = {};
   } else {
-    throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
+    validateObject(options, 'options');
   }
 
   storeHTTPOptions.call(this, options);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -511,7 +511,7 @@ function Server(options, requestListener) {
   storeHTTPOptions.call(this, options);
   net.Server.call(
     this,
-    { allowHalfOpen: true, noDelay: options.noDelay || true,
+    { allowHalfOpen: true, noDelay: options.noDelay ?? true,
       keepAlive: options.keepAlive,
       keepAliveInitialDelay: options.keepAliveInitialDelay });
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -503,7 +503,7 @@ function Server(options, requestListener) {
   if (typeof options === 'function') {
     requestListener = options;
     options = {};
-  } else if (options == null || typeof options === 'object') {
+  } else if (options == null || (typeof options === 'object' && !ArrayIsArray(options))) {
     options = { ...options };
   } else {
     throw new ERR_INVALID_ARG_TYPE('options', 'object', options);

--- a/lib/https.js
+++ b/lib/https.js
@@ -69,12 +69,14 @@ function Server(opts, requestListener) {
 
   FunctionPrototypeCall(storeHTTPOptions, this, opts);
   FunctionPrototypeCall(tls.Server, this,
-                        { ...opts,
-                          noDelay: opts.noDelay || true,
+                        { 
+                          noDelay: true,
                           // http/1.0 is not defined as Protocol IDs in IANA
                           // https://www.iana.org/assignments/tls-extensiontype-values
                           //       /tls-extensiontype-values.xhtml#alpn-protocol-ids
-                          ALPNProtocols: opts.ALPNProtocols || ['http/1.1'] },
+                          ALPNProtocols: ['http/1.1'],
+                          ...opts,
+                         },
                         _connectionListener);
 
   this.httpAllowHalfOpen = false;

--- a/lib/https.js
+++ b/lib/https.js
@@ -53,25 +53,28 @@ let debug = require('internal/util/debuglog').debuglog('https', (fn) => {
   debug = fn;
 });
 const { URL, urlToHttpOptions, searchParamsSymbol } = require('internal/url');
+const { validateObject } = require('internal/validators');
 
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
 
   if (typeof opts === 'function') {
     requestListener = opts;
-    opts = undefined;
-  }
-  opts = { ...opts };
-
-  if (!opts.ALPNProtocols) {
-    // http/1.0 is not defined as Protocol IDs in IANA
-    // https://www.iana.org/assignments/tls-extensiontype-values
-    //       /tls-extensiontype-values.xhtml#alpn-protocol-ids
-    opts.ALPNProtocols = ['http/1.1'];
+    opts = kEmptyObject;
+  } else if (opts == null) {
+    opts = kEmptyObject;
+  } else {
+    validateObject(opts, 'options');
   }
 
   FunctionPrototypeCall(storeHTTPOptions, this, opts);
-  FunctionPrototypeCall(tls.Server, this, opts, _connectionListener);
+  FunctionPrototypeCall(tls.Server, this,
+                        { ...opts,
+                          // http/1.0 is not defined as Protocol IDs in IANA
+                          // https://www.iana.org/assignments/tls-extensiontype-values
+                          //       /tls-extensiontype-values.xhtml#alpn-protocol-ids
+                          ALPNProtocols: opts.ALPNProtocols || ['http/1.1'] },
+                        _connectionListener);
 
   this.httpAllowHalfOpen = false;
 

--- a/lib/https.js
+++ b/lib/https.js
@@ -70,6 +70,7 @@ function Server(opts, requestListener) {
   FunctionPrototypeCall(storeHTTPOptions, this, opts);
   FunctionPrototypeCall(tls.Server, this,
                         { ...opts,
+                          noDelay: opts.noDelay || true,
                           // http/1.0 is not defined as Protocol IDs in IANA
                           // https://www.iana.org/assignments/tls-extensiontype-values
                           //       /tls-extensiontype-values.xhtml#alpn-protocol-ids

--- a/lib/https.js
+++ b/lib/https.js
@@ -69,14 +69,14 @@ function Server(opts, requestListener) {
 
   FunctionPrototypeCall(storeHTTPOptions, this, opts);
   FunctionPrototypeCall(tls.Server, this,
-                        { 
+                        {
                           noDelay: true,
                           // http/1.0 is not defined as Protocol IDs in IANA
                           // https://www.iana.org/assignments/tls-extensiontype-values
                           //       /tls-extensiontype-values.xhtml#alpn-protocol-ids
                           ALPNProtocols: ['http/1.1'],
                           ...opts,
-                         },
+                        },
                         _connectionListener);
 
   this.httpAllowHalfOpen = false;

--- a/test/parallel/test-http-server.js
+++ b/test/parallel/test-http-server.js
@@ -27,10 +27,7 @@ const http = require('http');
 const url = require('url');
 const qs = require('querystring');
 
-// TODO: documentation does not allow Array as an option, so testing that
-// should fail, but currently http.Server does not typecheck further than
-// if `option` is `typeof object` - so we don't test that here right now
-const invalid_options = [ 'foo', 42, true ];
+const invalid_options = [ 'foo', 42, true, [] ];
 
 invalid_options.forEach((option) => {
   assert.throws(() => {

--- a/test/parallel/test-https-simple.js
+++ b/test/parallel/test-https-simple.js
@@ -44,6 +44,15 @@ const serverCallback = common.mustCall(function(req, res) {
   res.end(body);
 });
 
+const invalid_options = [ 'foo', 42, true, [] ];
+invalid_options.forEach((option) => {
+  assert.throws(() => {
+    new https.Server(option);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+});
+
 const server = https.createServer(options, serverCallback);
 
 server.listen(0, common.mustCall(() => {


### PR DESCRIPTION
If options of http.Server is array, throw ERR_INVALID_ARG_TYPE.

Refs: https://github.com/nodejs/node/pull/24176

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
