### PR TITLE
tools: add a daily wpt.fyi synchronized report upload

### DIFF
--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -1,0 +1,110 @@
+# This workflow runs every night and tests various releases of Node.js
+# (latest nightly, current, and two latest LTS release lines) against the
+# `epochs/daily` branch of WPT.
+
+name: Daily WPT report
+
+on:
+  workflow_dispatch:
+    inputs:
+      node-versions:
+        description: Node.js versions (as supported by actions/setup-node) to test as JSON array
+        required: false
+        default: '["current", "lts/*", "lts/-1"]'
+  schedule:
+    # This is 20 minutes after `epochs/daily` branch is triggered to be created
+    # in WPT repo.
+    # https://github.com/web-platform-tests/wpt/blob/master/.github/workflows/epochs.yml
+    - cron: 30 0 * * *
+
+env:
+  PYTHON_VERSION: '3.11'
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    if: github.repository == 'nodejs/node' || github.event_name == 'workflow_dispatch'
+    strategy:
+      matrix:
+        node-version: ${{ fromJSON(github.event.inputs.node-versions || '["latest-nightly", "current", "lts/*", "lts/-1"]') }}
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Environment Information
+        run: npx envinfo
+
+      # install a version and checkout
+      - name: Get latest nightly
+        if: matrix.node-version == 'latest-nightly'
+        run: echo "NIGHTLY=$(curl -s https://nodejs.org/download/nightly/index.json | jq -r '.[0].version')" >> $GITHUB_ENV
+      - name: Install Node.js
+        id: setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NIGHTLY || matrix.node-version }}
+      - name: Get nightly ref
+        if: contains(matrix.node-version, 'nightly')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHORT_SHA=$(node -p 'process.version.split(/-nightly\d{8}/)[1]')
+          echo "NIGHTLY_REF=$(gh api /repos/nodejs/node/commits/$SHORT_SHA | jq -r '.sha')" >> $GITHUB_ENV
+      - name: Checkout ${{ steps.setup-node.outputs.node-version }}
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ env.NIGHTLY_REF || steps.setup-node.outputs.node-version }}
+      - name: Set env.NODE
+        run: echo "NODE=$(which node)" >> $GITHUB_ENV
+
+      # replace checked out WPT with the synchronized branch
+      - name: Remove stale WPT
+        run: rm -rf wpt
+        working-directory: test/fixtures
+      - name: Checkout epochs/daily WPT
+        uses: actions/checkout@v3
+        with:
+          repository: web-platform-tests/wpt
+          persist-credentials: false
+          path: test/fixtures/wpt
+          clean: false
+          ref: epochs/daily
+      - name: Set env.WPT_REVISION
+        run: echo "WPT_REVISION=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        working-directory: test/fixtures/wpt
+
+      - name: Run WPT and generate report
+        run: make test-wpt-report || true
+      - name: Clone report for upload
+        run: |
+          if [ -e out/wpt/wptreport.json ]; then
+            cd out/wpt
+            cp wptreport.json wptreport-${{ steps.setup-node.outputs.node-version }}.json
+          fi
+      - name: Upload GitHub Actions artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: out/wpt/wptreport-*.json
+          name: WPT Reports
+          if-no-files-found: warn
+      - name: Upload WPT Report to wpt.fyi API
+        env:
+          WPT_FYI_ENDPOINT: ${{ vars.WPT_FYI_ENDPOINT }}
+          WPT_FYI_USERNAME: ${{ vars.WPT_FYI_USERNAME }}
+          WPT_FYI_PASSWORD: ${{ secrets.WPT_FYI_PASSWORD }}
+        run: |
+          if [ -e out/wpt/wptreport.json ]; then
+            cd out/wpt
+            gzip wptreport.json
+            curl \
+              -u "$WPT_FYI_USERNAME:$WPT_FYI_PASSWORD" \
+              -F "result_file=@wptreport.json.gz" \
+              -F "labels=master" \
+              $WPT_FYI_ENDPOINT
+          fi

--- a/Makefile
+++ b/Makefile
@@ -595,6 +595,12 @@ test-message: test-build
 test-wpt: all
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) wpt
 
+.PHONY: test-wpt-report
+test-wpt-report:
+	$(RM) -r out/wpt
+	mkdir -p out/wpt
+	WPT_REPORT=1 $(PYTHON) tools/test.py --shell $(NODE) $(PARALLEL_ARGS) wpt
+
 .PHONY: test-simple
 test-simple: | cctest # Depends on 'all'.
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) parallel sequential

--- a/test/wpt/test-encoding.js
+++ b/test/wpt/test-encoding.js
@@ -4,7 +4,6 @@ const { WPTRunner } = require('../common/wpt');
 const runner = new WPTRunner('encoding');
 
 runner.setInitScript(`
-  globalThis.location ||= {};
   const { MessageChannel } = require('worker_threads');
   global.MessageChannel = MessageChannel;
 `);

--- a/test/wpt/test-webcrypto.js
+++ b/test/wpt/test-webcrypto.js
@@ -8,10 +8,6 @@ const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('WebCryptoAPI');
 
-runner.setInitScript(`
-  global.location = {};
-`);
-
 runner.pretendGlobalThisAs('Window');
 
 runner.runJsTests();


### PR DESCRIPTION
This PR introduces a daily job for uploading upstream synchronized WPT executed in four versions of Node.js to the wpt.fyi API.

Test run generated reports: https://github.com/nodejs/node-auto-test/suites/10778564147/artifacts/541679841
<details>
<summary>Example: Deno has their results submitted next to browsers as well</summary>

<img width="1222" alt="Screenshot 2023-01-31 at 13 59 23" src="https://user-images.githubusercontent.com/241506/215766571-dd03dfdc-79fd-430a-b532-68d3e7fa2bd8.png">

</details>

This PR has two commits, the first one that updates the WPTRunner and adds make target to generate the reports which we'll backport to v19.x, v18.x, and maybe v16.x.

The four versions are:
- 3 based on `actions/setup-node` - `current`, `lts/*` (always Active LTS), `lts/-1` (most often the Maintenance LTS)
- latest nightly build per https://nodejs.org/download/nightly/index.json

The job is setup to always execute the respective version's WPTRunner and the supported WPT subset but with the latest synchronized WPT fixtures.

The second commit introduces the daily job's workflow yaml file.

I have [requested](https://github.com/web-platform-tests/wpt.fyi/issues/3144) the credentials for accessing the API. This is a draft until we get them and I retest the flow via [nodejs/node-auto-test](https://github.com/nodejs/node-auto-test/actions/runs/4091649869) again once we get the credentials and set them as either organization or repository secrets.

- v19.x lands clean
- v18.x I will open backport PR for the WPTRunner and make target
- v16.x I will open backport PR for the WPTRunner and make target

The workflow file gracefully handles cases when the backport was not done yet and the way the Node.js versions are determined requires no upkeep.

Closes #46443