### PR TITLE
esm: increase test coverage of edge cases

### DIFF
--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -67,6 +67,21 @@ describe('Loader hooks', { concurrency: true }, () => {
       assert.strictEqual(code, 0);
       assert.strictEqual(signal, null);
     });
+
+    it('import.meta.resolve of a never-settling resolve', async () => {
+      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+        '--no-warnings',
+        '--experimental-import-meta-resolve',
+        '--experimental-loader',
+        fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+        fixtures.path('es-module-loaders/never-settling-resolve-step/import.meta.never-resolve.mjs'),
+      ]);
+
+      assert.strictEqual(stderr, '');
+      assert.match(stdout, /^should be output\r?\n$/);
+      assert.strictEqual(code, 13);
+      assert.strictEqual(signal, null);
+    });
   });
 
   describe('should handle never-settling hooks in CJS files', { concurrency: true }, () => {
@@ -163,6 +178,21 @@ describe('Loader hooks', { concurrency: true }, () => {
     assert.match(stderr, /code: 'ERR_ACCESS_DENIED'/);
     assert.strictEqual(stdout, '');
     assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should not leak internals or expose import.meta.resolve', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-import-meta-resolve',
+      '--experimental-loader',
+      fixtures.fileURL('es-module-loaders/loader-edge-cases.mjs'),
+      fixtures.path('empty.js'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
   });
 });

--- a/test/fixtures/es-module-loaders/loader-edge-cases.mjs
+++ b/test/fixtures/es-module-loaders/loader-edge-cases.mjs
@@ -1,0 +1,15 @@
+import { strictEqual } from "node:assert";
+import { isMainThread, workerData, parentPort } from "node:worker_threads";
+
+// TODO(aduh95): switch this to `false` when loader hooks are run on a separate thread.
+strictEqual(isMainThread, true);
+
+// We want to make sure that internals are not leaked on the public module:
+strictEqual(workerData, null);
+strictEqual(parentPort, null);
+
+// TODO(aduh95): switch to `"undefined"` when loader hooks are run on a separate thread.
+// We don't want `import.meta.resolve` being available from loaders
+// as the sync implementation is not compatible with calling async
+// functions on the same thread.
+strictEqual(typeof import.meta.resolve, 'function');

--- a/test/fixtures/es-module-loaders/never-settling-resolve-step/import.meta.never-resolve.mjs
+++ b/test/fixtures/es-module-loaders/never-settling-resolve-step/import.meta.never-resolve.mjs
@@ -1,0 +1,5 @@
+console.log('should be output');
+
+await import.meta.resolve('never-settle-resolve');
+
+console.log('should not be output');


### PR DESCRIPTION
This PR adds some important assertions in preparation for the off-thread PR.

- Assert that we do not leak internals using the publicly available `require('node:worker_thread').workerData`.
- Assert that `import.meta.resolve` is currently available from loader modules (that won't be the case when it's taken off thread).
- Assert that calling `import.meta.resolve` using a specifier that returns a never-settling promise exits the process with code 13. (not sure about this one, I think it's better than leaving the process in a dead lock forever, but also code 13 won't make as much sense if there's no longer a top-level await).

//cc @nodejs/loaders 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
