### PR TITLE
test: fix test-net-connect-reset-until-connected

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -31,8 +31,6 @@ test-crypto-dh-stateless: SKIP
 test-crypto-keygen: SKIP
 
 [$system==solaris] # Also applies to SmartOS
-# https://github.com/nodejs/node/issues/43446
-test-net-connect-reset-until-connected: PASS, FLAKY
 # https://github.com/nodejs/node/issues/43457
 test-domain-no-error-handler-abort-on-uncaught-0: PASS, FLAKY
 test-domain-no-error-handler-abort-on-uncaught-1: PASS,FLAKY
@@ -52,8 +50,6 @@ test-domain-with-abort-on-uncaught-exception: PASS, FLAKY
 test-fs-stat-bigint: PASS,FLAKY
 # https://github.com/nodejs/node/issues/31280
 test-worker-message-port-message-before-close: PASS,FLAKY
-# https://github.com/nodejs/node/issues/43446
-test-net-connect-reset-until-connected: PASS, FLAKY
 
 [$system==ibmi]
 # https://github.com/nodejs/node/pull/30819

--- a/test/parallel/test-net-connect-reset-until-connected.js
+++ b/test/parallel/test-net-connect-reset-until-connected.js
@@ -3,12 +3,21 @@
 const common = require('../common');
 const net = require('net');
 
+function barrier(count, cb) {
+  return function() {
+    if (--count === 0)
+      cb();
+  };
+}
+
 const server = net.createServer();
 server.listen(0, common.mustCall(function() {
   const port = server.address().port;
   const conn = net.createConnection(port);
+  const connok = barrier(2, () => conn.resetAndDestroy());
   conn.on('close', common.mustCall());
   server.on('connection', (socket) => {
+    connok();
     socket.on('error', common.expectsError({
       code: 'ECONNRESET',
       message: 'read ECONNRESET',
@@ -16,5 +25,5 @@ server.listen(0, common.mustCall(function() {
     }));
     server.close();
   });
-  conn.resetAndDestroy();
+  conn.on('connect', connok);
 }));


### PR DESCRIPTION
Fixes a race condition in test that causes the test to randomly timeout on Solaris 11.4, SmartOS and potentially also FreeBSD. TCP server starts listening and waits for client connection. The client resets the connection using conn.resetAndDestroy() and server is expected to see an error. The call to resetAndDestroy() is asynchronous is subject to race with earlier net.createConnection(). If effect of resetAndDestroy() occurs before server's listening socket accepts the connection, the test hangs. Test hang occurs since 'connection' event is never emitted as underlying function call to accept(3C) failed returning ECONNABORTED. The accept() failure is result of premature close(2) on client's file descriptor. Premature close(2) is result of too fast conn.resetAndDestroy().

The fix is to put a synchronization barrier that resets the connection only after it is established on both server and client side.

Below is a little bit more about the root cause. I show positive (test works) and negative (when test hangs) scenarios. The output contains only relevant system / library calls that were collected using truss(1). Without the fix the test randomly hangs. With the fix the test completes thousands of runs without single issue.

Race condition scenario:
```
connect(23, 0x7FFFBFFF7F10, 32, SOV_XPG4_2)Err#150 EINPROGRESS
^ client socket connects to server
close(23)= 0
^ client closes the socket too early
accept(21, 0x00000000, 0x00000000, SOV_DEFAULT)Err#130 ECONNABORTED
accept(21, 0x00000000, 0x00000000, SOV_DEFAULT)Err#11 EAGAIN
^ accept on listening socket fails
... test hangs and times out...
```

Working (good) scenario:
```
connect(23, 0x7FFFBFFF7F00, 32, SOV_XPG4_2)Err#150 EINPROGRESS
^ client socket connects to server
accept(21, 0x00000000, 0x00000000, SOV_DEFAULT)= 24
^ server accepts client connection on listening socket
close(23)= 0
^ client socket closes
read(24, 0x046B6010, 65536)Err#131 ECONNRESET
^ test gets so much wanted error while reading on accepted FD
close(24)= 0
^ accepted FD closes
... test completes, passes ...
```

Fixes: https://github.com/nodejs/node/issues/43446

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
