### PR TITLE
src: use stricter compile-time guidance

### DIFF
--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -164,22 +164,19 @@ class SnapshotSerializerDeserializer {
   V(std::string)
 
 #define V(TypeName)                                                            \
-  if (std::is_same_v<T, TypeName>) {                                           \
+  if constexpr (std::is_same_v<T, TypeName>) {                                 \
     return #TypeName;                                                          \
-  }
+  } else  // NOLINT(readability/braces)
     TYPE_LIST(V)
 #undef V
 
-    std::string name;
-    if (std::is_arithmetic_v<T>) {
-      if (!std::is_signed_v<T>) {
-        name += "u";
-      }
-      name += std::is_integral_v<T> ? "int" : "float";
-      name += std::to_string(sizeof(T) * 8);
-      name += "_t";
+    if constexpr (std::is_arithmetic_v<T>) {
+      return (std::is_unsigned_v<T>   ? "uint"
+              : std::is_integral_v<T> ? "int"
+                                      : "float") +
+             std::to_string(sizeof(T) * 8) + "_t";
     }
-    return name;
+    return "";
   }
 
   bool is_debug = false;


### PR DESCRIPTION
`SnapshotSerializerDeserializer::GetName()` appears to confuse static analysis such as Coverity.

This changes the function structure to a sequence of `if`-`else` blocks and marks all branch conditions as `constexpr`. (Unfortunately, this results in a dangling `else` keyword in the `V` macro.)

~As a side effect, this change ensures that `GetName<T>()` can only be called for known types T (instead of returning an empty string).~ As per a request in the PR discussion, this change does _not_ ensure that `GetName<T>()` can only be called for known types `T` and instead still returns an empty string in that case.

Also use `std::is_unsigned_v` instead of `!std::is_signed_v`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
