### PR TITLE
cli: implement node --run <script-in-package-json>

### DIFF
--- a/lib/internal/main/run.js
+++ b/lib/internal/main/run.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const {
+  JSONParse,
+  ObjectKeys
+} = primordials;
+
+const {
+  prepareMainThreadExecution,
+  markBootstrapComplete
+} = require('internal/process/pre_execution');
+const { internalModuleReadJSON } = internalBinding('fs');
+const { execSync } = require('child_process');
+const { getOptionValue } = require('internal/options');
+const { log, error } = console;
+
+prepareMainThreadExecution(false, false);
+
+markBootstrapComplete();
+
+const result = internalModuleReadJSON('package.json');
+if (result.length === 0) {
+  error(`Can't read package.json`);
+  process.exit(1);
+}
+
+const json = JSONParse(result[0]);
+const id = getOptionValue('--run');
+const command = json.scripts[id];
+
+if (!command) {
+  error(`Missing script: "${id}"`);
+  error('Available scripts are:\n');
+  for (const script of ObjectKeys(json.scripts)) {
+    error(`  ${script}: ${json.scripts[script]}`);
+  }
+  process.exit(1);
+}
+
+log('');
+log('>', id);
+log('>', command);
+log('');
+
+execSync(command, { stdio: 'inherit' });

--- a/src/node.cc
+++ b/src/node.cc
@@ -344,6 +344,10 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
     return StartExecution(env, "internal/main/watch_mode");
   }
 
+  if (!env->options()->run.empty()) {
+    return StartExecution(env, "internal/main/run");
+  }
+
   if (!first_argv.empty() && first_argv != "-") {
     return StartExecution(env, "internal/main/run_main_module");
   }

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1079,6 +1079,7 @@ static void InternalModuleReadJSON(const FunctionCallbackInfo<Value>& args) {
     } else if (n == 7) {
       if (0 == memcmp(s, "exports", 7)) break;
       if (0 == memcmp(s, "imports", 7)) break;
+      if (0 == memcmp(s, "scripts", 7)) break;
     }
   }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -506,6 +506,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--prof-process",
             "process V8 profiler output generated using --prof",
             &EnvironmentOptions::prof_process);
+  AddOption("--run",
+            "Run a script specified in package.json",
+            &EnvironmentOptions::run);
   // Options after --prof-process are passed through to the prof processor.
   AddAlias("--prof-process", { "--prof-process", "--" });
 #if HAVE_INSPECTOR

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -178,6 +178,7 @@ class EnvironmentOptions : public Options {
       false;
 #endif  // DEBUG
 
+  std::string run;
   bool watch_mode = false;
   bool watch_mode_report_to_parent = false;
   bool watch_mode_preserve_output = false;


### PR DESCRIPTION
This stemmed from a twitter thread: https://twitter.com/matteocollina/status/1622514656878161920. I was just curious to find out how slow/fast a `JSON.parse()` and `execSync` would be compared to `npm run`, and whether the difference is significant enough that a pure C++ implementation (like what deno task does) would make sense. On my server, with this:

```json
{
  "scripts": {
    "hello": "echo \"hello\""
  }
}
```
`npm run hello` runs for ~330ms, `out/Release/node --run hello` runs for ~35ms (~3-4ms overhead over starting up a no-op process), and a similar deno.json + `deno task hello` runs for ~5ms (that just does everything in native, no JS involved).

I don't feel very strongly about this patch (I personally feel it's more of the package managers'/user-land CLIs' job to simplify their workflow to reach this speed for this type of commands). So there are no tests and no proper error handling here (yet), and it probably needs a bunch more work to be closer to what people expect from these commands (e.g. handling env var or cross-platform support for shells). But since I already wrote this to find out about the numbers anyway, and it feels wrong to just ignore that 330ms -> 35ms difference and pretend that nothing happened, might as well open a PR even just as food for thought ;) A fully C++ implementation is possible too, though I am not sure a 35ms vs 5ms difference is really worth the effort. This is just trying to see what difference can be made with minimum effort.

EDIT: After more discussions I realized that this actually also makes sense even not for the sake of performance. To quote myself below:

> If the user uses yarn to manage their package.json, it's best to use yarn run. If they use npm to manage their package.json, it's best to use npm run. But what if they don't use any package managers (yet?) and just have a hand-written package.json? node --run would be a natural choice.

And in this case, supporting any features that's not commonly shared by most package managers would be a non-goal. It would make sense to ensure that upgrading from `node --run` to `npm run`, `yarn run`, et.al results in as fewer breakages as possible (or do not incur breakages that would not happen when switching between package managers), but not the other way around. Just like switching from Node.js built-in modules (e.g. fs) to the "enhanced" third-party versions of them (e.g. fs-extra) would usually be non-breaking, but it definitely does not happen the other way around.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
