### PR TITLE
meta: add single-executable labels and code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -142,4 +142,11 @@
 /lib/internal/test_runner/* @nodejs/test_runner
 
 # Single Executable Applications
+/deps/postject @nodejs/single-executable
+/doc/api/single-executable-applications.md @nodejs/single-executable
+/doc/contributing/maintaining-postject.md @nodejs/single-executable
+/doc/contributing/maintaining-single-executable-application-support.md @nodejs/single-executable
 /src/node_sea* @nodejs/single-executable
+/test/fixtures/postject-copy @nodejs/single-executable
+/test/parallel/test-single-executable-* @nodejs/single-executable
+/tools/dep_updaters/update-postject.sh @nodejs/single-executable

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -140,3 +140,6 @@
 /lib/test.js @nodejs/test_runner
 /lib/internal/main/test_runner.js @nodejs/test_runner
 /lib/internal/test_runner/* @nodejs/test_runner
+
+# Single Executable Applications
+/src/node_sea* @nodejs/single-executable

--- a/.github/label-pr-config.yml
+++ b/.github/label-pr-config.yml
@@ -33,6 +33,7 @@ subSystemLabels:
   /^src\/node_worker/: c++, worker
   /^src\/quic\/*/: c++, quic, dont-land-on-v14.x
   /^src\/node_bob*/: c++, quic, dont-land-on-v14.x
+  /^src\/node_sea/: single-executable
 
   # don't label python files as c++
   /^src\/.+\.py$/: python, needs-ci


### PR DESCRIPTION
I also created the `single-executable` label -> (hopefully there's no objection to that ;))

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
