### PR TITLE
test: fix tap escaping with and without --test

### DIFF
--- a/lib/internal/test_runner/reporter/tap.js
+++ b/lib/internal/test_runner/reporter/tap.js
@@ -132,14 +132,14 @@ function indent(nesting) {
 
 // In certain places, # and \ need to be escaped as \# and \\.
 function tapEscape(input) {
-  let result = StringPrototypeReplaceAll(input, '\\', '\\\\');
-  result = StringPrototypeReplaceAll(result, '#', '\\#');
-  result = StringPrototypeReplaceAll(result, '\b', '\\b');
+  let result = StringPrototypeReplaceAll(input, '\b', '\\b');
   result = StringPrototypeReplaceAll(result, '\f', '\\f');
   result = StringPrototypeReplaceAll(result, '\t', '\\t');
   result = StringPrototypeReplaceAll(result, '\n', '\\n');
   result = StringPrototypeReplaceAll(result, '\r', '\\r');
   result = StringPrototypeReplaceAll(result, '\v', '\\v');
+  result = StringPrototypeReplaceAll(result, '\\', '\\\\');
+  result = StringPrototypeReplaceAll(result, '#', '\\#');
   return result;
 }
 

--- a/test/message/test_runner_output.out
+++ b/test/message/test_runner_output.out
@@ -346,8 +346,8 @@ ok 36 - functionAndOptions # SKIP
   ---
   duration_ms: *
   ...
-# Subtest: escaped description \\ \# \\\#\\ \n \t \f \v \b \r
-ok 37 - escaped description \\ \# \\\#\\ \n \t \f \v \b \r
+# Subtest: escaped description \\ \# \\\#\\ \\n \\t \\f \\v \\b \\r
+ok 37 - escaped description \\ \# \\\#\\ \\n \\t \\f \\v \\b \\r
   ---
   duration_ms: *
   ...

--- a/test/message/test_runner_output_cli.out
+++ b/test/message/test_runner_output_cli.out
@@ -122,9 +122,9 @@ TAP version 13
       failureType: 'testCodeFailure'
       error: |-
         Expected values to be strictly equal:
-        
+
         true !== false
-        
+
       code: 'ERR_ASSERTION'
       expected: false
       actual: true
@@ -345,8 +345,8 @@ TAP version 13
       ---
       duration_ms: *
       ...
-    # Subtest: escaped description \\ \# \\\#\\ n \\t f \\v b \\r
-    ok 37 - escaped description \\ \# \\\#\\ n \\t f \\v b \\r
+    # Subtest: escaped description \\ \# \\\#\\ \\n \\t \\f \\v \\b \\r
+    ok 37 - escaped description \\ \# \\\#\\ \\n \\t \\f \\v \\b \\r
       ---
       duration_ms: *
       ...


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

fix: #45836

code
 
```
const test = require('node:test');
test('escaped description \\ # \\#\\ \n \t \f \v \b \r');
```

- tap escaping without `--test`

```
TAP version 13
# Subtest: escaped description \\ \# \\\#\\ \\n \\t \\f \\v \\b \\r
ok 1 - escaped description \\ \# \\\#\\ \\n \\t \\f \\v \\b \\r
  ---
  duration_ms: 3.569875
  ...
1..1
# tests 1
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 6.989541
```

- tap escaping with `--test`

```
TAP version 13
# Subtest: /Users/pulkitgupta/Desktop/node/test.js
    # Subtest: escaped description \\ \# \\\#\\ \\n \\t \\f \\v \\b \\r
    ok 1 - escaped description \\ \# \\\#\\ \\n \\t \\f \\v \\b \\r
      ---
      duration_ms: 2.582292
      ...
    1..1
ok 1 - /Users/pulkitgupta/Desktop/node/test.js
  ---
  duration_ms: 49.498875
  ...
1..1
# tests 1
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 50.930334
```

Also modify test output's [`test/message/test_runner_output.out `, `test/message/test_runner_output_cli.out`]
