### PR TITLE
[v18.x backport] stream: streams and webstreams interop related changes

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2579,6 +2579,9 @@ further errors except from `_destroy()` may be emitted as `'error'`.
 <!-- YAML
 added: v10.0.0
 changes:
+  - version: v18.14.0
+    pr-url: https://github.com/nodejs/node/pull/46205
+    description: Added support for `ReadableStream` and `WritableStream`.
   - version: v15.11.0
     pr-url: https://github.com/nodejs/node/pull/37354
     description: The `signal` option was added.
@@ -2598,7 +2601,9 @@ changes:
                  finished before the call to `finished(stream, cb)`.
 -->
 
-* `stream` {Stream} A readable and/or writable stream.
+* `stream` {Stream|ReadableStream|WritableStream}
+
+A readable and/or writable stream/webstream.
 
 * `options` {Object}
   * `error` {boolean} If set to `false`, then a call to `emit('error', err)` is
@@ -3022,10 +3027,16 @@ added: v17.0.0
 
 <!-- YAML
 added: v16.8.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46190
+    description: The `src` argument can now be a `ReadableStream` or
+                 `WritableStream`.
 -->
 
 * `src` {Stream|Blob|ArrayBuffer|string|Iterable|AsyncIterable|
-  AsyncGeneratorFunction|AsyncFunction|Promise|Object}
+  AsyncGeneratorFunction|AsyncFunction|Promise|Object|
+  ReadableStream|WritableStream}
 
 A utility method for creating duplex streams.
 
@@ -3045,6 +3056,8 @@ A utility method for creating duplex streams.
   `writable` into `Stream` and then combines them into `Duplex` where the
   `Duplex` will write to the `writable` and read from the `readable`.
 * `Promise` converts into readable `Duplex`. Value `null` is ignored.
+* `ReadableStream` converts into readable `Duplex`.
+* `WritableStream` converts into writable `Duplex`.
 * Returns: {stream.Duplex}
 
 If an `Iterable` object containing promises is passed as an argument,

--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -8,6 +8,8 @@ const {
   isReadableNodeStream,
   isWritableNodeStream,
   isDuplexNodeStream,
+  isReadableStream,
+  isWritableStream,
 } = require('internal/streams/utils');
 const eos = require('internal/streams/end-of-stream');
 const {
@@ -32,16 +34,6 @@ const { AbortController } = require('internal/abort_controller');
 const {
   FunctionPrototypeCall,
 } = primordials;
-
-
-const {
-  isBrandCheck,
-} = require('internal/webstreams/util');
-
-const isReadableStream =
-  isBrandCheck('ReadableStream');
-const isWritableStream =
-  isBrandCheck('WritableStream');
 
 // This is needed for pre node 17.
 class Duplexify extends Duplex {

--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -20,6 +20,7 @@ const {
 const { destroyer } = require('internal/streams/destroy');
 const Duplex = require('internal/streams/duplex');
 const Readable = require('internal/streams/readable');
+const Writable = require('internal/streams/writable');
 const { createDeferredPromise } = require('internal/util');
 const from = require('internal/streams/from');
 
@@ -31,6 +32,16 @@ const { AbortController } = require('internal/abort_controller');
 const {
   FunctionPrototypeCall,
 } = primordials;
+
+
+const {
+  isBrandCheck,
+} = require('internal/webstreams/util');
+
+const isReadableStream =
+  isBrandCheck('ReadableStream');
+const isWritableStream =
+  isBrandCheck('WritableStream');
 
 // This is needed for pre node 17.
 class Duplexify extends Duplex {
@@ -71,15 +82,13 @@ module.exports = function duplexify(body, name) {
     return _duplexify({ writable: false, readable: false });
   }
 
-  // TODO: Webstreams
-  // if (isReadableStream(body)) {
-  //   return _duplexify({ readable: Readable.fromWeb(body) });
-  // }
+  if (isReadableStream(body)) {
+    return _duplexify({ readable: Readable.fromWeb(body) });
+  }
 
-  // TODO: Webstreams
-  // if (isWritableStream(body)) {
-  //   return _duplexify({ writable: Writable.fromWeb(body) });
-  // }
+  if (isWritableStream(body)) {
+    return _duplexify({ writable: Writable.fromWeb(body) });
+  }
 
   if (typeof body === 'function') {
     const { value, write, final, destroy } = fromAsyncGen(body);
@@ -146,13 +155,12 @@ module.exports = function duplexify(body, name) {
     });
   }
 
-  // TODO: Webstreams.
-  // if (
-  //   isReadableStream(body?.readable) &&
-  //   isWritableStream(body?.writable)
-  // ) {
-  //   return Duplexify.fromWeb(body);
-  // }
+  if (
+    isReadableStream(body?.readable) &&
+    isWritableStream(body?.writable)
+  ) {
+    return Duplexify.fromWeb(body);
+  }
 
   if (
     typeof body?.writable === 'object' ||

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const { Duplex, Readable, Writable, pipeline, PassThrough } = require('stream');
+const { ReadableStream, WritableStream } = require('stream/web');
 const { Blob } = require('buffer');
 
 {
@@ -298,4 +299,105 @@ const { Blob } = require('buffer');
   }).on('end', common.mustCall(() => {
     assert.strictEqual(res, 'foobar');
   })).on('close', common.mustCall());
+}
+
+function makeATestReadableStream(value) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(value);
+      controller.close();
+    }
+  });
+}
+
+function makeATestWritableStream(writeFunc) {
+  return new WritableStream({
+    write(chunk) {
+      writeFunc(chunk);
+    }
+  });
+}
+
+{
+  const d = Duplex.from({
+    readable: makeATestReadableStream('foo'),
+  });
+  assert.strictEqual(d.readable, true);
+  assert.strictEqual(d.writable, false);
+
+  d.on('data', common.mustCall((data) => {
+    assert.strictEqual(data.toString(), 'foo');
+  }));
+
+  d.on('end', common.mustCall(() => {
+    assert.strictEqual(d.readable, false);
+  }));
+}
+
+{
+  const d = Duplex.from(makeATestReadableStream('foo'));
+
+  assert.strictEqual(d.readable, true);
+  assert.strictEqual(d.writable, false);
+
+  d.on('data', common.mustCall((data) => {
+    assert.strictEqual(data.toString(), 'foo');
+  }));
+
+  d.on('end', common.mustCall(() => {
+    assert.strictEqual(d.readable, false);
+  }));
+}
+
+{
+  let ret = '';
+  const d = Duplex.from({
+    writable: makeATestWritableStream((chunk) => ret += chunk),
+  });
+
+  assert.strictEqual(d.readable, false);
+  assert.strictEqual(d.writable, true);
+
+  d.end('foo');
+  d.on('finish', common.mustCall(() => {
+    assert.strictEqual(ret, 'foo');
+    assert.strictEqual(d.writable, false);
+  }));
+}
+
+{
+  let ret = '';
+  const d = Duplex.from(makeATestWritableStream((chunk) => ret += chunk));
+
+  assert.strictEqual(d.readable, false);
+  assert.strictEqual(d.writable, true);
+
+  d.end('foo');
+  d.on('finish', common.mustCall(() => {
+    assert.strictEqual(ret, 'foo');
+    assert.strictEqual(d.writable, false);
+  }));
+}
+
+{
+  let ret = '';
+  const d = Duplex.from({
+    readable: makeATestReadableStream('foo'),
+    writable: makeATestWritableStream((chunk) => ret += chunk),
+  });
+
+  d.end('bar');
+
+  d.on('data', common.mustCall((data) => {
+    assert.strictEqual(data.toString(), 'foo');
+  }));
+
+  d.on('end', common.mustCall(() => {
+    assert.strictEqual(d.readable, false);
+  }));
+
+  d.on('finish', common.mustCall(() => {
+    assert.strictEqual(ret, 'bar');
+    assert.strictEqual(d.writable, false);
+  }));
 }


### PR DESCRIPTION
Backports the following PRs:
https://github.com/nodejs/node/pull/46190
https://github.com/nodejs/node/pull/46273
https://github.com/nodejs/node/pull/46307
https://github.com/nodejs/node/pull/46312
https://github.com/nodejs/node/pull/46315
https://github.com/nodejs/node/pull/46403
https://github.com/nodejs/node/pull/46600
https://github.com/nodejs/node/pull/46675

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
