### PR TITLE
doc,test: extend the list of platforms supported by single-executables

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -153,8 +153,8 @@ platforms:
 
 * Windows
 * macOS
-* Linux (all distributions except Alpine and all architectures except s390x and
-  ppc64)
+* Linux (all distributions [supported by Node.js][] except Alpine and all
+  architectures [supported by Node.js][] except s390x and ppc64)
 
 This is due to a lack of better tools to generate single-executables that can be
 used to test this feature on other platforms.
@@ -175,3 +175,4 @@ to help us document them.
 [postject]: https://github.com/nodejs/postject
 [signtool]: https://learn.microsoft.com/en-us/windows/win32/seccrypto/signtool
 [single executable applications]: https://github.com/nodejs/single-executable
+[supported by Node.js]: https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -153,7 +153,8 @@ platforms:
 
 * Windows
 * macOS
-* Linux (AMD64 only)
+* Linux (all distributions except Alpine and all architectures except s390x and
+  ppc64)
 
 This is due to a lack of better tools to generate single-executables that can be
 used to test this feature on other platforms.

--- a/doc/contributing/maintaining-single-executable-application-support.md
+++ b/doc/contributing/maintaining-single-executable-application-support.md
@@ -54,7 +54,9 @@ for the following features are in the list of work we'd like to get to:
 * Running an archive of multiple files.
 * Embedding [Node.js CLI options][] into the binary.
 * [XCOFF][] executable format.
-* Run tests on Linux architectures/distributions other than AMD64 Ubuntu.
+* Run tests on Alpine Linux.
+* Run tests on s390x Linux.
+* Run tests on ppc64 Linux.
 
 ## Disabling single executable application support
 

--- a/test/parallel/test-single-executable-application.js
+++ b/test/parallel/test-single-executable-application.js
@@ -16,8 +16,10 @@ if (!process.config.variables.single_executable_application)
 if (!['darwin', 'win32', 'linux'].includes(process.platform))
   common.skip(`Unsupported platform ${process.platform}.`);
 
-if (process.platform === 'linux' && process.config.variables.asan)
-  common.skip('Running the resultant binary fails with `Segmentation fault (core dumped)`.');
+if (process.platform === 'linux' && process.config.variables.asan) {
+  // Source of the memory leak - https://github.com/nodejs/node/blob/da0bc6db98cef98686122ea1e2cd2dbd2f52d123/src/node_sea.cc#L94.
+  common.skip('Running the resultant binary fails because of a memory leak ASAN error.');
+}
 
 if (process.platform === 'linux' && process.config.variables.is_debug === 1)
   common.skip('Running the resultant binary fails with `Couldn\'t read target executable"`.');
@@ -39,17 +41,17 @@ if (process.config.variables.want_separate_host_toolset !== 0)
   common.skip('Running the resultant binary fails with `Segmentation fault (core dumped)`.');
 
 if (process.platform === 'linux') {
-  try {
-    const osReleaseText = readFileSync('/etc/os-release', { encoding: 'utf-8' });
-    if (!/^NAME="Ubuntu"/m.test(osReleaseText)) {
-      throw new Error('Not Ubuntu.');
-    }
-  } catch {
-    common.skip('Only supported Linux distribution is Ubuntu.');
+  const osReleaseText = readFileSync('/etc/os-release', { encoding: 'utf-8' });
+  if (/^NAME="Alpine Linux"/m.test(osReleaseText)) {
+    common.skip('Alpine Linux is not supported.');
   }
 
-  if (process.arch !== 'x64') {
-    common.skip(`Unsupported architecture for Linux - ${process.arch}.`);
+  if (process.arch === 's390x') {
+    common.skip('On s390x, postject fails with `memory access out of bounds`.');
+  }
+
+  if (process.arch === 'ppc64') {
+    common.skip('On ppc64, this test times out.');
   }
 }
 

--- a/test/parallel/test-single-executable-application.js
+++ b/test/parallel/test-single-executable-application.js
@@ -42,9 +42,8 @@ if (process.config.variables.want_separate_host_toolset !== 0)
 
 if (process.platform === 'linux') {
   const osReleaseText = readFileSync('/etc/os-release', { encoding: 'utf-8' });
-  if (/^NAME="Alpine Linux"/m.test(osReleaseText)) {
-    common.skip('Alpine Linux is not supported.');
-  }
+  const isAlpine = /^NAME="Alpine Linux"/m.test(osReleaseText);
+  if (isAlpine) common.skip('Alpine Linux is not supported.');
 
   if (process.arch === 's390x') {
     common.skip('On s390x, postject fails with `memory access out of bounds`.');


### PR DESCRIPTION
Now that https://github.com/nodejs/node/pull/46934 has landed, we can extend the list of platforms and architectures where we can run the single-executable test.

(Initially tested this in https://github.com/nodejs/node/pull/46868)

cc @nodejs/single-executable 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
