### PR TITLE
stream: refactor to use `validateAbortSignal`

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -371,7 +371,6 @@ ObjectDefineProperty(AbortController.prototype, SymbolToStringTag, {
 });
 
 module.exports = {
-  kAborted,
   AbortController,
   AbortSignal,
   ClonedAbortSignal,

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -58,13 +58,10 @@ const {
 } = require('internal/util');
 
 const {
+  validateAbortSignal,
   validateBuffer,
   validateObject,
 } = require('internal/validators');
-
-const {
-  kAborted,
-} = require('internal/abort_controller');
 
 const {
   MessageChannel,
@@ -381,8 +378,9 @@ class ReadableStream {
     const preventClose = options?.preventClose;
     const signal = options?.signal;
 
-    if (signal !== undefined && signal?.[kAborted] === undefined)
-      throw new ERR_INVALID_ARG_TYPE('options.signal', 'AbortSignal', signal);
+    if (signal !== undefined) {
+      validateAbortSignal(signal, 'options.signal');
+    }
 
     if (isReadableStreamLocked(this))
       throw new ERR_INVALID_STATE.TypeError('The ReadableStream is locked');
@@ -422,8 +420,9 @@ class ReadableStream {
       const preventClose = options?.preventClose;
       const signal = options?.signal;
 
-      if (signal !== undefined && signal?.[kAborted] === undefined)
-        throw new ERR_INVALID_ARG_TYPE('options.signal', 'AbortSignal', signal);
+      if (signal !== undefined) {
+        validateAbortSignal(signal, 'options.signal');
+      }
 
       if (isReadableStreamLocked(this))
         throw new ERR_INVALID_STATE.TypeError('The ReadableStream is locked');
@@ -1269,12 +1268,12 @@ function readableStreamPipeTo(
 
   let shuttingDown = false;
 
-  if (signal !== undefined && signal?.[kAborted] === undefined) {
-    return PromiseReject(
-      new ERR_INVALID_ARG_TYPE(
-        'options.signal',
-        'AbortSignal',
-        signal));
+  if (signal !== undefined) {
+    try {
+      validateAbortSignal(signal, 'options.signal');
+    } catch (error) {
+      return PromiseReject(error);
+    }
   }
 
   const promise = createDeferredPromise();


### PR DESCRIPTION
All APIs currently accept any `AbortSignal`-like objects, which is what `validateAbortSignal` checks for. Let's use this here for consistency.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
