### PR TITLE
tools,doc: fix commit message using test instead of deps

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -78,8 +78,8 @@ jobs:
                 ./tools/update-undici.sh
               fi
           - id: postject
-            subsystem: deps
-            label: dependencies
+            subsystem: test
+            label: test
             run: |
               NEW_VERSION=$(npm view postject dist-tags.latest)
               CURRENT_VERSION=$(node -p "require('./test/fixtures/postject-copy/node_modules/postject/package.json').version")

--- a/doc/contributing/maintaining-postject.md
+++ b/doc/contributing/maintaining-postject.md
@@ -16,8 +16,8 @@ Check that Node.js still builds and tests.
 2. Commit the changes: `git commit`.
 3. Add a message like:
 
-```text
-test: update postject to <version>
+   ```text
+   test: update postject to <version>
 
-Updated as described in doc/contributing/maintaining-postject.md.
-```
+   Updated as described in doc/contributing/maintaining-postject.md.
+   ```

--- a/doc/contributing/maintaining-postject.md
+++ b/doc/contributing/maintaining-postject.md
@@ -12,14 +12,12 @@ Check that Node.js still builds and tests.
 
 ## Committing postject
 
-* Add postject: `git add --all test/fixtures/postject-copy`
+1. Add postject: `git add --all test/fixtures/postject-copy`
+2. Commit the changes: `git commit`
+3. Add a message like:
 
-* Commit the changes: `git commit`
+ ```text
+ test: update postject to <version>
 
-* Add a message like:
-
-```text
-test: update postject to <version>
-
-Updated as described in doc/contributing/maintaining-postject.md.
-```
+ Updated as described in doc/contributing/maintaining-postject.md.
+ ```

--- a/doc/contributing/maintaining-postject.md
+++ b/doc/contributing/maintaining-postject.md
@@ -12,12 +12,12 @@ Check that Node.js still builds and tests.
 
 ## Committing postject
 
-1. Add postject: `git add --all test/fixtures/postject-copy`
-2. Commit the changes: `git commit`
+1. Add postject: `git add --all test/fixtures/postject-copy`.
+2. Commit the changes: `git commit`.
 3. Add a message like:
 
- ```text
- test: update postject to <version>
+```text
+test: update postject to <version>
 
- Updated as described in doc/contributing/maintaining-postject.md.
- ```
+Updated as described in doc/contributing/maintaining-postject.md.
+```

--- a/doc/contributing/maintaining-postject.md
+++ b/doc/contributing/maintaining-postject.md
@@ -12,12 +12,14 @@ Check that Node.js still builds and tests.
 
 ## Committing postject
 
-Add postject: `git add --all test/fixtures/postject-copy`
+* Add postject: `git add --all test/fixtures/postject-copy`
 
-Commit the changes with a message like:
+* Commit the changes: `git commit`
+
+* Add a message like:
 
 ```text
-deps: update postject to 1.0.0-alpha.4
+test: update postject to <version>
 
 Updated as described in doc/contributing/maintaining-postject.md.
 ```


### PR DESCRIPTION
I chatted with @RaisinTen the other day, and he mentioned that the commit title we propose in the documentation should contain the label `test` and not `deps` as `postject` is a part of test fixtures.

I took this opportunity to change a few things.

Let me know ^^

@targos @nodejs/single-executable