### PR TITLE
vm: fix leak in vm.compileFunction when importModuleDynamically is used

### DIFF
--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -20,6 +20,7 @@
 #define PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)                               \
   V(arrow_message_private_symbol, "node:arrowMessage")                         \
   V(contextify_context_private_symbol, "node:contextify:context")              \
+  V(compiled_function_entry, "node:compiled_function_entry")                   \
   V(decorated_private_symbol, "node:decorated")                                \
   V(napi_type_tag, "node:napi:type_tag")                                       \
   V(napi_wrapper, "node:napi:wrapper")                                         \

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -194,9 +194,6 @@ class CompiledFnEntry final : public BaseObject {
 
  private:
   uint32_t id_;
-  v8::Global<v8::Function> fn_;
-
-  static void WeakCallback(const v8::WeakCallbackInfo<CompiledFnEntry>& data);
 };
 
 v8::Maybe<bool> StoreCodeCacheResult(

--- a/test/pummel/test-vm-compile-function-leak.js
+++ b/test/pummel/test-vm-compile-function-leak.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// Flags: --max-old-space-size=10
+
+require('../common');
+const vm = require('vm');
+
+const code = `console.log("${'hello world '.repeat(1e5)}");`;
+
+for (let i = 0; i < 10000; i++) {
+  vm.compileFunction(code, [], {
+    importModuleDynamically: () => {},
+  });
+}


### PR DESCRIPTION
Previously in the implementation there was a cycle that V8 could not detect:

```
Strong global reference to CompiledFnEntry (JS wrapper)
    -> strong reference to callback setting (through the
       callbackMap key-value pair)
    -> importModuleDynamically (wrapper in internalCompileFunction())
    -> Strong reference to the compiled function (through closure in
       internalCompileFunction())
```

The CompiledFnEntry only gets GC'ed when the compiled function is GC'ed. Since the compiled function is always reachable as described above, there is a leak.

We only needed the first strong global reference because we didn't want the function to outlive the CompiledFnEntry. In this case it can be solved by using a private symbol instead of going with the global reference + destruction in the weak callback, which V8's GC is not going to understand.

Fixes: https://github.com/nodejs/node/issues/42080

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
