### PR TITLE
doc: improve documentation for util.types.isNativeError()

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2552,7 +2552,7 @@ which are `instanceof` native errors:
 ```js
 const myError = { __proto__: Error.prototype };
 console.log(util.types.isNativeError(myError)); // false
-console.log(myError instanceof Error)); // true
+console.log(myError instanceof Error); // true
 ```
 
 ### `util.types.isNumberObject(value)`

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2524,8 +2524,7 @@ console.log(util.types.isNativeError(new TypeError()));  // true
 console.log(util.types.isNativeError(new RangeError()));  // true
 ```
 
-Subclasses of the native error types will use the return value of the native
-error constructor as the new `this` and are therefore also native errors:
+Subclasses of the native error types are also native errors:
 
 ```js
 class MyError extends Error {}

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2532,7 +2532,7 @@ class MyError extends Error {}
 console.log(util.types.isNativeError(new MyError()));  // true
 ```
 
-A value being `instanceof` a native error is not equivalent to `isNativeError()`
+A value being `instanceof` a native error class is not equivalent to `isNativeError()`
 returning `true` for that value. `isNativeError()` returns `true` for errors
 which come from a different [realm][] while `instanceof Error` returns `false`
 for these errors:

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2542,8 +2542,9 @@ returning `true` for that value. Therefore, we recommend using
 ```js
 const vm = require('node:vm');
 const context = vm.createContext({});
-util.types.isNativeError(vm.runInContext('new Error()', context)); // Returns true
-vm.runInContext('new Error()', context) instanceof Error; // Returns false
+const myError = vm.runInContext('new Error', context);
+console.log(util.types.isNativeError(myError)); // true
+console.log(myError instanceof Error); // false
 ```
 
 Conversely, `isNativeError()` returns `false` for all objects which where not

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2552,8 +2552,9 @@ returned by the constructor of a native error. That includes values
 which are `instanceof` native errors:
 
 ```js
-util.types.isNativeError({__proto__: Error.prototype}); // Returns false
-({__proto__: Error.prototype} instanceof Error); // Returns true
+const myError = { __proto__: Error.prototype };
+console.log(util.types.isNativeError(myError)); // false
+console.log(myError instanceof Error)); // true
 ```
 
 ### `util.types.isNumberObject(value)`

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2533,11 +2533,9 @@ console.log(util.types.isNativeError(new MyError()));  // true
 ```
 
 A value being `instanceof` a native error is not equivalent to `isNativeError()`
-returning `true` for that value. Therefore, we recommend using
-`isNativeError(e) || e instanceof Error` to check if `e` is an error.
-
-`isNativeError()` returns `true` for errors which come from a different
-[realm][] while `instanceof Error` returns `false` for these errors:
+returning `true` for that value. `isNativeError()` returns `true` for errors
+which come from a different [realm][] while `instanceof Error` returns `false`
+for these errors:
 
 ```js
 const vm = require('node:vm');

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2529,7 +2529,7 @@ error constructor as the new `this` and are therefore also native errors:
 
 ```js
 class MyError extends Error {}
-util.types.isNativeError(new MyError());  // Returns true
+console.log(util.types.isNativeError(new MyError()));  // true
 ```
 
 A value being `instanceof` a native error is not equivalent to `isNativeError()`

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -3319,8 +3319,6 @@ util.log('Timestamped message.');
 [Customizing `util.inspect` colors]: #customizing-utilinspect-colors
 [Internationalization]: intl.md
 [Module Namespace Object]: https://tc39.github.io/ecma262/#sec-module-namespace-exotic-objects
-[realm]: https://tc39.es/ecma262/#realm
-[built-in `Error` type]: https://tc39.es/ecma262/#sec-error-objects
 [WHATWG Encoding Standard]: https://encoding.spec.whatwg.org/
 [`'uncaughtException'`]: process.md#event-uncaughtexception
 [`'warning'`]: process.md#event-warning
@@ -3369,10 +3367,12 @@ util.log('Timestamped message.');
 [`util.types.isNativeError()`]: #utiltypesisnativeerrorvalue
 [`util.types.isSharedArrayBuffer()`]: #utiltypesissharedarraybuffervalue
 [async function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
+[built-in `Error` type]: https://tc39.es/ecma262/#sec-error-objects
 [compare function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Parameters
 [constructor]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor
 [default sort]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
 [global symbol registry]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for
 [list of deprecated APIS]: deprecations.md#list-of-deprecated-apis
+[realm]: https://tc39.es/ecma262/#realm
 [semantically incompatible]: https://github.com/nodejs/node/issues/4179
 [util.inspect.custom]: #utilinspectcustom

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2519,9 +2519,9 @@ Returns `true` if the value was returned by the constructor of a
 [built-in `Error` type][].
 
 ```js
-util.types.isNativeError(new Error());  // Returns true
-util.types.isNativeError(new TypeError());  // Returns true
-util.types.isNativeError(new RangeError());  // Returns true
+console.log(util.types.isNativeError(new Error()));  // true
+console.log(util.types.isNativeError(new TypeError()));  // true
+console.log(util.types.isNativeError(new RangeError()));  // true
 ```
 
 Subclasses of the native error types will use the return value of the native

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2540,7 +2540,7 @@ returning `true` for that value. Therefore, we recommend using
 [realm][] while `instanceof Error` returns `false` for these errors:
 
 ```js
-const vm = require('vm');
+const vm = require('node:vm');
 const context = vm.createContext({});
 util.types.isNativeError(vm.runInContext('new Error()', context)); // Returns true
 vm.runInContext('new Error()', context) instanceof Error; // Returns false

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2545,7 +2545,7 @@ console.log(util.types.isNativeError(myError)); // true
 console.log(myError instanceof Error); // false
 ```
 
-Conversely, `isNativeError()` returns `false` for all objects which where not
+Conversely, `isNativeError()` returns `false` for all objects which were not
 returned by the constructor of a native error. That includes values
 which are `instanceof` native errors:
 


### PR DESCRIPTION
Makes clear what a native error is by linking the spec. Explains that `instanceof Error` and `util.types.isNativeError()` are not equivalent. Give examples for objects that are `instance of Error` but not native errors and vice versa. Recommends checking for both if one wants to find out if something is an error.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
