### PR TITLE
test: add trailing commas in `test/message`

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -79,7 +79,6 @@ overrides:
       - internet/*.js
       - js-native-api/*/*.js
       - known_issues/*.js
-      - message/*.js
       - node-api/*/*.js
       - parallel/*.js
       - parallel/*.mjs

--- a/test/message/async_error_eval_cjs.js
+++ b/test/message/async_error_eval_cjs.js
@@ -29,7 +29,7 @@ main();
     '-e',
     main,
   ], {
-    env: { ...process.env }
+    env: { ...process.env },
   });
 
   if (child.status !== 0) {

--- a/test/message/async_error_eval_esm.js
+++ b/test/message/async_error_eval_esm.js
@@ -31,7 +31,7 @@ main();
     '-e',
     main,
   ], {
-    env: { ...process.env }
+    env: { ...process.env },
   });
 
   if (child.status !== 0) {

--- a/test/message/console_low_stack_space.js
+++ b/test/message/console_low_stack_space.js
@@ -4,7 +4,7 @@ const consoleDescriptor = Object.getOwnPropertyDescriptor(global, 'console');
 Object.defineProperty(global, 'console', {
   configurable: true,
   writable: true,
-  value: {}
+  value: {},
 });
 
 require('../common');

--- a/test/message/test_runner_describe_it.js
+++ b/test/message/test_runner_describe_it.js
@@ -270,7 +270,7 @@ it('custom inspect symbol fail', () => {
     [util.inspect.custom]() {
       return 'customized';
     },
-    foo: 1
+    foo: 1,
   };
 
   throw obj;
@@ -281,7 +281,7 @@ it('custom inspect symbol that throws fail', () => {
     [util.inspect.custom]() {
       throw new Error('bad-inspect');
     },
-    foo: 1
+    foo: 1,
   };
 
   throw obj;

--- a/test/message/test_runner_output.js
+++ b/test/message/test_runner_output.js
@@ -303,7 +303,7 @@ test('custom inspect symbol fail', () => {
     [util.inspect.custom]() {
       return 'customized';
     },
-    foo: 1
+    foo: 1,
   };
 
   throw obj;
@@ -314,7 +314,7 @@ test('custom inspect symbol that throws fail', () => {
     [util.inspect.custom]() {
       throw new Error('bad-inspect');
     },
-    foo: 1
+    foo: 1,
   };
 
   throw obj;

--- a/test/message/test_runner_test_name_pattern.js
+++ b/test/message/test_runner_test_name_pattern.js
@@ -28,7 +28,7 @@ test('top level test enabled', common.mustCall(async (t) => {
   t.afterEach(common.mustCall());
   await t.test(
     'nested test runs because name includes PATTERN',
-    common.mustCall()
+    common.mustCall(),
   );
 }));
 

--- a/test/message/util-inspect-error-cause.js
+++ b/test/message/util-inspect-error-cause.js
@@ -19,11 +19,11 @@ const cause5 = new Error('Object cause', {
     message: 'Unique',
     name: 'Error',
     stack: 'Error: Unique\n' +
-           '    at Module._compile (node:internal/modules/cjs/loader:827:30)'
-  }
+           '    at Module._compile (node:internal/modules/cjs/loader:827:30)',
+  },
 });
 const cause6 = new Error('undefined cause', {
-  cause: undefined
+  cause: undefined,
 });
 
 console.log(cause4);

--- a/test/message/vm_dont_display_runtime_error.js
+++ b/test/message/vm_dont_display_runtime_error.js
@@ -30,7 +30,7 @@ console.error('beginning');
 try {
   vm.runInThisContext('throw new Error("boo!")', {
     filename: 'test.vm',
-    displayErrors: false
+    displayErrors: false,
   });
 } catch {
   // Continue regardless of error.
@@ -40,7 +40,7 @@ console.error('middle');
 
 vm.runInThisContext('throw new Error("boo!")', {
   filename: 'test.vm',
-  displayErrors: false
+  displayErrors: false,
 });
 
 console.error('end');

--- a/test/message/vm_dont_display_syntax_error.js
+++ b/test/message/vm_dont_display_syntax_error.js
@@ -30,7 +30,7 @@ console.error('beginning');
 try {
   vm.runInThisContext('var 5;', {
     filename: 'test.vm',
-    displayErrors: false
+    displayErrors: false,
   });
 } catch {
   // Continue regardless of error.
@@ -40,7 +40,7 @@ console.error('middle');
 
 vm.runInThisContext('var 5;', {
   filename: 'test.vm',
-  displayErrors: false
+  displayErrors: false,
 });
 
 console.error('end');


### PR DESCRIPTION
Only a few were missing in this folder, I added them and remove the folder from the linter override.