### PR TITLE
Fix Visual Studio installation detection for Arm64

### DIFF
--- a/tools/msvs/vswhere_usability_wrapper.cmd
+++ b/tools/msvs/vswhere_usability_wrapper.cmd
@@ -5,7 +5,7 @@
 
 @if not defined DEBUG_HELPER @ECHO OFF
 setlocal
-if "%~2"=="prerelease" set VSWHERE_WITH_PRERELEASE=1
+if "%~3"=="prerelease" set VSWHERE_WITH_PRERELEASE=1
 set "InstallerPath=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
 if not exist "%InstallerPath%" set "InstallerPath=%ProgramFiles%\Microsoft Visual Studio\Installer"
 if not exist "%InstallerPath%" goto :no-vswhere
@@ -13,7 +13,11 @@ if not exist "%InstallerPath%" goto :no-vswhere
 set "Path=%Path%;%InstallerPath%"
 where vswhere 2> nul > nul
 if errorlevel 1 goto :no-vswhere
-set VSWHERE_REQ=-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+if "%2"=="arm64" (
+    set VSWHERE_REQ=-requires Microsoft.VisualStudio.Component.VC.Tools.ARM64    
+) else (
+    set VSWHERE_REQ=-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+)
 set VSWHERE_PRP=-property installationPath
 set VSWHERE_LMT=-version %1
 vswhere -prerelease > nul

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -242,12 +242,12 @@ if defined noprojgen if defined nobuild goto :after-build
 set msvs_host_arch=x86
 if _%PROCESSOR_ARCHITECTURE%_==_AMD64_ set msvs_host_arch=amd64
 if _%PROCESSOR_ARCHITEW6432%_==_AMD64_ set msvs_host_arch=amd64
+if _%PROCESSOR_ARCHITECTURE%_==_ARM64_ set msvs_host_arch=arm64
 @rem usually vcvarsall takes an argument: host + '_' + target
 set vcvarsall_arg=%msvs_host_arch%_%target_arch%
-@rem unless both host and target are x64
+@rem unless both the host and the target are the same
 if %target_arch%==x64 if %msvs_host_arch%==amd64 set vcvarsall_arg=amd64
-@rem also if both are x86
-if %target_arch%==x86 if %msvs_host_arch%==x86 set vcvarsall_arg=x86
+if %target_arch%==%msvs_host_arch% set vcvarsall_arg=%target_arch%
 
 @rem Look for Visual Studio 2022
 :vs-set-2022
@@ -257,7 +257,7 @@ echo Looking for Visual Studio 2022
 @rem cleared first as vswhere_usability_wrapper.cmd doesn't when it fails to
 @rem detect the version searched for
 if not defined target_env set "VCINSTALLDIR="
-call tools\msvs\vswhere_usability_wrapper.cmd "[17.0,18.0)" "prerelease"
+call tools\msvs\vswhere_usability_wrapper.cmd "[17.0,18.0)" %target_arch% "prerelease"
 if "_%VCINSTALLDIR%_" == "__" goto vs-set-2019
 set "WIXSDKDIR=%WIX%\SDK\VS2017"
 if defined msi (
@@ -297,7 +297,7 @@ echo Looking for Visual Studio 2019
 @rem cleared first as vswhere_usability_wrapper.cmd doesn't when it fails to
 @rem detect the version searched for
 if not defined target_env set "VCINSTALLDIR="
-call tools\msvs\vswhere_usability_wrapper.cmd "[16.0,17.0)" "prerelease"
+call tools\msvs\vswhere_usability_wrapper.cmd "[16.0,17.0)" %target_arch% "prerelease"
 if "_%VCINSTALLDIR%_" == "__" goto msbuild-not-found
 set "WIXSDKDIR=%WIX%\SDK\VS2017"
 if defined msi (


### PR DESCRIPTION
When `vcbuild.bat arm64` was run on Windows Arm64 machine, the `vswhere_usability_wrapper.cmd` was detecting proper installation of Visual Studio according to presence of x64 Build Tools which fails when there is only Arm64 version of the Build Tools.
