### PR TITLE
test: make more crypto tests work with BoringSSL

### DIFF
--- a/test/parallel/test-tls-cert-chains-concat.js
+++ b/test/parallel/test-tls-cert-chains-concat.js
@@ -25,7 +25,7 @@ connect({
   assert.strictEqual(peer.subject.emailAddress, 'adam.lippai@tresorit.com');
   assert.strictEqual(peer.subject.CN, 'Ádám Lippai');
   assert.strictEqual(peer.issuer.CN, 'ca3');
-  assert.strictEqual(peer.serialNumber, '5B75D77EDC7FB5B7FA9F1424DA4C64FB815DCBDE');
+  assert.match(peer.serialNumber, /5B75D77EDC7FB5B7FA9F1424DA4C64FB815DCBDE/i);
 
   const next = pair.client.conn.getPeerCertificate(true).issuerCertificate;
   const root = next.issuerCertificate;
@@ -33,12 +33,12 @@ connect({
   debug('next:\n', next);
   assert.strictEqual(next.subject.CN, 'ca3');
   assert.strictEqual(next.issuer.CN, 'ca1');
-  assert.strictEqual(next.serialNumber, '147D36C1C2F74206DE9FAB5F2226D78ADB00A425');
+  assert.match(next.serialNumber, /147D36C1C2F74206DE9FAB5F2226D78ADB00A425/i);
 
   debug('root:\n', root);
   assert.strictEqual(root.subject.CN, 'ca1');
   assert.strictEqual(root.issuer.CN, 'ca1');
-  assert.strictEqual(root.serialNumber, '4AB16C8DFD6A7D0D2DFCABDF9C4B0E92C6AD0229');
+  assert.match(root.serialNumber, /4AB16C8DFD6A7D0D2DFCABDF9C4B0E92C6AD0229/i);
 
   // No client cert, so empty object returned.
   assert.deepStrictEqual(pair.server.conn.getPeerCertificate(), {});

--- a/test/parallel/test-tls-cert-chains-in-ca.js
+++ b/test/parallel/test-tls-cert-chains-in-ca.js
@@ -30,16 +30,16 @@ connect({
 
   const peer = pair.client.conn.getPeerCertificate();
   debug('peer:\n', peer);
-  assert.strictEqual(peer.serialNumber, '5B75D77EDC7FB5B7FA9F1424DA4C64FB815DCBDE');
+  assert.match(peer.serialNumber, /5B75D77EDC7FB5B7FA9F1424DA4C64FB815DCBDE/i);
 
   const next = pair.client.conn.getPeerCertificate(true).issuerCertificate;
   const root = next.issuerCertificate;
   delete next.issuerCertificate;
   debug('next:\n', next);
-  assert.strictEqual(next.serialNumber, '147D36C1C2F74206DE9FAB5F2226D78ADB00A425');
+  assert.match(next.serialNumber, /147D36C1C2F74206DE9FAB5F2226D78ADB00A425/i);
 
   debug('root:\n', root);
-  assert.strictEqual(root.serialNumber, '4AB16C8DFD6A7D0D2DFCABDF9C4B0E92C6AD0229');
+  assert.match(root.serialNumber, /4AB16C8DFD6A7D0D2DFCABDF9C4B0E92C6AD0229/i);
 
   return cleanup();
 });

--- a/test/parallel/test-tls-empty-sni-context.js
+++ b/test/parallel/test-tls-empty-sni-context.js
@@ -16,7 +16,7 @@ const options = {
 const server = tls.createServer(options, (c) => {
   assert.fail('Should not be called');
 }).on('tlsClientError', common.mustCall((err, c) => {
-  assert.match(err.message, /SSL_use_certificate:passed a null parameter/i);
+  assert.match(err.message, /passed a null parameter/i);
   server.close();
 })).listen(0, common.mustCall(() => {
   const c = tls.connect({

--- a/test/parallel/test-tls-set-ciphers-error.js
+++ b/test/parallel/test-tls-set-ciphers-error.js
@@ -15,11 +15,11 @@ const fixtures = require('../common/fixtures');
     ciphers: 'aes256-sha'
   };
   assert.throws(() => tls.createServer(options, common.mustNotCall()),
-                /no cipher match/i);
+                /no[_ ]cipher[_ ]match/i);
   options.ciphers = 'FOOBARBAZ';
   assert.throws(() => tls.createServer(options, common.mustNotCall()),
-                /no cipher match/i);
+                /no[_ ]cipher[_ ]match/i);
   options.ciphers = 'TLS_not_a_cipher';
   assert.throws(() => tls.createServer(options, common.mustNotCall()),
-                /no cipher match/i);
+                /no[_ ]cipher[_ ]match/i);
 }


### PR DESCRIPTION
This PR tweaks several crypto tests to work with BoringSSL so that Electron does not need to disable them and can smoke test our embedded Node.js executable with them.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
