### PR TITLE
doc: diagnostics_channel added in v14.17.0

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -1,7 +1,9 @@
 # Diagnostics Channel
 
 <!-- YAML
-added: v15.1.0
+added:
+  - v15.1.0
+  - v14.17.0
 changes:
   - version:
       - v19.2.0


### PR DESCRIPTION
- the `diagnostics_channel` module was backported to Node.js v14.17.0