### PR TITLE
test: mark test-http-max-sockets as flaky on win32

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -12,6 +12,8 @@ test-watch-mode: PASS, FLAKY
 test-watch-mode-inspect: PASS, FLAKY
 
 [$system==win32]
+# https://github.com/nodejs/node/issues/47116
+test-http-max-sockets: PASS, FLAKY
 
 [$system==linux]
 


### PR DESCRIPTION
Current Windows CI build trend:

![build trend of node-test-binary-windows-js-suites showing almost only failures recently](https://user-images.githubusercontent.com/3109072/225897270-a6e1f6d9-29f1-4c05-ba94-af4e1bd5882e.png)

I am not sure if marking it as flaky is going to be enough. Maybe we have to skip it entirely, but that's something that we should try to avoid.

Refs: https://github.com/nodejs/node/issues/47116

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
