### PR TITLE
bootstrap: print stack trace during environment creation failure

### DIFF
--- a/src/api/embed_helpers.cc
+++ b/src/api/embed_helpers.cc
@@ -135,8 +135,8 @@ CommonEnvironmentSetup::CommonEnvironmentSetup(
     TryCatch bootstrapCatch(isolate);
     auto print_Exception = OnScopeLeave([&]() {
       if (bootstrapCatch.HasCaught()) {
-        PrintCaughtException(
-            isolate, isolate->GetCurrentContext(), bootstrapCatch);
+        errors->push_back(FormatCaughtException(
+            isolate, isolate->GetCurrentContext(), bootstrapCatch));
       }
     });
 

--- a/src/api/embed_helpers.cc
+++ b/src/api/embed_helpers.cc
@@ -15,6 +15,7 @@ using v8::Maybe;
 using v8::Nothing;
 using v8::SealHandleScope;
 using v8::SnapshotCreator;
+using v8::TryCatch;
 
 namespace node {
 
@@ -129,12 +130,21 @@ CommonEnvironmentSetup::CommonEnvironmentSetup(
   {
     Locker locker(isolate);
     Isolate::Scope isolate_scope(isolate);
+    HandleScope handle_scope(isolate);
+
+    TryCatch bootstrapCatch(isolate);
+    auto print_Exception = OnScopeLeave([&]() {
+      if (bootstrapCatch.HasCaught()) {
+        PrintCaughtException(
+            isolate, isolate->GetCurrentContext(), bootstrapCatch);
+      }
+    });
+
     impl_->isolate_data.reset(CreateIsolateData(
         isolate, loop, platform, impl_->allocator.get(), snapshot_data));
     impl_->isolate_data->options()->build_snapshot =
         impl_->snapshot_creator.has_value();
 
-    HandleScope handle_scope(isolate);
     if (snapshot_data) {
       impl_->env.reset(make_env(this));
       if (impl_->env) {

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -196,10 +196,7 @@ static std::string FormatStackTrace(Isolate* isolate, Local<StackTrace> stack) {
 
     if (stack_frame->IsEval()) {
       if (stack_frame->GetScriptId() == Message::kNoScriptIdInfo) {
-        char buf[64];
-        snprintf(
-            buf, sizeof(buf), "    at [eval]:%i:%i\n", line_number, column);
-        result += std::string(buf);
+        result += SPrintF("    at [eval]:%i:%i\n", line_number, column);
       } else {
         std::vector<char> buf(script_name.length() + 64);
         snprintf(buf.data(),
@@ -238,7 +235,7 @@ static std::string FormatStackTrace(Isolate* isolate, Local<StackTrace> stack) {
 }
 
 static void PrintToStderrAndFlush(const std::string& str) {
-  FPrintF(stderr, "%s\n", str.c_str());
+  FPrintF(stderr, "%s\n", str);
   fflush(stderr);
 }
 

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -185,7 +185,8 @@ static std::string GetErrorSource(Isolate* isolate,
   return buf + std::string(underline_buf, off);
 }
 
-void PrintStackTrace(Isolate* isolate, Local<StackTrace> stack) {
+static std::string FormatStackTrace(Isolate* isolate, Local<StackTrace> stack) {
+  std::string result;
   for (int i = 0; i < stack->GetFrameCount(); i++) {
     Local<StackFrame> stack_frame = stack->GetFrame(isolate, i);
     node::Utf8Value fn_name_s(isolate, stack_frame->GetFunctionName());
@@ -195,53 +196,85 @@ void PrintStackTrace(Isolate* isolate, Local<StackTrace> stack) {
 
     if (stack_frame->IsEval()) {
       if (stack_frame->GetScriptId() == Message::kNoScriptIdInfo) {
-        FPrintF(stderr, "    at [eval]:%i:%i\n", line_number, column);
+        char buf[64];
+        snprintf(
+            buf, sizeof(buf), "    at [eval]:%i:%i\n", line_number, column);
+        result += std::string(buf);
       } else {
-        FPrintF(stderr,
-                "    at [eval] (%s:%i:%i)\n",
-                *script_name,
-                line_number,
-                column);
+        std::vector<char> buf(script_name.length() + 64);
+        snprintf(buf.data(),
+                 buf.size(),
+                 "    at [eval] (%s:%i:%i)\n",
+                 *script_name,
+                 line_number,
+                 column);
+        result += std::string(buf.data());
       }
       break;
     }
 
     if (fn_name_s.length() == 0) {
-      FPrintF(stderr, "    at %s:%i:%i\n", script_name, line_number, column);
+      std::vector<char> buf(script_name.length() + 64);
+      snprintf(buf.data(),
+               buf.size(),
+               "    at %s:%i:%i\n",
+               *script_name,
+               line_number,
+               column);
+      result += std::string(buf.data());
     } else {
-      FPrintF(stderr,
-              "    at %s (%s:%i:%i)\n",
-              fn_name_s,
-              script_name,
-              line_number,
-              column);
+      std::vector<char> buf(fn_name_s.length() + script_name.length() + 64);
+      snprintf(buf.data(),
+               buf.size(),
+               "    at %s (%s:%i:%i)\n",
+               *fn_name_s,
+               *script_name,
+               line_number,
+               column);
+      result += std::string(buf.data());
     }
   }
+  return result;
+}
+
+static void PrintToStderrAndFlush(const std::string& str) {
+  FPrintF(stderr, "%s\n", str.c_str());
   fflush(stderr);
 }
 
-void PrintException(Isolate* isolate,
-                    Local<Context> context,
-                    Local<Value> err,
-                    Local<Message> message) {
+void PrintStackTrace(Isolate* isolate, Local<StackTrace> stack) {
+  PrintToStderrAndFlush(FormatStackTrace(isolate, stack));
+}
+
+std::string FormatCaughtException(Isolate* isolate,
+                                  Local<Context> context,
+                                  Local<Value> err,
+                                  Local<Message> message) {
   node::Utf8Value reason(isolate,
                          err->ToDetailString(context)
                              .FromMaybe(Local<String>()));
   bool added_exception_line = false;
   std::string source =
       GetErrorSource(isolate, context, message, &added_exception_line);
-  FPrintF(stderr, "%s\n", source);
-  FPrintF(stderr, "%s\n", reason);
+  std::string result = source + '\n' + reason.ToString() + '\n';
 
   Local<v8::StackTrace> stack = message->GetStackTrace();
-  if (!stack.IsEmpty()) PrintStackTrace(isolate, stack);
+  if (!stack.IsEmpty()) result += FormatStackTrace(isolate, stack);
+  return result;
+}
+
+std::string FormatCaughtException(Isolate* isolate,
+                                  Local<Context> context,
+                                  const v8::TryCatch& try_catch) {
+  CHECK(try_catch.HasCaught());
+  return FormatCaughtException(
+      isolate, context, try_catch.Exception(), try_catch.Message());
 }
 
 void PrintCaughtException(Isolate* isolate,
                           Local<Context> context,
                           const v8::TryCatch& try_catch) {
-  CHECK(try_catch.HasCaught());
-  PrintException(isolate, context, try_catch.Exception(), try_catch.Message());
+  PrintToStderrAndFlush(FormatCaughtException(isolate, context, try_catch));
 }
 
 void AppendExceptionLine(Environment* env,
@@ -1087,7 +1120,8 @@ void TriggerUncaughtException(Isolate* isolate,
     // error is supposed to be thrown at this point.
     // Since we don't have access to Environment here, there is not
     // much we can do, so we just print whatever is useful and crash.
-    PrintException(isolate, context, error, message);
+    PrintToStderrAndFlush(
+        FormatCaughtException(isolate, context, error, message));
     Abort();
   }
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -83,6 +83,9 @@ void PrintStackTrace(v8::Isolate* isolate, v8::Local<v8::StackTrace> stack);
 void PrintCaughtException(v8::Isolate* isolate,
                           v8::Local<v8::Context> context,
                           const v8::TryCatch& try_catch);
+std::string FormatCaughtException(v8::Isolate* isolate,
+                                  v8::Local<v8::Context> context,
+                                  const v8::TryCatch& try_catch);
 
 void ResetStdio();  // Safe to call more than once and from signal handlers.
 #ifdef __POSIX__


### PR DESCRIPTION
https://github.com/nodejs/node/pull/45888 took the environment creation code out of the scope covered by the v8::TryCatch that we use to print early failures during environment creation. So e.g. when adding something that would fail in node.js, we get

```
node:internal/options:554: Uncaught Error: Should not query options before bootstrapping is done
```

This patch restores that by adding another v8::TryCatch for it:

```
node:internal/options:20
    ({ options: optionsMap } = getCLIOptions());
                               ^

Error: Should not query options before bootstrapping is done
    at getCLIOptionsFromBinding (node:internal/options:20:32)
    at getOptionValue (node:internal/options:45:19)
    at node:internal/bootstrap/node:433:29
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
