### PR TITLE
deps: cherry-pick ARM64 Windows changes to node-gyp

### DIFF
--- a/deps/npm/node_modules/node-gyp/lib/find-visualstudio.js
+++ b/deps/npm/node_modules/node-gyp/lib/find-visualstudio.js
@@ -126,7 +126,11 @@ VisualStudioFinder.prototype = {
   // Invoke the PowerShell script to get information about Visual Studio 2017
   // or newer installations
   findVisualStudio2017OrNewer: function findVisualStudio2017OrNewer (cb) {
-    var ps = path.join(process.env.SystemRoot, 'System32',
+    // SysWOW64 PowerShell is needed on ARM64 because of the COM classes and
+    // interfaces used by Find-VisualStudio.cs, which are not registered for
+    // being used from ARM64 processes. 
+    var systemDirectory = process.arch === 'arm64' ? 'SysWOW64' : 'System32'
+    var ps = path.join(process.env.SystemRoot, systemDirectory,
       'WindowsPowerShell', 'v1.0', 'powershell.exe')
     var csFile = path.join(__dirname, 'Find-VisualStudio.cs')
     var psArgs = [


### PR DESCRIPTION
As a part of an ongoing effort to make Windows on ARM a tier 2 supported platform, we've added Windows 11 ARM64 machines to the CI for testing. When running tests, we saw that native suites were failing because of the following error: Could not find any Visual Studio installation to use. One run showcasing this behavior can be observed in [this build](https://ci.nodejs.org/job/node-test-commit-windows-fanned/53738/).

Upon further investigation, we've discovered that this is an issue with COM classes and interfaces used for this, which weren't registered correctly for ARM64. (for more details on that, please see the PR being cherry-picked https://github.com/nodejs/node-gyp/pull/2810). With the changes proposed here, we're experiencing no problems running native test suites. One run showcasing this behavior can be observed in [this build](https://ci.nodejs.org/job/node-test-commit-windows-fanned/53737/).

We plan to have this fix added as a floating patch inside the node repo and to keep it here until, in some future release, npm is upgraded to a version with the same changes being part of its node-gyp module.

cc @nodejs/platform-windows-arm