### PR TITLE
[v18.x backport] crypto: add KeyObject Symbol.toStringTag

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -3,9 +3,11 @@
 const {
   ArrayFrom,
   ArrayPrototypeSlice,
+  ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Symbol,
+  SymbolToStringTag,
   Uint8Array,
 } = primordials;
 
@@ -135,6 +137,14 @@ const {
         this[kHandle].equals(otherKeyObject[kHandle]);
     }
   }
+
+  ObjectDefineProperties(KeyObject.prototype, {
+    [SymbolToStringTag]: {
+      __proto__: null,
+      configurable: true,
+      value: 'KeyObject',
+    },
+  });
 
   class SecretKeyObject extends KeyObject {
     constructor(handle) {

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -69,6 +69,7 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   const keybuf = randomBytes(32);
   const key = createSecretKey(keybuf);
   assert.strictEqual(key.type, 'secret');
+  assert.strictEqual(key.toString(), '[object KeyObject]');
   assert.strictEqual(key.symmetricKeySize, 32);
   assert.strictEqual(key.asymmetricKeyType, undefined);
   assert.strictEqual(key.asymmetricKeyDetails, undefined);
@@ -150,27 +151,32 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
 
   const publicKey = createPublicKey(publicPem);
   assert.strictEqual(publicKey.type, 'public');
+  assert.strictEqual(publicKey.toString(), '[object KeyObject]');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
   assert.strictEqual(publicKey.symmetricKeySize, undefined);
 
   const privateKey = createPrivateKey(privatePem);
   assert.strictEqual(privateKey.type, 'private');
+  assert.strictEqual(privateKey.toString(), '[object KeyObject]');
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
   assert.strictEqual(privateKey.symmetricKeySize, undefined);
 
   // It should be possible to derive a public key from a private key.
   const derivedPublicKey = createPublicKey(privateKey);
   assert.strictEqual(derivedPublicKey.type, 'public');
+  assert.strictEqual(derivedPublicKey.toString(), '[object KeyObject]');
   assert.strictEqual(derivedPublicKey.asymmetricKeyType, 'rsa');
   assert.strictEqual(derivedPublicKey.symmetricKeySize, undefined);
 
   const publicKeyFromJwk = createPublicKey({ key: publicJwk, format: 'jwk' });
   assert.strictEqual(publicKey.type, 'public');
+  assert.strictEqual(publicKey.toString(), '[object KeyObject]');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
   assert.strictEqual(publicKey.symmetricKeySize, undefined);
 
   const privateKeyFromJwk = createPrivateKey({ key: jwk, format: 'jwk' });
   assert.strictEqual(privateKey.type, 'private');
+  assert.strictEqual(privateKey.toString(), '[object KeyObject]');
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
   assert.strictEqual(privateKey.symmetricKeySize, undefined);
 


### PR DESCRIPTION
Backports #46043, despite landing cleanly it would be missing `ObjectDefineProperties` from a previous commit that will not be backported.