### PR TITLE
inspector: fix inspector open when there are sessions

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -945,6 +945,10 @@ bool Agent::IsActive() {
   return io_ != nullptr || client_->IsActive();
 }
 
+bool Agent::HasInspectorThread() {
+  return io_ != nullptr;
+}
+
 void Agent::SetParentHandle(
     std::unique_ptr<ParentInspectorHandle> parent_handle) {
   parent_handle_ = std::move(parent_handle);

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -59,6 +59,8 @@ class Agent {
   // --inspect command line flag) or if inspector JS API had been used.
   bool IsActive();
 
+  bool HasInspectorThread();
+
   // Blocks till frontend connects and sends "runIfWaitingForDebugger"
   void WaitForConnect();
   // Blocks till all the sessions with "WaitForDisconnectOnShutdown" disconnect

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -273,7 +273,7 @@ static void RegisterAsyncHookWrapper(const FunctionCallbackInfo<Value>& args) {
 
 void IsEnabled(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  args.GetReturnValue().Set(InspectorEnabled(env));
+  args.GetReturnValue().Set(env->inspector_agent()->HasInspectorThread());
 }
 
 void Open(const FunctionCallbackInfo<Value>& args) {

--- a/test/sequential/test-inspector-open-with-session.js
+++ b/test/sequential/test-inspector-open-with-session.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const { open, url } = require("inspector");
+const { Session } = require('inspector');
+const assert = require('assert');
+const session = new Session();
+session.connect();
+
+open();
+assert.ok(url() !== undefined);


### PR DESCRIPTION
fix `inspector.open` when there are sessions.

```js
const { Session, open } = require('inspector');
const session = new Session();
session.connect();
open();
```
this code above will throw an error ERR_INSPECTOR_ALREADY_ACTIVATED, but the following code works.
```js
const { Session, open } = require('inspector');
const session = new Session();
open();
session.connect();
```
i think we should only throw `ERR_INSPECTOR_ALREADY_ACTIVATED` when there is a inspector thread 🤔.

Refs: https://github.com/nodejs/node/pull/33015
cc @joyeecheung 

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
