### PR TITLE
[v18.x backport] crypto: add CryptoKey Symbol.toStringTag

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -750,6 +750,15 @@ class InternalCryptoKey {
     this[kExtractable] = extractable;
   }
 }
+
+ObjectDefineProperties(CryptoKey.prototype, {
+  [SymbolToStringTag]: {
+    __proto__: null,
+    configurable: true,
+    value: 'CryptoKey',
+  },
+});
+
 InternalCryptoKey.prototype.constructor = CryptoKey;
 ObjectSetPrototypeOf(InternalCryptoKey.prototype, CryptoKey.prototype);
 


### PR DESCRIPTION
Backports #46042 because it doesn't land cleanly without #45855 but is in itself useful to backport for the ecosystem given the longevity of the v18.x LTS release line.