### PR TITLE
meta: ask expected behavior reason in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -33,7 +33,7 @@ body:
       label: How often does it reproduce? Is there a required condition?
   - type: textarea
     attributes:
-      label: What is the expected behavior?
+      label: What is the expected behavior? Why is that the expected behavior?
       description: If possible please provide textual output instead of screenshots.
   - type: textarea
     attributes:


### PR DESCRIPTION
It happens too often that bug reporters only report _what_ they expect to see without motivating _why_. Having to repeatedly ask for that info gets old.