### PR TITLE
http: correctly calculate strict content length

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -391,7 +391,7 @@ function _writeRaw(data, encoding, callback, size) {
   }
 
   // TODO(sidwebworks): flip the `strictContentLength` default to `true` in a future PR
-  if (this.strictContentLength && size != null && conn && conn.writable && !this._removedContLen && this._hasBody) {
+  if (this.strictContentLength && size != null && !this._removedContLen && this._hasBody) {
     const skip = conn._httpMessage.statusCode === 304 || (this.hasHeader('transfer-encoding') || this.chunkedEncoding);
 
     if (typeof this._contentLength === 'number' && !skip) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -85,7 +85,6 @@ const HIGH_WATER_MARK = getDefaultHighWaterMark();
 const kCorked = Symbol('corked');
 const kUniqueHeaders = Symbol('kUniqueHeaders');
 const kBytesWritten = Symbol('kBytesWritten');
-const kEndCalled = Symbol('kEndCalled');
 const kErrored = Symbol('errored');
 
 const nop = () => {};
@@ -128,7 +127,6 @@ function OutgoingMessage() {
 
   this.strictContentLength = false;
   this[kBytesWritten] = 0;
-  this[kEndCalled] = false;
   this._contentLength = null;
   this._hasBody = true;
   this._trailer = '';
@@ -389,21 +387,18 @@ function _writeRaw(data, encoding, callback, size) {
     encoding = null;
   }
 
-  // TODO(sidwebworks): flip the `strictContentLength` default to `true` in a future PR
-  if (this.strictContentLength && size != null && !this._removedContLen && this._hasBody) {
-    const skip = conn._httpMessage.statusCode === 304 || (this.hasHeader('transfer-encoding') || this.chunkedEncoding);
-
-    if (typeof this._contentLength === 'number' && !skip) {
-      if ((size + this[kBytesWritten]) > this._contentLength) {
-        throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(size + this[kBytesWritten], this._contentLength);
-      }
-
-      if (this[kEndCalled] && (size + this[kBytesWritten]) !== this._contentLength) {
-        throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(size + this[kBytesWritten], this._contentLength);
-      }
-
-      this[kBytesWritten] += size;
+  if (size != null) {
+    if (
+      this.strictContentLength &&
+      this._hasBody &&
+      !this._removedContLen &&
+      !this.chunkedEncoding &&
+      this[kBytesWritten] + size > this._contentLength &&
+      !this.hasHeader('transfer-encoding')
+    ) {
+      throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(size + this[kBytesWritten], this._contentLength);
     }
+    this[kBytesWritten] += size;
   }
 
   if (conn && conn._httpMessage === this && conn.writable) {
@@ -990,8 +985,6 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     encoding = null;
   }
 
-  this[kEndCalled] = true;
-
   if (chunk) {
     if (this.finished) {
       onError(this,
@@ -1025,6 +1018,17 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
 
   if (typeof callback === 'function')
     this.once('finish', callback);
+
+  if (
+    this.strictContentLength &&
+    this._hasBody &&
+    !this._removedContLen &&
+    !this.chunkedEncoding &&
+    this[kBytesWritten] !== this._contentLength &&
+    !this.hasHeader('transfer-encoding')
+  ) {
+    throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(this[kBytesWritten], this._contentLength);
+  }
 
   const finish = onFinish.bind(undefined, this);
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -351,7 +351,7 @@ OutgoingMessage.prototype.destroy = function destroy(error) {
 
 
 // This abstract either writing directly to the socket or buffering it.
-OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
+OutgoingMessage.prototype._send = function _send(data, encoding, callback, byteLength) {
   // This is a shameful hack to get the headers and first body chunk onto
   // the same packet. Future versions of Node are going to take care of
   // this at a lower level and in a more general way.
@@ -373,20 +373,11 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
     }
     this._headerSent = true;
   }
-  return this._writeRaw(data, encoding, callback);
+  return this._writeRaw(data, encoding, callback, byteLength);
 };
 
-function _getMessageBodySize(chunk, headers, encoding) {
-  if (Buffer.isBuffer(chunk)) return chunk.length;
-  const chunkLength = chunk ? Buffer.byteLength(chunk, encoding) : 0;
-  const headerLength = headers ? headers.length : 0;
-  if (headerLength === chunkLength) return 0;
-  if (headerLength < chunkLength) return MathAbs(chunkLength - headerLength);
-  return chunkLength;
-}
-
 OutgoingMessage.prototype._writeRaw = _writeRaw;
-function _writeRaw(data, encoding, callback) {
+function _writeRaw(data, encoding, callback, size) {
   const conn = this.socket;
   if (conn && conn.destroyed) {
     // The socket was destroyed. If we're still trying to write to it,
@@ -400,12 +391,10 @@ function _writeRaw(data, encoding, callback) {
   }
 
   // TODO(sidwebworks): flip the `strictContentLength` default to `true` in a future PR
-  if (this.strictContentLength && conn && conn.writable && !this._removedContLen && this._hasBody) {
+  if (this.strictContentLength && size != null && conn && conn.writable && !this._removedContLen && this._hasBody) {
     const skip = conn._httpMessage.statusCode === 304 || (this.hasHeader('transfer-encoding') || this.chunkedEncoding);
 
     if (typeof this._contentLength === 'number' && !skip) {
-      const size = _getMessageBodySize(data, conn._httpMessage._header, encoding);
-
       if ((size + this[kBytesWritten]) > this._contentLength) {
         throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(size + this[kBytesWritten], this._contentLength);
       }
@@ -898,6 +887,10 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
 
   let len;
 
+  if (this.strictContentLength) {
+    len = typeof chunk === 'string' ? Buffer.byteLength(chunk, encoding) : chunk.byteLength;
+  }
+
   if (!msg._header) {
     if (fromEnd) {
       len ??= typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength;
@@ -920,13 +913,13 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
 
   let ret;
   if (msg.chunkedEncoding && chunk.length !== 0) {
-    len ??= typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength;
+    len ??= typeof chunk === 'string' ? Buffer.byteLength(chunk, encoding) : chunk.byteLength;
     msg._send(NumberPrototypeToString(len, 16), 'latin1', null);
     msg._send(crlf_buf, null, null);
-    msg._send(chunk, encoding, null);
+    msg._send(chunk, encoding, null, len);
     ret = msg._send(crlf_buf, null, callback);
   } else {
-    ret = msg._send(chunk, encoding, callback);
+    ret = msg._send(chunk, encoding, callback, len);
   }
 
   debug('write ret = ' + ret);
@@ -1039,7 +1032,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
   if (this._hasBody && this.chunkedEncoding) {
     this._send('0\r\n' + this._trailer + '\r\n', 'latin1', finish);
   } else if (!this._headerSent || this.writableLength || chunk) {
-    this._send('', 'latin1', finish);
+    this._send('', 'latin1', finish, 0);
   } else {
     process.nextTick(finish);
   }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -1032,7 +1032,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
   if (this._hasBody && this.chunkedEncoding) {
     this._send('0\r\n' + this._trailer + '\r\n', 'latin1', finish);
   } else if (!this._headerSent || this.writableLength || chunk) {
-    this._send('', 'latin1', finish, 0);
+    this._send('', 'latin1', finish);
   } else {
     process.nextTick(finish);
   }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -873,14 +873,9 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
   if (typeof callback !== 'function')
     callback = nop;
 
-  let len;
   if (chunk === null) {
     throw new ERR_STREAM_NULL_VALUES();
-  } else if (typeof chunk === 'string') {
-    len = Buffer.byteLength(chunk, encoding);
-  } else if (isUint8Array(chunk)) {
-    len = chunk.length;
-  } else {
+  } else if (typeof chunk !== 'string' && !isUint8Array(chunk)) {
     throw new ERR_INVALID_ARG_TYPE(
       'chunk', ['string', 'Buffer', 'Uint8Array'], chunk);
   }
@@ -901,8 +896,11 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     return false;
   }
 
+  let len;
+
   if (!msg._header) {
     if (fromEnd) {
+      len ??= typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength;
       msg._contentLength = len;
     }
     msg._implicitHeader();
@@ -922,6 +920,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
 
   let ret;
   if (msg.chunkedEncoding && chunk.length !== 0) {
+    len ??= typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength;
     msg._send(NumberPrototypeToString(len, 16), 'latin1', null);
     msg._send(crlf_buf, null, null);
     msg._send(chunk, encoding, null);

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -25,7 +25,6 @@ const {
   Array,
   ArrayIsArray,
   ArrayPrototypeJoin,
-  MathAbs,
   MathFloor,
   NumberPrototypeToString,
   ObjectDefineProperty,

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -387,20 +387,6 @@ function _writeRaw(data, encoding, callback, size) {
     encoding = null;
   }
 
-  if (size != null) {
-    if (
-      this.strictContentLength &&
-      this._hasBody &&
-      !this._removedContLen &&
-      !this.chunkedEncoding &&
-      this[kBytesWritten] + size > this._contentLength &&
-      !this.hasHeader('transfer-encoding')
-    ) {
-      throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(size + this[kBytesWritten], this._contentLength);
-    }
-    this[kBytesWritten] += size;
-  }
-
   if (conn && conn._httpMessage === this && conn.writable) {
     // There might be pending data in the this.output buffer.
     if (this.outputData.length) {
@@ -852,6 +838,17 @@ function emitErrorNt(msg, err, callback) {
   }
 }
 
+function strictContentLength(msg) {
+  return (
+    msg._contentLength != null &&
+    msg.strictContentLength &&
+    msg._hasBody &&
+    !msg._removedContLen &&
+    !msg.chunkedEncoding &&
+    !msg.hasHeader('transfer-encoding')
+  )
+}
+
 function write_(msg, chunk, encoding, callback, fromEnd) {
   if (typeof callback !== 'function')
     callback = nop;
@@ -879,10 +876,15 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     return false;
   }
 
-  let len;
+  let len = msg.strictContentLength ?
+    typeof chunk === 'string' ? Buffer.byteLength(chunk, encoding) : chunk.byteLength : null;
 
-  if (msg.strictContentLength) {
-    len = typeof chunk === 'string' ? Buffer.byteLength(chunk, encoding) : chunk.byteLength;
+  if (len != null) {
+    if (strictContentLength(msg) && (fromEnd ? msg[kBytesWritten] + len !== msg._contentLength : msg[kBytesWritten] + len > msg._contentLength)
+    ) {
+      throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(len + msg[kBytesWritten], msg._contentLength);
+    }
+    msg[kBytesWritten] += len;
   }
 
   if (!msg._header) {
@@ -1019,14 +1021,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
   if (typeof callback === 'function')
     this.once('finish', callback);
 
-  if (
-    this.strictContentLength &&
-    this._hasBody &&
-    !this._removedContLen &&
-    !this.chunkedEncoding &&
-    this[kBytesWritten] !== this._contentLength &&
-    !this.hasHeader('transfer-encoding')
-  ) {
+  if (strictContentLength(this) && this[kBytesWritten] !== this._contentLength) {
     throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(this[kBytesWritten], this._contentLength);
   }
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -840,13 +840,13 @@ function emitErrorNt(msg, err, callback) {
 
 function strictContentLength(msg) {
   return (
-    msg._contentLength != null &&
     msg.strictContentLength &&
+    msg._contentLength != null &&
     msg._hasBody &&
     !msg._removedContLen &&
     !msg.chunkedEncoding &&
     !msg.hasHeader('transfer-encoding')
-  )
+  );
 }
 
 function write_(msg, chunk, encoding, callback, fromEnd) {
@@ -880,7 +880,9 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     typeof chunk === 'string' ? Buffer.byteLength(chunk, encoding) : chunk.byteLength : null;
 
   if (len != null) {
-    if (strictContentLength(msg) && (fromEnd ? msg[kBytesWritten] + len !== msg._contentLength : msg[kBytesWritten] + len > msg._contentLength)
+    if (
+      strictContentLength(msg) &&
+      (fromEnd ? msg[kBytesWritten] + len !== msg._contentLength : msg[kBytesWritten] + len > msg._contentLength)
     ) {
       throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(len + msg[kBytesWritten], msg._contentLength);
     }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -893,7 +893,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
 
   if (!msg._header) {
     if (fromEnd) {
-      len ??= typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength;
+      len ??= typeof chunk === 'string' ? Buffer.byteLength(chunk, encoding) : chunk.byteLength;
       msg._contentLength = len;
     }
     msg._implicitHeader();

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -886,7 +886,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
 
   let len;
 
-  if (this.strictContentLength) {
+  if (msg.strictContentLength) {
     len = typeof chunk === 'string' ? Buffer.byteLength(chunk, encoding) : chunk.byteLength;
   }
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -876,16 +876,18 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     return false;
   }
 
-  let len = msg.strictContentLength ?
-    typeof chunk === 'string' ? Buffer.byteLength(chunk, encoding) : chunk.byteLength : null;
+  let len;
 
-  if (len != null) {
+  if (msg.strictContentLength) {
+    len ??= typeof chunk === 'string' ? Buffer.byteLength(chunk, encoding) : chunk.byteLength;
+
     if (
       strictContentLength(msg) &&
       (fromEnd ? msg[kBytesWritten] + len !== msg._contentLength : msg[kBytesWritten] + len > msg._contentLength)
     ) {
       throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(len + msg[kBytesWritten], msg._contentLength);
     }
+
     msg[kBytesWritten] += len;
   }
 

--- a/test/parallel/test-http-content-length-mismatch.js
+++ b/test/parallel/test-http-content-length-mismatch.js
@@ -57,7 +57,7 @@ function shouldThrowOnFewerBytes() {
     res.write('a');
     res.statusCode = 200;
     assert.throws(() => {
-      res.end();
+      res.end('aaa');
     }, {
       code: 'ERR_HTTP_CONTENT_LENGTH_MISMATCH'
     });


### PR DESCRIPTION
Previously Buffer.byteLength (which is slow) was run regardless of whether or not the len was required.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
