### PR TITLE
deps: update nghttp2 to 1.52.0

### DIFF
--- a/deps/nghttp2/lib/Makefile.in
+++ b/deps/nghttp2/lib/Makefile.in
@@ -107,13 +107,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = lib
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_boost_asio.m4 \
-	$(top_srcdir)/m4/ax_boost_base.m4 \
-	$(top_srcdir)/m4/ax_boost_system.m4 \
-	$(top_srcdir)/m4/ax_boost_thread.m4 \
-	$(top_srcdir)/m4/ax_check_compile_flag.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_compile_flag.m4 \
 	$(top_srcdir)/m4/ax_cxx_compile_stdcxx.m4 \
-	$(top_srcdir)/m4/ax_python_devel.m4 \
 	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
 	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
 	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
@@ -300,11 +295,6 @@ AUTOCONF = @AUTOCONF@
 AUTOHEADER = @AUTOHEADER@
 AUTOMAKE = @AUTOMAKE@
 AWK = @AWK@
-BOOST_ASIO_LIB = @BOOST_ASIO_LIB@
-BOOST_CPPFLAGS = @BOOST_CPPFLAGS@
-BOOST_LDFLAGS = @BOOST_LDFLAGS@
-BOOST_SYSTEM_LIB = @BOOST_SYSTEM_LIB@
-BOOST_THREAD_LIB = @BOOST_THREAD_LIB@
 BPFCFLAGS = @BPFCFLAGS@
 CC = @CC@
 CCDEPMODE = @CCDEPMODE@
@@ -321,7 +311,6 @@ CXXCPP = @CXXCPP@
 CXXDEPMODE = @CXXDEPMODE@
 CXXFLAGS = @CXXFLAGS@
 CYGPATH_W = @CYGPATH_W@
-CYTHON = @CYTHON@
 DEFS = @DEFS@
 DEPDIR = @DEPDIR@
 DLLTOOL = @DLLTOOL@
@@ -406,15 +395,9 @@ PKG_CONFIG = @PKG_CONFIG@
 PKG_CONFIG_LIBDIR = @PKG_CONFIG_LIBDIR@
 PKG_CONFIG_PATH = @PKG_CONFIG_PATH@
 PYTHON = @PYTHON@
-PYTHON_CPPFLAGS = @PYTHON_CPPFLAGS@
 PYTHON_EXEC_PREFIX = @PYTHON_EXEC_PREFIX@
-PYTHON_EXTRA_LDFLAGS = @PYTHON_EXTRA_LDFLAGS@
-PYTHON_EXTRA_LIBS = @PYTHON_EXTRA_LIBS@
-PYTHON_LIBS = @PYTHON_LIBS@
 PYTHON_PLATFORM = @PYTHON_PLATFORM@
-PYTHON_PLATFORM_SITE_PKG = @PYTHON_PLATFORM_SITE_PKG@
 PYTHON_PREFIX = @PYTHON_PREFIX@
-PYTHON_SITE_PKG = @PYTHON_SITE_PKG@
 PYTHON_VERSION = @PYTHON_VERSION@
 RANLIB = @RANLIB@
 SED = @SED@

--- a/deps/nghttp2/lib/Makefile.msvc
+++ b/deps/nghttp2/lib/Makefile.msvc
@@ -6,14 +6,7 @@
 # The MIT License apply.
 #
 
-#
-# Choose your weapons:
-#  Set 'USE_CYTHON=1' to build and install the 'nghttp2.pyd' Python extension.
-#
 THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
-
-USE_CYTHON := 0
-#USE_CYTHON := 1
 
 _VERSION	:= $(shell grep AC_INIT ../configure.ac | cut -d'[' -f3 | sed -e 's/-DEV//g' -e 's/], //g')
 _VERSION   	:= $(subst ., ,$(_VERSION))
@@ -102,7 +95,7 @@ NGHTTP2_OBJ_D := $(addprefix $(OBJ_DIR)/d_, $(notdir $(NGHTTP2_SRC:.c=.obj)))
 	clean_nghttp2_pyd_0 clean_nghttp2_pyd_1
 
 
-all: intro includes/nghttp2/nghttp2ver.h $(OBJ_DIR) $(TARGETS) build_nghttp2_pyd_$(USE_CYTHON)
+all: intro includes/nghttp2/nghttp2ver.h $(OBJ_DIR) $(TARGETS)
 	@echo 'Welcome to NgHTTP2 (release + debug).'
 	@echo 'Do a "make -f Makefile.MSVC install" at own risk!'
 
@@ -121,7 +114,7 @@ $(OBJ_DIR):
 
 install: includes/nghttp2/nghttp2.h includes/nghttp2/nghttp2ver.h \
          $(TARGETS) \
-         copy_headers_and_libs install_nghttp2_pyd_$(USE_CYTHON) 
+         copy_headers_and_libs
 
 #
 # This MUST be done before using the 'install_nghttp2_pyd_1' rule.
@@ -159,31 +152,6 @@ $(DLL_D): $(NGHTTP2_OBJ_D) $(OBJ_DIR)/d_nghttp2.res
 
 WIN_OBJDIR:=$(shell cygpath -w $(abspath $(OBJ_DIR)))
 WIN_OBJDIR:=$(subst \,/,$(WIN_OBJDIR))
-
-../python/setup.py: ../python/setup.py.in $(THIS_MAKEFILE)
-	cd ../python ; \
-	echo '# $(GENERATED). DO NOT EDIT.' > setup.py ; \
-	sed -e 's/@top_srcdir@/../'   \
-	    -e 's%@top_builddir@%$(WIN_OBJDIR)%' \
-	    -e 's/@PACKAGE_VERSION@/$(VERSION)/' setup.py.in >> setup.py ;
-
-build_nghttp2_pyd_0: ;
-
-build_nghttp2_pyd_1: $(addprefix ../python/, setup.py nghttp2.pyx)
-	cd ../python ; \
-	python setup.py build_ext -i -f bdist_wininst
-
-install_nghttp2_pyd_0: ;
-		
-install_nghttp2_pyd_1: $(addprefix ../python/, setup.py nghttp2.pyx)
-	cd ../python ; \
-	pip install .
-
-clean_nghttp2_pyd_0: ;
-
-clean_nghttp2_pyd_1:
-	cd ../python ; \
-	rm -fR build dist
 
 $(OBJ_DIR)/r_%.obj: %.c $(THIS_MAKEFILE)
 	$(CC) $(CFLAGS_R) $(CFLAGS) -Fo$@ -c $<
@@ -262,7 +230,7 @@ clean:
 	rm -f $(OBJ_DIR)/* includes/nghttp2/nghttp2ver.h
 	@echo
 
-vclean realclean: clean clean_nghttp2_pyd_$(USE_CYTHON)
+vclean realclean: clean
 	- rm -rf $(OBJ_DIR)
 	- rm -f .depend.MSVC
 

--- a/deps/nghttp2/lib/includes/Makefile.in
+++ b/deps/nghttp2/lib/includes/Makefile.in
@@ -114,13 +114,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = lib/includes
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_boost_asio.m4 \
-	$(top_srcdir)/m4/ax_boost_base.m4 \
-	$(top_srcdir)/m4/ax_boost_system.m4 \
-	$(top_srcdir)/m4/ax_boost_thread.m4 \
-	$(top_srcdir)/m4/ax_check_compile_flag.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_compile_flag.m4 \
 	$(top_srcdir)/m4/ax_cxx_compile_stdcxx.m4 \
-	$(top_srcdir)/m4/ax_python_devel.m4 \
 	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
 	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
 	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
@@ -208,11 +203,6 @@ AUTOCONF = @AUTOCONF@
 AUTOHEADER = @AUTOHEADER@
 AUTOMAKE = @AUTOMAKE@
 AWK = @AWK@
-BOOST_ASIO_LIB = @BOOST_ASIO_LIB@
-BOOST_CPPFLAGS = @BOOST_CPPFLAGS@
-BOOST_LDFLAGS = @BOOST_LDFLAGS@
-BOOST_SYSTEM_LIB = @BOOST_SYSTEM_LIB@
-BOOST_THREAD_LIB = @BOOST_THREAD_LIB@
 BPFCFLAGS = @BPFCFLAGS@
 CC = @CC@
 CCDEPMODE = @CCDEPMODE@
@@ -229,7 +219,6 @@ CXXCPP = @CXXCPP@
 CXXDEPMODE = @CXXDEPMODE@
 CXXFLAGS = @CXXFLAGS@
 CYGPATH_W = @CYGPATH_W@
-CYTHON = @CYTHON@
 DEFS = @DEFS@
 DEPDIR = @DEPDIR@
 DLLTOOL = @DLLTOOL@
@@ -314,15 +303,9 @@ PKG_CONFIG = @PKG_CONFIG@
 PKG_CONFIG_LIBDIR = @PKG_CONFIG_LIBDIR@
 PKG_CONFIG_PATH = @PKG_CONFIG_PATH@
 PYTHON = @PYTHON@
-PYTHON_CPPFLAGS = @PYTHON_CPPFLAGS@
 PYTHON_EXEC_PREFIX = @PYTHON_EXEC_PREFIX@
-PYTHON_EXTRA_LDFLAGS = @PYTHON_EXTRA_LDFLAGS@
-PYTHON_EXTRA_LIBS = @PYTHON_EXTRA_LIBS@
-PYTHON_LIBS = @PYTHON_LIBS@
 PYTHON_PLATFORM = @PYTHON_PLATFORM@
-PYTHON_PLATFORM_SITE_PKG = @PYTHON_PLATFORM_SITE_PKG@
 PYTHON_PREFIX = @PYTHON_PREFIX@
-PYTHON_SITE_PKG = @PYTHON_SITE_PKG@
 PYTHON_VERSION = @PYTHON_VERSION@
 RANLIB = @RANLIB@
 SED = @SED@

--- a/deps/nghttp2/lib/includes/nghttp2/nghttp2ver.h
+++ b/deps/nghttp2/lib/includes/nghttp2/nghttp2ver.h
@@ -29,7 +29,7 @@
  * @macro
  * Version number of the nghttp2 library release
  */
-#define NGHTTP2_VERSION "1.51.0"
+#define NGHTTP2_VERSION "1.52.0"
 
 /**
  * @macro
@@ -37,6 +37,6 @@
  * release. This is a 24 bit number with 8 bits for major number, 8 bits
  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
  */
-#define NGHTTP2_VERSION_NUM 0x013300
+#define NGHTTP2_VERSION_NUM 0x013400
 
 #endif /* NGHTTP2VER_H */


### PR DESCRIPTION
Refs: https://github.com/nghttp2/nghttp2/releases/tag/v1.52.0

Note that https://github.com/nodejs/node/issues/45572 is still relevant.
I don't know if `config.h` is a generated file. I just reverted its removal.