### PR TITLE
test: s390x zlib test case fixes

### DIFF
--- a/test/parallel/test-whatwg-webstreams-compression.js
+++ b/test/parallel/test-whatwg-webstreams-compression.js
@@ -20,11 +20,19 @@ async function test(format) {
   const reader = gunzip.readable.getReader();
   const writer = gzip.writable.getWriter();
 
+  const compressed_data = [];
+  const reader_function = ({ value, done }) => {
+    if (value)
+      compressed_data.push(value);
+    if (!done)
+      return reader.read().then(reader_function);
+    assert.strictEqual(dec.decode(Buffer.concat(compressed_data)), 'hello');
+  };
+  const reader_promise = reader.read().then(reader_function);
+
   await Promise.all([
-    reader.read().then(({ value, done }) => {
-      assert.strictEqual(dec.decode(value), 'hello');
-    }),
-    reader.read().then(({ done }) => assert(done)),
+    reader_promise,
+    reader_promise.then(() => reader.read().then(({ done }) => assert(done))),
     writer.write('hello'),
     writer.close(),
   ]);


### PR DESCRIPTION
This is similar to https://github.com/nodejs/node/pull/44117 and addresses the indeterminate nature of the hardware accelerated compression.

The fix looks kind of ugly but I wanted to keep the asserts the same.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
