### PR TITLE
test_runner: add `describe.only` and `it.only` shorthands

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -808,6 +808,15 @@ Shorthand for skipping a suite, same as [`describe([name], { skip: true }[, fn])
 Shorthand for marking a suite as `TODO`, same as
 [`describe([name], { todo: true }[, fn])`][describe options].
 
+## `describe.only([name][, options][, fn])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Shorthand for marking a suite as `only`, same as
+[`describe([name], { only: true }[, fn])`][describe options].
+
 ## `it([name][, options][, fn])`
 
 * `name` {string} The name of the test, which is displayed when reporting test
@@ -831,6 +840,15 @@ same as [`it([name], { skip: true }[, fn])`][it options].
 
 Shorthand for marking a test as `TODO`,
 same as [`it([name], { todo: true }[, fn])`][it options].
+
+## `it.only([name][, options][, fn])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Shorthand for marking a test as `only`,
+same as [`it([name], { only: true }[, fn])`][it options].
 
 ## `before([fn][, options])`
 

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -191,7 +191,7 @@ function runInParentContext(Factory) {
     run(name, options, fn);
   };
 
-  ArrayPrototypeForEach(['skip', 'todo'], (keyword) => {
+  ArrayPrototypeForEach(['skip', 'todo', 'only'], (keyword) => {
     cb[keyword] = (name, options, fn) => {
       run(name, options, fn, { [keyword]: true });
     };

--- a/test/message/test_runner_only_tests.js
+++ b/test/message/test_runner_only_tests.js
@@ -1,7 +1,7 @@
 // Flags: --no-warnings --test-only
 'use strict';
 require('../common');
-const test = require('node:test');
+const { test, describe, it } = require('node:test');
 
 // These tests should be skipped based on the 'only' option.
 test('only = undefined');
@@ -45,4 +45,38 @@ test('only = true, with subtests', { only: true }, async (t) => {
   // Explicitly do not run these tests.
   await t.test('skipped subtest 3', { only: false });
   await t.test('skipped subtest 4', { skip: true });
+});
+
+describe.only('describe only = true, with subtests', () => {
+  it('`it` subtest 1 should run', () => {});
+
+  it('`it` subtest 2 should run', async () => {});
+});
+
+describe.only('describe only = true, with a mixture of subtests', () => {
+  it.only('`it` subtest 1', () => {});
+
+  it.only('`it` async subtest 1', async () => {});
+
+  it('`it` subtest 2 only=true', { only: true });
+
+  it('`it` subtest 2 only=false', { only: false }, () => {
+    throw new Error('This should not run');
+  });
+
+  it.skip('`it` subtest 3 skip', () => {
+    throw new Error('This should not run');
+  });
+
+  it.todo('`it` subtest 4 todo', { only: false }, () => {
+    throw new Error('This should not run');
+  });
+});
+
+describe.only('describe only = true, with subtests', () => {
+  test('subtest should run', () => {});
+
+  test('async subtest should run', async () => {});
+
+  test('subtest should be skipped', { only: false }, () => {});
 });

--- a/test/message/test_runner_only_tests.out
+++ b/test/message/test_runner_only_tests.out
@@ -116,9 +116,82 @@ ok 11 - only = true, with subtests
   ---
   duration_ms: *
   ...
-1..11
-# tests 11
-# pass 1
+# Subtest: describe only = true, with subtests
+    # Subtest: `it` subtest 1 should run
+    ok 1 - `it` subtest 1 should run
+      ---
+      duration_ms: *
+      ...
+    # Subtest: `it` subtest 2 should run
+    ok 2 - `it` subtest 2 should run
+      ---
+      duration_ms: *
+      ...
+    1..2
+ok 12 - describe only = true, with subtests
+  ---
+  duration_ms: *
+  ...
+# Subtest: describe only = true, with a mixture of subtests
+    # Subtest: `it` subtest 1
+    ok 1 - `it` subtest 1
+      ---
+      duration_ms: *
+      ...
+    # Subtest: `it` async subtest 1
+    ok 2 - `it` async subtest 1
+      ---
+      duration_ms: *
+      ...
+    # Subtest: `it` subtest 2 only=true
+    ok 3 - `it` subtest 2 only=true
+      ---
+      duration_ms: *
+      ...
+    # Subtest: `it` subtest 2 only=false
+    ok 4 - `it` subtest 2 only=false # SKIP 'only' option not set
+      ---
+      duration_ms: *
+      ...
+    # Subtest: `it` subtest 3 skip
+    ok 5 - `it` subtest 3 skip # SKIP
+      ---
+      duration_ms: *
+      ...
+    # Subtest: `it` subtest 4 todo
+    ok 6 - `it` subtest 4 todo # SKIP 'only' option not set
+      ---
+      duration_ms: *
+      ...
+    1..6
+ok 13 - describe only = true, with a mixture of subtests
+  ---
+  duration_ms: *
+  ...
+# Subtest: describe only = true, with subtests
+    # Subtest: subtest should run
+    ok 1 - subtest should run
+      ---
+      duration_ms: *
+      ...
+    # Subtest: async subtest should run
+    ok 2 - async subtest should run
+      ---
+      duration_ms: *
+      ...
+    # Subtest: subtest should be skipped
+    ok 3 - subtest should be skipped # SKIP 'only' option not set
+      ---
+      duration_ms: *
+      ...
+    1..3
+ok 14 - describe only = true, with subtests
+  ---
+  duration_ms: *
+  ...
+1..14
+# tests 14
+# pass 4
 # fail 0
 # cancelled 0
 # skipped 10


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes: https://github.com/nodejs/node/issues/46562

This PR adds support for `describe.only` and `it.only` shorthands in the test_runner. It follows the existing semantics for how `only` works.