### PR TITLE
os: improve network interface performance

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -28,7 +28,6 @@ const {
   ObjectDefineProperties,
   StringPrototypeEndsWith,
   StringPrototypeSlice,
-  StringPrototypeSplit,
   SymbolToPrimitive,
 } = primordials;
 
@@ -225,6 +224,7 @@ function getCIDR(address, netmask, family) {
   let range = 10;
   let groupLength = 8;
   let hasZeros = false;
+  let lastPos = 0;
 
   if (family === 'IPv6') {
     split = ':';
@@ -232,21 +232,30 @@ function getCIDR(address, netmask, family) {
     groupLength = 16;
   }
 
-  const parts = StringPrototypeSplit(netmask, split);
-  for (let i = 0; i < parts.length; i++) {
-    if (parts[i] !== '') {
-      const binary = NumberParseInt(parts[i], range);
-      const tmp = countBinaryOnes(binary);
-      ones += tmp;
+  for (let i = 0; i < netmask.length; i++) {
+    if (netmask[i] !== split) {
+      if (i + 1 < netmask.length) {
+        continue;
+      }
+      i++;
+    }
+    const part = StringPrototypeSlice(netmask, lastPos, i);
+    lastPos = i + 1;
+    if (part !== '') {
       if (hasZeros) {
-        if (tmp !== 0) {
+        if (part !== '0') {
           return null;
         }
-      } else if (tmp !== groupLength) {
-        if ((binary & 1) !== 0) {
-          return null;
+      } else {
+        const binary = NumberParseInt(part, range);
+        const binaryOnes = countBinaryOnes(binary);
+        ones += binaryOnes;
+        if (binaryOnes !== groupLength) {
+          if ((binary & 1) !== 0) {
+            return null;
+          }
+          hasZeros = true;
         }
-        hasZeros = true;
       }
     }
   }


### PR DESCRIPTION
This reduces the overhead of getCIDR() to a minimum. No array is allocated anymore and parts are directly sliced out of the netmask string instead.

```
                                confidence improvement accuracy (*)   (**)  (***)
os/networkInterfaces.js n=10000        ***      3.59 %       ±1.42% ±1.88% ±2.42%
```

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
