### PR TITLE
test_runner: display skipped subtests in spec reporter output

### DIFF
--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -30,6 +30,7 @@ const symbols = {
   'test:pass': '\u2714 ',
   'test:diagnostic': '\u2139 ',
   'arrow:right': '\u25B6 ',
+  'hyphen:minus': '\uFE63 ',
 };
 class SpecReporter extends Transform {
   #stack = [];
@@ -60,8 +61,8 @@ class SpecReporter extends Transform {
     return `\n${indent}  ${message}\n`;
   }
   #handleEvent({ type, data }) {
-    const color = colors[type] ?? white;
-    const symbol = symbols[type] ?? ' ';
+    let color = colors[type] ?? white;
+    let symbol = symbols[type] ?? ' ';
 
     switch (type) {
       case 'test:fail':
@@ -81,15 +82,20 @@ class SpecReporter extends Transform {
           ArrayPrototypeUnshift(this.#reported, msg);
           prefix += `${this.#indent(msg.nesting)}${symbols['arrow:right']}${msg.name}\n`;
         }
+        const skippedSubtest = subtest && data.skip && data.skip !== undefined;
         const indent = this.#indent(data.nesting);
         const duration_ms = data.details?.duration_ms ? ` ${gray}(${data.details.duration_ms}ms)${white}` : '';
-        const title = `${data.name}${duration_ms}`;
+        const title = `${data.name}${duration_ms}${skippedSubtest ? ' # SKIP' : ''}`;
         if (this.#reported[0] && this.#reported[0].nesting === data.nesting && this.#reported[0].name === data.name) {
-          // If this test has had children - it was already reporter, so slightly modify the output
+          // If this test has had children - it was already reported, so slightly modify the output
           ArrayPrototypeShift(this.#reported);
           return `${prefix}${indent}${color}${symbols['arrow:right']}${white}${title}\n\n`;
         }
         const error = this.#formatError(data.details?.error, indent);
+        if (skippedSubtest) {
+          color = gray;
+          symbol = symbols['hyphen:minus'];
+        }
         return `${prefix}${indent}${color}${symbol}${title}${error}${white}\n`;
       }
       case 'test:start':

--- a/test/message/test_runner_output_spec_reporter.out
+++ b/test/message/test_runner_output_spec_reporter.out
@@ -20,8 +20,8 @@
   *
   *
 
- sync skip pass (*ms)
- sync skip pass with message (*ms)
+ sync skip pass (*ms) # SKIP
+ sync skip pass with message (*ms) # SKIP
  sync pass (*ms)
  this test should pass
  sync throw fail (*ms)
@@ -34,7 +34,7 @@
   *
   *
 
- async skip pass (*ms)
+ async skip pass (*ms) # SKIP
  async pass (*ms)
  async throw fail (*ms)
   Error: thrown from async throw fail
@@ -46,7 +46,7 @@
   *
   *
 
- async skip fail (*ms)
+ async skip fail (*ms) # SKIP
   Error: thrown from async throw fail
   *
   *
@@ -129,8 +129,8 @@
  top level (*ms)
 
  invalid subtest - pass but subtest fails (*ms)
- sync skip option (*ms)
- sync skip option with message (*ms)
+ sync skip option (*ms) # SKIP
+ sync skip option with message (*ms) # SKIP
  sync skip option is false fail (*ms)
   Error: this should be executed
   *
@@ -146,13 +146,13 @@
  <anonymous> (*ms)
  test with only a name provided (*ms)
  <anonymous> (*ms)
- <anonymous> (*ms)
- test with a name and options provided (*ms)
- functionAndOptions (*ms)
+ <anonymous> (*ms) # SKIP
+ test with a name and options provided (*ms) # SKIP
+ functionAndOptions (*ms) # SKIP
  escaped description \ # *
  	 *
  (*ms)
- escaped skip message (*ms)
+ escaped skip message (*ms) # SKIP
  escaped todo message (*ms)
  escaped diagnostic (*ms)
  #diagnostic


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR highlights skipped tests when running with `--test-reporter=spec`. 

At the moment this is using the same approach as the tap reporter which is to display the `# SKIP` message. I've also updated the icon/color in the `spec` style to visually indicate what tests are skipped. 

Given the following block of tests, here are some before/after snippets to highlight the minor change.

```js
const { test, describe, it } = require('node:test');

describe('parent block', () => {
  it('child subtest 1 should run', () => {
    console.log('running first');
  });

  it('child subtest 2 should not run', { skip: true }, () => {
    console.log('running second');
  });
});

test('parent block', async (t) => {
  await t.test('child subtest 1 should run', () => {
    console.log('running first');
  });

  await t.test('child subtest 2 should not run', { skip: true }, () => {
    console.log('running second');
  });
});

test('parent block three', (t) => {
  t.skip('this is skipped');
});
```


#### Before

```
▶ parent block
  ✔ child subtest 1 should run (1.365111ms)
  ✔ child subtest 2 should not run (0.08218ms)
▶ parent block (4.580764ms)

▶ parent block
  ✔ child subtest 1 should run (0.157236ms)
  ✔ child subtest 2 should not run (0.081149ms)
▶ parent block (0.634555ms)

✔ parent block three (0.119197ms)
ℹ tests 3
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 1
ℹ todo 0
```

#### After

```
▶ parent block
  ✔ child subtest 1 should run (1.403468ms)
  ✔ child subtest 2 should not run (0.090423ms) # SKIP
▶ parent block (5.349161ms)

▶ parent block
  ✔ child subtest 1 should run (0.169557ms)
  ✔ child subtest 2 should not run (0.119462ms) # SKIP
▶ parent block (0.780943ms)

✔ parent block three (0.130612ms) # SKIP
ℹ tests 3
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 1
ℹ todo 0
ℹ duration_ms 11.546297
```
