### PR TITLE
src: fix clang 14 linker error

### DIFF
--- a/src/inspector/node_string.cc
+++ b/src/inspector/node_string.cc
@@ -2,6 +2,7 @@
 #include "node/inspector/protocol/Protocol.h"
 #include "node_util.h"
 #include "simdutf.h"
+#include "util-inl.h"
 
 namespace node {
 namespace inspector {


### PR DESCRIPTION
Compiling with clang 14 on Ubuntu was failing with a linker error that
`node::MaybeStackBuffer::AllocateSufficientStorage` was undefined in
`src/inspector/node_string.cc`. I bisected it to the referenced PR.
Add the missing `util-inl.h` include.

Refs: https://github.com/nodejs/node/pull/46817