### PR TITLE
test: remove useless WPT init scripts

### DIFF
--- a/test/wpt/test-blob.js
+++ b/test/wpt/test-blob.js
@@ -5,11 +5,4 @@ const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('FileAPI/blob');
 
-runner.setInitScript(`
-  const { Blob } = require('buffer');
-  const { ReadableStream } = require('stream/web');
-  global.Blob = Blob;
-  global.ReadableStream = ReadableStream;
-`);
-
 runner.runJsTests();

--- a/test/wpt/test-broadcastchannel.js
+++ b/test/wpt/test-broadcastchannel.js
@@ -5,9 +5,4 @@ const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('webmessaging/broadcastchannel');
 
-runner.setInitScript(`
-  const { BroadcastChannel } = require('worker_threads');
-  global.BroadcastChannel = BroadcastChannel;
-`);
-
 runner.runJsTests();

--- a/test/wpt/test-encoding.js
+++ b/test/wpt/test-encoding.js
@@ -3,9 +3,4 @@ require('../common');
 const { WPTRunner } = require('../common/wpt');
 const runner = new WPTRunner('encoding');
 
-runner.setInitScript(`
-  const { MessageChannel } = require('worker_threads');
-  global.MessageChannel = MessageChannel;
-`);
-
 runner.runJsTests();


### PR DESCRIPTION
These init scripts are no longer needed, they're setting globals which are already globals in v18.x