### PR TITLE
tools: fix regex strings in Python tools

### DIFF
--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -501,7 +501,7 @@ def load_objects_from_file(objfilename, checktypes):
   #
   entries = typestr.split(',');
   for entry in entries:
-    types[re.sub(r'\s*=.*', '', entry).lstrip()] = True;
+    types[re.sub('\s*=.*', '', entry).lstrip()] = True;
   entries = torque_typestr.split('\\')
   for entry in entries:
     name = re.sub(r' *V\(|\).*', '', entry)
@@ -514,7 +514,7 @@ def load_objects_from_file(objfilename, checktypes):
     start = entry.find('(');
     end = entry.find(')', start);
     rest = entry[start + 1: end];
-    args = re.split(r'\s*,\s*', rest);
+    args = re.split('\s*,\s*', rest);
     typename = args[0]
     typeconst = args[1]
     types[typeconst] = True
@@ -617,7 +617,7 @@ def parse_field(call):
   idx = call.find('(');
   kind = call[0:idx];
   rest = call[idx + 1: len(call) - 1];
-  args = re.split(r'\s*,\s*', rest);
+  args = re.split('\s*,\s*', rest);
 
   consts = [];
 
@@ -718,7 +718,7 @@ def emit_set(out, consts):
 
   # Fix up overzealous parses.  This could be done inside the
   # parsers but as there are several, it's easiest to do it here.
-  ws = re.compile(r'\s+')
+  ws = re.compile('\s+')
   for const in consts:
     name = ws.sub('', const['name'])
     value = ws.sub('', str(const['value']))  # Can be a number.

--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -501,7 +501,7 @@ def load_objects_from_file(objfilename, checktypes):
   #
   entries = typestr.split(',');
   for entry in entries:
-    types[re.sub('\s*=.*', '', entry).lstrip()] = True;
+    types[re.sub(r'\s*=.*', '', entry).lstrip()] = True;
   entries = torque_typestr.split('\\')
   for entry in entries:
     name = re.sub(r' *V\(|\).*', '', entry)
@@ -514,7 +514,7 @@ def load_objects_from_file(objfilename, checktypes):
     start = entry.find('(');
     end = entry.find(')', start);
     rest = entry[start + 1: end];
-    args = re.split('\s*,\s*', rest);
+    args = re.split(r'\s*,\s*', rest);
     typename = args[0]
     typeconst = args[1]
     types[typeconst] = True
@@ -617,7 +617,7 @@ def parse_field(call):
   idx = call.find('(');
   kind = call[0:idx];
   rest = call[idx + 1: len(call) - 1];
-  args = re.split('\s*,\s*', rest);
+  args = re.split(r'\s*,\s*', rest);
 
   consts = [];
 
@@ -718,7 +718,7 @@ def emit_set(out, consts):
 
   # Fix up overzealous parses.  This could be done inside the
   # parsers but as there are several, it's easiest to do it here.
-  ws = re.compile('\s+')
+  ws = re.compile(r'\s+')
   for const in consts:
     name = ws.sub('', const['name'])
     value = ws.sub('', str(const['value']))  # Can be a number.

--- a/tools/getsharedopensslhasquic.py
+++ b/tools/getsharedopensslhasquic.py
@@ -14,7 +14,7 @@ def get_has_quic(include_path):
     except OSError:
       return False
 
-    regex = '^#\s*define OPENSSL_INFO_QUIC'
+    regex = r'^#\s*define OPENSSL_INFO_QUIC'
 
     for line in f:
       if (re.match(regex, line)):

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -92,7 +92,7 @@ INITIALIZER = '{{"{0}", UnionBytes{{{1}, {2}}} }},'
 
 CONFIG_GYPI_ID = 'config_raw'
 
-SLUGGER_RE =re.compile('[.\-/]')
+SLUGGER_RE =re.compile(r'[.\-/]')
 
 is_verbose = False
 

--- a/tools/v8_gypfiles/GN-scraper.py
+++ b/tools/v8_gypfiles/GN-scraper.py
@@ -3,7 +3,7 @@
 import re
 import os
 
-PLAIN_SOURCE_RE = re.compile('\s*"([^/$].+)"\s*')
+PLAIN_SOURCE_RE = re.compile(r'\s*"([^/$].+)"\s*')
 def DoMain(args):
   gn_filename, pattern = args
   src_root = os.path.dirname(gn_filename)


### PR DESCRIPTION
tools: fix regex strings in Python tools

Strings used to construct regular expressions shall be marked as raw
otherwise newer versions of Python throw "SyntaxError" because of
invalid escape sequences.

