### PR TITLE
doc: update `stream.reduce` concurrency note

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2501,21 +2501,44 @@ This method calls `fn` on each chunk of the stream in order, passing it the
 result from the calculation on the previous element. It returns a promise for
 the final value of the reduction.
 
-The reducer function iterates the stream element-by-element which means that
-there is no `concurrency` parameter or parallelism. To perform a `reduce`
-concurrently, it can be chained to the [`readable.map`][] method.
-
 If no `initial` value is supplied the first chunk of the stream is used as the
 initial value. If the stream is empty, the promise is rejected with a
 `TypeError` with the `ERR_INVALID_ARGS` code property.
 
 ```mjs
 import { Readable } from 'node:stream';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 
-const ten = await Readable.from([1, 2, 3, 4]).reduce((previous, data) => {
-  return previous + data;
-});
-console.log(ten); // 10
+const directoryPath = './src';
+const filesInDir = await readdir(directoryPath);
+
+const folderSize = await Readable.from(filesInDir)
+  .reduce(async (totalSize, file) => {
+    const { size } = await stat(join(directoryPath, file));
+    return totalSize + size;
+  }, 0);
+
+console.log(folderSize);
+```
+
+The reducer function iterates the stream element-by-element which means that
+there is no `concurrency` parameter or parallelism. To perform a `reduce`
+concurrently, you can extract the async function to [`readable.map`][] method.
+
+```mjs
+import { Readable } from 'node:stream';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const directoryPath = './src';
+const filesInDir = await readdir(directoryPath);
+
+const folderSize = await Readable.from(filesInDir)
+  .map((file) => stat(join(directoryPath, file)), { concurrency: 2 })
+  .reduce((totalSize, { size }) => totalSize + size, 0);
+
+console.log(folderSize);
 ```
 
 ### Duplex and transform streams


### PR DESCRIPTION
At first, when I read that note I thought I should do this:
```mjs
import { Readable } from 'node:stream';

const totalViews = await Readable.from(videosUrl)
  .map((url) => url, { concurrency: 2 })
  .reduce(async (total, url) => {
    const views = await getViewsAsync(url)
    total + views
  }, 0);

console.log(totalViews);
```

This did not work and does not make any sense as the map items are emitted in the order that got from the readable stream.

So I thought of changing to note to recommend implementing reduce using `.forEach` with concurrency but then I understand what @benjamingr meant when he wrote that note - because the only way you will need concurrency is if you do some async operation (because sync block the loop - bla bla) and that operation can be parallelized so I updated the note with an example

@benjamingr, hope this is what you meant 😅  