### PR TITLE
test: fix default WPT titles

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -781,6 +781,9 @@ class WPTRunner {
   resultCallback(filename, test, reportResult) {
     const status = this.getTestStatus(test.status);
     const title = this.getTestTitle(filename);
+    if (/^Untitled( \d+)?$/.test(test.name)) {
+      test.name = `${title}${test.name.slice(8)}`;
+    }
     console.log(`---- ${title} ----`);
     if (status !== kPass) {
       this.fail(filename, test, status, reportResult);


### PR DESCRIPTION
See https://staging.wpt.fyi/results/dom/events/Event-constructors.any.html?run_id=5247378118410240&run_id=6086989598162944&view=subtest. This fixes the "Untitled" to be correctly the file's META title, in the end this allows the wpt dashboard to match the subtests based on their unique name.