### PR TITLE
src: prevent changing `FunctionTemplateInfo` after publish

### DIFF
--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -346,7 +346,8 @@ void HistogramBase::Initialize(IsolateData* isolate_data,
   SetConstructorFunction(isolate_data->isolate(),
                          target,
                          "Histogram",
-                         GetConstructorTemplate(isolate_data));
+                         GetConstructorTemplate(isolate_data),
+                         SetConstructorFunctionFlag::NONE);
 }
 
 BaseObjectPtr<BaseObject> HistogramBase::HistogramTransferData::Deserialize(
@@ -372,6 +373,7 @@ Local<FunctionTemplate> IntervalHistogram::GetConstructorTemplate(
     Isolate* isolate = env->isolate();
     tmpl = NewFunctionTemplate(isolate, nullptr);
     tmpl->Inherit(HandleWrap::GetConstructorTemplate(env));
+    tmpl->SetClassName(OneByteString(isolate, "Histogram"));
     tmpl->InstanceTemplate()->SetInternalFieldCount(
         HistogramBase::kInternalFieldCount);
     SetProtoMethodNoSideEffect(isolate, tmpl, "count", GetCount);

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -1495,13 +1495,16 @@ static void InitMessaging(Local<Object> target,
     t->Inherit(BaseObject::GetConstructorTemplate(env));
     t->InstanceTemplate()->SetInternalFieldCount(
         JSTransferable::kInternalFieldCount);
-    SetConstructorFunction(context, target, "JSTransferable", t);
+    t->SetClassName(OneByteString(isolate, "JSTransferable"));
+    SetConstructorFunction(
+        context, target, "JSTransferable", t, SetConstructorFunctionFlag::NONE);
   }
 
   SetConstructorFunction(context,
                          target,
                          env->message_port_constructor_string(),
-                         GetMessagePortConstructorTemplate(env));
+                         GetMessagePortConstructorTemplate(env),
+                         SetConstructorFunctionFlag::NONE);
 
   // These are not methods on the MessagePort prototype, because
   // the browser equivalents do not provide them.


### PR DESCRIPTION
Refs https://chromium-review.googlesource.com/c/v8/v8/+/2718147

Fixes an issue where Node.js tries to call SetClassName on a FunctionTemplate twice in some cases. The above CL made it so that V8 CHECKs when this occurs. It is fixed by ensuring SetClassName is only called once.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
