### PR TITLE
test: improve control flow in test-tls-dhe

### DIFF
--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -29,14 +29,13 @@ if (!common.opensslCli)
   common.skip('missing openssl-cli');
 
 const assert = require('assert');
+const { once } = require('events');
 const tls = require('tls');
-const spawn = require('child_process').spawn;
+const { execFile } = require('child_process');
 const fixtures = require('../common/fixtures');
 
 const key = fixtures.readKey('agent2-key.pem');
 const cert = fixtures.readKey('agent2-cert.pem');
-let nsuccess = 0;
-let ntests = 0;
 const ciphers = 'DHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
 
 // Test will emit a warning because the DH parameter size is < 2048 bits
@@ -48,7 +47,7 @@ function loadDHParam(n) {
   return fixtures.readKey(keyname);
 }
 
-function test(keylen, expectedCipher, cb) {
+function test(keylen, expectedCipher) {
   const options = {
     key: key,
     cert: cert,
@@ -57,61 +56,29 @@ function test(keylen, expectedCipher, cb) {
     maxVersion: 'TLSv1.2',
   };
 
-  const server = tls.createServer(options, function(conn) {
-    conn.end();
-  });
+  const server = tls.createServer(options, (conn) => conn.end());
 
-  server.on('close', function(err) {
-    assert.ifError(err);
-    if (cb) cb();
-  });
-
-  server.listen(0, '127.0.0.1', function() {
-    const args = ['s_client', '-connect', `127.0.0.1:${this.address().port}`,
+  server.listen(0, '127.0.0.1', common.mustCall(() => {
+    const args = ['s_client', '-connect', `127.0.0.1:${server.address().port}`,
                   '-cipher', ciphers];
 
-    const client = spawn(common.opensslCli, args);
-    let out = '';
-    client.stdout.setEncoding('utf8');
-    client.stdout.on('data', function(d) {
-      out += d;
-    });
-    client.stdout.on('end', function() {
+    execFile(common.opensslCli, args, common.mustSucceed((stdout) => {
       assert(keylen === 'error' ||
-             out.includes(`Server Temp Key: DH, ${keylen} bits`));
-      const reg = new RegExp(`Cipher    : ${expectedCipher}`);
-      if (reg.test(out)) {
-        nsuccess++;
-        server.close();
-      }
-    });
-  });
+             stdout.includes(`Server Temp Key: DH, ${keylen} bits`));
+      assert(stdout.includes(`Cipher    : ${expectedCipher}`));
+      server.close();
+    }));
+  }));
+
+  return once(server, 'close');
 }
 
-function test512() {
-  assert.throws(function() {
-    test(512, 'DHE-RSA-AES128-SHA256', null);
+(async () => {
+  assert.throws(() => {
+    test(512, 'DHE-RSA-AES128-SHA256');
   }, /DH parameter is less than 1024 bits/);
-}
 
-function test1024() {
-  test(1024, 'DHE-RSA-AES128-SHA256', test2048);
-  ntests++;
-}
-
-function test2048() {
-  test(2048, 'DHE-RSA-AES128-SHA256', testError);
-  ntests++;
-}
-
-function testError() {
-  test('error', 'ECDHE-RSA-AES128-SHA256', test512);
-  ntests++;
-}
-
-test1024();
-
-process.on('exit', function() {
-  assert.strictEqual(ntests, nsuccess);
-  assert.strictEqual(ntests, 3);
-});
+  await test(1024, 'DHE-RSA-AES128-SHA256');
+  await test(2048, 'DHE-RSA-AES128-SHA256');
+  await test('error', 'ECDHE-RSA-AES128-SHA256');
+})().then(common.mustCall());


### PR DESCRIPTION
If this test fails, e.g., if the `s_client` output does not match the expectation, the previous implementation would not produce any helpful error messages. Rework the control flow to be more idiomatic. Avoid the `'exit'` event handler, unnecessary `RegExp`, callback chaining, and stream operations. Also, the TLS server `'close'` event does not pass an error to the event handler, so remove the respective assertion.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
