### PR TITLE
test_runner: enable in-source testing

### DIFF
--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -3,7 +3,7 @@
 const { getOptionValue } = require('internal/options');
 const experimentalImportMetaResolve =
   getOptionValue('--experimental-import-meta-resolve');
-const isTestRunner = getOptionValue('--test');
+const isTestRunner = getOptionValue('--test-in-source');
 const {
   PromisePrototypeThen,
   PromiseReject,
@@ -57,7 +57,7 @@ function initializeImportMeta(meta, context) {
     const { test, describe, it, before, after, beforeEach, afterEach } = lazyLoadTestModule();
     const { run } = lazyLoadRunnerModule();
     meta.test = test;
-    ObjectAssign(meta, {
+    ObjectAssign(meta.test, {
       after,
       afterEach,
       before,

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -3,11 +3,30 @@
 const { getOptionValue } = require('internal/options');
 const experimentalImportMetaResolve =
   getOptionValue('--experimental-import-meta-resolve');
+const isTestRunner = getOptionValue('--test');
 const {
   PromisePrototypeThen,
   PromiseReject,
+  ObjectAssign,
 } = primordials;
 const asyncESM = require('internal/process/esm_loader');
+
+let testModule;
+let runnerModule;
+
+function lazyLoadTestModule() {
+  if (testModule === undefined) {
+    testModule = require('internal/test_runner/harness');
+  }
+  return testModule;
+}
+
+function lazyLoadRunnerModule() {
+  if (runnerModule === undefined) {
+    runnerModule = require('internal/test_runner/runner');
+  }
+  return runnerModule;
+}
 
 function createImportMetaResolve(defaultParentUrl) {
   return async function resolve(specifier, parentUrl = defaultParentUrl) {
@@ -34,6 +53,21 @@ function initializeImportMeta(meta, context) {
   }
 
   meta.url = url;
+  if (isTestRunner) {
+    const { test, describe, it, before, after, beforeEach, afterEach } = lazyLoadTestModule();
+    const { run } = lazyLoadRunnerModule();
+    meta.test = test;
+    ObjectAssign(meta, {
+      after,
+      afterEach,
+      before,
+      beforeEach,
+      describe,
+      it,
+      run,
+      test,
+    });
+  }
 }
 
 module.exports = {

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -21,7 +21,7 @@ const { kCancelledByParent, Test, ItTest, Suite } = require('internal/test_runne
 const { setupTestReporters } = require('internal/test_runner/utils');
 const { bigint: hrtime } = process.hrtime;
 
-const isTestRunnerCli = getOptionValue('--test');
+const isTestRunnerCli = getOptionValue('--test') || getOptionValue('--test-in-source');
 const testResources = new SafeMap();
 const wasRootSetup = new SafeWeakSet();
 

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -64,7 +64,7 @@ const kTestTimeoutFailure = 'testTimeoutFailure';
 const kHookFailure = 'hookFailed';
 const kDefaultTimeout = null;
 const noop = FunctionPrototype;
-const isTestRunner = getOptionValue('--test');
+const isTestRunner = getOptionValue('--test') || getOptionValue('--test-in-source');
 const testOnlyFlag = !isTestRunner && getOptionValue('--test-only');
 const testNamePatternFlag = isTestRunner ? null :
   getOptionValue('--test-name-pattern');

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -556,6 +556,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--test",
             "launch test runner on startup",
             &EnvironmentOptions::test_runner);
+  AddOption("--test-in-source", 
+            "run tests within source file",
+            &EnvironmentOptions::test_runner_in_source);
   AddOption("--experimental-test-coverage",
             "enable code coverage in the test runner",
             &EnvironmentOptions::test_runner_coverage);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -155,6 +155,7 @@ class EnvironmentOptions : public Options {
   std::string diagnostic_dir;
   bool test_runner = false;
   bool test_runner_coverage = false;
+  bool test_runner_in_source = false;
   std::vector<std::string> test_name_pattern;
   std::vector<std::string> test_reporter;
   std::vector<std::string> test_reporter_destination;


### PR DESCRIPTION
Just opening a draft PR to ask for feedback plus seek some help, have been trying implement in-source testing as per the linked issue, and would like to know if 

a) This is the correct way to make the change
b) Also it seems that `--test` option value is not getting recognized somehow when using it within `lib/internal/modules/esm/initialize_import_meta.js` which is quite weird if anyone can explain this would be very helpful!!

Also most importantly would need discussion on whether this feature even is acceptable, the discussion on the original issue stopped some time back so hoping this one can continue the conversation


Fixes: https://github.com/nodejs/node/issues/45771

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
