### PR TITLE
build,test: add proper support for IBM i

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,6 +368,9 @@ DOCBUILDSTAMP_PREREQS = tools/doc/addon-verify.mjs doc/api/addons.md
 ifeq ($(OSTYPE),aix)
 DOCBUILDSTAMP_PREREQS := $(DOCBUILDSTAMP_PREREQS) out/$(BUILDTYPE)/node.exp
 endif
+ifeq ($(OSTYPE),os400)
+DOCBUILDSTAMP_PREREQS := $(DOCBUILDSTAMP_PREREQS) out/$(BUILDTYPE)/node.exp
+endif
 
 node_use_openssl = $(call available-node,"-p" \
 			 "process.versions.openssl != undefined")

--- a/common.gypi
+++ b/common.gypi
@@ -137,7 +137,7 @@
         'defines': [ 'DEBUG', '_DEBUG', 'V8_ENABLE_CHECKS' ],
         'cflags': [ '-g', '-O0' ],
         'conditions': [
-          ['OS=="aix"', {
+          ['OS in "aix os400"', {
             'cflags': [ '-gxcoff' ],
             'ldflags': [ '-Wl,-bbigtoc' ],
           }],
@@ -393,11 +393,11 @@
           'BUILDING_UV_SHARED=1',
         ],
       }],
-      [ 'OS in "linux freebsd openbsd solaris aix"', {
+      [ 'OS in "linux freebsd openbsd solaris aix os400"', {
         'cflags': [ '-pthread' ],
         'ldflags': [ '-pthread' ],
       }],
-      [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+      [ 'OS in "linux freebsd openbsd solaris android aix os400 cloudabi"', {
         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
         'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++17' ],
         'defines': [ '__STDC_FORMAT_MACROS' ],
@@ -421,11 +421,11 @@
             'cflags': [ '-m64' ],
             'ldflags': [ '-m64' ],
           }],
-          [ 'target_arch=="ppc" and OS!="aix"', {
+          [ 'target_arch=="ppc" and OS not in "aix os400"', {
             'cflags': [ '-m32' ],
             'ldflags': [ '-m32' ],
           }],
-          [ 'target_arch=="ppc64" and OS!="aix"', {
+          [ 'target_arch=="ppc64" and OS not in "aix os400"', {
             'cflags': [ '-m64', '-mminimal-toc' ],
             'ldflags': [ '-m64' ],
           }],
@@ -444,7 +444,7 @@
           }],
         ],
       }],
-      [ 'OS=="aix"', {
+      [ 'OS in "aix os400"', {
         'variables': {
           # Used to differentiate `AIX` and `OS400`(IBM i).
           'aix_variant_name': '<!(uname -s)',

--- a/configure.py
+++ b/configure.py
@@ -45,7 +45,7 @@ from utils import SearchFiles
 parser = argparse.ArgumentParser()
 
 valid_os = ('win', 'mac', 'solaris', 'freebsd', 'openbsd', 'linux',
-            'android', 'aix', 'cloudabi', 'ios')
+            'android', 'aix', 'cloudabi', 'os400', 'ios')
 valid_arch = ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'mips64el', 'ppc',
               'ppc64', 'x64', 'x86', 'x86_64', 's390x', 'riscv64', 'loong64')
 valid_arm_float_abi = ('soft', 'softfp', 'hard')
@@ -1302,7 +1302,7 @@ def configure_node(o):
   elif sys.platform == 'zos':
     configure_zos(o)
 
-  if flavor == 'aix':
+  if flavor in ('aix', 'os400'):
     o['variables']['node_target_type'] = 'static_library'
 
   if target_arch in ('x86', 'x64', 'ia32', 'x32'):
@@ -1402,6 +1402,8 @@ def configure_node(o):
   elif sys.platform == 'darwin':
     shlib_suffix = '%s.dylib'
   elif sys.platform.startswith('aix'):
+    shlib_suffix = '%s.a'
+  elif sys.platform == 'os400':
     shlib_suffix = '%s.a'
   elif sys.platform.startswith('zos'):
     shlib_suffix = '%s.x'
@@ -1916,6 +1918,9 @@ def configure_intl(o):
   elif flavor == 'mac':
     icu_config['variables']['icu_asm_ext'] = 'S'
     icu_config['variables']['icu_asm_opts'] = [ '-a', 'gcc-darwin' ]
+  elif sys.platform == 'os400':
+    icu_config['variables']['icu_asm_ext'] = 'S'
+    icu_config['variables']['icu_asm_opts'] = [ '-a', 'xlc' ]
   elif sys.platform.startswith('aix'):
     icu_config['variables']['icu_asm_ext'] = 'S'
     icu_config['variables']['icu_asm_opts'] = [ '-a', 'xlc' ]

--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -9,7 +9,7 @@
           '_GNU_SOURCE'
         ]
       }],
-      [ 'OS=="aix"', {
+      [ 'OS in "aix os400"', {
         'include_dirs': [ 'config/aix' ],
         'sources': [ 'config/aix/ares_config.h' ],
         'defines': [

--- a/deps/uv/common.gypi
+++ b/deps/uv/common.gypi
@@ -135,7 +135,7 @@
           }]
         ]
       }],
-      ['OS in "freebsd dragonflybsd linux openbsd solaris android aix"', {
+      ['OS in "freebsd dragonflybsd linux openbsd solaris android aix os400"', {
         'cflags': [ '-Wall' ],
         'cflags_cc': [ '-fno-rtti', '-fno-exceptions' ],
         'target_conditions': [

--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -326,6 +326,21 @@
             }],
           ]
         }],
+        [ 'OS=="os400"', {
+          'sources': [
+            'src/unix/aix-common.c',
+            'src/unix/ibmi.c',
+            'src/unix/posix-poll.c',
+            'src/unix/no-fsevents.c',
+            'src/unix/no-proctitle.c',
+          ],
+          'defines': [
+            '_ALL_SOURCE',
+            '_XOPEN_SOURCE=500',
+            '_LINUX_SOURCE_COMPAT',
+            '_THREAD_SAFE',
+          ],
+        }],
         [ 'OS=="freebsd" or OS=="dragonflybsd"', {
           'sources': [ 'src/unix/freebsd.c' ],
         }],

--- a/node.gyp
+++ b/node.gyp
@@ -61,7 +61,7 @@
       [ 'node_shared=="true"', {
         'node_target_type%': 'shared_library',
         'conditions': [
-          ['OS=="aix"', {
+          ['OS in "aix os400"', {
             # For AIX, always generate static library first,
             # It needs an extra step to generate exp and
             # then use both static lib and exp to create
@@ -110,7 +110,7 @@
     },
 
     'conditions': [
-      ['OS=="aix"', {
+      ['OS in "aix os400"', {
         'ldflags': [
           '-Wl,-bnoerrmsg',
         ],
@@ -192,7 +192,7 @@
           },
         }],
         [ 'node_intermediate_lib_type=="static_library" and '
-            'node_shared=="true" and OS=="aix"', {
+            'node_shared=="true" and OS in "aix os400"', {
           # For AIX, shared lib is linked by static lib and .exp. In the
           # case here, the executable needs to link to shared lib.
           # Therefore, use 'node_aix_shared' target to generate the
@@ -227,7 +227,7 @@
             },
           },
           'conditions': [
-            ['OS != "aix" and OS != "mac" and OS != "ios"', {
+            ['OS != "aix" and OS != "os400" and OS != "mac" and OS != "ios"', {
               'ldflags': [
                 '-Wl,--whole-archive',
                 '<(obj_dir)/<(STATIC_LIB_PREFIX)<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
@@ -741,7 +741,7 @@
             'NODE_USE_NODE_CODE_CACHE=1',
           ],
         }],
-        ['node_shared=="true" and OS=="aix"', {
+        ['node_shared=="true" and OS in "aix os400"', {
           'product_name': 'node_base',
         }],
         [ 'v8_enable_inspector==1', {
@@ -1170,7 +1170,7 @@
   ], # end targets
 
   'conditions': [
-    ['OS=="aix" and node_shared=="true"', {
+    ['OS in "aix os400" and node_shared=="true"', {
       'targets': [
         {
           'target_name': 'node_aix_shared',

--- a/node.gypi
+++ b/node.gypi
@@ -156,7 +156,7 @@
             },
           },
           'conditions': [
-            ['OS!="aix" and OS!="ios" and node_shared=="false"', {
+            ['OS!="aix" and OS!="os400" and OS!="ios" and node_shared=="false"', {
               'ldflags': [
                 '-Wl,--whole-archive',
                 '<(obj_dir)/deps/zlib/<(STATIC_LIB_PREFIX)zlib<(STATIC_LIB_SUFFIX)',
@@ -195,7 +195,7 @@
             },
           },
           'conditions': [
-            ['OS!="aix" and OS!="ios" and node_shared=="false"', {
+            ['OS!="aix" and OS!="os400" and OS!="ios" and node_shared=="false"', {
               'ldflags': [
                 '-Wl,--whole-archive',
                 '<(obj_dir)/deps/uv/<(STATIC_LIB_PREFIX)uv<(STATIC_LIB_SUFFIX)',
@@ -233,7 +233,7 @@
         '-lkvm',
       ],
     }],
-    [ 'OS=="aix"', {
+    [ 'OS in "aix os400"', {
       'defines': [
         '_LINUX_SOURCE_COMPAT',
         '__STDC_FORMAT_MACROS',

--- a/test/addons/common.gypi
+++ b/test/addons/common.gypi
@@ -1,7 +1,7 @@
 {
   'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
   'conditions': [
-    [ 'OS in "linux freebsd openbsd solaris android aix cloudabi"', {
+    [ 'OS in "linux freebsd openbsd solaris android aix os400 cloudabi"', {
       'cflags': ['-Wno-cast-function-type'],
     }],
   ],

--- a/test/addons/dlopen-ping-pong/binding.gyp
+++ b/test/addons/dlopen-ping-pong/binding.gyp
@@ -11,7 +11,7 @@
             'OTHER_LDFLAGS': [ '-Wl,-undefined', '-Wl,dynamic_lookup' ]
         }}],
         # Enable the shared object to be linked by runtime linker
-        ['OS=="aix"', {
+        ['OS in "aix os400"', {
           'ldflags': [ '-Wl,-G' ]
         }]],
     },

--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -6,7 +6,7 @@
       'conditions': [
         ['node_use_openssl=="true"', {
           'conditions': [
-            ['OS=="aix"', {
+            ['OS in "aix os400"', {
               'variables': {
                 # Used to differentiate `AIX` and `OS400`(IBM i).
                 'aix_variant_name': '<!(uname -s)',

--- a/test/addons/openssl-providers/binding.gyp
+++ b/test/addons/openssl-providers/binding.gyp
@@ -6,7 +6,7 @@
       'conditions': [
         ['node_use_openssl=="true"', {
           'conditions': [
-            ['OS=="aix"', {
+            ['OS in "aix os400"', {
               'variables': {
                 # Used to differentiate `AIX` and `OS400`(IBM i).
                 'aix_variant_name': '<!(uname -s)',

--- a/test/addons/zlib-binding/binding.gyp
+++ b/test/addons/zlib-binding/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'binding',
       'conditions': [
-        ['OS=="aix"', {
+        ['OS in "aix os400"', {
           'variables': {
             # Used to differentiate `AIX` and `OS400`(IBM i).
             'aix_variant_name': '<!(uname -s)',

--- a/tools/install.py
+++ b/tools/install.py
@@ -274,7 +274,7 @@ def headers(action):
   ], 'include/node/')
 
   # Add the expfile that is created on AIX
-  if sys.platform.startswith('aix'):
+  if sys.platform.startswith('aix') or sys.platform == "os400":
     action(['out/Release/node.exp'], 'include/node/')
 
   subdir_files('deps/v8/include', 'include/node/', wanted_v8_headers)

--- a/tools/v8_gypfiles/d8.gyp
+++ b/tools/v8_gypfiles/d8.gyp
@@ -47,7 +47,7 @@
         }],
         ['(OS=="linux" or OS=="mac" or OS=="freebsd" or OS=="netbsd" \
            or OS=="openbsd" or OS=="solaris" or OS=="android" \
-           or OS=="qnx" or OS=="aix")', {
+           or OS=="qnx" or OS=="aix" or OS=="os400")', {
              'sources': [ '<(V8_ROOT)/src/d8/d8-posix.cc', ]
            }],
         [ 'OS=="win"', {

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -330,11 +330,11 @@
               'V8_TARGET_ARCH_PPC_BE',
             ],
             'conditions': [
-              ['OS=="aix"', {
+              ['OS=="aix" or OS=="os400"', {
                 # Work around AIX ceil, trunc and round oddities.
                 'cflags': [ '-mcpu=power5+ -mfprnd' ],
               }],
-              ['OS=="aix"', {
+              ['OS=="aix" or OS=="os400"', {
                 # Work around AIX assembler popcntb bug.
                 'cflags': [ '-mno-popcntb' ],
               }],
@@ -651,7 +651,7 @@
         ],
       }],
       ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris" \
-         or OS=="netbsd" or OS=="qnx" or OS=="aix"', {
+         or OS=="netbsd" or OS=="qnx" or OS=="aix" or OS=="os400"', {
         'conditions': [
           [ 'v8_no_strict_aliasing==1', {
             'cflags': [ '-fno-strict-aliasing' ],
@@ -667,7 +667,7 @@
       ['OS=="netbsd"', {
         'cflags': [ '-I/usr/pkg/include' ],
       }],
-      ['OS=="aix"', {
+      ['OS=="aix" or OS=="os400"', {
         'defines': [
           # Support for malloc(0)
           '_LINUX_SOURCE_COMPAT=1',
@@ -700,7 +700,7 @@
             # Support for backtrace_symbols.
             'ldflags': [ '-rdynamic' ],
           }],
-          ['OS=="aix"', {
+          ['OS=="aix" or OS=="os400"', {
             'ldflags': [ '-Wl,-bbigtoc' ],
             'conditions': [
               ['v8_target_arch=="ppc64"', {
@@ -744,7 +744,7 @@
             },
             'conditions': [
               ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="netbsd" or \
-            OS=="qnx" or OS=="aix"', {
+            OS=="qnx" or OS=="aix" or OS=="os400"', {
                 'cflags!': [
                   '-O3',
                   '-O2',
@@ -795,7 +795,7 @@
             },
             'conditions': [
               ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="netbsd" or \
-            OS=="qnx" or OS=="aix"', {
+            OS=="qnx" or OS=="aix" or OS=="os400"', {
                 'cflags!': [
                   '-O0',
                   '-O1',
@@ -845,7 +845,7 @@
         'defines!': ['ENABLE_HANDLE_ZAPPING',],
         'conditions': [
           ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="netbsd" \
-            or OS=="aix"', {
+            or OS=="aix" or OS=="os400"', {
             'cflags!': [
               '-Os',
             ],

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1064,7 +1064,7 @@
             '<(V8_ROOT)/src/base/platform/platform-posix.h',
           ],
           'conditions': [
-            ['OS != "aix" and OS != "solaris"', {
+            ['OS != "aix" and OS != "os400" and OS != "solaris"', {
               'sources': [
                 '<(V8_ROOT)/src/base/platform/platform-posix-time.cc',
                 '<(V8_ROOT)/src/base/platform/platform-posix-time.h',
@@ -1084,7 +1084,7 @@
             ],
           },
         }],
-        ['OS=="aix"', {
+        ['OS in "aix os400"', {
           'variables': {
             # Used to differentiate `AIX` and `OS400`(IBM i).
             'aix_variant_name': '<!(uname -s)',


### PR DESCRIPTION
Python 3.9 on IBM i now properly returns "os400" for sys.platform instead of claiming to be AIX as it did previously. While the IBM i PASE environment is compatible with AIX, it is a subset and has numerous differences which makes it beneficial to distinguish, however this means that it now needs explicit support here.

This PR is based on #46510

Related PR:
- https://github.com/nodejs/node-gyp/pull/2626
- V8 patch: https://chromium-review.googlesource.com/c/v8/v8/+/4259330