### PR TITLE
lib, doc: standardize params in PerformanceObserver.observe

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -1272,7 +1272,7 @@ changes:
   * `buffered` {boolean} If true, the observer callback is called with a
     list global `PerformanceEntry` buffered entries. If false, only
     `PerformanceEntry`s created after the time point are sent to the
-    observer callback. **Default:** `false`.
+    observer callback. Must be used only with `options.type`.
 
 Subscribes the {PerformanceObserver} instance to notifications of new
 {PerformanceEntry} instances identified either by `options.entryTypes`

--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -260,7 +260,7 @@ class PerformanceObserver {
     } = { ...options };
     if (entryTypes === undefined && type === undefined)
       throw new ERR_MISSING_ARGS('options.entryTypes', 'options.type');
-    if (entryTypes != null && (type != null || buffered))
+    if (entryTypes != null && (type != null || buffered != null))
       throw new ERR_INVALID_ARG_VALUE('options.entryTypes',
                                       entryTypes,
                                       'options.entryTypes can not set with ' +

--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -260,11 +260,11 @@ class PerformanceObserver {
     } = { ...options };
     if (entryTypes === undefined && type === undefined)
       throw new ERR_MISSING_ARGS('options.entryTypes', 'options.type');
-    if (entryTypes != null && type != null)
+    if (entryTypes != null && (type != null || buffered))
       throw new ERR_INVALID_ARG_VALUE('options.entryTypes',
                                       entryTypes,
                                       'options.entryTypes can not set with ' +
-                                      'options.type together');
+                                      'options.type or options.buffered together');
 
     switch (this.#type) {
       case undefined:

--- a/test/fixtures/wpt/performance-timeline/po-observe-type.any.js
+++ b/test/fixtures/wpt/performance-timeline/po-observe-type.any.js
@@ -33,6 +33,13 @@ test(() => {
   });
 }, "Calling observe() with type and entryTypes should throw a TypeError");
 
+test(() => {
+  const obs = new PerformanceObserver(() =>{});
+  assert_throws_js(TypeError, function () {
+    obs.observe({buffered: true, entryTypes: ["measure"]});
+  });
+}, "Calling observe() with buffered and entryTypes should throw a TypeError");
+
 test(function () {
   const obs = new PerformanceObserver(() =>{});
   // Definitely not an entry type.


### PR DESCRIPTION
This fixes missing validation when options.buffered and options.entryType are both set in PerformanceObserver.observe
[https://www.w3.org/TR/performance-timeline/#observe-method](url)

> If options's [entryTypes](https://www.w3.org/TR/performance-timeline/#dom-performanceobserverinit-entrytypes) is present and any other member is also present, then [throw](https://webidl.spec.whatwg.org/#dfn-throw) a "[TypeError](https://webidl.spec.whatwg.org/#exceptiondef-typeerror)".