### PR TITLE
lib: expose undici's `ProxyAgent` as global object

### DIFF
--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -254,6 +254,7 @@ function setupFetch() {
     Headers: lazyInterface('Headers'),
     Request: lazyInterface('Request'),
     Response: lazyInterface('Response'),
+    ProxyAgent: lazyInterface('ProxyAgent'),
   });
 
   // The WebAssembly Web API: https://webassembly.github.io/spec/web-api

--- a/test/parallel/test-fetch.mjs
+++ b/test/parallel/test-fetch.mjs
@@ -9,6 +9,7 @@ assert.strictEqual(typeof globalThis.FormData, 'function');
 assert.strictEqual(typeof globalThis.Headers, 'function');
 assert.strictEqual(typeof globalThis.Request, 'function');
 assert.strictEqual(typeof globalThis.Response, 'function');
+assert.strictEqual(typeof globalThis.ProxyAgent, 'function');
 
 const server = http.createServer(common.mustCall((req, res) => {
   res.end('Hello world');


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/43187 *(not completely)*

**Why**
Currently, to use the `fetch` method using `ProxyAgent`, you need to download the entire undici library.

This is my first contribution to a super-large project, if I did a mistake, please correct me in the comments.