### PR TITLE
doc: improve `fsPromises.copyFile()` documentation and code example

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -937,19 +937,20 @@ will be made to remove the destination.
 ```mjs
 import { copyFile, constants } from 'node:fs/promises';
 
+// Example 1: Copy the file, overwriting the destination file if it exists
 try {
   await copyFile('source.txt', 'destination.txt');
-  console.log('source.txt was copied to destination.txt');
-} catch {
-  console.error('The file could not be copied');
+  console.log('File copied successfully: source.txt -> destination.txt');
+} catch (err) {
+  console.error(`Error copying file: ${err.message}`);
 }
 
-// By using COPYFILE_EXCL, the operation will fail if destination.txt exists.
+// Example 2: By using COPYFILE_EXCL, the operation will fail if destination.txt exists.
 try {
   await copyFile('source.txt', 'destination.txt', constants.COPYFILE_EXCL);
-  console.log('source.txt was copied to destination.txt');
-} catch {
-  console.error('The file could not be copied');
+  console.log('File copied successfully: source.txt -> destination.txt');
+} catch (err) {
+  console.error(`Error copying file: ${err.message}`);
 }
 ```
 


### PR DESCRIPTION
Update the documentation and code example for `fsPromises.copyFile()`
`fs/promises` module to provide better guidance and error handling.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
