### PR TITLE
worker: skip main thread when stdio is inherited

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1293,30 +1293,6 @@ active handle in the event system. If the worker is already `unref()`ed calling
 
 ## Notes
 
-### Synchronous blocking of stdio
-
-`Worker`s utilize message passing via {MessagePort} to implement interactions
-with `stdio`. This means that `stdio` output originating from a `Worker` can
-get blocked by synchronous code on the receiving end that is blocking the
-Node.js event loop.
-
-```mjs
-import {
-  Worker,
-  isMainThread,
-} from 'worker_threads';
-
-if (isMainThread) {
-  new Worker(new URL(import.meta.url));
-  for (let n = 0; n < 1e10; n++) {
-    // Looping to simulate work.
-  }
-} else {
-  // This output will be blocked by the for loop in the main thread.
-  console.log('foo');
-}
-```
-
 ```cjs
 'use strict';
 

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -5,6 +5,7 @@
 
 const {
   ArrayPrototypeForEach,
+  ArrayPrototypePop,
   ArrayPrototypePushApply,
   ArrayPrototypeSplice,
   ObjectDefineProperty,
@@ -26,6 +27,7 @@ const {
   threadId,
   getEnvMessagePort,
 } = internalBinding('worker');
+const { write } = require('fs');
 
 const workerIo = require('internal/worker/io');
 const {
@@ -97,6 +99,8 @@ port.on('message', (message) => {
       manifestSrc,
       manifestURL,
       hasStdin,
+      directStdout,
+      directStderr,
     } = message;
 
     if (argv !== undefined) {
@@ -134,6 +138,27 @@ port.on('message', (message) => {
 
     if (!hasStdin)
       process.stdin.push(null);
+
+    if (directStdout) {
+      process.stdout._writev = function _writev(chunks, cb) {
+        const { chunk, encoding } = ArrayPrototypePop(chunks);
+        write(1, chunk, { __proto__: null }, encoding, (err) => {
+          if (err) cb(err);
+          else if (chunks.length === 0) cb();
+          else this._writev(chunks, cb);
+        });
+      };
+    }
+    if (directStderr) {
+      process.stderr._writev = function _writev(chunks, cb) {
+        const { chunk, encoding } = ArrayPrototypePop(chunks);
+        write(2, chunk, { __proto__: null }, encoding, (err) => {
+          if (err) cb(err);
+          else if (chunks.length === 0) cb();
+          else this._writev(chunks, cb);
+        });
+      };
+    }
 
     debug(`[${threadId}] starts worker script ${filename} ` +
           `(eval = ${doEval}) at cwd = ${process.cwd()}`);

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -225,12 +225,10 @@ class Worker extends EventEmitter {
     const stdout = new ReadableWorkerStdio(this[kPort], 'stdout');
     if (!options.stdout) {
       stdout[kIncrementsPortRef] = false;
-      pipeWithoutWarning(stdout, process.stdout);
     }
     const stderr = new ReadableWorkerStdio(this[kPort], 'stderr');
     if (!options.stderr) {
       stderr[kIncrementsPortRef] = false;
-      pipeWithoutWarning(stderr, process.stderr);
     }
 
     this[kParentSideStdio] = { stdin, stdout, stderr };
@@ -263,6 +261,8 @@ class Worker extends EventEmitter {
         require('internal/process/policy').src :
         null,
       hasStdin: !!options.stdin,
+      directStdout: !options.stdout,
+      directStderr: !options.stderr,
     }, transferList);
     // Use this to cache the Worker's loopStart value once available.
     this[kLoopStartTime] = -1;
@@ -439,18 +439,6 @@ class Worker extends EventEmitter {
       };
     });
   }
-}
-
-function pipeWithoutWarning(source, dest) {
-  const sourceMaxListeners = source._maxListeners;
-  const destMaxListeners = dest._maxListeners;
-  source.setMaxListeners(Infinity);
-  dest.setMaxListeners(Infinity);
-
-  source.pipe(dest);
-
-  source._maxListeners = sourceMaxListeners;
-  dest._maxListeners = destMaxListeners;
 }
 
 const resourceLimitsArray = new Float64Array(kTotalResourceLimitCount);

--- a/test/fixtures/worker-stdio.mjs
+++ b/test/fixtures/worker-stdio.mjs
@@ -1,0 +1,13 @@
+import {
+    Worker,
+    isMainThread,
+} from 'worker_threads';
+  
+if (isMainThread) {
+    new Worker(new URL(import.meta.url));
+    while(true); // never-ending loop
+} else {
+    // This output will be blocked by the for loop in the main thread.
+    console.log('foo');
+    console.error('bar');
+}

--- a/test/parallel/test-worker-never-blocked-stdio.mjs
+++ b/test/parallel/test-worker-never-blocked-stdio.mjs
@@ -1,0 +1,20 @@
+import '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import assert from 'node:assert';
+import { execPath } from 'node:process';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+
+const cp = spawn(execPath, [fixtures.path('worker-stdio.mjs')]);
+try {
+  await Promise.all([
+    once(cp.stdout, 'data').then((data) => {
+      assert.match(data.toString(), /^foo\r?\n$/);
+    }),
+    once(cp.stderr, 'data').then((data) => {
+      assert.match(data.toString(), /^bar\r?\n$/);
+    }),
+  ]);
+} finally {
+  cp.kill();
+}


### PR DESCRIPTION
Currently, when the main thread is blocked, the `console.log` calls from the worker are swallowed.
In https://github.com/nodejs/node/issues/25630, @jasnell and @addaleax seems to think the current behavior is correct, but I have to side with @devsnek on this, I think we can do better. Here's my (naive) attempt at this. There are some broken tests with this PR, but I would like to hear more from @nodejs/workers before spending more time on this, in case there are good reasons to disregard this approach.

Fixes: https://github.com/nodejs/node/issues/25630
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
