### PR TITLE
test_runner: remove root tracking set

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -3,7 +3,6 @@ const {
   ArrayPrototypeForEach,
   PromiseResolve,
   SafeMap,
-  SafeWeakSet,
 } = primordials;
 const {
   createHook,
@@ -25,7 +24,6 @@ const {
 const { bigint: hrtime } = process.hrtime;
 
 const testResources = new SafeMap();
-const wasRootSetup = new SafeWeakSet();
 
 function createTestTree(options = kEmptyObject) {
   return setup(new Test({ __proto__: null, ...options, name: '<root>' }));
@@ -108,7 +106,7 @@ function collectCoverage(rootTest, coverage) {
 }
 
 function setup(root) {
-  if (wasRootSetup.has(root)) {
+  if (root.startTime !== null) {
     return root;
   }
 
@@ -172,8 +170,6 @@ function setup(root) {
     coverage: null,
   };
   root.startTime = hrtime();
-
-  wasRootSetup.add(root);
   return root;
 }
 


### PR DESCRIPTION
The `wasRootSetup` `Set` in the test harness appears to be redundant, since the `startTime` field can be used interchangeably. This commit removes `wasRootSetup`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
