### PR TITLE
test: fix assertions in test-snapshot-dns-lookup*

### DIFF
--- a/test/internet/test-snapshot-dns-lookup.js
+++ b/test/internet/test-snapshot-dns-lookup.js
@@ -19,8 +19,8 @@ const env = {
 
 tmpdir.refresh();
 function checkOutput(stderr, stdout) {
-  assert(stdout.match(stdout, /address: "\d+\.\d+\.\d+\.\d+"/));
-  assert(stdout.match(stdout, /family: 4/));
+  assert.match(stdout, /address: "\d+\.\d+\.\d+\.\d+"/);
+  assert.match(stdout, /family: 4/);
   assert.strictEqual(stdout.trim().split('\n').length, 2);
 }
 {

--- a/test/parallel/test-snapshot-dns-lookup-localhost-promise.js
+++ b/test/parallel/test-snapshot-dns-lookup-localhost-promise.js
@@ -19,8 +19,8 @@ function checkOutput(stderr, stdout) {
   // We allow failures as it's not always possible to resolve localhost.
   // Functional tests are done in test/internet instead.
   if (!stderr.startsWith('error:')) {
-    assert(stdout.match(stdout, /address: "\d+\.\d+\.\d+\.\d+"/));
-    assert(stdout.match(stdout, /family: 4/));
+    assert.match(stdout, /address: "\d+\.\d+\.\d+\.\d+"/);
+    assert.match(stdout, /family: 4/);
     assert.strictEqual(stdout.trim().split('\n').length, 2);
   }
 }

--- a/test/parallel/test-snapshot-dns-lookup-localhost.js
+++ b/test/parallel/test-snapshot-dns-lookup-localhost.js
@@ -19,8 +19,8 @@ function checkOutput(stderr, stdout) {
   // We allow failures as it's not always possible to resolve localhost.
   // Functional tests are done in test/internet instead.
   if (!stderr.startsWith('error:')) {
-    assert(stdout.match(stdout, /address: "\d+\.\d+\.\d+\.\d+"/));
-    assert(stdout.match(stdout, /family: 4/));
+    assert.match(stdout, /address: "\d+\.\d+\.\d+\.\d+"/);
+    assert.match(stdout, /family: 4/);
     assert.strictEqual(stdout.trim().split('\n').length, 2);
   }
 }


### PR DESCRIPTION
Due to the unfortunate nature of JavaScript, the extraneous arguments are silently ignored. In this case, the assertion trivially passes regardless of the given regular expressions.

Refs: https://github.com/nodejs/node/pull/44633

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
