### PR TITLE
build: warn for gcc versions earlier than 10.1

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -152,7 +152,7 @@ Depending on the host platform, the selection of toolchains may vary.
 
 | Operating System | Compiler Versions                                              |
 | ---------------- | -------------------------------------------------------------- |
-| Linux            | GCC >= 8.3                                                     |
+| Linux            | GCC >= 10.1                                                    |
 | Windows          | Visual Studio >= 2019 with the Windows 10 SDK on a 64-bit host |
 | macOS            | Xcode >= 11 (Apple LLVM >= 11)                                 |
 
@@ -223,7 +223,7 @@ The Node.js project supports Python >= 3 for building and testing.
 
 #### Unix prerequisites
 
-* `gcc` and `g++` >= 8.3 or newer
+* `gcc` and `g++` >= 10.1 or newer
 * GNU Make 3.81 or newer
 * Python >=3.6 <=3.11 (see note above)
   * For test coverage, your Python installation must include pip.

--- a/configure.py
+++ b/configure.py
@@ -1032,8 +1032,8 @@ def check_compiler(o):
                 ('clang ' if is_clang else '', CXX, version_str))
   if not ok:
     warn('failed to autodetect C++ compiler version (CXX=%s)' % CXX)
-  elif clang_version < (8, 0, 0) if is_clang else gcc_version < (8, 3, 0):
-    warn('C++ compiler (CXX=%s, %s) too old, need g++ 8.3.0 or clang++ 8.0.0' %
+  elif clang_version < (8, 0, 0) if is_clang else gcc_version < (10, 1, 0):
+    warn('C++ compiler (CXX=%s, %s) too old, need g++ 10.1.0 or clang++ 8.0.0' %
          (CXX, version_str))
 
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CC, 'c')


### PR DESCRIPTION
Update the warning threshold for gcc to 10.1 starting from Node.js 20.
Builds can still proceed with earlier versions of gcc, but are not
guaranteed to work.

Refs: https://github.com/nodejs/node/discussions/45892

---

Notes:
- We are not planning on changing glibc requirements so the gcc-compiled Node.js 20 binaries should continue to run on the same platforms as Node.js 18 does.
- gcc 10 has been chosen because it is available on all of the platforms that we current build official binaries on that are already using gcc.
- https://gcc.gnu.org/releases.html doesn't list a gcc 10.0, hence the warning is set for less than 10.1.
- The "Official binary platforms and toolchains" section will be updated in a later PR when the build infrastructure has been updated accordingly for Node.js 20.
- See also https://github.com/nodejs/node/issues/45402 re. possibly moving to C++20 for Node.js 20.

cc @nodejs/build @nodejs/releasers @nodejs/tsc @nodejs/distros 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
