### PR TITLE
http: close the connection after sending a body without declared length

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -547,6 +547,10 @@ function _storeHeader(firstLine, headers) {
       // Transfer-Encoding are removed by the user.
       // See: test/parallel/test-http-remove-header-stays-removed.js
       debug('Both Content-Length and Transfer-Encoding are removed');
+
+      // We can't keep alive in this case, because with no header info the body
+      // is defined as all data until the connection is closed.
+      this._last = true;
     }
   }
 

--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -37,8 +37,6 @@ const server = http.createServer(function(request, response) {
   response.setHeader('date', 'coffee o clock');
 
   response.end('beep boop\n');
-
-  this.close();
 });
 
 let response = '';
@@ -57,5 +55,12 @@ server.listen(0, function() {
     res.on('data', function(chunk) {
       response += chunk;
     });
+
+    setTimeout(function() {
+      // The socket should be closed immediately, with no keep-alive, because
+      // no content-length or transfer-encoding are used:
+      assert.strictEqual(res.socket.closed, true);
+      server.close();
+    }, 10);
   });
 });


### PR DESCRIPTION
This is related to #46331 but not directly dependent - it's a separate issue I've just noticed en route.

Previously, if you removed both the content-length and transfer-encoding headers, everything was sent as normal, and the connection would still be kept alive by default. This is problematic, because without those headers to declare the size of the message body, the only way the client knows when the body is completed is when the connection closes. With KA, the connection doesn't close for ages.

See https://www.rfc-editor.org/rfc/rfc7230#section-3.3.3 for more details on this message body handling logic. This is the final case (7):

> Otherwise, this is a response message without a declared message body length, so the message body length is determined by the number of octets received prior to the server closing the connection.

This meant that in effect, if you removed both headers then every response came with a 5 second delay at the end (the default KA timeout) before the client could process it.

With this PR, if you remove both headers then the connection closes automatically immediately, so the client knows straight away that it has received the whole message body and everything works correctly.

This does behave slightly differently with & without #46331:

* Currently, without that PR, this only affects code that removes the content-length & transfer-encoding headers, but does _not_ remove the connection header (because doing so disables KA, which solves the issue).
  Note that the only test covering this does exactly that, so the modified test here actually still passes on `main` even without this change.
* Once that other PR is merged, this issue would affect any code that removes both headers, regardless of whether they remove the Connection header, because doing so no longer disables KA. The modified test here does fail if run against that PR branch (and does pass when run with this test + fix on top of that branch).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
