### PR TITLE
src: check return value of ftell()

### DIFF
--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -877,6 +877,7 @@ bool SnapshotData::FromBlob(SnapshotData* out, FILE* in) {
   int err = fseek(in, 0, SEEK_END);
   CHECK_EQ(err, 0);
   size_t size = ftell(in);
+  CHECK_NE(size, static_cast<size_t>(-1L));
   err = fseek(in, 0, SEEK_SET);
   CHECK_EQ(err, 0);
 


### PR DESCRIPTION
If `ftell()` returns `-1L`, abort instead of passing `static_cast<size_t>(-1)` to the vector allocator and `fread()`.

Refs: https://github.com/nodejs/node/pull/46463

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
