### PR TITLE
src: stop copying code cache

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -505,8 +505,8 @@ struct IsolateSettings {
 // feature during the build step by passing the --disable-shared-readonly-heap
 // flag to the configure script.
 //
-// The snapshot *must* be kept alive during the execution of the environment /
-// isolate that it is derived from.
+// The snapshot *must* be kept alive during the execution of the Isolate
+// that was created using it.
 //
 // Snapshots are an *experimental* feature. In particular, the embedder API
 // exposed through this class is subject to change or removal between Node.js

--- a/src/node.h
+++ b/src/node.h
@@ -505,6 +505,9 @@ struct IsolateSettings {
 // feature during the build step by passing the --disable-shared-readonly-heap
 // flag to the configure script.
 //
+// The snapshot *must* be kept alive during the execution of the environment /
+// isolate that it is derived from.
+//
 // Snapshots are an *experimental* feature. In particular, the embedder API
 // exposed through this class is subject to change or removal between Node.js
 // versions, including possible API and ABI breakage.

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -502,15 +502,16 @@ void BuiltinLoader::CopyCodeCache(std::vector<CodeCacheInfo>* out) const {
 void BuiltinLoader::RefreshCodeCache(const std::vector<CodeCacheInfo>& in) {
   RwLock::ScopedLock lock(code_cache_->mutex);
   code_cache_->map.reserve(in.size());
-  CHECK_EQ(code_cache_->map.size(), 0);
+  DCHECK(code_cache_->map.empty());
   for (auto const& item : in) {
-    auto new_cache = std::make_unique<v8::ScriptCompiler::CachedData>(
-        item.data.data(),
-        item.data.size(),
-        v8::ScriptCompiler::CachedData::BufferNotOwned);
-    code_cache_->map[item.id] = std::move(new_cache);
+    auto result = code_cache_->map.emplace(
+        item.id,
+        std::make_unique<v8::ScriptCompiler::CachedData>(
+            item.data.data(),
+            item.data.size(),
+            v8::ScriptCompiler::CachedData::BufferNotOwned));
+    DCHECK(result.second);
   }
-  CHECK_EQ(code_cache_->map.size(), in.size());
   code_cache_->has_code_cache = true;
 }
 

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -501,14 +501,16 @@ void BuiltinLoader::CopyCodeCache(std::vector<CodeCacheInfo>* out) const {
 
 void BuiltinLoader::RefreshCodeCache(const std::vector<CodeCacheInfo>& in) {
   RwLock::ScopedLock lock(code_cache_->mutex);
+  code_cache_->map.reserve(in.size());
+  CHECK_EQ(code_cache_->map.size(), 0);
   for (auto const& item : in) {
-    size_t length = item.data.size();
-    uint8_t* buffer = new uint8_t[length];
-    memcpy(buffer, item.data.data(), length);
     auto new_cache = std::make_unique<v8::ScriptCompiler::CachedData>(
-        buffer, length, v8::ScriptCompiler::CachedData::BufferOwned);
+        item.data.data(),
+        item.data.size(),
+        v8::ScriptCompiler::CachedData::BufferNotOwned);
     code_cache_->map[item.id] = std::move(new_cache);
   }
+  CHECK_EQ(code_cache_->map.size(), in.size());
   code_cache_->has_code_cache = true;
 }
 

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -510,6 +510,7 @@ void BuiltinLoader::RefreshCodeCache(const std::vector<CodeCacheInfo>& in) {
             item.data.data(),
             item.data.size(),
             v8::ScriptCompiler::CachedData::BufferNotOwned));
+    USE(result.second);
     DCHECK(result.second);
   }
   code_cache_->has_code_cache = true;


### PR DESCRIPTION
The code cache is quite large - around 1.3 MiB. Change the code to use non-owning buffers to avoid copying it. For starting up an otherwise empty main isolate, this saves around 1.3 MiB of unique set size memory (9.9 MiB -> 8.6 MiB) and 1.1ms elapsed time (22.9 ms -> 21.8 ms).

Copying the code cache is unnecessary since:

1. for the builtin snapshot, the code cache data has static lifetime.
2. for non-builtin snapshots, we create copies of the code cache data in `SnapshotDeserializer::ReadVector`. These copies are owned by the `Environment` (through `IsolateData` -> `SnapshotData`), so they won't be deallocated.
3. a worker thread can copy a parent's isolate's code cache, but in that case we still know that the parent isolate will outlive the worker isolate.

(Admittedly point (2) feels a little fragile from a lifetime perspective, and I would be happy to restrict this optimization to the builtin snapshot.)

```console
$ perf stat -r 100 -e ... ./node -e 0

 Performance counter stats for './node -e 0' (100 runs):

             21.78 msec task-clock
              2760      page-faults
         113161604      instructions
          18437648      branches
            423230      branch-misses
            853093      cache-references
             41474      cache-misses

         0.0225473 +- 0.0000504 seconds time elapsed  ( +-  0.22% )

$ perf stat -r 100 -e ... ./node-main -e 0

 Performance counter stats for './node-main -e 0' (100 runs):

             22.91 msec task-clock
              3102      page-faults
         114890673      instructions
          18751329      branches
            428909      branch-misses
            895721      cache-references
             45202      cache-misses

         0.0233760 +- 0.0000741 seconds time elapsed  ( +-  0.32% )
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
