### PR TITLE
buffer: add Buffer.copyFrom(...)

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1058,6 +1058,28 @@ console.log(bufA.length);
 `Buffer.concat()` may also use the internal `Buffer` pool like
 [`Buffer.allocUnsafe()`][] does.
 
+### Static method: `Buffer.copyBytesFrom(view[, offset[, length]])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `view` {TypedArray} The {TypedArray} to copy.
+* `offset` {integer} The starting offset within `view`. **Default:**: `0`.
+* `length` {integer} The number of elements from `view` to copy.
+  **Default:** `view.length - offset`.
+
+Copies the underlying memory of `view` into a new `Buffer`.
+
+```js
+const u16 = new Uint16Array([0, 0xffff]);
+const buf = Buffer.copyBytesFrom(u16, 0, 1);
+u16[1] = 0;
+console.log(buf.length); // 2
+console.log(buf[0]); // 255
+console.log(buf[1]); // 255
+```
+
 ### Static method: `Buffer.from(array)`
 
 <!-- YAML

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -43,9 +43,13 @@ const {
   StringPrototypeTrim,
   SymbolSpecies,
   SymbolToPrimitive,
+  TypedArrayPrototypeGetBuffer,
   TypedArrayPrototypeGetByteLength,
+  TypedArrayPrototypeGetByteOffset,
   TypedArrayPrototypeFill,
+  TypedArrayPrototypeGetLength,
   TypedArrayPrototypeSet,
+  TypedArrayPrototypeSlice,
   Uint8Array,
   Uint8ArrayPrototype,
 } = primordials;
@@ -328,6 +332,48 @@ Buffer.from = function from(value, encodingOrOffset, length) {
     ['string', 'Buffer', 'ArrayBuffer', 'Array', 'Array-like Object'],
     value
   );
+};
+
+/**
+ * Creates the Buffer as a copy of the underlying ArrayBuffer of the view
+ * rather than the contents of the view.
+ * @param {TypedArray} view
+ * @param {number} [offset]
+ * @param {number} [length]
+ * @returns {Buffer}
+ */
+Buffer.copyBytesFrom = function copyBytesFrom(view, offset, length) {
+  if (!isTypedArray(view)) {
+    throw new ERR_INVALID_ARG_TYPE('view', [ 'TypedArray' ], view);
+  }
+
+  const viewLength = TypedArrayPrototypeGetLength(view);
+  if (viewLength === 0) {
+    return Buffer.alloc(0);
+  }
+
+  if (offset !== undefined || length !== undefined) {
+    if (offset !== undefined) {
+      validateInteger(offset, 'offset', 0);
+      if (offset >= viewLength) return Buffer.alloc(0);
+    } else {
+      offset = 0;
+    }
+    let end;
+    if (length !== undefined) {
+      validateInteger(length, 'length', 0);
+      end = offset + length;
+    } else {
+      end = viewLength;
+    }
+
+    view = TypedArrayPrototypeSlice(view, offset, end);
+  }
+
+  return fromArrayLike(new Uint8Array(
+    TypedArrayPrototypeGetBuffer(view),
+    TypedArrayPrototypeGetByteOffset(view),
+    TypedArrayPrototypeGetByteLength(view)));
 };
 
 // Identical to the built-in %TypedArray%.of(), but avoids using the deprecated


### PR DESCRIPTION
This is a variation on `Buffer.from(arrayBufferView)` that copies the bytes and does not truncate when using a multibyte TypedArray.  For instance,

```
Buffer.from(new Uint16Array([0xffff]))
<Buffer ff>

Buffer.copyBytesFrom(new Uint16Array([0xffff]))
<Buffer ff ff> 
```

Open to suggestions on a better name.

Fixes: https://github.com/nodejs/node/issues/43862
