### PR TITLE
test: fix logInTimeout is not function

### DIFF
--- a/test/parallel/test-child-process-exec-timeout-kill.js
+++ b/test/parallel/test-child-process-exec-timeout-kill.js
@@ -8,13 +8,13 @@ const cp = require('child_process');
 
 const {
   cleanupStaleProcess,
-  logInTimeout,
+  logAfterTime,
   kExpiringChildRunTime,
   kExpiringParentTimer,
 } = require('../common/child_process');
 
 if (process.argv[2] === 'child') {
-  logInTimeout(kExpiringChildRunTime);
+  logAfterTime(kExpiringChildRunTime);
   return;
 }
 


### PR DESCRIPTION
fix `logInTimeout` is not function in `test-child-process-exec-timeout-kill.js`.
cc @joyeecheung 
Refs: https://github.com/nodejs/node/pull/44390

The error is as follows.

```
[stdout]
[stderr] /home/iojs/build/workspace/node-test-commit-linuxone/test/parallel/test-child-process-exec-timeout-kill.js:17
  logInTimeout(kExpiringChildRunTime);
  ^

TypeError: logInTimeout is not a function
    at Object.<anonymous> (/home/iojs/build/workspace/node-test-commit-linuxone/test/parallel/test-child-process-exec-timeout-kill.js:17:3)
    at Module._compile (node:internal/modules/cjs/loader:1246:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1300:10)
    at Module.load (node:internal/modules/cjs/loader:1103:32)
    at Module._load (node:internal/modules/cjs/loader:942:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
    at node:internal/main/run_main_module:23:47
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
