### PR TITLE
lib: expose getOptionValue via process

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2009,6 +2009,49 @@ if (process.getgroups) {
 This function is only available on POSIX platforms (i.e. not Windows or
 Android).
 
+## `process.getOptionValue(option)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `option` {string}
+* Returns: {any}
+
+The `process.getOptionValue()` method returns the parsed value of
+that command line option. This method respects [`NODE_OPTIONS`][] value.
+
+For example, assuming the following script for `process-getoptionvalue.js`:
+
+```mjs
+import process from 'node:process';
+
+console.log('--pending-deprecation:', process.getOptionValue('--pending-deprecation'));
+console.log('--conditions:', process.getOptionValue('--conditions'));
+```
+
+```cjs
+const process = require('node:process');
+
+console.log('--pending-deprecation:', process.getOptionValue('--pending-deprecation'));
+console.log('--conditions:', process.getOptionValue('--conditions'));
+```
+
+Launching the Node.js process as:
+
+```console
+$ node --pending-deprecation -C additional process-getoptionvalue.js
+```
+
+Would generate the output:
+
+```text
+--pending-deprecation: true
+--conditions: [ 'additional' ]
+```
+
 ## `process.getuid()`
 
 <!-- YAML

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -178,6 +178,8 @@ function patchProcessObject(expandArgv1) {
   addReadOnlyProcessAlias('traceDeprecation', '--trace-deprecation');
   addReadOnlyProcessAlias('_breakFirstLine', '--inspect-brk', false);
   addReadOnlyProcessAlias('_breakNodeFirstLine', '--inspect-brk-node', false);
+
+  process.getOptionValue = getOptionValue;
 }
 
 function addReadOnlyProcessAlias(name, option, enumerable = true) {

--- a/test/parallel/test-process-getOptionValue.js
+++ b/test/parallel/test-process-getOptionValue.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Flags: --pending-deprecation -C additional
+
+require('../common');
+const assert = require('node:assert');
+
+// This test ensures that process.getOptionValue is exposed on process variable.
+
+assert.strictEqual(process.getOptionValue('--pending-deprecation'), true);
+assert.deepStrictEqual(process.getOptionValue('--conditions'), ['additional']);


### PR DESCRIPTION
Add `process.getOptionValue` that exposes `getOptionValue` in `internal/options`.

Fixes: https://github.com/nodejs/node/issues/36935

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
