### PR TITLE
lib: refactor to use `validateBuffer`

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -120,14 +120,15 @@ const {
 } = require('internal/errors');
 const {
   isUint32,
+  validateAbortSignal,
+  validateBoolean,
+  validateBuffer,
   validateFunction,
   validateInt32,
   validateInteger,
   validateNumber,
   validateString,
   validateUint32,
-  validateAbortSignal,
-  validateBoolean,
 } = require('internal/validators');
 const fsPromisesInternal = require('internal/fs/promises');
 const { utcDate } = require('internal/http');
@@ -1377,10 +1378,8 @@ class Http2Session extends EventEmitter {
       callback = payload;
       payload = undefined;
     }
-    if (payload && !isArrayBufferView(payload)) {
-      throw new ERR_INVALID_ARG_TYPE('payload',
-                                     ['Buffer', 'TypedArray', 'DataView'],
-                                     payload);
+    if (payload) {
+      validateBuffer(payload, 'payload');
     }
     if (payload && payload.length !== 8) {
       throw new ERR_HTTP2_PING_LENGTH();
@@ -1506,10 +1505,8 @@ class Http2Session extends EventEmitter {
     if (this.destroyed)
       throw new ERR_HTTP2_INVALID_SESSION();
 
-    if (opaqueData !== undefined && !isArrayBufferView(opaqueData)) {
-      throw new ERR_INVALID_ARG_TYPE('opaqueData',
-                                     ['Buffer', 'TypedArray', 'DataView'],
-                                     opaqueData);
+    if (opaqueData !== undefined) {
+      validateBuffer(opaqueData, 'opaqueData');
     }
     validateNumber(code, 'code');
     validateNumber(lastStreamID, 'lastStreamID');

--- a/lib/internal/tls/secure-context.js
+++ b/lib/internal/tls/secure-context.js
@@ -26,6 +26,7 @@ const {
 } = require('internal/util/types');
 
 const {
+  validateBuffer,
   validateInt32,
   validateObject,
   validateString,
@@ -292,12 +293,7 @@ function configSecureContext(context, options = kEmptyObject, name = 'options') 
   }
 
   if (ticketKeys !== undefined && ticketKeys !== null) {
-    if (!isArrayBufferView(ticketKeys)) {
-      throw new ERR_INVALID_ARG_TYPE(
-        `${name}.ticketKeys`,
-        ['Buffer', 'TypedArray', 'DataView'],
-        ticketKeys);
-    }
+    validateBuffer(ticketKeys, `${name}.ticketKeys`);
     if (ticketKeys.byteLength !== 48) {
       throw new ERR_INVALID_ARG_VALUE(
         `${name}.ticketKeys`,

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -40,10 +40,8 @@ const {
   ERR_INVALID_ARG_TYPE,
 } = require('internal/errors').codes;
 const {
-  isArrayBufferView,
-} = require('internal/util/types');
-const {
   validateBoolean,
+  validateBuffer,
   validateFunction,
   validateInt32,
   validateObject,
@@ -84,12 +82,8 @@ class Script extends ContextifyScript {
     validateString(filename, 'options.filename');
     validateInt32(lineOffset, 'options.lineOffset');
     validateInt32(columnOffset, 'options.columnOffset');
-    if (cachedData !== undefined && !isArrayBufferView(cachedData)) {
-      throw new ERR_INVALID_ARG_TYPE(
-        'options.cachedData',
-        ['Buffer', 'TypedArray', 'DataView'],
-        cachedData
-      );
+    if (cachedData !== undefined) {
+      validateBuffer(cachedData, 'options.cachedData');
     }
     validateBoolean(produceCachedData, 'options.produceCachedData');
 


### PR DESCRIPTION
Use validateBuffer to remove duplicate implementation.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
