### PR TITLE
readline: add paste bracket mode - fixes #45213

### DIFF
--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -148,8 +148,10 @@ function* emitKeys(stream) {
          *
          *  - `;5` part is optional, e.g. it could be `\x1b[24~`
          *  - first part can contain one or two digits
+         *  - there is also special case when there can be 3 digits
+         *    but without modifier. They are the case of paste bracket mode
          *
-         * So the generic regexp is like /^\d\d?(;\d)?[~^$]$/
+         * So the generic regexp is like /^(?:\d\d?(;\d)?[~^$]|\d{3}~)$/
          *
          *
          * 2. `\x1b[1;5H` should be parsed as { code: '[H', modifier: 5 }
@@ -170,6 +172,10 @@ function* emitKeys(stream) {
 
           if (ch >= '0' && ch <= '9') {
             s += (ch = yield);
+
+            if (ch >= '0' && ch <= '9') {
+              s += (ch = yield);
+            }
           }
         }
 
@@ -189,9 +195,13 @@ function* emitKeys(stream) {
         const cmd = StringPrototypeSlice(s, cmdStart);
         let match;
 
-        if ((match = RegExpPrototypeExec(/^(\d\d?)(;(\d))?([~^$])$/, cmd))) {
-          code += match[1] + match[4];
-          modifier = (match[3] || 1) - 1;
+        if ((match = RegExpPrototypeExec(/^(?:(\d\d?)(?:;(\d))?([~^$])|(\d{3}~))$/, cmd))) {
+          if (match[4]) {
+            code += match[4];
+          } else {
+            code += match[1] + match[3];
+            modifier = (match[2] || 1) - 1;
+          }
         } else if (
           (match = RegExpPrototypeExec(/^((\d;)?(\d))?([A-Za-z])$/, cmd))
         ) {
@@ -227,6 +237,10 @@ function* emitKeys(stream) {
         case '[12~': key.name = 'f2'; break;
         case '[13~': key.name = 'f3'; break;
         case '[14~': key.name = 'f4'; break;
+
+        /* paste bracket mode */
+        case '[200~': key.name = 'paste-start'; break;
+        case '[201~': key.name = 'paste-end'; break;
 
         /* from Cygwin and used in libuv */
         case '[[A': key.name = 'f1'; break;


### PR DESCRIPTION
The paste bracket mode allows REPL to have auto-indentation that is handled differently when the user copy-pastes the code from the clipboard and the code already has an indentation.

There are no unit tests because there is no way to test copy-pate. You will need to have the equivalent of Cypress or Playwright for Terminal to test (but I'm also not sure if you can easily test copy-paste in those front-end frameworks).

Fixes: https://github.com/nodejs/node/issues/45213

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
