### PR TITLE
bootstrap: store internal loaders in C++ via a binding

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -182,6 +182,7 @@ const loaderId = 'internal/bootstrap/loaders';
 const {
   builtinIds,
   compileFunction,
+  setInternalLoaders,
 } = internalBinding('builtins');
 
 const getOwn = (target, property, receiver) => {
@@ -373,5 +374,5 @@ function requireWithFallbackInDeps(request) {
   return requireBuiltin(request);
 }
 
-// Pass the exports back to C++ land for C++ internals to use.
-return loaderExports;
+// Store the internal loaders in C++.
+setInternalLoaders(internalBinding, requireBuiltin);

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -647,6 +647,16 @@ void BuiltinLoader::HasCachedBuiltins(const FunctionCallbackInfo<Value>& args) {
       args.GetIsolate(), instance->code_cache_->has_code_cache));
 }
 
+void SetInternalLoaders(const FunctionCallbackInfo<Value>& args) {
+  Realm* realm = Realm::GetCurrent(args);
+  CHECK(args[0]->IsFunction());
+  CHECK(args[1]->IsFunction());
+  DCHECK(realm->internal_binding_loader().IsEmpty());
+  DCHECK(realm->builtin_module_require().IsEmpty());
+  realm->set_internal_binding_loader(args[0].As<Function>());
+  realm->set_builtin_module_require(args[1].As<Function>());
+}
+
 void BuiltinLoader::CopySourceAndCodeCacheReferenceFrom(
     const BuiltinLoader* other) {
   code_cache_ = other->code_cache_;
@@ -685,6 +695,7 @@ void BuiltinLoader::CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, proto, "getCacheUsage", BuiltinLoader::GetCacheUsage);
   SetMethod(isolate, proto, "compileFunction", BuiltinLoader::CompileFunction);
   SetMethod(isolate, proto, "hasCachedBuiltins", HasCachedBuiltins);
+  SetMethod(isolate, proto, "setInternalLoaders", SetInternalLoaders);
 }
 
 void BuiltinLoader::CreatePerContextProperties(Local<Object> target,
@@ -703,6 +714,7 @@ void BuiltinLoader::RegisterExternalReferences(
   registry->Register(GetCacheUsage);
   registry->Register(CompileFunction);
   registry->Register(HasCachedBuiltins);
+  registry->Register(SetInternalLoaders);
 }
 
 }  // namespace builtins

--- a/src/node_realm.cc
+++ b/src/node_realm.cc
@@ -174,42 +174,14 @@ MaybeLocal<Value> Realm::ExecuteBootstrapper(const char* id) {
   return scope.EscapeMaybe(result);
 }
 
-MaybeLocal<Value> Realm::BootstrapInternalLoaders() {
-  EscapableHandleScope scope(isolate_);
-
-  // Bootstrap internal loaders
-  Local<Value> loader_exports;
-  if (!ExecuteBootstrapper("internal/bootstrap/loaders")
-           .ToLocal(&loader_exports)) {
-    return MaybeLocal<Value>();
-  }
-  CHECK(loader_exports->IsObject());
-  Local<Object> loader_exports_obj = loader_exports.As<Object>();
-  Local<Value> internal_binding_loader =
-      loader_exports_obj->Get(context(), env_->internal_binding_string())
-          .ToLocalChecked();
-  CHECK(internal_binding_loader->IsFunction());
-  set_internal_binding_loader(internal_binding_loader.As<Function>());
-  Local<Value> require =
-      loader_exports_obj->Get(context(), env_->require_string())
-          .ToLocalChecked();
-  CHECK(require->IsFunction());
-  set_builtin_module_require(require.As<Function>());
-
-  return scope.Escape(loader_exports);
-}
-
 MaybeLocal<Value> Realm::RunBootstrapping() {
   EscapableHandleScope scope(isolate_);
 
   CHECK(!has_run_bootstrapping_code());
 
-  if (BootstrapInternalLoaders().IsEmpty()) {
-    return MaybeLocal<Value>();
-  }
-
   Local<Value> result;
-  if (!BootstrapRealm().ToLocal(&result)) {
+  if (!ExecuteBootstrapper("internal/bootstrap/loaders").ToLocal(&result) ||
+      !BootstrapRealm().ToLocal(&result)) {
     return MaybeLocal<Value>();
   }
 

--- a/src/node_realm.cc
+++ b/src/node_realm.cc
@@ -10,7 +10,6 @@ namespace node {
 
 using v8::Context;
 using v8::EscapableHandleScope;
-using v8::Function;
 using v8::HandleScope;
 using v8::Local;
 using v8::MaybeLocal;

--- a/src/node_realm.h
+++ b/src/node_realm.h
@@ -129,7 +129,6 @@ class Realm : public MemoryRetainer {
  protected:
   ~Realm();
 
-  v8::MaybeLocal<v8::Value> BootstrapInternalLoaders();
   virtual v8::MaybeLocal<v8::Value> BootstrapRealm() = 0;
 
   Environment* env_;


### PR DESCRIPTION
Instead of returning the internal loaders from the bootstrap script, we can simply call a binding to store them in C++. This eliminates the need for specializing the handling of this script.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
