### PR TITLE
src: remove unused `v8::Uint32Array` from encoding

### DIFF
--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -20,7 +20,6 @@ using v8::Local;
 using v8::MaybeLocal;
 using v8::Object;
 using v8::String;
-using v8::Uint32Array;
 using v8::Uint8Array;
 using v8::Value;
 


### PR DESCRIPTION
Introduced by commit https://github.com/nodejs/node/commit/e5933c83257b2ed4b2e71998837fd2da2b548a16, this pull request removes the unused include which causes cpp linting error.

cc @joyeecheung 