### PR TITLE
[v18.x backport] test: assume priv ports start at 1024 if it can't be changed

### DIFF
--- a/test/parallel/test-cluster-bind-privileged-port.js
+++ b/test/parallel/test-cluster-bind-privileged-port.js
@@ -24,13 +24,16 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
-const { execSync } = require('child_process');
+const { readFileSync, statSync } = require('fs');
 
 if (common.isLinux) {
-  const sysctlOutput = execSync('sysctl net.ipv4.ip_unprivileged_port_start').toString();
-  const unprivilegedPortStart = parseInt(sysctlOutput.split(' ')[2], 10);
-  if (unprivilegedPortStart <= 42) {
-    common.skip('Port 42 is unprivileged');
+  const procFileName = '/proc/sys/net/ipv4/ip_unprivileged_port_start';
+  // Does not exist for Kernel < 4.1 where answer is 1024. So only test limit if limit exists
+  if (statSync(procFileName, { throwIfNoEntry: false })) {
+    const unprivilegedPortStart = parseInt(readFileSync(procFileName));
+    if (unprivilegedPortStart <= 42) {
+      common.skip('Port 42 is unprivileged');
+    }
   }
 }
 


### PR DESCRIPTION
An update to test/parallel/test-cluster-bind-privileged-port.js checks the lowest privileged port to ensure 42 is privileged This only works on kernels > 4.1. On older kernels, this is locked at 1024 so the check is not needed.

Fixes: https://github.com/nodejs/node/issues/45838

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
