### PR TITLE
crypto: re-add padding for AES-KW wrapped JWKs

### DIFF
--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -9,6 +9,7 @@ const {
   ReflectApply,
   ReflectConstruct,
   SafeSet,
+  StringPrototypeRepeat,
   SymbolToStringTag,
 } = primordials;
 
@@ -685,7 +686,16 @@ async function wrapKey(format, key, wrappingKey, algorithm) {
   let keyData = await ReflectApply(exportKey, this, [format, key]);
 
   if (format === 'jwk') {
-    keyData = new TextEncoder().encode(JSONStringify(keyData));
+    const ec = new TextEncoder();
+    const raw = JSONStringify(keyData);
+    // As per the NOTE in step 13 https://w3c.github.io/webcrypto/#SubtleCrypto-method-wrapKey
+    // we're padding AES-KW wrapped JWK to make sure it is always a multiple of 8 bytes
+    // in length
+    if (algorithm.name === 'AES-KW' && raw.length % 8 !== 0) {
+      keyData = ec.encode(raw + StringPrototypeRepeat(' ', 8 - (raw.length % 8)));
+    } else {
+      keyData = ec.encode(raw);
+    }
   }
 
   return cipherOrWrap(

--- a/test/parallel/test-webcrypto-wrap-unwrap.js
+++ b/test/parallel/test-webcrypto-wrap-unwrap.js
@@ -231,6 +231,10 @@ function getFormats(key) {
 // material length must be a multiple of 8.
 // If the wrapping algorithm is RSA-OAEP, the exported key
 // material maximum length is a factor of the modulusLength
+//
+// As per the NOTE in step 13 https://w3c.github.io/webcrypto/#SubtleCrypto-method-wrapKey
+// we're padding AES-KW wrapped JWK to make sure it is always a multiple of 8 bytes
+// in length
 async function wrappingIsPossible(name, exported) {
   if ('byteLength' in exported) {
     switch (name) {
@@ -239,13 +243,8 @@ async function wrappingIsPossible(name, exported) {
       case 'RSA-OAEP':
         return exported.byteLength <= 446;
     }
-  } else if ('kty' in exported) {
-    switch (name) {
-      case 'AES-KW':
-        return JSON.stringify(exported).length % 8 === 0;
-      case 'RSA-OAEP':
-        return JSON.stringify(exported).length <= 478;
-    }
+  } else if ('kty' in exported && name === 'RSA-OAEP') {
+    return JSON.stringify(exported).length <= 478;
   }
   return true;
 }


### PR DESCRIPTION
This re-introduces auto-padding of JWK exported keys that are to be wrapped with AES-KW if they don't meet the pre-conditions for AES-KW (length % 8 === 0). This is optional as per NOTE in step 13 of https://w3c.github.io/webcrypto/#SubtleCrypto-method-wrapKey.

> The key wrapping operations for some algorithms place constraints on the payload size. For example AES-KW requires the payload to be a multiple of 8 bytes in length and RSA-OAEP places a restriction on the length. For key formats that offer flexibility in serialization of a given key (for example JWK), implementations may choose to adapt the serialization to the constraints of the wrapping algorithm. This is why JSON.stringify is not normatively required, as otherwise it would prohibit implementations from introducing added padding.


This is being re-added because I have unfortunately removed it in #46067 due to not having any effect on test or WPT outcome. Now with enabled test vectors for it in `test/parallel/test-webcrypto-wrap-unwrap.js`.

When this PR lands I will add it to the v18.x backport of #46067 (#46252).