### PR TITLE
src: fix typo in process.env accessor error message

### DIFF
--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -444,8 +444,8 @@ static void EnvDefiner(Local<Name> property,
   } else if (desc.has_get() || desc.has_set()) {
     // we don't accept a getter/setter in 'process.env'
     THROW_ERR_INVALID_OBJECT_DEFINE_PROPERTY(env,
-                             "'process.env' does not accept an"
-                                             "accessor(getter/setter)"
+                                             "'process.env' does not accept an"
+                                             " accessor(getter/setter)"
                                              " descriptor");
   } else {
     THROW_ERR_INVALID_OBJECT_DEFINE_PROPERTY(env,

--- a/test/parallel/test-process-env-ignore-getter-setter.js
+++ b/test/parallel/test-process-env-ignore-getter-setter.js
@@ -33,7 +33,7 @@ assert.throws(
   {
     code: 'ERR_INVALID_OBJECT_DEFINE_PROPERTY',
     name: 'TypeError',
-    message: '\'process.env\' does not accept an' +
+    message: '\'process.env\' does not accept an ' +
         'accessor(getter/setter) descriptor'
   }
 );


### PR DESCRIPTION
Tiny commit to fix a missing white space in the error message "\'process.env\' does not accept anaccessor(getter/setter) descriptor". 