### PR TITLE
vm: properly support symbols on globals

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -530,7 +530,7 @@ void ContextifyContext::PropertySetterCallback(
     return;
 
   USE(ctx->sandbox()->Set(context, property, value));
-  if (is_function) {
+  if (is_contextual_store || is_function) {
     args.GetReturnValue().Set(value);
   }
 }

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -530,7 +530,9 @@ void ContextifyContext::PropertySetterCallback(
     return;
 
   USE(ctx->sandbox()->Set(context, property, value));
-  args.GetReturnValue().Set(value);
+  if (is_function) {
+    args.GetReturnValue().Set(value);
+  }
 }
 
 // static

--- a/test/parallel/test-vm-global-symbol.js
+++ b/test/parallel/test-vm-global-symbol.js
@@ -1,0 +1,15 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+const global = vm.runInContext('this', vm.createContext());
+const totoSymbol = Symbol.for('toto');
+Object.defineProperty(global, totoSymbol, {
+  enumerable: true,
+  writable: true,
+  value: 4,
+  configurable: true,
+});
+assert.ok(global[totoSymbol] === 4);
+assert.ok(Object.getOwnPropertySymbols(global).includes(totoSymbol));

--- a/test/parallel/test-vm-global-symbol.js
+++ b/test/parallel/test-vm-global-symbol.js
@@ -11,5 +11,5 @@ Object.defineProperty(global, totoSymbol, {
   value: 4,
   configurable: true,
 });
-assert.ok(global[totoSymbol] === 4);
+assert.strictEqual(global[totoSymbol], 4);
 assert.ok(Object.getOwnPropertySymbols(global).includes(totoSymbol));


### PR DESCRIPTION
A regression has been introduced in node 18.2.0, it lakes the following snippet fails while it used to work in the past:

```js
const assert = require('assert');
const vm = require('vm');
const global = vm.runInContext('this', vm.createContext());
const totoSymbol = Symbol.for('toto');
Object.defineProperty(global, totoSymbol, {
  enumerable: true,
  writable: true,
  value: 4,
  configurable: true,
});
assert(Object.getOwnPropertySymbols(global).includes(totoSymbol));
```

The PR that introduced the regression is: https://github.com/nodejs/node/pull/42963. So I basically attempted to start understanding what it changed to make it still fix the initial issue while not breaking the symbol related one.

Fixes: https://github.com/nodejs/node/issues/45983

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
