### PR TITLE
src: do not track BaseObjects directly in Realm

### DIFF
--- a/src/node_realm.cc
+++ b/src/node_realm.cc
@@ -47,12 +47,6 @@ void Realm::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("cleanup_queue", cleanup_queue_);
   tracker->TrackField("builtins_with_cache", builtins_with_cache);
   tracker->TrackField("builtins_without_cache", builtins_without_cache);
-
-  ForEachBaseObject([&](BaseObject* obj) {
-    if (obj->IsDoneInitializing()) {
-      tracker->Track(obj);
-    }
-  });
 }
 
 void Realm::CreateProperties() {


### PR DESCRIPTION
They are referenced through the CleanupQueue which is already tracked. Tracking them again in Realms results in duplicates in the heap snapshot.

Example of duplicates (the Realm doesn't actually reference the BindingData directly, and also Realm isn't an array/vector/list where indices make sense, the only valid reference is the one through CleanupQueue, where indices would somewhat make sense):

<img width="414" alt="Screen Shot 2023-02-02 at 16 50 36" src="https://user-images.githubusercontent.com/4299420/216373428-36e93f07-14bb-4fdd-b882-df3beff5be31.png">

After this patch:

<img width="398" alt="Screen Shot 2023-02-02 at 16 54 31" src="https://user-images.githubusercontent.com/4299420/216374336-05d53b1d-ea91-4926-b212-d62a87b597ed.png">



<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
