### PR TITLE
deps: V8: cherry-pick 215ccd593edb

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.10',
+    'v8_embedder_string': '-node.11',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/common/checks.h
+++ b/deps/v8/src/common/checks.h
@@ -15,7 +15,7 @@
 
 #ifdef ENABLE_SLOW_DCHECKS
 #define SLOW_DCHECK(condition) \
-  CHECK(!v8::internal::v8_flags.enable_slow_asserts || (condition))
+  CHECK(!v8::internal::v8_flags.enable_slow_asserts.value() || (condition))
 #define SLOW_DCHECK_IMPLIES(lhs, rhs) SLOW_DCHECK(!(lhs) || (rhs))
 #else
 #define SLOW_DCHECK(condition) ((void)0)


### PR DESCRIPTION
Currently `./configure --v8-non-optimized-debug` is broken without this patch, which makes debugging into V8 harder. The upstream works fine without this probably because there V8 is always built using a specified version of clang but for Node.js we need to float this until the patch gets in with the next V8 update.

Original commit message:

    Use FlagValue::value() in SLOW_DCHECK

    Previously SLOW_DCHECK used the non-constexpr bool() operator
    of FlagValue, which cannot be used in constexpr. Switch to
    FlagValue::value() instead for make it compile in constexpr.

    Change-Id: I3e4f70d82c0027cf56999b6c4639479606151696
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4341495
    Reviewed-by: Jakob Linke <jgruber@chromium.org>
    Commit-Queue: Joyee Cheung <joyee@igalia.com>
    Cr-Commit-Position: refs/heads/main@{#86611}

Refs: https://github.com/v8/v8/commit/215ccd593edbf18170fa1aae109b6b1cccf0ccbf

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
