### PR TITLE
tools: dont use stale cached node versions in daily wpt

### DIFF
--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NIGHTLY || matrix.node-version }}
+          check-latest: true
       - name: Get nightly ref
         if: contains(matrix.node-version, 'nightly')
         env:


### PR DESCRIPTION
Even after https://github.com/actions/node-versions already tracks v18.15.0 tonight's run resolved lts/* to v18.14.2. This change [should help](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#check-latest-version).