### PR TITLE
lib: rename internal module declaration as internal bindings

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -20,7 +20,7 @@
 //   NM_F_LINKED.
 // - internalBinding(): the private internal C++ binding loader, inaccessible
 //   from user land unless through `require('internal/test/binding')`.
-//   These C++ bindings are created using NODE_MODULE_CONTEXT_AWARE_INTERNAL()
+//   These C++ bindings are created using NODE_BINDING_CONTEXT_AWARE_INTERNAL()
 //   and have their nm_flags set to NM_F_INTERNAL.
 //
 // Internal JavaScript module loader:


### PR DESCRIPTION
This is a follow-up to https://github.com/nodejs/node/pull/45551.

Renaming NODE_MODULE_CONTEXT_AWARE_INTERNAL to
NODE_BINDING_CONTEXT_AWARE_INTERNAL. 
As these bindings are already loaded with the function `internalBinding` 
in the JS land, the term "internal binding" can be straightforward to be adopted.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
