### PR TITLE
src: replace impossible THROW with CHECK

### DIFF
--- a/src/crypto/crypto_dsa.cc
+++ b/src/crypto/crypto_dsa.cc
@@ -83,16 +83,12 @@ Maybe<bool> DsaKeyGenTraits::AdditionalConfig(
     const FunctionCallbackInfo<Value>& args,
     unsigned int* offset,
     DsaKeyPairGenConfig* params) {
-  Environment* env = Environment::GetCurrent(args);
   CHECK(args[*offset]->IsUint32());  // modulus bits
   CHECK(args[*offset + 1]->IsInt32());  // divisor bits
 
   params->params.modulus_bits = args[*offset].As<Uint32>()->Value();
   params->params.divisor_bits = args[*offset + 1].As<Int32>()->Value();
-  if (params->params.divisor_bits < -1) {
-    THROW_ERR_OUT_OF_RANGE(env, "invalid value for divisor_bits");
-    return Nothing<bool>();
-  }
+  CHECK_GE(params->params.divisor_bits, -1);
 
   *offset += 2;
 

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -1278,7 +1278,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }
 
   // Test invalid divisor lengths. (out of range)
-  for (const divisorLength of [-6, -9, 2147483648]) {
+  for (const divisorLength of [-1, -6, -9, 2147483648]) {
     assert.throws(() => generateKeyPair('dsa', {
       modulusLength: 2048,
       divisorLength


### PR DESCRIPTION
The JS layer already verifies that `divisor_bits` is either a non-negative 32-bit signed integer or `null`/`undefined`, in which case it passes `-1` to the C++ layer. In either case, the C++ layer receives a 32-bit signed integer greater than or equal to `-1`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
