### PR TITLE
crypto: tweak `IsSupportedAuthenticatedMode` switch case

### DIFF
--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -27,7 +27,8 @@ using v8::Value;
 namespace crypto {
 namespace {
 bool IsSupportedAuthenticatedMode(const EVP_CIPHER* cipher) {
-  switch (EVP_CIPHER_mode(cipher)) {
+  const int mode = EVP_CIPHER_mode(cipher);
+  switch (mode) {
   case EVP_CIPH_CCM_MODE:
   case EVP_CIPH_GCM_MODE:
 #ifndef OPENSSL_NO_OCB


### PR DESCRIPTION
This causes type narrowing issues owing to incompatibilities between OpenSSL and BoringSSL:

```
../../third_party/electron_node/src/crypto/crypto_cipher.cc:32:8: error: case value evaluates to -1, which cannot be narrowed to type 'uint32_t' (aka 'unsigned int') [-Wc++11-narrowing]
  case EVP_CIPH_CCM_MODE:
       ^
../../third_party/boringssl/src/include/openssl/cipher.h:510:27: note: expanded from macro 'EVP_CIPH_CCM_MODE'
                          ^
1 error generated.
```

which are fixed by extracting the EVP_CIPHER_mode call. This allows Electron to remove a patch.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
