### PR TITLE
test_runner: centralize CLI option handling

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -16,12 +16,13 @@ const {
 const { exitCodes: { kGenericUserError } } = internalBinding('errors');
 
 const { kEmptyObject } = require('internal/util');
-const { getOptionValue } = require('internal/options');
 const { kCancelledByParent, Test, ItTest, Suite } = require('internal/test_runner/test');
-const { setupTestReporters } = require('internal/test_runner/utils');
+const {
+  parseCommandLine,
+  setupTestReporters,
+} = require('internal/test_runner/utils');
 const { bigint: hrtime } = process.hrtime;
 
-const isTestRunnerCli = getOptionValue('--test');
 const testResources = new SafeMap();
 const wasRootSetup = new SafeWeakSet();
 
@@ -56,8 +57,8 @@ function createProcessEventHandler(eventName, rootTest) {
   };
 }
 
-function configureCoverage(rootTest) {
-  if (!getOptionValue('--experimental-test-coverage')) {
+function configureCoverage(rootTest, globalOptions) {
+  if (!globalOptions.coverage) {
     return null;
   }
 
@@ -98,6 +99,11 @@ function setup(root) {
   if (wasRootSetup.has(root)) {
     return root;
   }
+
+  // Parse the command line options before the hook is enabled. We don't want
+  // global input validation errors to end up in the uncaughtException handler.
+  const globalOptions = parseCommandLine();
+
   const hook = createHook({
     init(asyncId, type, triggerAsyncId, resource) {
       if (resource instanceof Test) {
@@ -122,7 +128,7 @@ function setup(root) {
     createProcessEventHandler('uncaughtException', root);
   const rejectionHandler =
     createProcessEventHandler('unhandledRejection', root);
-  const coverage = configureCoverage(root);
+  const coverage = configureCoverage(root, globalOptions);
   const exitHandler = () => {
     root.coverage = collectCoverage(root, coverage);
     root.postRun(new ERR_TEST_FAILURE(
@@ -142,8 +148,8 @@ function setup(root) {
   process.on('uncaughtException', exceptionHandler);
   process.on('unhandledRejection', rejectionHandler);
   process.on('beforeExit', exitHandler);
-  // TODO(MoLow): Make it configurable to hook when isTestRunnerCli === false.
-  if (isTestRunnerCli) {
+  // TODO(MoLow): Make it configurable to hook when isTestRunner === false.
+  if (globalOptions.isTestRunner) {
     process.on('SIGINT', terminationHandler);
     process.on('SIGTERM', terminationHandler);
   }

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -1,6 +1,5 @@
 'use strict';
 const {
-  ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypeReduce,
   ArrayPrototypeShift,
@@ -31,13 +30,12 @@ const {
   },
   AbortError,
 } = require('internal/errors');
-const { getOptionValue } = require('internal/options');
 const { MockTracker } = require('internal/test_runner/mock');
 const { TestsStream } = require('internal/test_runner/tests_stream');
 const {
-  convertStringToRegExp,
   createDeferredCallback,
   isTestFailureError,
+  parseCommandLine,
 } = require('internal/test_runner/utils');
 const {
   createDeferredPromise,
@@ -64,22 +62,13 @@ const kTestTimeoutFailure = 'testTimeoutFailure';
 const kHookFailure = 'hookFailed';
 const kDefaultTimeout = null;
 const noop = FunctionPrototype;
-const isTestRunner = getOptionValue('--test');
-const testOnlyFlag = !isTestRunner && getOptionValue('--test-only');
-const testNamePatternFlag = isTestRunner ? null :
-  getOptionValue('--test-name-pattern');
-const testNamePatterns = testNamePatternFlag?.length > 0 ?
-  ArrayPrototypeMap(
-    testNamePatternFlag,
-    (re) => convertStringToRegExp(re, '--test-name-pattern'),
-  ) : null;
 const kShouldAbort = Symbol('kShouldAbort');
 const kFilename = process.argv?.[1];
 const kHookNames = ObjectSeal(['before', 'after', 'beforeEach', 'afterEach']);
 const kUnwrapErrors = new SafeSet()
   .add(kTestCodeFailure).add(kHookFailure)
   .add('uncaughtException').add('unhandledRejection');
-
+const { testNamePatterns, testOnlyFlag } = parseCommandLine();
 
 function stopTest(timeout, signal) {
   if (timeout === kDefaultTimeout) {

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -1,5 +1,6 @@
 'use strict';
 const {
+  ArrayPrototypeMap,
   ArrayPrototypePush,
   ObjectGetOwnPropertyDescriptor,
   SafePromiseAllReturnArrayLike,
@@ -148,8 +149,27 @@ async function getReportersMap(reporters, destinations) {
 
 
 async function setupTestReporters(testsStream) {
+  const { reporters, destinations } = parseCommandLine();
+  const reportersMap = await getReportersMap(reporters, destinations);
+  for (let i = 0; i < reportersMap.length; i++) {
+    const { reporter, destination } = reportersMap[i];
+    compose(testsStream, reporter).pipe(destination);
+  }
+}
+
+let globalTestOptions;
+
+function parseCommandLine() {
+  if (globalTestOptions) {
+    return globalTestOptions;
+  }
+
+  const isTestRunner = getOptionValue('--test');
+  const coverage = getOptionValue('--experimental-test-coverage');
   const destinations = getOptionValue('--test-reporter-destination');
   const reporters = getOptionValue('--test-reporter');
+  let testNamePatterns;
+  let testOnlyFlag;
 
   if (reporters.length === 0 && destinations.length === 0) {
     ArrayPrototypePush(reporters, kDefaultReporter);
@@ -160,15 +180,37 @@ async function setupTestReporters(testsStream) {
   }
 
   if (destinations.length !== reporters.length) {
-    throw new ERR_INVALID_ARG_VALUE('--test-reporter', reporters,
-                                    'must match the number of specified \'--test-reporter-destination\'');
+    throw new ERR_INVALID_ARG_VALUE(
+      '--test-reporter',
+      reporters,
+      'must match the number of specified \'--test-reporter-destination\'',
+    );
   }
 
-  const reportersMap = await getReportersMap(reporters, destinations);
-  for (let i = 0; i < reportersMap.length; i++) {
-    const { reporter, destination } = reportersMap[i];
-    compose(testsStream, reporter).pipe(destination);
+  if (isTestRunner) {
+    testOnlyFlag = false;
+    testNamePatterns = null;
+  } else {
+    const testNamePatternFlag = getOptionValue('--test-name-pattern');
+    testOnlyFlag = getOptionValue('--test-only');
+    testNamePatterns = testNamePatternFlag?.length > 0 ?
+      ArrayPrototypeMap(
+        testNamePatternFlag,
+        (re) => convertStringToRegExp(re, '--test-name-pattern'),
+      ) : null;
   }
+
+  globalTestOptions = {
+    __proto__: null,
+    isTestRunner,
+    coverage,
+    testOnlyFlag,
+    testNamePatterns,
+    reporters,
+    destinations,
+  };
+
+  return globalTestOptions;
 }
 
 module.exports = {
@@ -177,5 +219,6 @@ module.exports = {
   doesPathMatchFilter,
   isSupportedFileType,
   isTestFailureError,
+  parseCommandLine,
   setupTestReporters,
 };


### PR DESCRIPTION
The test runner relies on a few CLI options. That code was spread across a few locations. This commit centralizes that logic.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
