### PR TITLE
node-api: add __wasm32__ guards on async works

### DIFF
--- a/src/node_api.h
+++ b/src/node_api.h
@@ -175,6 +175,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_get_buffer_info(napi_env env,
                                                         void** data,
                                                         size_t* length);
 
+#ifndef __wasm32__
 // Methods to manage simple async operations
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_async_work(napi_env env,
@@ -190,6 +191,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_queue_async_work(napi_env env,
                                                          napi_async_work work);
 NAPI_EXTERN napi_status NAPI_CDECL napi_cancel_async_work(napi_env env,
                                                           napi_async_work work);
+#endif  // __wasm32__
 
 // version management
 NAPI_EXTERN napi_status NAPI_CDECL


### PR DESCRIPTION
Threaded work `napi_async_work` is not available on wasm. Hide their declaration if `__wasm32__` is defined.

Refs: https://github.com/nodejs/node/pull/33597
Refs: https://github.com/nodejs/node-addon-api/pull/1283