### PR TITLE
buffer: use private properties for brand checks in File

### DIFF
--- a/lib/internal/file.js
+++ b/lib/internal/file.js
@@ -21,7 +21,6 @@ const {
 
 const {
   codes: {
-    ERR_INVALID_THIS,
     ERR_MISSING_ARGS,
   },
 } = require('internal/errors');
@@ -64,18 +63,10 @@ class File extends Blob {
   }
 
   get name() {
-    if (!this || !(#name in this)) {
-      throw new ERR_INVALID_THIS('File');
-    }
-
     return this.#name;
   }
 
   get lastModified() {
-    if (!this || !(#name in this)) {
-      throw new ERR_INVALID_THIS('File');
-    }
-
     return this.#lastModified;
   }
 

--- a/test/parallel/test-file.js
+++ b/test/parallel/test-file.js
@@ -146,10 +146,15 @@ const { inspect } = require('util');
 
 {
   const getter = Object.getOwnPropertyDescriptor(File.prototype, 'name').get;
-  assert.throws(
-    () => getter.call(undefined), // eslint-disable-line no-useless-call
-    {
-      code: 'ERR_INVALID_THIS',
-    }
-  );
+
+  [
+    undefined,
+    null,
+    true,
+  ].forEach((invalidThis) => {
+    assert.throws(
+      () => getter.call(invalidThis),
+      TypeError
+    );
+  });
 }


### PR DESCRIPTION
The current checks wouldn't work for certain values, and other places in the code have moved to this behavior as well.

```mjs
import { File } from 'node:buffer'

const pd = Object.getOwnPropertyDescriptor(File.prototype, 'name')

pd.get.call(true) // Uncaught TypeError: Cannot use 'in' operator to search for '#name' in true

pd.get.call(null) // Uncaught TypeError [ERR_INVALID_THIS]: Value of "this" must be of type File
```

Refs: https://github.com/nodejs/node/pull/46904/

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
