### PR TITLE
net: fix setting of value in 'setDefaultAutoSelectFamilyAttemptTimeout'

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1661,7 +1661,7 @@ added: REPLACEME
 Sets the default value of the `autoSelectFamilyAttemptTimeout` option of [`socket.connect(options)`][].
 
 * `value` {number} The new default value, which must be a positive number. If the number is less than `10`,
-  the value `10` is used insted The initial default value is `250`.
+  the value `10` is used instead. The initial default value is `250`.
 
 ## `net.isIP(input)`
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -247,7 +247,7 @@ function getDefaultAutoSelectFamilyAttemptTimeout() {
 function setDefaultAutoSelectFamilyAttemptTimeout(value) {
   validateInt32(value, 'value', 1);
 
-  if (value < 1) {
+  if (value < 10) {
     value = 10;
   }
 

--- a/test/parallel/test-net-socket-connect-invalid-autoselectfamilyattempttimeout.js
+++ b/test/parallel/test-net-socket-connect-invalid-autoselectfamilyattempttimeout.js
@@ -18,3 +18,10 @@ for (const autoSelectFamilyAttemptTimeout of [-10, 0]) {
     net.setDefaultAutoSelectFamilyAttemptTimeout(autoSelectFamilyAttemptTimeout);
   }, { code: 'ERR_OUT_OF_RANGE' });
 }
+
+// Check the default value of autoSelectFamilyAttemptTimeout is 10
+// if passed number is less than 10
+for (const autoSelectFamilyAttemptTimeout of [1, 9]) {
+  net.setDefaultAutoSelectFamilyAttemptTimeout(autoSelectFamilyAttemptTimeout);
+  assert.strictEqual(net.getDefaultAutoSelectFamilyAttemptTimeout(), 10);
+}


### PR DESCRIPTION
Document describes that the value have to be 10 if passed value to `setDefaultAutoSelectFamilyAttemptTimeout` is less than 10. So need to use 10 for 'if' statement and fix typo in document.

Refs: https://github.com/nodejs/node/blob/main/doc/api/net.md#netsetdefaultautoselectfamilyattempttimeoutvalue

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
