### PR TITLE
test_runner: emit test-only diagnostic warning

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -278,6 +278,12 @@ class Test extends AsyncResource {
     };
     this.waitingOn = 0;
     this.finished = false;
+
+    if (!testOnlyFlag && (only || this.runOnlySubtests)) {
+      const warning =
+        "'only' and 'runOnly' require the --test-only command-line option.";
+      this.diagnostic(warning);
+    }
   }
 
   hasConcurrency() {

--- a/test/message/test_runner_output.out
+++ b/test/message/test_runner_output.out
@@ -475,11 +475,13 @@ ok 52 - callback async throw after done
       ---
       duration_ms: *
       ...
+    # 'only' and 'runOnly' require the --test-only command-line option.
     # Subtest: running subtest 3
     ok 3 - running subtest 3
       ---
       duration_ms: *
       ...
+    # 'only' and 'runOnly' require the --test-only command-line option.
     # Subtest: running subtest 4
     ok 4 - running subtest 4
       ---
@@ -490,6 +492,7 @@ ok 53 - only is set but not in only mode
   ---
   duration_ms: *
   ...
+# 'only' and 'runOnly' require the --test-only command-line option.
 # Subtest: custom inspect symbol fail
 not ok 54 - custom inspect symbol fail
   ---

--- a/test/message/test_runner_output_cli.out
+++ b/test/message/test_runner_output_cli.out
@@ -475,11 +475,13 @@ ok 52 - callback async throw after done
       ---
       duration_ms: *
       ...
+    # 'only' and 'runOnly' require the --test-only command-line option.
     # Subtest: running subtest 3
     ok 3 - running subtest 3
       ---
       duration_ms: *
       ...
+    # 'only' and 'runOnly' require the --test-only command-line option.
     # Subtest: running subtest 4
     ok 4 - running subtest 4
       ---
@@ -490,6 +492,7 @@ ok 53 - only is set but not in only mode
   ---
   duration_ms: *
   ...
+# 'only' and 'runOnly' require the --test-only command-line option.
 # Subtest: custom inspect symbol fail
 not ok 54 - custom inspect symbol fail
   ---

--- a/test/message/test_runner_output_spec_reporter.out
+++ b/test/message/test_runner_output_spec_reporter.out
@@ -199,9 +199,12 @@
  only is set but not in only mode
    running subtest 1 (*ms)
    running subtest 2 (*ms)
+   'only' and 'runOnly' require the --test-only command-line option.
    running subtest 3 (*ms)
+   'only' and 'runOnly' require the --test-only command-line option.
    running subtest 4 (*ms)
  only is set but not in only mode (*ms)
+ 'only' and 'runOnly' require the --test-only command-line option.
 
  custom inspect symbol fail (*ms)
   customized


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes: https://github.com/nodejs/node/issues/46448

This PR:
- emits a test diagnostic when running tests with `{ only: true }` or `runOnlyTests(true)` without the `--test-only` CLI flag. 