### PR TITLE
fs: implement byob mode for readableWebStream()

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -446,7 +446,7 @@ Reads data from the file and stores that in the given buffer.
 If the file is not modified concurrently, the end-of-file is reached when the
 number of bytes read is zero.
 
-#### `filehandle.readableWebStream()`
+#### `filehandle.readableWebStream(options)`
 
 <!-- YAML
 added: v17.0.0
@@ -457,6 +457,10 @@ changes:
 -->
 
 > Stability: 1 - Experimental
+
+* `options` {Object}
+  * `type` {string|undefined} Whether to open a normal or a `'bytes'` stream.
+    **Default:** `undefined`
 
 * Returns: {ReadableStream}
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -450,6 +450,10 @@ number of bytes read is zero.
 
 <!-- YAML
 added: v17.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46933
+    description: Added option to create a 'bytes' stream.
 -->
 
 > Stability: 1 - Experimental

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -14,6 +14,7 @@ const {
   SafePromisePrototypeFinally,
   Symbol,
   Uint8Array,
+  FunctionPrototypeBind,
 } = primordials;
 
 const { fs: constants } = internalBinding('constants');
@@ -249,7 +250,7 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
    * } ReadableStream
    * @returns {ReadableStream}
    */
-  readableWebStream() {
+  readableWebStream(options = kEmptyObject) {
     if (this[kFd] === -1)
       throw new ERR_INVALID_STATE('The FileHandle is closed');
     if (this[kClosePromise])
@@ -257,21 +258,60 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
     if (this[kLocked])
       throw new ERR_INVALID_STATE('The FileHandle is locked');
     this[kLocked] = true;
-    const {
-      newReadableStreamFromStreamBase,
-    } = require('internal/webstreams/adapters');
-    const readable = newReadableStreamFromStreamBase(
-      this[kHandle],
-      undefined,
-      { ondone: () => this[kUnref]() });
 
-    const {
-      readableStreamCancel,
-    } = require('internal/webstreams/readablestream');
-    this[kRef]();
-    this.once('close', () => {
-      readableStreamCancel(readable);
-    });
+    if (options.type !== undefined) {
+      validateString(options.type, 'options.type');
+    }
+
+    let readable;
+
+    if (options.type !== 'bytes') {
+      const {
+        newReadableStreamFromStreamBase,
+      } = require('internal/webstreams/adapters');
+      readable = newReadableStreamFromStreamBase(
+        this[kHandle],
+        undefined,
+        { ondone: () => this[kUnref]() });
+
+      const {
+        readableStreamCancel,
+      } = require('internal/webstreams/readablestream');
+      this[kRef]();
+      this.once('close', () => {
+        readableStreamCancel(readable);
+      });
+    } else {
+      const {
+        readableStreamCancel,
+        ReadableStream,
+      } = require('internal/webstreams/readablestream');
+      this[kRef]();
+      this.once('close', () => {
+        readableStreamCancel(readable);
+      });
+      const readFn = FunctionPrototypeBind(this.read, this);
+      readable = new ReadableStream({
+        type: 'bytes',
+        autoAllocateChunkSize: 16384,
+
+        async pull(controller) {
+          const view = controller.byobRequest.view;
+          const { bytesRead } = await readFn(view, view.byteOffset, view.byteLength);
+
+          if (bytesRead === 0) {
+            try {
+              controller.close();
+              this[kUnref]();
+            } catch (error) {
+              controller.error(error);
+            }
+          }
+
+          controller.byobRequest.respond(bytesRead);
+        },
+      });
+    }
 
     return readable;
   }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -286,11 +286,10 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
         readableStreamCancel,
         ReadableStream,
       } = require('internal/webstreams/readablestream');
-      this[kRef]();
-      this.once('close', () => {
-        readableStreamCancel(readable);
-      });
+
       const readFn = FunctionPrototypeBind(this.read, this);
+      const ondone = FunctionPrototypeBind(this[kUnref], this);
+
       readable = new ReadableStream({
         type: 'bytes',
         autoAllocateChunkSize: 16384,
@@ -300,16 +299,22 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
           const { bytesRead } = await readFn(view, view.byteOffset, view.byteLength);
 
           if (bytesRead === 0) {
-            try {
-              controller.close();
-              this[kUnref]();
-            } catch (error) {
-              controller.error(error);
-            }
+            ondone();
+            controller.close();
           }
 
           controller.byobRequest.respond(bytesRead);
         },
+
+        cancel() {
+          ondone();
+        },
+      });
+
+      this[kRef]();
+
+      this.once('close', () => {
+        readableStreamCancel(readable);
       });
     }
 

--- a/test/parallel/test-filehandle-readablestream.js
+++ b/test/parallel/test-filehandle-readablestream.js
@@ -86,3 +86,87 @@ const check = readFileSync(__filename, { encoding: 'utf8' });
   mc.port1.close();
   await file.close();
 })().then(common.mustCall());
+
+// Make sure 'bytes' stream works
+(async () => {
+  const file = await open(__filename);
+  const dec = new TextDecoder();
+  const readable = file.readableWebStream({ type: 'bytes' });
+  const reader = readable.getReader({ mode: 'byob' });
+
+  let data = '';
+  let result;
+  do {
+    const buff = new ArrayBuffer(100);
+    result = await reader.read(new DataView(buff));
+    if (result.value !== undefined) {
+      data += dec.decode(result.value);
+      assert.ok(result.value.byteLength <= 100);
+    }
+  } while (!result.done);
+
+  assert.strictEqual(check, data);
+
+  assert.throws(() => file.readableWebStream(), {
+    code: 'ERR_INVALID_STATE',
+  });
+
+  await file.close();
+})().then(common.mustCall());
+
+// Make sure that acquiring a ReadableStream 'bytes' stream
+// fails if the FileHandle is already closed.
+(async () => {
+  const file = await open(__filename);
+  await file.close();
+
+  assert.throws(() => file.readableWebStream({ type: 'bytes' }), {
+    code: 'ERR_INVALID_STATE',
+  });
+})().then(common.mustCall());
+
+// Make sure that acquiring a ReadableStream 'bytes' stream
+// fails if the FileHandle is already closing.
+(async () => {
+  const file = await open(__filename);
+  file.close();
+
+  assert.throws(() => file.readableWebStream({ type: 'bytes' }), {
+    code: 'ERR_INVALID_STATE',
+  });
+})().then(common.mustCall());
+
+// Make sure the 'bytes' ReadableStream is closed when the underlying
+// FileHandle is closed.
+(async () => {
+  const file = await open(__filename);
+  const readable = file.readableWebStream({ type: 'bytes' });
+  const reader = readable.getReader({ mode: 'byob' });
+  file.close();
+  await reader.closed;
+})().then(common.mustCall());
+
+// Make sure the 'bytes' ReadableStream is closed when the underlying
+// FileHandle is closed.
+(async () => {
+  const file = await open(__filename);
+  const readable = file.readableWebStream({ type: 'bytes' });
+  file.close();
+  const reader = readable.getReader({ mode: 'byob' });
+  await reader.closed;
+})().then(common.mustCall());
+
+// Make sure that the FileHandle is properly marked "in use"
+// when a 'bytes' ReadableStream has been acquired for it.
+(async () => {
+  const file = await open(__filename);
+  file.readableWebStream({ type: 'bytes' });
+  const mc = new MessageChannel();
+  mc.port1.onmessage = common.mustNotCall();
+  assert.throws(() => mc.port2.postMessage(file, [file]), {
+    code: 25,
+    name: 'DataCloneError',
+  });
+  mc.port1.close();
+  await file.close();
+})().then(common.mustCall());


### PR DESCRIPTION
~~This is an initial draft~~ trying to implement allowing usage of 'byob' mode for readable web streams created from file handles.

~~Would like some feedback before I start working on tests :-)~~

Have added tests and doc updates,
the implementation is similar to how the implementation is here https://nodejs.org/api/webstreams.html#class-readablestreambyobreader


Fixes: https://github.com/nodejs/node/issues/45853

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
