### PR TITLE
src: use SIMD for snapshot checksum

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -4,6 +4,8 @@
 {
   'variables': {
     'V8_ROOT': '../../deps/v8',
+    'V8_ZLIB_ROOT': '<(V8_ROOT)/third_party/zlib',
+    'arm_fpu%': '',
     'v8_code': 1,
     'v8_random_seed%': 314159265,
     'v8_vector_stores%': 0,
@@ -1885,6 +1887,54 @@
     },  # postmortem-metadata
 
     {
+      'target_name': 'v8_zlib_adler32_simd',
+      'type': 'static_library',
+      'conditions': [
+        ['target_arch in "ia32 x64" and OS!="ios"', {
+          'defines': [ 'ADLER32_SIMD_SSSE3' ],
+          'conditions': [
+            ['OS=="win"', {
+              'defines': [ 'X86_WINDOWS' ],
+            },{
+              'defines': [ 'X86_NOT_WINDOWS' ],
+            }],
+            ['OS!="win" or llvm_version!="0.0"', {
+              'cflags': [ '-mssse3' ],
+              'xcode_settings': {
+                'OTHER_CFLAGS': [ '-mssse3' ],
+              },
+            }],
+          ],
+        }],
+        ['arm_fpu=="neon"', {
+          'defines': [ 'ADLER32_SIMD_NEON' ],
+        }],
+      ],
+      'include_dirs': [ '<(V8_ZLIB_ROOT)' ],
+      'direct_dependent_settings': {
+        'conditions': [
+          ['target_arch in "ia32 x64" and OS!="ios"', {
+            'defines': [ 'ADLER32_SIMD_SSSE3' ],
+            'conditions': [
+              ['OS=="win"', {
+                'defines': [ 'X86_WINDOWS' ],
+              },{
+                'defines': [ 'X86_NOT_WINDOWS' ],
+              }],
+            ],
+          }],
+          ['arm_fpu=="neon"', {
+            'defines': [ 'ADLER32_SIMD_NEON' ],
+          }],
+        ],
+        'include_dirs': [ '<(V8_ZLIB_ROOT)' ],
+      },
+      'sources': [
+        '<!@pymod_do_main(GN-scraper "<(V8_ZLIB_ROOT)/BUILD.gn" "\\"zlib_adler32_simd\\".*?sources = ")',
+      ],
+    }, # v8_zlib_adler32_simd
+
+    {
       'target_name': 'v8_zlib',
       'type': 'static_library',
       'toolsets': ['host', 'target'],
@@ -1898,52 +1948,61 @@
             }]
           ]
         }],
+        ['target_arch in "ia32 x64" and OS!="ios"', {
+          'dependencies': [
+            'v8_zlib_adler32_simd',
+          ],
+        }],
+        ['arm_fpu=="neon"', {
+          'dependencies': [
+            'v8_zlib_adler32_simd',
+          ],
+        }],
       ],
       'direct_dependent_settings': {
         'include_dirs': [
-          '<(V8_ROOT)/third_party/zlib',
-          '<(V8_ROOT)/third_party/zlib/google',
+          '<(V8_ZLIB_ROOT)',
+          '<(V8_ZLIB_ROOT)/google',
         ],
       },
       'defines': [ 'ZLIB_IMPLEMENTATION' ],
       'include_dirs': [
-        '<(V8_ROOT)/third_party/zlib',
-        '<(V8_ROOT)/third_party/zlib/google',
+        '<(V8_ZLIB_ROOT)',
+        '<(V8_ZLIB_ROOT)/google',
       ],
       'sources': [
-        '<(V8_ROOT)/third_party/zlib/adler32.c',
-        '<(V8_ROOT)/third_party/zlib/chromeconf.h',
-        '<(V8_ROOT)/third_party/zlib/compress.c',
-        '<(V8_ROOT)/third_party/zlib/contrib/optimizations/insert_string.h',
-        '<(V8_ROOT)/third_party/zlib/contrib/optimizations/insert_string.h',
-        '<(V8_ROOT)/third_party/zlib/cpu_features.c',
-        '<(V8_ROOT)/third_party/zlib/cpu_features.h',
-        '<(V8_ROOT)/third_party/zlib/crc32.c',
-        '<(V8_ROOT)/third_party/zlib/crc32.h',
-        '<(V8_ROOT)/third_party/zlib/deflate.c',
-        '<(V8_ROOT)/third_party/zlib/deflate.h',
-        '<(V8_ROOT)/third_party/zlib/gzclose.c',
-        '<(V8_ROOT)/third_party/zlib/gzguts.h',
-        '<(V8_ROOT)/third_party/zlib/gzlib.c',
-        '<(V8_ROOT)/third_party/zlib/gzread.c',
-        '<(V8_ROOT)/third_party/zlib/gzwrite.c',
-        '<(V8_ROOT)/third_party/zlib/infback.c',
-        '<(V8_ROOT)/third_party/zlib/inffast.c',
-        '<(V8_ROOT)/third_party/zlib/inffast.h',
-        '<(V8_ROOT)/third_party/zlib/inffixed.h',
-        '<(V8_ROOT)/third_party/zlib/inflate.c',
-        '<(V8_ROOT)/third_party/zlib/inflate.h',
-        '<(V8_ROOT)/third_party/zlib/inftrees.c',
-        '<(V8_ROOT)/third_party/zlib/inftrees.h',
-        '<(V8_ROOT)/third_party/zlib/trees.c',
-        '<(V8_ROOT)/third_party/zlib/trees.h',
-        '<(V8_ROOT)/third_party/zlib/uncompr.c',
-        '<(V8_ROOT)/third_party/zlib/zconf.h',
-        '<(V8_ROOT)/third_party/zlib/zlib.h',
-        '<(V8_ROOT)/third_party/zlib/zutil.c',
-        '<(V8_ROOT)/third_party/zlib/zutil.h',
-        '<(V8_ROOT)/third_party/zlib/google/compression_utils_portable.cc',
-        '<(V8_ROOT)/third_party/zlib/google/compression_utils_portable.h',
+        '<(V8_ZLIB_ROOT)/chromeconf.h',
+        '<(V8_ZLIB_ROOT)/adler32.c',
+        '<(V8_ZLIB_ROOT)/compress.c',
+        '<(V8_ZLIB_ROOT)/contrib/optimizations/insert_string.h',
+        '<(V8_ZLIB_ROOT)/cpu_features.c',
+        '<(V8_ZLIB_ROOT)/cpu_features.h',
+        '<(V8_ZLIB_ROOT)/crc32.c',
+        '<(V8_ZLIB_ROOT)/crc32.h',
+        '<(V8_ZLIB_ROOT)/deflate.c',
+        '<(V8_ZLIB_ROOT)/deflate.h',
+        '<(V8_ZLIB_ROOT)/gzclose.c',
+        '<(V8_ZLIB_ROOT)/gzguts.h',
+        '<(V8_ZLIB_ROOT)/gzlib.c',
+        '<(V8_ZLIB_ROOT)/gzread.c',
+        '<(V8_ZLIB_ROOT)/gzwrite.c',
+        '<(V8_ZLIB_ROOT)/infback.c',
+        '<(V8_ZLIB_ROOT)/inffast.c',
+        '<(V8_ZLIB_ROOT)/inffast.h',
+        '<(V8_ZLIB_ROOT)/inffixed.h',
+        '<(V8_ZLIB_ROOT)/inflate.c',
+        '<(V8_ZLIB_ROOT)/inflate.h',
+        '<(V8_ZLIB_ROOT)/inftrees.c',
+        '<(V8_ZLIB_ROOT)/inftrees.h',
+        '<(V8_ZLIB_ROOT)/trees.c',
+        '<(V8_ZLIB_ROOT)/trees.h',
+        '<(V8_ZLIB_ROOT)/uncompr.c',
+        '<(V8_ZLIB_ROOT)/zconf.h',
+        '<(V8_ZLIB_ROOT)/zlib.h',
+        '<(V8_ZLIB_ROOT)/zutil.c',
+        '<(V8_ZLIB_ROOT)/zutil.h',
+        '<(V8_ZLIB_ROOT)/google/compression_utils_portable.cc',
+        '<(V8_ZLIB_ROOT)/google/compression_utils_portable.h',
       ],
     },  # v8_zlib
   ],


### PR DESCRIPTION
Snapshot checksum verification uses `v8::Internal::Checksum`, which uses zlib's adler32 checksum. However it was using the slow version of adler32 for machines with no SIMD. Let's change it to use the SIMD version when it is available. Fortunately the necessary incantations were already included in our _other_ copy of Chromium's zlib in `deps/zlib/zlib.gyp`, so this is mostly just copying from there.

On a very recent Intel machine, this speeds up the snapshot checksumming from 870us to 300us (a 570us startup saving), according to:

```bash
for i in {1..100}; do
  ./node --profile-deserialization -e 0
done \
  |& grep 'Verifying snapshot checksum' \
  | awk '{s+=$5} END{print s/NR}'
```

P.S.: maybe we should just disable this entirely via `--no-verify-snapshot-checksum`? It doesn't feel like a super necessary protection.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
