### PR TITLE
fs: fix filehandle.read(buffer) can't read file when options are omitted

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -577,7 +577,11 @@ async function read(handle, bufferOrParams, offset, length, position) {
     validateInteger(offset, 'offset', 0);
   }
 
-  length |= 0;
+  if (length == null) {
+    length = buffer.byteLength - offset;
+  } else {
+    length |= 0;
+  }
 
   if (length === 0)
     return { __proto__: null, bytesRead: length, buffer };

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -14,7 +14,7 @@ const assert = require('assert');
 const tmpDir = tmpdir.path;
 
 async function read(fileHandle, buffer, offset, length, position, options) {
-  return options.useConf ?
+  return options && options.useConf ?
     fileHandle.read({ buffer, offset, length, position }) :
     fileHandle.read(buffer, offset, length, position);
 }
@@ -97,12 +97,22 @@ async function validateReadLength(len) {
 }
 
 
+async function validateReadWithNoOptions(byte) {
+  const buf = Buffer.alloc(byte);
+  const filePath = fixtures.path('x.txt');
+  const fileHandle = await open(filePath, 'r');
+  const { bytesRead } = await read(fileHandle, buf);
+  assert.strictEqual(bytesRead, byte);
+}
+
 (async function() {
   tmpdir.refresh();
   await validateRead('Hello world', 'read-file', { useConf: false });
   await validateRead('', 'read-empty-file', { useConf: false });
   await validateRead('Hello world', 'read-file-conf', { useConf: true });
   await validateRead('', 'read-empty-file-conf', { useConf: true });
+  await validateReadWithNoOptions(4);
+  await validateReadWithNoOptions(0);
   await validateLargeRead({ useConf: false });
   await validateLargeRead({ useConf: true });
   await validateReadNoParams();

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -65,7 +65,7 @@ async function validateReadNoParams() {
   const filePath = fixtures.path('x.txt');
   const fileHandle = await open(filePath, 'r');
   // Should not throw
-  await fileHandle.read();
+ await fileHandle.read();
 }
 
 // Validates that the zero position is respected after the position has been
@@ -101,8 +101,16 @@ async function validateReadWithNoOptions(byte) {
   const buf = Buffer.alloc(byte);
   const filePath = fixtures.path('x.txt');
   const fileHandle = await open(filePath, 'r');
-  const { bytesRead } = await read(fileHandle, buf);
-  assert.strictEqual(bytesRead, byte);
+  let response = await read(fileHandle, buf);
+  assert.strictEqual(response.bytesRead, byte);
+  response = await read(fileHandle, buf, 0, undefined, 0);
+  assert.strictEqual(response.bytesRead, byte);
+  response = await read(fileHandle, buf, 0, null, 0);
+  assert.strictEqual(response.bytesRead, byte);
+  response = await read(fileHandle, buf, 0, undefined, 0, { useConf: true });
+  assert.strictEqual(response.bytesRead, byte);
+  response = await read(fileHandle, buf, 0, null, 0, { useConf: true });
+  assert.strictEqual(response.bytesRead, byte);
 }
 
 (async function() {
@@ -112,7 +120,7 @@ async function validateReadWithNoOptions(byte) {
   await validateRead('Hello world', 'read-file-conf', { useConf: true });
   await validateRead('', 'read-empty-file-conf', { useConf: true });
   await validateReadWithNoOptions(4);
-  await validateReadWithNoOptions(0);
+  await validateReadWithNoOptions(4);
   await validateLargeRead({ useConf: false });
   await validateLargeRead({ useConf: true });
   await validateReadNoParams();

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -14,7 +14,7 @@ const assert = require('assert');
 const tmpDir = tmpdir.path;
 
 async function read(fileHandle, buffer, offset, length, position, options) {
-  return options && options.useConf ?
+  return options?.useConf ?
     fileHandle.read({ buffer, offset, length, position }) :
     fileHandle.read(buffer, offset, length, position);
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fix #47183 