### PR TITLE
lib: remove unnecessary ObjectGetValueSafe

### DIFF
--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -4,21 +4,11 @@ const {
   ArrayPrototypeMap,
   JSONParse,
   ObjectKeys,
-  ObjectGetOwnPropertyDescriptor,
-  ObjectPrototypeHasOwnProperty,
   RegExpPrototypeExec,
   RegExpPrototypeSymbolSplit,
   SafeMap,
   StringPrototypeSplit,
 } = primordials;
-
-function ObjectGetValueSafe(obj, key) {
-  const desc = ObjectGetOwnPropertyDescriptor(obj, key);
-  if (desc === undefined) {
-    return undefined;
-  }
-  return ObjectPrototypeHasOwnProperty(desc, 'value') ? desc.value : undefined;
-}
 
 // See https://sourcemaps.info/spec.html for SourceMap V3 specification.
 const { Buffer } = require('buffer');
@@ -301,11 +291,11 @@ function sourceMapCacheToObject() {
 
 function appendCJSCache(obj) {
   for (const value of getCjsSourceMapCache()) {
-    obj[ObjectGetValueSafe(value, 'filename')] = {
+    obj[value.filename] = {
       __proto__: null,
-      lineLengths: ObjectGetValueSafe(value, 'lineLengths'),
-      data: ObjectGetValueSafe(value, 'data'),
-      url: ObjectGetValueSafe(value, 'url')
+      lineLengths: value.lineLengths,
+      data: value.data,
+      url: value.url,
     };
   }
 }
@@ -320,8 +310,8 @@ function findSourceMap(sourceURL) {
   let entry = esmSourceMapCache.get(sourceURL) ?? generatedSourceMapCache.get(sourceURL);
   if (entry === undefined) {
     for (const value of getCjsSourceMapCache()) {
-      const filename = ObjectGetValueSafe(value, 'filename');
-      const cachedSourceURL = ObjectGetValueSafe(value, 'sourceURL');
+      const filename = value.filename;
+      const cachedSourceURL = value.sourceURL;
       if (sourceURL === filename || sourceURL === cachedSourceURL) {
         entry = value;
       }
@@ -330,9 +320,9 @@ function findSourceMap(sourceURL) {
   if (entry === undefined) {
     return undefined;
   }
-  let sourceMap = ObjectGetValueSafe(entry, 'sourceMap');
+  let sourceMap = entry.sourceMap;
   if (sourceMap === undefined) {
-    sourceMap = new SourceMap(ObjectGetValueSafe(entry, 'data'));
+    sourceMap = new SourceMap(entry.data);
     entry.sourceMap = sourceMap;
   }
   return sourceMap;


### PR DESCRIPTION
Fixes the comment https://github.com/nodejs/node/pull/46225#pullrequestreview-1260734972.

The prototype pollution test should have been covered in https://github.com/nodejs/node/blob/main/test/parallel/test-worker-terminate-source-map.js