### PR TITLE
doc: correct the `sed` command for macOS in release process docs

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -428,6 +428,12 @@ and substitute this node version with
 sed -i "s/REPLACEME/$VERSION/g" doc/api/*.md
 ```
 
+For macOS requires the extension to be specified.
+
+```bash
+sed -i "" "s/REPLACEME/$VERSION/g" doc/api/*.md
+```
+
 or
 
 ```console


### PR DESCRIPTION
The documented sed command was failing in my machine during a release proposal preparation.

```console
sed: 1: "MD-FILE": extra characters at the end of d command
```

You could see this https://stackoverflow.com/a/62309999 as a ref to the issue of the `sed` command in macOS which makes the sed command works again in macOS