### PR TITLE
permission: add path separator to loader check

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -423,7 +423,7 @@ function readPackageScope(checkPath) {
     checkPath = StringPrototypeSlice(checkPath, 0, separatorIndex);
     // Stop the search when the process doesn't have permissions
     // to walk upwards
-    if (enabledPermission && !permission.has('fs.read', checkPath)) {
+    if (enabledPermission && !permission.has('fs.read', checkPath + sep)) {
       return false;
     }
     if (StringPrototypeEndsWith(checkPath, sep + 'node_modules'))

--- a/test/fixtures/permission/loader/index.js
+++ b/test/fixtures/permission/loader/index.js
@@ -1,0 +1,3 @@
+const fs = require('node:fs');
+
+fs.readFile('/etc/passwd', () => {});

--- a/test/parallel/test-cli-permission-deny-fs.js
+++ b/test/parallel/test-cli-permission-deny-fs.js
@@ -1,9 +1,12 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+
+const fixtures = require('../common/fixtures');
 const { spawnSync } = require('child_process');
 const assert = require('assert');
 const fs = require('fs');
+const path = require('path');
 
 {
   const { status, stdout } = spawnSync(
@@ -125,4 +128,24 @@ const fs = require('fs');
     stderr);
   assert.strictEqual(status, 1);
   assert.ok(!fs.existsSync('permission-deny-example.md'));
+}
+
+{
+  const { root } = path.parse(process.cwd());
+  const abs = (p) => path.join(root, p);
+  const firstPath = abs(path.sep + process.cwd().split(path.sep, 2)[1]);
+  if (firstPath.startsWith('/etc')) {
+    common.skip('/etc as firstPath');
+  }
+  const file = fixtures.path('permission', 'loader', 'index.js');
+  const { status, stderr } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-permission',
+      `--allow-fs-read=${firstPath}`,
+      file,
+    ]
+  );
+  assert.match(stderr.toString(), /resource: '.*?[\\/](?:etc|passwd)'/);
+  assert.strictEqual(status, 1);
 }


### PR DESCRIPTION
When no package.json is found the loader walks upwards until the root path `/`.  When checking the root, the `checkPath` is empty (`''`) and an attempt to read `/package.json` is made. However, reading from `/` isn't allowed (considering --allow-fs-read=/Users/ was passed).

This commit fixes this behavior.