### PR TITLE
doc: include context on .toWeb() parameters

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3007,7 +3007,8 @@ added: v17.0.0
   * `strategy` {Object}
     * `highWaterMark` {number} The maximum internal queue size (of the created
       `ReadableStream`) before backpressure is applied in reading from the given
-      `stream.Readable`.
+      `stream.Readable`. The default value is taken from the `highWaterMark` of the 
+      given `stream.Readable`.
     * `size` {Function} A function that size of the given chunk of data
       * `chunk` {any}
       * Returns: {number}

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3009,7 +3009,8 @@ added: v17.0.0
       `ReadableStream`) before backpressure is applied in reading from the given
       `stream.Readable`. If no value is provided, it will be taken from the
       given `stream.Readable`.
-    * `size` {Function} A function that size of the given chunk of data
+    * `size` {Function} A function that size of the given chunk of data. If no value is
+      provided, the size will be `1` for all the chunks.
       * `chunk` {any}
       * Returns: {number}
 * Returns: {ReadableStream}

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3007,7 +3007,7 @@ added: v17.0.0
   * `strategy` {Object}
     * `highWaterMark` {number} The maximum internal queue size (of the created
       `ReadableStream`) before backpressure is applied in reading from the given
-      `stream.Readable`. The default value is taken from the `highWaterMark` of the 
+      `stream.Readable`. If no value is provided, it will be taken from the
       given `stream.Readable`.
     * `size` {Function} A function that size of the given chunk of data
       * `chunk` {any}

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3009,8 +3009,8 @@ added: v17.0.0
       `ReadableStream`) before backpressure is applied in reading from the given
       `stream.Readable`. If no value is provided, it will be taken from the
       given `stream.Readable`.
-    * `size` {Function} A function that size of the given chunk of data. If no value is
-      provided, the size will be `1` for all the chunks.
+    * `size` {Function} A function that size of the given chunk of data.
+      If no value is provided, the size will be `1` for all the chunks.
       * `chunk` {any}
       * Returns: {number}
 * Returns: {ReadableStream}

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3005,8 +3005,12 @@ added: v17.0.0
 * `streamReadable` {stream.Readable}
 * `options` {Object}
   * `strategy` {Object}
-    * `highWaterMark` {number}
-    * `size` {Function}
+    * `highWaterMark` {number} The maximum internal queue size (of the created
+      `ReadableStream`) before backpressure is applied in reading from the given
+      `stream.Readable`.
+    * `size` {Function} A function that size of the given chunk of data
+      * `chunk` {any}
+      * Returns: {number}
 * Returns: {ReadableStream}
 
 ### `stream.Writable.fromWeb(writableStream[, options])`


### PR DESCRIPTION
Added some context on the parameters of the `toWeb()`  which can be helpful in context of the referenced issue

Refs: https://github.com/nodejs/node/issues/46347

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
