### PR TITLE
test: isolate hr-time specific wpt global init

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -484,9 +484,7 @@ class WPTRunner {
   pretendGlobalThisAs(name) {
     switch (name) {
       case 'Window': {
-        this.globalThisInitScripts.push(
-          `global.Window = Object.getPrototypeOf(globalThis).constructor;
-          self.GLOBAL.isWorker = () => false;`);
+        this.globalThisInitScripts.push('globalThis.Window = Object.getPrototypeOf(globalThis).constructor;');
         this.loadLazyGlobals();
         break;
       }

--- a/test/wpt/test-hr-time.js
+++ b/test/wpt/test-hr-time.js
@@ -5,6 +5,9 @@ const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('hr-time');
 
+runner.setInitScript(`
+  self.GLOBAL.isWorker = () => false;
+`);
 runner.pretendGlobalThisAs('Window');
 runner.brandCheckGlobalScopeAttribute('performance');
 


### PR DESCRIPTION
This removes a global scope WPT hack and only adds it to the WPT that needs it (hr-time).