### PR TITLE
tools: upgrade Windows digital signature to SHA256

### DIFF
--- a/tools/sign.bat
+++ b/tools/sign.bat
@@ -3,7 +3,7 @@
 set timeservers=(http://timestamp.globalsign.com/scripts/timestamp.dll http://timestamp.comodoca.com/authenticode http://timestamp.verisign.com/scripts/timestamp.dll http://tsa.starfieldtech.com)
 
 for %%s in %timeservers% do (
-    signtool sign /a /d "Node.js" /du "https://nodejs.org" /t %%s %1
+    signtool sign /a /d "Node.js" /du "https://nodejs.org" /fd SHA256 /t %%s %1
     if not ERRORLEVEL 1 (
         echo Successfully signed %1 using timeserver %%s
         exit /b 0


### PR DESCRIPTION
signtool still defaults to SHA1, which is vulnerable to certain collisions. This switches to SHA256, which is stronger and which also matches the hash function used by the signing certificate.

Technically, `/fd certHash` would be a better choice, but I don't know if it is widely supported.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
