### PR TITLE
permission: fix spawnSync permission check

### DIFF
--- a/benchmark/fs/readfile-permission-enabled.js
+++ b/benchmark/fs/readfile-permission-enabled.js
@@ -19,7 +19,12 @@ const bench = common.createBenchmark(main, {
   len: [1024, 16 * 1024 * 1024],
   concurrent: [1, 10],
 }, {
-  flags: ['--experimental-permission', '--allow-fs-read=*', '--allow-fs-write=*'],
+  flags: [
+    '--experimental-permission',
+    '--allow-fs-read=*',
+    '--allow-fs-write=*',
+    '--allow-child-process',
+  ],
 });
 
 function main({ len, duration, concurrent, encoding }) {

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -369,6 +369,8 @@ void SyncProcessRunner::Initialize(Local<Object> target,
 
 void SyncProcessRunner::Spawn(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kChildProcess, "");
   env->PrintSyncTrace();
   SyncProcessRunner p(env);
   Local<Value> result;

--- a/test/parallel/test-permission-deny-child-process-cli.js
+++ b/test/parallel/test-permission-deny-child-process-cli.js
@@ -25,7 +25,19 @@ if (process.argv[2] === 'child') {
     permission: 'ChildProcess',
   }));
   assert.throws(() => {
+    childProcess.spawnSync(process.execPath, ['--version']);
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'ChildProcess',
+  }));
+  assert.throws(() => {
     childProcess.exec(process.execPath, ['--version']);
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'ChildProcess',
+  }));
+  assert.throws(() => {
+    childProcess.execSync(process.execPath, ['--version']);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',
@@ -38,6 +50,12 @@ if (process.argv[2] === 'child') {
   }));
   assert.throws(() => {
     childProcess.execFile(process.execPath, ['--version']);
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'ChildProcess',
+  }));
+  assert.throws(() => {
+    childProcess.execFileSync(process.execPath, ['--version']);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',

--- a/test/parallel/test-permission-deny-child-process.js
+++ b/test/parallel/test-permission-deny-child-process.js
@@ -32,7 +32,19 @@ if (process.argv[2] === 'child') {
     permission: 'ChildProcess',
   }));
   assert.throws(() => {
+    childProcess.spawnSync(process.execPath, ['--version']);
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'ChildProcess',
+  }));
+  assert.throws(() => {
     childProcess.exec(process.execPath, ['--version']);
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'ChildProcess',
+  }));
+  assert.throws(() => {
+    childProcess.execSync(process.execPath, ['--version']);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',
@@ -45,6 +57,12 @@ if (process.argv[2] === 'child') {
   }));
   assert.throws(() => {
     childProcess.execFile(process.execPath, ['--version']);
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'ChildProcess',
+  }));
+  assert.throws(() => {
+    childProcess.execFileSync(process.execPath, ['--version']);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',

--- a/test/parallel/test-permission-deny-fs-symlink-target-write.js
+++ b/test/parallel/test-permission-deny-fs-symlink-target-write.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-permission --allow-fs-read=* --allow-fs-write=*
+// Flags: --experimental-permission --allow-fs-read=* --allow-fs-write=* --allow-child-process
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-permission-deny-fs-symlink.js
+++ b/test/parallel/test-permission-deny-fs-symlink.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-permission --allow-fs-read=* --allow-fs-write=*
+// Flags: --experimental-permission --allow-fs-read=* --allow-fs-write=* --allow-child-process
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-permission-fs-relative-path.js
+++ b/test/parallel/test-permission-fs-relative-path.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-permission --allow-fs-read=*
+// Flags: --experimental-permission --allow-fs-read=* --allow-child-process
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-permission-fs-windows-path.js
+++ b/test/parallel/test-permission-fs-windows-path.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-permission --allow-fs-read=* --allow-fs-write=*
+// Flags: --experimental-permission --allow-fs-read=* --allow-fs-write=* --allow-child-process
 'use strict';
 
 const common = require('../common');


### PR DESCRIPTION
It was missing in the original PR #44004.

Fixes: https://github.com/nodejs-private/node-private/issues/394