### PR TITLE
url: conform structuredClone url serialization

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -811,6 +811,11 @@ added: v0.0.1
 
 <!-- YAML
 added: v17.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/47214
+    description: Throws a DOM exception when used with `URL` and
+                 `URLSearchParams` to conform with WHATWG specification.
 -->
 
 <!-- type=global -->

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -111,6 +111,10 @@ added:
   - v7.0.0
   - v6.13.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/47214
+    description: The class is now not serializable/deserializable through
+                 `structuredClone` to conform to the WHATWG specification.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18281
     description: The class is now available on the global object.
@@ -669,6 +673,10 @@ added:
   - v7.5.0
   - v6.13.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/47214
+    description: The class is now not serializable/deserializable through
+                 `structuredClone` to conform to the WHATWG specification.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18281
     description: The class is now available on the global object.

--- a/lib/internal/structured_clone.js
+++ b/lib/internal/structured_clone.js
@@ -5,14 +5,33 @@ const {
 } = require('internal/errors');
 
 const {
+  lazyDOMException,
+} = require('internal/util');
+
+const {
   MessageChannel,
   receiveMessageOnPort,
 } = require('internal/worker/io');
+
+const {
+  isURL,
+  isURLSearchParams,
+} = require('internal/url');
 
 let channel;
 function structuredClone(value, options = undefined) {
   if (arguments.length === 0) {
     throw new ERR_MISSING_ARGS('value');
+  }
+
+  if (isURL(value)) {
+    throw new lazyDOMException(
+      'URL: no structured serialize/deserialize support',
+      'DataCloneError');
+  } else if (isURLSearchParams(value)) {
+    throw new lazyDOMException(
+      'URLSearchParams: no structured serialize/deserialize support',
+      'DataCloneError');
   }
 
   // TODO: Improve this with a more efficient solution that avoids

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1279,4 +1279,5 @@ module.exports = {
   urlToHttpOptions,
   encodeStr,
   isURL,
+  isURLSearchParams,
 };

--- a/test/wpt/status/url.json
+++ b/test/wpt/status/url.json
@@ -11,9 +11,7 @@
     "fail": {
       "note": "We are faking location with a URL object for the sake of the testharness and it has searchParams.",
       "expected": [
-        "searchParams on location object",
-        "URL: no structured serialize/deserialize support",
-        "URLSearchParams: no structured serialize/deserialize support"
+        "searchParams on location object"
       ]
     }
   },


### PR DESCRIPTION
Enabled 2 more web platform tests for URL and URLSearchParams for disallowing them to be called in `structuredClone`. cc @nodejs/url