### PR TITLE
inspector: add tips for Session

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -54,6 +54,10 @@ Create a new instance of the `inspector.Session` class. The inspector session
 needs to be connected through [`session.connect()`][] before the messages
 can be dispatched to the inspector backend.
 
+When using `Session`, the object outputed by the console API will not be
+released, unless we performed manually `Runtime.DiscardConsoleEntries`
+command.
+
 #### Event: `'inspectorNotification'`
 
 <!-- YAML
@@ -222,6 +226,10 @@ added: v8.0.0
 Create a new instance of the `inspector.Session` class. The inspector session
 needs to be connected through [`session.connect()`][] before the messages
 can be dispatched to the inspector backend.
+
+When using `Session`, the object outputed by the console API will not be
+released, unless we performed manually `Runtime.DiscardConsoleEntries`
+command.
 
 #### Event: `'inspectorNotification'`
 


### PR DESCRIPTION
When using `Session`, the object outputed by the console API will not be released.

The example is as follows.
```js
const inspector = require('inspector');

class AAA {
    constructor() {
        const len = 10000000;
        this.memory = new Array(len);
        for (let i = 0; i < len; i++) {
            this.memory[i] = i;
        }
    }
};

const session = new inspector.Session();
// comment out this and test again
session.connect();

const heapUsed = process.memoryUsage().heapUsed;
setInterval(() => {
    const obj = new AAA();
    console.log(obj);
    gc();
    console.log(process.memoryUsage().heapUsed - heapUsed);
}, 100);
```
node --expose-gc test.js

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
