### PR TITLE
test_runner: support defining test reporter in NODE_OPTIONS

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1434,12 +1434,6 @@ added: v19.6.0
 The destination for the corresponding test reporter. See the documentation on
 [test reporters][] for more details.
 
-### `--test-child-process`
-
-A flag to identify the process as a child of another test process to ensure
-that test reporting is formatted correctly to be parsed by a parent test
-process.
-
 ### `--test-only`
 
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2265,9 +2265,7 @@ on unsupported platforms will not be fixed.
 ### `NODE_TEST_CONTEXT=value`
 
 If `value` equals `'child'`, test reporter options will be overridden and test
-output will be sent to stdout in the TAP format. This is intended to facilitate
-parsing and aggregating test output by a parent process that spawns one or more
-children.
+output will be sent to stdout in the TAP format.
 
 ### `NODE_TLS_REJECT_UNAUTHORIZED=value`
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1434,6 +1434,12 @@ added: v19.6.0
 The destination for the corresponding test reporter. See the documentation on
 [test reporters][] for more details.
 
+### `--test-child-process`
+
+A flag to identify the process as a child of another test process to ensure
+that test reporting is formatted correctly to be parsed by a parent test
+process.
+
 ### `--test-only`
 
 <!-- YAML
@@ -2119,6 +2125,8 @@ Node.js options that are allowed are:
 * `--secure-heap`
 * `--snapshot-blob`
 * `--test-only`
+* `--test-reporter-destination`
+* `--test-reporter`
 * `--throw-deprecation`
 * `--title`
 * `--tls-cipher-list`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2262,6 +2262,13 @@ If `value` equals `'1'`, the check for a supported platform is skipped during
 Node.js startup. Node.js might not execute correctly. Any issues encountered
 on unsupported platforms will not be fixed.
 
+### `NODE_TEST_CONTEXT=value`
+
+If `value` equals `'child'`, test reporter options will be overridden and test
+output will be sent to stdout in the TAP format. This is intended to facilitate
+parsing and aggregating test output by a parent process that spawns one or more
+children.
+
 ### `NODE_TLS_REJECT_UNAUTHORIZED=value`
 
 If `value` equals `'0'`, certificate validation is disabled for TLS connections.

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -261,7 +261,7 @@ function runTestFile(path, root, inspectPort, filesWatcher) {
   const subtest = root.createSubtest(FileTest, path, async (t) => {
     const args = getRunArgs({ path, inspectPort });
     const stdio = ['pipe', 'pipe', 'pipe'];
-    const env = { ...process.env, TEST_CONTEXT: 'child' };
+    const env = { ...process.env, NODE_TEST_CONTEXT: 'child' };
     if (filesWatcher) {
       stdio.push('ipc');
       env.WATCH_REPORT_DEPENDENCIES = '1';

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -145,7 +145,6 @@ function getRunArgs({ path, inspectPort }) {
     ArrayPrototypePush(argv, `--inspect-port=${getInspectPort(inspectPort)}`);
   }
   ArrayPrototypePush(argv, path);
-  ArrayPrototypeUnshift(argv, '--test-child-process');
 
   return argv;
 }
@@ -262,7 +261,7 @@ function runTestFile(path, root, inspectPort, filesWatcher) {
   const subtest = root.createSubtest(FileTest, path, async (t) => {
     const args = getRunArgs({ path, inspectPort });
     const stdio = ['pipe', 'pipe', 'pipe'];
-    const env = { ...process.env };
+    const env = { ...process.env, TEST_CONTEXT: 'child' };
     if (filesWatcher) {
       stdio.push('ipc');
       env.WATCH_REPORT_DEPENDENCIES = '1';

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -23,7 +23,6 @@ const {
   SafeSet,
   StringPrototypeIndexOf,
   StringPrototypeSlice,
-  StringPrototypeSplit,
   StringPrototypeStartsWith,
 } = primordials;
 

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -23,6 +23,7 @@ const {
   SafeSet,
   StringPrototypeIndexOf,
   StringPrototypeSlice,
+  StringPrototypeSplit,
   StringPrototypeStartsWith,
 } = primordials;
 
@@ -145,6 +146,8 @@ function getRunArgs({ path, inspectPort }) {
     ArrayPrototypePush(argv, `--inspect-port=${getInspectPort(inspectPort)}`);
   }
   ArrayPrototypePush(argv, path);
+  ArrayPrototypeUnshift(argv, '--test-child-process');
+
   return argv;
 }
 

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -173,9 +173,9 @@ function parseCommandLine() {
 
   const isTestRunner = getOptionValue('--test');
   const coverage = getOptionValue('--experimental-test-coverage');
-  let destinations = getOptionValue('--test-reporter-destination');
-  let reporters = getOptionValue('--test-reporter');
   const isChildProcess = process.env.NODE_TEST_CONTEXT === 'child';
+  let destinations;
+  let reporters;
   let testNamePatterns;
   let testOnlyFlag;
 
@@ -183,6 +183,8 @@ function parseCommandLine() {
     reporters = [kDefaultReporter];
     destinations = [kDefaultDestination];
   } else {
+    destinations = getOptionValue('--test-reporter-destination')
+    reporters = getOptionValue('--test-reporter');
     if (reporters.length === 0 && destinations.length === 0) {
       ArrayPrototypePush(reporters, kDefaultReporter);
     }

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -175,7 +175,7 @@ function parseCommandLine() {
   const coverage = getOptionValue('--experimental-test-coverage');
   let destinations = getOptionValue('--test-reporter-destination');
   let reporters = getOptionValue('--test-reporter');
-  const isChildProcess = process.env.TEST_CONTEXT === 'child';
+  const isChildProcess = process.env.NODE_TEST_CONTEXT === 'child';
   let testNamePatterns;
   let testOnlyFlag;
 

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -183,7 +183,7 @@ function parseCommandLine() {
     reporters = [kDefaultReporter];
     destinations = [kDefaultDestination];
   } else {
-    destinations = getOptionValue('--test-reporter-destination')
+    destinations = getOptionValue('--test-reporter-destination');
     reporters = getOptionValue('--test-reporter');
     if (reporters.length === 0 && destinations.length === 0) {
       ArrayPrototypePush(reporters, kDefaultReporter);

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -172,25 +172,31 @@ function parseCommandLine() {
 
   const isTestRunner = getOptionValue('--test');
   const coverage = getOptionValue('--experimental-test-coverage');
-  const destinations = getOptionValue('--test-reporter-destination');
-  const reporters = getOptionValue('--test-reporter');
+  let destinations = getOptionValue('--test-reporter-destination');
+  let reporters = getOptionValue('--test-reporter');
+  const isChildProcess = getOptionValue('--test-child-process');
   let testNamePatterns;
   let testOnlyFlag;
 
-  if (reporters.length === 0 && destinations.length === 0) {
-    ArrayPrototypePush(reporters, kDefaultReporter);
-  }
+  if (isChildProcess) {
+    reporters = [kDefaultReporter];
+    destinations = [kDefaultDestination];
+  } else {
+    if (reporters.length === 0 && destinations.length === 0) {
+      ArrayPrototypePush(reporters, kDefaultReporter);
+    }
 
-  if (reporters.length === 1 && destinations.length === 0) {
-    ArrayPrototypePush(destinations, kDefaultDestination);
-  }
+    if (reporters.length === 1 && destinations.length === 0) {
+      ArrayPrototypePush(destinations, kDefaultDestination);
+    }
 
-  if (destinations.length !== reporters.length) {
-    throw new ERR_INVALID_ARG_VALUE(
-      '--test-reporter',
-      reporters,
-      'must match the number of specified \'--test-reporter-destination\'',
-    );
+    if (destinations.length !== reporters.length) {
+      throw new ERR_INVALID_ARG_VALUE(
+        '--test-reporter',
+        reporters,
+        'must match the number of specified \'--test-reporter-destination\'',
+      );
+    }
   }
 
   if (isTestRunner) {

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -9,6 +9,7 @@ const {
   SafeMap,
   Symbol,
 } = primordials;
+
 const { basename } = require('path');
 const { createWriteStream } = require('fs');
 const { pathToFileURL } = require('internal/url');
@@ -174,7 +175,7 @@ function parseCommandLine() {
   const coverage = getOptionValue('--experimental-test-coverage');
   let destinations = getOptionValue('--test-reporter-destination');
   let reporters = getOptionValue('--test-reporter');
-  const isChildProcess = getOptionValue('--test-child-process');
+  const isChildProcess = process.env.TEST_CONTEXT === 'child';
   let testNamePatterns;
   let testOnlyFlag;
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -590,10 +590,14 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::test_name_pattern);
   AddOption("--test-reporter",
             "report test output using the given reporter",
-            &EnvironmentOptions::test_reporter);
+            &EnvironmentOptions::test_reporter,
+            kAllowedInEnvvar);
   AddOption("--test-reporter-destination",
             "report given reporter to the given destination",
-            &EnvironmentOptions::test_reporter_destination);
+            &EnvironmentOptions::test_reporter_destination,
+            kAllowedInEnvvar);
+  AddOption("--test-child-process", "",  // for internal use by test runner
+            &EnvironmentOptions::test_child_process);
   AddOption("--test-only",
             "run tests with 'only' option set",
             &EnvironmentOptions::test_only,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -596,9 +596,6 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "report given reporter to the given destination",
             &EnvironmentOptions::test_reporter_destination,
             kAllowedInEnvvar);
-  AddOption("--test-child-process",
-            "",  // for internal use by test runner
-            &EnvironmentOptions::test_child_process);
   AddOption("--test-only",
             "run tests with 'only' option set",
             &EnvironmentOptions::test_only,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -596,7 +596,8 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "report given reporter to the given destination",
             &EnvironmentOptions::test_reporter_destination,
             kAllowedInEnvvar);
-  AddOption("--test-child-process", "",  // for internal use by test runner
+  AddOption("--test-child-process",
+            "",  // for internal use by test runner
             &EnvironmentOptions::test_child_process);
   AddOption("--test-only",
             "run tests with 'only' option set",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -163,7 +163,6 @@ class EnvironmentOptions : public Options {
   std::vector<std::string> test_name_pattern;
   std::vector<std::string> test_reporter;
   std::vector<std::string> test_reporter_destination;
-  bool test_child_process = false;
   bool test_only = false;
   bool test_udp_no_try_send = false;
   bool throw_deprecation = false;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -163,6 +163,7 @@ class EnvironmentOptions : public Options {
   std::vector<std::string> test_name_pattern;
   std::vector<std::string> test_reporter;
   std::vector<std::string> test_reporter_destination;
+  bool test_child_process = false;
   bool test_only = false;
   bool test_udp_no_try_send = false;
   bool throw_deprecation = false;


### PR DESCRIPTION
Adds --test-reporter and --test-reporter-destination as allowable options in NODE_OPTIONS.

Fixes: https://github.com/nodejs/node/issues/46484

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
