### PR TITLE
fs: add statfs() functions

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1531,6 +1531,19 @@ changes:
 * Returns: {Promise}  Fulfills with the {fs.Stats} object for the
   given `path`.
 
+### `fsPromises.statfs(path[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    {fs.StatFs} object should be `bigint`. **Default:** `false`.
+* Returns: {Promise} Fulfills with the {fs.StatFs} object for the
+  given `path`.
+
 ### `fsPromises.symlink(target, path[, type])`
 
 <!-- YAML
@@ -4101,6 +4114,26 @@ Stats {
 }
 ```
 
+### `fs.statfs(path[, options], callback)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    {fs.StatFs} object should be `bigint`. **Default:** `false`.
+* `callback` {Function}
+  * `err` {Error}
+  * `stats` {fs.StatFs}
+
+Asynchronous statfs(2). Returns information about the mounted file system which
+contains `path`. The callback gets two arguments `(err, stats)` where `stats`
+is an {fs.StatFs} object.
+
+In case of an error, the `err.code` will be one of [Common System Errors][].
+
 ### `fs.symlink(target, path[, type], callback)`
 
 <!-- YAML
@@ -5852,6 +5885,23 @@ changes:
 
 Retrieves the {fs.Stats} for the path.
 
+### `fs.statfsSync(path[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `path` {string|Buffer|URL}
+* `options` {Object}
+  * `bigint` {boolean} Whether the numeric values in the returned
+    {fs.StatFs} object should be `bigint`. **Default:** `false`.
+* Returns: {fs.StatFs}
+
+Synchronous statfs(2). Returns information about the mounted file system which
+contains `path`.
+
+In case of an error, the `err.code` will be one of [Common System Errors][].
+
 ### `fs.symlinkSync(target, path[, type])`
 
 <!-- YAML
@@ -6944,6 +6994,114 @@ The times in the stat object have the following semantics:
 Prior to Node.js 0.12, the `ctime` held the `birthtime` on Windows systems. As
 of 0.12, `ctime` is not "creation time", and on Unix systems, it never was.
 
+### Class: `fs.StatFs`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Provides information about a mounted file system.
+
+Objects returned from [`fs.statfs()`][] and its synchronous counterpart are of
+this type. If `bigint` in the `options` passed to those methods is `true`, the
+numeric values will be `bigint` instead of `number`.
+
+```console
+StatFs {
+  type: 1397114950,
+  bsize: 4096,
+  blocks: 121938943,
+  bfree: 61058895,
+  bavail: 61058895,
+  files: 999,
+  ffree: 1000000
+}
+```
+
+`bigint` version:
+
+```console
+StatFs {
+  type: 1397114950n,
+  bsize: 4096n,
+  blocks: 121938943n,
+  bfree: 61058895n,
+  bavail: 61058895n,
+  files: 999n,
+  ffree: 1000000n
+}
+```
+
+#### `statfs.bavail`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number|bigint}
+
+Free blocks available to unprivileged users.
+
+#### `statfs.bfree`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number|bigint}
+
+Free blocks in file system.
+
+#### `statfs.blocks`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number|bigint}
+
+Total data blocks in file system.
+
+#### `statfs.bsize`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number|bigint}
+
+Optimal transfer block size.
+
+#### `statfs.ffree`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number|bigint}
+
+Free file nodes in file system.
+
+#### `statfs.files`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number|bigint}
+
+Total file nodes in file system.
+
+#### `statfs.type`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number|bigint}
+
+Type of file system.
+
 ### Class: `fs.WriteStream`
 
 <!-- YAML
@@ -7787,6 +7945,7 @@ the file contents.
 [`fs.rmSync()`]: #fsrmsyncpath-options
 [`fs.rmdir()`]: #fsrmdirpath-options-callback
 [`fs.stat()`]: #fsstatpath-options-callback
+[`fs.statfs()`]: #fsstatfspath-options-callback
 [`fs.symlink()`]: #fssymlinktarget-path-type-callback
 [`fs.utimes()`]: #fsutimespath-atime-mtime-callback
 [`fs.watch()`]: #fswatchfilename-options-listener

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -102,6 +102,7 @@ const {
   nullCheck,
   preprocessSymlinkDestination,
   Stats,
+  getStatFsFromBinding,
   getStatsFromBinding,
   realpathCacheKey,
   stringToFlags,
@@ -189,6 +190,18 @@ function makeStatsCallback(cb) {
   return (err, stats) => {
     if (err) return cb(err);
     cb(err, getStatsFromBinding(stats));
+  };
+}
+
+function makeStatFsCallback(cb) {
+  validateFunction(cb, 'cb');
+
+  return (err, stats) => {
+    if (err) {
+      return cb(err);
+    }
+
+    cb(err, getStatFsFromBinding(stats));
   };
 }
 
@@ -1509,6 +1522,18 @@ function stat(path, options = { bigint: false }, callback) {
   binding.stat(pathModule.toNamespacedPath(path), options.bigint, req);
 }
 
+function statfs(path, options = { bigint: false }, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = kEmptyObject;
+  }
+  callback = makeStatFsCallback(callback);
+  path = getValidatedPath(path);
+  const req = new FSReqCallback(options.bigint);
+  req.oncomplete = callback;
+  binding.statfs(pathModule.toNamespacedPath(path), options.bigint, req);
+}
+
 function hasNoEntryError(ctx) {
   if (ctx.errno) {
     const uvErr = uvErrmapGet(ctx.errno);
@@ -1581,6 +1606,15 @@ function statSync(path, options = { bigint: false, throwIfNoEntry: true }) {
   }
   handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
+}
+
+function statfsSync(path, options = { bigint: false }) {
+  path = getValidatedPath(path);
+  const ctx = { path };
+  const stats = binding.statfs(pathModule.toNamespacedPath(path),
+                               options.bigint, undefined, ctx);
+  handleErrorFromBinding(ctx);
+  return getStatFsFromBinding(stats);
 }
 
 /**
@@ -3013,7 +3047,9 @@ module.exports = fs = {
   rmdir,
   rmdirSync,
   stat,
+  statfs,
   statSync,
+  statfsSync,
   symlink,
   symlinkSync,
   truncate,

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -193,18 +193,6 @@ function makeStatsCallback(cb) {
   };
 }
 
-function makeStatFsCallback(cb) {
-  validateFunction(cb, 'cb');
-
-  return (err, stats) => {
-    if (err) {
-      return cb(err);
-    }
-
-    cb(err, getStatFsFromBinding(stats));
-  };
-}
-
 const isFd = isUint32;
 
 function isFileType(stats, fileType) {
@@ -1527,10 +1515,16 @@ function statfs(path, options = { bigint: false }, callback) {
     callback = options;
     options = kEmptyObject;
   }
-  callback = makeStatFsCallback(callback);
+  callback = maybeCallback(callback);
   path = getValidatedPath(path);
   const req = new FSReqCallback(options.bigint);
-  req.oncomplete = callback;
+  req.oncomplete = (err, stats) => {
+    if (err) {
+      return callback(err);
+    }
+
+    callback(err, getStatFsFromBinding(stats));
+  };
   binding.statfs(pathModule.toNamespacedPath(path), options.bigint, req);
 }
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -52,6 +52,7 @@ const {
   emitRecursiveRmdirWarning,
   getDirents,
   getOptions,
+  getStatFsFromBinding,
   getStatsFromBinding,
   getValidatedPath,
   getValidMode,
@@ -781,6 +782,13 @@ async function stat(path, options = { bigint: false }) {
   return getStatsFromBinding(result);
 }
 
+async function statfs(path, options = { bigint: false }) {
+  path = getValidatedPath(path);
+  const result = await binding.statfs(pathModule.toNamespacedPath(path),
+                                      options.bigint, kUsePromises);
+  return getStatFsFromBinding(result);
+}
+
 async function link(existingPath, newPath) {
   existingPath = getValidatedPath(existingPath, 'existingPath');
   newPath = getValidatedPath(newPath, 'newPath');
@@ -953,6 +961,7 @@ module.exports = {
     symlink,
     lstat,
     stat,
+    statfs,
     link,
     unlink,
     chmod,

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -556,6 +556,24 @@ function getStatsFromBinding(stats, offset = 0) {
   );
 }
 
+class StatFs {
+  constructor(type, bsize, blocks, bfree, bavail, files, ffree) {
+    this.type = type;
+    this.bsize = bsize;
+    this.blocks = blocks;
+    this.bfree = bfree;
+    this.bavail = bavail;
+    this.files = files;
+    this.ffree = ffree;
+  }
+}
+
+function getStatFsFromBinding(stats) {
+  return new StatFs(
+    stats[0], stats[1], stats[2], stats[3], stats[4], stats[5], stats[6]
+  );
+}
+
 function stringToFlags(flags, name = 'flags') {
   if (typeof flags === 'number') {
     validateInt32(flags, name);
@@ -912,6 +930,7 @@ module.exports = {
   nullCheck,
   preprocessSymlinkDestination,
   realpathCacheKey: Symbol('realpathCacheKey'),
+  getStatFsFromBinding,
   getStatsFromBinding,
   stringToFlags,
   stringToSymlinkType,

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -27,6 +27,7 @@ const {
   rename,
   rmdir,
   stat,
+  statfs,
   symlink,
   truncate,
   unlink,
@@ -79,6 +80,19 @@ function verifyStatObject(stat) {
   assert.strictEqual(typeof stat, 'object');
   assert.strictEqual(typeof stat.dev, 'number');
   assert.strictEqual(typeof stat.mode, 'number');
+}
+
+function verifyStatFsObject(stat, isBigint = false) {
+  const valueType = isBigint ? 'bigint' : 'number';
+
+  assert.strictEqual(typeof stat, 'object');
+  assert.strictEqual(typeof stat.type, valueType);
+  assert.strictEqual(typeof stat.bsize, valueType);
+  assert.strictEqual(typeof stat.blocks, valueType);
+  assert.strictEqual(typeof stat.bfree, valueType);
+  assert.strictEqual(typeof stat.bavail, valueType);
+  assert.strictEqual(typeof stat.files, valueType);
+  assert.strictEqual(typeof stat.ffree, valueType);
 }
 
 async function getHandle(dest) {
@@ -135,6 +149,18 @@ async function executeOnHandle(dest, func) {
         await handle.datasync();
         await handle.sync();
       });
+    }
+
+    // File system stats
+    {
+      const statFs = await statfs(dest);
+      verifyStatFsObject(statFs);
+    }
+
+    // File system stats bigint
+    {
+      const statFs = await statfs(dest, { bigint: true });
+      verifyStatFsObject(statFs, true);
     }
 
     // Test fs.read promises when length to read is zero bytes

--- a/test/parallel/test-fs-statfs.js
+++ b/test/parallel/test-fs-statfs.js
@@ -1,0 +1,59 @@
+'use strict';
+const common = require('../common');
+const assert = require('node:assert');
+const fs = require('node:fs');
+
+function verifyStatFsObject(statfs, isBigint = false) {
+  const valueType = isBigint ? 'bigint' : 'number';
+
+  [
+    'type', 'bsize', 'blocks', 'bfree', 'bavail', 'files', 'ffree',
+  ].forEach((k) => {
+    assert.ok(Object.hasOwn(statfs, k));
+    assert.strictEqual(typeof statfs[k], valueType,
+                       `${k} should be a ${valueType}`);
+  });
+}
+
+fs.statfs(__filename, common.mustSucceed(function(stats) {
+  verifyStatFsObject(stats);
+  assert.strictEqual(this, undefined);
+}));
+
+fs.statfs(__filename, { bigint: true }, function(err, stats) {
+  assert.ifError(err);
+  verifyStatFsObject(stats, true);
+  assert.strictEqual(this, undefined);
+});
+
+// Synchronous
+{
+  const statFsObj = fs.statfsSync(__filename);
+  verifyStatFsObject(statFsObj);
+}
+
+// Synchronous Bigint
+{
+  const statFsBigIntObj = fs.statfsSync(__filename, { bigint: true });
+  verifyStatFsObject(statFsBigIntObj, true);
+}
+
+[false, 1, {}, [], null, undefined].forEach((input) => {
+  assert.throws(
+    () => fs.statfs(input, common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    }
+  );
+  assert.throws(
+    () => fs.statfsSync(input),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    }
+  );
+});
+
+// Should not throw an error
+fs.statfs(__filename, undefined, common.mustCall());

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -127,6 +127,7 @@ const customTypesMap = {
   'fs.FSWatcher': 'fs.html#class-fsfswatcher',
   'fs.ReadStream': 'fs.html#class-fsreadstream',
   'fs.Stats': 'fs.html#class-fsstats',
+  'fs.StatFs': 'fs.html#class-fsstatfs',
   'fs.StatWatcher': 'fs.html#class-fsstatwatcher',
   'fs.WriteStream': 'fs.html#class-fswritestream',
 


### PR DESCRIPTION
This commit adds `statfs()` and `statfsSync()` to the `fs` module, and `statfs()` to the `fsPromises` module.

This is a revival of https://github.com/nodejs/node/pull/31351 with the bit rot cleaned up. The original PR was approved, but was failing CI on Windows, and the author abandoned it. That Windows bug was fixed in libuv a few years ago, so let's try again to land this.