### PR TITLE
http: use v8::Array::New() with a prebuilt vector

### DIFF
--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -1049,8 +1049,7 @@ void ConnectionsList::All(const FunctionCallbackInfo<Value>& args) {
   }
 
   return args.GetReturnValue().Set(
-    Array::New(isolate, result.data(), result.size())
-  );
+      Array::New(isolate, result.data(), result.size()));
 }
 
 void ConnectionsList::Idle(const FunctionCallbackInfo<Value>& args) {
@@ -1069,8 +1068,7 @@ void ConnectionsList::Idle(const FunctionCallbackInfo<Value>& args) {
   }
 
   return args.GetReturnValue().Set(
-    Array::New(isolate, result.data(), result.size())
-  );
+      Array::New(isolate, result.data(), result.size()));
 }
 
 void ConnectionsList::Active(const FunctionCallbackInfo<Value>& args) {
@@ -1087,8 +1085,7 @@ void ConnectionsList::Active(const FunctionCallbackInfo<Value>& args) {
   }
 
   return args.GetReturnValue().Set(
-    Array::New(isolate, result.data(), result.size())
-  );
+      Array::New(isolate, result.data(), result.size()));
 }
 
 void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
@@ -1140,8 +1137,7 @@ void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
   }
 
   return args.GetReturnValue().Set(
-    Array::New(isolate, result.data(), result.size())
-  );
+      Array::New(isolate, result.data(), result.size()));
 }
 
 const llhttp_settings_t Parser::settings = {

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -1043,6 +1043,7 @@ void ConnectionsList::All(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&list, args.Holder());
 
   std::vector<Local<Value>> result;
+  result.reserve(list->all_connections_.size());
   for (auto parser : list->all_connections_) {
     result.emplace_back(parser->object());
   }
@@ -1060,6 +1061,7 @@ void ConnectionsList::Idle(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&list, args.Holder());
 
   std::vector<Local<Value>> result;
+  result.reserve(list->all_connections_.size());
   for (auto parser : list->all_connections_) {
     if (parser->last_message_start_ == 0) {
       result.emplace_back(parser->object());
@@ -1079,6 +1081,7 @@ void ConnectionsList::Active(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&list, args.Holder());
 
   std::vector<Local<Value>> result;
+  result.reserve(list->active_connections_.size());
   for (auto parser : list->active_connections_) {
     result.emplace_back(parser->object());
   }
@@ -1117,6 +1120,7 @@ void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
   auto end = list->active_connections_.end();
 
   std::vector<Local<Value>> result;
+  result.reserve(list->active_connections_.size());
   while (iter != end) {
     Parser* parser = *iter;
     iter++;

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -1037,68 +1037,60 @@ void ConnectionsList::New(const FunctionCallbackInfo<Value>& args) {
 
 void ConnectionsList::All(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  Local<Context> context = isolate->GetCurrentContext();
 
-  Local<Array> all = Array::New(isolate);
   ConnectionsList* list;
 
   ASSIGN_OR_RETURN_UNWRAP(&list, args.Holder());
 
-  uint32_t i = 0;
+  std::vector<Local<Value>> result;
   for (auto parser : list->all_connections_) {
-    if (all->Set(context, i++, parser->object()).IsNothing()) {
-      return;
-    }
+    result.emplace_back(parser->object());
   }
 
-  return args.GetReturnValue().Set(all);
+  return args.GetReturnValue().Set(
+    Array::New(isolate, result.data(), result.size())
+  );
 }
 
 void ConnectionsList::Idle(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  Local<Context> context = isolate->GetCurrentContext();
 
-  Local<Array> idle = Array::New(isolate);
   ConnectionsList* list;
 
   ASSIGN_OR_RETURN_UNWRAP(&list, args.Holder());
 
-  uint32_t i = 0;
+  std::vector<Local<Value>> result;
   for (auto parser : list->all_connections_) {
     if (parser->last_message_start_ == 0) {
-      if (idle->Set(context, i++, parser->object()).IsNothing()) {
-        return;
-      }
+      result.emplace_back(parser->object());
     }
   }
 
-  return args.GetReturnValue().Set(idle);
+  return args.GetReturnValue().Set(
+    Array::New(isolate, result.data(), result.size())
+  );
 }
 
 void ConnectionsList::Active(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  Local<Context> context = isolate->GetCurrentContext();
 
-  Local<Array> active = Array::New(isolate);
   ConnectionsList* list;
 
   ASSIGN_OR_RETURN_UNWRAP(&list, args.Holder());
 
-  uint32_t i = 0;
+  std::vector<Local<Value>> result;
   for (auto parser : list->active_connections_) {
-    if (active->Set(context, i++, parser->object()).IsNothing()) {
-      return;
-    }
+    result.emplace_back(parser->object());
   }
 
-  return args.GetReturnValue().Set(active);
+  return args.GetReturnValue().Set(
+    Array::New(isolate, result.data(), result.size())
+  );
 }
 
 void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  Local<Context> context = isolate->GetCurrentContext();
 
-  Local<Array> expired = Array::New(isolate);
   ConnectionsList* list;
 
   ASSIGN_OR_RETURN_UNWRAP(&list, args.Holder());
@@ -1110,7 +1102,7 @@ void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
     static_cast<uint64_t>(args[1].As<Uint32>()->Value()) * 1000000;
 
   if (headers_timeout == 0 && request_timeout == 0) {
-    return args.GetReturnValue().Set(expired);
+    return args.GetReturnValue().Set(Array::New(isolate, 0));
   } else if (request_timeout > 0 && headers_timeout > request_timeout) {
     std::swap(headers_timeout, request_timeout);
   }
@@ -1121,9 +1113,10 @@ void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
   const uint64_t request_deadline =
     request_timeout > 0 ? now - request_timeout : 0;
 
-  uint32_t i = 0;
   auto iter = list->active_connections_.begin();
   auto end = list->active_connections_.end();
+
+  std::vector<Local<Value>> result;
   while (iter != end) {
     Parser* parser = *iter;
     iter++;
@@ -1136,15 +1129,15 @@ void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
         request_deadline > 0 &&
         parser->last_message_start_ < request_deadline)
     ) {
-      if (expired->Set(context, i++, parser->object()).IsNothing()) {
-        return;
-      }
+      result.emplace_back(parser->object());
 
       list->active_connections_.erase(parser);
     }
   }
 
-  return args.GetReturnValue().Set(expired);
+  return args.GetReturnValue().Set(
+    Array::New(isolate, result.data(), result.size())
+  );
 }
 
 const llhttp_settings_t Parser::settings = {


### PR DESCRIPTION
Avoid using v8::Array::Set() which results in JS execution and is thus slow. Prebuild the vector in C++ land and build the JS array directly with that vector whereever possible.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
