### PR TITLE
tools: ensure daily wpt nightly node version can be installed

### DIFF
--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -42,7 +42,7 @@ jobs:
       # install a version and checkout
       - name: Get latest nightly
         if: matrix.node-version == 'latest-nightly'
-        run: echo "NIGHTLY=$(curl -s https://nodejs.org/download/nightly/index.json | jq -r '.[0].version')" >> $GITHUB_ENV
+        run: echo "NIGHTLY=$(curl -s https://nodejs.org/download/nightly/index.json | jq -r '[.[] | select(.files[] | contains("linux-x64"))][0].version')" >> $GITHUB_ENV
       - name: Install Node.js
         id: setup-node
         uses: actions/setup-node@v3


### PR DESCRIPTION
This PR updates the nightly version query to ensure that a build for platform linux and architecture x64 exists by adding a query to jq, it is now looking for the first listed nightly with `"linux-x64"` in files.

This will avoid the issue that occurred during the [latest run](https://github.com/nodejs/node/actions/runs/4298838538/jobs/7493414529#step:5:17) possibly caused by a nightly build failing. See `v20.0.0-nightly202302287a37829ccb ` in https://nodejs.org/download/nightly/index.json