### PR TITLE
doc: document how to use the tls.DEFAULT_CIPHERS

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -2259,7 +2259,7 @@ added: REPLACEME
 * {string} The default value of the `ciphers` option of
   [`tls.createSecureContext()`][]. It can be assigned any of the supported
   OpenSSL ciphers.  Defaults to the content of
-  `'crypto.constants.defaultCoreCipherList'`, unless changed using CLI options
+  `crypto.constants.defaultCoreCipherList`, unless changed using CLI options
   using `--tls-default-ciphers`.
 
 [CVE-2021-44531]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44531

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -374,7 +374,7 @@ sockets, it will not affect sockets already opened. For example:
 
 ```js
 // Remove Obsolete CBC Ciphers and RSA Key Exchange based Ciphers as they don't provide Forward Secrecy
-tls_module.DEFAULT_CIPHERS +=
+tls.DEFAULT_CIPHERS +=
   ':!ECDHE-RSA-AES128-SHA:!ECDHE-RSA-AES128-SHA256:!ECDHE-RSA-AES256-SHA:!ECDHE-RSA-AES256-SHA384' +
   ':!ECDHE-ECDSA-AES128-SHA:!ECDHE-ECDSA-AES128-SHA256:!ECDHE-ECDSA-AES256-SHA:!ECDHE-ECDSA-AES256-SHA384' +
   ':!kRSA';

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -356,6 +356,26 @@ export NODE_OPTIONS=--tls-cipher-list='ECDHE-RSA-AES128-GCM-SHA256:!RC4'
 node server.js
 ```
 
+To verify, use the following command to show the set cipher list, note the 
+difference between `defaultCoreCipherList` and `defaultCipherList`:
+```bash
+node --tls-cipher-list='ECDHE-RSA-AES128-GCM-SHA256:!RC4' -p crypto.constants.defaultCipherList | tr ':' '\n'
+ECDHE-RSA-AES128-GCM-SHA256
+!RC4
+```
+i.e. the `defaultCoreCipherList` list is set at compilation time and the 
+`defaultCipherList` is set at runtime.
+
+To modify the default cipher suites from within the runtime, modify the 
+`tls.DEFAULT_CIPHERS` variable, this must be performed before listening on any 
+sockets, it will not affect sockets already opened. For example:
+```js
+tls.DEFAULT_CIPHERS=tls.DEFAULT_CIPHERS +
+  ':!ECDHE-RSA-AES128-SHA:!ECDHE-RSA-AES128-SHA256:!ECDHE-RSA-AES256-SHA:!ECDHE-RSA-AES256-SHA384' + // Obsolete CBC Ciphers
+  ':!ECDHE-ECDSA-AES128-SHA:!ECDHE-ECDSA-AES128-SHA256:!ECDHE-ECDSA-AES256-SHA:!ECDHE-ECDSA-AES256-SHA384' + // Obsolete CBC Ciphers using elliptic keys
+  ':!kRSA'; // RSA Key Exchange Algorithm considered weak, doesn't provide forward secrecy
+```
+
 The default can also be replaced on a per client or server basis using the
 `ciphers` option from [`tls.createSecureContext()`][], which is also available
 in [`tls.createServer()`][], [`tls.connect()`][], and when creating new
@@ -2225,6 +2245,18 @@ added: v11.4.0
   the default to `'TLSv1.1'`. Using `--tls-min-v1.3` sets the default to
   `'TLSv1.3'`. If multiple of the options are provided, the lowest minimum is
   used.
+
+## `tls.DEFAULT_CIPHERS`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string} The default value of the `ciphers` option of
+  [`tls.createSecureContext()`][]. It can be assigned any of the supported 
+  OpenSSL ciphers.  Defaults to the content of 
+  `'crypto.constants.defaultCoreCipherList'`, unless changed using CLI options 
+  using `--tls-default-ciphers`.
 
 [CVE-2021-44531]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44531
 [Chrome's 'modern cryptography' setting]: https://www.chromium.org/Home/chromium-security/education/tls#TOC-Cipher-Suites

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -356,24 +356,28 @@ export NODE_OPTIONS=--tls-cipher-list='ECDHE-RSA-AES128-GCM-SHA256:!RC4'
 node server.js
 ```
 
-To verify, use the following command to show the set cipher list, note the 
+To verify, use the following command to show the set cipher list, note the
 difference between `defaultCoreCipherList` and `defaultCipherList`:
+
 ```bash
 node --tls-cipher-list='ECDHE-RSA-AES128-GCM-SHA256:!RC4' -p crypto.constants.defaultCipherList | tr ':' '\n'
 ECDHE-RSA-AES128-GCM-SHA256
 !RC4
 ```
-i.e. the `defaultCoreCipherList` list is set at compilation time and the 
+
+i.e. the `defaultCoreCipherList` list is set at compilation time and the
 `defaultCipherList` is set at runtime.
 
-To modify the default cipher suites from within the runtime, modify the 
-`tls.DEFAULT_CIPHERS` variable, this must be performed before listening on any 
+To modify the default cipher suites from within the runtime, modify the
+`tls.DEFAULT_CIPHERS` variable, this must be performed before listening on any
 sockets, it will not affect sockets already opened. For example:
+
 ```js
-tls.DEFAULT_CIPHERS=tls.DEFAULT_CIPHERS +
-  ':!ECDHE-RSA-AES128-SHA:!ECDHE-RSA-AES128-SHA256:!ECDHE-RSA-AES256-SHA:!ECDHE-RSA-AES256-SHA384' + // Obsolete CBC Ciphers
-  ':!ECDHE-ECDSA-AES128-SHA:!ECDHE-ECDSA-AES128-SHA256:!ECDHE-ECDSA-AES256-SHA:!ECDHE-ECDSA-AES256-SHA384' + // Obsolete CBC Ciphers using elliptic keys
-  ':!kRSA'; // RSA Key Exchange Algorithm considered weak, doesn't provide forward secrecy
+// Remove Obsolete CBC Ciphers and RSA Key Exchange based Ciphers as they don't provide Forward Secrecy
+tls_module.DEFAULT_CIPHERS +=
+  ':!ECDHE-RSA-AES128-SHA:!ECDHE-RSA-AES128-SHA256:!ECDHE-RSA-AES256-SHA:!ECDHE-RSA-AES256-SHA384' +
+  ':!ECDHE-ECDSA-AES128-SHA:!ECDHE-ECDSA-AES128-SHA256:!ECDHE-ECDSA-AES256-SHA:!ECDHE-ECDSA-AES256-SHA384' +
+  ':!kRSA';
 ```
 
 The default can also be replaced on a per client or server basis using the
@@ -2253,9 +2257,9 @@ added: REPLACEME
 -->
 
 * {string} The default value of the `ciphers` option of
-  [`tls.createSecureContext()`][]. It can be assigned any of the supported 
-  OpenSSL ciphers.  Defaults to the content of 
-  `'crypto.constants.defaultCoreCipherList'`, unless changed using CLI options 
+  [`tls.createSecureContext()`][]. It can be assigned any of the supported
+  OpenSSL ciphers.  Defaults to the content of
+  `'crypto.constants.defaultCoreCipherList'`, unless changed using CLI options
   using `--tls-default-ciphers`.
 
 [CVE-2021-44531]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44531


### PR DESCRIPTION
The `tls.DEFAULT_CIPHERS` var already exists, this change shows how to use it.

Fixes: https://github.com/nodejs/node/issues/46462

I have attempted to keep my changes in style with the rest, I tried finding the `Style Guide` but the link just sent me back to the top-level `README.md` so I couldn't find it.

I hope this is helpful!
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
