### PR TITLE
wasi: add support for version when creating WASI

### DIFF
--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -122,7 +122,7 @@ added:
  - v12.16.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/
+   pr-url: https://github.com/nodejs/node/pull/46469
    description: version field added to options.
 -->
 

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -156,7 +156,7 @@ added: REPLACEME
 -->
 
 Return an import object that can be passed to `wasi.start` if
-no other WASM imports are needed beyond those provided by wasi. It
+no other WASM imports are needed beyond those provided by WASI. It
 will reflect the version of wasi requested when `new WASI` was
 called.
 

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -16,7 +16,7 @@ import { WASI } from 'wasi';
 import { argv, env } from 'node:process';
 
 const wasi = new WASI({
-  version: 'wasi_snapshot_preview1',
+  version: 'preview1',
   args: argv,
   env,
   preopens: {
@@ -40,7 +40,7 @@ const { argv, env } = require('node:process');
 const { join } = require('node:path');
 
 const wasi = new WASI({
-  version: 'wasi_snapshot_preview1',
+  version: 'preview1',
   args: argv,
   env,
   preopens: {

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -16,6 +16,7 @@ import { WASI } from 'wasi';
 import { argv, env } from 'node:process';
 
 const wasi = new WASI({
+  version: 'wasi_snapshot_preview1',
   args: argv,
   env,
   preopens: {
@@ -23,14 +24,10 @@ const wasi = new WASI({
   },
 });
 
-// Some WASI binaries require:
-//   const importObject = { wasi_unstable: wasi.wasiImport };
-const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
-
 const wasm = await WebAssembly.compile(
   await readFile(new URL('./demo.wasm', import.meta.url)),
 );
-const instance = await WebAssembly.instantiate(wasm, importObject);
+const instance = await WebAssembly.instantiate(wasm, wasi.getImportObject());
 
 wasi.start(instance);
 ```
@@ -43,6 +40,7 @@ const { argv, env } = require('node:process');
 const { join } = require('node:path');
 
 const wasi = new WASI({
+  version: 'wasi_snapshot_preview1',
   args: argv,
   env,
   preopens: {
@@ -50,15 +48,11 @@ const wasi = new WASI({
   },
 });
 
-// Some WASI binaries require:
-//   const importObject = { wasi_unstable: wasi.wasiImport };
-const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
-
 (async () => {
   const wasm = await WebAssembly.compile(
     await readFile(join(__dirname, 'demo.wasm')),
   );
-  const instance = await WebAssembly.instantiate(wasm, importObject);
+  const instance = await WebAssembly.instantiate(wasm, wasi.getImportObject());
 
   wasi.start(instance);
 })();
@@ -126,6 +120,10 @@ sandbox directory structure configured explicitly.
 added:
  - v13.3.0
  - v12.16.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/
+   description: version field added to options.
 -->
 
 * `options` {Object}
@@ -148,6 +146,19 @@ added:
     WebAssembly application. **Default:** `1`.
   * `stderr` {integer} The file descriptor used as standard error in the
     WebAssembly application. **Default:** `2`.
+  * `version` {string} The version of wasi requested. Currently the only
+    supported version is `wasi_snapshot_preview1`
+
+### `wasi.getImportObject()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Return an import object that can be passed to `wasi.start` if
+no other WASM imports are needed beyond those provided by wasi. It
+will reflect the version of wasi requested when `new WASI` was
+called.
 
 ### `wasi.start(instance)`
 

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -155,9 +155,9 @@ changes:
 added: REPLACEME
 -->
 
-Return an import object that can be passed to `wasi.start` if
+Return an import object that can be passed to `WebAssembly.instantiate()` if
 no other WASM imports are needed beyond those provided by WASI. It
-will reflect the version of wasi requested when `new WASI` was
+will reflect the version of WASI requested when the WASI constructor was
 called.
 
 ### `wasi.start(instance)`

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -147,7 +147,7 @@ changes:
   * `stderr` {integer} The file descriptor used as standard error in the
     WebAssembly application. **Default:** `2`.
   * `version` {string} The version of WASI requested. Currently the only
-    supported version is `wasi_snapshot_preview1`.
+    supported versions are `unstable` and `preview1`. **Default:** `preview1`.
 
 ### `wasi.getImportObject()`
 
@@ -156,9 +156,20 @@ added: REPLACEME
 -->
 
 Return an import object that can be passed to `WebAssembly.instantiate()` if
-no other WASM imports are needed beyond those provided by WASI. It
-will reflect the version of WASI requested when the WASI constructor was
-called.
+no other WASM imports are needed beyond those provided by WASI.
+
+If version `unstable` was passed into the constructor it will return:
+
+```json
+{ wasi_unstable: wasi.wasiImport }
+```
+
+If version `preview1` was passed into the constructor or no version was
+specified it will return:
+
+```json
+{ wasi_snapshot_preview1: wasi.wasiImport }
+```
 
 ### `wasi.start(instance)`
 

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -147,7 +147,7 @@ changes:
   * `stderr` {integer} The file descriptor used as standard error in the
     WebAssembly application. **Default:** `2`.
   * `version` {string} The version of WASI requested. Currently the only
-    supported version is `wasi_snapshot_preview1`
+    supported version is `wasi_snapshot_preview1`.
 
 ### `wasi.getImportObject()`
 

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -146,7 +146,7 @@ changes:
     WebAssembly application. **Default:** `1`.
   * `stderr` {integer} The file descriptor used as standard error in the
     WebAssembly application. **Default:** `2`.
-  * `version` {string} The version of wasi requested. Currently the only
+  * `version` {string} The version of WASI requested. Currently the only
     supported version is `wasi_snapshot_preview1`
 
 ### `wasi.getImportObject()`

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -30,7 +30,7 @@ const kExitCode = Symbol('kExitCode');
 const kSetMemory = Symbol('kSetMemory');
 const kStarted = Symbol('kStarted');
 const kInstance = Symbol('kInstance');
-const kVersion = Symbol('kVersion');
+const kBindingName = Symbol('kBindingName');
 
 emitExperimentalWarning('WASI');
 
@@ -51,8 +51,14 @@ class WASI {
     if (options.version !== undefined) {
       validateString(options.version, 'options.version');
       switch (options.version) {
-        case 'wasi_snapshot_preview1':
+        case 'unstable':
           ({ WASI: _WASI } = internalBinding('wasi'));
+          this[kBindingName] = 'wasi_unstable';
+          break;
+        // When adding support for additional wasi versions add case here
+        case 'preview1':
+          ({ WASI: _WASI } = internalBinding('wasi'));
+          this[kBindingName] = 'wasi_snapshot_preview1';
           break;
         // When adding support for additional wasi versions add case here
         default:
@@ -60,11 +66,10 @@ class WASI {
                                           options.version,
                                           'unsupported WASI version');
       }
-      this[kVersion] = options.version;
     } else {
       // TODO(mdawson): Remove this in a SemVer major PR before Node.js 20
       ({ WASI: _WASI } = internalBinding('wasi'));
-      this[kVersion] = 'wasi_snapshot_preview1';
+      this[kBindingName] = 'wasi_snapshot_preview1';
     }
 
     if (options.args !== undefined)
@@ -162,7 +167,7 @@ class WASI {
   }
 
   getImportObject() {
-    return { [this[kVersion]]: this.wasiImport };
+    return { [this[kBindingName]]: this.wasiImport };
   }
 }
 

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -62,6 +62,7 @@ class WASI {
       }
       this[kVersion] = options.version;
     } else {
+      // TODO(mdawson): Remove this in a SemVer major PR before Node.js 20
       ({ WASI: _WASI } = internalBinding('wasi'));
       this[kVersion] = 'wasi_snapshot_preview1';
     }

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -58,7 +58,7 @@ class WASI {
         default:
           throw new ERR_INVALID_ARG_VALUE('options.version',
                                           options.version,
-                                          'unsupported wasi version');
+                                          'unsupported WASI version');
       }
       this[kVersion] = options.version;
     } else {

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -10,6 +10,7 @@ const {
 } = primordials;
 
 const {
+  ERR_INVALID_ARG_VALUE,
   ERR_WASI_ALREADY_STARTED
 } = require('internal/errors').codes;
 const {
@@ -22,13 +23,14 @@ const {
   validateFunction,
   validateInt32,
   validateObject,
+  validateString,
   validateUndefined,
 } = require('internal/validators');
-const { WASI: _WASI } = internalBinding('wasi');
 const kExitCode = Symbol('kExitCode');
 const kSetMemory = Symbol('kSetMemory');
 const kStarted = Symbol('kStarted');
 const kInstance = Symbol('kInstance');
+const kVersion = Symbol('kVersion');
 
 emitExperimentalWarning('WASI');
 
@@ -44,6 +46,25 @@ function setupInstance(self, instance) {
 class WASI {
   constructor(options = kEmptyObject) {
     validateObject(options, 'options');
+
+    let _WASI;
+    if (options.version !== undefined) {
+      validateString(options.version, 'options.version');
+      switch (options.version) {
+        case 'wasi_snapshot_preview1':
+          ({ WASI: _WASI } = internalBinding('wasi'));
+          break;
+        // When adding support for additional wasi versions add case here
+        default:
+          throw new ERR_INVALID_ARG_VALUE('options.version',
+                                          options.version,
+                                          'unsupported wasi version');
+      }
+      this[kVersion] = options.version;
+    } else {
+      ({ WASI: _WASI } = internalBinding('wasi'));
+      this[kVersion] = 'wasi_snapshot_preview1';
+    }
 
     if (options.args !== undefined)
       validateArray(options.args, 'options.args');
@@ -138,8 +159,11 @@ class WASI {
       _initialize();
     }
   }
-}
 
+  getImportObject() {
+    return { [this[kVersion]]: this.wasiImport };
+  }
+}
 
 module.exports = { WASI };
 

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -1247,10 +1247,10 @@ void WASI::_SetMemory(const FunctionCallbackInfo<Value>& args) {
   wasi->memory_.Reset(wasi->env()->isolate(), args[0].As<WasmMemoryObject>());
 }
 
-static void Initialize(Local<Object> target,
-                       Local<Value> unused,
-                       Local<Context> context,
-                       void* priv) {
+static void InitializePreview1(Local<Object> target,
+                               Local<Value> unused,
+                               Local<Context> context,
+                               void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
 
@@ -1313,8 +1313,7 @@ static void Initialize(Local<Object> target,
   SetConstructorFunction(context, target, "WASI", tmpl);
 }
 
-
 }  // namespace wasi
 }  // namespace node
 
-NODE_BINDING_CONTEXT_AWARE_INTERNAL(wasi, node::wasi::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(wasi, node::wasi::InitializePreview1)

--- a/test/wasi/test-wasi-options-validation.js
+++ b/test/wasi/test-wasi-options-validation.js
@@ -47,3 +47,12 @@ assert.throws(() => { new WASI({ stderr: 'fhqwhgads' }); },
 assert.throws(() => {
   new WASI({ preopens: { '/sandbox': '__/not/real/path' } });
 }, { code: 'UVWASI_ENOENT', message: /uvwasi_init/ });
+
+// If version is not a string, it should throw
+assert.throws(() => { new WASI({ version: { x: 'y' } }); },
+              { code: 'ERR_INVALID_ARG_TYPE', message: /\bversion\b/ });
+
+
+// If version is an unsupported version, it should throw
+assert.throws(() => { new WASI({ version: 'not_a_version' }); },
+              { code: 'ERR_INVALID_ARG_VALUE', message: /\bversion\b/ });

--- a/test/wasi/test-wasi.js
+++ b/test/wasi/test-wasi.js
@@ -68,43 +68,6 @@ if (process.argv[2] === 'wasi-child-default') {
 
     wasiPreview1.start(instancePreview1);
   })().then(common.mustCall());
-} else if (process.argv[2] === 'wasi-child-unstable') {
-  // Test version set to unstable
-  const assert = require('assert');
-  const fixtures = require('../common/fixtures');
-  const tmpdir = require('../common/tmpdir');
-  const fs = require('fs');
-  const path = require('path');
-
-  common.expectWarning('ExperimentalWarning',
-                       'WASI is an experimental feature and might change at any time');
-
-  const { WASI } = require('wasi');
-  tmpdir.refresh();
-  const wasmDir = path.join(__dirname, 'wasm');
-  const wasiUnstable = new WASI({
-    version: 'unstable',
-    args: ['foo', '-bar', '--baz=value'],
-    env: process.env,
-    preopens: {
-      '/sandbox': fixtures.path('wasi'),
-      '/tmp': tmpdir.path,
-    },
-  });
-
-  // Validate the getImportObject helper
-  assert.strictEqual(wasiUnstable.wasiImport,
-                     wasiUnstable.getImportObject().wasi_unstable);
-  const modulePathUnstable = path.join(wasmDir, `${process.argv[3]}.wasm`);
-  const bufferUnstable = fs.readFileSync(modulePathUnstable);
-
-  (async () => {
-    const { instance: instanceUnstable } =
-      await WebAssembly.instantiate(bufferUnstable,
-                                    wasiUnstable.getImportObject());
-
-    wasiUnstable.start(instanceUnstable);
-  })().then(common.mustCall());
 } else {
   const assert = require('assert');
   const cp = require('child_process');
@@ -140,8 +103,6 @@ if (process.argv[2] === 'wasi-child-default') {
     innerRunWASI(options, ['--no-turbo-fast-api-calls']);
     innerRunWASI(options, ['--turbo-fast-api-calls']);
     innerRunWASI(options, ['--turbo-fast-api-calls'], 'preview1');
-    // TODO(mhdawson) do we need testing for unstable?
-    // innerRunWASI(options, ['--turbo-fast-api-calls'], 'unstable');
   }
 
   runWASI({ test: 'cant_dotdot' });

--- a/test/wasi/test-wasi.js
+++ b/test/wasi/test-wasi.js
@@ -1,7 +1,8 @@
 'use strict';
 const common = require('../common');
 
-if (process.argv[2] === 'wasi-child') {
+if (process.argv[2] === 'wasi-child-default') {
+  // test default case
   const fixtures = require('../common/fixtures');
   const tmpdir = require('../common/tmpdir');
   const fs = require('fs');
@@ -30,12 +31,49 @@ if (process.argv[2] === 'wasi-child') {
 
     wasi.start(instance);
   })().then(common.mustCall());
+} else if (process.argv[2] === 'wasi-child-preview1') {
+  // Test version set to wasi_snapshot_preview1
+  const assert = require('assert');
+  const fixtures = require('../common/fixtures');
+  const tmpdir = require('../common/tmpdir');
+  const fs = require('fs');
+  const path = require('path');
+
+  common.expectWarning('ExperimentalWarning',
+                       'WASI is an experimental feature and might change at any time');
+
+  const { WASI } = require('wasi');
+  tmpdir.refresh();
+  const wasmDir = path.join(__dirname, 'wasm');
+  const wasiPreview1 = new WASI({
+    version: 'wasi_snapshot_preview1',
+    args: ['foo', '-bar', '--baz=value'],
+    env: process.env,
+    preopens: {
+      '/sandbox': fixtures.path('wasi'),
+      '/tmp': tmpdir.path,
+    },
+  });
+
+  // Validate the getImportObject helper
+  assert.strictEqual(wasiPreview1.wasiImport,
+                     wasiPreview1.getImportObject().wasi_snapshot_preview1);
+  const modulePathPreview1 = path.join(wasmDir, `${process.argv[3]}.wasm`);
+  const bufferPreview1 = fs.readFileSync(modulePathPreview1);
+
+  (async () => {
+    const { instance: instancePreview1 } =
+      await WebAssembly.instantiate(bufferPreview1,
+                                    wasiPreview1.getImportObject());
+
+    wasiPreview1.start(instancePreview1);
+  })().then(common.mustCall());
 } else {
   const assert = require('assert');
   const cp = require('child_process');
   const { checkoutEOL } = common;
 
-  function innerRunWASI(options, args) {
+  function innerRunWASI(options, args, flavor = 'default') {
     console.log('executing', options.test);
     const opts = {
       env: {
@@ -52,7 +90,7 @@ if (process.argv[2] === 'wasi-child') {
       ...args,
       '--experimental-wasi-unstable-preview1',
       __filename,
-      'wasi-child',
+      'wasi-child-' + flavor,
       options.test,
     ], opts);
     console.log(child.stderr.toString());
@@ -64,6 +102,7 @@ if (process.argv[2] === 'wasi-child') {
   function runWASI(options) {
     innerRunWASI(options, ['--no-turbo-fast-api-calls']);
     innerRunWASI(options, ['--turbo-fast-api-calls']);
+    innerRunWASI(options, ['--turbo-fast-api-calls'], 'preview1');
   }
 
   runWASI({ test: 'cant_dotdot' });

--- a/test/wasi/test-wasi.js
+++ b/test/wasi/test-wasi.js
@@ -32,7 +32,7 @@ if (process.argv[2] === 'wasi-child-default') {
     wasi.start(instance);
   })().then(common.mustCall());
 } else if (process.argv[2] === 'wasi-child-preview1') {
-  // Test version set to wasi_snapshot_preview1
+  // Test version set to preview1
   const assert = require('assert');
   const fixtures = require('../common/fixtures');
   const tmpdir = require('../common/tmpdir');
@@ -69,7 +69,7 @@ if (process.argv[2] === 'wasi-child-default') {
     wasiPreview1.start(instancePreview1);
   })().then(common.mustCall());
 } else if (process.argv[2] === 'wasi-child-unstable') {
-  // Test version set to wasi_snapshot_preview1
+  // Test version set to unstable
   const assert = require('assert');
   const fixtures = require('../common/fixtures');
   const tmpdir = require('../common/tmpdir');
@@ -140,6 +140,8 @@ if (process.argv[2] === 'wasi-child-default') {
     innerRunWASI(options, ['--no-turbo-fast-api-calls']);
     innerRunWASI(options, ['--turbo-fast-api-calls']);
     innerRunWASI(options, ['--turbo-fast-api-calls'], 'preview1');
+    // TODO(mhdawson) do we need testing for unstable?
+    // innerRunWASI(options, ['--turbo-fast-api-calls'], 'unstable');
   }
 
   runWASI({ test: 'cant_dotdot' });


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/46254

- add version to options when creating WASI object
- add convenience function to return importObject

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
