### PR TITLE
url: simplify and improve url formatting

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -77,7 +77,6 @@ const path = require('path');
 
 const {
   validateFunction,
-  validateObject,
 } = require('internal/validators');
 
 const querystring = require('querystring');
@@ -150,8 +149,6 @@ class URLContext {
   password = '';
   port = '';
   hash = '';
-  hasHost = false;
-  hasOpaquePath = false;
 }
 
 function isURLSearchParams(self) {
@@ -282,7 +279,9 @@ class URLSearchParams {
     name = toUSVString(name);
     value = toUSVString(value);
     ArrayPrototypePush(this[searchParams], name, value);
-    update(this[context], this);
+    if (this[context]) {
+      this[context].search = this.toString();
+    }
   }
 
   delete(name) {
@@ -303,7 +302,9 @@ class URLSearchParams {
         i += 2;
       }
     }
-    update(this[context], this);
+    if (this[context]) {
+      this[context].search = this.toString();
+    }
   }
 
   get(name) {
@@ -398,7 +399,9 @@ class URLSearchParams {
       ArrayPrototypePush(list, name, value);
     }
 
-    update(this[context], this);
+    if (this[context]) {
+      this[context].search = this.toString();
+    }
   }
 
   sort() {
@@ -442,7 +445,9 @@ class URLSearchParams {
       }
     }
 
-    update(this[context], this);
+    if (this[context]) {
+      this[context].search = this.toString();
+    }
   }
 
   // https://heycam.github.io/webidl/#es-iterators
@@ -528,46 +533,6 @@ function isURLThis(self) {
   return (self !== undefined && self !== null && self[context] !== undefined);
 }
 
-function constructHref(ctx, options) {
-  if (options)
-    validateObject(options, 'options');
-
-  options = {
-    fragment: true,
-    unicode: false,
-    search: true,
-    auth: true,
-    ...options
-  };
-
-  // https://url.spec.whatwg.org/#url-serializing
-  let ret = ctx.protocol;
-  if (ctx.hasHost) {
-    ret += '//';
-    const hasUsername = ctx.username !== '';
-    const hasPassword = ctx.password !== '';
-    if (options.auth && (hasUsername || hasPassword)) {
-      if (hasUsername)
-        ret += ctx.username;
-      if (hasPassword)
-        ret += `:${ctx.password}`;
-      ret += '@';
-    }
-    ret += options.unicode ?
-      domainToUnicode(ctx.hostname) : ctx.hostname;
-    if (ctx.port !== '')
-      ret += `:${ctx.port}`;
-  } else if (!ctx.hasOpaquePath && ctx.pathname.lastIndexOf('/') !== 0 && ctx.pathname.startsWith('//')) {
-    ret += '/.';
-  }
-  ret += ctx.pathname;
-  if (options.search)
-    ret += ctx.search;
-  if (options.fragment)
-    ret += ctx.hash;
-  return ret;
-}
-
 class URL {
   constructor(input, base = undefined) {
     // toUSVString is not needed.
@@ -620,14 +585,8 @@ class URL {
     return `${constructor.name} ${inspect(obj, opts)}`;
   }
 
-  [kFormat](options) {
-    // TODO(@anonrig): Replace kFormat with actually calling setters.
-    return constructHref(this[context], options);
-  }
-
   #onParseComplete = (href, origin, protocol, hostname, pathname,
-                      search, username, password, port, hash, hasHost,
-                      hasOpaquePath) => {
+                      search, username, password, port, hash) => {
     const ctx = this[context];
     ctx.href = href;
     ctx.origin = origin;
@@ -639,9 +598,6 @@ class URL {
     ctx.password = password;
     ctx.port = port;
     ctx.hash = hash;
-    // TODO(@anonrig): Remove hasHost and hasOpaquePath when kFormat is removed.
-    ctx.hasHost = hasHost;
-    ctx.hasOpaquePath = hasOpaquePath;
     if (!this[searchParams]) { // Invoked from URL constructor
       this[searchParams] = new URLSearchParams();
       this[searchParams][context] = this;
@@ -853,33 +809,6 @@ ObjectDefineProperties(URL, {
   createObjectURL: kEnumerableProperty,
   revokeObjectURL: kEnumerableProperty,
 });
-
-function update(url, params) {
-  if (!url)
-    return;
-
-  const ctx = url[context];
-  const serializedParams = params.toString();
-  if (serializedParams.length > 0) {
-    ctx.search = '?' + serializedParams;
-  } else {
-    ctx.search = '';
-
-    // Potentially strip trailing spaces from an opaque path
-    if (ctx.hasOpaquePath && ctx.hash.length === 0) {
-      let length = ctx.pathname.length;
-      while (length > 0 && ctx.pathname.charCodeAt(length - 1) === 32) {
-        length--;
-      }
-
-      // No need to copy the whole string if there is no space at the end
-      if (length !== ctx.pathname.length) {
-        ctx.pathname = ctx.pathname.slice(0, length);
-      }
-    }
-  }
-  ctx.href = constructHref(ctx);
-}
 
 function initSearchParams(url, init) {
   if (!init) {
@@ -1379,7 +1308,6 @@ module.exports = {
   domainToASCII,
   domainToUnicode,
   urlToHttpOptions,
-  formatSymbol: kFormat,
   searchParamsSymbol: searchParams,
   encodeStr
 };

--- a/lib/url.js
+++ b/lib/url.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  Boolean,
   Int8Array,
   ObjectKeys,
   SafeSet,
@@ -37,7 +38,10 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_URL,
 } = require('internal/errors').codes;
-const { validateString } = require('internal/validators');
+const {
+  validateString,
+  validateObject,
+} = require('internal/validators');
 
 // This ensures setURLConstructor() is called before the native
 // URL::ToObject() method is used.
@@ -50,10 +54,13 @@ const {
   domainToASCII,
   domainToUnicode,
   fileURLToPath,
-  formatSymbol,
   pathToFileURL,
   urlToHttpOptions,
 } = require('internal/url');
+
+const {
+  formatUrl,
+} = internalBinding('url');
 
 // Original url.parse() API
 
@@ -587,13 +594,36 @@ function urlFormat(urlObject, options) {
   } else if (typeof urlObject !== 'object' || urlObject === null) {
     throw new ERR_INVALID_ARG_TYPE('urlObject',
                                    ['Object', 'string'], urlObject);
-  } else if (!(urlObject instanceof Url)) {
-    const format = urlObject[formatSymbol];
-    return format ?
-      format.call(urlObject, options) :
-      Url.prototype.format.call(urlObject);
+  } else if (urlObject instanceof URL) {
+    let fragment = true;
+    let unicode = false;
+    let search = true;
+    let auth = true;
+
+    if (options) {
+      validateObject(options, 'options');
+
+      if (options.fragment != null) {
+        fragment = Boolean(options.fragment);
+      }
+
+      if (options.unicode != null) {
+        unicode = Boolean(options.unicode);
+      }
+
+      if (options.search != null) {
+        search = Boolean(options.search);
+      }
+
+      if (options.auth != null) {
+        auth = Boolean(options.auth);
+      }
+    }
+
+    return formatUrl(urlObject.href, fragment, unicode, search, auth);
   }
-  return urlObject.format();
+
+  return Url.prototype.format.call(urlObject);
 }
 
 // These characters do not need escaping:

--- a/test/parallel/test-whatwg-url-custom-inspect.js
+++ b/test/parallel/test-whatwg-url-custom-inspect.js
@@ -55,9 +55,7 @@ assert.strictEqual(
     username: 'username',
     password: 'password',
     port: '8080',
-    hash: '#hash',
-    hasHost: true,
-    hasOpaquePath: false
+    hash: '#hash'
   }
 }`);
 


### PR DESCRIPTION
This pull request separates the logic of `kFormat` and `URL` and moves the logic to C++.

Quick summary:

- Move Url.format implementation to C++ where it directly calls Ada. This is done to avoid having any URL logic inside Node.js
- Call `search` setter whenever searchParams is changed, instead of calculating href on the JS layer. This was done to remove any URL logic inside Node.js.
- Remove `kFormat` since it isn't used anymore after step 1 and 2.
- Remove `hasOpaquePath` and `hasHost` from URL, since it was only needed for `kFormat` and `searchParams` setter.
- Ise `ToStringView()` and `ToString()` methods that @addaleax recommended. 

cc @nodejs/url @nodejs/cpp-reviewers 