### PR TITLE
debugger: improve validations and documents for watch and unwatch

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -197,6 +197,7 @@ debug>
   after)
 * `watch(expr)`: Add expression to watch list
 * `unwatch(expr)`: Remove expression from watch list
+* `unwatch(index)`: Remove expression at specific index from watch list
 * `watchers`: List all watchers and their values (automatically listed on each
   breakpoint)
 * `repl`: Open debugger's repl for evaluation in debugging script's context

--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -91,6 +91,7 @@ breakOnNone           Don't pause on exceptions (this is the default)
 
 watch(expr)           Start watching the given expression
 unwatch(expr)         Stop watching an expression
+unwatch(index)        Stop watching an expression at specific index from watch list
 watchers              Print all watched expressions and their current values
 
 exec(expr), p(expr), exec expr, p expr
@@ -1068,6 +1069,7 @@ function createRepl(inspector) {
       },
 
       watch(expr) {
+        validateString(expr, 'expression');
         ArrayPrototypePush(watchedExpressions, expr);
       },
 

--- a/test/sequential/test-debugger-watch-validation.js
+++ b/test/sequential/test-debugger-watch-validation.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const startCLI = require('../common/debugger');
+
+const assert = require('assert');
+
+const cli = startCLI([fixtures.path('debugger/break.js')]);
+
+(async () => {
+  await cli.waitForInitialBreak();
+  await cli.command('watch()');
+  await cli.waitFor(/ERR_INVALID_ARG_TYPE/);
+  assert.match(cli.output, /TypeError \[ERR_INVALID_ARG_TYPE\]: The "expression" argument must be of type string\. Received undefined/);
+})()
+.finally(() => cli.quit())
+.then(common.mustCall());

--- a/test/sequential/test-debugger-watchers.mjs
+++ b/test/sequential/test-debugger-watchers.mjs
@@ -28,18 +28,25 @@ try {
   await cli.command('watchers');
 
   assert.match(cli.output, /x is not defined/);
+  assert.match(cli.output, /1: "Hello" = 'Hello'/);
+  assert.match(cli.output, /2: 42 = 42/);
+  assert.match(cli.output, /3: NaN = NaN/);
+  assert.match(cli.output, /4: true = true/);
+  assert.match(cli.output, /5: \[1, 2\] = \[ 1, 2 \]/);
+  assert.match(cli.output, /6: process\.env =\n\s+\{[\s\S]+,\n\s+\.\.\. \}/,
+               'shows "..." for process.env');
 
+  await cli.command('unwatch(4)');
   await cli.command('unwatch("42")');
   await cli.stepCommand('n');
 
   assert.match(cli.output, /0: x = 10/);
   assert.match(cli.output, /1: "Hello" = 'Hello'/);
   assert.match(cli.output, /2: NaN = NaN/);
-  assert.match(cli.output, /3: true = true/);
-  assert.match(cli.output, /4: \[1, 2\] = \[ 1, 2 \]/);
+  assert.match(cli.output, /3: \[1, 2\] = \[ 1, 2 \]/);
   assert.match(
     cli.output,
-    /5: process\.env =\n\s+\{[\s\S]+,\n\s+\.\.\. \}/,
+    /4: process\.env =\n\s+\{[\s\S]+,\n\s+\.\.\. \}/,
     'shows "..." for process.env'
   );
 


### PR DESCRIPTION
https://github.com/nodejs/node/pull/42882
https://github.com/nodejs/node/pull/42913

I combined what was reflected in each PR.
- add information on unwatch(index) command
- add string validation for watch command