### PR TITLE
doc: add missing test runner flags to man page

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -413,6 +413,12 @@ Starts the Node.js command line test runner.
 A regular expression that configures the test runner to only execute tests
 whose name matches the provided pattern.
 .
+.It Fl -test-reporter
+A test reporter to use when running tests.
+.
+.It Fl -test-reporter-destination
+The destination for the corresponding test reporter.
+.
 .It Fl -test-only
 Configures the test runner to only execute top level tests that have the `only`
 option set.


### PR DESCRIPTION
`--test-reporter` and `--test-reporter-destination` were previously missing from the man page.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
