### PR TITLE
Skip broken tests on Windows ARM64

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -14,6 +14,10 @@ test-crypto-keygen: PASS,FLAKY
 # https://github.com/nodejs/node/issues/41201
 test-fs-rmdir-recursive: PASS, FLAKY
 
+# Windows on ARM
+[$system==win32 && $arch==arm64]
+test-child-process-exec-cwd: SKIP
+
 [$system==linux]
 # https://github.com/nodejs/node/issues/39368
 test-domain-error-types: PASS,FLAKY


### PR DESCRIPTION
This PR marks 2 tests for skipping on Windows on ARM. The changes introduced here aim to enable passing JS test suites in the CI. There is another [PR](https://github.com/nodejs/node/pull/46995) that focuses on native test suites. Together their goal is to [enable Windows ARM64 tests in CI](https://github.com/nodejs/build/issues/3046)

cc @nodejs/platform-windows-arm 