### PR TITLE
test: fallback to IPv4 if IPv6 is unavailable

### DIFF
--- a/test/sequential/test-tls-psk-client.js
+++ b/test/sequential/test-tls-psk-client.js
@@ -14,7 +14,7 @@ const { spawn } = require('child_process');
 const CIPHERS = 'PSK+HIGH';
 const KEY = 'd731ef57be09e5204f0b205b60627028';
 const IDENTITY = 'Client_identity';  // Hardcoded by `openssl s_server`
-const useIPv4 = common.hasIPv6 ? false : true;
+const useIPv4 = !common.hasIPv6;
 
 const server = spawn(common.opensslCli, [
   's_server',

--- a/test/sequential/test-tls-psk-client.js
+++ b/test/sequential/test-tls-psk-client.js
@@ -14,6 +14,7 @@ const { spawn } = require('child_process');
 const CIPHERS = 'PSK+HIGH';
 const KEY = 'd731ef57be09e5204f0b205b60627028';
 const IDENTITY = 'Client_identity';  // Hardcoded by `openssl s_server`
+const useIPv4 = common.hasIPv6 ? false : true;
 
 const server = spawn(common.opensslCli, [
   's_server',
@@ -23,6 +24,7 @@ const server = spawn(common.opensslCli, [
   '-psk_hint', IDENTITY,
   '-nocert',
   '-rev',
+  ...(useIPv4 ? ['-4'] : []),
 ], { encoding: 'utf8' });
 let serverErr = '';
 let serverOut = '';

--- a/test/sequential/test-tls-securepair-client.js
+++ b/test/sequential/test-tls-securepair-client.js
@@ -38,6 +38,8 @@ const fixtures = require('../common/fixtures');
 const tls = require('tls');
 const spawn = require('child_process').spawn;
 
+const useIPv4 = common.hasIPv6 ? false : true;
+
 test1();
 
 // simple/test-tls-securepair-client
@@ -64,7 +66,9 @@ function test(keyPath, certPath, check, next) {
   const server = spawn(common.opensslCli, ['s_server',
                                            '-accept', 0,
                                            '-cert', fixtures.path(certPath),
-                                           '-key', fixtures.path(keyPath)]);
+                                           '-key', fixtures.path(keyPath),
+                                           ...(useIPv4 ? ['-4'] : []),
+  ]);
   server.stdout.pipe(process.stdout);
   server.stderr.pipe(process.stdout);
 

--- a/test/sequential/test-tls-securepair-client.js
+++ b/test/sequential/test-tls-securepair-client.js
@@ -38,7 +38,7 @@ const fixtures = require('../common/fixtures');
 const tls = require('tls');
 const spawn = require('child_process').spawn;
 
-const useIPv4 = common.hasIPv6 ? false : true;
+const useIPv4 = !common.hasIPv6;
 
 test1();
 


### PR DESCRIPTION
openssl seems to default to use IPv6.
This change adds a check if IPv6 is unavailable and uses IPv4 instead.
On the Node.js CI IBM i build system IPv6 is currently disabled. 
This change should resolve the following test case failures:

- https://ci.nodejs.org/job/node-test-commit-ibmi/nodes=ibmi73-ppc64/1085/testReport/(root)/test/sequential_test_tls_psk_client_/

- https://ci.nodejs.org/job/node-test-commit-ibmi/nodes=ibmi73-ppc64/1085/testReport/(root)/test/sequential_test_tls_securepair_client_/

CC

@nodejs/platform-ibmi
@richardlau 


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
