### PR TITLE
test: reduce flakiness of parallel/test-http-remove-header-stays-removed.js

### DIFF
--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const http = require('http');
@@ -54,13 +54,14 @@ server.listen(0, function() {
     res.setEncoding('ascii');
     res.on('data', function(chunk) {
       response += chunk;
+      if (response?.toString() === 'beep boop\n') {
+        setTimeout(function() {
+          // The socket should be closed immediately, with no keep-alive, because
+          // no content-length or transfer-encoding are used:
+          assert.strictEqual(res.socket.closed, true);
+          server.close();
+        }, common.platformTimeout(15));
+      }
     });
-
-    setTimeout(function() {
-      // The socket should be closed immediately, with no keep-alive, because
-      // no content-length or transfer-encoding are used:
-      assert.strictEqual(res.socket.closed, true);
-      server.close();
-    }, 10);
   });
 });

--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -54,7 +54,7 @@ server.listen(0, function() {
     res.setEncoding('ascii');
     res.on('data', function(chunk) {
       response += chunk;
-      if (response?.toString() === 'beep boop\n') {
+      if (response === 'beep boop\n') {
         setTimeout(function() {
           // The socket should be closed immediately, with no keep-alive, because
           // no content-length or transfer-encoding are used:


### PR DESCRIPTION
The test `test-http-remove-header-stays-removed.js` seems to be slightly flaky as seen in https://github.com/nodejs/reliability/issues/508 and also reproducible locally by running `python3 tools/test.py test/parallel/test-http-remove-header-stays-removed.js --repeat 1000` 

Since the test checks that the socket is closed right after receiving the last chunk of data hence moved the checking for the same after the data has been received and slightly increased the timeout, the flakiness no longer reproduces

Refs: https://github.com/nodejs/reliability/issues/508
Refs: https://github.com/nodejs/node/pull/46333

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
