### PR TITLE
url: add pending-deprecation to `url.parse()`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3288,6 +3288,9 @@ Node-API callbacks.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/47203
+    description: Added support for `--pending-deprecation`.
   - version:
       - v19.0.0
       - v18.13.0
@@ -3295,7 +3298,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Documentation-only (supports [`--pending-deprecation`][])
 
 [`url.parse()`][] behavior is not standardized and prone to errors that
 have security implications. Use the [WHATWG URL API][] instead. CVEs are not

--- a/lib/url.js
+++ b/lib/url.js
@@ -62,6 +62,8 @@ const {
   formatUrl,
 } = internalBinding('url');
 
+const { getOptionValue } = require('internal/options');
+
 // Original url.parse() API
 
 function Url() {
@@ -146,7 +148,20 @@ const {
   CHAR_COLON,
 } = require('internal/constants');
 
+let urlParseWarned = false;
+
 function urlParse(url, parseQueryString, slashesDenoteHost) {
+  if (getOptionValue('--pending-deprecation') && !urlParseWarned) {
+    urlParseWarned = true;
+    process.emitWarning(
+      '`url.parse()` behavior is not standardized and prone to ' +
+      'errors that have security implications. Use the WHATWG URL API ' +
+      'instead. CVEs are not issued for `url.parse()` vulnerabilities.',
+      'DeprecationWarning',
+      'DEP0169',
+    );
+  }
+
   if (url instanceof Url) return url;
 
   const urlObject = new Url();

--- a/lib/url.js
+++ b/lib/url.js
@@ -151,7 +151,7 @@ const {
 let urlParseWarned = false;
 
 function urlParse(url, parseQueryString, slashesDenoteHost) {
-  if (getOptionValue('--pending-deprecation') && !urlParseWarned) {
+  if (!urlParseWarned && getOptionValue('--pending-deprecation')) {
     urlParseWarned = true;
     process.emitWarning(
       '`url.parse()` behavior is not standardized and prone to ' +


### PR DESCRIPTION
I propose adding support for `--pending-deprecation` for the `url.parse()` method. The new improvements in WHATWG URL and Ada hints us towards a runtime deprecation in the upcoming years. 