### PR TITLE
src: add SetFastMethodNoSideEffect()

### DIFF
--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -481,8 +481,9 @@ v8::CFunction BindingData::fast_bigint_(v8::CFunction::Make(FastBigInt));
 
 void BindingData::AddMethods() {
   Local<Context> ctx = env()->context();
-  SetFastMethod(ctx, object(), "hrtime", SlowNumber, &fast_number_);
-  SetFastMethod(ctx, object(), "hrtimeBigInt", SlowBigInt, &fast_bigint_);
+  SetFastMethodNoSideEffect(ctx, object(), "hrtime", SlowNumber, &fast_number_);
+  SetFastMethodNoSideEffect(
+      ctx, object(), "hrtimeBigInt", SlowBigInt, &fast_bigint_);
 }
 
 void BindingData::RegisterExternalReferences(

--- a/src/util.cc
+++ b/src/util.cc
@@ -403,6 +403,27 @@ void SetFastMethod(Local<v8::Context> context,
                           slow_callback,
                           Local<v8::Signature>(),
                           v8::ConstructorBehavior::kThrow,
+                          v8::SideEffectType::kHasSideEffect,
+                          c_function)
+          ->GetFunction(context)
+          .ToLocalChecked();
+  const v8::NewStringType type = v8::NewStringType::kInternalized;
+  Local<v8::String> name_string =
+      v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+  that->Set(context, name_string, function).Check();
+}
+
+void SetFastMethodNoSideEffect(Local<v8::Context> context,
+                               Local<v8::Object> that,
+                               const char* name,
+                               v8::FunctionCallback slow_callback,
+                               const v8::CFunction* c_function) {
+  Isolate* isolate = context->GetIsolate();
+  Local<v8::Function> function =
+      NewFunctionTemplate(isolate,
+                          slow_callback,
+                          Local<v8::Signature>(),
+                          v8::ConstructorBehavior::kThrow,
                           v8::SideEffectType::kHasNoSideEffect,
                           c_function)
           ->GetFunction(context)

--- a/src/util.h
+++ b/src/util.h
@@ -894,6 +894,11 @@ void SetFastMethod(v8::Local<v8::Context> context,
                    const char* name,
                    v8::FunctionCallback slow_callback,
                    const v8::CFunction* c_function);
+void SetFastMethodNoSideEffect(v8::Local<v8::Context> context,
+                               v8::Local<v8::Object> that,
+                               const char* name,
+                               v8::FunctionCallback slow_callback,
+                               const v8::CFunction* c_function);
 
 void SetProtoMethod(v8::Isolate* isolate,
                     v8::Local<v8::FunctionTemplate> that,


### PR DESCRIPTION
The original SetFastMethod() uses v8::SideEffectType::kHasNoSideEffect by default, which is different from SetMethod(). Follow the previous convention and add a new SetFastMethodNoSideEffect() instead.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
