### PR TITLE
doc: keep import syntax consistent between mjs, cjs

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -179,9 +179,9 @@ const asyncHook = createHook({
 ```
 
 ```cjs
-const async_hooks = require('node:async_hooks');
+const { createHook } = require('node:async_hooks');
 
-const asyncHook = async_hooks.createHook({
+const asyncHook = createHook({
   init(asyncId, type, triggerAsyncId, resource) { },
   destroy(asyncId) { },
 });
@@ -245,12 +245,12 @@ function debug(...args) {
 ```
 
 ```cjs
-const fs = require('node:fs');
-const util = require('node:util');
+const { writeFileSync } = require('node:fs');
+const { format } = require('node:util');
 
 function debug(...args) {
   // Use a function like this one when debugging inside an AsyncHook callback
-  fs.writeFileSync('log.out', `${util.format(...args)}\n`, { flag: 'a' });
+  writeFileSync('log.out', `${format(...args)}\n`, { flag: 'a' });
 }
 ```
 
@@ -282,9 +282,9 @@ const hook = createHook(callbacks).enable();
 ```
 
 ```cjs
-const async_hooks = require('node:async_hooks');
+const { createHook } = require('node:async_hooks');
 
-const hook = async_hooks.createHook(callbacks).enable();
+const hook = createHook(callbacks).enable();
 ```
 
 ### `asyncHook.disable()`
@@ -330,7 +330,9 @@ clearTimeout(setTimeout(() => {}, 10));
 ```
 
 ```cjs
-require('node:net').createServer().listen(function() { this.close(); });
+const { createServer } = require('node:net');
+
+createServer().listen(function() { this.close(); });
 // OR
 clearTimeout(setTimeout(() => {}, 10));
 ```
@@ -374,7 +376,7 @@ The following is a simple demonstration of `triggerAsyncId`:
 ```mjs
 import { createHook, executionAsyncId } from 'node:async_hooks';
 import { stdout } from 'node:process';
-import net from 'node:net';
+import { createServer } from 'node:net';
 
 createHook({
   init(asyncId, type, triggerAsyncId) {
@@ -385,13 +387,13 @@ createHook({
   },
 }).enable();
 
-net.createServer((conn) => {}).listen(8080);
+createServer((conn) => {}).listen(8080);
 ```
 
 ```cjs
 const { createHook, executionAsyncId } = require('node:async_hooks');
 const { stdout } = require('node:process');
-const net = require('node:net');
+const { createServer } = require('node:net');
 
 createHook({
   init(asyncId, type, triggerAsyncId) {
@@ -402,7 +404,7 @@ createHook({
   },
 }).enable();
 
-net.createServer((conn) => {}).listen(8080);
+createServer((conn) => {}).listen(8080);
 ```
 
 Output when hitting the server with `nc localhost 8080`:
@@ -730,9 +732,9 @@ fs.open(path, 'r', (err, fd) => {
 ```
 
 ```cjs
-const async_hooks = require('node:async_hooks');
+const { executionAsyncId } = require('node:async_hooks');
 
-console.log(async_hooks.executionAsyncId());  // 1 - bootstrap
+console.log(executionAsyncId());  // 1 - bootstrap
 fs.open(path, 'r', (err, fd) => {
   console.log(async_hooks.executionAsyncId());  // 6 - open()
 });


### PR DESCRIPTION
* Most of the examples are using `es6` destructing import syntax, there are a few inconsistencies fixed in this PR in `async_hooks` doc while reading it, yet it is another nit pick 😛.
* ~~Add missing `fs` import [in the code example](https://github.com/nodejs/node/pull/46882/files#diff-cfacde5f1154593965e866b7f65c8e25e136dd16ee53fa76bfbfbd280d2ee6e3R727),~~ thank you @apapirovski for spotting it in the code review (_EDIT: this part has been moved to a separate PR_)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
