### PR TITLE
test: remove OpenSSL 1.0.2 error message compat

### DIFF
--- a/test/parallel/test-tls-junk-server.js
+++ b/test/parallel/test-tls-junk-server.js
@@ -21,9 +21,7 @@ server.listen(0, function() {
   req.end();
 
   req.once('error', common.mustCall(function(err) {
-    // OpenSSL 1.0.x and 1.1.x use different error messages for junk inputs.
-    assert(/unknown protocol/.test(err.message) ||
-           /wrong version number/.test(err.message));
+    assert(/wrong version number/.test(err.message));
     server.close();
   }));
 });

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -42,8 +42,6 @@ process.on('exit', function() {
     common.printSkipMessage('`openssl s_client -ssl3` not supported.');
   } else {
     assert.strictEqual(errors.length, 1);
-    // OpenSSL 1.0.x and 1.1.x report invalid client versions differently.
-    assert(/:wrong version number/.test(errors[0].message) ||
-           /:version too low/.test(errors[0].message));
+    assert(/:version too low/.test(errors[0].message));
   }
 });

--- a/test/parallel/test-tls-server-failed-handshake-emits-clienterror.js
+++ b/test/parallel/test-tls-server-failed-handshake-emits-clienterror.js
@@ -20,9 +20,8 @@ const server = tls.createServer({})
   }).on('tlsClientError', common.mustCall(function(e) {
     assert.ok(e instanceof Error,
               'Instance of Error should be passed to error handler');
-    // OpenSSL 1.0.x and 1.1.x use different error codes for junk inputs.
     assert.ok(
-      /SSL routines:[^:]*:(unknown protocol|wrong version number)/.test(
+      /SSL routines:[^:]*:wrong version number/.test(
         e.message),
       'Expecting SSL unknown protocol');
 

--- a/test/parallel/test-tls-socket-failed-handshake-emits-error.js
+++ b/test/parallel/test-tls-socket-failed-handshake-emits-error.js
@@ -20,9 +20,8 @@ const server = net.createServer(function(c) {
     s.on('error', common.mustCall(function(e) {
       assert.ok(e instanceof Error,
                 'Instance of Error should be passed to error handler');
-      // OpenSSL 1.0.x and 1.1.x use different error codes for junk inputs.
       assert.ok(
-        /SSL routines:[^:]*:(unknown protocol|wrong version number)/.test(
+        /SSL routines:[^:]*:wrong version number/.test(
           e.message),
         'Expecting SSL unknown protocol');
     }));


### PR DESCRIPTION
While upgrading from OpenSSL 1.0.2 to 1.1.1, these tests were modified to recognize error messages from both OpenSSL releases. Given that OpenSSL 1.0.2 has been unsupported for years, it is safe to remove the older message patterns.

Refs: https://github.com/nodejs/node/pull/16130

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
