### PR TITLE
tools: add HTML previews for PR containing doc changes

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -41,3 +41,32 @@ jobs:
           path: out/doc
       - name: Test
         run: NODE=$(command -v node) make test-doc-ci TEST_CI_ARGS="-p actions --measure-flakiness 9"
+  build-preview:
+    if: github.event.pull_request
+    needs: build-docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out the gh-pages branch
+        uses: actions/checkout@v3
+        with:
+          # We want to persist credentials so we can push to gh-pages
+          persist-credentials: true
+          ref: gh-pages
+      - name: Erase previous version (if it exists)
+        run: rm -rf "${{ github.event.pull_request.number }}"
+      - name: Download tarball from build job
+        uses: actions/download-artifact@v3
+        with:
+          name: docs
+          path: ${{ github.event.pull_request.number }}
+      - name: Commit the doc preview to gh-pages
+        run: |
+          git config user.email "github-bot@iojs.org"
+          git config user.name "Node.js GitHub Bot"
+          git add "${{ github.event.pull_request.number }}"
+          git commit \
+            -m "Add/Update preview for ${{ github.event.pull_request.html_url }}" \
+            -m "The preview will be available at https://${{ github.repository_owner }}.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.event.pull_request.number }}/api/"
+          git push origin HEAD:gh-pages


### PR DESCRIPTION
For PR containing doc changes, the GitHub Actions workflow will push the built docs to the `gh-pages` branch so reviewers can have a preview of the changes without needing to pull the PR and build the docs locally. The commit that is pushed to `gh-pages` has a reference to the PR so the commit will appear on the GH web UI (so no need to comment I think).

You can see this PR in action on https://github.com/nodejs/node-auto-test/pull/53.

Before this can land (if we do want to land it), the following needs to happen:
1. An empty git tree should be pushed to the `gh-pages` branch.
2. GitHub Pages should be activated on this repo (this should happen automatically if the above is done by a repo admin).

Note that this PR is only adding files to the `gh-pages`, which will eventually get cluttered with old PR content. If you have an idea how we can manage, please chime in, otherwise we can leave the problem for our future selves to solve (reseting the `gh-pages` branch back to an empty git tree every few months should work well enough for our use case I think).

/cc @nodejs/tsc 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
4. Update documentation if relevant.
5. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
