### PR TITLE
Cherry pick cppgc fixes for #45704

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.10',
+    'v8_embedder_string': '-node.11',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/heap/cppgc/heap-base.cc
+++ b/deps/v8/src/heap/cppgc/heap-base.cc
@@ -94,41 +94,6 @@ class AgeTableResetter final : protected HeapVisitor<AgeTableResetter> {
 };
 #endif  // defined(CPPGC_YOUNG_GENERATION)
 
-class PlatformWithPageAllocator final : public cppgc::Platform {
- public:
-  explicit PlatformWithPageAllocator(std::shared_ptr<cppgc::Platform> delegate)
-      : delegate_(std::move(delegate)),
-        page_allocator_(GetGlobalPageAllocator()) {
-    // This platform wrapper should only be used if the platform doesn't provide
-    // a `PageAllocator`.
-    CHECK_NULL(delegate_->GetPageAllocator());
-  }
-  ~PlatformWithPageAllocator() override = default;
-
-  PageAllocator* GetPageAllocator() final { return &page_allocator_; }
-
-  double MonotonicallyIncreasingTime() final {
-    return delegate_->MonotonicallyIncreasingTime();
-  }
-
-  std::shared_ptr<TaskRunner> GetForegroundTaskRunner() final {
-    return delegate_->GetForegroundTaskRunner();
-  }
-
-  std::unique_ptr<JobHandle> PostJob(TaskPriority priority,
-                                     std::unique_ptr<JobTask> job_task) final {
-    return delegate_->PostJob(std::move(priority), std::move(job_task));
-  }
-
-  TracingController* GetTracingController() final {
-    return delegate_->GetTracingController();
-  }
-
- private:
-  std::shared_ptr<cppgc::Platform> delegate_;
-  cppgc::PageAllocator& page_allocator_;
-};
-
 }  // namespace
 
 HeapBase::HeapBase(
@@ -137,11 +102,7 @@ HeapBase::HeapBase(
     StackSupport stack_support, MarkingType marking_support,
     SweepingType sweeping_support, GarbageCollector& garbage_collector)
     : raw_heap_(this, custom_spaces),
-      platform_(platform->GetPageAllocator()
-                    ? std::move(platform)
-                    : std::static_pointer_cast<cppgc::Platform>(
-                          std::make_shared<PlatformWithPageAllocator>(
-                              std::move(platform)))),
+      platform_(std::move(platform)),
       oom_handler_(std::make_unique<FatalOutOfMemoryHandler>(this)),
 #if defined(LEAK_SANITIZER)
       lsan_page_allocator_(std::make_unique<v8::base::LsanPageAllocator>(

--- a/deps/v8/src/heap/cppgc/heap-base.cc
+++ b/deps/v8/src/heap/cppgc/heap-base.cc
@@ -101,7 +101,7 @@ class PlatformWithPageAllocator final : public cppgc::Platform {
         page_allocator_(GetGlobalPageAllocator()) {
     // This platform wrapper should only be used if the platform doesn't provide
     // a `PageAllocator`.
-    CHECK_NULL(delegate->GetPageAllocator());
+    CHECK_NULL(delegate_->GetPageAllocator());
   }
   ~PlatformWithPageAllocator() override = default;
 


### PR DESCRIPTION
Cherry-pick the cppgc fixes that are prerequisites for #45704.

The two commits landed as follows:

* https://github.com/v8/v8/commit/22ef44b6553d8207aac5766c5fd7624a1e41fbc4
  * [11.1.119](https://github.com/v8/v8/releases/tag/11.1.119)
* https://github.com/v8/v8/commit/eea8a2f22bcf2bcfd12a093a0e1ba762b8d0a5ec
  * [11.2.165](https://github.com/v8/v8/releases/tag/11.2.165)