### PR TITLE
src: use simdutf utf8 to utf16 instead of icu

### DIFF
--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -289,7 +289,7 @@ Deletable* MainThreadInterface::GetObjectIfExists(int id) {
   return iterator->second.get();
 }
 
-std::unique_ptr<StringBuffer> Utf8ToStringView(const std::string& message) {
+std::unique_ptr<StringBuffer> Utf8ToStringView(const std::string_view message) {
   size_t expected_u16_length =
       simdutf::utf16_length_from_utf8(message.data(), message.length());
   MaybeStackBuffer<char16_t> buffer(expected_u16_length);

--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -1,12 +1,8 @@
 #include "main_thread_interface.h"
 
 #include "env-inl.h"
-#include "node_mutex.h"
 #include "simdutf.h"
-#include "util-inl.h"
 #include "v8-inspector.h"
-
-#include <unicode/unistr.h>
 
 #include <functional>
 #include <memory>

--- a/src/inspector/main_thread_interface.h
+++ b/src/inspector/main_thread_interface.h
@@ -34,7 +34,7 @@ class Deletable {
 };
 
 std::unique_ptr<v8_inspector::StringBuffer> Utf8ToStringView(
-    const std::string& message);
+    const std::string_view message);
 
 using MessageQueue = std::deque<std::unique_ptr<Request>>;
 


### PR DESCRIPTION
Replacing one of the crucial parts with `simdutf` for faster performance.