### PR TITLE
lib: fix `BroadcastChannel` initialization location

### DIFF
--- a/lib/internal/bootstrap/browser.js
+++ b/lib/internal/bootstrap/browser.js
@@ -39,6 +39,7 @@ defineOperation(globalThis, 'setInterval', timers.setInterval);
 defineOperation(globalThis, 'setTimeout', timers.setTimeout);
 
 // Lazy ones.
+exposeLazyInterfaces(globalThis, 'internal/worker/io', ['BroadcastChannel']);
 exposeLazyInterfaces(globalThis, 'internal/abort_controller', [
   'AbortController', 'AbortSignal',
 ]);

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -72,7 +72,6 @@ const {
   defineOperation,
   deprecate,
   defineLazyProperties,
-  exposeLazyInterfaces,
 } = require('internal/util');
 const {
   validateInteger,
@@ -226,11 +225,6 @@ defineLazyProperties(
   ['structuredClone'],
 );
 
-exposeLazyInterfaces(
-  globalThis,
-  'internal/worker/io',
-  ['BroadcastChannel'],
-);
 // Set the per-Environment callback that will be called
 // when the TrackingTraceStateObserver updates trace state.
 // Note that when NODE_USE_V8_PLATFORM is true, the observer is


### PR DESCRIPTION
Refs https://github.com/electron/electron/issues/37417.
Refs https://github.com/nodejs/node/pull/40532.
Refs https://github.com/electron/electron/pull/37421.

Fixes a bug wherein `BroadcastChannel` should have been initialized in `lib/internal/bootstrap/browser.js` instead of `lib/internal/bootstrap/node.js`. That inadvertently made it such that there was incorrect handling of the DOM vs Node.js implementations of `BroadcastChannel`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
