### PR TITLE
test: close all connections to prevent server hang

### DIFF
--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -53,6 +53,15 @@ function parent() {
     const args = [__filename, 'child', this.address().port];
     const child = spawn(process.execPath, args, { stdio: 'inherit' });
     child.on('close', common.mustCall(function() {
+      if (common.isIBMi) {
+        // On IBM i calling server.close after the child process closes
+        // is not enough to end the server. For some reason the connection still
+        // lingers around with the server even though the process was closed.
+        // Calling closeAllConnections cleans up the lingering connection.
+        // Then calling server.close stops the server from listening
+        // for new connections and ends the server.
+        server.closeAllConnections();
+      }
       server.close();
     }));
 


### PR DESCRIPTION
On IBM i calling server.close after the child process closes is not enough to end the server. For some reason the connection still lingers around with the server even though the process was closed. Calling closeAllConnections cleans up the lingering connection. Then calling server.close stops the server from listening for new connections and ends the server. On other platforms, closing the child client process causes the connection to close properly without having to call closeAllConnections. I ran this test case on Linux and AIX.

This fix should help resolve the timeout in the following test case:

- https://ci.nodejs.org/job/node-test-commit-ibmi/nodes=ibmi73-ppc64/1089/testReport/(root)/test/parallel_test_http_pipeline_flood/

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
