### PR TITLE
permission: fix some vulnerabilities in fs

### DIFF
--- a/test/parallel/test-permission-deny-fs-read.js
+++ b/test/parallel/test-permission-deny-fs-read.js
@@ -249,6 +249,21 @@ const gid = os.userInfo().gid;
   fs.open(regularFile, 'r', (err) => {
     assert.ifError(err);
   });
+
+  // Extra flags should not enable trivially bypassing all restrictions.
+  // See https://github.com/nodejs/node/issues/47090.
+  assert.throws(() => {
+    fs.openSync(blockedFile, fs.constants.O_RDONLY | fs.constants.O_NOCTTY);
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+  });
+  assert.throws(() => {
+    fs.open(blockedFile, fs.constants.O_RDWR | 0x10000000, common.mustNotCall());
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+  });
 }
 
 // fs.opendir


### PR DESCRIPTION
Without this patch, any restrictions imposed by the permission model can be easily bypassed, granting **full read and write access to any file**. On Windows, this could even be used to delete files that are supposed to be write-protected.

This likely also fixes a separate bug in `fsPromises.open()`, which currently incorrectly requires read permissions even for write-only access. (Unless that was somehow intentional?)

I'm not very confident in my understanding of the permission model. Please review carefully.

Fixes: https://github.com/nodejs/node/issues/47090

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
