### PR TITLE
Optimizing `TracingAgent::start()`

### DIFF
--- a/src/inspector/tracing_agent.cc
+++ b/src/inspector/tracing_agent.cc
@@ -133,34 +133,19 @@ void TracingAgent::Wire(UberDispatcher* dispatcher) {
   NodeTracing::Dispatcher::wire(dispatcher, this);
 }
 
-DispatchResponse TracingAgent::start(
-    std::unique_ptr<protocol::NodeTracing::TraceConfig> traceConfig) {
-  if (!trace_writer_.empty()) {
-    return DispatchResponse::Error(
-        "Call NodeTracing::end to stop tracing before updating the config");
-  }
-  if (!env_->owns_process_state()) {
-    return DispatchResponse::Error(
-        "Tracing properties can only be changed through main thread sessions");
-  }
+DispatchResponse TracingAgent::start(std::unique_ptr<protocol::NodeTracing::TraceConfig> traceConfig) {
+  if (!trace_writer_.empty() || !env_->owns_process_state()) 
+    return DispatchResponse::Error("Tracing not allowed, end current tracing or call from main thread");
 
-  std::set<std::string> categories_set;
-  protocol::Array<std::string>* categories =
-      traceConfig->getIncludedCategories();
-  for (size_t i = 0; i < categories->length(); i++)
-    categories_set.insert(categories->get(i));
+  auto categories = traceConfig->getIncludedCategories();
+  if (categories->length() == 0)
+    return DispatchResponse::Error("At least one category must be enabled");
 
-  if (categories_set.empty())
-    return DispatchResponse::Error("At least one category should be enabled");
-
-  tracing::AgentWriterHandle* writer = GetTracingAgentWriter();
-  if (writer != nullptr) {
-    trace_writer_ =
-        writer->agent()->AddClient(categories_set,
-                                   std::make_unique<InspectorTraceWriter>(
-                                       frontend_object_id_, main_thread_),
-                                   tracing::Agent::kIgnoreDefaultCategories);
-  }
+  auto writer = GetTracingAgentWriter();
+  if (writer)
+    trace_writer_ = writer->agent()->AddClient({categories->begin(), categories->end()},
+                                                std::make_unique<InspectorTraceWriter>(frontend_object_id_, main_thread_),
+                                                tracing::Agent::kIgnoreDefaultCategories);
   return DispatchResponse::OK();
 }
 


### PR DESCRIPTION
I believe that the `DispatchResponse TracingAgent::start()` function can be improved to be more efficient and more readable for those who wish to contribute.

1. Unified the two error checking conditions into one;
2. Used the `length()` function to check whether at least one category has been enabled;
3. Used the set initialization `std::set` to insert elements directly from an array;
4. Unified the two null checks into one.

I believe that this way, it is easier to interpret what is happening in this snippet code and look for further improvements.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
