### PR TITLE
test: remove unnecessary urlToHttpOptions test

### DIFF
--- a/test/parallel/test-url-urltooptions.js
+++ b/test/parallel/test-url-urltooptions.js
@@ -18,20 +18,3 @@ assert.strictEqual(opts.hash, '#test');
 
 const { hostname } = urlToHttpOptions(new URL('http://[::1]:21'));
 assert.strictEqual(hostname, '::1');
-
-// If a WHATWG URL object is copied, it is possible that the resulting copy
-// contains the Symbols that Node uses for brand checking, but not the data
-// properties, which are getters. Verify that urlToHttpOptions() can handle
-// such a case.
-const copiedUrlObj = { ...urlObj };
-const copiedOpts = urlToHttpOptions(copiedUrlObj);
-assert.strictEqual(copiedOpts instanceof URL, false);
-assert.strictEqual(copiedOpts.protocol, undefined);
-assert.strictEqual(copiedOpts.auth, undefined);
-assert.strictEqual(copiedOpts.hostname, undefined);
-assert.strictEqual(copiedOpts.port, NaN);
-assert.strictEqual(copiedOpts.path, '');
-assert.strictEqual(copiedOpts.pathname, undefined);
-assert.strictEqual(copiedOpts.search, undefined);
-assert.strictEqual(copiedOpts.hash, undefined);
-assert.strictEqual(copiedOpts.href, undefined);


### PR DESCRIPTION
The following test is not needed anymore. We removed the symbol in URL, and the following test is unnecessary. Reference: https://github.com/nodejs/node/pull/46904

We don't even check for isURL on urlToHttpOptions, but the parameter of urlToHttpOptions is expected to be `URL`.

Referencing the discussion with @aduh95 on https://github.com/nodejs/node/pull/46989

cc @nodejs/url