### PR TITLE
sea: snapshot support in single executable applications

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -6,6 +6,10 @@
 added:
   - v19.7.0
   - v18.16.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46824
+    description: Added support for "useSnapshot".
 -->
 
 > Stability: 1 - Experimental: This feature is being designed and will change.
@@ -169,13 +173,32 @@ The configuration currently reads the following top-level fields:
 {
   "main": "/path/to/bundled/script.js",
   "output": "/path/to/write/the/generated/blob.blob",
-  "disableExperimentalSEAWarning": true // Default: false
+  "disableExperimentalSEAWarning": true, // Default: false
+  "useSnapshot": true  // Default: false
 }
 ```
 
 If the paths are not absolute, Node.js will use the path relative to the
 current working directory. The version of the Node.js binary used to produce
 the blob must be the same as the one to which the blob will be injected.
+
+### Startup snapshot support
+
+When `useSnapshot` is set to true in the configuration, during the generation
+of the single executable preparation blob, Node.js will run the `main` script
+to generate a startup snapshot. The script must invoke
+[`v8.startupSnapshot.setDeserializeMainFunction()`][] to set up the entry point.
+The generated startup snapshot would be part of the preparation blob and get
+injected into the final executable. When the single executable application is
+launched, instead of running the `main` script from scratch, Node.js would
+instead deserialize the snapshot to get to the state initialized during
+build-time directly.
+
+The general constraints of the startup snapshot scripts also apply to the main
+script when it's used to build snapshot for the single executable application,
+and the main script can use the [`v8.startupSnapshot` API][] to adapt to
+these constraints. See
+[documentation about startup snapshot support in Node.js][].
 
 ## Notes
 
@@ -249,6 +272,9 @@ to help us document them.
 [`process.execPath`]: process.md#processexecpath
 [`require()`]: modules.md#requireid
 [`require.main`]: modules.md#accessing-the-main-module
+[`v8.startupSnapshot.setDeserializeMainFunction()`]: v8.md#v8startupsnapshotsetdeserializemainfunctioncallback-data
+[`v8.startupSnapshot` API]: v8.md#startup-snapshot-api
+[documentation about startup snapshot support in Node.js]: cli.md#--build-snapshot
 [fuse]: https://www.electronjs.org/docs/latest/tutorial/fuses
 [postject]: https://github.com/nodejs/postject
 [signtool]: https://learn.microsoft.com/en-us/windows/win32/seccrypto/signtool

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -16,6 +16,10 @@ const {
   anonymousMainPath,
 } = internalBinding('mksnapshot');
 
+const { isExperimentalSeaWarningNeeded } = internalBinding('sea');
+
+const { emitExperimentalWarning } = require('internal/util');
+
 const {
   getOptionValue,
 } = require('internal/options');
@@ -126,6 +130,7 @@ function requireForUserSnapshot(id) {
   return require(normalizedId);
 }
 
+
 function main() {
   prepareMainThreadExecution(true, false);
   initializeCallbacks();
@@ -166,6 +171,10 @@ function main() {
   }
 
   const serializeMainArgs = [process, requireForUserSnapshot, minimalRunCjs];
+
+  if (isExperimentalSeaWarningNeeded()) {
+    emitExperimentalWarning('Single executable application');
+  }
 
   if (getOptionValue('--inspect-brk')) {
     internalBinding('inspector').callAndPauseOnStart(

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -174,7 +174,7 @@ function patchProcessObject(expandArgv1) {
     __proto__: null,
     enumerable: true,
     // Only set it to true during snapshot building.
-    configurable: getOptionValue('--build-snapshot'),
+    configurable: isBuildingSnapshot(),
     value: process.argv[0],
   });
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1253,7 +1253,7 @@ bool LoadSnapshotData(const SnapshotData** snapshot_data_ptr) {
   }
 
   if (per_process::cli_options->node_snapshot) {
-    // If --snapshot-blob is not specified or if the SEA contains not snapshot,
+    // If --snapshot-blob is not specified or if the SEA contains no snapshot,
     // we are reading the embedded snapshot, but we will skip it if
     // --no-node-snapshot is specified.
     const node::SnapshotData* read_data =

--- a/src/node.cc
+++ b/src/node.cc
@@ -292,6 +292,17 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
 
   CHECK(!env->isolate_data()->is_building_snapshot());
 
+#ifndef DISABLE_SINGLE_EXECUTABLE_APPLICATION
+  if (sea::IsSingleExecutable()) {
+    sea::SeaResource sea = sea::FindSingleExecutableResource();
+    // The SEA preparation blob building process should already enforce this,
+    // this check is just here to guard against the unlikely case where
+    // the SEA preparation blob has been manually modified by someone.
+    CHECK_IMPLIES(sea.use_snapshot(),
+                  !env->snapshot_deserialize_main().IsEmpty());
+  }
+#endif
+
   // TODO(joyeecheung): move these conditions into JS land and let the
   // deserialize main function take precedence. For workers, we need to
   // move the pre-execution part into a different file that can be
@@ -1198,49 +1209,66 @@ ExitCode GenerateAndWriteSnapshotData(const SnapshotData** snapshot_data_ptr,
   return exit_code;
 }
 
-ExitCode LoadSnapshotDataAndRun(const SnapshotData** snapshot_data_ptr,
-                                const InitializationResultImpl* result) {
-  ExitCode exit_code = result->exit_code_enum();
+bool LoadSnapshotData(const SnapshotData** snapshot_data_ptr) {
   // nullptr indicates there's no snapshot data.
   DCHECK_NULL(*snapshot_data_ptr);
+
+  bool is_sea = false;
+#ifndef DISABLE_SINGLE_EXECUTABLE_APPLICATION
+  if (sea::IsSingleExecutable()) {
+    is_sea = true;
+    sea::SeaResource sea = sea::FindSingleExecutableResource();
+    if (sea.use_snapshot()) {
+      std::unique_ptr<SnapshotData> read_data =
+          std::make_unique<SnapshotData>();
+      std::string_view snapshot = sea.main_code_or_snapshot;
+      if (SnapshotData::FromBlob(read_data.get(), snapshot)) {
+        *snapshot_data_ptr = read_data.release();
+        return true;
+      } else {
+        fprintf(stderr, "Invalid snapshot data in single executable binary\n");
+        return false;
+      }
+    }
+  }
+#endif
+
   // --snapshot-blob indicates that we are reading a customized snapshot.
-  if (!per_process::cli_options->snapshot_blob.empty()) {
+  // Ignore it when we are loading from SEA.
+  if (!is_sea && !per_process::cli_options->snapshot_blob.empty()) {
     std::string filename = per_process::cli_options->snapshot_blob;
     FILE* fp = fopen(filename.c_str(), "rb");
     if (fp == nullptr) {
       fprintf(stderr, "Cannot open %s", filename.c_str());
-      exit_code = ExitCode::kStartupSnapshotFailure;
-      return exit_code;
+      return false;
     }
     std::unique_ptr<SnapshotData> read_data = std::make_unique<SnapshotData>();
     bool ok = SnapshotData::FromFile(read_data.get(), fp);
     fclose(fp);
     if (!ok) {
-      // If we fail to read the customized snapshot,
-      // simply exit with kStartupSnapshotFailure.
-      exit_code = ExitCode::kStartupSnapshotFailure;
-      return exit_code;
+      return false;
     }
     *snapshot_data_ptr = read_data.release();
-  } else if (per_process::cli_options->node_snapshot) {
-    // If --snapshot-blob is not specified, we are reading the embedded
-    // snapshot, but we will skip it if --no-node-snapshot is specified.
+    return true;
+  }
+
+  if (per_process::cli_options->node_snapshot) {
+    // If --snapshot-blob is not specified or if the SEA contains not snapshot,
+    // we are reading the embedded snapshot, but we will skip it if
+    // --no-node-snapshot is specified.
     const node::SnapshotData* read_data =
         SnapshotBuilder::GetEmbeddedSnapshotData();
-    if (read_data != nullptr && read_data->Check()) {
+    if (read_data != nullptr) {
+      if (!read_data->Check()) {
+        return false;
+      }
       // If we fail to read the embedded snapshot, treat it as if Node.js
       // was built without one.
       *snapshot_data_ptr = read_data;
     }
   }
 
-  NodeMainInstance main_instance(*snapshot_data_ptr,
-                                 uv_default_loop(),
-                                 per_process::v8_platform.Platform(),
-                                 result->args(),
-                                 result->exec_args());
-  exit_code = main_instance.Run();
-  return exit_code;
+  return true;
 }
 
 static ExitCode StartInternal(int argc, char** argv) {
@@ -1275,7 +1303,8 @@ static ExitCode StartInternal(int argc, char** argv) {
 
   std::string sea_config = per_process::cli_options->experimental_sea_config;
   if (!sea_config.empty()) {
-    return sea::BuildSingleExecutableBlob(sea_config);
+    return sea::BuildSingleExecutableBlob(
+        sea_config, result->args(), result->exec_args());
   }
 
   // --build-snapshot indicates that we are in snapshot building mode.
@@ -1290,7 +1319,15 @@ static ExitCode StartInternal(int argc, char** argv) {
   }
 
   // Without --build-snapshot, we are in snapshot loading mode.
-  return LoadSnapshotDataAndRun(&snapshot_data, result.get());
+  if (!LoadSnapshotData(&snapshot_data)) {
+    return ExitCode::kStartupSnapshotFailure;
+  }
+  NodeMainInstance main_instance(snapshot_data,
+                                 uv_default_loop(),
+                                 per_process::v8_platform.Platform(),
+                                 result->args(),
+                                 result->exec_args());
+  return main_instance.Run();
 }
 
 int Start(int argc, char** argv) {

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -92,12 +92,16 @@ void NodeMainInstance::Run(ExitCode* exit_code, Environment* env) {
     bool runs_sea_code = false;
 #ifndef DISABLE_SINGLE_EXECUTABLE_APPLICATION
     if (sea::IsSingleExecutable()) {
-      runs_sea_code = true;
       sea::SeaResource sea = sea::FindSingleExecutableResource();
-      std::string_view code = sea.code;
-      LoadEnvironment(env, code);
+      if (!sea.use_snapshot()) {
+        runs_sea_code = true;
+        std::string_view code = sea.main_code_or_snapshot;
+        LoadEnvironment(env, code);
+      }
     }
 #endif
+    // Either there is already a snapshot main function from SEA, or it's not
+    // a SEA at all.
     if (!runs_sea_code) {
       LoadEnvironment(env, StartExecutionCallback{});
     }

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -168,6 +168,13 @@ bool IsSingleExecutable() {
 }
 
 void IsExperimentalSeaWarningNeeded(const FunctionCallbackInfo<Value>& args) {
+  bool is_building_sea =
+      !per_process::cli_options->experimental_sea_config.empty();
+  if (is_building_sea) {
+    args.GetReturnValue().Set(true);
+    return;
+  }
+
   if (!IsSingleExecutable()) {
     args.GetReturnValue().Set(false);
     return;

--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -6,8 +6,10 @@
 #if !defined(DISABLE_SINGLE_EXECUTABLE_APPLICATION)
 
 #include <cinttypes>
+#include <string>
 #include <string_view>
 #include <tuple>
+#include <vector>
 #include "node_exit_code.h"
 
 namespace node {
@@ -21,19 +23,24 @@ const uint32_t kMagic = 0x143da20;
 enum class SeaFlags : uint32_t {
   kDefault = 0,
   kDisableExperimentalSeaWarning = 1 << 0,
+  kUseSnapshot = 1 << 1,
 };
 
 struct SeaResource {
   SeaFlags flags = SeaFlags::kDefault;
-  std::string_view code;
+  std::string_view main_code_or_snapshot;
 
+  bool use_snapshot() const;
   static constexpr size_t kHeaderSize = sizeof(kMagic) + sizeof(SeaFlags);
 };
 
 bool IsSingleExecutable();
 SeaResource FindSingleExecutableResource();
 std::tuple<int, char**> FixupArgsForSEA(int argc, char** argv);
-node::ExitCode BuildSingleExecutableBlob(const std::string& config_path);
+node::ExitCode BuildSingleExecutableBlob(
+    const std::string& config_path,
+    const std::vector<std::string>& args,
+    const std::vector<std::string>& exec_args);
 }  // namespace sea
 }  // namespace node
 

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -585,7 +585,9 @@ size_t SnapshotSerializer::Write(const SnapshotMetadata& data) {
 // [    ...       ]  code_cache
 
 std::vector<char> SnapshotData::ToBlob() const {
+  std::vector<char> result;
   SnapshotSerializer w;
+
   w.Debug("SnapshotData::ToBlob()\n");
 
   size_t written_total = 0;
@@ -603,7 +605,10 @@ std::vector<char> SnapshotData::ToBlob() const {
   w.Debug("Write code_cache\n");
   written_total += w.WriteVector<builtins::CodeCacheInfo>(code_cache);
   w.Debug("SnapshotData::ToBlob() Wrote %d bytes\n", written_total);
-  return w.sink;
+
+  // Return using the temporary value to enable copy elision.
+  std::swap(result, w.sink);
+  return result;
 }
 
 void SnapshotData::ToFile(FILE* out) const {

--- a/test/sequential/test-single-executable-application-snapshot.js
+++ b/test/sequential/test-single-executable-application-snapshot.js
@@ -1,0 +1,83 @@
+'use strict';
+
+require('../common');
+
+const {
+  injectAndCodeSign,
+  skipIfSingleExecutableIsNotSupported,
+} = require('../common/sea');
+
+skipIfSingleExecutableIsNotSupported();
+
+// This tests the snapshot support in single executable applications.
+
+const tmpdir = require('../common/tmpdir');
+const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const { execFileSync, spawnSync } = require('child_process');
+const { join } = require('path');
+const assert = require('assert');
+
+const configFile = join(tmpdir.path, 'sea-config.json');
+const seaPrepBlob = join(tmpdir.path, 'sea-prep.blob');
+const outputFile = join(tmpdir.path, process.platform === 'win32' ? 'sea.exe' : 'sea');
+
+{
+  tmpdir.refresh();
+
+  writeFileSync(join(tmpdir.path, 'snapshot.js'), '', 'utf-8');
+  writeFileSync(configFile, `
+  {
+    "main": "snapshot.js",
+    "output": "sea-prep.blob",
+    "useSnapshot": true
+  }
+  `);
+
+  const child = spawnSync(
+    process.execPath,
+    ['--experimental-sea-config', 'sea-config.json'],
+    {
+      cwd: tmpdir.path
+    });
+
+  assert.match(
+    child.stderr.toString(),
+    /snapshot\.js does not invoke v8\.startupSnapshot\.setDeserializeMainFunction\(\)/);
+}
+
+{
+  tmpdir.refresh();
+  const code = `
+  const {
+    setDeserializeMainFunction,
+  } = require('v8').startupSnapshot;
+  
+  setDeserializeMainFunction(() => {
+    console.log('Hello from snapshot');
+  });
+  `;
+
+  writeFileSync(join(tmpdir.path, 'snapshot.js'), code, 'utf-8');
+  writeFileSync(configFile, `
+  {
+    "main": "snapshot.js",
+    "output": "sea-prep.blob",
+    "useSnapshot": true
+  }
+  `);
+
+  execFileSync(
+    process.execPath,
+    ['--experimental-sea-config', 'sea-config.json'],
+    {
+      cwd: tmpdir.path
+    });
+
+  assert(existsSync(seaPrepBlob));
+
+  copyFileSync(process.execPath, outputFile);
+  injectAndCodeSign(outputFile, seaPrepBlob);
+
+  const out = execFileSync(outputFile);
+  assert.strictEqual(out.toString().trim(), 'Hello from snapshot');
+}


### PR DESCRIPTION
Refs: https://github.com/nodejs/single-executable/discussions/57

This patch adds snapshot support to single executable applications.
To build a snapshot from the main script when preparing the
blob that will be injected into the single executable application,
add `"useSnapshot": true` to the configuration passed to
`--experimental-sea-config`. For example:

```
{
    "main": "snapshot.js",
    "output": "sea-prep.blob",
    "useSnapshot": true
}
```

The main script used to build the snapshot must invoke
`v8.startupSnapshot.setDeserializeMainFunction()` to configure the
entry point. The generated startup snapshot would be part of the
preparation blob and get injected into the final executable.

When the single executable application is launched, instead of running
the `main` script from scratch, Node.js would instead deserialize the
snapshot to get to the state initialized during build-time directly.

```
$ /path/to/node --experimental-sea-config sea-config.json
$ cp /path/to/node sea
$ postject sea NODE_SEA_BLOB sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
$ ./sea
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
