### PR TITLE
src: fix useless call in permission.cc

### DIFF
--- a/src/permission/permission.cc
+++ b/src/permission/permission.cc
@@ -136,22 +136,23 @@ void Permission::ThrowAccessDenied(Environment* env,
                                    const std::string_view& res) {
   Local<Value> err = ERR_ACCESS_DENIED(env->isolate());
   CHECK(err->IsObject());
-  err.As<Object>()
-      ->Set(env->context(),
-            env->permission_string(),
-            v8::String::NewFromUtf8(env->isolate(),
-                                    PermissionToString(perm),
-                                    v8::NewStringType::kNormal)
-                .ToLocalChecked())
-      .FromMaybe(false);
-  err.As<Object>()
-      ->Set(env->context(),
-            env->resource_string(),
-            v8::String::NewFromUtf8(env->isolate(),
-                                    std::string(res).c_str(),
-                                    v8::NewStringType::kNormal)
-                .ToLocalChecked())
-      .FromMaybe(false);
+  if (err.As<Object>()
+          ->Set(env->context(),
+                env->permission_string(),
+                v8::String::NewFromUtf8(env->isolate(),
+                                        PermissionToString(perm),
+                                        v8::NewStringType::kNormal)
+                    .ToLocalChecked())
+          .IsNothing() ||
+      err.As<Object>()
+          ->Set(env->context(),
+                env->resource_string(),
+                v8::String::NewFromUtf8(env->isolate(),
+                                        std::string(res).c_str(),
+                                        v8::NewStringType::kNormal)
+                    .ToLocalChecked())
+          .IsNothing())
+    return;
   env->isolate()->ThrowException(err);
 }
 


### PR DESCRIPTION
`FromMaybe()` has no side effects and the return value is ignored. Use `Check()` instead to ensure that the operation succeeded.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
