### PR TITLE
test_runner: better handle async bootstrap errors

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1604,8 +1604,8 @@ E('ERR_TAP_VALIDATION_ERROR', function(errorMsg) {
 }, Error);
 E('ERR_TEST_FAILURE', function(error, failureType) {
   hideInternalStackFrames(this);
-  assert(typeof failureType === 'string',
-         "The 'failureType' argument must be of type string.");
+  assert(typeof failureType === 'string' || typeof failureType === 'symbol',
+         "The 'failureType' argument must be of type string or symbol.");
 
   let msg = error?.message ?? error;
 

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -18,6 +18,7 @@ const { exitCodes: { kGenericUserError } } = internalBinding('errors');
 const { kEmptyObject } = require('internal/util');
 const { kCancelledByParent, Test, ItTest, Suite } = require('internal/test_runner/test');
 const {
+  kAsyncBootstrapFailure,
   parseCommandLine,
   setupTestReporters,
 } = require('internal/test_runner/utils');
@@ -32,6 +33,13 @@ function createTestTree(options = kEmptyObject) {
 
 function createProcessEventHandler(eventName, rootTest) {
   return (err) => {
+    if (err?.failureType === kAsyncBootstrapFailure) {
+      // Something went wrong during the asynchronous portion of bootstrapping
+      // the test runner. Since the test runner is not setup properly, we can't
+      // do anything but throw the error.
+      throw err.cause;
+    }
+
     // Check if this error is coming from a test. If it is, fail the test.
     const test = testResources.get(executionAsyncId());
 

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -7,6 +7,7 @@ const {
   RegExp,
   RegExpPrototypeExec,
   SafeMap,
+  Symbol,
 } = primordials;
 const { basename } = require('path');
 const { createWriteStream } = require('fs');
@@ -23,6 +24,7 @@ const {
 } = require('internal/errors');
 const { compose } = require('stream');
 
+const kAsyncBootstrapFailure = Symbol('asyncBootstrapFailure');
 const kMultipleCallbackInvocations = 'multipleCallbackInvocations';
 const kRegExpPattern = /^\/(.*)\/([a-z]*)$/;
 const kSupportedFileExtensions = /\.[cm]?js$/;
@@ -149,11 +151,15 @@ async function getReportersMap(reporters, destinations) {
 
 
 async function setupTestReporters(testsStream) {
-  const { reporters, destinations } = parseCommandLine();
-  const reportersMap = await getReportersMap(reporters, destinations);
-  for (let i = 0; i < reportersMap.length; i++) {
-    const { reporter, destination } = reportersMap[i];
-    compose(testsStream, reporter).pipe(destination);
+  try {
+    const { reporters, destinations } = parseCommandLine();
+    const reportersMap = await getReportersMap(reporters, destinations);
+    for (let i = 0; i < reportersMap.length; i++) {
+      const { reporter, destination } = reportersMap[i];
+      compose(testsStream, reporter).pipe(destination);
+    }
+  } catch (err) {
+    throw new ERR_TEST_FAILURE(err, kAsyncBootstrapFailure);
   }
 }
 
@@ -219,6 +225,7 @@ module.exports = {
   doesPathMatchFilter,
   isSupportedFileType,
   isTestFailureError,
+  kAsyncBootstrapFailure,
   parseCommandLine,
   setupTestReporters,
 };

--- a/test/parallel/test-runner-reporters.js
+++ b/test/parallel/test-runner-reporters.js
@@ -120,7 +120,7 @@ describe('node:test reporters', { concurrency: true }, () => {
   it('should throw when reporter setup throws asynchronously', async () => {
     const child = spawnSync(
       process.execPath,
-      ['--test', '--test-reporter', fixtures.path('empty.js'), 'reporters.js'],
+      ['--test', '--test-reporter', fixtures.fileURL('empty.js'), 'reporters.js'],
       { cwd: fixtures.path('test-runner') }
     );
     assert.strictEqual(child.status, 7);

--- a/test/parallel/test-runner-reporters.js
+++ b/test/parallel/test-runner-reporters.js
@@ -116,4 +116,16 @@ describe('node:test reporters', { concurrency: true }, () => {
       /^package: reporter-esm{"test:start":4,"test:pass":2,"test:fail":2,"test:plan":2,"test:diagnostic":\d+}$/,
     );
   });
+
+  it('should throw when reporter setup throws asynchronously', async () => {
+    const child = spawnSync(
+      process.execPath,
+      ['--test', '--test-reporter', fixtures.path('empty.js'), 'reporters.js'],
+      { cwd: fixtures.path('test-runner') }
+    );
+    assert.strictEqual(child.status, 7);
+    assert.strictEqual(child.signal, null);
+    assert.strictEqual(child.stdout.toString(), '');
+    assert.match(child.stderr.toString(), /ERR_INVALID_ARG_TYPE/);
+  });
 });


### PR DESCRIPTION
The test runner is bootstrapped synchronously, with the exception of importing custom reporters. To better handle asynchronously throw errors, this commit introduces an internal error type that can be checked for from the test runner's `'uncaughtException'` handler.

After https://github.com/nodejs/node/pull/46707 and this change land, the other `throw` statement in the `'uncaughtException'` handler can be removed. This will allow the test runner to handle errors thrown from outside of tests (which currently prevents the test runner from reporting results).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
