### PR TITLE
crypto: don't assume FIPS is disabled by default

### DIFF
--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -120,7 +120,9 @@ bool ProcessFipsOptions() {
     return EVP_default_properties_enable_fips(nullptr, 1) &&
            EVP_default_properties_is_fips_enabled(nullptr);
 #else
-    return FIPS_mode() == 0 && FIPS_mode_set(1);
+    if (FIPS_mode() == 0)
+      return FIPS_mode_set(1);
+
 #endif
   }
   return true;

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -120,8 +120,7 @@ bool ProcessFipsOptions() {
     return EVP_default_properties_enable_fips(nullptr, 1) &&
            EVP_default_properties_is_fips_enabled(nullptr);
 #else
-    if (FIPS_mode() == 0)
-      return FIPS_mode_set(1);
+    if (FIPS_mode() == 0) return FIPS_mode_set(1);
 
 #endif
   }

--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -77,13 +77,17 @@ testHelper(
   'process.versions',
   process.env);
 
-// By default FIPS should be off in both FIPS and non-FIPS builds.
-testHelper(
-  'stdout',
-  [],
-  FIPS_DISABLED,
-  'require("crypto").getFips()',
-  { ...process.env, 'OPENSSL_CONF': ' ' });
+// By default FIPS should be off in both FIPS and non-FIPS builds
+// unless Node.js was configured using --shared-openssl in
+// which case it may be enabled by the system.
+if (!sharedOpenSSL()) {
+  testHelper(
+    'stdout',
+    [],
+    FIPS_DISABLED,
+    'require("crypto").getFips()',
+    { ...process.env, 'OPENSSL_CONF': ' ' });
+}
 
 // Toggling fips with setFips should not be allowed from a worker thread
 testHelper(


### PR DESCRIPTION
For binaries that use --shared-openssl FIPs may be enabled by default by the system. Allow --force-fips and --enable-fips to be specified in these cases.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
