### PR TITLE
doc: add steps about signing the binary in single-executable docs

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -41,7 +41,10 @@ tool, [postject][]:
    $ codesign --remove-signature hello
    ```
 
-   * On Windows:
+   * On Windows (optional):
+
+   [signtool][] can be used from the installed [Windows SDK][]. If this step is
+   skipped, ignore any signature-related warning from postject.
 
    ```console
    $ signtool remove /s hello
@@ -83,7 +86,10 @@ tool, [postject][]:
    $ codesign --sign - hello
    ```
 
-   * On Windows:
+   * On Windows (optional):
+
+   A certificate needs to be present for this to work. However, the unsigned
+   binary would still be runnable.
 
    ```console
    $ signtool sign /fd SHA256 hello
@@ -160,9 +166,11 @@ to help us document them.
 [ELF]: https://en.wikipedia.org/wiki/Executable_and_Linkable_Format
 [Mach-O]: https://en.wikipedia.org/wiki/Mach-O
 [PE]: https://en.wikipedia.org/wiki/Portable_Executable
+[Windows SDK]: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/
 [`process.execPath`]: process.md#processexecpath
 [`require()`]: modules.md#requireid
 [`require.main`]: modules.md#accessing-the-main-module
 [fuse]: https://www.electronjs.org/docs/latest/tutorial/fuses
 [postject]: https://github.com/nodejs/postject
+[signtool]: https://learn.microsoft.com/en-us/windows/win32/seccrypto/signtool
 [single executable applications]: https://github.com/nodejs/single-executable

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -33,7 +33,21 @@ tool, [postject][]:
    $ cp $(command -v node) hello
    ```
 
-3. Inject the JavaScript file into the copied binary by running `postject` with
+3. Remove the signature of the binary:
+
+   * On macOS:
+
+   ```console
+   $ codesign --remove-signature hello
+   ```
+
+   * On Windows:
+
+   ```console
+   $ signtool remove /s hello
+   ```
+
+4. Inject the JavaScript file into the copied binary by running `postject` with
    the following options:
 
    * `hello` - The name of the copy of the `node` executable created in step 2.
@@ -61,7 +75,21 @@ tool, [postject][]:
          --macho-segment-name NODE_JS
      ```
 
-4. Run the binary:
+5. Sign the binary:
+
+   * On macOS:
+
+   ```console
+   $ codesign --sign - hello
+   ```
+
+   * On Windows:
+
+   ```console
+   $ signtool sign /fd SHA256 hello
+   ```
+
+6. Run the binary:
    ```console
    $ ./hello world
    Hello, world!


### PR DESCRIPTION
We didn't catch this in https://github.com/nodejs/node/pull/45038 because the binary wasn't signed by default unlike the official Node.js binary, which is signed by the Node.js Foundation identity by default.

Refs: https://github.com/nodejs/postject/issues/76 (macOS arm64 part only)
Fixes: https://github.com/nodejs/postject/issues/75

cc @nodejs/single-executable @targos @ShenHongFei

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
