### PR TITLE
test: use newish OpenSSL feature in test-tls-dhe

### DIFF
--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -77,8 +77,8 @@ function test(keylen, expectedCipher, cb) {
       out += d;
     });
     client.stdout.on('end', function() {
-      // DHE key length can be checked -brief option in s_client but it
-      // is only supported in openssl 1.0.2 so we cannot check it.
+      assert(keylen === 'error' ||
+             out.includes(`Server Temp Key: DH, ${keylen} bits`));
       const reg = new RegExp(`Cipher    : ${expectedCipher}`);
       if (reg.test(out)) {
         nsuccess++;


### PR DESCRIPTION
According to the comment that is being replaced here, this was not possible with the current version of OpenSSL 1.0.2 at the time the test was written. New OpenSSL versions appear to always print the length of the temporary key.

Refs: https://github.com/nodejs/node-v0.x-archive/pull/8272

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
