### PR TITLE
repl: fix wrong parentheses

### DIFF
--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -745,10 +745,21 @@ function setupReverseSearch(repl) {
 function isValidSyntax(input) {
   const Parser = require('internal/deps/acorn/acorn/dist/acorn').Parser;
   try {
-    Parser.parse(input, { ecmaVersion: 'latest' });
+    Parser.parse(input, {
+      ecmaVersion: 'latest',
+      allowAwaitOutsideFunction: true,
+    });
     return true;
   } catch {
-    return false;
+    try {
+      Parser.parse(`_=${input}`, {
+        ecmaVersion: 'latest',
+        allowAwaitOutsideFunction: true,
+      });
+      return true;
+    } catch {
+      return false;
+    }
   }
 }
 

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -300,7 +300,7 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
     // curly brace with parenthesis.
     if (StringPrototypeStartsWith(input, '{') &&
         !StringPrototypeEndsWith(input, ';') &&
-        isValidParentheses(input) &&
+        isValidSyntax(input) &&
         !wrapped) {
       input = `(${input})`;
       wrapped = true;
@@ -742,27 +742,14 @@ function setupReverseSearch(repl) {
   return { reverseSearch };
 }
 
-function isValidParentheses(input) {
-  const stack = [];
-  const pairs = {
-    '(': ')',
-    '[': ']',
-    '{': '}',
-  };
-
-  for (let i = 0; i < input.length; i++) {
-    const char = input[i];
-
-    if (pairs[char]) {
-      stack.push(char);
-    } else if (char === ')' || char === ']' || char === '}') {
-      if (pairs[stack.pop()] !== char) {
-        return false;
-      }
-    }
+function isValidSyntax(input) {
+  const Parser = require('internal/deps/acorn/acorn/dist/acorn').Parser;
+  try {
+    let result = Parser.parse(input, { ecmaVersion: 'latest' });
+    return true;
+  } catch(e) {
+    return false;
   }
-
-  return stack.length === 0;
 }
 
 module.exports = {
@@ -772,5 +759,5 @@ module.exports = {
   kStandaloneREPL: Symbol('kStandaloneREPL'),
   setupPreview,
   setupReverseSearch,
-  isValidParentheses,
+  isValidSyntax,
 };

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -299,7 +299,9 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
     // For similar reasons as `defaultEval`, wrap expressions starting with a
     // curly brace with parenthesis.
     if (StringPrototypeStartsWith(input, '{') &&
-        !StringPrototypeEndsWith(input, ';') && !wrapped) {
+        !StringPrototypeEndsWith(input, ';') &&
+        isValidParentheses(input) &&
+        !wrapped) {
       input = `(${input})`;
       wrapped = true;
     }
@@ -740,6 +742,29 @@ function setupReverseSearch(repl) {
   return { reverseSearch };
 }
 
+function isValidParentheses(input) {
+  const stack = [];
+  const pairs = {
+    '(': ')',
+    '[': ']',
+    '{': '}',
+  };
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (pairs[char]) {
+      stack.push(char);
+    } else if (char === ')' || char === ']' || char === '}') {
+      if (pairs[stack.pop()] !== char) {
+        return false;
+      }
+    }
+  }
+
+  return stack.length === 0;
+}
+
 module.exports = {
   REPL_MODE_SLOPPY: Symbol('repl-sloppy'),
   REPL_MODE_STRICT,
@@ -747,4 +772,5 @@ module.exports = {
   kStandaloneREPL: Symbol('kStandaloneREPL'),
   setupPreview,
   setupReverseSearch,
+  isValidParentheses,
 };

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -745,9 +745,9 @@ function setupReverseSearch(repl) {
 function isValidSyntax(input) {
   const Parser = require('internal/deps/acorn/acorn/dist/acorn').Parser;
   try {
-    let result = Parser.parse(input, { ecmaVersion: 'latest' });
+    Parser.parse(input, { ecmaVersion: 'latest' });
     return true;
-  } catch(e) {
+  } catch {
     return false;
   }
 }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -163,7 +163,7 @@ const {
   kStandaloneREPL,
   setupPreview,
   setupReverseSearch,
-  isValidParentheses,
+  isValidSyntax,
 } = require('internal/repl/utils');
 const {
   constants: {
@@ -422,7 +422,7 @@ function REPLServer(prompt,
     // lib/internal/repl/utils.js needs to be changed to match.
     if (RegExpPrototypeExec(/^\s*{/, code) !== null &&
         RegExpPrototypeExec(/;\s*$/, code) === null &&
-        isValidParentheses(code)) {
+        isValidSyntax(code)) {
       code = `(${StringPrototypeTrim(code)})\n`;
       wrappedCmd = true;
     }
@@ -1821,6 +1821,7 @@ module.exports = {
   REPL_MODE_SLOPPY,
   REPL_MODE_STRICT,
   Recoverable,
+  isValidSyntax,
 };
 
 ObjectDefineProperty(module.exports, 'builtinModules', {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -163,6 +163,7 @@ const {
   kStandaloneREPL,
   setupPreview,
   setupReverseSearch,
+  isValidParentheses,
 } = require('internal/repl/utils');
 const {
   constants: {
@@ -420,7 +421,8 @@ function REPLServer(prompt,
     // an expression.  Note that if the above condition changes,
     // lib/internal/repl/utils.js needs to be changed to match.
     if (RegExpPrototypeExec(/^\s*{/, code) !== null &&
-        RegExpPrototypeExec(/;\s*$/, code) === null) {
+        RegExpPrototypeExec(/;\s*$/, code) === null &&
+        isValidParentheses(code)) {
       code = `(${StringPrototypeTrim(code)})\n`;
       wrappedCmd = true;
     }

--- a/test/parallel/test-repl-preview.js
+++ b/test/parallel/test-repl-preview.js
@@ -162,7 +162,7 @@ async function tests(options) {
     noPreview: 'Uncaught ReferenceError: aaaa is not defined',
     preview: [
       'aaaa\r',
-      'Uncaught ReferenceError: aaaa is not defined'
+      'Uncaught ReferenceError: aaaa is not defined',
     ]
   }, {
     input: '/0',
@@ -174,6 +174,16 @@ async function tests(options) {
       '',
       'Uncaught SyntaxError: Invalid regular expression: missing /',
     ]
+  }, {
+    input: '{})',
+    noPreview: '{})',
+    preview: [
+      '{})\r',
+      '{})',
+      '  ^',
+      '',
+      "Uncaught SyntaxError: Unexpected token ')'",
+    ],
   }];
 
   const hasPreview = repl.terminal &&
@@ -195,7 +205,7 @@ async function tests(options) {
     } else {
       assert.ok(lines[0].includes(noPreview), lines.map(inspect));
       if (preview.length !== 1 || preview[0] !== `${input}\r`) {
-        if (preview[preview.length-1].includes('Uncaught SyntaxError')) { // Syntax error
+        if (preview[preview.length - 1].includes('Uncaught SyntaxError')) {
           assert.strictEqual(lines.length, 5);
         } else {
           assert.strictEqual(lines.length, 2);

--- a/test/parallel/test-repl-preview.js
+++ b/test/parallel/test-repl-preview.js
@@ -184,6 +184,13 @@ async function tests(options) {
       '',
       "Uncaught SyntaxError: Unexpected token ')'",
     ],
+  }, {
+    input: "{ a: '{' }",
+    noPreview: "{ a: \x1B[32m'{'\x1B[39m }",
+    preview: [
+      "{ a: '{' }\r",
+      "{ a: \x1B[32m'{'\x1B[39m }",
+    ],
   }];
 
   const hasPreview = repl.terminal &&

--- a/test/parallel/test-repl-preview.js
+++ b/test/parallel/test-repl-preview.js
@@ -191,6 +191,22 @@ async function tests(options) {
       "{ a: '{' }\r",
       "{ a: \x1B[32m'{'\x1B[39m }",
     ],
+  }, {
+    input: "{'{':0}",
+    noPreview: "{ \x1B[32m'{'\x1B[39m: \x1B[33m0\x1B[39m }",
+    preview: [
+      "{'{':0}",
+      "\x1B[90m{ '{': 0 }\x1B[39m\x1B[15G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r",
+      "{ \x1B[32m'{'\x1B[39m: \x1B[33m0\x1B[39m }",
+    ],
+  }, {
+    input: '{[Symbol.for("{")]: 0 }',
+    noPreview: '{ [\x1B[32mSymbol({)\x1B[39m]: \x1B[33m0\x1B[39m }',
+    preview: [
+      // eslint-disable-next-line max-len
+      '{[Sym\x1B[90mbol\x1B[39m\x1B[13G\x1B[0Kb\x1B[90mol\x1B[39m\x1B[14G\x1B[0Ko\x1B[90ml\x1B[39m\x1B[15G\x1B[0Kl.for("{")]: 0 }\r',
+      '{ [\x1B[32mSymbol({)\x1B[39m]: \x1B[33m0\x1B[39m }',
+    ],
   }];
 
   const hasPreview = repl.terminal &&

--- a/test/parallel/test-repl-preview.js
+++ b/test/parallel/test-repl-preview.js
@@ -207,6 +207,28 @@ async function tests(options) {
       '{[Sym\x1B[90mbol\x1B[39m\x1B[13G\x1B[0Kb\x1B[90mol\x1B[39m\x1B[14G\x1B[0Ko\x1B[90ml\x1B[39m\x1B[15G\x1B[0Kl.for("{")]: 0 }\r',
       '{ [\x1B[32mSymbol({)\x1B[39m]: \x1B[33m0\x1B[39m }',
     ],
+  }, {
+    input: '{},{}',
+    noPreview: '{}',
+    preview: [
+      '{},{}',
+      '\x1B[90m{}\x1B[39m\x1B[13G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r',
+      '{}',
+    ],
+  }, {
+    input: '{} //',
+    noPreview: 'repl > ',
+    preview: [
+      '{} //\r',
+    ],
+  }, {
+    input: '{throw 0}',
+    noPreview: 'Uncaught \x1B[33m0\x1B[39m',
+    preview: [
+      '{thr\x1B[90mow\x1B[39m\x1B[12G\x1B[0Ko\x1B[90mw\x1B[39m\x1B[13G\x1B[0Kw 0}',
+      '\x1B[90m0\x1B[39m\x1B[17G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r',
+      'Uncaught \x1B[33m0\x1B[39m',
+    ],
   }];
 
   const hasPreview = repl.terminal &&

--- a/test/parallel/test-repl-preview.js
+++ b/test/parallel/test-repl-preview.js
@@ -164,6 +164,16 @@ async function tests(options) {
       'aaaa\r',
       'Uncaught ReferenceError: aaaa is not defined'
     ]
+  }, {
+    input: '/0',
+    noPreview: '/0',
+    preview: [
+      '/0\r',
+      '/0',
+      '^',
+      '',
+      'Uncaught SyntaxError: Invalid regular expression: missing /',
+    ]
   }];
 
   const hasPreview = repl.terminal &&
@@ -184,8 +194,13 @@ async function tests(options) {
       assert.deepStrictEqual(lines, preview);
     } else {
       assert.ok(lines[0].includes(noPreview), lines.map(inspect));
-      if (preview.length !== 1 || preview[0] !== `${input}\r`)
-        assert.strictEqual(lines.length, 2);
+      if (preview.length !== 1 || preview[0] !== `${input}\r`) {
+        if (preview[preview.length-1].includes('Uncaught SyntaxError')) { // Syntax error
+          assert.strictEqual(lines.length, 5);
+        } else {
+          assert.strictEqual(lines.length, 2);
+        }
+      }
     }
   }
 }

--- a/test/parallel/test-repl-preview.js
+++ b/test/parallel/test-repl-preview.js
@@ -157,6 +157,13 @@ async function tests(options) {
       '\x1B[90m1\x1B[39m\x1B[12G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r',
       '\x1B[33m1\x1B[39m',
     ]
+  }, {
+    input: 'aaaa',
+    noPreview: 'Uncaught ReferenceError: aaaa is not defined',
+    preview: [
+      'aaaa\r',
+      'Uncaught ReferenceError: aaaa is not defined'
+    ]
   }];
 
   const hasPreview = repl.terminal &&

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -311,6 +311,19 @@ const errorTests = [
   },
   // Multiline object
   {
+    send: '{}),({}',
+    expect: '... ',
+  },
+  {
+    send: '}',
+    expect: [
+      '{}),({}',
+      kArrow,
+      '',
+      /^Uncaught SyntaxError: /,
+    ]
+  },
+  {
     send: '{ a: ',
     expect: '... '
   },


### PR DESCRIPTION
If the input isn't a valid syntax, don't wrap it

Fix https://github.com/nodejs/node/issues/46877