### PR TITLE
test: remove useless require('../common') from WPTs

### DIFF
--- a/test/wpt/.eslintrc.yaml
+++ b/test/wpt/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+  node-core/required-modules: off
+  node-core/require-common-first: off

--- a/test/wpt/README.md
+++ b/test/wpt/README.md
@@ -46,7 +46,6 @@ For example, for the URL tests, add a file `test/wpt/test-url.js`:
 ```js
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('url');

--- a/test/wpt/test-abort.js
+++ b/test/wpt/test-abort.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('dom/abort');

--- a/test/wpt/test-atob.js
+++ b/test/wpt/test-atob.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('html/webappapis/atob');

--- a/test/wpt/test-blob.js
+++ b/test/wpt/test-blob.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('FileAPI/blob');

--- a/test/wpt/test-broadcastchannel.js
+++ b/test/wpt/test-broadcastchannel.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('webmessaging/broadcastchannel');

--- a/test/wpt/test-console.js
+++ b/test/wpt/test-console.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('console');

--- a/test/wpt/test-domexception.js
+++ b/test/wpt/test-domexception.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('webidl/ecmascript-binding/es-exceptions');

--- a/test/wpt/test-encoding.js
+++ b/test/wpt/test-encoding.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+
 const { WPTRunner } = require('../common/wpt');
 const runner = new WPTRunner('encoding');
 

--- a/test/wpt/test-events.js
+++ b/test/wpt/test-events.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('dom/events');

--- a/test/wpt/test-file.js
+++ b/test/wpt/test-file.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('FileAPI/file');

--- a/test/wpt/test-hr-time.js
+++ b/test/wpt/test-hr-time.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('hr-time');

--- a/test/wpt/test-microtask-queuing.js
+++ b/test/wpt/test-microtask-queuing.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('html/webappapis/microtask-queuing');

--- a/test/wpt/test-performance-timeline.js
+++ b/test/wpt/test-performance-timeline.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('performance-timeline');

--- a/test/wpt/test-resource-timing.js
+++ b/test/wpt/test-resource-timing.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('resource-timing');

--- a/test/wpt/test-streams.js
+++ b/test/wpt/test-streams.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('streams');

--- a/test/wpt/test-structured-clone.js
+++ b/test/wpt/test-structured-clone.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('html/webappapis/structured-clone');

--- a/test/wpt/test-timers.js
+++ b/test/wpt/test-timers.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('html/webappapis/timers');

--- a/test/wpt/test-url.js
+++ b/test/wpt/test-url.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('url');

--- a/test/wpt/test-user-timing.js
+++ b/test/wpt/test-user-timing.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('user-timing');

--- a/test/wpt/test-wasm-webapi.js
+++ b/test/wpt/test-wasm-webapi.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('../common');
 const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('wasm/webapi');


### PR DESCRIPTION
Removes the need to put a useless `require('../common');` at the top of every WPT startup file.