### PR TITLE
debugger: fix behavior of { a: 1 } in the debugger repl

### DIFF
--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -573,8 +573,16 @@ function createRepl(inspector) {
     if (input === '\n') return lastCommand;
     // Add parentheses: exec process.title => exec("process.title");
     const match = RegExpPrototypeExec(/^\s*(?:exec|p)\s+([^\n]*)/, input);
+    input = match ? match[1] : input;
+
+    // Add parentheses to make sure input is parsed as expression
+    if (RegExpPrototypeExec(/^\s*{/, input) !== null &&
+        RegExpPrototypeExec(/;\s*$/, input) === null) {
+      input = `(${StringPrototypeTrim(input)})\n`;
+    }
+
     if (match) {
-      lastCommand = `exec(${JSONStringify(match[1])})`;
+      lastCommand = `exec(${JSONStringify(input)})`;
     } else {
       lastCommand = input;
     }


### PR DESCRIPTION
fix: #46808

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
