### PR TITLE
deps: copy `postject-api.h` and `LICENSE` to the `deps` folder

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -78,7 +78,7 @@ jobs:
                 ./tools/update-undici.sh
               fi
           - id: postject
-            subsystem: test
+            subsystem: deps,test
             label: test
             run: |
               NEW_VERSION=$(npm view postject dist-tags.latest)

--- a/deps/postject/LICENSE
+++ b/deps/postject/LICENSE
@@ -1,0 +1,236 @@
+Postject is licensed for use as follows:
+
+"""
+MIT License
+
+Copyright (c) 2022 Postman, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+The Postject license applies to all parts of Postject that are not externally
+maintained libraries.
+
+The externally maintained libraries used by Postject are:
+
+- LIEF, located at vendor/LIEF, is licensed as follows:
+  """
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+
+       APPENDIX: How to apply the Apache License to your work.
+
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "{}"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+
+       Copyright 2017 - 2022 R. Thomas
+       Copyright 2017 - 2022 Quarkslab
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+  """

--- a/deps/postject/postject-api.h
+++ b/deps/postject/postject-api.h
@@ -1,0 +1,197 @@
+#ifndef POSTJECT_API_H_
+#define POSTJECT_API_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <mach-o/dyld.h>
+#include <mach-o/getsect.h>
+#elif defined(__linux__)
+#include <elf.h>
+#include <link.h>
+#include <sys/auxv.h>
+#include <sys/param.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#endif
+
+#ifndef POSTJECT_SENTINEL_FUSE
+#define POSTJECT_SENTINEL_FUSE \
+  "POSTJECT_SENTINEL_fce680ab2cc467b6e072b8b5df1996b2"
+#endif
+
+struct postject_options {
+  const char* elf_section_name;
+  const char* macho_framework_name;
+  const char* macho_section_name;
+  const char* macho_segment_name;
+  const char* pe_resource_name;
+};
+
+inline void postject_options_init(struct postject_options* options) {
+  options->elf_section_name = NULL;
+  options->macho_framework_name = NULL;
+  options->macho_section_name = NULL;
+  options->macho_segment_name = NULL;
+  options->pe_resource_name = NULL;
+}
+
+static inline bool postject_has_resource() {
+  static const volatile char* sentinel = POSTJECT_SENTINEL_FUSE ":0";
+  return sentinel[sizeof(POSTJECT_SENTINEL_FUSE)] == '1';
+}
+
+static const void* postject_find_resource(
+    const char* name,
+    size_t* size,
+    const struct postject_options* options) {
+  // Always zero out the size pointer to start
+  if (size != NULL) {
+    *size = 0;
+  }
+
+#if defined(__APPLE__) && defined(__MACH__)
+  char* section_name = NULL;
+  const char* segment_name = "__POSTJECT";
+
+  if (options != NULL && options->macho_segment_name != NULL) {
+    segment_name = options->macho_segment_name;
+  }
+
+  if (options != NULL && options->macho_section_name != NULL) {
+    name = options->macho_section_name;
+  } else if (strncmp(name, "__", 2) != 0) {
+    // Automatically prepend __ to match naming convention
+    section_name = (char*)malloc(strlen(name) + 3);
+    if (section_name == NULL) {
+      return NULL;
+    }
+    strcpy(section_name, "__");
+    strcat(section_name, name);
+  }
+
+  unsigned long section_size;
+  char* ptr = NULL;
+  if (options != NULL && options->macho_framework_name != NULL) {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    ptr = getsectdatafromFramework(options->macho_framework_name, segment_name,
+                                   section_name != NULL ? section_name : name,
+                                   &section_size);
+  } else {
+    ptr = getsectdata(segment_name, section_name != NULL ? section_name : name,
+                      &section_size);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+    if (ptr != NULL) {
+      // Add the "virtual memory address slide" amount to ensure a valid pointer
+      // in cases where the virtual memory address have been adjusted by the OS.
+      //
+      // NOTE - `getsectdataFromFramework` already handles this adjustment for
+      //        us, which is why we only do it for `getsectdata`, see:
+      //        https://web.archive.org/web/20220613234007/https://opensource.apple.com/source/cctools/cctools-590/libmacho/getsecbyname.c.auto.html
+      ptr += _dyld_get_image_vmaddr_slide(0);
+    }
+  }
+
+  free(section_name);
+
+  if (size != NULL) {
+    *size = (size_t)section_size;
+  }
+
+  return ptr;
+#elif defined(__linux__)
+
+  if (options != NULL && options->elf_section_name != NULL) {
+    name = options->elf_section_name;
+  }
+
+  uintptr_t p = getauxval(AT_PHDR);
+  size_t n = getauxval(AT_PHNUM);
+  uintptr_t base_addr = p - sizeof(ElfW(Ehdr));
+
+  // iterate program header
+  for (; n > 0; n--, p += sizeof(ElfW(Phdr))) {
+    ElfW(Phdr)* phdr = (ElfW(Phdr)*)p;
+
+    // skip everything but notes
+    if (phdr->p_type != PT_NOTE) {
+      continue;
+    }
+
+    // note segment starts at base address + segment virtual address
+    uintptr_t pos = (base_addr + phdr->p_vaddr);
+    uintptr_t end = (pos + phdr->p_memsz);
+
+    // iterate through segment until we reach the end
+    while (pos < end) {
+      if (pos + sizeof(ElfW(Nhdr)) > end) {
+        break;  // invalid
+      }
+
+      ElfW(Nhdr)* note = (ElfW(Nhdr)*)(uintptr_t)pos;
+      if (note->n_namesz != 0 && note->n_descsz != 0 &&
+          strncmp((char*)(pos + sizeof(ElfW(Nhdr))), (char*)name,
+                  sizeof(name)) == 0) {
+        *size = note->n_descsz;
+        // advance past note header and aligned name
+        // to get to description data
+        return (void*)((uintptr_t)note + sizeof(ElfW(Nhdr)) +
+                       roundup(note->n_namesz, 4));
+      }
+
+      pos += (sizeof(ElfW(Nhdr)) + roundup(note->n_namesz, 4) +
+              roundup(note->n_descsz, 4));
+    }
+  }
+  return NULL;
+
+#elif defined(_WIN32)
+  void* ptr = NULL;
+  char* resource_name = NULL;
+
+  if (options != NULL && options->pe_resource_name != NULL) {
+    name = options->pe_resource_name;
+  } else {
+    // Automatically uppercase the resource name or it won't be found
+    resource_name = (char*)malloc(strlen(name) + 1);
+    if (resource_name == NULL) {
+      return NULL;
+    }
+    strcpy_s(resource_name, strlen(name) + 1, name);
+    CharUpperA(resource_name);  // Uppercases inplace
+  }
+
+  HRSRC resource_handle =
+      FindResourceA(NULL, resource_name != NULL ? resource_name : name,
+                    MAKEINTRESOURCEA(10) /* RT_RCDATA */);
+
+  if (resource_handle) {
+    HGLOBAL global_resource_handle = LoadResource(NULL, resource_handle);
+
+    if (global_resource_handle) {
+      if (size != NULL) {
+        *size = SizeofResource(NULL, resource_handle);
+      }
+
+      ptr = LockResource(global_resource_handle);
+    }
+  }
+
+  free(resource_name);
+
+  return ptr;
+#else
+  return NULL;
+#endif
+}
+
+#endif  // POSTJECT_API_H_

--- a/doc/contributing/maintaining-postject.md
+++ b/doc/contributing/maintaining-postject.md
@@ -12,12 +12,16 @@ Check that Node.js still builds and tests.
 
 ## Committing postject
 
-1. Add postject: `git add --all test/fixtures/postject-copy`.
+1. Add postject:
+   ```console
+   $ git add test/fixtures/postject-copy
+   $ git add deps/postject
+   ```
 2. Commit the changes: `git commit`.
 3. Add a message like:
 
    ```text
-   test: update postject to <version>
+   deps,test: update postject to <version>
 
    Updated as described in doc/contributing/maintaining-postject.md.
    ```

--- a/tools/dep_updaters/update-postject.sh
+++ b/tools/dep_updaters/update-postject.sh
@@ -20,3 +20,9 @@ NPM="$ROOT/deps/npm/bin/npm-cli.js"
 "$NODE" "$NPM" init --yes
 
 "$NODE" "$NPM" install --no-bin-links --ignore-scripts postject
+
+cd ../../..
+rm -rf deps/postject
+mkdir deps/postject
+cp test/fixtures/postject-copy/node_modules/postject/LICENSE deps/postject
+cp test/fixtures/postject-copy/node_modules/postject/dist/postject-api.h deps/postject

--- a/tools/dep_updaters/update-postject.sh
+++ b/tools/dep_updaters/update-postject.sh
@@ -21,6 +21,7 @@ NPM="$ROOT/deps/npm/bin/npm-cli.js"
 
 "$NODE" "$NPM" install --no-bin-links --ignore-scripts postject
 
+# TODO(RaisinTen): Replace following with $WORKSPACE
 cd ../../..
 rm -rf deps/postject
 mkdir deps/postject


### PR DESCRIPTION
Since `postject-api.h` gets compiled into Node.js, it makes more sense to put it in the `deps` directory instead of `test/fixtures`.

Refs: https://github.com/nodejs/node/pull/45038#discussion_r1100752158
Signed-off-by: Darshan Sen <raisinten@gmail.com>

cc @mhdawson @nodejs/single-executable

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
