### PR TITLE
crypto: remove ALPN_ENABLED

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5981,10 +5981,6 @@ See the [list of SSL OP Flags][] for details.
     <td></td>
   </tr>
   <tr>
-    <td><code>ALPN_ENABLED</code></td>
-    <td></td>
-  </tr>
-  <tr>
     <td><code>RSA_PKCS1_PADDING</code></td>
     <td></td>
   </tr>

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1032,9 +1032,6 @@ void DefineCryptoConstants(Local<Object> target) {
     NODE_DEFINE_CONSTANT(target, DH_NOT_SUITABLE_GENERATOR);
 #endif
 
-#define ALPN_ENABLED 1
-    NODE_DEFINE_CONSTANT(target, ALPN_ENABLED);
-
 #ifdef RSA_PKCS1_PADDING
     NODE_DEFINE_CONSTANT(target, RSA_PKCS1_PADDING);
 #endif

--- a/typings/internalBinding/constants.d.ts
+++ b/typings/internalBinding/constants.d.ts
@@ -243,7 +243,6 @@ declare function InternalBinding(binding: 'constants'): {
     DH_CHECK_P_NOT_PRIME: 1;
     DH_UNABLE_TO_CHECK_GENERATOR: 4;
     DH_NOT_SUITABLE_GENERATOR: 8;
-    ALPN_ENABLED: 1;
     RSA_PKCS1_PADDING: 1;
     RSA_SSLV23_PADDING: 2;
     RSA_NO_PADDING: 3;


### PR DESCRIPTION
This constant was likely introduced for feature detection, but it has been pointless for a long time.

1. I am not aware of any possible Node.js build configuration (on any recent/supported release line) that would have `crypto.constants` but not `crypto.constants.ALPN_ENABLED`.
2. There is no evidence of this constant ever being used for feature detection in the ecosystem. In fact, both internal and external type definitions for `crypto.constants` simply assume that the constant exists.
3. There is no good reason for any modern TLS stack to not support ALPN. It looks like ALPN might have been optional in much earlier versions of OpenSSL, but all recent versions of OpenSSL unconditionally support ALPN as far as I can tell.

I would like to propose skipping any deprecation cycle for this change.

Refs: https://github.com/nodejs/node/pull/46956

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
