### PR TITLE
benchmark: update README to include all benchmarks

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -9,39 +9,22 @@ directory, see [the guide on benchmarks](../doc/contributing/writing-and-running
 
 ## Table of Contents
 
-* [Benchmark directories](#benchmark-directories)
+* [File tree structure](#file-tree-structure)
 * [Common API](#common-api)
 
-## Benchmark Directories
+## File tree structure
 
-| Directory       | Purpose                                                                                                          |
-| --------------- | ---------------------------------------------------------------------------------------------------------------- |
-| assert          | Benchmarks for the `assert` subsystem.                                                                           |
-| buffers         | Benchmarks for the `buffer` subsystem.                                                                           |
-| child\_process  | Benchmarks for the `child_process` subsystem.                                                                    |
-| crypto          | Benchmarks for the `crypto` subsystem.                                                                           |
-| dgram           | Benchmarks for the `dgram` subsystem.                                                                            |
-| domain          | Benchmarks for the `domain` subsystem.                                                                           |
-| es              | Benchmarks for various new ECMAScript features and their pre-ES2015 counterparts.                                |
-| events          | Benchmarks for the `events` subsystem.                                                                           |
-| fixtures        | Benchmarks fixtures used in various benchmarks throughout the benchmark suite.                                   |
-| fs              | Benchmarks for the `fs` subsystem.                                                                               |
-| http            | Benchmarks for the `http` subsystem.                                                                             |
-| http2           | Benchmarks for the `http2` subsystem.                                                                            |
-| misc            | Miscellaneous benchmarks and benchmarks for shared internal modules.                                             |
-| module          | Benchmarks for the `module` subsystem.                                                                           |
-| net             | Benchmarks for the `net` subsystem.                                                                              |
-| path            | Benchmarks for the `path` subsystem.                                                                             |
-| perf\_hooks     | Benchmarks for the `perf_hooks` subsystem.                                                                       |
-| process         | Benchmarks for the `process` subsystem.                                                                          |
-| querystring     | Benchmarks for the `querystring` subsystem.                                                                      |
-| streams         | Benchmarks for the `streams` subsystem.                                                                          |
-| string\_decoder | Benchmarks for the `string_decoder` subsystem.                                                                   |
-| timers          | Benchmarks for the `timers` subsystem, including `setTimeout`, `setInterval`, .etc.                              |
-| tls             | Benchmarks for the `tls` subsystem.                                                                              |
-| url             | Benchmarks for the `url` subsystem, including the legacy `url` implementation and the WHATWG URL implementation. |
-| util            | Benchmarks for the `util` subsystem.                                                                             |
-| vm              | Benchmarks for the `vm` subsystem.                                                                               |
+### Directories
+
+Benchmarks testing the performance of a single node submodule are placed into a
+directory with the corresponding name, so that they can be executed by submodule
+or individually.
+Benchmarks that span multiple submodules may either be placed into the `misc`
+directory or into a directory named after the feature they benchmark.
+E.g. benchmarks for various new ECMAScript features and their pre-ES2015
+counterparts are placed in a directory named `es`.
+Fixtures that are not specific to a certain benchmark but can be reused
+throughout the benchmark suite should be placed in the `fixtures` directory.
 
 ### Other Top-level files
 


### PR DESCRIPTION
### Background
During #46731 @cola119 mentioned that the benchmark for readline was not documented in `benchmark/README.md`.
This PR will fix this (and also add other unmentioned benchmarks).

### Update the markdown table in `benchmark/README.md`
The content of `benchmark/README.md` has become stale, no longer providing an overview over all existing benchmarks. To address this, the markdown table has been updated to incorporate all current benchmarks. 

### Move benchmarks for parts of submodules into the corresponding directory
Furthermore, some benchmarks were in separate directories from the benchmarks of their respective node submodules. These benchmarks have been moved into the directory of their submodule.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
