### PR TITLE
url: implement URLSearchParams size getter

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -940,6 +940,14 @@ console.log(params.toString());
 // Prints foo=def&abc=def&xyz=opq
 ```
 
+#### `urlSearchParams.size`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The total number of parameter entries.
+
 #### `urlSearchParams.sort()`
 
 <!-- YAML

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -271,6 +271,12 @@ class URLSearchParams {
     return `${this.constructor.name} {}`;
   }
 
+  get size() {
+    if (!isURLSearchParams(this))
+      throw new ERR_INVALID_THIS('URLSearchParams');
+    return this[searchParams].length / 2;
+  }
+
   append(name, value) {
     if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
@@ -506,6 +512,7 @@ ObjectDefineProperties(URLSearchParams.prototype, {
   getAll: kEnumerableProperty,
   has: kEnumerableProperty,
   set: kEnumerableProperty,
+  size: kEnumerableProperty,
   sort: kEnumerableProperty,
   entries: kEnumerableProperty,
   forEach: kEnumerableProperty,

--- a/test/parallel/test-whatwg-url-properties.js
+++ b/test/parallel/test-whatwg-url-properties.js
@@ -65,6 +65,14 @@ const { URL, URLSearchParams, format } = require('url');
   testMethod(URLSearchParams.prototype, name, methodName);
 });
 
+{
+  const params = new URLSearchParams();
+  params.append('a', 'b');
+  params.append('a', 'c');
+  params.append('b', 'c');
+  assert.strictEqual(params.size, 3);
+}
+
 function stringifyName(name) {
   if (typeof name === 'symbol') {
     const { description } = name;


### PR DESCRIPTION
Implementation in preparation for https://github.com/whatwg/url/pull/734 ... I wouldn't land this until the upstream spec change lands but want to make it ready.

Refs: https://github.com/whatwg/url/pull/734

