### PR TITLE
inspector: fix session.disconnect crash

### DIFF
--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -123,9 +123,11 @@ class JSBindingsConnection : public AsyncWrap {
     new JSBindingsConnection(env, info.This(), callback);
   }
 
+  // See https://github.com/nodejs/node/pull/46942
   void Disconnect() {
+    BaseObjectPtr<JSBindingsConnection> strong_ref{this};
     session_.reset();
-    delete this;
+    Detach();
   }
 
   static void Disconnect(const FunctionCallbackInfo<Value>& info) {

--- a/test/parallel/test-inspector-connect-to-main-thread.js
+++ b/test/parallel/test-inspector-connect-to-main-thread.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const { Session } = require('inspector');
+const { Worker, isMainThread, workerData } = require('worker_threads');
+
+if (!workerData) {
+  common.skipIfWorker();
+}
+
+if (isMainThread) {
+  new Worker(__filename, { workerData: {} });
+} else {
+  const session = new Session();
+  session.connectToMainThread();
+  // Do not crash
+  session.disconnect();
+}


### PR DESCRIPTION
 fix `session.disconnect` crash.

When worker calls  `session.disconnect()`, `JSBindingsSessionDelegate` will be destroyed asynchronously, so we need to make sure that `JSBindingsConnection` is destroyed after `JSBindingsSessionDelegate`.

The test is as follows.
```js

const { Session } = require('inspector');
const { Worker, isMainThread } = require('worker_threads'); 

if (isMainThread) {
  new Worker(__filename);
} else {
  const session = new Session();
  session.connectToMainThread();
  session.disconnect();
}
```
The error message is as follows.
```
../src/base_object-inl.h:52:virtual node::BaseObject::~BaseObject(): Assertion `(metadata->strong_ptr_count) == (0)' failed.
 1: 0x1029e5de8 node::Abort() [/usr/local/bin/node]
 2: 0x1029e5c36 node::AppendExceptionLine(node::Environment*, v8::Local<v8::Value>, v8::Local<v8::Message>, node::ErrorHandlingMode) [/usr/local/bin/node]
 3: 0x10294c6ec node::AsyncWrap::~AsyncWrap() [/usr/local/bin/node]
 4: 0x102aa77be node::inspector::(anonymous namespace)::JSBindingsConnection<node::inspector::(anonymous namespace)::MainThreadConnection>::~JSBindingsConnection() [/usr/local/bin/node]
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
