### PR TITLE
v8: add getMaxOldGenerationSize and getMaxYoungGenerationSize API

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -267,6 +267,34 @@ v8.setFlagsFromString('--trace_gc');
 setTimeout(() => { v8.setFlagsFromString('--notrace_gc'); }, 60e3);
 ```
 
+## `v8.getMaxOldGenerationSize()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {number}
+
+The `v8.getMaxOldGenerationSize()` method returns the maximum memory
+size(`bytes`) of the old generation in the current thread.
+
+The value returned by this method is invalid If you set `--max-old-space-size`
+for `V8`.
+
+## `v8.getMaxYoungGenerationSize()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {number}
+
+The `v8.getMaxYoungGenerationSize()` method returns the maximum memory
+size(`bytes`) of the young generation in the current thread.
+
+The value returned by this method is invalid If you set `--max-semi-space-size`
+for `V8`.
+
 ## `v8.stopCoverage()`
 
 <!-- YAML

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -435,5 +435,7 @@ module.exports = {
   promiseHooks,
   startupSnapshot,
   setHeapSnapshotNearHeapLimit,
+  getMaxYoungGenerationSize: binding.getMaxYoungGenerationSize,
+  getMaxOldGenerationSize: binding.getMaxOldGenerationSize,
   GCProfiler,
 };

--- a/src/env.h
+++ b/src/env.h
@@ -167,6 +167,7 @@ class NODE_EXTERN_PRIVATE IsolateData : public MemoryRetainer {
   inline v8::Local<v8::String> async_wrap_provider(int index) const;
 
   size_t max_young_gen_size = 1;
+  size_t max_old_gen_size = 1;
   std::unordered_map<const char*, v8::Eternal<v8::String>> static_str_map;
 
   inline v8::Isolate* isolate() const;

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -90,6 +90,8 @@ NodeMainInstance::NodeMainInstance(const SnapshotData* snapshot_data,
 
   isolate_data_->max_young_gen_size =
       isolate_params_->constraints.max_young_generation_size_in_bytes();
+  isolate_data_->max_old_gen_size =
+      isolate_params_->constraints.max_old_generation_size_in_bytes();
 }
 
 void NodeMainInstance::Dispose() {

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -389,6 +389,18 @@ void GCProfiler::Stop(const FunctionCallbackInfo<v8::Value>& args) {
                                 .ToLocalChecked());
 }
 
+void GetMaxYoungGenerationSize(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  size_t value = env->isolate_data()->max_young_gen_size;
+  args.GetReturnValue().Set(v8::Number::New(env->isolate(), value));
+}
+
+void GetMaxOldGenerationSize(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  size_t value = env->isolate_data()->max_old_gen_size;
+  args.GetReturnValue().Set(v8::Number::New(env->isolate(), value));
+}
+
 void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
@@ -451,6 +463,10 @@ void Initialize(Local<Object> target,
 
   // Export symbols used by v8.setFlagsFromString()
   SetMethod(context, target, "setFlagsFromString", SetFlagsFromString);
+  SetMethod(
+      context, target, "getMaxYoungGenerationSize", GetMaxYoungGenerationSize);
+  SetMethod(
+      context, target, "getMaxOldGenerationSize", GetMaxOldGenerationSize);
 
   // GCProfiler
   Local<FunctionTemplate> t =
@@ -468,6 +484,8 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(UpdateHeapSpaceStatisticsBuffer);
   registry->Register(SetFlagsFromString);
   registry->Register(SetHeapSnapshotNearHeapLimit);
+  registry->Register(GetMaxYoungGenerationSize);
+  registry->Register(GetMaxOldGenerationSize);
   registry->Register(GCProfiler::New);
   registry->Register(GCProfiler::Start);
   registry->Register(GCProfiler::Stop);

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -186,6 +186,8 @@ class WorkerThreadData {
       isolate_data_->set_worker_context(w_);
       isolate_data_->max_young_gen_size =
           params.constraints.max_young_generation_size_in_bytes();
+      isolate_data_->max_old_gen_size =
+          params.constraints.max_old_generation_size_in_bytes();
     }
 
     Mutex::ScopedLock lock(w_->mutex_);

--- a/test/parallel/test-v8-max-memory-size-api.js
+++ b/test/parallel/test-v8-max-memory-size-api.js
@@ -1,0 +1,20 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const v8 = require('v8');
+const { Worker } = require('worker_threads');
+
+if (!process.env.isWorker) {
+  process.env.isWorker = true;
+  new Worker(__filename, {
+    resourceLimits: {
+      maxYoungGenerationSizeMb: 50,
+      maxOldGenerationSizeMb: 500,
+    }
+  });
+  assert.ok(v8.getMaxYoungGenerationSize() > 0);
+  assert.ok(v8.getMaxOldGenerationSize() > 0);
+} else {
+  assert.ok(v8.getMaxYoungGenerationSize() === 50 * 1024 * 1024);
+  assert.ok(v8.getMaxOldGenerationSize() === 500 * 1024 * 1024);
+}


### PR DESCRIPTION
add `getMaxOldGenerationSize` and `getMaxYoungGenerationSize` API.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
