### PR TITLE
benchmark: add a benchmark for URLSearchParams creation and toString()

### DIFF
--- a/benchmark/url/url-searchparams-creation.js
+++ b/benchmark/url/url-searchparams-creation.js
@@ -1,0 +1,79 @@
+'use strict';
+const common = require('../common.js');
+
+const values = {
+  noencode: {
+    foo: 'bar',
+    baz: 'quux',
+    xyzzy: 'thud',
+  },
+  encodemany: {
+    '\u0080\u0083\u0089': 'bar',
+    '\u008C\u008E\u0099': 'quux',
+    'xyzzy': '\u00A5q\u00A3r',
+  },
+  encodelast: {
+    foo: 'bar',
+    baz: 'quux',
+    xyzzy: 'thu\u00AC',
+  },
+  array: {
+    foo: [],
+    baz: ['bar'],
+    xyzzy: ['bar', 'quux', 'thud'],
+  },
+  multiprimitives: {
+    foo: false,
+    bar: -13.37,
+    baz: 'baz',
+  },
+};
+
+function paramGenerator(paramType) {
+  const valueKeys = Object.keys(values);
+  switch (paramType) {
+    case 'string':
+      // Return the values object with all values as strings
+      return valueKeys.reduce((acc, key) => {
+        acc[key] = Object.keys(values[key]).reduce((acc, k, i) => {
+          acc += `${k}=${values[key][k]}${i < valueKeys.length - 1 ? '&' : ''}`;
+          return acc;
+        }, '');
+        return acc;
+      }, {});
+    case 'iterable':
+      // Return the values object with all values as iterable
+      return valueKeys.reduce((acc, key) => {
+        acc[key] = Object.keys(values[key]).reduce((acc, k) => {
+          acc.push([k, values[key][k]]);
+          return acc;
+        }, []);
+        return acc;
+      }, {});
+    case 'object':
+      // Return the values object with all values as objects
+      return values;
+    default:
+  }
+}
+
+const bench = common.createBenchmark(main, {
+  type: ['noencode', 'encodemany', 'encodelast', 'array', 'multiprimitives'],
+  inputType: ['string', 'iterable', 'object'],
+  n: [1e6],
+});
+
+function main({ n, type, inputType }) {
+  const inputs = paramGenerator(inputType);
+  const input = inputs[type];
+
+  // Force optimization before starting the benchmark
+  for (const name in inputs) {
+    new URLSearchParams(inputs[name]);
+  }
+
+  bench.start();
+  for (let i = 0; i < n; i += 1)
+    new URLSearchParams(input);
+  bench.end(n);
+}

--- a/benchmark/url/url-searchparams-toString.js
+++ b/benchmark/url/url-searchparams-toString.js
@@ -1,0 +1,76 @@
+'use strict';
+const common = require('../common.js');
+
+const values = {
+  noencode: {
+    foo: 'bar',
+    baz: 'quux',
+    xyzzy: 'thud',
+  },
+  encodemany: {
+    '\u0080\u0083\u0089': 'bar',
+    '\u008C\u008E\u0099': 'quux',
+    'xyzzy': '\u00A5q\u00A3r',
+  },
+  encodelast: {
+    foo: 'bar',
+    baz: 'quux',
+    xyzzy: 'thu\u00AC',
+  },
+  array: {
+    foo: [],
+    baz: ['bar'],
+    xyzzy: ['bar', 'quux', 'thud'],
+  },
+  multiprimitives: {
+    foo: false,
+    bar: -13.37,
+    baz: 'baz',
+  },
+};
+
+function paramGenerator(paramType) {
+  const valueKeys = Object.keys(values);
+  switch (paramType) {
+    case 'string':
+      // Return the values object with all values as strings
+      return valueKeys.reduce((acc, key) => {
+        const objectKeys = Object.keys(values[key]);
+        acc[key] = objectKeys.reduce((acc, k, i) => {
+          acc += `${k}=${values[key][k]}${i < objectKeys.length - 1 ? '&' : ''}`;
+          return acc;
+        }, '');
+        return acc;
+      }, {});
+    case 'iterable':
+      // Return the values object with all values as iterable
+      return valueKeys.reduce((acc, key) => {
+        acc[key] = Object.keys(values[key]).reduce((acc, k) => {
+          acc.push([k, values[key][k]]);
+          return acc;
+        }, []);
+        return acc;
+      }, {});
+    case 'object':
+      // Return the values object with all values as objects
+      return values;
+    default:
+  }
+}
+
+const bench = common.createBenchmark(main, {
+  type: ['noencode', 'encodemany', 'encodelast', 'array', 'multiprimitives'],
+  inputType: ['string', 'iterable', 'object'],
+  n: [1e6],
+});
+
+function main({ n, type, inputType }) {
+  const inputs = paramGenerator(inputType);
+  const input = inputs[type];
+  const u = new URLSearchParams(input);
+
+  bench.start();
+  for (let i = 0; i < n; i += 1)
+    u.toString();
+  bench.end(n);
+}


### PR DESCRIPTION
Was trying to work on https://github.com/nodejs/performance/issues/56 noticed there is no benchmark on `URLSearchParams.toString()` hence adding one same as `benchmark/querystring/querystring-stringify.js`

Refs: https://github.com/nodejs/performance/issues/56

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
