### PR TITLE
lib: make sure globals can be loaded after globalThis is sealed

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -15,6 +15,7 @@ const {
   ObjectGetOwnPropertyDescriptors,
   ObjectGetPrototypeOf,
   ObjectFreeze,
+  ObjectIsFrozen,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
   ObjectValues,
@@ -532,7 +533,10 @@ function defineLazyProperties(target, id, keys, enumerable = true) {
       mod ??= require(id);
       if (lazyLoadedValue === undefined) {
         lazyLoadedValue = mod[key];
-        set(lazyLoadedValue);
+        if (!ObjectIsFrozen(this)) {
+          // Replace it with a data property.
+          set(lazyLoadedValue);
+        }
       }
       return lazyLoadedValue;
     }

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -15,7 +15,7 @@ const {
   ObjectGetOwnPropertyDescriptors,
   ObjectGetPrototypeOf,
   ObjectFreeze,
-  ObjectIsFrozen,
+  ObjectIsSealed,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
   ObjectValues,
@@ -530,10 +530,10 @@ function defineLazyProperties(target, id, keys, enumerable = true) {
       value: `set ${key}`,
     });
     function get() {
-      mod ??= require(id);
       if (lazyLoadedValue === undefined) {
+        mod ??= require(id);
         lazyLoadedValue = mod[key];
-        if (!ObjectIsFrozen(this)) {
+        if (!ObjectIsSealed(this)) {
           // Replace it with a data property.
           set(lazyLoadedValue);
         }

--- a/test/parallel/test-frozen-global.js
+++ b/test/parallel/test-frozen-global.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// This tests that the globals can still be loaded after globalThis is freezed.
+
+require('../common');
+const assert = require('assert');
+
+Object.freeze(globalThis);
+const keys = Reflect.ownKeys(globalThis).filter((k) => typeof k === 'string');
+
+// These failures come from undici. We can remove them once they are fixed.
+const knownFailures = new Set(['FormData', 'Headers', 'Request', 'Response']);
+const failures = new Map();
+const success = new Map();
+for (const key of keys) {
+  try {
+    success.set(key, globalThis[key]);
+  } catch (e) {
+    failures.set(key, e);
+  }
+}
+
+console.log(failures);
+assert.deepStrictEqual(new Set(failures.keys()), knownFailures);

--- a/test/parallel/test-frozen-global.js
+++ b/test/parallel/test-frozen-global.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// This tests that the globals can still be loaded after globalThis is freezed.
+// This tests that the globals can still be loaded after globalThis is frozen.
 
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-sealed-global.js
+++ b/test/parallel/test-sealed-global.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// This tests that the globals can still be loaded after globalThis is freezed.
+// This tests that the globals can still be loaded after globalThis is sealed.
 
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-sealed-global.js
+++ b/test/parallel/test-sealed-global.js
@@ -5,7 +5,7 @@
 require('../common');
 const assert = require('assert');
 
-Object.freeze(globalThis);
+Object.seal(globalThis);
 const keys = Reflect.ownKeys(globalThis).filter((k) => typeof k === 'string');
 
 // These failures come from undici. We can remove them once they are fixed.


### PR DESCRIPTION
Since we made some of the globals lazily loaded to reduce startup overhead, and tried to update then as data properties once loaded, the lazily-loaded globals can no longer be loaded once globalThis is freezed. Fix this by not attempting to overwrite the property on loading these globals (so the property descriptors won't be spec-compliant in this case, but at least it's a good compromise between breakages and startup overhead).

Note that certain globals that come from undici are still broken because undici attempts to define a global dispatcher symbol on globalThis. This is reflected in the test.

Refs: https://github.com/nodejs/node/issues/46788

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
