### PR TITLE
v8: Support getting GC time in `v8.GCProfiler`

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -1057,15 +1057,47 @@ Returns true if the Node.js instance is run to build a snapshot.
 added: v19.6.0
 -->
 
-This API collects GC data in current thread.
+### `GCProfile.GC_PROFILER_MODE`
 
-### `new v8.GCProfiler()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `GCProfile.GC_PROFILER_MODE.TIME`: Only the GC total time will be collected.
+* `GCProfile.GC_PROFILER_MODE.ALL`: the GC total time and heap statistic will
+  be collected.
+
+Define which data the `GCProfile` will collect.
+
+### `GCProfile.GC_PROFILER_MODE`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `GCProfile.GC_PROFILER_FORMAT.NONE`: return `undefined`.
+* `GCProfile.GC_PROFILER_FORMAT.OBJECT`: return an `object`.
+* `GCProfile.GC_PROFILER_FORMAT.STRING`: return a `string`.
+
+Define the return value in `stop` API.
+
+### `new v8.GCProfiler([options])`
 
 <!-- YAML
 added: v19.6.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46733
+    description: support GC mode and format.
 -->
 
-Create a new instance of the `v8.GCProfiler` class.
+* `options` {Object}
+  * `mode` {number} which data will be collected, defined by
+    `GCProfiler.GC_PROFILER_MODE`.
+    **Default:** `GCProfiler.GC_PROFILER_MODE.ALL`.
+
+Create a new instance of the `v8.GCProfiler` class, This instance collects GC
+data in current thread.
 
 ### `profiler.start()`
 
@@ -1075,14 +1107,22 @@ added: v19.6.0
 
 Start collecting GC data.
 
-### `profiler.stop()`
+### `profiler.stop([format])`
 
 <!-- YAML
 added: v19.6.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46733
+    description: support GC mode and format.
 -->
 
-Stop collecting GC data and return an object.The content of object
-is as follows.
+* `format` {number} The data type returned by `stop`, defined by
+  `GCProfiler.GC_PROFILER_MODE`.
+  **Default:** `GCProfiler.GC_PROFILER_MODE.OBJECT`.
+
+Stop collecting GC data and return a value depend on the
+`format` parameter. The content format is as follows.
 
 ```json
 {
@@ -1142,9 +1182,18 @@ is as follows.
       }
     }
   ],
-  "endTime": 1674059036865
+  "endTime": 1674059036865,
+  "totalGCTime": 1574.14
 }
 ```
+
+### `profiler.getTotalGCTime()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Get the total time spent on GC since the profiler starts tracking.
 
 Here's an example.
 

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -33,7 +33,12 @@ const {
 } = primordials;
 
 const { Buffer } = require('buffer');
-const { validateString, validateUint32 } = require('internal/validators');
+const {
+  validateString,
+  validateUint32,
+  validateObject,
+  validateOneOf,
+} = require('internal/validators');
 const {
   Serializer,
   Deserializer
@@ -63,7 +68,6 @@ const {
 } = require('internal/heap_utils');
 const promiseHooks = require('internal/promise_hooks');
 const { getOptionValue } = require('internal/options');
-const { JSONParse } = primordials;
 /**
  * Generates a snapshot of the current V8 heap
  * and writes it to a JSON file.
@@ -139,6 +143,10 @@ const {
   kBytecodeAndMetadataSizeIndex,
   kExternalScriptSourceSizeIndex,
   kCPUProfilerMetaDataSizeIndex,
+
+  // GCProfiler
+  GC_PROFILER_MODE,
+  GC_PROFILER_FORMAT,
 } = binding;
 
 const kNumberOfHeapSpaces = kHeapSpaces.length;
@@ -399,19 +407,63 @@ function deserialize(buffer) {
 
 class GCProfiler {
   #profiler = null;
+  #options = {
+    mode: GC_PROFILER_MODE.ALL,
+  };
+  constructor(options) {
+    if (options) {
+      validateObject(options);
+      if (options.mode !== undefined) {
+        validateUint32(options.mode, 'options.mode');
+        validateOneOf(options.mode,
+                      'options.mode',
+                      [
+                        GC_PROFILER_MODE.TIME,
+                        GC_PROFILER_MODE.ALL,
+                      ]);
+        this.#options.mode = options.mode;
+      }
+    }
+  }
+
+  static get GC_PROFILER_MODE() {
+    return GC_PROFILER_MODE;
+  }
+
+  static get GC_PROFILER_FORMAT() {
+    return GC_PROFILER_FORMAT;
+  }
 
   start() {
     if (!this.#profiler) {
-      this.#profiler = new binding.GCProfiler();
+      this.#profiler = new binding.GCProfiler(this.#options.mode);
       this.#profiler.start();
     }
   }
 
-  stop() {
+  getTotalGCTime() {
     if (this.#profiler) {
-      const data = this.#profiler.stop();
-      this.#profiler = null;
-      return JSONParse(data);
+      return this.#profiler.getTotalGCTime();
+    }
+  }
+  // Backward compatibility
+  stop(format = GC_PROFILER_FORMAT.OBJECT) {
+    if (format !== undefined) {
+      validateUint32(format, 'format');
+      validateOneOf(format,
+                    'format',
+                    [
+                      GC_PROFILER_FORMAT.NONE,
+                      GC_PROFILER_FORMAT.OBJECT,
+                      GC_PROFILER_FORMAT.STRING,
+                    ]);
+    }
+    if (this.#profiler) {
+      try {
+        return this.#profiler.stop(format);
+      } finally {
+        this.#profiler = null;
+      }
     }
   }
 }

--- a/src/node_v8.h
+++ b/src/node_v8.h
@@ -39,11 +39,18 @@ class BindingData : public SnapshotableObject {
 class GCProfiler : public BaseObject {
  public:
   enum class GCProfilerState { kInitialized, kStarted, kStopped };
-  GCProfiler(Environment* env, v8::Local<v8::Object> object);
+  enum class GCProfilerMode { TIME, ALL };
+  enum class GCProfilerFormat { NONE, OBJECT, STRING };
+  GCProfiler(Environment* env,
+             v8::Local<v8::Object> object,
+             GCProfilerMode profile_mode);
   inline ~GCProfiler() override;
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Stop(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetTotalGCTime(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  bool is_collect_all();
 
   JSONWriter* writer();
 
@@ -53,7 +60,9 @@ class GCProfiler : public BaseObject {
   SET_MEMORY_INFO_NAME(GCProfiler)
   SET_SELF_SIZE(GCProfiler)
 
+  GCProfilerMode mode;
   uint64_t start_time;
+  uint64_t gc_time;
   uint8_t current_gc_type;
   GCProfilerState state;
 

--- a/test/parallel/test-v8-collect-gc-profile-binding.js
+++ b/test/parallel/test-v8-collect-gc-profile-binding.js
@@ -1,8 +1,9 @@
+// Flags: --expose-gc
 'use strict';
 require('../common');
 const { GCProfiler } = require('v8');
 
-// Test if it makes the process crash.
+// Test start and stop more than once
 {
   const profiler = new GCProfiler();
   profiler.start();
@@ -10,6 +11,16 @@ const { GCProfiler } = require('v8');
   profiler.start();
   profiler.stop();
 }
+
+// Test free the GCProfiler memory when GC
+{
+  const profiler = new GCProfiler();
+  profiler.start();
+  profiler.stop();
+}
+global?.gc();
+
+// Test free the GCProfiler memory when the Environment exits
 {
   const profiler = new GCProfiler();
   profiler.start();

--- a/test/parallel/test-v8-collect-gc-profile-in-worker.js
+++ b/test/parallel/test-v8-collect-gc-profile-in-worker.js
@@ -2,15 +2,12 @@
 'use strict';
 require('../common');
 const { Worker } = require('worker_threads');
-const { testGCProfiler } = require('../common/v8');
+const { testGCProfiler, emitGC } = require('../common/v8');
 
 if (process.env.isWorker) {
   process.env.isWorker = 1;
   new Worker(__filename);
 } else {
   testGCProfiler();
-  for (let i = 0; i < 100; i++) {
-    new Array(100);
-  }
-  global?.gc();
+  emitGC();
 }

--- a/test/parallel/test-v8-collect-gc-profile.js
+++ b/test/parallel/test-v8-collect-gc-profile.js
@@ -1,12 +1,76 @@
 // Flags: --expose-gc
 'use strict';
 require('../common');
-const { testGCProfiler } = require('../common/v8');
+const assert = require('assert');
+const { GCProfiler } = require('v8');
+const { testGCProfiler, emitGC } = require('../common/v8');
 
-testGCProfiler();
+assert.throws(() => {
+  new GCProfiler({
+    mode: 'invalid type',
+  });
+}, /ERR_INVALID_ARG_TYPE/);
 
-for (let i = 0; i < 100; i++) {
-  new Array(100);
+assert.throws(() => {
+  new GCProfiler({
+    mode: 12345,
+  });
+}, /ERR_INVALID_ARG_VALUE/);
+
+const options = [
+  undefined,
+  {
+    mode: GCProfiler.GC_PROFILER_MODE.TIME,
+    format: GCProfiler.GC_PROFILER_FORMAT.STRING,
+  },
+  {
+    mode: GCProfiler.GC_PROFILER_MODE.TIME,
+    format: GCProfiler.GC_PROFILER_FORMAT.OBJECT,
+  },
+  {
+    mode: GCProfiler.GC_PROFILER_MODE.TIME,
+    format: GCProfiler.GC_PROFILER_FORMAT.NONE,
+  },
+  {
+    mode: GCProfiler.GC_PROFILER_MODE.ALL,
+    format: GCProfiler.GC_PROFILER_FORMAT.STRING,
+  },
+  {
+    mode: GCProfiler.GC_PROFILER_MODE.ALL,
+    format: GCProfiler.GC_PROFILER_FORMAT.OBJECT,
+  },
+  {
+    mode: GCProfiler.GC_PROFILER_MODE.ALL,
+    format: GCProfiler.GC_PROFILER_FORMAT.NONE,
+  },
+];
+
+options.forEach((option) => testGCProfiler(option));
+
+// Test getTotalGCTime
+{
+  const profiler = new GCProfiler();
+  assert.ok(profiler.getTotalGCTime() === undefined);
+  profiler.start();
+  emitGC();
+  assert.ok(profiler.getTotalGCTime() >= 0);
+  profiler.stop(GCProfiler.GC_PROFILER_FORMAT.NONE);
+  assert.ok(profiler.getTotalGCTime() === undefined);
 }
 
-global?.gc();
+// Test stop
+{
+  const profiler = new GCProfiler();
+  // Call stop before start
+  profiler.stop();
+  profiler.start();
+  assert.throws(() => {
+    profiler.stop('invalid type');
+  }, /ERR_INVALID_ARG_TYPE/);
+  assert.throws(() => {
+    profiler.stop(12345);
+  }, /ERR_INVALID_ARG_VALUE/);
+  assert.ok(profiler.stop(GCProfiler.GC_PROFILER_FORMAT.NONE) === undefined);
+  // Call stop after stop
+  profiler.stop();
+}


### PR DESCRIPTION
Support GC mode and format in `v8.GCProfiler`. The user can control
1. which data will be collected in GC callback.
2. which data type will be returned in `stop` API.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
