### PR TITLE
bootstrap: bind properties of the global console in the default snapshot

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -90,7 +90,6 @@ const kIsConsole = Symbol('kIsConsole');
 const kWriteToConsole = Symbol('kWriteToConsole');
 const kBindProperties = Symbol('kBindProperties');
 const kBindStreamsEager = Symbol('kBindStreamsEager');
-const kBindStreamsLazy = Symbol('kBindStreamsLazy');
 const kUseStdout = Symbol('kUseStdout');
 const kUseStderr = Symbol('kUseStderr');
 
@@ -189,38 +188,6 @@ ObjectDefineProperties(Console.prototype, {
       ObjectDefineProperties(this, {
         '_stdout': { __proto__: null, ...consolePropAttributes, value: stdout },
         '_stderr': { __proto__: null, ...consolePropAttributes, value: stderr },
-      });
-    },
-  },
-  [kBindStreamsLazy]: {
-    __proto__: null,
-    ...consolePropAttributes,
-    // Lazily load the stdout and stderr from an object so we don't
-    // create the stdio streams when they are not even accessed
-    value: function(object) {
-      let stdout;
-      let stderr;
-      ObjectDefineProperties(this, {
-        '_stdout': {
-          __proto__: null,
-          enumerable: false,
-          configurable: true,
-          get() {
-            if (!stdout) stdout = object.stdout;
-            return stdout;
-          },
-          set(value) { stdout = value; },
-        },
-        '_stderr': {
-          __proto__: null,
-          enumerable: false,
-          configurable: true,
-          get() {
-            if (!stderr) { stderr = object.stderr; }
-            return stderr;
-          },
-          set(value) { stderr = value; },
-        },
       });
     },
   },
@@ -685,9 +652,6 @@ Console.prototype.error = Console.prototype.warn;
 Console.prototype.groupCollapsed = Console.prototype.group;
 
 function initializeGlobalConsole(globalConsole) {
-  globalConsole[kBindStreamsLazy](process);
-  globalConsole[kBindProperties](true, 'auto');
-
   const {
     namespace: {
       addSerializeCallback,
@@ -714,12 +678,15 @@ function initializeGlobalConsole(globalConsole) {
     for (const key of inspectorConsoleKeys) {
       globalConsole[key] = undefined;
     }
+    // Reset the streams so they are re-initialized after the user-land
+    // snapshot is deserialized.
+    globalConsole._stdout = undefined;
+    globalConsole._stderr = undefined;
   });
 }
 
 module.exports = {
   Console,
-  kBindStreamsLazy,
   kBindProperties,
   initializeGlobalConsole,
   formatTime, // exported for tests

--- a/lib/internal/console/global.js
+++ b/lib/internal/console/global.js
@@ -14,6 +14,7 @@
 
 const {
   FunctionPrototypeBind,
+  ObjectDefineProperties,
   ReflectDefineProperty,
   ReflectGetOwnPropertyDescriptor,
   ReflectOwnKeys,
@@ -21,6 +22,7 @@ const {
 
 const {
   Console,
+  kBindProperties,
 } = require('internal/console/constructor');
 
 const globalConsole = { __proto__: {} };
@@ -40,6 +42,36 @@ for (const prop of ReflectOwnKeys(Console.prototype)) {
   }
   ReflectDefineProperty(globalConsole, prop, desc);
 }
+
+let stdout;
+let stderr;
+
+// Lazily load the stdout and stderr from the process object so we don't
+// create the stdio streams when they are not even accessed.
+ObjectDefineProperties(globalConsole, {
+  '_stdout': {
+    __proto__: null,
+    enumerable: false,
+    configurable: true,
+    get() {
+      if (!stdout) stdout = process.stdout;
+      return stdout;
+    },
+    set(value) { stdout = value; },
+  },
+  '_stderr': {
+    __proto__: null,
+    enumerable: false,
+    configurable: true,
+    get() {
+      if (!stderr) { stderr = process.stderr; }
+      return stderr;
+    },
+    set(value) { stderr = value; },
+  },
+});
+
+globalConsole[kBindProperties](true, 'auto');
 
 // This is a legacy feature - the Console constructor is exposed on
 // the global console instance.


### PR DESCRIPTION
If it safe to bind the properties of the global console when building the default snapshot as long as they are not actually accessed during snapshot building. Bind them early instead of doing it at run time.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
