### PR TITLE
lib: tighten `AbortSignal.prototype.throwIfAborted` implementation

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -94,7 +94,7 @@ function customInspect(self, obj, depth, options) {
   return `${self.constructor.name} ${inspect(obj, opts)}`;
 }
 
-function validateAbortSignal(obj) {
+function validateThisAbortSignal(obj) {
   if (obj?.[kAborted] === undefined)
     throw new ERR_INVALID_THIS('AbortSignal');
 }
@@ -132,7 +132,7 @@ class AbortSignal extends EventTarget {
    * @type {boolean}
    */
   get aborted() {
-    validateAbortSignal(this);
+    validateThisAbortSignal(this);
     return !!this[kAborted];
   }
 
@@ -140,13 +140,14 @@ class AbortSignal extends EventTarget {
    * @type {any}
    */
   get reason() {
-    validateAbortSignal(this);
+    validateThisAbortSignal(this);
     return this[kReason];
   }
 
   throwIfAborted() {
-    if (this.aborted) {
-      throw this.reason;
+    validateThisAbortSignal(this);
+    if (this[kAborted]) {
+      throw this[kReason];
     }
   }
 
@@ -202,7 +203,7 @@ class AbortSignal extends EventTarget {
   }
 
   [kTransfer]() {
-    validateAbortSignal(this);
+    validateThisAbortSignal(this);
     const aborted = this.aborted;
     if (aborted) {
       const reason = this.reason;

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -254,3 +254,20 @@ const { setTimeout: sleep } = require('timers/promises');
   const ac = new AbortController();
   ac.signal.throwIfAborted();
 }
+
+{
+  const originalDesc = Reflect.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted');
+  const actualReason = new Error();
+  Reflect.defineProperty(AbortSignal.prototype, 'aborted', { value: false });
+  throws(() => AbortSignal.abort(actualReason).throwIfAborted(), actualReason);
+  Reflect.defineProperty(AbortSignal.prototype, 'aborted', originalDesc);
+}
+
+{
+  const originalDesc = Reflect.getOwnPropertyDescriptor(AbortSignal.prototype, 'reason');
+  const actualReason = new Error();
+  const fakeExcuse = new Error();
+  Reflect.defineProperty(AbortSignal.prototype, 'reason', { value: fakeExcuse });
+  throws(() => AbortSignal.abort(actualReason).throwIfAborted(), actualReason);
+  Reflect.defineProperty(AbortSignal.prototype, 'reason', originalDesc);
+}


### PR DESCRIPTION
All other runtimes I've tested check their internal flag rather than the getter. Let's do that for consistency as well.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
