### PR TITLE
events: add listener argument to listenerCount

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -752,7 +752,7 @@ changes:
 Type: Documentation-only
 
 The [`events.listenerCount(emitter, eventName)`][] API is
-deprecated. Please use [`emitter.listenerCount(eventName)`][] instead.
+deprecated. Please use [`emitter.listenerCount(eventName, listener)`][] instead.
 
 ### DEP0034: `fs.exists(path, callback)`
 
@@ -3402,7 +3402,7 @@ be added when a function is bound to an `AsyncResource`.
 [`dnsPromises.lookup()`]: dns.md#dnspromiseslookuphostname-options
 [`domain`]: domain.md
 [`ecdh.setPublicKey()`]: crypto.md#ecdhsetpublickeypublickey-encoding
-[`emitter.listenerCount(eventName)`]: events.md#emitterlistenercounteventname
+[`emitter.listenerCount(eventName, listener)`]: events.md#emitterlistenercounteventname-listener
 [`events.listenerCount(emitter, eventName)`]: events.md#eventslistenercountemitter-eventname
 [`fs.FileHandle`]: fs.md#class-filehandle
 [`fs.access()`]: fs.md#fsaccesspath-mode-callback

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -752,7 +752,7 @@ changes:
 Type: Documentation-only
 
 The [`events.listenerCount(emitter, eventName)`][] API is
-deprecated. Please use [`emitter.listenerCount(eventName, listener)`][] instead.
+deprecated. Please use [`emitter.listenerCount(eventName)`][] instead.
 
 ### DEP0034: `fs.exists(path, callback)`
 
@@ -3402,7 +3402,7 @@ be added when a function is bound to an `AsyncResource`.
 [`dnsPromises.lookup()`]: dns.md#dnspromiseslookuphostname-options
 [`domain`]: domain.md
 [`ecdh.setPublicKey()`]: crypto.md#ecdhsetpublickeypublickey-encoding
-[`emitter.listenerCount(eventName, listener)`]: events.md#emitterlistenercounteventname-listener
+[`emitter.listenerCount(eventName)`]: events.md#emitterlistenercounteventname-listener
 [`events.listenerCount(emitter, eventName)`]: events.md#eventslistenercountemitter-eventname
 [`fs.FileHandle`]: fs.md#class-filehandle
 [`fs.access()`]: fs.md#fsaccesspath-mode-callback

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -646,16 +646,23 @@ Returns the current max listener value for the `EventEmitter` which is either
 set by [`emitter.setMaxListeners(n)`][] or defaults to
 [`events.defaultMaxListeners`][].
 
-### `emitter.listenerCount(eventName)`
+### `emitter.listenerCount(eventName, [listener])`
 
 <!-- YAML
 added: v3.2.0
+changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Added the listener argument.
 -->
 
 * `eventName` {string|symbol} The name of the event being listened for
+* `listener` {Function} The name of the listener
 * Returns: {integer}
 
 Returns the number of listeners listening to the event named `eventName`.
+If `listener` is provided, it will return `1` if the listener is found
+in the list of the listeners of the event, `0` otherwise.
 
 ### `emitter.listeners(eventName)`
 
@@ -2468,7 +2475,7 @@ to the `EventTarget`.
 [`EventTarget` error handling]: #eventtarget-error-handling
 [`Event` Web API]: https://dom.spec.whatwg.org/#event
 [`domain`]: domain.md
-[`emitter.listenerCount()`]: #emitterlistenercounteventname
+[`emitter.listenerCount()`]: #emitterlistenercounteventname-listener
 [`emitter.removeListener()`]: #emitterremovelistenereventname-listener
 [`emitter.setMaxListeners(n)`]: #emittersetmaxlistenersn
 [`event.defaultPrevented`]: #eventdefaultprevented

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -646,7 +646,7 @@ Returns the current max listener value for the `EventEmitter` which is either
 set by [`emitter.setMaxListeners(n)`][] or defaults to
 [`events.defaultMaxListeners`][].
 
-### `emitter.listenerCount(eventName, [listener])`
+### `emitter.listenerCount(eventName[, listener])`
 
 <!-- YAML
 added: v3.2.0
@@ -657,12 +657,12 @@ changes:
 -->
 
 * `eventName` {string|symbol} The name of the event being listened for
-* `listener` {Function} The name of the listener
+* `listener` {Function} The event handler function
 * Returns: {integer}
 
-Returns the number of listeners listening to the event named `eventName`.
-If `listener` is provided, it will return `1` if the listener is found
-in the list of the listeners of the event, `0` otherwise.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 ### `emitter.listeners(eventName)`
 

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -653,7 +653,7 @@ added: v3.2.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/46523
-    description: Added the listener argument.
+    description: Added the `listener` argument.
 -->
 
 * `eventName` {string|symbol} The name of the event being listened for

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -652,7 +652,7 @@ set by [`emitter.setMaxListeners(n)`][] or defaults to
 added: v3.2.0
 changes:
   - version: REPLACEME
-    pr-url: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46523
     description: Added the listener argument.
 -->
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -33,7 +33,6 @@ const {
   ErrorCaptureStackTrace,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
-  Number,
   NumberMAX_SAFE_INTEGER,
   ObjectDefineProperty,
   ObjectDefineProperties,
@@ -844,19 +843,21 @@ function listenerCount(type, listener) {
 
     if (typeof evlistener === 'function') {
       if (listener) {
-        return Number(listener === evlistener);
+        return listener === evlistener ? 1 : 0;
       }
 
       return 1;
     } else if (evlistener !== undefined) {
       if (listener) {
+        let matching = 0;
+
         for (let i = 0, l = evlistener.length; i < l; i++) {
           if (evlistener[i] === listener || evlistener[i].listener === listener) {
-            return 1;
+            matching++;
           }
         }
 
-        return 0;
+        return matching;
       }
 
       return evlistener.length;

--- a/lib/events.js
+++ b/lib/events.js
@@ -842,13 +842,13 @@ function listenerCount(type, listener) {
     const evlistener = events[type];
 
     if (typeof evlistener === 'function') {
-      if (listener) {
+      if (listener != null) {
         return listener === evlistener ? 1 : 0;
       }
 
       return 1;
     } else if (evlistener !== undefined) {
-      if (listener) {
+      if (listener != null) {
         let matching = 0;
 
         for (let i = 0, l = evlistener.length; i < l; i++) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -33,6 +33,7 @@ const {
   ErrorCaptureStackTrace,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
+  Number,
   NumberMAX_SAFE_INTEGER,
   ObjectDefineProperty,
   ObjectDefineProperties,
@@ -832,17 +833,32 @@ EventEmitter.prototype.listenerCount = listenerCount;
  * Returns the number of listeners listening to event name
  * specified as `type`.
  * @param {string | symbol} type
+ * @param {Function} listener
  * @returns {number}
  */
-function listenerCount(type) {
+function listenerCount(type, listener) {
   const events = this._events;
 
   if (events !== undefined) {
     const evlistener = events[type];
 
     if (typeof evlistener === 'function') {
+      if (listener) {
+        return Number(listener === evlistener);
+      }
+
       return 1;
     } else if (evlistener !== undefined) {
+      if (listener) {
+        for (let i = 0, l = evlistener.length; i < l; i++) {
+          if (evlistener[i] === listener || evlistener[i].listener === listener) {
+            return 1;
+          }
+        }
+
+        return 0;
+      }
+
       return evlistener.length;
     }
   }

--- a/test/parallel/test-events-listener-count-with-listener.js
+++ b/test/parallel/test-events-listener-count-with-listener.js
@@ -5,7 +5,7 @@ const EventEmitter = require('events');
 const assert = require('assert');
 
 const EE = new EventEmitter();
-const handler = common.mustCall(undefined, 2);
+const handler = common.mustCall(undefined, 3);
 const anotherHandler = common.mustCall();
 
 assert.strictEqual(EE.listenerCount('event'), 0);
@@ -27,6 +27,12 @@ assert.strictEqual(EE.listenerCount('event', anotherHandler), 1);
 assert.strictEqual(EE.listenerCount('another-event'), 0);
 assert.strictEqual(EE.listenerCount('another-event', handler), 0);
 assert.strictEqual(EE.listenerCount('another-event', anotherHandler), 0);
+
+EE.once('event', handler);
+
+assert.strictEqual(EE.listenerCount('event'), 3);
+assert.strictEqual(EE.listenerCount('event', handler), 2);
+assert.strictEqual(EE.listenerCount('event', anotherHandler), 1);
 
 EE.emit('event');
 

--- a/test/parallel/test-events-listener-count-with-listener.js
+++ b/test/parallel/test-events-listener-count-with-listener.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common');
+const EventEmitter = require('events');
+const assert = require('assert');
+
+const EE = new EventEmitter();
+const handler = common.mustCall(undefined, 2);
+const anotherHandler = common.mustCall();
+
+assert.strictEqual(EE.listenerCount('event'), 0);
+assert.strictEqual(EE.listenerCount('event', handler), 0);
+assert.strictEqual(EE.listenerCount('event', anotherHandler), 0);
+
+EE.on('event', handler);
+
+assert.strictEqual(EE.listenerCount('event'), 1);
+assert.strictEqual(EE.listenerCount('event', handler), 1);
+assert.strictEqual(EE.listenerCount('event', anotherHandler), 0);
+
+EE.once('event', anotherHandler);
+
+assert.strictEqual(EE.listenerCount('event'), 2);
+assert.strictEqual(EE.listenerCount('event', handler), 1);
+assert.strictEqual(EE.listenerCount('event', anotherHandler), 1);
+
+assert.strictEqual(EE.listenerCount('another-event'), 0);
+assert.strictEqual(EE.listenerCount('another-event', handler), 0);
+assert.strictEqual(EE.listenerCount('another-event', anotherHandler), 0);
+
+EE.emit('event');
+
+assert.strictEqual(EE.listenerCount('event'), 1);
+assert.strictEqual(EE.listenerCount('event', handler), 1);
+assert.strictEqual(EE.listenerCount('event', anotherHandler), 0);
+
+EE.emit('event');
+
+assert.strictEqual(EE.listenerCount('event'), 1);
+assert.strictEqual(EE.listenerCount('event', handler), 1);
+assert.strictEqual(EE.listenerCount('event', anotherHandler), 0);
+
+EE.off('event', handler);
+
+assert.strictEqual(EE.listenerCount('event'), 0);
+assert.strictEqual(EE.listenerCount('event', handler), 0);
+assert.strictEqual(EE.listenerCount('event', anotherHandler), 0);


### PR DESCRIPTION
This PR introduces a new method for EventEmitter, called hasListener.
It returns true if a listener is already registered for an event.
This can be helpful to avoid adding a listener too many times and therefore helps avoiding leaks.

Fixes #43548.