### PR TITLE
src: fix AliasedBuffer memory attribution in heap snapshots

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -571,6 +571,7 @@
         'src/uv.cc',
         # headers to make for a more pleasant IDE experience
         'src/aliased_buffer.h',
+        'src/aliased_buffer-inl.h',
         'src/aliased_struct.h',
         'src/aliased_struct-inl.h',
         'src/async_wrap.h',

--- a/src/aliased_buffer-inl.h
+++ b/src/aliased_buffer-inl.h
@@ -206,6 +206,25 @@ void AliasedBufferBase<NativeT, V8T>::reserve(size_t new_capacity) {
   count_ = new_capacity;
 }
 
+template <typename NativeT, typename V8T>
+inline size_t AliasedBufferBase<NativeT, V8T>::SelfSize() const {
+  return sizeof(*this);
+}
+
+#define VM(NativeT, V8T)                                                       \
+  template <>                                                                  \
+  inline const char* AliasedBufferBase<NativeT, v8::V8T>::MemoryInfoName()     \
+      const {                                                                  \
+    return "Aliased" #V8T;                                                     \
+  }                                                                            \
+  template <>                                                                  \
+  inline void AliasedBufferBase<NativeT, v8::V8T>::MemoryInfo(                 \
+      node::MemoryTracker* tracker) const {                                    \
+    tracker->TrackField("js_array", js_array_);                                \
+  }
+ALIASED_BUFFER_LIST(VM)
+#undef VM
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/aliased_buffer-inl.h
+++ b/src/aliased_buffer-inl.h
@@ -1,0 +1,213 @@
+#ifndef SRC_ALIASED_BUFFER_INL_H_
+#define SRC_ALIASED_BUFFER_INL_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include "aliased_buffer.h"
+#include "util-inl.h"
+
+namespace node {
+
+typedef size_t AliasedBufferIndex;
+
+template <typename NativeT, typename V8T>
+AliasedBufferBase<NativeT, V8T>::AliasedBufferBase(
+    v8::Isolate* isolate, const size_t count, const AliasedBufferIndex* index)
+    : isolate_(isolate), count_(count), byte_offset_(0), index_(index) {
+  CHECK_GT(count, 0);
+  if (index != nullptr) {
+    // Will be deserialized later.
+    return;
+  }
+  const v8::HandleScope handle_scope(isolate_);
+  const size_t size_in_bytes =
+      MultiplyWithOverflowCheck(sizeof(NativeT), count);
+
+  // allocate v8 ArrayBuffer
+  v8::Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(isolate_, size_in_bytes);
+  buffer_ = static_cast<NativeT*>(ab->Data());
+
+  // allocate v8 TypedArray
+  v8::Local<V8T> js_array = V8T::New(ab, byte_offset_, count);
+  js_array_ = v8::Global<V8T>(isolate, js_array);
+}
+
+template <typename NativeT, typename V8T>
+AliasedBufferBase<NativeT, V8T>::AliasedBufferBase(
+    v8::Isolate* isolate,
+    const size_t byte_offset,
+    const size_t count,
+    const AliasedBufferBase<uint8_t, v8::Uint8Array>& backing_buffer,
+    const AliasedBufferIndex* index)
+    : isolate_(isolate),
+      count_(count),
+      byte_offset_(byte_offset),
+      index_(index) {
+  if (index != nullptr) {
+    // Will be deserialized later.
+    return;
+  }
+  const v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::ArrayBuffer> ab = backing_buffer.GetArrayBuffer();
+
+  // validate that the byte_offset is aligned with sizeof(NativeT)
+  CHECK_EQ(byte_offset & (sizeof(NativeT) - 1), 0);
+  // validate this fits inside the backing buffer
+  CHECK_LE(MultiplyWithOverflowCheck(sizeof(NativeT), count),
+           ab->ByteLength() - byte_offset);
+
+  buffer_ = reinterpret_cast<NativeT*>(
+      const_cast<uint8_t*>(backing_buffer.GetNativeBuffer() + byte_offset));
+
+  v8::Local<V8T> js_array = V8T::New(ab, byte_offset, count);
+  js_array_ = v8::Global<V8T>(isolate, js_array);
+}
+
+template <typename NativeT, typename V8T>
+AliasedBufferBase<NativeT, V8T>::AliasedBufferBase(
+    const AliasedBufferBase& that)
+    : isolate_(that.isolate_),
+      count_(that.count_),
+      byte_offset_(that.byte_offset_),
+      buffer_(that.buffer_) {
+  DCHECK_NULL(index_);
+  js_array_ = v8::Global<V8T>(that.isolate_, that.GetJSArray());
+}
+
+template <typename NativeT, typename V8T>
+AliasedBufferIndex AliasedBufferBase<NativeT, V8T>::Serialize(
+    v8::Local<v8::Context> context, v8::SnapshotCreator* creator) {
+  DCHECK_NULL(index_);
+  return creator->AddData(context, GetJSArray());
+}
+
+template <typename NativeT, typename V8T>
+inline void AliasedBufferBase<NativeT, V8T>::Deserialize(
+    v8::Local<v8::Context> context) {
+  DCHECK_NOT_NULL(index_);
+  v8::Local<V8T> arr =
+      context->GetDataFromSnapshotOnce<V8T>(*index_).ToLocalChecked();
+  // These may not hold true for AliasedBuffers that have grown, so should
+  // be removed when we expand the snapshot support.
+  DCHECK_EQ(count_, arr->Length());
+  DCHECK_EQ(byte_offset_, arr->ByteOffset());
+  uint8_t* raw = static_cast<uint8_t*>(arr->Buffer()->Data());
+  buffer_ = reinterpret_cast<NativeT*>(raw + byte_offset_);
+  js_array_.Reset(isolate_, arr);
+  index_ = nullptr;
+}
+
+template <typename NativeT, typename V8T>
+AliasedBufferBase<NativeT, V8T>& AliasedBufferBase<NativeT, V8T>::operator=(
+    AliasedBufferBase<NativeT, V8T>&& that) noexcept {
+  DCHECK_NULL(index_);
+  this->~AliasedBufferBase();
+  isolate_ = that.isolate_;
+  count_ = that.count_;
+  byte_offset_ = that.byte_offset_;
+  buffer_ = that.buffer_;
+
+  js_array_.Reset(isolate_, that.js_array_.Get(isolate_));
+
+  that.buffer_ = nullptr;
+  that.js_array_.Reset();
+  return *this;
+}
+
+template <typename NativeT, typename V8T>
+v8::Local<V8T> AliasedBufferBase<NativeT, V8T>::GetJSArray() const {
+  DCHECK_NULL(index_);
+  return js_array_.Get(isolate_);
+}
+
+template <typename NativeT, typename V8T>
+void AliasedBufferBase<NativeT, V8T>::Release() {
+  DCHECK_NULL(index_);
+  js_array_.Reset();
+}
+
+template <typename NativeT, typename V8T>
+v8::Local<v8::ArrayBuffer> AliasedBufferBase<NativeT, V8T>::GetArrayBuffer()
+    const {
+  return GetJSArray()->Buffer();
+}
+
+template <typename NativeT, typename V8T>
+inline const NativeT* AliasedBufferBase<NativeT, V8T>::GetNativeBuffer() const {
+  DCHECK_NULL(index_);
+  return buffer_;
+}
+
+template <typename NativeT, typename V8T>
+inline const NativeT* AliasedBufferBase<NativeT, V8T>::operator*() const {
+  return GetNativeBuffer();
+}
+
+template <typename NativeT, typename V8T>
+inline void AliasedBufferBase<NativeT, V8T>::SetValue(const size_t index,
+                                                      NativeT value) {
+  DCHECK_LT(index, count_);
+  DCHECK_NULL(index_);
+  buffer_[index] = value;
+}
+
+template <typename NativeT, typename V8T>
+inline const NativeT AliasedBufferBase<NativeT, V8T>::GetValue(
+    const size_t index) const {
+  DCHECK_NULL(index_);
+  DCHECK_LT(index, count_);
+  return buffer_[index];
+}
+
+template <typename NativeT, typename V8T>
+typename AliasedBufferBase<NativeT, V8T>::Reference
+AliasedBufferBase<NativeT, V8T>::operator[](size_t index) {
+  DCHECK_NULL(index_);
+  return Reference(this, index);
+}
+
+template <typename NativeT, typename V8T>
+NativeT AliasedBufferBase<NativeT, V8T>::operator[](size_t index) const {
+  return GetValue(index);
+}
+
+template <typename NativeT, typename V8T>
+size_t AliasedBufferBase<NativeT, V8T>::Length() const {
+  return count_;
+}
+
+template <typename NativeT, typename V8T>
+void AliasedBufferBase<NativeT, V8T>::reserve(size_t new_capacity) {
+  DCHECK_NULL(index_);
+  DCHECK_GE(new_capacity, count_);
+  DCHECK_EQ(byte_offset_, 0);
+  const v8::HandleScope handle_scope(isolate_);
+
+  const size_t old_size_in_bytes = sizeof(NativeT) * count_;
+  const size_t new_size_in_bytes =
+      MultiplyWithOverflowCheck(sizeof(NativeT), new_capacity);
+
+  // allocate v8 new ArrayBuffer
+  v8::Local<v8::ArrayBuffer> ab =
+      v8::ArrayBuffer::New(isolate_, new_size_in_bytes);
+
+  // allocate new native buffer
+  NativeT* new_buffer = static_cast<NativeT*>(ab->Data());
+  // copy old content
+  memcpy(new_buffer, buffer_, old_size_in_bytes);
+
+  // allocate v8 TypedArray
+  v8::Local<V8T> js_array = V8T::New(ab, byte_offset_, new_capacity);
+
+  // move over old v8 TypedArray
+  js_array_ = std::move(v8::Global<V8T>(isolate_, js_array));
+
+  buffer_ = new_buffer;
+  count_ = new_capacity;
+}
+
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_ALIASED_BUFFER_INL_H_

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -4,7 +4,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include <cinttypes>
-#include "util-inl.h"
 #include "v8.h"
 
 namespace node {
@@ -28,34 +27,14 @@ typedef size_t AliasedBufferIndex;
  * The encapsulation herein provides a placeholder where such writes can be
  * observed. Any notification APIs will be left as a future exercise.
  */
-template <class NativeT,
-          class V8T,
-          // SFINAE NativeT to be scalar
-          typename = std::enable_if_t<std::is_scalar<NativeT>::value>>
+template <class NativeT, class V8T>
 class AliasedBufferBase {
  public:
+  static_assert(std::is_scalar<NativeT>::value);
+
   AliasedBufferBase(v8::Isolate* isolate,
                     const size_t count,
-                    const AliasedBufferIndex* index = nullptr)
-      : isolate_(isolate), count_(count), byte_offset_(0), index_(index) {
-    CHECK_GT(count, 0);
-    if (index != nullptr) {
-      // Will be deserialized later.
-      return;
-    }
-    const v8::HandleScope handle_scope(isolate_);
-    const size_t size_in_bytes =
-        MultiplyWithOverflowCheck(sizeof(NativeT), count);
-
-    // allocate v8 ArrayBuffer
-    v8::Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(
-        isolate_, size_in_bytes);
-    buffer_ = static_cast<NativeT*>(ab->Data());
-
-    // allocate v8 TypedArray
-    v8::Local<V8T> js_array = V8T::New(ab, byte_offset_, count);
-    js_array_ = v8::Global<V8T>(isolate, js_array);
-  }
+                    const AliasedBufferIndex* index = nullptr);
 
   /**
    * Create an AliasedBufferBase over a sub-region of another aliased buffer.
@@ -71,74 +50,16 @@ class AliasedBufferBase {
       const size_t byte_offset,
       const size_t count,
       const AliasedBufferBase<uint8_t, v8::Uint8Array>& backing_buffer,
-      const AliasedBufferIndex* index = nullptr)
-      : isolate_(isolate),
-        count_(count),
-        byte_offset_(byte_offset),
-        index_(index) {
-    if (index != nullptr) {
-      // Will be deserialized later.
-      return;
-    }
-    const v8::HandleScope handle_scope(isolate_);
-    v8::Local<v8::ArrayBuffer> ab = backing_buffer.GetArrayBuffer();
+      const AliasedBufferIndex* index = nullptr);
 
-    // validate that the byte_offset is aligned with sizeof(NativeT)
-    CHECK_EQ(byte_offset & (sizeof(NativeT) - 1), 0);
-    // validate this fits inside the backing buffer
-    CHECK_LE(MultiplyWithOverflowCheck(sizeof(NativeT), count),
-             ab->ByteLength() - byte_offset);
-
-    buffer_ = reinterpret_cast<NativeT*>(
-        const_cast<uint8_t*>(backing_buffer.GetNativeBuffer() + byte_offset));
-
-    v8::Local<V8T> js_array = V8T::New(ab, byte_offset, count);
-    js_array_ = v8::Global<V8T>(isolate, js_array);
-  }
-
-  AliasedBufferBase(const AliasedBufferBase& that)
-      : isolate_(that.isolate_),
-        count_(that.count_),
-        byte_offset_(that.byte_offset_),
-        buffer_(that.buffer_) {
-    DCHECK_NULL(index_);
-    js_array_ = v8::Global<V8T>(that.isolate_, that.GetJSArray());
-  }
+  AliasedBufferBase(const AliasedBufferBase& that);
 
   AliasedBufferIndex Serialize(v8::Local<v8::Context> context,
-                              v8::SnapshotCreator* creator) {
-    DCHECK_NULL(index_);
-    return creator->AddData(context, GetJSArray());
-  }
+                               v8::SnapshotCreator* creator);
 
-  inline void Deserialize(v8::Local<v8::Context> context) {
-    DCHECK_NOT_NULL(index_);
-    v8::Local<V8T> arr =
-        context->GetDataFromSnapshotOnce<V8T>(*index_).ToLocalChecked();
-    // These may not hold true for AliasedBuffers that have grown, so should
-    // be removed when we expand the snapshot support.
-    DCHECK_EQ(count_, arr->Length());
-    DCHECK_EQ(byte_offset_, arr->ByteOffset());
-    uint8_t* raw = static_cast<uint8_t*>(arr->Buffer()->Data());
-    buffer_ = reinterpret_cast<NativeT*>(raw + byte_offset_);
-    js_array_.Reset(isolate_, arr);
-    index_ = nullptr;
-  }
+  inline void Deserialize(v8::Local<v8::Context> context);
 
-  AliasedBufferBase& operator=(AliasedBufferBase&& that) noexcept {
-    DCHECK_NULL(index_);
-    this->~AliasedBufferBase();
-    isolate_ = that.isolate_;
-    count_ = that.count_;
-    byte_offset_ = that.byte_offset_;
-    buffer_ = that.buffer_;
-
-    js_array_.Reset(isolate_, that.js_array_.Get(isolate_));
-
-    that.buffer_ = nullptr;
-    that.js_array_.Reset();
-    return *this;
-  }
+  AliasedBufferBase& operator=(AliasedBufferBase&& that) noexcept;
 
   /**
    * Helper class that is returned from operator[] to support assignment into
@@ -191,105 +112,50 @@ class AliasedBufferBase {
   /**
    *  Get the underlying v8 TypedArray overlayed on top of the native buffer
    */
-  v8::Local<V8T> GetJSArray() const {
-    DCHECK_NULL(index_);
-    return js_array_.Get(isolate_);
-  }
+  v8::Local<V8T> GetJSArray() const;
 
-  void Release() {
-    DCHECK_NULL(index_);
-    js_array_.Reset();
-  }
+  void Release();
 
   /**
   *  Get the underlying v8::ArrayBuffer underlying the TypedArray and
   *  overlaying the native buffer
   */
-  v8::Local<v8::ArrayBuffer> GetArrayBuffer() const {
-    return GetJSArray()->Buffer();
-  }
+  v8::Local<v8::ArrayBuffer> GetArrayBuffer() const;
 
   /**
    *  Get the underlying native buffer. Note that all reads/writes should occur
    *  through the GetValue/SetValue/operator[] methods
    */
-  inline const NativeT* GetNativeBuffer() const {
-    DCHECK_NULL(index_);
-    return buffer_;
-  }
+  inline const NativeT* GetNativeBuffer() const;
 
   /**
    *  Synonym for GetBuffer()
    */
-  inline const NativeT* operator * () const {
-    return GetNativeBuffer();
-  }
+  inline const NativeT* operator*() const;
 
   /**
    *  Set position index to given value.
    */
-  inline void SetValue(const size_t index, NativeT value) {
-    DCHECK_LT(index, count_);
-    DCHECK_NULL(index_);
-    buffer_[index] = value;
-  }
+  inline void SetValue(const size_t index, NativeT value);
 
   /**
    *  Get value at position index
    */
-  inline const NativeT GetValue(const size_t index) const {
-    DCHECK_NULL(index_);
-    DCHECK_LT(index, count_);
-    return buffer_[index];
-  }
+  inline const NativeT GetValue(const size_t index) const;
 
   /**
    *  Effectively, a synonym for GetValue/SetValue
    */
-  Reference operator[](size_t index) {
-    DCHECK_NULL(index_);
-    return Reference(this, index);
-  }
+  Reference operator[](size_t index);
 
-  NativeT operator[](size_t index) const {
-    return GetValue(index);
-  }
+  NativeT operator[](size_t index) const;
 
-  size_t Length() const {
-    return count_;
-  }
+  size_t Length() const;
 
   // Should only be used to extend the array.
   // Should only be used on an owning array, not one created as a sub array of
   // an owning `AliasedBufferBase`.
-  void reserve(size_t new_capacity) {
-    DCHECK_NULL(index_);
-    DCHECK_GE(new_capacity, count_);
-    DCHECK_EQ(byte_offset_, 0);
-    const v8::HandleScope handle_scope(isolate_);
-
-    const size_t old_size_in_bytes = sizeof(NativeT) * count_;
-    const size_t new_size_in_bytes = MultiplyWithOverflowCheck(sizeof(NativeT),
-                                                              new_capacity);
-
-    // allocate v8 new ArrayBuffer
-    v8::Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(
-        isolate_, new_size_in_bytes);
-
-    // allocate new native buffer
-    NativeT* new_buffer = static_cast<NativeT*>(ab->Data());
-    // copy old content
-    memcpy(new_buffer, buffer_, old_size_in_bytes);
-
-    // allocate v8 TypedArray
-    v8::Local<V8T> js_array = V8T::New(ab, byte_offset_, new_capacity);
-
-    // move over old v8 TypedArray
-    js_array_ = std::move(v8::Global<V8T>(isolate_, js_array));
-
-    buffer_ = new_buffer;
-    count_ = new_capacity;
-  }
+  void reserve(size_t new_capacity);
 
  private:
   v8::Isolate* isolate_ = nullptr;
@@ -302,11 +168,22 @@ class AliasedBufferBase {
   const AliasedBufferIndex* index_ = nullptr;
 };
 
-typedef AliasedBufferBase<int32_t, v8::Int32Array> AliasedInt32Array;
-typedef AliasedBufferBase<uint8_t, v8::Uint8Array> AliasedUint8Array;
-typedef AliasedBufferBase<uint32_t, v8::Uint32Array> AliasedUint32Array;
-typedef AliasedBufferBase<double, v8::Float64Array> AliasedFloat64Array;
-typedef AliasedBufferBase<int64_t, v8::BigInt64Array> AliasedBigInt64Array;
+#define ALIASED_BUFFER_LIST(V)                                                 \
+  V(int8_t, Int8Array)                                                         \
+  V(uint8_t, Uint8Array)                                                       \
+  V(int16_t, Int16Array)                                                       \
+  V(uint16_t, Uint16Array)                                                     \
+  V(int32_t, Int32Array)                                                       \
+  V(uint32_t, Uint32Array)                                                     \
+  V(float, Float32Array)                                                       \
+  V(double, Float64Array)                                                      \
+  V(int64_t, BigInt64Array)
+
+#define V(NativeT, V8T)                                                        \
+  typedef AliasedBufferBase<NativeT, v8::V8T> Aliased##V8T;
+ALIASED_BUFFER_LIST(V)
+#undef V
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include <cinttypes>
+#include "memory_tracker.h"
 #include "v8.h"
 
 namespace node {
@@ -28,7 +29,7 @@ typedef size_t AliasedBufferIndex;
  * observed. Any notification APIs will be left as a future exercise.
  */
 template <class NativeT, class V8T>
-class AliasedBufferBase {
+class AliasedBufferBase : public MemoryRetainer {
  public:
   static_assert(std::is_scalar<NativeT>::value);
 
@@ -156,6 +157,11 @@ class AliasedBufferBase {
   // Should only be used on an owning array, not one created as a sub array of
   // an owning `AliasedBufferBase`.
   void reserve(size_t new_capacity);
+
+  inline size_t SelfSize() const override;
+
+  inline const char* MemoryInfoName() const override;
+  inline void MemoryInfo(node::MemoryTracker* tracker) const override;
 
  private:
   v8::Isolate* isolate_ = nullptr;

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -24,7 +24,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "aliased_buffer.h"
+#include "aliased_buffer-inl.h"
 #include "callback_queue-inl.h"
 #include "env.h"
 #include "node.h"

--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -3,6 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include "aliased_buffer-inl.h"
 #include "memory_tracker.h"
 
 namespace node {

--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -3,8 +3,8 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "aliased_buffer-inl.h"
 #include "memory_tracker.h"
+#include "util-inl.h"
 
 namespace node {
 
@@ -268,13 +268,6 @@ void MemoryTracker::TrackInlineField(const char* name,
                                      const uv_async_t& value,
                                      const char* node_name) {
   TrackInlineFieldWithSize(name, sizeof(value), "uv_async_t");
-}
-
-template <class NativeT, class V8T>
-void MemoryTracker::TrackField(const char* name,
-                               const AliasedBufferBase<NativeT, V8T>& value,
-                               const char* node_name) {
-  TrackField(name, value.GetJSArray(), "AliasedBuffer");
 }
 
 void MemoryTracker::Track(const MemoryRetainer* retainer,

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -13,7 +13,14 @@
 #include <string>
 #include <unordered_map>
 
+namespace v8 {
+class BackingStore;
+}
+
 namespace node {
+
+template <typename T>
+struct MallocedBuffer;
 
 // Set the node name of a MemoryRetainer to klass
 #define SET_MEMORY_INFO_NAME(Klass)                                            \

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -2,7 +2,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "aliased_buffer.h"
 #include "v8-profiler.h"
 
 #include <uv.h>
@@ -238,10 +237,6 @@ class MemoryTracker {
   inline void TrackInlineField(const char* edge_name,
                                const uv_async_t& value,
                                const char* node_name = nullptr);
-  template <class NativeT, class V8T>
-  inline void TrackField(const char* edge_name,
-                         const AliasedBufferBase<NativeT, V8T>& value,
-                         const char* node_name = nullptr);
 
   // Put a memory container into the graph, create an edge from
   // the current node if there is one on the stack.

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "node_file.h"  // NOLINT(build/include_inline)
-#include "aliased_buffer.h"
+#include "aliased_buffer-inl.h"
 #include "memory_tracker-inl.h"
 #include "node_buffer.h"
 #include "node_external_reference.h"

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1,5 +1,5 @@
 #include "node_http2.h"
-#include "aliased_buffer.h"
+#include "aliased_buffer-inl.h"
 #include "aliased_struct-inl.h"
 #include "debug_utils-inl.h"
 #include "histogram-inl.h"

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -1,5 +1,5 @@
 #include "node_perf.h"
-#include "aliased_buffer.h"
+#include "aliased_buffer-inl.h"
 #include "env-inl.h"
 #include "histogram-inl.h"
 #include "memory_tracker-inl.h"

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -20,6 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "node_v8.h"
+#include "aliased_buffer-inl.h"
 #include "base_object-inl.h"
 #include "env-inl.h"
 #include "memory_tracker-inl.h"

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -510,6 +510,22 @@ SlicedArguments::SlicedArguments(
     (*this)[i] = args[i + start];
 }
 
+template <typename T, size_t kStackStorageSize>
+void MaybeStackBuffer<T, kStackStorageSize>::AllocateSufficientStorage(
+    size_t storage) {
+  CHECK(!IsInvalidated());
+  if (storage > capacity()) {
+    bool was_allocated = IsAllocated();
+    T* allocated_ptr = was_allocated ? buf_ : nullptr;
+    buf_ = Realloc(allocated_ptr, storage);
+    capacity_ = storage;
+    if (!was_allocated && length_ > 0)
+      memcpy(buf_, buf_st_, length_ * sizeof(buf_[0]));
+  }
+
+  length_ = storage;
+}
+
 template <typename T, size_t S>
 ArrayBufferViewContents<T, S>::ArrayBufferViewContents(
     v8::Local<v8::Value> value) {

--- a/src/util.h
+++ b/src/util.h
@@ -412,19 +412,7 @@ class MaybeStackBuffer {
   // This method can be called multiple times throughout the lifetime of the
   // buffer, but once this has been called Invalidate() cannot be used.
   // Content of the buffer in the range [0, length()) is preserved.
-  void AllocateSufficientStorage(size_t storage) {
-    CHECK(!IsInvalidated());
-    if (storage > capacity()) {
-      bool was_allocated = IsAllocated();
-      T* allocated_ptr = was_allocated ? buf_ : nullptr;
-      buf_ = Realloc(allocated_ptr, storage);
-      capacity_ = storage;
-      if (!was_allocated && length_ > 0)
-        memcpy(buf_, buf_st_, length_ * sizeof(buf_[0]));
-    }
-
-    length_ = storage;
-  }
+  void AllocateSufficientStorage(size_t storage);
 
   void SetLength(size_t length) {
     // capacity() returns how much memory is actually available.

--- a/test/cctest/test_aliased_buffer.cc
+++ b/test/cctest/test_aliased_buffer.cc
@@ -1,6 +1,7 @@
-#include "v8.h"
+#include "aliased_buffer-inl.h"
 #include "aliased_buffer.h"
 #include "node_test_fixture.h"
+#include "v8.h"
 
 using node::AliasedBufferBase;
 

--- a/test/cctest/test_aliased_buffer.cc
+++ b/test/cctest/test_aliased_buffer.cc
@@ -1,5 +1,4 @@
 #include "aliased_buffer-inl.h"
-#include "aliased_buffer.h"
 #include "node_test_fixture.h"
 #include "v8.h"
 

--- a/test/pummel/test-heapdump-fs-promise.js
+++ b/test/pummel/test-heapdump-fs-promise.js
@@ -10,7 +10,7 @@ validateSnapshotNodes('Node / FSReqPromise', [
   {
     children: [
       { node_name: 'FSReqPromise', edge_name: 'native_to_javascript' },
-      { node_name: 'Float64Array', edge_name: 'stats_field_array' },
+      { node_name: 'Node / AliasedFloat64Array', edge_name: 'stats_field_array' },
     ],
   },
 ]);


### PR DESCRIPTION
### src: make util.h self-containted

Before it depended on util-inl.h. Fix it by moving
MaybeStackBuffer::AllocateSufficientStorage() into
util-inl.h

### src: move AliasedBuffer implementation to -inl.h

Drive-by: Replace the SFINAE with a static_assert because we don't
have (or need) an implementation for non-scalar AliasedBufferBase
otherwise. Add forward declarations to memory_tracker.h now that
aliased-buffer.h no longer includes util-inl.h.

### src: fix AliasedBuffer memory attribution in heap snapshots

Before the AliasedBuffers were represented solely by the TypedArrays
event though they also retain additional memory themselves.
Make the accounting more accurate by implementing MemoryRetainer in
AliasedBuffer.

Before:

<img width="790" alt="Screenshot 2023-02-24 at 16 06 00" src="https://user-images.githubusercontent.com/4299420/221213112-af4ef1e9-9a17-4fd0-8112-aef58b3edef5.png">

After:

<img width="789" alt="Screenshot 2023-02-24 at 16 05 51" src="https://user-images.githubusercontent.com/4299420/221213182-7d0f7d77-b26f-4db0-92d8-e81f18511408.png">


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
