### PR TITLE
buffer: graduate File from experimental and expose as global

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -5056,7 +5056,7 @@ added:
   - v18.13.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/47153
     description: No longer experimental.
 -->
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -5054,9 +5054,11 @@ See [`Buffer.from(string[, encoding])`][`Buffer.from(string)`].
 added:
   - v19.2.0
   - v18.13.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: No longer experimental.
 -->
-
-> Stability: 1 - Experimental
 
 * Extends: {Blob}
 

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -477,9 +477,7 @@ A browser-compatible implementation of the [`fetch()`][] function.
 ## Class: `File`
 
 <!-- YAML
-added:
-  - v19.2.0
-  - v18.13.0
+added: REPLACEME
 -->
 
 <!-- type=global -->

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -474,6 +474,18 @@ changes:
 
 A browser-compatible implementation of the [`fetch()`][] function.
 
+## Class: `File`
+
+<!-- YAML
+added:
+  - v19.2.0
+  - v18.13.0
+-->
+
+<!-- type=global -->
+
+See {File}.
+
 ## Class `FormData`
 
 <!-- YAML

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -59,6 +59,8 @@ rules:
       message: Use `const { Event } = require('internal/event_target');` instead of the global.
     - name: EventTarget
       message: Use `const { EventTarget } = require('internal/event_target');` instead of the global.
+    - name: File
+      message: Use `const { File } = require('buffer');` instead of the global.
     - name: FormData
       message: Use `const { FormData } = require('internal/deps/undici/undici');` instead of the global.
     - name: Headers

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -34,6 +34,8 @@ exposeLazyInterfaces(globalThis, 'internal/worker/io', [
 defineLazyProperties(globalThis, 'buffer', ['atob', 'btoa']);
 // https://www.w3.org/TR/FileAPI/#dfn-Blob
 exposeLazyInterfaces(globalThis, 'internal/blob', ['Blob']);
+// https://www.w3.org/TR/FileAPI/#dfn-file
+exposeLazyInterfaces(globalThis, 'internal/file', ['File']);
 // https://www.w3.org/TR/hr-time-2/#the-performance-attribute
 exposeLazyInterfaces(globalThis, 'perf_hooks', [
   'Performance', 'PerformanceEntry', 'PerformanceMark', 'PerformanceMeasure',

--- a/lib/internal/file.js
+++ b/lib/internal/file.js
@@ -13,7 +13,6 @@ const {
 
 const {
   customInspectSymbol: kInspect,
-  emitExperimentalWarning,
   kEnumerableProperty,
   kEmptyObject,
   toUSVString,
@@ -38,8 +37,6 @@ class File extends Blob {
   #lastModified;
 
   constructor(fileBits, fileName, options = kEmptyObject) {
-    emitExperimentalWarning('buffer.File');
-
     if (arguments.length < 2) {
       throw new ERR_MISSING_ARGS('fileBits', 'fileName');
     }


### PR DESCRIPTION
Undici has been using the native File class by default for over 3 months now, and we haven't had a single issue reported about it or using it with fetch/FormData. It's a very small wrapper around Blob too, I don't personally see much reason in keeping a class with 2 additional properties experimental.

I based this commit heavily on jasnell's which made Blob global, lmk if I'm missing something
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
