### PR TITLE
benchmark: add real-world examples for url parsing

### DIFF
--- a/benchmark/url/whatwg-url-parse.js
+++ b/benchmark/url/whatwg-url-parse.js
@@ -1,0 +1,34 @@
+'use strict';
+const common = require('../common.js');
+const { URL } = require('url');
+const fs = require('fs');
+const path = require('path');
+
+// This benchmark uses 100,000 unique URLs gathered by the top 100 visited
+// websites in the world. It is used to understand the real world impact of
+// the URL parser performance.
+// Reference: https://github.com/ada-url/url-dataset
+const filePath = path.join(__dirname, '../../test/fixtures/url-dataset.txt');
+const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+
+const bench = common.createBenchmark(main, {
+  n: [1, 5, 10],
+});
+
+function main({ n }) {
+  let result = 0;
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    for (const line of lines) {
+      try {
+        const url = new URL(line);
+        // eslint-disable-next-line no-unused-vars
+        result += url.toString().length;
+      } catch {
+        // do nothing
+      }
+    }
+  }
+  bench.end(n);
+}


### PR DESCRIPTION
We (@lemire and I) recently developed a small crawler to generate a large enough dataset (currently 100,000 URLs) for URL parser benchmarks. 

Current benchmarks in Node.js uses Web Platform Tests, which creates a non-realistic output since it contains a lot of edge cases that no real-world application would ever encounter. This new benchmark creates a more realistic scenario with extensive data from top-visited websites.

The whole project for generating this dataset is available at https://github.com/ada-url/url-dataset.

cc @nodejs/url @nodejs/performance 