### PR TITLE
esm: skip file: URL conversion to path when possible

### DIFF
--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -4,9 +4,10 @@ const {
   ObjectPrototypeHasOwnProperty,
   PromisePrototypeThen,
   PromiseResolve,
+  StringPrototypeCharCodeAt,
   StringPrototypeSlice,
 } = primordials;
-const { basename, extname, relative } = require('path');
+const { basename, relative } = require('path');
 const { getOptionValue } = require('internal/options');
 const {
   extensionFormatMap,
@@ -17,6 +18,7 @@ const experimentalNetworkImports =
   getOptionValue('--experimental-network-imports');
 const { getPackageType, getPackageScopeConfig } = require('internal/modules/esm/resolve');
 const { URL, fileURLToPath } = require('internal/url');
+const assert = require('internal/assert');
 const { ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
 
 const protocolHandlers = {
@@ -41,6 +43,29 @@ function getDataProtocolModuleFormat(parsed) {
   return mimeToFormat(mime);
 }
 
+const DOT_CODE = 46;
+const SLASH_CODE = 47;
+
+/**
+ * Returns the file extension from a file: URL. Should give similar result than
+ * require('node:path').extname(require('node:url').fileURLToPath(url)).
+ * @param {URL} url A file: URL.
+ * @returns {string}
+ */
+function extname(url) {
+  const { pathname } = url;
+  for (let i = pathname.length - 1; i > 0; i--) {
+    switch (StringPrototypeCharCodeAt(pathname, i)) {
+      case SLASH_CODE:
+        return '';
+
+      case DOT_CODE:
+        return StringPrototypeCharCodeAt(pathname, i - 1) === SLASH_CODE ? '' : StringPrototypeSlice(pathname, i);
+    }
+  }
+  return '';
+}
+
 /**
  * @param {URL} url
  * @param {{parentURL: string}} context
@@ -48,8 +73,7 @@ function getDataProtocolModuleFormat(parsed) {
  * @returns {string}
  */
 function getFileProtocolModuleFormat(url, context, ignoreErrors) {
-  const filepath = fileURLToPath(url);
-  const ext = extname(filepath);
+  const ext = extname(url);
   if (ext === '.js') {
     return getPackageType(url) === 'module' ? 'module' : 'commonjs';
   }
@@ -59,6 +83,7 @@ function getFileProtocolModuleFormat(url, context, ignoreErrors) {
 
   // Explicit undefined return indicates load hook should rerun format check
   if (ignoreErrors) { return undefined; }
+  const filepath = fileURLToPath(url);
   let suggestion = '';
   if (getPackageType(url) === 'module' && ext === '') {
     const config = getPackageScopeConfig(url);
@@ -119,4 +144,5 @@ module.exports = {
   defaultGetFormat,
   defaultGetFormatWithoutErrors,
   extensionFormatMap,
+  extname,
 };

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -18,7 +18,6 @@ const experimentalNetworkImports =
   getOptionValue('--experimental-network-imports');
 const { getPackageType, getPackageScopeConfig } = require('internal/modules/esm/resolve');
 const { URL, fileURLToPath } = require('internal/url');
-const assert = require('internal/assert');
 const { ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
 
 const protocolHandlers = {

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -48,7 +48,7 @@ const SLASH_CODE = 47;
 /**
  * Returns the file extension from a URL. Should give similar result to
  * require('node:path').extname(require('node:url').fileURLToPath(url)).
- * @param {URL} url A file: URL.
+ * @param {URL} url
  * @returns {string}
  */
 function extname(url) {

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -46,7 +46,7 @@ const DOT_CODE = 46;
 const SLASH_CODE = 47;
 
 /**
- * Returns the file extension from a file: URL. Should give similar result than
+ * Returns the file extension from a URL. Should give similar result to
  * require('node:path').extname(require('node:url').fileURLToPath(url)).
  * @param {URL} url A file: URL.
  * @returns {string}

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -47,7 +47,8 @@ const SLASH_CODE = 47;
 
 /**
  * Returns the file extension from a URL. Should give similar result to
- * require('node:path').extname(require('node:url').fileURLToPath(url)).
+ * `require('node:path').extname(require('node:url').fileURLToPath(url))`
+ * when used with a `file:` URL.
  * @param {URL} url
  * @returns {string}
  */

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -35,8 +35,7 @@ const {
   Module: CJSModule,
   cjsParseCache,
 } = require('internal/modules/cjs/loader');
-const internalURLModule = require('internal/url');
-const { fileURLToPath, URL } = require('url');
+const { fileURLToPath, URL } = require('internal/url');
 let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
   debug = fn;
 });
@@ -147,9 +146,7 @@ translators.set('commonjs', async function commonjsStrategy(url, source,
                                                             isMain) {
   debug(`Translating CJSModule ${url}`);
 
-  let filename = internalURLModule.fileURLToPath(new URL(url));
-  if (isWindows)
-    filename = StringPrototypeReplaceAll(filename, '/', '\\');
+  const filename = fileURLToPath(new URL(url));
 
   if (!cjsParse) await initCJSParse();
   const { module, exportNames } = cjsPreparseModuleExports(filename);

--- a/test/parallel/test-esm-url-extname.js
+++ b/test/parallel/test-esm-url-extname.js
@@ -1,0 +1,27 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('node:assert');
+const path = require('node:path');
+const { extname } = require('node:internal/modules/esm/get_format');
+const { fileURLToPath } = require('node:url');
+
+[
+  'file:///path/to/file',
+  'file:///path/to/file.ext',
+  'file:///path.to/file.ext',
+  'file:///path.to/file',
+  'file:///path.to/.file',
+  'file:///path.to/.file.ext',
+  'file:///path/to/f.ext',
+  'file:///path/to/..ext',
+  'file:///path/to/..',
+  'file:///file',
+  'file:///file.ext',
+  'file:///.file',
+  'file:///.file.ext',
+].forEach((input) => {
+  const inputAsURL = new URL(input);
+  const inputAsPath = fileURLToPath(inputAsURL);
+  assert.strictEqual(extname(inputAsURL), path.extname(inputAsPath));
+});

--- a/test/parallel/test-esm-url-extname.js
+++ b/test/parallel/test-esm-url-extname.js
@@ -7,19 +7,19 @@ const { extname } = require('node:internal/modules/esm/get_format');
 const { fileURLToPath } = require('node:url');
 
 [
-  'file:///path/to/file',
-  'file:///path/to/file.ext',
-  'file:///path.to/file.ext',
-  'file:///path.to/file',
-  'file:///path.to/.file',
-  'file:///path.to/.file.ext',
-  'file:///path/to/f.ext',
-  'file:///path/to/..ext',
-  'file:///path/to/..',
-  'file:///file',
-  'file:///file.ext',
-  'file:///.file',
-  'file:///.file.ext',
+  'file:///c:/path/to/file',
+  'file:///c:/path/to/file.ext',
+  'file:///c:/path.to/file.ext',
+  'file:///c:/path.to/file',
+  'file:///c:/path.to/.file',
+  'file:///c:/path.to/.file.ext',
+  'file:///c:/path/to/f.ext',
+  'file:///c:/path/to/..ext',
+  'file:///c:/path/to/..',
+  'file:///c:/file',
+  'file:///c:/file.ext',
+  'file:///c:/.file',
+  'file:///c:/.file.ext',
 ].forEach((input) => {
   const inputAsURL = new URL(input);
   const inputAsPath = fileURLToPath(inputAsURL);


### PR DESCRIPTION
`require('node:path').extname` has to do several checks to comply with relative paths, however `URL` instances are always absolute so skipping the translation to a path and implement a simplified version of `extname` makes sense IMHO.

We could potentially do the same for `basename`, but it's only used in the error path where performance don't matter as much, so this PR is only doing `extname`.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
