### PR TITLE
test: fix WPT title when no META title is present

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -752,7 +752,7 @@ class WPTRunner {
 
   getTestTitle(filename) {
     const spec = this.specMap.get(filename);
-    return spec.meta?.title || filename;
+    return spec.meta?.title || filename.split('.')[0];
   }
 
   // Map WPT test status to strings


### PR DESCRIPTION
Similar to #46778 this fixes a test title but in cases when no explicit title is defined and the test has no META title.

[This](https://staging.wpt.fyi/results/html/webappapis/timers/type-long-settimeout.any.html?run_id=5297950251024384&run_id=4570073553436672&run_id=5668268907954176&run_id=5695973460279296&run_id=5276738380627968&view=subtest) was `"Untitled"` before #46778, is `"type-long-settimeout.any.js"` with #46678, but needs to be just `"type-long-settimeout"`.

Edit: fix as seen [here](https://staging.wpt.fyi/results/html/webappapis/timers/type-long-settimeout.any.html?view=subtest&run_id=5297950251024384&run_id=4570073553436672&run_id=5695973460279296&run_id=5276738380627968&run_id=5097844537032704).