### PR TITLE
test: fix IPv6 checks on IBM i

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -940,7 +940,14 @@ const common = {
 
   get hasIPv6() {
     const iFaces = require('os').networkInterfaces();
-    const re = isWindows ? /Loopback Pseudo-Interface/ : /lo/;
+    let re;
+    if (isWindows) {
+      re = /Loopback Pseudo-Interface/;
+    } else if (this.isIBMi) {
+      re = /\*LOOPBACK/;
+    } else {
+      re = /lo/;
+    }
     return Object.keys(iFaces).some((name) => {
       return re.test(name) &&
              iFaces[name].some(({ family }) => family === 'IPv6');

--- a/test/parallel/test-net-autoselectfamily.js
+++ b/test/parallel/test-net-autoselectfamily.js
@@ -217,6 +217,10 @@ if (common.hasIPv6) {
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
         } else if (error.code === 'EAFNOSUPPORT') {
           assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
+        } else if (common.isIBMi) {
+          // IBMi returns EUNATCH (ERRNO 42) when IPv6 is disabled
+          // keep this errno assertion until EUNATCH is recognized by libuv
+          assert.strictEqual(error.errno, -42);
         } else {
           assert.strictEqual(error.code, 'EADDRNOTAVAIL');
           assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);

--- a/test/parallel/test-net-autoselectfamilydefault.js
+++ b/test/parallel/test-net-autoselectfamilydefault.js
@@ -129,6 +129,10 @@ function createDnsServer(ipv6Addr, ipv4Addr, cb) {
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
         } else if (error.code === 'EAFNOSUPPORT') {
           assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
+        } else if (common.isIBMi) {
+          // IBMi returns EUNATCH (ERRNO 42) when IPv6 is disabled
+          // keep this errno assertion until EUNATCH is recognized by libuv
+          assert.strictEqual(error.errno, -42);
         } else {
           assert.strictEqual(error.code, 'EADDRNOTAVAIL');
           assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


This fix should help resolve some test failures:

-  [test.parallel/test-net-autoselectfamily](https://ci.nodejs.org/job/node-test-commit-ibmi/1032/nodes=ibmi73-ppc64/testReport/(root)/test/parallel_test_net_autoselectfamily/)
-  [test.parallel/test-net-autoselectfamilydefault](https://ci.nodejs.org/job/node-test-commit-ibmi/1032/nodes=ibmi73-ppc64/testReport/(root)/test/parallel_test_net_autoselectfamilydefault/)

That fail with:

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected

+ 'Unknown system error -42'
- 'EADDRNOTAVAIL'
    at Socket.<anonymous> (/home/IOJS/build/workspace/node-test-commit-ibmi/nodes/ibmi73-ppc64/test/parallel/test-net-autoselectfamilydefault.js:131:18)
    at Socket.<anonymous> (/home/IOJS/build/workspace/node-test-commit-ibmi/nodes/ibmi73-ppc64/test/common/index.js:448:15)
    at Socket.emit (node:events:518:28)
    at emitErrorNT (node:internal/streams/destroy:151:8)
    at emitErrorCloseNT (node:internal/streams/destroy:116:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: 'Unknown system error -42',
  expected: 'EADDRNOTAVAIL',
  operator: 'strictEqual'
}

Node.js v20.0.0-pre
```


The issues I discovered were 2 fold:

1) The `hasIPv6` function cannot determine IPv6 on IBM i. The loop back interface on IBM i is named `*LOOPBACK`. 

2) When IPv6 is disabled IBM i returns EUNATCH (errno 42). For now, I've added an errno check in test case for. I believe that libuv needs to get updated to handle EUNATCH so that the error code can be addressed as `EUNATCH`. Similar to https://github.com/libuv/libuv/pull/3145


CC @nodejs/platform-ibmi
CC @richardlau 