### PR TITLE
doc: remove remaining SSL_OP_NETSCAPE_*_BUG

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5834,14 +5834,6 @@ See the [list of SSL OP Flags][] for details.
     <td>Allows initial connection to servers that do not support RI.</td>
   </tr>
   <tr>
-    <td><code>SSL_OP_NETSCAPE_CA_DN_BUG</code></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><code>SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG</code></td>
-    <td></td>
-  </tr>
-  <tr>
     <td><code>SSL_OP_NO_COMPRESSION</code></td>
     <td>Instructs OpenSSL to disable support for SSL/TLS compression.</td>
   </tr>


### PR DESCRIPTION
I missed these two in db81af61ce0d55c052723e30ac7f6b7ad60f70c3 because I went by OpenSSL's list of obsolete flags, which turned out to be incomplete. See https://github.com/openssl/openssl/pull/20443.

Refs: https://github.com/nodejs/node/pull/46954
Refs: https://github.com/openssl/openssl/pull/20443

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
