### PR TITLE
src: allow optional Isolate termination in `node::Stop()`

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -911,10 +911,11 @@ void Environment::InitializeLibuv() {
   StartProfilerIdleNotifier();
 }
 
-void Environment::ExitEnv() {
+void Environment::ExitEnv(StopFlags::Flags flags) {
   // Should not access non-thread-safe methods here.
   set_stopping(true);
-  isolate_->TerminateExecution();
+  if ((flags & StopFlags::kDoNotTerminateIsolate) == 0)
+    isolate_->TerminateExecution();
   SetImmediateThreadsafe([](Environment* env) {
     env->set_can_call_into_js(false);
     uv_stop(env->event_loop());

--- a/src/env.h
+++ b/src/env.h
@@ -636,7 +636,7 @@ class Environment : public MemoryRetainer {
   void RegisterHandleCleanups();
   void CleanupHandles();
   void Exit(ExitCode code);
-  void ExitEnv();
+  void ExitEnv(StopFlags::Flags flags);
 
   // Register clean-up cb to be called on environment destruction.
   inline void RegisterHandleCleanup(uv_handle_t* handle,

--- a/src/node.cc
+++ b/src/node.cc
@@ -1254,7 +1254,11 @@ int Start(int argc, char** argv) {
 }
 
 int Stop(Environment* env) {
-  env->ExitEnv();
+  return Stop(env, StopFlags::kNoFlags);
+}
+
+int Stop(Environment* env, StopFlags::Flags flags) {
+  env->ExitEnv(flags);
   return 0;
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -273,6 +273,15 @@ enum Flags : uint32_t {
 }  // namespace ProcessInitializationFlags
 namespace ProcessFlags = ProcessInitializationFlags;  // Legacy alias.
 
+namespace StopFlags {
+enum Flags : uint32_t {
+  kNoFlags = 0,
+  // Do not explicitly terminate the Isolate
+  // when exiting the Environment.
+  kDoNotTerminateIsolate = 1 << 0,
+};
+}  // namespace StopFlags
+
 class NODE_EXTERN InitializationResult {
  public:
   virtual ~InitializationResult();
@@ -309,6 +318,7 @@ NODE_EXTERN int Start(int argc, char* argv[]);
 // Tear down Node.js while it is running (there are active handles
 // in the loop and / or actively executing JavaScript code).
 NODE_EXTERN int Stop(Environment* env);
+NODE_EXTERN int Stop(Environment* env, StopFlags::Flags flags);
 
 // Set up per-process state needed to run Node.js. This will consume arguments
 // from argv, fill exec_argv, and possibly add errors resulting from parsing


### PR DESCRIPTION
This patch allows for `node::Stop()` to conditionally call `v8:Isolate::TerminateExecution()`.

In several cases, we do not want to invoke a termination exception at exit when we're running with `only_terminate_in_safe_scope` set to false. Heap and coverage profilers run after environment exit and if there is a pending exception at this stage then they will fail to generate the appropriate profiles. This happens because V8's JSON logic, used by profilers [here](https://github.com/nodejs/node/blob/fcfde3412efbe7e990018c8453222d20a1a637ca/src/inspector_profiler.cc#L256), expects that there are no pending exceptions. Node.js does not call `node::Stop()` on teardown and therefore does not have this issue when also running with `only_terminate_in_safe_scope` set to false (this is the default). Before this change, we were working around the problem by calling `env->isolate()->CancelTerminateExecution()`, but it would be preferable to be able to specify it here.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
