### PR TITLE
url: improve URLSearchParams creation performance

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -2,6 +2,7 @@
 
 const {
   Array,
+  ArrayIsArray,
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
   ArrayPrototypePush,
@@ -151,13 +152,18 @@ function isURLSearchParams(self) {
 }
 
 class URLSearchParams {
+  [searchParams] = [];
+
+  // "associated url object"
+  [context] = null;
+
   // URL Standard says the default value is '', but as undefined and '' have
   // the same result, undefined is used to prevent unnecessary parsing.
   // Default parameter is necessary to keep URLSearchParams.length === 0 in
   // accordance with Web IDL spec.
   constructor(init = undefined) {
-    if (init === null || init === undefined) {
-      this[searchParams] = [];
+    if (init == null) {
+      // Do nothing
     } else if (typeof init === 'object' || typeof init === 'function') {
       const method = init[SymbolIterator];
       if (method === this[SymbolIterator]) {
@@ -165,38 +171,55 @@ class URLSearchParams {
         // shortcut to avoid having to go through the costly generic iterator.
         const childParams = init[searchParams];
         this[searchParams] = childParams.slice();
-      } else if (method !== null && method !== undefined) {
+      } else if (method != null) {
+        // Sequence<sequence<USVString>>
         if (typeof method !== 'function') {
           throw new ERR_ARG_NOT_ITERABLE('Query pairs');
         }
 
-        // Sequence<sequence<USVString>>
-        // Note: per spec we have to first exhaust the lists then process them
-        const pairs = [];
+        // The following implementationd differs from the URL specification:
+        // Sequences must first be converted from ECMAScript objects before
+        // and operations are done on them, and the operation of converting
+        // the sequences would first exhaust the iterators. If the iterator
+        // returns something invalid in the middle, whether it would be called
+        // after that would be an observable change to the users.
+        // Exhausting the iterator and later converting them to USVString comes
+        // with a significant cost (~40-80%). In order optimize URLSearchParams
+        // creation duration, Node.js merges the iteration and converting
+        // iterations into a single iteration.
         for (const pair of init) {
-          if ((typeof pair !== 'object' && typeof pair !== 'function') ||
-              pair === null ||
-              typeof pair[SymbolIterator] !== 'function') {
+          if (pair == null) {
             throw new ERR_INVALID_TUPLE('Each query pair', '[name, value]');
-          }
-          const convertedPair = [];
-          for (const element of pair)
-            ArrayPrototypePush(convertedPair, toUSVString(element));
-          ArrayPrototypePush(pairs, convertedPair);
-        }
+          } else if (ArrayIsArray(pair)) {
+            // If innerSequence's size is not 2, then throw a TypeError.
+            if (pair.length !== 2) {
+              throw new ERR_INVALID_TUPLE('Each query pair', '[name, value]');
+            }
+            // Append (innerSequence[0], innerSequence[1]) to querys list.
+            ArrayPrototypePush(this[searchParams], toUSVString(pair[0]), toUSVString(pair[1]));
+          } else {
+            if (((typeof pair !== 'object' && typeof pair !== 'function') ||
+                typeof pair[SymbolIterator] !== 'function')) {
+              throw new ERR_INVALID_TUPLE('Each query pair', '[name, value]');
+            }
 
-        this[searchParams] = [];
-        for (const pair of pairs) {
-          if (pair.length !== 2) {
-            throw new ERR_INVALID_TUPLE('Each query pair', '[name, value]');
+            let length = 0;
+
+            for (const element of pair) {
+              length++;
+              ArrayPrototypePush(this[searchParams], toUSVString(element));
+            }
+
+            // If innerSequence's size is not 2, then throw a TypeError.
+            if (length !== 2) {
+              throw new ERR_INVALID_TUPLE('Each query pair', '[name, value]');
+            }
           }
-          ArrayPrototypePush(this[searchParams], pair[0], pair[1]);
         }
       } else {
         // Record<USVString, USVString>
         // Need to use reflection APIs for full spec compliance.
         const visited = {};
-        this[searchParams] = [];
         const keys = ReflectOwnKeys(init);
         for (let i = 0; i < keys.length; i++) {
           const key = keys[i];
@@ -218,13 +241,10 @@ class URLSearchParams {
         }
       }
     } else {
-      // USVString
+      // https://url.spec.whatwg.org/#dom-urlsearchparams-urlsearchparams
       init = toUSVString(init);
       this[searchParams] = init ? parseParams(init) : [];
     }
-
-    // "associated url object"
-    this[context] = null;
   }
 
   [inspect.custom](recurseTimes, ctx) {

--- a/test/parallel/test-whatwg-url-custom-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-constructor.js
@@ -47,6 +47,10 @@ function makeIterableFunc(array) {
   assert.throws(() => new URLSearchParams([null]), tupleError);
   assert.throws(() => new URLSearchParams([{ [Symbol.iterator]: 42 }]),
                 tupleError);
+
+  assert.throws(() => new URLSearchParams(
+    makeIterableFunc([['key', 'val', 'val2']])
+  ), tupleError);
 }
 
 {


### PR DESCRIPTION
## Summary

- Validation: We didn't check for the length of the iterable objects passed to the URLSearchParams. This pull request adds that.
- Performance: My local benchmarks show 45 to 80% faster URLSearchParams creation. 

## Footnote

There is one particular change made regarding to a comment written in 2017:

```
// Note: per spec we have to first exhaust the lists then process them
```

Upon investigating URL spec, I couldn't find any specific reasoning for this and removed it. The spec mentions that:

```
To initialize a [URLSearchParams](https://url.spec.whatwg.org/#urlsearchparams) object query with init, run these steps:

If init is a [sequence](https://webidl.spec.whatwg.org/#idl-sequence), then [for each](https://infra.spec.whatwg.org/#list-iterate) innerSequence of init:

If innerSequence’s [size](https://infra.spec.whatwg.org/#list-size) is not 2, then [throw](https://webidl.spec.whatwg.org/#dfn-throw) a [TypeError](https://webidl.spec.whatwg.org/#exceptiondef-typeerror).

[Append](https://infra.spec.whatwg.org/#list-append) (innerSequence[0], innerSequence[1]) to query’s [list](https://url.spec.whatwg.org/#concept-urlsearchparams-list).
```

### Benchmark Result

```
                                                                                     confidence improvement accuracy (*)   (**)   (***)
url/url-searchparams-creation.js n=10000 inputType='iterable' type='array'                  ***     45.05 %       ±6.82% ±9.19% ±12.19%
url/url-searchparams-creation.js n=10000 inputType='iterable' type='encodelast'             ***     81.96 %       ±2.30% ±3.08%  ±4.06%
url/url-searchparams-creation.js n=10000 inputType='iterable' type='encodemany'             ***     83.22 %       ±1.73% ±2.32%  ±3.05%
url/url-searchparams-creation.js n=10000 inputType='iterable' type='multiprimitives'        ***     80.23 %       ±2.69% ±3.58%  ±4.66%
url/url-searchparams-creation.js n=10000 inputType='iterable' type='noencode'               ***     80.30 %       ±2.55% ±3.42%  ±4.49%
url/url-searchparams-creation.js n=10000 inputType='object' type='array'                             1.47 %       ±2.71% ±3.62%  ±4.74%
url/url-searchparams-creation.js n=10000 inputType='object' type='encodelast'                **      2.78 %       ±1.72% ±2.30%  ±3.00%
url/url-searchparams-creation.js n=10000 inputType='object' type='encodemany'                       -0.26 %       ±3.28% ±4.41%  ±5.82%
url/url-searchparams-creation.js n=10000 inputType='object' type='multiprimitives'          ***      2.76 %       ±1.21% ±1.62%  ±2.11%
url/url-searchparams-creation.js n=10000 inputType='object' type='noencode'                          1.39 %       ±1.59% ±2.12%  ±2.76%
url/url-searchparams-creation.js n=10000 inputType='string' type='array'                             2.38 %       ±5.54% ±7.46%  ±9.88%
url/url-searchparams-creation.js n=10000 inputType='string' type='encodelast'                        1.04 %       ±1.99% ±2.65%  ±3.47%
url/url-searchparams-creation.js n=10000 inputType='string' type='encodemany'                       -0.97 %       ±1.19% ±1.58%  ±2.06%
url/url-searchparams-creation.js n=10000 inputType='string' type='multiprimitives'                  -1.60 %       ±1.67% ±2.23%  ±2.90%
url/url-searchparams-creation.js n=10000 inputType='string' type='noencode'                          0.74 %       ±4.75% ±6.37%  ±8.40%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 15 comparisons, you can thus expect the following amount of false-positive results:
  0.75 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.15 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```

cc @nodejs/url