### PR TITLE
src: fix c++ exception on bad command line arg

### DIFF
--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -444,7 +444,8 @@ void OptionsParser<Options>::Parse(
         *Lookup<int64_t>(info.field, options) = std::atoll(value.c_str());
         break;
       case kUInteger:
-        *Lookup<uint64_t>(info.field, options) = std::stoull(value);
+        *Lookup<uint64_t>(info.field, options) =
+            std::strtoull(value.c_str(), nullptr, 10);
         break;
       case kString:
         *Lookup<std::string>(info.field, options) = value;

--- a/test/sequential/test-cpu-prof-invalid-options.js
+++ b/test/sequential/test-cpu-prof-invalid-options.js
@@ -58,11 +58,11 @@ const {
 }
 
 // --cpu-prof-interval without --cpu-prof
-{
+for (const arg of [kCpuProfInterval, 'crashme']) {
   tmpdir.refresh();
   const output = spawnSync(process.execPath, [
     '--cpu-prof-interval',
-    kCpuProfInterval,
+    arg,
     fixtures.path('workload', 'fibonacci.js'),
   ], {
     cwd: tmpdir.path,


### PR DESCRIPTION
Replace stoull() with strtoull(). The former throws an exception when the input is malformed, the latter doesn't.

Fixes: https://github.com/nodejs/node/issues/46223