### PR TITLE
doc: rename the startup performance initiative to startup snapshot

### DIFF
--- a/doc/contributing/strategic-initiatives.md
+++ b/doc/contributing/strategic-initiatives.md
@@ -11,7 +11,7 @@ agenda to ensure they are active and have the support they need.
 | Core Promise APIs      | [Antoine du Hamel][aduh95]  | <https://github.com/nodejs/TSC/issues/1094>   |
 | QUIC / HTTP3           | [James M Snell][jasnell]    | <https://github.com/nodejs/quic>              |
 | Shadow Realm           | [Chengzhong Wu][legendecas] | <https://github.com/nodejs/node/issues/42528> |
-| Startup performance    | [Joyee Cheung][joyeecheung] | <https://github.com/nodejs/node/issues/35711> |
+| Startup Snapshot       | [Joyee Cheung][joyeecheung] | <https://github.com/nodejs/node/issues/35711> |
 | V8 Currency            | [Michaël Zasso][targos]     |                                               |
 | Next-10                | [Michael Dawson][mhdawson]  | <https://github.com/nodejs/next-10>           |
 | Single executable apps | [Darshan Sen][RaisinTen]    | <https://github.com/nodejs/node/issues/43432> |


### PR DESCRIPTION
The initiative has been more focused on startup snapshot integration which is more of a feature on its own, so rename it to "startup snapshot".

Background: we are also considering adding a more generic performance initiative in https://github.com/nodejs/TSC/issues/1343.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
