### PR TITLE
lib: use strict to_ascii for url parsing

### DIFF
--- a/test/parallel/test-http-correct-hostname.js
+++ b/test/parallel/test-http-correct-hostname.js
@@ -16,13 +16,18 @@ if (common.hasCrypto) {
 }
 
 Object.keys(modules).forEach((module) => {
-  const doNotCall = common.mustNotCall(
-    `${module}.request should not connect to ${module}://example.com%60x.example.com`
-  );
-  const req = modules[module].request(`${module}://example.com%60x.example.com`, doNotCall);
-  assert.deepStrictEqual(req[kOutHeaders].host, [
-    'Host',
-    'example.com`x.example.com',
-  ]);
-  req.abort();
+  assert.throws(() => {
+    const doNotCall = common.mustNotCall(
+      `${module}.request should not connect to ${module}://example.com%60x.example.com`
+    );
+    const req = modules[module].request(`${module}://example.com%60x.example.com`, doNotCall);
+    assert.deepStrictEqual(req[kOutHeaders].host, [
+      'Host',
+      'example.com`x.example.com',
+    ]);
+
+    req.abort();
+  }, {
+    code: 'ERR_INVALID_URL'
+  });
 });

--- a/test/parallel/test-http2-altsvc.js
+++ b/test/parallel/test-http2-altsvc.js
@@ -94,9 +94,7 @@ server.on('session', common.mustCall((session) => {
                      `http://example.${'a'.repeat(17000)}.org:8000`);
     },
     {
-      code: 'ERR_HTTP2_ALTSVC_LENGTH',
-      name: 'TypeError',
-      message: 'HTTP/2 ALTSVC frames are limited to 16382 bytes'
+      code: 'ERR_INVALID_URL',
     }
   );
 }));

--- a/test/parallel/test-http2-origin.js
+++ b/test/parallel/test-http2-origin.js
@@ -74,8 +74,7 @@ const ca = readKey('fake-startcom-root-cert.pem', 'binary');
     throws(
       () => session.origin(longInput),
       {
-        code: 'ERR_HTTP2_ORIGIN_LENGTH',
-        name: 'TypeError'
+        code: 'ERR_INVALID_URL',
       }
     );
   }));


### PR DESCRIPTION
We should use `kStrict` on `to_ascii` step of the URL parsing to conform to URL spec. Particularly `VerifyDnsLength` of Unicode ToASCII specification limits the use of hostnames larger than 255, and labels to 63 characters.

Fixes https://github.com/nodejs/node/issues/46338

cc @nodejs/url