### PR TITLE
assert: remove deprecated getFunction() usage

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -308,12 +308,7 @@ function getErrMessage(message, fn) {
       return;
     }
   } else {
-    const fn = call.getFunction();
-    if (!fn) {
-      return message;
-    }
-    code = String(fn);
-    identifier = `${code}${line}${column}`;
+    return message;
   }
 
   if (errorCache.has(identifier)) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -921,7 +921,7 @@ assert.throws(
   {
     code: 'ERR_ASSERTION',
     constructor: assert.AssertionError,
-    message: 'The expression evaluated to a falsy value:\n\n  assert(1 === 2)\n'
+    message: 'false == true'
   }
 );
 assert.throws(


### PR DESCRIPTION
The method is meant to be removed by the V8 team. It is not a critical functionality that is removed, therefore no alternative is checked for either.

Refs: https://bugs.chromium.org/p/v8/issues/detail?id=9421

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

@nodejs/v8 PTAL