### PR TITLE
test: fix test-permission-deny-fs-wildcard (win32)

### DIFF
--- a/test/parallel/test-permission-deny-fs-wildcard.js
+++ b/test/parallel/test-permission-deny-fs-wildcard.js
@@ -6,25 +6,28 @@ common.skipIfWorker();
 
 const assert = require('assert');
 const fs = require('fs');
+const path = require('path');
 
 if (common.isWindows) {
+  const { root } = path.parse(process.cwd());
+  const abs = (p) => path.join(root, p);
   const denyList = [
-    'C:\\tmp\\*',
-    'C:\\example\\foo*',
-    'C:\\example\\bar*',
-    'C:\\folder\\*',
-    'C:\\show',
-    'C:\\slower',
-    'C:\\slown',
-    'C:\\home\\foo\\*',
-  ];
+    'tmp\\*',
+    'example\\foo*',
+    'example\\bar*',
+    'folder\\*',
+    'show',
+    'slower',
+    'slown',
+    'home\\foo\\*',
+  ].map(abs);
   assert.ok(process.permission.deny('fs.read', denyList));
-  assert.ok(process.permission.has('fs.read', 'C:\\slow'));
-  assert.ok(process.permission.has('fs.read', 'C:\\slows'));
-  assert.ok(!process.permission.has('fs.read', 'C:\\slown'));
-  assert.ok(!process.permission.has('fs.read', 'C:\\home\\foo'));
-  assert.ok(!process.permission.has('fs.read', 'C:\\home\\foo\\'));
-  assert.ok(process.permission.has('fs.read', 'C:\\home\\fo'));
+  assert.ok(process.permission.has('fs.read', abs('slow')));
+  assert.ok(process.permission.has('fs.read', abs('slows')));
+  assert.ok(!process.permission.has('fs.read', abs('slown')));
+  assert.ok(!process.permission.has('fs.read', abs('home\\foo')));
+  assert.ok(!process.permission.has('fs.read', abs('home\\foo\\')));
+  assert.ok(process.permission.has('fs.read', abs('home\\fo')));
 } else {
   const denyList = [
     '/tmp/*',


### PR DESCRIPTION
The test fails on Windows when the working directory is not on a 'C:' drive. For example, it always fails during the coverage-windows GitHub action, which runs tests on drive 'D:'.

Fixes: https://github.com/nodejs/node/issues/47093

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
