### PR TITLE
src: make edge names in BaseObjects more descriptive in heap snapshots

### DIFF
--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -318,8 +318,8 @@ MemoryRetainerNode* MemoryTracker::AddNode(const MemoryRetainer* retainer,
   if (CurrentNode() != nullptr) graph_->AddEdge(CurrentNode(), n, edge_name);
 
   if (n->JSWrapperNode() != nullptr) {
-    graph_->AddEdge(n, n->JSWrapperNode(), "wrapped");
-    graph_->AddEdge(n->JSWrapperNode(), n, "wrapper");
+    graph_->AddEdge(n, n->JSWrapperNode(), "native_to_javascript");
+    graph_->AddEdge(n->JSWrapperNode(), n, "javascript_to_native");
   }
 
   return n;

--- a/test/pummel/test-heapdump-dns.js
+++ b/test/pummel/test-heapdump-dns.js
@@ -12,7 +12,7 @@ validateSnapshotNodes('Node / ChannelWrap', [
     children: [
       { node_name: 'Node / NodeAresTask::List', edge_name: 'task_list' },
       // `Node / ChannelWrap` (C++) -> `ChannelWrap` (JS)
-      { node_name: 'ChannelWrap', edge_name: 'wrapped' },
+      { node_name: 'ChannelWrap', edge_name: 'native_to_javascript' },
     ],
     detachedness: 2
   },

--- a/test/pummel/test-heapdump-fs-promise.js
+++ b/test/pummel/test-heapdump-fs-promise.js
@@ -9,7 +9,7 @@ fs.stat(__filename);
 validateSnapshotNodes('Node / FSReqPromise', [
   {
     children: [
-      { node_name: 'FSReqPromise', edge_name: 'wrapped' },
+      { node_name: 'FSReqPromise', edge_name: 'native_to_javascript' },
       { node_name: 'Float64Array', edge_name: 'stats_field_array' },
     ]
   },

--- a/test/pummel/test-heapdump-http2.js
+++ b/test/pummel/test-heapdump-http2.js
@@ -28,7 +28,7 @@ server.listen(0, () => {
       {
         children: [
           // current_headers and/or queue could be empty
-          { node_name: 'Http2Stream', edge_name: 'wrapped' },
+          { node_name: 'Http2Stream', edge_name: 'native_to_javascript' },
         ]
       },
     ], { loose: true });
@@ -37,7 +37,7 @@ server.listen(0, () => {
     state.validateSnapshotNodes('Node / FileHandle', [
       {
         children: [
-          { node_name: 'FileHandle', edge_name: 'wrapped' },
+          { node_name: 'FileHandle', edge_name: 'native_to_javascript' },
           // current_headers could be empty
         ]
       },
@@ -45,14 +45,14 @@ server.listen(0, () => {
     state.validateSnapshotNodes('Node / TCPSocketWrap', [
       {
         children: [
-          { node_name: 'TCP', edge_name: 'wrapped' },
+          { node_name: 'TCP', edge_name: 'native_to_javascript' },
         ]
       },
     ], { loose: true });
     state.validateSnapshotNodes('Node / TCPServerWrap', [
       {
         children: [
-          { node_name: 'TCP', edge_name: 'wrapped' },
+          { node_name: 'TCP', edge_name: 'native_to_javascript' },
         ]
       },
     ], { loose: true });
@@ -60,7 +60,7 @@ server.listen(0, () => {
     state.validateSnapshotNodes('Node / StreamPipe', [
       {
         children: [
-          { node_name: 'StreamPipe', edge_name: 'wrapped' },
+          { node_name: 'StreamPipe', edge_name: 'native_to_javascript' },
         ]
       },
     ]);
@@ -68,7 +68,7 @@ server.listen(0, () => {
     state.validateSnapshotNodes('Node / Http2Session', [
       {
         children: [
-          { node_name: 'Http2Session', edge_name: 'wrapped' },
+          { node_name: 'Http2Session', edge_name: 'native_to_javascript' },
           { node_name: 'Node / nghttp2_memory', edge_name: 'nghttp2_memory' },
           {
             node_name: 'Node / streams', edge_name: 'streams'

--- a/test/pummel/test-heapdump-inspector.js
+++ b/test/pummel/test-heapdump-inspector.js
@@ -30,7 +30,7 @@ const snapshotNode = {
     {
       children: [
         { node_name: 'Node / InspectorSession', edge_name: 'session' },
-        { node_name: 'Connection', edge_name: 'wrapped' },
+        { node_name: 'Connection', edge_name: 'native_to_javascript' },
         (edge) => edge.name === 'callback' &&
           (edge.to.type === undefined || // embedded graph
            edge.to.type === 'closure'), // snapshot

--- a/test/pummel/test-heapdump-tls.js
+++ b/test/pummel/test-heapdump-tls.js
@@ -27,7 +27,7 @@ const server = net.createServer(common.mustCall((c) => {
         { node_name: 'Node / NodeBIO', edge_name: 'enc_out' },
         { node_name: 'Node / NodeBIO', edge_name: 'enc_in' },
         // `Node / TLSWrap` (C++) -> `TLSWrap` (JS)
-        { node_name: 'TLSWrap', edge_name: 'wrapped' },
+        { node_name: 'TLSWrap', edge_name: 'native_to_javascript' },
         // pending_cleartext_input could be empty
       ]
     },

--- a/test/pummel/test-heapdump-zlib.js
+++ b/test/pummel/test-heapdump-zlib.js
@@ -10,7 +10,7 @@ const gzip = zlib.createGzip();
 validateSnapshotNodes('Node / ZlibStream', [
   {
     children: [
-      { node_name: 'Zlib', edge_name: 'wrapped' },
+      { node_name: 'Zlib', edge_name: 'native_to_javascript' },
       // No entry for memory because zlib memory is initialized lazily.
     ]
   },
@@ -20,7 +20,7 @@ gzip.write('hello world', common.mustCall(() => {
   validateSnapshotNodes('Node / ZlibStream', [
     {
       children: [
-        { node_name: 'Zlib', edge_name: 'wrapped' },
+        { node_name: 'Zlib', edge_name: 'native_to_javascript' },
         { node_name: 'Node / zlib_memory', edge_name: 'zlib_memory' },
       ]
     },


### PR DESCRIPTION
Previously these were named "wrapper" and "wrapped", which can be somewhat difficult to understand. This patch renames them to "javascript_to_native" and "native_to_javascript".

Previously:
<img width="401" alt="Screen Shot 2023-02-04 at 01 52 08" src="https://user-images.githubusercontent.com/4299420/216737611-12c20049-0a9e-45e0-aa69-b2864565b744.png">

After:
<img width="504" alt="Screen Shot 2023-02-04 at 01 52 20" src="https://user-images.githubusercontent.com/4299420/216737614-20f4c194-e516-4711-9d6d-91eb391c1c07.png">


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
