### PR TITLE
win,src: revert simdutf to icu for win arm64

### DIFF
--- a/src/inspector/node_string.cc
+++ b/src/inspector/node_string.cc
@@ -1,7 +1,13 @@
 #include "node_string.h"
 #include "node/inspector/protocol/Protocol.h"
 #include "node_util.h"
+#if !defined(_WIN32) || !defined(_M_ARM64)
 #include "simdutf.h"
+#endif
+
+#if defined(_WIN32) && defined(_M_ARM64)
+#include <unicode/unistr.h>
+#endif
 
 namespace node {
 namespace inspector {
@@ -15,6 +21,13 @@ void builderAppendQuotedString(StringBuilder& builder,
                                const std::string_view string) {
   builder.put('"');
   if (!string.empty()) {
+#if defined(_WIN32) && defined(_M_ARM64)
+    icu::UnicodeString utf16 = icu::UnicodeString::fromUTF8(
+        icu::StringPiece(string.data(), string.length()));
+    escapeWideStringForJSON(
+        reinterpret_cast<const uint16_t*>(utf16.getBuffer()), utf16.length(),
+        &builder);
+#else
     size_t expected_utf16_length =
         simdutf::utf16_length_from_utf8(string.data(), string.length());
     MaybeStackBuffer<char16_t> buffer(expected_utf16_length);
@@ -24,6 +37,7 @@ void builderAppendQuotedString(StringBuilder& builder,
     escapeWideStringForJSON(reinterpret_cast<const uint16_t*>(buffer.out()),
                             utf16_length,
                             &builder);
+#endif
   }
   builder.put('"');
 }
@@ -31,6 +45,13 @@ void builderAppendQuotedString(StringBuilder& builder,
 std::unique_ptr<Value> parseJSON(const std::string_view string) {
   if (string.empty())
     return nullptr;
+#if defined(_WIN32) && defined(_M_ARM64)
+  icu::UnicodeString utf16 =
+      icu::UnicodeString::fromUTF8(icu::StringPiece(string.data(),
+                                                    string.length()));
+  return parseJSONCharacters(
+      reinterpret_cast<const uint16_t*>(utf16.getBuffer()), utf16.length());
+#else
   size_t expected_utf16_length =
       simdutf::utf16_length_from_utf8(string.data(), string.length());
   MaybeStackBuffer<char16_t> buffer(expected_utf16_length);
@@ -39,6 +60,7 @@ std::unique_ptr<Value> parseJSON(const std::string_view string) {
   CHECK_EQ(expected_utf16_length, utf16_length);
   return parseJSONCharacters(reinterpret_cast<const uint16_t*>(buffer.out()),
                              utf16_length);
+#endif
 }
 
 std::unique_ptr<Value> parseJSON(v8_inspector::StringView string) {
@@ -56,6 +78,26 @@ String StringViewToUtf8(v8_inspector::StringView view) {
     return std::string(reinterpret_cast<const char*>(view.characters8()),
                        view.length());
   }
+#if defined(_WIN32) && defined(_M_ARM64)
+  const uint16_t* source = view.characters16();
+  const UChar* unicodeSource = reinterpret_cast<const UChar*>(source);
+  static_assert(sizeof(*source) == sizeof(*unicodeSource),
+                "sizeof(*source) == sizeof(*unicodeSource)");
+
+  size_t result_length = view.length() * sizeof(*source);
+  std::string result(result_length, '\0');
+  icu::UnicodeString utf16(unicodeSource, view.length());
+  // ICU components for std::string compatibility are not enabled in build...
+  bool done = false;
+  while (!done) {
+    icu::CheckedArrayByteSink sink(&result[0], result_length);
+    utf16.toUTF8(sink);
+    result_length = sink.NumberOfBytesAppended();
+    result.resize(result_length);
+    done = !sink.Overflowed();
+  }
+  return result;
+#else
   const char16_t* source =
       reinterpret_cast<const char16_t*>(view.characters16());
   size_t expected_utf8_length =
@@ -65,6 +107,7 @@ String StringViewToUtf8(v8_inspector::StringView view) {
       simdutf::convert_utf16_to_utf8(source, view.length(), buffer.out());
   CHECK_EQ(expected_utf8_length, utf8_length);
   return String(buffer.out(), utf8_length);
+#endif
 }
 
 String fromDouble(double d) {
@@ -107,6 +150,11 @@ String fromUTF8(const uint8_t* data, size_t length) {
 }
 
 String fromUTF16(const uint16_t* data, size_t length) {
+#if defined(_WIN32) && defined(_M_ARM64)
+  icu::UnicodeString utf16(reinterpret_cast<const char16_t*>(data), length);
+  std::string result;
+  return utf16.toUTF8String(result);
+#else
   auto casted_data = reinterpret_cast<const char16_t*>(data);
   size_t expected_utf8_length =
       simdutf::utf8_length_from_utf16(casted_data, length);
@@ -115,6 +163,7 @@ String fromUTF16(const uint16_t* data, size_t length) {
       simdutf::convert_utf16_to_utf8(casted_data, length, buffer.out());
   CHECK_EQ(expected_utf8_length, utf8_length);
   return String(buffer.out(), utf8_length);
+#endif
 }
 
 const uint8_t* CharactersUTF8(const std::string_view s) {
@@ -122,8 +171,14 @@ const uint8_t* CharactersUTF8(const std::string_view s) {
 }
 
 size_t CharacterCount(const std::string_view s) {
+#if defined(_WIN32) && defined(_M_ARM64)
+  icu::UnicodeString utf16 =
+      icu::UnicodeString::fromUTF8(icu::StringPiece(s.data(), s.length()));
+  return utf16.countChar32();
+#else
   // TODO(@anonrig): Test to make sure CharacterCount returns correctly.
   return simdutf::utf32_length_from_utf8(s.data(), s.length());
+#endif
 }
 
 }  // namespace StringUtil


### PR DESCRIPTION
Recently, there has been a huge increase in the failing test count in Node.js on Windows on ARM64. One of the runs showcasing that can be viewed [here](https://gitlab.com/Linaro/windowsonarm/nightly/-/jobs/3757476282). After investigating, I discovered that those failures are caused by migration from icu to simdutf. This PR reverts those changes for Windows on ARM, thus eliminating the regression.

There is an active effort, which I'm a part of, working on adding Windows on ARM to the list of officially supported platforms (adding it to CI, etc.). Once that's done, all changes will be tested there and we'll be able to see regressions earlier while still in PR. I've also opened an issue upstream in the simdutf repo to discuss it and find an appropriate solution.

cc: @nodejs/platform-windows-arm, @anonrig

Refs: https://github.com/nodejs/build/issues/3046
Refs: https://github.com/nodejs/node/issues/25998
Refs: https://github.com/nodejs/node/pull/46471
Refs: https://github.com/nodejs/node/pull/46472
Refs: https://github.com/nodejs/node/pull/46548
Refs: https://github.com/simdutf/simdutf/issues/216