### PR TITLE
src: fail CommonEnvironmentSetup if environment bootstrapping failed

### DIFF
--- a/src/api/embed_helpers.cc
+++ b/src/api/embed_helpers.cc
@@ -180,6 +180,16 @@ CommonEnvironmentSetup::CreateForSnapshotting(
       nullptr,
       true,
       [&](const CommonEnvironmentSetup* setup) -> Environment* {
+        v8::TryCatch bootstrap_catch(setup->isolate());
+
+        auto print_exception = OnScopeLeave([&]() {
+          if (bootstrap_catch.HasCaught()) {
+            PrintCaughtException(setup->isolate(),
+                                 setup->isolate()->GetCurrentContext(),
+                                 bootstrap_catch);
+            errors->push_back("Failed to bootstrap environment.");
+          }
+        });
         return CreateEnvironment(
             setup->isolate_data(),
             setup->context(),

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1119,12 +1119,12 @@ ExitCode SnapshotBuilder::Generate(SnapshotData* out,
 
   {
     HandleScope scope(isolate);
-    TryCatch bootstrapCatch(isolate);
+    TryCatch bootstrap_catch(isolate);
 
-    auto print_Exception = OnScopeLeave([&]() {
-      if (bootstrapCatch.HasCaught()) {
+    auto print_exception = OnScopeLeave([&]() {
+      if (bootstrap_catch.HasCaught()) {
         PrintCaughtException(
-            isolate, isolate->GetCurrentContext(), bootstrapCatch);
+            isolate, isolate->GetCurrentContext(), bootstrap_catch);
       }
     });
 


### PR DESCRIPTION
If the `Environment` is failed to bootstrap at development time (e.g. syntax errors or uncaught exceptions in the JavaScript bootstrapping codes), the `CommonEnvironmentSetup::CreateForSnapshotting` should return a `nullptr` instead of a `CommonEnvironmentSetup` with a nullptr `env` member, which would lead to invalid access.

Unfortunately, I'm not aware of a method to run an unhappy path in bootstrapping to add a test case for this behavior.