### PR TITLE
test_runner: align behavior of it and test

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -156,8 +156,7 @@ test('skip() method with message', (t) => {
 Running tests can also be done using `describe` to declare a suite
 and `it` to declare a test.
 A suite is used to organize and group related tests together.
-`it` is an alias for `test`, except there is no test context passed,
-since nesting is done using suites.
+`it` is a shorthand for [`test()`][].
 
 ```js
 describe('A thing', () => {
@@ -851,17 +850,17 @@ Shorthand for marking a suite as `only`, same as
 
 ## `it([name][, options][, fn])`
 
-* `name` {string} The name of the test, which is displayed when reporting test
-  results. **Default:** The `name` property of `fn`, or `'<anonymous>'` if `fn`
-  does not have a name.
-* `options` {Object} Configuration options for the suite.
-  supports the same options as `test([name][, options][, fn])`.
-* `fn` {Function|AsyncFunction} The function under test.
-  If the test uses callbacks, the callback function is passed as an argument.
-  **Default:** A no-op function.
-* Returns: `undefined`.
+<!-- YAML
+added: v18.6.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46889
+    description: it is now a shorthand for test and behaves the same way.
+-->
 
-The `it()` function is the value imported from the `node:test` module.
+Shorthand for [`test()`][].
+
+The `it()` function is imported from the `node:test` module.
 
 ## `it.skip([name][, options][, fn])`
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -851,11 +851,13 @@ Shorthand for marking a suite as `only`, same as
 ## `it([name][, options][, fn])`
 
 <!-- YAML
-added: v18.6.0
+added:
+  - v18.6.0
+  - v16.17.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/46889
-    description: it is now a shorthand for test and behaves the same way.
+    description: Calling `it()` is now equivalent to calling `test()`.
 -->
 
 Shorthand for [`test()`][].

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -17,7 +17,7 @@ const {
 const { exitCodes: { kGenericUserError } } = internalBinding('errors');
 
 const { kEmptyObject } = require('internal/util');
-const { kCancelledByParent, Test, ItTest, Suite } = require('internal/test_runner/test');
+const { kCancelledByParent, Test, Suite } = require('internal/test_runner/test');
 const {
   kAsyncBootstrapFailure,
   parseCommandLine,
@@ -221,7 +221,7 @@ module.exports = {
   createTestTree,
   test: runInParentContext(Test, false),
   describe: runInParentContext(Suite),
-  it: runInParentContext(ItTest),
+  it: runInParentContext(Test),
   before: hook('before'),
   after: hook('after'),
   beforeEach: hook('beforeEach'),

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -745,13 +745,6 @@ class TestHook extends Test {
   }
 }
 
-class ItTest extends Test {
-  constructor(opt) { super(opt); } // eslint-disable-line no-useless-constructor
-  getRunArgs() {
-    return { ctx: { signal: this.signal, name: this.name }, args: [] };
-  }
-}
-
 class Suite extends Test {
   constructor(options) {
     super(options);
@@ -824,7 +817,6 @@ class Suite extends Test {
 }
 
 module.exports = {
-  ItTest,
   kCancelledByParent,
   kSubtestsFailed,
   kTestCodeFailure,

--- a/test/es-module/test-esm-repl-imports.js
+++ b/test/es-module/test-esm-repl-imports.js
@@ -9,7 +9,7 @@ const { describe, it } = require('node:test');
 
 
 describe('ESM: REPL runs', { concurrency: true }, () => {
-  it((done) => {
+  it((t, done) => {
     const child = spawn(execPath, [
       '--interactive',
     ], {

--- a/test/message/test_runner_describe_it.js
+++ b/test/message/test_runner_describe_it.js
@@ -47,7 +47,7 @@ it('async throw fail', async () => {
   throw new Error('thrown from async throw fail');
 });
 
-it('async skip fail', async (t) => {
+it('async skip fail', async (t, done) => {
   t.skip();
   throw new Error('thrown from async throw fail');
 });
@@ -206,61 +206,61 @@ it('escaped skip message', { skip: '#skip' });
 // A test whose todo message needs to be escaped.
 it('escaped todo message', { todo: '#todo' });
 
-it('callback pass', (done) => {
+it('callback pass', (t, done) => {
   setImmediate(done);
 });
 
-it('callback fail', (done) => {
+it('callback fail', (t, done) => {
   setImmediate(() => {
     done(new Error('callback failure'));
   });
 });
 
-it('sync t is this in test', function() {
-  assert.deepStrictEqual(this, { signal: this.signal, name: this.name });
+it('sync t is this in test', function(t) {
+  assert.strictEqual(this, t);
 });
 
-it('async t is this in test', async function() {
-  assert.deepStrictEqual(this, { signal: this.signal, name: this.name });
+it('async t is this in test', async function(t) {
+  assert.strictEqual(this, t);
 });
 
-it('callback t is this in test', function(done) {
-  assert.deepStrictEqual(this, { signal: this.signal, name: this.name });
+it('callback t is this in test', function(t, done) {
+  assert.strictEqual(this, t);
   done();
 });
 
-it('callback also returns a Promise', async (done) => {
+it('callback also returns a Promise', async (t, done) => {
   throw new Error('thrown from callback also returns a Promise');
 });
 
-it('callback throw', (done) => {
+it('callback throw', (t, done) => {
   throw new Error('thrown from callback throw');
 });
 
-it('callback called twice', (done) => {
+it('callback called twice', (t, done) => {
   done();
   done();
 });
 
-it('callback called twice in different ticks', (done) => {
+it('callback called twice in different ticks', (t, done) => {
   setImmediate(done);
   done();
 });
 
-it('callback called twice in future tick', (done) => {
+it('callback called twice in future tick', (t, done) => {
   setImmediate(() => {
     done();
     done();
   });
 });
 
-it('callback async throw', (done) => {
+it('callback async throw', (t, done) => {
   setImmediate(() => {
     throw new Error('thrown from callback async throw');
   });
 });
 
-it('callback async throw after done', (done) => {
+it('callback async throw after done', (t, done) => {
   setImmediate(() => {
     throw new Error('thrown from callback async throw after done');
   });
@@ -316,7 +316,7 @@ describe('timeouts', () => {
     });
   });
 
-  it('timed out callback test', { timeout: 5 }, (done) => {
+  it('timed out callback test', { timeout: 5 }, (t, done) => {
     setTimeout(done, 100);
   });
 
@@ -327,7 +327,7 @@ describe('timeouts', () => {
     });
   });
 
-  it('large timeout callback test is ok', { timeout: 30_000_000 }, (done) => {
+  it('large timeout callback test is ok', { timeout: 30_000_000 }, (t, done) => {
     setTimeout(done, 10);
   });
 });

--- a/test/message/test_runner_describe_it.out
+++ b/test/message/test_runner_describe_it.out
@@ -104,7 +104,7 @@ not ok 12 - async throw fail
     *
   ...
 # Subtest: async skip fail
-not ok 13 - async skip fail
+not ok 13 - async skip fail # SKIP
   ---
   duration_ms: *
   failureType: 'callbackAndPromisePresent'
@@ -645,8 +645,8 @@ not ok 60 - invalid subtest fail
 # Warning: Test "callback async throw after done" generated asynchronous activity after the test ended. This activity created the error "Error: thrown from callback async throw after done" and would have caused the test to fail, but instead triggered an uncaughtException event.
 # tests 60
 # pass 23
-# fail 23
+# fail 22
 # cancelled 0
-# skipped 9
+# skipped 10
 # todo 5
 # duration_ms *


### PR DESCRIPTION
following https://github.com/nodejs/node/pull/46544 and https://github.com/nodejs/node/pull/46888,
I think the differences between `test` and `it` lead to a lot of confusion and was a mistake.

once https://github.com/nodejs/node/pull/46888 lands I propose we remove the differences.
feedback is welcomed

TODO:
- [x] update docs