### PR TITLE
deps: cherry-pick win/arm64/clang fixes

### DIFF
--- a/deps/histogram/src/hdr_atomic.h
+++ b/deps/histogram/src/hdr_atomic.h
@@ -8,7 +8,7 @@
 #define HDR_ATOMIC_H__
 
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !(defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64)))
 
 #include <stdint.h>
 #include <intrin.h>

--- a/deps/histogram/src/hdr_histogram.c
+++ b/deps/histogram/src/hdr_histogram.c
@@ -127,7 +127,7 @@ static int64_t power(int64_t base, int64_t exp)
     return result;
 }
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !(defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64)))
 #   if defined(_WIN64)
 #       pragma intrinsic(_BitScanReverse64)
 #   else
@@ -137,7 +137,7 @@ static int64_t power(int64_t base, int64_t exp)
 
 static int32_t count_leading_zeros_64(int64_t value)
 {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !(defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64)))
     uint32_t leading_zero = 0;
 #if defined(_WIN64)
     _BitScanReverse64(&leading_zero, value);

--- a/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c
+++ b/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c
@@ -33,7 +33,7 @@
 
 #include "nghttp3_macro.h"
 
-#if defined(_MSC_VER) && defined(_M_ARM64)
+#if defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64))
 unsigned int __popcnt(unsigned int x) {
   unsigned int c = 0;
   for (; x; ++c) {

--- a/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c
+++ b/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c
@@ -31,7 +31,7 @@
 
 #include "ngtcp2_macro.h"
 
-#if defined(_MSC_VER) && defined(_M_ARM64)
+#if defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64))
 unsigned int __popcnt(unsigned int x) {
   unsigned int c = 0;
   for (; x; ++c) {


### PR DESCRIPTION
Fix compilation errors when building Windows/ARM64 target with clang.

Refs: ngtcp2/nghttp3#112
Refs: ngtcp2/ngtcp2#692
Refs: HdrHistogram/HdrHistogram_c#114
