### PR TITLE
vm: properly handle defining props on any value

### DIFF
--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -136,6 +136,7 @@
   V(frames_received_string, "framesReceived")                                  \
   V(frames_sent_string, "framesSent")                                          \
   V(function_string, "function")                                               \
+  V(get_string, "get")                                                         \
   V(get_data_clone_error_string, "_getDataCloneError")                         \
   V(get_shared_array_buffer_id_string, "_getSharedArrayBufferId")              \
   V(gid_string, "gid")                                                         \
@@ -271,6 +272,7 @@
   V(servername_string, "servername")                                           \
   V(service_string, "service")                                                 \
   V(session_id_string, "sessionId")                                            \
+  V(set_string, "set")                                                         \
   V(shell_string, "shell")                                                     \
   V(signal_string, "signal")                                                   \
   V(sink_string, "sink")                                                       \

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -533,13 +533,11 @@ void ContextifyContext::PropertySetterCallback(
           ->GetOwnPropertyDescriptor(context, property)
           .ToLocal(&desc) &&
       desc->IsObject()) {
+    Environment* env = Environment::GetCurrent(context);
     Local<Object> desc_obj = desc.As<Object>();
-    Isolate* isolate = context->GetIsolate();
-    Local<Name> get = String::NewFromUtf8(isolate, "get").ToLocalChecked();
-    Local<Name> set = String::NewFromUtf8(isolate, "set").ToLocalChecked();
     is_get_set_property =
-        desc_obj->HasOwnProperty(context, get).FromMaybe(false) ||
-        desc_obj->HasOwnProperty(context, set).FromMaybe(false);
+        desc_obj->HasOwnProperty(context, env->get_string()).FromMaybe(false) ||
+        desc_obj->HasOwnProperty(context, env->set_string()).FromMaybe(false);
   }
 
   USE(ctx->sandbox()->Set(context, property, value));

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -526,7 +526,7 @@ void ContextifyContext::PropertySetterCallback(
       !is_function)
     return;
 
-  USE(ctx->sandbox()->Set(context, property, value));
+  if (ctx->sandbox()->Set(context, property, value).IsNothing()) return;
 
   Local<Value> desc;
   if (is_declared_on_sandbox &&
@@ -538,8 +538,8 @@ void ContextifyContext::PropertySetterCallback(
 
     // We have to specify the return value for any contextual or get/set
     // property
-    if (desc_obj->HasOwnProperty(context, env->get_string()).FromJust() ||
-        desc_obj->HasOwnProperty(context, env->set_string()).FromJust())
+    if (desc_obj->HasOwnProperty(context, env->get_string()).FromMaybe(false) ||
+        desc_obj->HasOwnProperty(context, env->set_string()).FromMaybe(false))
       args.GetReturnValue().Set(value);
   }
 }

--- a/test/parallel/test-vm-global-setter.js
+++ b/test/parallel/test-vm-global-setter.js
@@ -3,27 +3,156 @@ const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
+const getSetSymbolReceivingFunction = Symbol('sym-1');
+const getSetSymbolReceivingNumber = Symbol('sym-2');
+const symbolReceivingNumber = Symbol('sym-3');
+const unknownSymbolReceivingNumber = Symbol('sym-4');
+
 const window = createWindow();
 
-const descriptor =
-  Object.getOwnPropertyDescriptor(window.globalProxy, 'onhashchange');
+const descriptor1 = Object.getOwnPropertyDescriptor(
+  window.globalProxy,
+  'getSetPropReceivingFunction'
+);
+assert.strictEqual(typeof descriptor1.get, 'function');
+assert.strictEqual(typeof descriptor1.set, 'function');
+assert.strictEqual(descriptor1.configurable, true);
 
-assert.strictEqual(typeof descriptor.get, 'function');
-assert.strictEqual(typeof descriptor.set, 'function');
-assert.strictEqual(descriptor.configurable, true);
+const descriptor2 = Object.getOwnPropertyDescriptor(
+  window.globalProxy,
+  'getSetPropReceivingNumber'
+);
+assert.strictEqual(typeof descriptor2.get, 'function');
+assert.strictEqual(typeof descriptor2.set, 'function');
+assert.strictEqual(descriptor2.configurable, true);
+
+const descriptor3 = Object.getOwnPropertyDescriptor(
+  window.globalProxy,
+  'propReceivingNumber'
+);
+assert.strictEqual(descriptor3.value, 44);
+
+const descriptor4 = Object.getOwnPropertyDescriptor(
+  window.globalProxy,
+  'unknownPropReceivingNumber'
+);
+assert.strictEqual(descriptor4, undefined);
+
+const descriptor5 = Object.getOwnPropertyDescriptor(
+  window.globalProxy,
+  getSetSymbolReceivingFunction
+);
+assert.strictEqual(typeof descriptor5.get, 'function');
+assert.strictEqual(typeof descriptor5.set, 'function');
+assert.strictEqual(descriptor5.configurable, true);
+
+const descriptor6 = Object.getOwnPropertyDescriptor(
+  window.globalProxy,
+  getSetSymbolReceivingNumber
+);
+assert.strictEqual(typeof descriptor6.get, 'function');
+assert.strictEqual(typeof descriptor6.set, 'function');
+assert.strictEqual(descriptor6.configurable, true);
+
+const descriptor7 = Object.getOwnPropertyDescriptor(
+  window.globalProxy,
+  symbolReceivingNumber
+);
+assert.strictEqual(descriptor7.value, 48);
+
+const descriptor8 = Object.getOwnPropertyDescriptor(
+  window.globalProxy,
+  unknownSymbolReceivingNumber
+);
+assert.strictEqual(descriptor8, undefined);
+
+const descriptor9 = Object.getOwnPropertyDescriptor(
+  window.globalProxy,
+  'getSetPropThrowing'
+);
+assert.strictEqual(typeof descriptor9.get, 'function');
+assert.strictEqual(typeof descriptor9.set, 'function');
+assert.strictEqual(descriptor9.configurable, true);
+
+const descriptor10 = Object.getOwnPropertyDescriptor(
+  window.globalProxy,
+  'nonWritableProp'
+);
+assert.strictEqual(descriptor10.value, 51);
+assert.strictEqual(descriptor10.writable, false);
 
 // Regression test for GH-42962. This assignment should not throw.
-window.globalProxy.onhashchange = () => {};
+window.globalProxy.getSetPropReceivingFunction = () => {};
+assert.strictEqual(window.globalProxy.getSetPropReceivingFunction, 42);
 
-assert.strictEqual(window.globalProxy.onhashchange, 42);
+window.globalProxy.getSetPropReceivingNumber = 143;
+assert.strictEqual(window.globalProxy.getSetPropReceivingNumber, 43);
+
+window.globalProxy.propReceivingNumber = 144;
+assert.strictEqual(window.globalProxy.propReceivingNumber, 144);
+
+window.globalProxy.unknownPropReceivingNumber = 145;
+assert.strictEqual(window.globalProxy.unknownPropReceivingNumber, 145);
+
+window.globalProxy[getSetSymbolReceivingFunction] = () => {};
+assert.strictEqual(window.globalProxy[getSetSymbolReceivingFunction], 46);
+
+window.globalProxy[getSetSymbolReceivingNumber] = 147;
+assert.strictEqual(window.globalProxy[getSetSymbolReceivingNumber], 47);
+
+window.globalProxy[symbolReceivingNumber] = 148;
+assert.strictEqual(window.globalProxy[symbolReceivingNumber], 148);
+
+window.globalProxy[unknownSymbolReceivingNumber] = 149;
+assert.strictEqual(window.globalProxy[unknownSymbolReceivingNumber], 149);
+
+assert.throws(
+  () => (window.globalProxy.getSetPropThrowing = 150),
+  new Error('setter called')
+);
+assert.strictEqual(window.globalProxy.getSetPropThrowing, 50);
+
+assert.throws(
+  () => (window.globalProxy.nonWritableProp = 151),
+  new TypeError('Cannot redefine property: nonWritableProp')
+);
+assert.strictEqual(window.globalProxy.nonWritableProp, 51);
 
 function createWindow() {
   const obj = {};
   vm.createContext(obj);
-  Object.defineProperty(obj, 'onhashchange', {
+  Object.defineProperty(obj, 'getSetPropReceivingFunction', {
     get: common.mustCall(() => 42),
     set: common.mustCall(),
-    configurable: true
+    configurable: true,
+  });
+  Object.defineProperty(obj, 'getSetPropReceivingNumber', {
+    get: common.mustCall(() => 43),
+    set: common.mustCall(),
+    configurable: true,
+  });
+  obj.propReceivingNumber = 44;
+  Object.defineProperty(obj, getSetSymbolReceivingFunction, {
+    get: common.mustCall(() => 46),
+    set: common.mustCall(),
+    configurable: true,
+  });
+  Object.defineProperty(obj, getSetSymbolReceivingNumber, {
+    get: common.mustCall(() => 47),
+    set: common.mustCall(),
+    configurable: true,
+  });
+  obj[symbolReceivingNumber] = 48;
+  Object.defineProperty(obj, 'getSetPropThrowing', {
+    get: common.mustCall(() => 50),
+    set: common.mustCall(() => {
+      throw new Error('setter called');
+    }),
+    configurable: true,
+  });
+  Object.defineProperty(obj, 'nonWritableProp', {
+    value: 51,
+    writable: false,
   });
 
   obj.globalProxy = vm.runInContext('this', obj);

--- a/test/parallel/test-vm-global-symbol.js
+++ b/test/parallel/test-vm-global-symbol.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const vm = require('vm');
 
 const global = vm.runInContext('this', vm.createContext());
+
 const totoSymbol = Symbol.for('toto');
 Object.defineProperty(global, totoSymbol, {
   enumerable: true,
@@ -13,3 +14,13 @@ Object.defineProperty(global, totoSymbol, {
 });
 assert.strictEqual(global[totoSymbol], 4);
 assert.ok(Object.getOwnPropertySymbols(global).includes(totoSymbol));
+
+const totoKey = 'toto';
+Object.defineProperty(global, totoKey, {
+  enumerable: true,
+  writable: true,
+  value: 5,
+  configurable: true,
+});
+assert.strictEqual(global[totoKey], 5);
+assert.ok(Object.getOwnPropertyNames(global).includes(totoKey));

--- a/test/parallel/test-vm-not-strict.js
+++ b/test/parallel/test-vm-not-strict.js
@@ -1,7 +1,7 @@
-/* eslint-disable strict, no-var, no-delete-var, node-core/required-modules, node-core/require-common-first */
-// While common, should be used as first require of the test, using it causes errors: Unexpected global(s) found: data, b.
-// Actually in this specific test case calling vm.runInThisContext exposes variables outside of the vm (behaviour existing since at least v14).
-// The other rules (strict, no-var, no-delete-var) have been disabled to test this specific not strict case.
+/* eslint-disable strict, no-var, no-delete-var, no-undef, node-core/required-modules, node-core/require-common-first */
+// Importing common would break the execution. Indeed running `vm.runInThisContext` alters the global context
+// when declaring new variables with `var`. The other rules (strict, no-var, no-delete-var) have been disabled
+// in order to be able to test this specific not-strict case playing with `var` and `delete`.
 // Related to bug report: https://github.com/nodejs/node/issues/43129
 var assert = require('assert');
 var vm = require('vm');
@@ -33,7 +33,5 @@ data.push(c);
 
 assert.deepStrictEqual(data, ['direct', 'this', 'new']);
 
-// While the variables have been declared in the vm context, they are accessible in the global one too.
-// This behaviour has been there at least from v14 of node, and still exist in 16 and 18.
-assert.equal(typeof unusedB, 'number');
-assert.equal(typeof unusedC, 'number');
+assert.strictEqual(typeof unusedB, 'number'); // Declared within runInThisContext
+assert.strictEqual(typeof unusedC, 'undefined'); // Declared within runInContext

--- a/test/parallel/test-vm-not-strict.js
+++ b/test/parallel/test-vm-not-strict.js
@@ -1,0 +1,39 @@
+/* eslint-disable strict, no-var, no-delete-var, node-core/required-modules, node-core/require-common-first */
+// While common, should be used as first require of the test, using it causes errors: Unexpected global(s) found: data, b.
+// Actually in this specific test case calling vm.runInThisContext exposes variables outside of the vm (behaviour existing since at least v14).
+// The other rules (strict, no-var, no-delete-var) have been disabled to test this specific not strict case.
+// Related to bug report: https://github.com/nodejs/node/issues/43129
+var assert = require('assert');
+var vm = require('vm');
+
+var data = [];
+var a = 'direct';
+delete a;
+data.push(a);
+
+var item2 = vm.runInThisContext(`
+var unusedB = 1;
+var data = [];
+var b = "this";
+delete b;
+data.push(b);
+data[0]
+`);
+data.push(item2);
+
+vm.runInContext(
+  `
+var unusedC = 1;
+var c = "new";
+delete c;
+data.push(c);
+`,
+  vm.createContext({ data: data })
+);
+
+assert.deepStrictEqual(data, ['direct', 'this', 'new']);
+
+// While the variables have been declared in the vm context, they are accessible in the global one too.
+// This behaviour has been there at least from v14 of node, and still exist in 16 and 18.
+assert.equal(typeof unusedB, 'number');
+assert.equal(typeof unusedC, 'number');


### PR DESCRIPTION
While it was supposed to fix most of the remaining issues, https://github.com/nodejs/node/pull/46458 missed some in strict mode.

This PR adds some additional checks.

It also clarifies what we are really checking to execute or not the `GetReturnValue`. The `is_function` I resurrected from 17.x was actually not a good option as it made some assignations of non-function values starting to fail. It seems that while it was relevant in 17.x, it was probably not the best option for 18.x.

Fix #43129

---

Here is a quick overview of what worked or not for each version of node:

<details>
<summary>OwnPropertySymbols should list new symbols</summary>

```js
const totoSymbol = Symbol.for('toto');
Object.defineProperty(global, totoSymbol, {
  enumerable: true,
  writable: true,
  value: 4,
  configurable: true,
});
assert.strictEqual(global[totoSymbol], 4);
assert.ok(Object.getOwnPropertySymbols(global).includes(totoSymbol));
```

- [x] Pass on 17.9.0
- [x] Pass on 18.0.0
- [ ] Pass on 18.2.0 (after #42963)
- [x] Pass after #46458
</details>

<details>
<summary>OwnPropertyNames should list new keys</summary>

```js
const totoKey = 'toto';
Object.defineProperty(global, totoKey, {
  enumerable: true,
  writable: true,
  value: 5,
  configurable: true,
});
assert.strictEqual(global[totoKey], 5);
assert.ok(Object.getOwnPropertyNames(global).includes(totoKey));
```

- [x] Pass on 17.9.0
- [x] Pass on 18.0.0
- [x] Pass on 18.2.0 (after #42963)
- [x] Pass after #46458
</details>

<details>
<summary>Override proxy with function</summary>

```js
window.globalProxy.prop1 = () => {};
assert.strictEqual(window.globalProxy.prop1, 42);
```

- [x] Pass on 17.9.0
- [ ] Pass on 18.0.0
- [x] Pass on 18.2.0 (after #42963)
- [x] Pass after #46458
</details>

<details>
<summary>Override proxy with number</summary>

```js
window.globalProxy.prop2 = 143;
assert.strictEqual(window.globalProxy.prop2, 43);
```

- [x] Pass on 17.9.0
- [ ] Pass on 18.0.0
- [x] Pass on 18.2.0 (after #42963)
- [ ] Pass after #46458
</details>

<details>
<summary>Override proxy with number on basic value</summary>

```js
window.globalProxy.prop3 = 144;
assert.strictEqual(window.globalProxy.prop3, 144);
```

- [x] Pass on 17.9.0
- [x] Pass on 18.0.0
- [x] Pass on 18.2.0 (after #42963)
- [x] Pass after #46458
</details>

<details>
<summary>Override proxy with number on unknown value</summary>

```js
window.globalProxy.prop4 = 145;
assert.strictEqual(window.globalProxy.prop4, 145);
```

- [x] Pass on 17.9.0
- [x] Pass on 18.0.0
- [x] Pass on 18.2.0 (after #42963)
- [x] Pass after #46458
</details>

<details>
<summary>Override proxy with function on symbol</summary>

```js
window.globalProxy[sym1] = () => {};
assert.strictEqual(window.globalProxy[sym1], 46);
```

- [x] Pass on 17.9.0
- [ ] Pass on 18.0.0
- [x] Pass on 18.2.0 (after #42963)
- [x] Pass after #46458
</details>

<details>
<summary>Override proxy with number</summary>

```js
window.globalProxy[sym2] = 147;
assert.strictEqual(window.globalProxy[sym2], 47);
```

- [x] Pass on 17.9.0
- [ ] Pass on 18.0.0
- [x] Pass on 18.2.0 (after #42963)
- [ ] Pass after #46458
</details>

<details>
<summary>Override proxy with number on basic value on symbol</summary>

```js
window.globalProxy[sym3] = 148;
assert.strictEqual(window.globalProxy[sym3], 148);
```

- [x] Pass on 17.9.0
- [x] Pass on 18.0.0
- [x] Pass on 18.2.0 (after #42963)
- [x] Pass after #46458
</details>

<details>
<summary>Override proxy with number on unknown value on symbol</summary>

```js
window.globalProxy[sym4] = 149;
assert.strictEqual(window.globalProxy[sym4], 149);
```

- [x] Pass on 17.9.0
- [x] Pass on 18.0.0
- [x] Pass on 18.2.0 (after #42963)
- [x] Pass after #46458
</details>
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
