### PR TITLE
worker: add support for worker name in inspector and trace_events

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1009,7 +1009,7 @@ changes:
     * `stackSizeMb` {number} The default maximum stack size for the thread.
       Small values may lead to unusable Worker instances. **Default:** `4`.
   * `name` {string} An optional `name` to be appended to the worker title
-    for debuggin/identification purposes, making the final title as 
+    for debuggin/identification purposes, making the final title as
     `[Worker ${id}] ${name}`. **Default:** `''`.
 
 ### Event: `'error'`

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -906,6 +906,10 @@ if (isMainThread) {
 <!-- YAML
 added: v10.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46832
+    description: Added support for a `titlePrefix` option, which allows
+                 adding a custom prefix to the worker title.
   - version: v14.9.0
     pr-url: https://github.com/nodejs/node/pull/34584
     description: The `filename` parameter can be a WHATWG `URL` object using
@@ -1004,6 +1008,9 @@ changes:
       used for generated code.
     * `stackSizeMb` {number} The default maximum stack size for the thread.
       Small values may lead to unusable Worker instances. **Default:** `4`.
+  * `titlePrefix` {string} A prefix to use for the title of the worker thread.
+    The final title will be `titlePrefix` + `Worker ${threadId}`. **Default:**
+    `''`.
 
 ### Event: `'error'`
 

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -908,8 +908,8 @@ added: v10.5.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/46832
-    description: Added support for a `titlePrefix` option, which allows
-                 adding a custom prefix to the worker title.
+    description: Added support for a `name` option, which allows
+                 adding a name to worker title for debugging.
   - version: v14.9.0
     pr-url: https://github.com/nodejs/node/pull/34584
     description: The `filename` parameter can be a WHATWG `URL` object using
@@ -1008,9 +1008,9 @@ changes:
       used for generated code.
     * `stackSizeMb` {number} The default maximum stack size for the thread.
       Small values may lead to unusable Worker instances. **Default:** `4`.
-  * `titlePrefix` {string} A prefix to use for the title of the worker thread.
-    The final title will be `titlePrefix` + `Worker ${threadId}`. **Default:**
-    `''`.
+  * `name` {string} An optional `name` to be appended to the worker title
+    for debuggin/identification purposes, making the final title as 
+    `[Worker ${id}] ${name}`. **Default:** `''`.
 
 ### Event: `'error'`
 

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1010,7 +1010,7 @@ changes:
       Small values may lead to unusable Worker instances. **Default:** `4`.
   * `name` {string} An optional `name` to be appended to the worker title
     for debuggin/identification purposes, making the final title as
-    `[Worker ${id}] ${name}`. **Default:** `''`.
+    `[worker ${id}] ${name}`. **Default:** `''`.
 
 ### Event: `'error'`
 

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -57,7 +57,7 @@ const {
 const { deserializeError } = require('internal/error_serdes');
 const { fileURLToPath, isURLInstance, pathToFileURL } = require('internal/url');
 const { kEmptyObject } = require('internal/util');
-const { validateArray } = require('internal/validators');
+const { validateArray, validateString } = require('internal/validators');
 
 const {
   ownsProcessState,
@@ -188,12 +188,19 @@ class Worker extends EventEmitter {
         options.env);
     }
 
+    let title_prefix = '';
+    if (options.titlePrefix) {
+      validateString(options.titlePrefix, 'options.titlePrefix');
+      title_prefix = options.titlePrefix;
+    }
+
     // Set up the C++ handle for the worker, as well as some internal wiring.
     this[kHandle] = new WorkerImpl(url,
                                    env === process.env ? null : env,
                                    options.execArgv,
                                    parseResourceLimits(options.resourceLimits),
-                                   !!(options.trackUnmanagedFds ?? true));
+                                   !!(options.trackUnmanagedFds ?? true),
+                                   title_prefix);
     if (this[kHandle].invalidExecArgv) {
       throw new ERR_WORKER_INVALID_EXEC_ARGV(this[kHandle].invalidExecArgv);
     }

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -189,10 +189,10 @@ class Worker extends EventEmitter {
         options.env);
     }
 
-    let title_prefix = '';
-    if (options.titlePrefix) {
-      validateString(options.titlePrefix, 'options.titlePrefix');
-      title_prefix = StringPrototypeTrim(options.titlePrefix);
+    let name = '';
+    if (options.name) {
+      validateString(options.name, 'options.name');
+      name = StringPrototypeTrim(options.name);
     }
 
     // Set up the C++ handle for the worker, as well as some internal wiring.
@@ -201,7 +201,7 @@ class Worker extends EventEmitter {
                                    options.execArgv,
                                    parseResourceLimits(options.resourceLimits),
                                    !!(options.trackUnmanagedFds ?? true),
-                                   title_prefix);
+                                   name);
     if (this[kHandle].invalidExecArgv) {
       throw new ERR_WORKER_INVALID_EXEC_ARGV(this[kHandle].invalidExecArgv);
     }

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -16,6 +16,7 @@ const {
   SafeArrayIterator,
   SafeMap,
   String,
+  StringPrototypeTrim,
   Symbol,
   SymbolFor,
   TypedArrayPrototypeFill,
@@ -191,7 +192,7 @@ class Worker extends EventEmitter {
     let title_prefix = '';
     if (options.titlePrefix) {
       validateString(options.titlePrefix, 'options.titlePrefix');
-      title_prefix = options.titlePrefix;
+      title_prefix = StringPrototypeTrim(options.titlePrefix);
     }
 
     // Set up the C++ handle for the worker, as well as some internal wiring.

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -513,10 +513,7 @@ NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
 }
 
 NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
-    Environment* env,
-    ThreadId thread_id,
-    const char* url,
-    const char* name) {
+    Environment* env, ThreadId thread_id, const char* url, const char* name) {
   CHECK_NOT_NULL(env);
   if (name == nullptr) name = "";
   CHECK_NE(thread_id.id, static_cast<uint64_t>(-1));

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -509,14 +509,7 @@ NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
     Environment* env,
     ThreadId thread_id,
     const char* url) {
-  CHECK_NOT_NULL(env);
-  CHECK_NE(thread_id.id, static_cast<uint64_t>(-1));
-#if HAVE_INSPECTOR
-  return std::make_unique<InspectorParentHandleImpl>(
-      env->inspector_agent()->GetParentHandle(thread_id.id, url, ""));
-#else
-  return {};
-#endif
+  return GetInspectorParentHandle(env, thread_id, url, "");
 }
 
 NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -525,6 +525,7 @@ NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
     const char* url,
     const char* title_prefix) {
   CHECK_NOT_NULL(env);
+  if (title_prefix == nullptr) title_prefix = "";
   CHECK_NE(thread_id.id, static_cast<uint64_t>(-1));
 #if HAVE_INSPECTOR
   return std::make_unique<InspectorParentHandleImpl>(

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -508,6 +508,20 @@ void FreeEnvironment(Environment* env) {
 NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
     Environment* env,
     ThreadId thread_id,
+    const char* url) {
+  CHECK_NOT_NULL(env);
+  CHECK_NE(thread_id.id, static_cast<uint64_t>(-1));
+#if HAVE_INSPECTOR
+  return std::make_unique<InspectorParentHandleImpl>(
+      env->inspector_agent()->GetParentHandle(thread_id.id, url, ""));
+#else
+  return {};
+#endif
+}
+
+NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
+    Environment* env,
+    ThreadId thread_id,
     const char* url,
     const char* title_prefix) {
   CHECK_NOT_NULL(env);

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -516,13 +516,13 @@ NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
     Environment* env,
     ThreadId thread_id,
     const char* url,
-    const char* title_prefix) {
+    const char* name) {
   CHECK_NOT_NULL(env);
-  if (title_prefix == nullptr) title_prefix = "";
+  if (name == nullptr) name = "";
   CHECK_NE(thread_id.id, static_cast<uint64_t>(-1));
 #if HAVE_INSPECTOR
   return std::make_unique<InspectorParentHandleImpl>(
-      env->inspector_agent()->GetParentHandle(thread_id.id, url, title_prefix));
+      env->inspector_agent()->GetParentHandle(thread_id.id, url, name));
 #else
   return {};
 #endif

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -508,12 +508,13 @@ void FreeEnvironment(Environment* env) {
 NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
     Environment* env,
     ThreadId thread_id,
-    const char* url) {
+    const char* url,
+    const char* title_prefix) {
   CHECK_NOT_NULL(env);
   CHECK_NE(thread_id.id, static_cast<uint64_t>(-1));
 #if HAVE_INSPECTOR
   return std::make_unique<InspectorParentHandleImpl>(
-      env->inspector_agent()->GetParentHandle(thread_id.id, url));
+      env->inspector_agent()->GetParentHandle(thread_id.id, url, title_prefix));
 #else
   return {};
 #endif

--- a/src/inspector/worker_inspector.cc
+++ b/src/inspector/worker_inspector.cc
@@ -14,9 +14,10 @@ class WorkerStartedRequest : public Request {
       uint64_t id,
       const std::string& url,
       std::shared_ptr<node::inspector::MainThreadHandle> worker_thread,
-      bool waiting)
+      bool waiting,
+      const std::string& title_prefix)
       : id_(id),
-        info_(BuildWorkerTitle(id), url, worker_thread),
+        info_(BuildWorkerTitle(id, title_prefix), url, worker_thread),
         waiting_(waiting) {}
   void Call(MainThreadInterface* thread) override {
     auto manager = thread->inspector_agent()->GetWorkerManager();
@@ -24,8 +25,8 @@ class WorkerStartedRequest : public Request {
   }
 
  private:
-  static std::string BuildWorkerTitle(int id) {
-    return "Worker " + std::to_string(id);
+  static std::string BuildWorkerTitle(int id, const std::string& title_prefix) {
+    return title_prefix + "Worker " + std::to_string(id);
   }
 
   uint64_t id_;
@@ -57,11 +58,13 @@ ParentInspectorHandle::ParentInspectorHandle(
     uint64_t id,
     const std::string& url,
     std::shared_ptr<MainThreadHandle> parent_thread,
-    bool wait_for_connect)
+    bool wait_for_connect,
+    const std::string& title_prefix)
     : id_(id),
       url_(url),
       parent_thread_(parent_thread),
-      wait_(wait_for_connect) {}
+      wait_(wait_for_connect),
+      title_prefix_(title_prefix) {}
 
 ParentInspectorHandle::~ParentInspectorHandle() {
   parent_thread_->Post(
@@ -71,7 +74,7 @@ ParentInspectorHandle::~ParentInspectorHandle() {
 void ParentInspectorHandle::WorkerStarted(
     std::shared_ptr<MainThreadHandle> worker_thread, bool waiting) {
   std::unique_ptr<Request> request(
-      new WorkerStartedRequest(id_, url_, worker_thread, waiting));
+      new WorkerStartedRequest(id_, url_, worker_thread, waiting, title_prefix_));
   parent_thread_->Post(std::move(request));
 }
 
@@ -97,9 +100,9 @@ void WorkerManager::WorkerStarted(uint64_t session_id,
 }
 
 std::unique_ptr<ParentInspectorHandle> WorkerManager::NewParentHandle(
-    uint64_t thread_id, const std::string& url) {
+    uint64_t thread_id, const std::string& url, const std::string& title_prefix) {
   bool wait = !delegates_waiting_on_start_.empty();
-  return std::make_unique<ParentInspectorHandle>(thread_id, url, thread_, wait);
+  return std::make_unique<ParentInspectorHandle>(thread_id, url, thread_, wait, title_prefix);
 }
 
 void WorkerManager::RemoveAttachDelegate(int id) {

--- a/src/inspector/worker_inspector.cc
+++ b/src/inspector/worker_inspector.cc
@@ -26,7 +26,8 @@ class WorkerStartedRequest : public Request {
 
  private:
   static std::string BuildWorkerTitle(int id, const std::string& title_prefix) {
-    return title_prefix + "Worker " + std::to_string(id);
+    return "[Worker " + std::to_string(id) + "]" +
+           (title_prefix == "" ? "" : " " + title_prefix);
   }
 
   uint64_t id_;

--- a/src/inspector/worker_inspector.cc
+++ b/src/inspector/worker_inspector.cc
@@ -73,8 +73,8 @@ ParentInspectorHandle::~ParentInspectorHandle() {
 
 void ParentInspectorHandle::WorkerStarted(
     std::shared_ptr<MainThreadHandle> worker_thread, bool waiting) {
-  std::unique_ptr<Request> request(
-      new WorkerStartedRequest(id_, url_, worker_thread, waiting, title_prefix_));
+  std::unique_ptr<Request> request(new WorkerStartedRequest(
+      id_, url_, worker_thread, waiting, title_prefix_));
   parent_thread_->Post(std::move(request));
 }
 
@@ -100,9 +100,12 @@ void WorkerManager::WorkerStarted(uint64_t session_id,
 }
 
 std::unique_ptr<ParentInspectorHandle> WorkerManager::NewParentHandle(
-    uint64_t thread_id, const std::string& url, const std::string& title_prefix) {
+    uint64_t thread_id,
+    const std::string& url,
+    const std::string& title_prefix) {
   bool wait = !delegates_waiting_on_start_.empty();
-  return std::make_unique<ParentInspectorHandle>(thread_id, url, thread_, wait, title_prefix);
+  return std::make_unique<ParentInspectorHandle>(
+      thread_id, url, thread_, wait, title_prefix);
 }
 
 void WorkerManager::RemoveAttachDelegate(int id) {

--- a/src/inspector/worker_inspector.cc
+++ b/src/inspector/worker_inspector.cc
@@ -74,8 +74,8 @@ ParentInspectorHandle::~ParentInspectorHandle() {
 
 void ParentInspectorHandle::WorkerStarted(
     std::shared_ptr<MainThreadHandle> worker_thread, bool waiting) {
-  std::unique_ptr<Request> request(new WorkerStartedRequest(
-      id_, url_, worker_thread, waiting, name_));
+  std::unique_ptr<Request> request(
+      new WorkerStartedRequest(id_, url_, worker_thread, waiting, name_));
   parent_thread_->Post(std::move(request));
 }
 
@@ -101,9 +101,7 @@ void WorkerManager::WorkerStarted(uint64_t session_id,
 }
 
 std::unique_ptr<ParentInspectorHandle> WorkerManager::NewParentHandle(
-    uint64_t thread_id,
-    const std::string& url,
-    const std::string& name) {
+    uint64_t thread_id, const std::string& url, const std::string& name) {
   bool wait = !delegates_waiting_on_start_.empty();
   return std::make_unique<ParentInspectorHandle>(
       thread_id, url, thread_, wait, name);

--- a/src/inspector/worker_inspector.h
+++ b/src/inspector/worker_inspector.h
@@ -63,11 +63,8 @@ class ParentInspectorHandle {
       uint64_t thread_id,
       const std::string& url,
       const std::string& title_prefix) {
-    return std::make_unique<ParentInspectorHandle>(thread_id,
-                                                   url,
-                                                   parent_thread_,
-                                                   wait_,
-                                                   title_prefix);
+    return std::make_unique<ParentInspectorHandle>(
+        thread_id, url, parent_thread_, wait_, title_prefix);
   }
   void WorkerStarted(std::shared_ptr<MainThreadHandle> worker_thread,
                      bool waiting);

--- a/src/inspector/worker_inspector.h
+++ b/src/inspector/worker_inspector.h
@@ -56,14 +56,16 @@ class ParentInspectorHandle {
   ParentInspectorHandle(uint64_t id,
                         const std::string& url,
                         std::shared_ptr<MainThreadHandle> parent_thread,
-                        bool wait_for_connect);
+                        bool wait_for_connect,
+                        const std::string& title_prefix);
   ~ParentInspectorHandle();
   std::unique_ptr<ParentInspectorHandle> NewParentInspectorHandle(
-      uint64_t thread_id, const std::string& url) {
+      uint64_t thread_id, const std::string& url, const std::string& title_prefix) {
     return std::make_unique<ParentInspectorHandle>(thread_id,
                                                    url,
                                                    parent_thread_,
-                                                   wait_);
+                                                   wait_,
+                                                   title_prefix);
   }
   void WorkerStarted(std::shared_ptr<MainThreadHandle> worker_thread,
                      bool waiting);
@@ -80,6 +82,7 @@ class ParentInspectorHandle {
   std::string url_;
   std::shared_ptr<MainThreadHandle> parent_thread_;
   bool wait_;
+  std::string title_prefix_;
 };
 
 class WorkerManager : public std::enable_shared_from_this<WorkerManager> {
@@ -88,7 +91,7 @@ class WorkerManager : public std::enable_shared_from_this<WorkerManager> {
                          : thread_(thread) {}
 
   std::unique_ptr<ParentInspectorHandle> NewParentHandle(
-      uint64_t thread_id, const std::string& url);
+      uint64_t thread_id, const std::string& url, const std::string& title_prefix);
   void WorkerStarted(uint64_t session_id, const WorkerInfo& info, bool waiting);
   void WorkerFinished(uint64_t session_id);
   std::unique_ptr<WorkerManagerEventHandle> SetAutoAttach(

--- a/src/inspector/worker_inspector.h
+++ b/src/inspector/worker_inspector.h
@@ -60,7 +60,9 @@ class ParentInspectorHandle {
                         const std::string& title_prefix);
   ~ParentInspectorHandle();
   std::unique_ptr<ParentInspectorHandle> NewParentInspectorHandle(
-      uint64_t thread_id, const std::string& url, const std::string& title_prefix) {
+      uint64_t thread_id,
+      const std::string& url,
+      const std::string& title_prefix) {
     return std::make_unique<ParentInspectorHandle>(thread_id,
                                                    url,
                                                    parent_thread_,
@@ -91,7 +93,9 @@ class WorkerManager : public std::enable_shared_from_this<WorkerManager> {
                          : thread_(thread) {}
 
   std::unique_ptr<ParentInspectorHandle> NewParentHandle(
-      uint64_t thread_id, const std::string& url, const std::string& title_prefix);
+      uint64_t thread_id,
+      const std::string& url,
+      const std::string& title_prefix);
   void WorkerStarted(uint64_t session_id, const WorkerInfo& info, bool waiting);
   void WorkerFinished(uint64_t session_id);
   std::unique_ptr<WorkerManagerEventHandle> SetAutoAttach(

--- a/src/inspector/worker_inspector.h
+++ b/src/inspector/worker_inspector.h
@@ -57,14 +57,14 @@ class ParentInspectorHandle {
                         const std::string& url,
                         std::shared_ptr<MainThreadHandle> parent_thread,
                         bool wait_for_connect,
-                        const std::string& title_prefix);
+                        const std::string& name);
   ~ParentInspectorHandle();
   std::unique_ptr<ParentInspectorHandle> NewParentInspectorHandle(
       uint64_t thread_id,
       const std::string& url,
-      const std::string& title_prefix) {
+      const std::string& name) {
     return std::make_unique<ParentInspectorHandle>(
-        thread_id, url, parent_thread_, wait_, title_prefix);
+        thread_id, url, parent_thread_, wait_, name);
   }
   void WorkerStarted(std::shared_ptr<MainThreadHandle> worker_thread,
                      bool waiting);
@@ -81,7 +81,7 @@ class ParentInspectorHandle {
   std::string url_;
   std::shared_ptr<MainThreadHandle> parent_thread_;
   bool wait_;
-  std::string title_prefix_;
+  std::string name_;
 };
 
 class WorkerManager : public std::enable_shared_from_this<WorkerManager> {
@@ -92,7 +92,7 @@ class WorkerManager : public std::enable_shared_from_this<WorkerManager> {
   std::unique_ptr<ParentInspectorHandle> NewParentHandle(
       uint64_t thread_id,
       const std::string& url,
-      const std::string& title_prefix);
+      const std::string& name);
   void WorkerStarted(uint64_t session_id, const WorkerInfo& info, bool waiting);
   void WorkerFinished(uint64_t session_id);
   std::unique_ptr<WorkerManagerEventHandle> SetAutoAttach(

--- a/src/inspector/worker_inspector.h
+++ b/src/inspector/worker_inspector.h
@@ -60,9 +60,7 @@ class ParentInspectorHandle {
                         const std::string& name);
   ~ParentInspectorHandle();
   std::unique_ptr<ParentInspectorHandle> NewParentInspectorHandle(
-      uint64_t thread_id,
-      const std::string& url,
-      const std::string& name) {
+      uint64_t thread_id, const std::string& url, const std::string& name) {
     return std::make_unique<ParentInspectorHandle>(
         thread_id, url, parent_thread_, wait_, name);
   }
@@ -90,9 +88,7 @@ class WorkerManager : public std::enable_shared_from_this<WorkerManager> {
                          : thread_(thread) {}
 
   std::unique_ptr<ParentInspectorHandle> NewParentHandle(
-      uint64_t thread_id,
-      const std::string& url,
-      const std::string& name);
+      uint64_t thread_id, const std::string& url, const std::string& name);
   void WorkerStarted(uint64_t session_id, const WorkerInfo& info, bool waiting);
   void WorkerFinished(uint64_t session_id);
   std::unique_ptr<WorkerManagerEventHandle> SetAutoAttach(

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -952,9 +952,7 @@ void Agent::SetParentHandle(
 }
 
 std::unique_ptr<ParentInspectorHandle> Agent::GetParentHandle(
-    uint64_t thread_id,
-    const std::string& url,
-    const std::string& name) {
+    uint64_t thread_id, const std::string& url, const std::string& name) {
   if (!parent_env_->should_create_inspector() && !client_) {
     ThrowUninitializedInspectorError(parent_env_);
     return std::unique_ptr<ParentInspectorHandle>{};
@@ -962,11 +960,9 @@ std::unique_ptr<ParentInspectorHandle> Agent::GetParentHandle(
 
   CHECK_NOT_NULL(client_);
   if (!parent_handle_) {
-    return client_->getWorkerManager()->NewParentHandle(
-        thread_id, url, name);
+    return client_->getWorkerManager()->NewParentHandle(thread_id, url, name);
   } else {
-    return parent_handle_->NewParentInspectorHandle(
-        thread_id, url, name);
+    return parent_handle_->NewParentInspectorHandle(thread_id, url, name);
   }
 }
 

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -952,7 +952,7 @@ void Agent::SetParentHandle(
 }
 
 std::unique_ptr<ParentInspectorHandle> Agent::GetParentHandle(
-    uint64_t thread_id, const std::string& url) {
+    uint64_t thread_id, const std::string& url, const std::string& title_prefix) {
   if (!parent_env_->should_create_inspector() && !client_) {
     ThrowUninitializedInspectorError(parent_env_);
     return std::unique_ptr<ParentInspectorHandle>{};
@@ -960,9 +960,9 @@ std::unique_ptr<ParentInspectorHandle> Agent::GetParentHandle(
 
   CHECK_NOT_NULL(client_);
   if (!parent_handle_) {
-    return client_->getWorkerManager()->NewParentHandle(thread_id, url);
+    return client_->getWorkerManager()->NewParentHandle(thread_id, url, title_prefix);
   } else {
-    return parent_handle_->NewParentInspectorHandle(thread_id, url);
+    return parent_handle_->NewParentInspectorHandle(thread_id, url, title_prefix);
   }
 }
 

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -954,7 +954,7 @@ void Agent::SetParentHandle(
 std::unique_ptr<ParentInspectorHandle> Agent::GetParentHandle(
     uint64_t thread_id,
     const std::string& url,
-    const std::string& title_prefix) {
+    const std::string& name) {
   if (!parent_env_->should_create_inspector() && !client_) {
     ThrowUninitializedInspectorError(parent_env_);
     return std::unique_ptr<ParentInspectorHandle>{};
@@ -963,10 +963,10 @@ std::unique_ptr<ParentInspectorHandle> Agent::GetParentHandle(
   CHECK_NOT_NULL(client_);
   if (!parent_handle_) {
     return client_->getWorkerManager()->NewParentHandle(
-        thread_id, url, title_prefix);
+        thread_id, url, name);
   } else {
     return parent_handle_->NewParentInspectorHandle(
-        thread_id, url, title_prefix);
+        thread_id, url, name);
   }
 }
 

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -952,7 +952,9 @@ void Agent::SetParentHandle(
 }
 
 std::unique_ptr<ParentInspectorHandle> Agent::GetParentHandle(
-    uint64_t thread_id, const std::string& url, const std::string& title_prefix) {
+    uint64_t thread_id,
+    const std::string& url,
+    const std::string& title_prefix) {
   if (!parent_env_->should_create_inspector() && !client_) {
     ThrowUninitializedInspectorError(parent_env_);
     return std::unique_ptr<ParentInspectorHandle>{};
@@ -960,9 +962,11 @@ std::unique_ptr<ParentInspectorHandle> Agent::GetParentHandle(
 
   CHECK_NOT_NULL(client_);
   if (!parent_handle_) {
-    return client_->getWorkerManager()->NewParentHandle(thread_id, url, title_prefix);
+    return client_->getWorkerManager()->NewParentHandle(
+        thread_id, url, title_prefix);
   } else {
-    return parent_handle_->NewParentInspectorHandle(thread_id, url, title_prefix);
+    return parent_handle_->NewParentInspectorHandle(
+        thread_id, url, title_prefix);
   }
 }
 

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -84,7 +84,7 @@ class Agent {
   std::unique_ptr<ParentInspectorHandle> GetParentHandle(
       uint64_t thread_id,
       const std::string& url,
-      const std::string& title_prefix);
+      const std::string& name);
 
   // Called to create inspector sessions that can be used from the same thread.
   // The inspector responds by using the delegate to send messages back.

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -82,7 +82,9 @@ class Agent {
 
   void SetParentHandle(std::unique_ptr<ParentInspectorHandle> parent_handle);
   std::unique_ptr<ParentInspectorHandle> GetParentHandle(
-      uint64_t thread_id, const std::string& url, const std::string& title_prefix);
+      uint64_t thread_id,
+      const std::string& url,
+      const std::string& title_prefix);
 
   // Called to create inspector sessions that can be used from the same thread.
   // The inspector responds by using the delegate to send messages back.

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -82,7 +82,7 @@ class Agent {
 
   void SetParentHandle(std::unique_ptr<ParentInspectorHandle> parent_handle);
   std::unique_ptr<ParentInspectorHandle> GetParentHandle(
-      uint64_t thread_id, const std::string& url);
+      uint64_t thread_id, const std::string& url, const std::string& title_prefix);
 
   // Called to create inspector sessions that can be used from the same thread.
   // The inspector responds by using the delegate to send messages back.

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -82,9 +82,7 @@ class Agent {
 
   void SetParentHandle(std::unique_ptr<ParentInspectorHandle> parent_handle);
   std::unique_ptr<ParentInspectorHandle> GetParentHandle(
-      uint64_t thread_id,
-      const std::string& url,
-      const std::string& name);
+      uint64_t thread_id, const std::string& url, const std::string& name);
 
   // Called to create inspector sessions that can be used from the same thread.
   // The inspector responds by using the delegate to send messages back.

--- a/src/node.h
+++ b/src/node.h
@@ -677,6 +677,11 @@ NODE_EXTERN Environment* CreateEnvironment(
 NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
     Environment* parent_env,
     ThreadId child_thread_id,
+    const char* child_url);
+
+NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
+    Environment* parent_env,
+    ThreadId child_thread_id,
     const char* child_url,
     const char* title_prefix);
 

--- a/src/node.h
+++ b/src/node.h
@@ -683,7 +683,7 @@ NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
     Environment* parent_env,
     ThreadId child_thread_id,
     const char* child_url,
-    const char* title_prefix);
+    const char* name);
 
 struct StartExecutionCallbackInfo {
   v8::Local<v8::Object> process_object;

--- a/src/node.h
+++ b/src/node.h
@@ -677,7 +677,8 @@ NODE_EXTERN Environment* CreateEnvironment(
 NODE_EXTERN std::unique_ptr<InspectorParentHandle> GetInspectorParentHandle(
     Environment* parent_env,
     ThreadId child_thread_id,
-    const char* child_url);
+    const char* child_url,
+    const char* title_prefix);
 
 struct StartExecutionCallbackInfo {
   v8::Local<v8::Object> process_object;

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -59,6 +59,7 @@ Worker::Worker(Environment* env,
       exec_argv_(exec_argv),
       platform_(env->isolate_data()->platform()),
       thread_id_(AllocateEnvironmentThreadId()),
+      name_(name),
       env_vars_(env_vars),
       snapshot_data_(snapshot_data) {
   Debug(this, "Creating new worker instance with thread id %llu",
@@ -265,11 +266,10 @@ size_t Worker::NearHeapLimit(void* data, size_t current_heap_limit,
 }
 
 void Worker::Run() {
-  std::string name = "WorkerThread ";
-  name += std::to_string(thread_id_.id);
+  std::string trace_name ="[worker " + std::to_string(thread_id_.id) + "]" + (name_ == "" ? "" : " " + name_);
   TRACE_EVENT_METADATA1(
       "__metadata", "thread_name", "name",
-      TRACE_STR_COPY(name.c_str()));
+      TRACE_STR_COPY(trace_name.c_str()));
   CHECK_NOT_NULL(platform_);
 
   Debug(this, "Creating isolate for worker with id %llu", thread_id_.id);

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -266,7 +266,8 @@ size_t Worker::NearHeapLimit(void* data, size_t current_heap_limit,
 }
 
 void Worker::Run() {
-  std::string trace_name ="[worker " + std::to_string(thread_id_.id) + "]" + (name_ == "" ? "" : " " + name_);
+  std::string trace_name = "[worker " + std::to_string(thread_id_.id) + "]" +
+                           (name_ == "" ? "" : " " + name_);
   TRACE_EVENT_METADATA1(
       "__metadata", "thread_name", "name",
       TRACE_STR_COPY(trace_name.c_str()));

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -84,8 +84,8 @@ Worker::Worker(Environment* env,
                 Number::New(env->isolate(), static_cast<double>(thread_id_.id)))
       .Check();
 
-  inspector_parent_handle_ = GetInspectorParentHandle(
-      env, thread_id_, url.c_str(), name.c_str());
+  inspector_parent_handle_ =
+      GetInspectorParentHandle(env, thread_id_, url.c_str(), name.c_str());
 
   argv_ = std::vector<std::string>{env->argv()[0]};
   // Mark this Worker object as weak until we actually start the thread.
@@ -269,8 +269,7 @@ void Worker::Run() {
   std::string trace_name = "[worker " + std::to_string(thread_id_.id) + "]" +
                            (name_ == "" ? "" : " " + name_);
   TRACE_EVENT_METADATA1(
-      "__metadata", "thread_name", "name",
-      TRACE_STR_COPY(trace_name.c_str()));
+      "__metadata", "thread_name", "name", TRACE_STR_COPY(trace_name.c_str()));
   CHECK_NOT_NULL(platform_);
 
   Debug(this, "Creating isolate for worker with id %llu", thread_id_.id);

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -49,7 +49,7 @@ constexpr double kMB = 1024 * 1024;
 Worker::Worker(Environment* env,
                Local<Object> wrap,
                const std::string& url,
-               const std::string& title_prefix,
+               const std::string& name,
                std::shared_ptr<PerIsolateOptions> per_isolate_opts,
                std::vector<std::string>&& exec_argv,
                std::shared_ptr<KVStore> env_vars,
@@ -84,7 +84,7 @@ Worker::Worker(Environment* env,
       .Check();
 
   inspector_parent_handle_ = GetInspectorParentHandle(
-      env, thread_id_, url.c_str(), title_prefix.c_str());
+      env, thread_id_, url.c_str(), name.c_str());
 
   argv_ = std::vector<std::string>{env->argv()[0]};
   // Mark this Worker object as weak until we actually start the thread.
@@ -468,7 +468,7 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
   }
 
   std::string url;
-  std::string title_prefix;
+  std::string name;
   std::shared_ptr<PerIsolateOptions> per_isolate_opts = nullptr;
   std::shared_ptr<KVStore> env_vars = nullptr;
 
@@ -484,7 +484,7 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
   if (!args[5]->IsNullOrUndefined()) {
     Utf8Value value(
         isolate, args[5]->ToString(env->context()).FromMaybe(Local<String>()));
-    title_prefix.append(value.out(), value.length());
+    name.append(value.out(), value.length());
   }
 
   if (args[1]->IsNull()) {
@@ -597,7 +597,7 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
   Worker* worker = new Worker(env,
                               args.This(),
                               url,
-                              title_prefix,
+                              name,
                               per_isolate_opts,
                               std::move(exec_argv_out),
                               env_vars,

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -30,6 +30,7 @@ class Worker : public AsyncWrap {
   Worker(Environment* env,
          v8::Local<v8::Object> wrap,
          const std::string& url,
+         const std::string& title_prefix,
          std::shared_ptr<PerIsolateOptions> per_isolate_opts,
          std::vector<std::string>&& exec_argv,
          std::shared_ptr<KVStore> env_vars,

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -30,7 +30,7 @@ class Worker : public AsyncWrap {
   Worker(Environment* env,
          v8::Local<v8::Object> wrap,
          const std::string& url,
-         const std::string& title_prefix,
+         const std::string& name,
          std::shared_ptr<PerIsolateOptions> per_isolate_opts,
          std::vector<std::string>&& exec_argv,
          std::shared_ptr<KVStore> env_vars,

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -100,6 +100,8 @@ class Worker : public AsyncWrap {
   ExitCode exit_code_ = ExitCode::kNoFailure;
   ThreadId thread_id_;
   uintptr_t stack_base_ = 0;
+  // Optional name used for debugging in inspector and trace events.
+  std::string name_;
 
   // Custom resource constraints:
   double resource_limits_[kTotalResourceLimitCount];

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -449,7 +449,7 @@ TEST_F(EnvironmentTest, InspectorMultipleEmbeddedEnvironments) {
   ChildEnvironmentData data;
   data.thread_id = node::AllocateEnvironmentThreadId();
   data.inspector_parent_handle =
-      GetInspectorParentHandle(*env, data.thread_id, "file:///embedded.js", "");
+      GetInspectorParentHandle(*env, data.thread_id, "file:///embedded.js");
   CHECK(data.inspector_parent_handle);
   data.platform = GetMultiIsolatePlatform(*env);
   CHECK_NOT_NULL(data.platform);

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -449,7 +449,7 @@ TEST_F(EnvironmentTest, InspectorMultipleEmbeddedEnvironments) {
   ChildEnvironmentData data;
   data.thread_id = node::AllocateEnvironmentThreadId();
   data.inspector_parent_handle =
-      GetInspectorParentHandle(*env, data.thread_id, "file:///embedded.js");
+      GetInspectorParentHandle(*env, data.thread_id, "file:///embedded.js", "");
   CHECK(data.inspector_parent_handle);
   data.platform = GetMultiIsolatePlatform(*env);
   CHECK_NOT_NULL(data.platform);

--- a/test/fixtures/worker-name.js
+++ b/test/fixtures/worker-name.js
@@ -1,0 +1,17 @@
+const { Session } = require('inspector');
+const { parentPort } = require('worker_threads');
+
+const session = new Session();
+
+parentPort.once('message', () => {}); // Prevent the worker from exiting.
+
+session.connectToMainThread();
+
+session.on(
+  'NodeWorker.attachedToWorker',
+  ({ params: { workerInfo } }) => {
+    // send the worker title to the main thread
+    parentPort.postMessage(workerInfo.title);
+  }
+);
+session.post('NodeWorker.enable', { waitForDebuggerOnStart: false });

--- a/test/parallel/test-trace-events-worker-metadata-with-name.js
+++ b/test/parallel/test-trace-events-worker-metadata-with-name.js
@@ -7,7 +7,7 @@ const { isMainThread } = require('worker_threads');
 
 if (isMainThread) {
   const CODE = 'const { Worker } = require(\'worker_threads\'); ' +
-               `new Worker('${__filename.replace(/\\/g, '/')}')`;
+               `new Worker('${__filename.replace(/\\/g, '/')}', { name: 'foo' })`;
   const FILE_NAME = 'node_trace.1.log';
   const tmpdir = require('../common/tmpdir');
   tmpdir.refresh();
@@ -23,7 +23,7 @@ if (isMainThread) {
       assert(traces.length > 0);
       assert(traces.some((trace) =>
         trace.cat === '__metadata' && trace.name === 'thread_name' &&
-          trace.args.name === '[worker 1]'));
+          trace.args.name === '[worker 1] foo'));
     }));
   }));
 } else {

--- a/test/parallel/test-worker-name.js
+++ b/test/parallel/test-worker-name.js
@@ -23,5 +23,5 @@ if (isMainThread) {
   }));
   session.post('NodeWorker.enable', { waitForDebuggerOnStart: false });
 } else {
-  console.log('inside worker');
+  // nothing to do
 }

--- a/test/parallel/test-worker-name.js
+++ b/test/parallel/test-worker-name.js
@@ -8,17 +8,17 @@ const { Worker, isMainThread } = require('worker_threads');
 const { Session } = require('inspector');
 
 if (isMainThread) {
-  const titlePrefix = 'Hello Thread ';
+  const name = 'Hello Thread ';
   new Worker(__filename, {
     workerData: 'Test Worker',
-    titlePrefix,
+    name,
   });
 
   const session = new Session();
   session.connect();
   session.on('NodeWorker.attachedToWorker', ({ params: { workerInfo } }) => {
     const id = workerInfo.id;
-    const expectedTitle = `${titlePrefix}Worker ${id}`;
+    const expectedTitle = `[Worker ${id}] ${name}`;
     assert.strictEqual(workerInfo.title, expectedTitle);
   });
   session.post('NodeWorker.enable', { waitForDebuggerOnStart: false });

--- a/test/parallel/test-worker-name.js
+++ b/test/parallel/test-worker-name.js
@@ -1,28 +1,22 @@
 'use strict';
 
 const common = require('../common');
-common.skipIfInspectorDisabled();
-const assert = require('assert');
-const { Worker, isMainThread, parentPort } = require('worker_threads');
+const fixtures = require('../common/fixtures');
 
-const { Session } = require('inspector');
+common.skipIfInspectorDisabled();
+common.skipIfWorker(); // This test requires both main and worker threads.
+
+const assert = require('assert');
+const { Worker, isMainThread } = require('worker_threads');
 
 if (isMainThread) {
   const name = 'Hello Thread';
-  const worker = new Worker(__filename, {
+  const expectedTitle = `[worker 1] ${name}`;
+  const worker = new Worker(fixtures.path('worker-name.js'), {
     name,
   });
-  const expectedTitle = `[worker 1] ${name}`;
   worker.once('message', common.mustCall((message) => {
     assert.strictEqual(message, expectedTitle);
     worker.postMessage('done');
   }));
-} else {
-  const session = new Session();
-  parentPort.once('message', () => {});
-  session.connectToMainThread();
-  session.on('NodeWorker.attachedToWorker', common.mustCall(({ params: { workerInfo } }) => {
-    parentPort.postMessage(workerInfo.title);
-  }));
-  session.post('NodeWorker.enable', { waitForDebuggerOnStart: false });
 }

--- a/test/parallel/test-worker-name.js
+++ b/test/parallel/test-worker-name.js
@@ -8,7 +8,7 @@ const { Worker, isMainThread } = require('worker_threads');
 const { Session } = require('inspector');
 
 if (isMainThread) {
-  const name = 'Hello Thread ';
+  const name = 'Hello Thread';
   new Worker(__filename, {
     workerData: 'Test Worker',
     name,
@@ -16,10 +16,12 @@ if (isMainThread) {
 
   const session = new Session();
   session.connect();
-  session.on('NodeWorker.attachedToWorker', ({ params: { workerInfo } }) => {
-    const id = workerInfo.id;
+  session.on('NodeWorker.attachedToWorker', common.mustCall(({ params: { workerInfo } }) => {
+    const id = workerInfo.workerId;
     const expectedTitle = `[Worker ${id}] ${name}`;
     assert.strictEqual(workerInfo.title, expectedTitle);
-  });
+  }));
   session.post('NodeWorker.enable', { waitForDebuggerOnStart: false });
+} else {
+  console.log('inside worker');
 }

--- a/test/parallel/test-worker-name.js
+++ b/test/parallel/test-worker-name.js
@@ -15,9 +15,11 @@ if (isMainThread) {
   const expectedTitle = `[worker 1] ${name}`;
   worker.once('message', common.mustCall((message) => {
     assert.strictEqual(message, expectedTitle);
+    worker.postMessage('done');
   }));
 } else {
   const session = new Session();
+  parentPort.once('message', () => {});
   session.connectToMainThread();
   session.on('NodeWorker.attachedToWorker', common.mustCall(({ params: { workerInfo } }) => {
     parentPort.postMessage(workerInfo.title);

--- a/test/parallel/test-worker-title-prefix.js
+++ b/test/parallel/test-worker-title-prefix.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+const assert = require('assert');
+const { Worker, isMainThread } = require('worker_threads');
+
+const { Session } = require('inspector');
+
+if (isMainThread) {
+  const titlePrefix = 'Hello Thread ';
+  new Worker(__filename, {
+    workerData: 'Test Worker',
+    titlePrefix,
+  });
+
+  const session = new Session();
+  session.connect();
+  session.on('NodeWorker.attachedToWorker', ({ params: { workerInfo } }) => {
+    const id = workerInfo.id;
+    const expectedTitle = `${titlePrefix}Worker ${id}`;
+    assert.strictEqual(workerInfo.title, expectedTitle);
+  });
+  session.post('NodeWorker.enable', { waitForDebuggerOnStart: false });
+}


### PR DESCRIPTION
This is an attempt at adding a title prefix for the names of workers, while the change works well on VSCode ~~I have no idea how to write a unit test for the same, so any help on that aspect would be helpful~~, also my cpp knowledge is shaky at best have tried my best to trace the code and add the variable here :-)

EDIT: Added tests and doc

Fixes: https://github.com/nodejs/node/issues/41589

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
