### PR TITLE
util: reduce javascript call for ToUSVString

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -69,16 +69,8 @@ const experimentalWarnings = new SafeSet();
 
 const colorRegExp = /\u001b\[\d\d?m/g; // eslint-disable-line no-control-regex
 
-const unpairedSurrogateRe =
-  /(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
 function toUSVString(val) {
-  const str = `${val}`;
-  // As of V8 5.5, `str.search()` (and `unpairedSurrogateRe[@@search]()`) are
-  // slower than `unpairedSurrogateRe.exec()`.
-  const match = RegExpPrototypeExec(unpairedSurrogateRe, str);
-  if (!match)
-    return str;
-  return _toUSVString(str, match.index);
+  return _toUSVString(`${val}`);
 }
 
 let uvBinding;

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -322,16 +322,12 @@ static void GuessHandleType(const FunctionCallbackInfo<Value>& args) {
 
 static void ToUSVString(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  CHECK_GE(args.Length(), 2);
+  CHECK_GE(args.Length(), 1);
   CHECK(args[0]->IsString());
-  CHECK(args[1]->IsNumber());
 
   TwoByteValue value(env->isolate(), args[0]);
 
-  int64_t start = args[1]->IntegerValue(env->context()).FromJust();
-  CHECK_GE(start, 0);
-
-  for (size_t i = start; i < value.length(); i++) {
+  for (size_t i = 0; i < value.length(); i++) {
     char16_t c = value[i];
     if (!IsUnicodeSurrogate(c)) {
       continue;


### PR DESCRIPTION
ToUSVString is mostly called with small inputs and optimizing it for very large strings does not reflect the real-world usage. Removing `RegExpPrototypeExec` from JavaScript improves things.

```
                                        confidence improvement accuracy (*)   (**)  (***)
util/to-usv-string.js size=10 n=100000         ***     38.74 %       ±2.10% ±2.82% ±3.73%
util/to-usv-string.js size=100 n=100000        ***      7.42 %       ±0.60% ±0.80% ±1.04%
util/to-usv-string.js size=500 n=100000        ***      1.21 %       ±0.50% ±0.66% ±0.86%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 3 comparisons, you can thus expect the following amount of false-positive results:
  0.15 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.03 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

cc @nodejs/util 