### PR TITLE
stream: validate writable defaultEncoding

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -122,7 +122,13 @@ function WritableState(options, stream, isDuplex) {
   // Crypto is kind of old and crusty.  Historically, its default string
   // encoding is 'binary' so we have to make this configurable.
   // Everything else in the universe uses 'utf8', though.
-  this.defaultEncoding = (options && options.defaultEncoding) || 'utf8';
+  const defaultEncoding = options?.defaultEncoding;
+
+  if (defaultEncoding && !Buffer.isEncoding(defaultEncoding)) {
+    throw new ERR_UNKNOWN_ENCODING(defaultEncoding);
+  }
+
+  this.defaultEncoding = defaultEncoding || 'utf8';
 
   // Not an actual buffer we keep track of, but a measurement
   // of how much we're waiting to get pushed to some underlying

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -123,12 +123,13 @@ function WritableState(options, stream, isDuplex) {
   // encoding is 'binary' so we have to make this configurable.
   // Everything else in the universe uses 'utf8', though.
   const defaultEncoding = options?.defaultEncoding;
-
-  if (defaultEncoding && !Buffer.isEncoding(defaultEncoding)) {
+  if (defaultEncoding == null) {
+    this.defaultEncoding = 'utf8';
+  } else if (Buffer.isEncoding(defaultEncoding)) {
+    this.defaultEncoding = defaultEncoding;
+  } else {
     throw new ERR_UNKNOWN_ENCODING(defaultEncoding);
   }
-
-  this.defaultEncoding = defaultEncoding || 'utf8';
 
   // Not an actual buffer we keep track of, but a measurement
   // of how much we're waiting to get pushed to some underlying

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -56,3 +56,27 @@ class MyWritable extends stream.Writable {
   m.write('some-text', 'utf8');
   m.end();
 }
+
+{
+  assert.throws(() => {
+    const m = new MyWritable(null, {
+      defaultEncoding: 'my invalid encoding',
+    });
+    m.end();
+  }, {
+    code: 'ERR_UNKNOWN_ENCODING',
+  });
+}
+
+{
+  const w = new MyWritable(function(isBuffer, type, enc) {
+    assert(!isBuffer);
+    assert.strictEqual(type, 'string');
+    assert.strictEqual(enc, 'hex');
+  }, {
+    defaultEncoding: 'hex',
+    decodeStrings: false
+  });
+  w.write('asd');
+  w.end();
+}

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -93,3 +93,13 @@ class MyWritable extends stream.Writable {
   w.write('asd');
   w.end();
 }
+
+{
+  const m = new MyWritable(function(isBuffer, type, enc) {
+    assert.strictEqual(type, 'object');
+    assert.strictEqual(enc, 'utf8');
+  }, { defaultEncoding: 'hex',
+       objectMode: true });
+  m.write({ foo: 'bar' }, 'utf8');
+  m.end();
+}

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -80,3 +80,16 @@ class MyWritable extends stream.Writable {
   w.write('asd');
   w.end();
 }
+
+{
+  const w = new MyWritable(function(isBuffer, type, enc) {
+    assert(!isBuffer);
+    assert.strictEqual(type, 'string');
+    assert.strictEqual(enc, 'utf8');
+  }, {
+    defaultEncoding: null,
+    decodeStrings: false
+  });
+  w.write('asd');
+  w.end();
+}


### PR DESCRIPTION
fixes: https://github.com/nodejs/node/issues/46301
this has to be done for `stream.Readable` too for consistency. I'll open another pr for readable if this gets approved
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
