### PR TITLE
test: fix 'checks' validation test for checkPrime

### DIFF
--- a/test/parallel/test-crypto-prime.js
+++ b/test/parallel/test-crypto-prime.js
@@ -229,14 +229,16 @@ generatePrime(
   });
 });
 
-['hello', {}, []].forEach((i) => {
-  assert.throws(() => checkPrime(2, { checks: i }), {
-    code: 'ERR_INVALID_ARG_TYPE'
-  }, common.mustNotCall());
-  assert.throws(() => checkPrimeSync(2, { checks: i }), {
-    code: 'ERR_INVALID_ARG_TYPE'
+for (const checks of ['hello', {}, []]) {
+  assert.throws(() => checkPrime(2n, { checks }, common.mustNotCall()), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: /checks/
   });
-});
+  assert.throws(() => checkPrimeSync(2n, { checks }), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: /checks/
+  });
+}
 
 assert(!checkPrimeSync(Buffer.from([0x1])));
 assert(checkPrimeSync(Buffer.from([0x2])));


### PR DESCRIPTION
This test had two problems:

* The first argument was a number in both cases, which is what caused the (expected) `ERR_INVALID_ARG_TYPE` error -- the validity of the `checks` option was not actually verified at all. Thus, the first argument should be valid for this particular test.
* The function returned by `common.mustNotCall()` was passed to `assert.throws()` as a third argument instead of being passed to `checkPrime()` as a third argument. (Isn't JavaScript great?) This again led to the (expected) `ERR_INVALID_ARG_TYPE` error, but again, the validity of the `checks` option was not verified.

Fix both issues by ensuring that all arguments except the `checks` option are valid.

Refs: https://github.com/nodejs/node/pull/36997

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
