### PR TITLE
stream: don't wait for next item in take when finished

### DIFF
--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -409,7 +409,10 @@ function take(number, options = undefined) {
       }
       if (number-- > 0) {
         yield val;
-      } else {
+      }
+
+      // Don't get another item from iterator in case we reached the end
+      if (number <= 0) {
         return;
       }
     }


### PR DESCRIPTION
currently, in the `take` operator, we wait for the next item in the stream to check whether to finish or not

now we don't need to wait anymore