### PR TITLE
deps: V8: cherry-pick 90be99fab31c

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/objects/js-date-time-format.cc
+++ b/deps/v8/src/objects/js-date-time-format.cc
@@ -1395,6 +1395,11 @@ MaybeHandle<String> FormatDateTime(Isolate* isolate,
   icu::UnicodeString result;
   date_format.format(date_value, result);
 
+  // Revert ICU 72 change that introduced U+202F instead of U+0020
+  // to separate time from AM/PM. See https://crbug.com/1414292.
+  result = result.findAndReplace(icu::UnicodeString(0x202f),
+                                 icu::UnicodeString(0x20));
+
   return Intl::ToString(isolate, result);
 }
 

--- a/deps/v8/test/mjsunit/mjsunit.status
+++ b/deps/v8/test/mjsunit/mjsunit.status
@@ -464,6 +464,9 @@
 
   # Non-BMP characters currently aren't considered identifiers in no_i18n
   'harmony/private-name-surrogate-pair': [PASS,FAIL],
+
+  # Tests ICU-specific behavior.
+  'regress/regress-crbug-1414292': [SKIP],
 }],  # 'no_i18n'
 
 ##############################################################################

--- a/deps/v8/test/mjsunit/regress/regress-crbug-1414292.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-1414292.js
@@ -1,0 +1,17 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const date = new Date("Wed Feb 15 2023 00:00:00 GMT+0100");
+const localeString = date.toLocaleString("en-US");
+// No narrow-width space should be found
+assertEquals(-1, localeString.search('\u202f'));
+// Regular space should match the character between time and AM/PM.
+assertMatches(/:\d\d:\d\d [AP]M$/, localeString);
+
+const formatter = new Intl.DateTimeFormat('en', {timeStyle: "long"})
+const formattedString = formatter.format(date)
+// No narrow-width space should be found
+assertEquals(-1, formattedString.search('\u202f'));
+// Regular space should match the character between time and AM/PM.
+assertMatches(/:\d\d:\d\d [AP]M$/, localeString);

--- a/deps/v8/test/test262/test262.status
+++ b/deps/v8/test/test262/test262.status
@@ -669,6 +669,10 @@
   'language/expressions/assignmenttargettype/direct-callexpression-arguments': [FAIL],
   'language/expressions/assignmenttargettype/parenthesized-callexpression-arguments': [FAIL],
 
+  # We replace U+202F (narrow-width space) with U+0020 (regular space).
+  # https://crbug.com/1414292
+  'intl402/DateTimeFormat/prototype/format/timedatestyle-en': [FAIL],
+
   ############################ INVALID TESTS #############################
 
   # Test makes unjustified assumptions about the number of calls to SortCompare.

--- a/test/parallel/test-icu-env.js
+++ b/test/parallel/test-icu-env.js
@@ -122,7 +122,7 @@ if (isMockable) {
   assert.deepStrictEqual(
     locales.map((LANG) => runEnvOutside({ LANG, TZ: 'Europe/Zurich' }, 'new Date(333333333333).toLocaleString()')),
     [
-      '7/25/1980, 1:35:33 AM',
+      '7/25/1980, 1:35:33 AM',
       '1980/7/25 01:35:33',
       '25/7/1980, 1:35:33 am',
       '25/7/1980, 1:35:33',

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -97,11 +97,7 @@ if (!common.hasIntl) {
   // Test format
   {
     const localeString = date0.toLocaleString(['en'], optsGMT);
-    if (Number(process.versions.cldr) >= 42) {
-      assert.strictEqual(localeString, '1/1/1970, 12:00:00 AM');
-    } else {
-      assert.strictEqual(localeString, '1/1/1970, 12:00:00 AM');
-    }
+    assert.strictEqual(localeString, '1/1/1970, 12:00:00 AM');
   }
   // number format
   {


### PR DESCRIPTION

Original commit message:

        [intl] Revert date formatting behavior change from ICU 72

        Replace U+202F with U+0020 after formatting date. This lets websites
        continue to work without any changes.

        This matches Firefox behavior, according to
        https://bugzilla.mozilla.org/show_bug.cgi?id=1806042#c17.

        Bug: chromium:1414292, chromium:1401829, chromium:1392814
        Change-Id: I7c2b58414d0890f8705e737f903403dc54e5fe57
        Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4237675
        Commit-Queue: Adam Klein <adamk@chromium.org>
        Reviewed-by: Shu-yu Guo <syg@chromium.org>
        Cr-Commit-Position: refs/heads/main@{#85757}

Refs: https://github.com/v8/v8/commit/90be99fab31c8299568e4114be1f0abd3741d615
Refs: https://github.com/nodejs/node/issues/46123
