### PR TITLE
async_hooks: deprecate the AsyncResource.bind asyncResource property

### DIFF
--- a/doc/api/async_context.md
+++ b/doc/api/async_context.md
@@ -466,6 +466,11 @@ added:
   - v14.8.0
   - v12.19.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46432
+    description: The `asyncResource` property added to the bound function
+                 has been deprecated and will be removed in a future
+                 version.
   - version:
     - v17.8.0
     - v16.15.0
@@ -484,9 +489,6 @@ changes:
 
 Binds the given function to the current execution context.
 
-The returned function will have an `asyncResource` property referencing
-the `AsyncResource` to which the function is bound.
-
 ### `asyncResource.bind(fn[, thisArg])`
 
 <!-- YAML
@@ -494,6 +496,11 @@ added:
   - v14.8.0
   - v12.19.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46432
+    description: The `asyncResource` property added to the bound function
+                 has been deprecated and will be removed in a future
+                 version.
   - version:
     - v17.8.0
     - v16.15.0
@@ -509,9 +516,6 @@ changes:
 * `thisArg` {any}
 
 Binds the given function to execute to this `AsyncResource`'s scope.
-
-The returned function will have an `asyncResource` property referencing
-the `AsyncResource` to which the function is bound.
 
 ### `asyncResource.runInAsyncScope(fn[, thisArg, ...args])`
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3339,6 +3339,20 @@ In a future version of Node.js, [`message.headers`][],
 [`message.headersDistinct`][], [`message.trailers`][], and
 [`message.trailersDistinct`][] will be read-only.
 
+### DEP0172: The `asyncResource` property of `AsyncResource` bound functions
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46432
+    description: Runtime-deprecation.
+-->
+
+Type: Runtime
+
+In a future version of Node.js, the `asyncResource` property will no longer
+be added when a function is bound to an `AsyncResource`.
+
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [RFC 8247 Section 2.4]: https://www.rfc-editor.org/rfc/rfc8247#section-2.4

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -20,7 +20,10 @@ const {
   ERR_ASYNC_TYPE,
   ERR_INVALID_ASYNC_ID
 } = require('internal/errors').codes;
-const { kEmptyObject } = require('internal/util');
+const {
+  deprecate,
+  kEmptyObject,
+} = require('internal/util');
 const {
   validateFunction,
   validateObject,
@@ -238,6 +241,7 @@ class AsyncResource {
     } else {
       bound = FunctionPrototypeBind(this.runInAsyncScope, this, fn, thisArg);
     }
+    let self = this;
     ObjectDefineProperties(bound, {
       'length': {
         __proto__: null,
@@ -250,8 +254,12 @@ class AsyncResource {
         __proto__: null,
         configurable: true,
         enumerable: true,
-        value: this,
-        writable: true,
+        get: deprecate(function() {
+          return self;
+        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172'),
+        set: deprecate(function(val) {
+          self = val;
+        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172'),
       }
     });
     return bound;


### PR DESCRIPTION
Runtime-deprecates the `asyncResource` property that is attached to the wrapper function returned by `asyncResource.bind()`. This property is not expected to align with the equivalent `asyncContext.wrap()` API in the proposed TC39 standard.

/cc @nodejs/async_hooks 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
