### PR TITLE
stream: validate readable defaultEncoding

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -65,6 +65,7 @@ const {
     ERR_OUT_OF_RANGE,
     ERR_STREAM_PUSH_AFTER_EOF,
     ERR_STREAM_UNSHIFT_AFTER_END_EVENT,
+    ERR_UNKNOWN_ENCODING
   }
 } = require('internal/errors');
 const { validateObject } = require('internal/validators');
@@ -162,7 +163,14 @@ function ReadableState(options, stream, isDuplex) {
   // Crypto is kind of old and crusty.  Historically, its default string
   // encoding is 'binary' so we have to make this configurable.
   // Everything else in the universe uses 'utf8', though.
-  this.defaultEncoding = (options && options.defaultEncoding) || 'utf8';
+  const defaultEncoding = options?.defaultEncoding;
+  if (defaultEncoding == null) {
+    this.defaultEncoding = 'utf8';
+  } else if (Buffer.isEncoding(defaultEncoding)) {
+    this.defaultEncoding = defaultEncoding;
+  } else {
+    throw new ERR_UNKNOWN_ENCODING(defaultEncoding);
+  }
 
   // Ref the piped dest which we need a drain event on it
   // type: null | Writable | Set<Writable>.

--- a/test/parallel/test-stream-readable-default-encoding.js
+++ b/test/parallel/test-stream-readable-default-encoding.js
@@ -22,13 +22,7 @@ const { Readable } = require('stream');
 
   r.push('ab');
 
-  const chunks = [];
-  r.on('data', (chunk) => chunks.push(chunk));
-
-  process.nextTick(common.mustCall(() => {
-    assert.strictEqual(Buffer.concat(chunks).toString('hex'), 'ab');
-  }), 1);
-
+  r.on('data', common.mustCall((chunk) => assert.strictEqual(chunk.toString('hex'), 'ab')), 1);
 }
 
 {
@@ -37,12 +31,7 @@ const { Readable } = require('stream');
     defaultEncoding: 'hex',
   });
 
-  r.push('ab', 'utf-8');
+  r.push('xy', 'utf-8');
 
-  const chunks = [];
-  r.on('data', (chunk) => chunks.push(chunk));
-
-  process.nextTick(common.mustCall(() => {
-    assert.strictEqual(Buffer.concat(chunks).toString('utf-8'), 'ab');
-  }), 1);
+  r.on('data', common.mustCall((chunk) => assert.strictEqual(chunk.toString('utf-8'), 'xy')), 1);
 }

--- a/test/parallel/test-stream-readable-default-encoding.js
+++ b/test/parallel/test-stream-readable-default-encoding.js
@@ -1,0 +1,48 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Readable } = require('stream');
+
+{
+  assert.throws(() => {
+    new Readable({
+      read: () => {},
+      defaultEncoding: 'my invalid encoding',
+    });
+  }, {
+    code: 'ERR_UNKNOWN_ENCODING',
+  });
+}
+
+{
+  const r = new Readable({
+    read() {},
+    defaultEncoding: 'hex'
+  });
+
+  r.push('ab');
+
+  const chunks = [];
+  r.on('data', (chunk) => chunks.push(chunk));
+
+  process.nextTick(common.mustCall(() => {
+    assert.strictEqual(Buffer.concat(chunks).toString('hex'), 'ab');
+  }), 1);
+
+}
+
+{
+  const r = new Readable({
+    read() {},
+    defaultEncoding: 'hex',
+  });
+
+  r.push('ab', 'utf-8');
+
+  const chunks = [];
+  r.on('data', (chunk) => chunks.push(chunk));
+
+  process.nextTick(common.mustCall(() => {
+    assert.strictEqual(Buffer.concat(chunks).toString('utf-8'), 'ab');
+  }), 1);
+}


### PR DESCRIPTION
Part 2 of https://github.com/nodejs/node/pull/46322.
Related to: https://github.com/nodejs/node/issues/46301.
With this PR, it will check if the option `defaultEncoding` of a `Readable` is a valid encoding, if not it will throw.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
