### PR TITLE
lib: predeclare Event.isTrusted property descriptor

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -78,6 +78,13 @@ const isTrusted = ObjectGetOwnPropertyDescriptor({
   }
 }, 'isTrusted').get;
 
+const isTrustedDescriptor = {
+  __proto__: null,
+  configurable: false,
+  enumerable: true,
+  get: isTrusted,
+};
+
 function isEvent(value) {
   return typeof value?.[kType] === 'string';
 }
@@ -113,12 +120,7 @@ class Event {
     }
 
     // isTrusted is special (LegacyUnforgeable)
-    ObjectDefineProperty(this, 'isTrusted', {
-      __proto__: null,
-      get: isTrusted,
-      enumerable: true,
-      configurable: false
-    });
+    ObjectDefineProperty(this, 'isTrusted', isTrustedDescriptor);
     this[kTarget] = null;
     this[kIsBeingDispatched] = false;
   }


### PR DESCRIPTION
It improves Event creation performance.

I'm seeing these numbers:
```
]$ ./node benchmark/compare.js --new ./node --old ./node_old --runs 30 --filter messageport --filter eventtarget worker events  | Rscript benchmark/compare.R
[00:08:18|% 100| 2/2 files | 60/60 runs | 3/3 configs]: Done
                                                                       confidence improvement accuracy (*)   (**)  (***)
events/eventtarget.js listeners=1 n=1000000                                  ***     20.25 %       ±1.64% ±2.18% ±2.85%
events/eventtarget.js listeners=10 n=1000000                                 ***     18.27 %       ±0.88% ±1.18% ±1.53%
events/eventtarget.js listeners=5 n=1000000                                  ***     19.13 %       ±0.96% ±1.29% ±1.71%
worker/messageport.js n=1000000 style='eventemitter' payload='object'                -0.51 %       ±1.85% ±2.46% ±3.20%
worker/messageport.js n=1000000 style='eventemitter' payload='string'                 0.44 %       ±1.12% ±1.49% ±1.94%
worker/messageport.js n=1000000 style='eventtarget' payload='object'         ***      7.18 %       ±1.62% ±2.16% ±2.81%
worker/messageport.js n=1000000 style='eventtarget' payload='string'         ***     10.79 %       ±0.99% ±1.31% ±1.71%
```