### PR TITLE
test: fix test file path in `test-permission-deny-fs-symlink-target-write.js`

### DIFF
--- a/test/parallel/test-permission-deny-fs-symlink-target-write.js
+++ b/test/parallel/test-permission-deny-fs-symlink-target-write.js
@@ -53,7 +53,7 @@ fs.writeFileSync(path.join(readWriteFolder, 'file'), 'NO evil file contents');
     }));
 
     // App will be able to write to the symlink
-    fs.writeFile(path.join(writeOnlyFolder, 'link-to-read-write'), 'some content', mustSucceed());
+    fs.writeFile(path.join(writeOnlyFolder, 'link-to-read-write'), 'some content', common.mustSucceed());
   });
 
   // App won't be able to symlink to a readOnlyFolder

--- a/test/parallel/test-permission-deny-fs-symlink-target-write.js
+++ b/test/parallel/test-permission-deny-fs-symlink-target-write.js
@@ -53,9 +53,7 @@ fs.writeFileSync(path.join(readWriteFolder, 'file'), 'NO evil file contents');
     }));
 
     // App will be able to write to the symlink
-    fs.writeFile(path.join(writeOnlyFolder, 'link-to-read-write'), 'some content', (err) => {
-      assert.ifError(err);
-    });
+    fs.writeFile(path.join(writeOnlyFolder, 'link-to-read-write'), 'some content', mustSucceed());
   });
 
   // App won't be able to symlink to a readOnlyFolder

--- a/test/parallel/test-permission-deny-fs-symlink-target-write.js
+++ b/test/parallel/test-permission-deny-fs-symlink-target-write.js
@@ -53,7 +53,7 @@ fs.writeFileSync(path.join(readWriteFolder, 'file'), 'NO evil file contents');
     }));
 
     // App will be able to write to the symlink
-    fs.writeFile('file', 'some content', (err) => {
+    fs.writeFile(path.join(writeOnlyFolder, 'link-to-read-write'), 'some content', (err) => {
       assert.ifError(err);
     });
   });


### PR DESCRIPTION
This test creates `file` with `some content` in current working directory. Let's move it to tmpdir.