### PR TITLE
crypto: use openssl's own memory BIOs in crypto_context.cc

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -1052,6 +1052,7 @@
           'sources': [
             'test/cctest/test_crypto_clienthello.cc',
             'test/cctest/test_node_crypto.cc',
+            'test/cctest/test_node_crypto_env.cc',
             'test/cctest/test_quic_cid.cc',
             'test/cctest/test_quic_tokens.cc',
           ]

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -62,18 +62,16 @@ inline X509_STORE* GetOrCreateRootCertStore() {
 // Takes a string or buffer and loads it into a BIO.
 // Caller responsible for BIO_free_all-ing the returned object.
 BIOPointer LoadBIO(Environment* env, Local<Value> v) {
-  HandleScope scope(env->isolate());
-
-  if (v->IsString()) {
-    Utf8Value s(env->isolate(), v);
-    return NodeBIO::NewFixed(*s, s.length());
+  if (v->IsString() || v->IsArrayBufferView()) {
+    BIOPointer bio(BIO_new(BIO_s_secmem()));
+    if (!bio) return nullptr;
+    ByteSource bsrc = ByteSource::FromStringOrBuffer(env, v);
+    if (bsrc.size() > INT_MAX) return nullptr;
+    int written = BIO_write(bio.get(), bsrc.data<char>(), bsrc.size());
+    if (written < 0) return nullptr;
+    if (static_cast<size_t>(written) != bsrc.size()) return nullptr;
+    return bio;
   }
-
-  if (v->IsArrayBufferView()) {
-    ArrayBufferViewContents<char> buf(v.As<ArrayBufferView>());
-    return NodeBIO::NewFixed(buf.data(), buf.length());
-  }
-
   return nullptr;
 }
 

--- a/test/cctest/test_node_crypto_env.cc
+++ b/test/cctest/test_node_crypto_env.cc
@@ -1,0 +1,31 @@
+#include "crypto/crypto_bio.h"
+#include "gtest/gtest.h"
+#include "node_options.h"
+#include "node_test_fixture.h"
+#include "openssl/err.h"
+
+using v8::Local;
+using v8::String;
+
+/*
+ * This test verifies that an object created by LoadBIO supports BIO_tell
+ * and BIO_seek, otherwise PEM_read_bio_PrivateKey fails on some keys
+ * (if OpenSSL needs to rewind pointer between pem_read_bio_key()
+ * and pem_read_bio_key_legacy() inside PEM_read_bio_PrivateKey).
+ */
+class NodeCryptoEnv : public EnvironmentTestFixture {};
+
+TEST_F(NodeCryptoEnv, LoadBIO) {
+  v8::HandleScope handle_scope(isolate_);
+  Argv argv;
+  Env env{handle_scope, argv};
+  //  just put a random string into BIO
+  Local<String> key = String::NewFromUtf8(isolate_, "abcdef").ToLocalChecked();
+  node::crypto::BIOPointer bio(node::crypto::LoadBIO(*env, key));
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  BIO_seek(bio.get(), 2);
+  ASSERT_EQ(BIO_tell(bio.get()), 2);
+#endif
+  ASSERT_EQ(ERR_peek_error(), 0UL) << "There should not have left "
+                                      "any errors on the OpenSSL error stack\n";
+}


### PR DESCRIPTION
NodeBIO's memory buffer structure does not support BIO_C_FILE_SEEK and B IO_C_FILE_TELL. This prevents OpenSSL PEM_read_bio_PrivateKey from readi ng some private keys. So I switched to OpenSSL's own protected memory bu ffers.

Fixes: https://github.com/nodejs/node/issues/47008

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
