### PR TITLE
doc: add tip for session.post function

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -325,6 +325,10 @@ by V8. Chrome DevTools Protocol domain provides an interface for interacting
 with one of the runtime agents used to inspect the application state and listen
 to the run-time events.
 
+You can not set `reportProgress` to `true` when sending a
+`HeapProfiler.takeHeapSnapshot` or `HeapProfiler.stopTrackingHeapObjects`
+command to V8.
+
 #### Example usage
 
 Apart from the debugger, various V8 Profilers are available through the DevTools

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -1081,7 +1081,7 @@ Start collecting GC data.
 added: REPLACEME
 -->
 
-Stop collecting GC data and return a object.The content of object
+Stop collecting GC data and return an object.The content of object
 is as follows.
 
 ```json


### PR DESCRIPTION
Do not set `reportProgress` to `true` when post `HeapProfiler.takeHeapSnapshot` or `HeapProfiler.stopTrackingHeapObjects` command to V8.

cc @bnoordhuis 
Refs: https://github.com/nodejs/node/issues/44634

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
