### PR TITLE
test: fix test-v8-collect-gc-profile-in-worker.js

### DIFF
--- a/test/parallel/test-v8-collect-gc-profile-in-worker.js
+++ b/test/parallel/test-v8-collect-gc-profile-in-worker.js
@@ -4,7 +4,7 @@ require('../common');
 const { Worker } = require('worker_threads');
 const { testGCProfiler } = require('../common/v8');
 
-if (process.env.isWorker) {
+if (!process.env.isWorker) {
   process.env.isWorker = 1;
   new Worker(__filename);
 } else {


### PR DESCRIPTION
fix `test-v8-collect-gc-profile-in-worker.js`.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
