### PR TITLE
test: avoid trying to call sysctl directly

### DIFF
--- a/test/parallel/test-cluster-bind-privileged-port.js
+++ b/test/parallel/test-cluster-bind-privileged-port.js
@@ -24,11 +24,10 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
-const { execSync } = require('child_process');
+const { readFileSync } = require('fs');
 
 if (common.isLinux) {
-  const sysctlOutput = execSync('sysctl net.ipv4.ip_unprivileged_port_start').toString();
-  const unprivilegedPortStart = parseInt(sysctlOutput.split(' ')[2], 10);
+  const unprivilegedPortStart = parseInt(readFileSync('/proc/sys/net/ipv4/ip_unprivileged_port_start'));
   if (unprivilegedPortStart <= 42) {
     common.skip('Port 42 is unprivileged');
   }


### PR DESCRIPTION
sysctl is often installed in /usr/sbin, which is not conveniently accessible to non-root. Secondly, the setting can just be read directly from the standard location and does not need to be parsed in any special fashion.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
