### PR TITLE
stream: remove brandchecks from stream duplexify

### DIFF
--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -8,6 +8,8 @@ const {
   isReadableNodeStream,
   isWritableNodeStream,
   isDuplexNodeStream,
+  isReadableStream,
+  isWritableStream,
 } = require('internal/streams/utils');
 const eos = require('internal/streams/end-of-stream');
 const {
@@ -32,16 +34,6 @@ const { AbortController } = require('internal/abort_controller');
 const {
   FunctionPrototypeCall
 } = primordials;
-
-
-const {
-  isBrandCheck,
-} = require('internal/webstreams/util');
-
-const isReadableStream =
-  isBrandCheck('ReadableStream');
-const isWritableStream =
-  isBrandCheck('WritableStream');
 
 // This is needed for pre node 17.
 class Duplexify extends Duplex {


### PR DESCRIPTION
Using imports from webstreams could cause dependency issues in `readable-stream` as referenced in the discussion, hence removing brandchecks and replacing with utils in streams

Refs: https://github.com/nodejs/node/pull/46190
Refs: https://github.com/nodejs/node/pull/46205#discussion_r1070551161

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
