### PR TITLE
src: use an array for faster binding data lookup

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -573,6 +573,7 @@
         'src/async_wrap-inl.h',
         'src/base_object.h',
         'src/base_object-inl.h',
+        'src/base_object_types.h',
         'src/base64.h',
         'src/base64-inl.h',
         'src/callback_queue.h',

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -25,6 +25,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include <type_traits>  // std::remove_reference
+#include "base_object_types.h"
 #include "memory_tracker.h"
 #include "v8.h"
 

--- a/src/base_object_types.h
+++ b/src/base_object_types.h
@@ -1,0 +1,69 @@
+#ifndef SRC_BASE_OBJECT_TYPES_H_
+#define SRC_BASE_OBJECT_TYPES_H_
+
+#include <cinttypes>
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+namespace node {
+// List of internalBinding() data wrappers. The first argument should match
+// what the class passes to SET_BINDING_ID(), the second argument should match
+// the C++ class name.
+#define SERIALIZABLE_BINDING_TYPES(V)                                          \
+  V(fs_binding_data, fs::BindingData)                                          \
+  V(v8_binding_data, v8_utils::BindingData)                                    \
+  V(blob_binding_data, BlobBindingData)                                        \
+  V(process_binding_data, process::BindingData)
+
+#define UNSERIALIZABLE_BINDING_TYPES(V)                                        \
+  V(http2_binding_data, http2::BindingData)                                    \
+  V(http_parser_binding_data, http_parser::BindingData)
+
+// List of (non-binding) BaseObjects that are serializable in the snapshot.
+// The first argument should match what the type passes to
+// SET_OBJECT_ID(), the second argument should match the C++ class
+// name.
+#define SERIALIZABLE_NON_BINDING_TYPES(V)                                      \
+  V(util_weak_reference, util::WeakReference)
+
+// Helper list of all binding data wrapper types.
+#define BINDING_TYPES(V)                                                       \
+  SERIALIZABLE_BINDING_TYPES(V)                                                \
+  UNSERIALIZABLE_BINDING_TYPES(V)
+
+// Helper list of all BaseObjects that implement snapshot support.
+#define SERIALIZABLE_OBJECT_TYPES(V)                                           \
+  SERIALIZABLE_BINDING_TYPES(V)                                                \
+  SERIALIZABLE_NON_BINDING_TYPES(V)
+
+#define V(TypeId, NativeType) k_##TypeId,
+enum class BindingDataType : uint8_t { BINDING_TYPES(V) kBindingDataTypeCount };
+// Make sure that we put the bindings first so that we can also use the enums
+// for the bindings as index to the binding data store.
+enum class EmbedderObjectType : uint8_t {
+  BINDING_TYPES(V) SERIALIZABLE_NON_BINDING_TYPES(V)
+  // We do not need to know about all the unserializable non-binding types for
+  // now so we do not list them.
+  kEmbedderObjectTypeCount
+};
+#undef V
+
+// For now, BaseObjects only need to call this when they implement snapshot
+// support.
+#define SET_OBJECT_ID(TypeId)                                                  \
+  static constexpr EmbedderObjectType type_int = EmbedderObjectType::k_##TypeId;
+
+// Binding data should call this so that they can be looked up from the binding
+// data store.
+#define SET_BINDING_ID(TypeId)                                                 \
+  static constexpr BindingDataType binding_type_int =                          \
+      BindingDataType::k_##TypeId;                                             \
+  SET_OBJECT_ID(TypeId)                                                        \
+  static_assert(static_cast<uint8_t>(type_int) ==                              \
+                static_cast<uint8_t>(binding_type_int));
+
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_BASE_OBJECT_TYPES_H_

--- a/src/node_blob.h
+++ b/src/node_blob.h
@@ -117,9 +117,7 @@ class BlobBindingData : public SnapshotableObject {
 
   SERIALIZABLE_OBJECT_METHODS()
 
-  static constexpr FastStringKey type_name{"node::BlobBindingData"};
-  static constexpr EmbedderObjectType type_int =
-      EmbedderObjectType::k_blob_binding_data;
+  SET_BINDING_ID(blob_binding_data)
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_SELF_SIZE(BlobBindingData)

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -70,9 +70,7 @@ class BindingData : public SnapshotableObject {
 
   using InternalFieldInfo = InternalFieldInfoBase;
   SERIALIZABLE_OBJECT_METHODS()
-  static constexpr FastStringKey type_name{"node::fs::BindingData"};
-  static constexpr EmbedderObjectType type_int =
-      EmbedderObjectType::k_fs_binding_data;
+  SET_BINDING_ID(fs_binding_data)
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_SELF_SIZE(BindingData)

--- a/src/node_http2_state.h
+++ b/src/node_http2_state.h
@@ -125,7 +125,7 @@ class Http2State : public BaseObject {
   SET_SELF_SIZE(Http2State)
   SET_MEMORY_INFO_NAME(Http2State)
 
-  static constexpr FastStringKey type_name { "http2" };
+  SET_BINDING_ID(http2_binding_data)
 
  private:
   struct http2_state_internal {

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -95,7 +95,7 @@ class BindingData : public BaseObject {
  public:
   BindingData(Realm* realm, Local<Object> obj) : BaseObject(realm, obj) {}
 
-  static constexpr FastStringKey type_name { "http_parser" };
+  SET_BINDING_ID(http_parser_binding_data)
 
   std::vector<char> parser_buffer;
   bool parser_buffer_in_use = false;

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -54,9 +54,7 @@ class BindingData : public SnapshotableObject {
   using InternalFieldInfo = InternalFieldInfoBase;
 
   SERIALIZABLE_OBJECT_METHODS()
-  static constexpr FastStringKey type_name{"node::process::BindingData"};
-  static constexpr EmbedderObjectType type_int =
-      EmbedderObjectType::k_process_binding_data;
+  SET_BINDING_ID(process_binding_data)
 
   BindingData(Realm* realm, v8::Local<v8::Object> object);
 

--- a/src/node_realm.cc
+++ b/src/node_realm.cc
@@ -302,8 +302,9 @@ void Realm::DoneBootstrapping() {
 
 void Realm::RunCleanup() {
   TRACE_EVENT0(TRACING_CATEGORY_NODE1(realm), "RunCleanup");
-  binding_data_store_.clear();
-
+  for (size_t i = 0; i < binding_data_store_.size(); ++i) {
+    binding_data_store_[i].reset();
+  }
   cleanup_queue_.Drain();
 }
 

--- a/src/node_realm.h
+++ b/src/node_realm.h
@@ -21,9 +21,9 @@ struct RealmSerializeInfo {
   friend std::ostream& operator<<(std::ostream& o, const RealmSerializeInfo& i);
 };
 
-using BindingDataStore = std::unordered_map<FastStringKey,
-                                            BaseObjectPtr<BaseObject>,
-                                            FastStringKey::Hash>;
+using BindingDataStore = std::array<BaseObjectPtr<BaseObject>,
+                     static_cast<size_t>(
+                         BindingDataType::kBindingDataTypeCount)>;
 
 /**
  * node::Realm is a container for a set of JavaScript objects and functions

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1289,11 +1289,11 @@ SnapshotableObject::SnapshotableObject(Realm* realm,
                                        EmbedderObjectType type)
     : BaseObject(realm, wrap), type_(type) {}
 
-std::string_view SnapshotableObject::GetTypeName() const {
+std::string SnapshotableObject::GetTypeName() const {
   switch (type_) {
 #define V(PropertyName, NativeTypeName)                                        \
   case EmbedderObjectType::k_##PropertyName: {                                 \
-    return NativeTypeName::type_name.as_string_view();                         \
+    return #NativeTypeName;                                                    \
   }
     SERIALIZABLE_OBJECT_TYPES(V)
 #undef V
@@ -1334,7 +1334,7 @@ void DeserializeNodeInternalFields(Local<Object> holder,
     per_process::Debug(DebugCategory::MKSNAPSHOT,                              \
                        "Object %p is %s\n",                                    \
                        (*holder),                                              \
-                       NativeTypeName::type_name.as_string_view());            \
+                       #NativeTypeName);                                       \
     env_ptr->EnqueueDeserializeRequest(                                        \
         NativeTypeName::Deserialize,                                           \
         holder,                                                                \
@@ -1421,7 +1421,7 @@ void SerializeSnapshotableObjects(Realm* realm,
     }
     SnapshotableObject* ptr = static_cast<SnapshotableObject*>(obj);
 
-    std::string type_name{ptr->GetTypeName()};
+    std::string type_name = ptr->GetTypeName();
     per_process::Debug(DebugCategory::MKSNAPSHOT,
                        "Serialize snapshotable object %i (%p), "
                        "object=%p, type=%s\n",

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -22,19 +22,6 @@ struct PropInfo {
   SnapshotIndex index;  // In the snapshot
 };
 
-#define SERIALIZABLE_OBJECT_TYPES(V)                                           \
-  V(fs_binding_data, fs::BindingData)                                          \
-  V(v8_binding_data, v8_utils::BindingData)                                    \
-  V(blob_binding_data, BlobBindingData)                                        \
-  V(process_binding_data, process::BindingData)                                \
-  V(util_weak_reference, util::WeakReference)
-
-enum class EmbedderObjectType : uint8_t {
-#define V(PropertyName, NativeType) k_##PropertyName,
-  SERIALIZABLE_OBJECT_TYPES(V)
-#undef V
-};
-
 typedef size_t SnapshotIndex;
 
 // When serializing an embedder object, we'll serialize the native states
@@ -101,7 +88,7 @@ class SnapshotableObject : public BaseObject {
   SnapshotableObject(Realm* realm,
                      v8::Local<v8::Object> wrap,
                      EmbedderObjectType type);
-  std::string_view GetTypeName() const;
+  std::string GetTypeName() const;
 
   // If returns false, the object will not be serialized.
   virtual bool PrepareForSerialization(v8::Local<v8::Context> context,

--- a/src/node_util.h
+++ b/src/node_util.h
@@ -14,9 +14,7 @@ class WeakReference : public SnapshotableObject {
  public:
   SERIALIZABLE_OBJECT_METHODS()
 
-  static constexpr FastStringKey type_name{"node::util::WeakReference"};
-  static constexpr EmbedderObjectType type_int =
-      EmbedderObjectType::k_util_weak_reference;
+  SET_OBJECT_ID(util_weak_reference)
 
   WeakReference(Realm* realm,
                 v8::Local<v8::Object> object,

--- a/src/node_v8.h
+++ b/src/node_v8.h
@@ -23,9 +23,7 @@ class BindingData : public SnapshotableObject {
   using InternalFieldInfo = InternalFieldInfoBase;
 
   SERIALIZABLE_OBJECT_METHODS()
-  static constexpr FastStringKey type_name{"node::v8::BindingData"};
-  static constexpr EmbedderObjectType type_int =
-      EmbedderObjectType::k_v8_binding_data;
+  SET_BINDING_ID(v8_binding_data)
 
   AliasedFloat64Array heap_statistics_buffer;
   AliasedFloat64Array heap_space_statistics_buffer;


### PR DESCRIPTION
src: use an array for faster binding data lookup

Locally the hashing of the binding names sometimes has significant
presence in the profile of bindings, because there can be collisions,
which makes the cost of adding a new binding data non-trivial,
but it's wasteful to spend time on hashing them or dealing with
collisions at all, since we can just use the EmbedderObjectType
enum as the key, as the string names are not actually used beyond
debugging purposes and can be easily matched with a macro.
And since we can just use the enum as the key, we do not even
need the map and can just use an array with the enum as indices
for the lookup.

Background: I was trying to move the encoding-related bindings to a new binding with its own BindingData and noticed ~15% regression in some TextEncoder benchmarks, and the hashing showed up in the profile. With this patch the regression goes away and the hashing no longer has any presence in the profile.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
