### PR TITLE
src: use the internal field to determine if an object is a BaseObject

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -342,7 +342,6 @@ Local<FunctionTemplate> AsyncWrap::GetConstructorTemplate(
     tmpl = NewFunctionTemplate(isolate, nullptr);
     tmpl->SetClassName(
         FIXED_ONE_BYTE_STRING(isolate_data->isolate(), "AsyncWrap"));
-    tmpl->Inherit(BaseObject::GetConstructorTemplate(isolate_data));
     SetProtoMethod(isolate, tmpl, "getAsyncId", AsyncWrap::GetAsyncId);
     SetProtoMethod(isolate, tmpl, "asyncReset", AsyncWrap::AsyncReset);
     SetProtoMethod(

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -79,14 +79,14 @@ bool BaseObject::IsBaseObject(v8::Local<v8::Object> obj) {
   return ptr == &kNodeEmbedderId;
 }
 
-void BaseObject::TagNodeObject(v8::Local<v8::Object> object) {
+void BaseObject::TagBaseObject(v8::Local<v8::Object> object) {
   DCHECK_GE(object->InternalFieldCount(), BaseObject::kInternalFieldCount);
   object->SetAlignedPointerInInternalField(BaseObject::kEmbedderType,
                                            &kNodeEmbedderId);
 }
 
 void BaseObject::SetInternalFields(v8::Local<v8::Object> object, void* slot) {
-  TagNodeObject(object);
+  TagBaseObject(object);
   object->SetAlignedPointerInInternalField(BaseObject::kSlot, slot);
 }
 

--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -38,12 +38,6 @@ BaseObject::BaseObject(Environment* env, v8::Local<v8::Object> object)
   // while allowing to create a BaseObject in a vm context.
 }
 
-// static
-v8::Local<v8::FunctionTemplate> BaseObject::GetConstructorTemplate(
-    Environment* env) {
-  return BaseObject::GetConstructorTemplate(env->isolate_data());
-}
-
 void BaseObject::Detach() {
   CHECK_GT(pointer_data()->strong_ptr_count, 0);
   pointer_data()->is_detached = true;
@@ -74,6 +68,15 @@ Environment* BaseObject::env() const {
 
 Realm* BaseObject::realm() const {
   return realm_;
+}
+
+bool BaseObject::IsBaseObject(v8::Local<v8::Object> obj) {
+  if (obj->InternalFieldCount() < BaseObject::kInternalFieldCount) {
+    return false;
+  }
+  void* ptr =
+      obj->GetAlignedPointerFromInternalField(BaseObject::kEmbedderType);
+  return ptr == &kNodeEmbedderId;
 }
 
 void BaseObject::TagNodeObject(v8::Local<v8::Object> object) {

--- a/src/base_object.cc
+++ b/src/base_object.cc
@@ -89,7 +89,6 @@ Local<FunctionTemplate> BaseObject::MakeLazilyInitializedJSTemplate(
     IsolateData* isolate_data) {
   Local<FunctionTemplate> t = NewFunctionTemplate(
       isolate_data->isolate(), LazilyInitializedJSTemplateConstructor);
-  t->Inherit(BaseObject::GetConstructorTemplate(isolate_data));
   t->InstanceTemplate()->SetInternalFieldCount(BaseObject::kInternalFieldCount);
   return t;
 }
@@ -143,18 +142,6 @@ Local<Object> BaseObject::WrappedObject() const {
 
 bool BaseObject::IsRootNode() const {
   return !persistent_handle_.IsWeak();
-}
-
-Local<FunctionTemplate> BaseObject::GetConstructorTemplate(
-    IsolateData* isolate_data) {
-  Local<FunctionTemplate> tmpl = isolate_data->base_object_ctor_template();
-  if (tmpl.IsEmpty()) {
-    tmpl = NewFunctionTemplate(isolate_data->isolate(), nullptr);
-    tmpl->SetClassName(
-        FIXED_ONE_BYTE_STRING(isolate_data->isolate(), "BaseObject"));
-    isolate_data->set_base_object_ctor_template(tmpl);
-  }
-  return tmpl;
 }
 
 bool BaseObject::IsNotIndicativeOfMemoryLeakAtExit() const {

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -76,6 +76,7 @@ class BaseObject : public MemoryRetainer {
   // e.g. when the JS object used `MakeLazilyInitializedJSTemplate`.
   static inline void SetInternalFields(v8::Local<v8::Object> object,
                                        void* slot);
+  static inline bool IsBaseObject(v8::Local<v8::Object> object);
   static inline void TagNodeObject(v8::Local<v8::Object> object);
   static void LazilyInitializedJSTemplateConstructor(
       const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -77,7 +77,7 @@ class BaseObject : public MemoryRetainer {
   static inline void SetInternalFields(v8::Local<v8::Object> object,
                                        void* slot);
   static inline bool IsBaseObject(v8::Local<v8::Object> object);
-  static inline void TagNodeObject(v8::Local<v8::Object> object);
+  static inline void TagBaseObject(v8::Local<v8::Object> object);
   static void LazilyInitializedJSTemplateConstructor(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static inline BaseObject* FromJSObject(v8::Local<v8::Value> object);

--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -277,9 +277,7 @@ void CipherBase::Initialize(Environment* env, Local<Object> target) {
 
   Local<FunctionTemplate> t = NewFunctionTemplate(isolate, New);
 
-  t->InstanceTemplate()->SetInternalFieldCount(
-      CipherBase::kInternalFieldCount);
-  t->Inherit(BaseObject::GetConstructorTemplate(env));
+  t->InstanceTemplate()->SetInternalFieldCount(CipherBase::kInternalFieldCount);
 
   SetProtoMethod(isolate, t, "init", Init);
   SetProtoMethod(isolate, t, "initiv", InitIv);

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -268,7 +268,6 @@ Local<FunctionTemplate> SecureContext::GetConstructorTemplate(
     tmpl = NewFunctionTemplate(isolate, New);
     tmpl->InstanceTemplate()->SetInternalFieldCount(
         SecureContext::kInternalFieldCount);
-    tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
     tmpl->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "SecureContext"));
 
     SetProtoMethod(isolate, tmpl, "init", Init);

--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -69,7 +69,6 @@ void DiffieHellman::Initialize(Environment* env, Local<Object> target) {
 
     t->InstanceTemplate()->SetInternalFieldCount(
         DiffieHellman::kInternalFieldCount);
-    t->Inherit(BaseObject::GetConstructorTemplate(env));
 
     SetProtoMethod(isolate, t, "generateKeys", GenerateKeys);
     SetProtoMethod(isolate, t, "computeSecret", ComputeSecret);

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -66,7 +66,6 @@ void ECDH::Initialize(Environment* env, Local<Object> target) {
   Local<Context> context = env->context();
 
   Local<FunctionTemplate> t = NewFunctionTemplate(isolate, New);
-  t->Inherit(BaseObject::GetConstructorTemplate(env));
 
   t->InstanceTemplate()->SetInternalFieldCount(ECDH::kInternalFieldCount);
 

--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -57,9 +57,7 @@ void Hash::Initialize(Environment* env, Local<Object> target) {
   Local<Context> context = env->context();
   Local<FunctionTemplate> t = NewFunctionTemplate(isolate, New);
 
-  t->InstanceTemplate()->SetInternalFieldCount(
-      Hash::kInternalFieldCount);
-  t->Inherit(BaseObject::GetConstructorTemplate(env));
+  t->InstanceTemplate()->SetInternalFieldCount(Hash::kInternalFieldCount);
 
   SetProtoMethod(isolate, t, "update", HashUpdate);
   SetProtoMethod(isolate, t, "digest", HashDigest);

--- a/src/crypto/crypto_hmac.cc
+++ b/src/crypto/crypto_hmac.cc
@@ -41,9 +41,7 @@ void Hmac::Initialize(Environment* env, Local<Object> target) {
   Isolate* isolate = env->isolate();
   Local<FunctionTemplate> t = NewFunctionTemplate(isolate, New);
 
-  t->InstanceTemplate()->SetInternalFieldCount(
-      Hmac::kInternalFieldCount);
-  t->Inherit(BaseObject::GetConstructorTemplate(env));
+  t->InstanceTemplate()->SetInternalFieldCount(Hmac::kInternalFieldCount);
 
   SetProtoMethod(isolate, t, "init", HmacInit);
   SetProtoMethod(isolate, t, "update", HmacUpdate);

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -901,7 +901,6 @@ v8::Local<v8::Function> KeyObjectHandle::Initialize(Environment* env) {
     templ = NewFunctionTemplate(isolate, New);
     templ->InstanceTemplate()->SetInternalFieldCount(
         KeyObjectHandle::kInternalFieldCount);
-    templ->Inherit(BaseObject::GetConstructorTemplate(env));
 
     SetProtoMethod(isolate, templ, "init", Init);
     SetProtoMethodNoSideEffect(
@@ -1342,7 +1341,6 @@ void NativeKeyObject::CreateNativeKeyObjectClass(
       NewFunctionTemplate(isolate, NativeKeyObject::New);
   t->InstanceTemplate()->SetInternalFieldCount(
       KeyObjectHandle::kInternalFieldCount);
-  t->Inherit(BaseObject::GetConstructorTemplate(env));
 
   Local<Value> ctor;
   if (!t->GetFunction(env->context()).ToLocal(&ctor))

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -329,9 +329,7 @@ void Sign::Initialize(Environment* env, Local<Object> target) {
   Isolate* isolate = env->isolate();
   Local<FunctionTemplate> t = NewFunctionTemplate(isolate, New);
 
-  t->InstanceTemplate()->SetInternalFieldCount(
-      SignBase::kInternalFieldCount);
-  t->Inherit(BaseObject::GetConstructorTemplate(env));
+  t->InstanceTemplate()->SetInternalFieldCount(SignBase::kInternalFieldCount);
 
   SetProtoMethod(isolate, t, "init", SignInit);
   SetProtoMethod(isolate, t, "update", SignUpdate);
@@ -459,9 +457,7 @@ void Verify::Initialize(Environment* env, Local<Object> target) {
   Isolate* isolate = env->isolate();
   Local<FunctionTemplate> t = NewFunctionTemplate(isolate, New);
 
-  t->InstanceTemplate()->SetInternalFieldCount(
-      SignBase::kInternalFieldCount);
-  t->Inherit(BaseObject::GetConstructorTemplate(env));
+  t->InstanceTemplate()->SetInternalFieldCount(SignBase::kInternalFieldCount);
 
   SetProtoMethod(isolate, t, "init", VerifyInit);
   SetProtoMethod(isolate, t, "update", VerifyUpdate);

--- a/src/crypto/crypto_x509.cc
+++ b/src/crypto/crypto_x509.cc
@@ -59,7 +59,6 @@ Local<FunctionTemplate> X509Certificate::GetConstructorTemplate(
     tmpl = NewFunctionTemplate(isolate, nullptr);
     tmpl->InstanceTemplate()->SetInternalFieldCount(
         BaseObject::kInternalFieldCount);
-    tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
     tmpl->SetClassName(
         FIXED_ONE_BYTE_STRING(env->isolate(), "X509Certificate"));
     SetProtoMethod(isolate, tmpl, "subject", Subject);

--- a/src/env.cc
+++ b/src/env.cc
@@ -480,7 +480,6 @@ void IsolateData::CreateProperties() {
   Local<FunctionTemplate> templ = FunctionTemplate::New(isolate());
   templ->InstanceTemplate()->SetInternalFieldCount(
       BaseObject::kInternalFieldCount);
-  templ->Inherit(BaseObject::GetConstructorTemplate(this));
   set_binding_data_ctor_template(templ);
   binding::CreateInternalBindingTemplates(this);
 

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -330,7 +330,6 @@
 #define PER_ISOLATE_TEMPLATE_PROPERTIES(V)                                     \
   V(async_wrap_ctor_template, v8::FunctionTemplate)                            \
   V(async_wrap_object_ctor_template, v8::FunctionTemplate)                     \
-  V(base_object_ctor_template, v8::FunctionTemplate)                           \
   V(binding_data_ctor_template, v8::FunctionTemplate)                          \
   V(blob_constructor_template, v8::FunctionTemplate)                           \
   V(blob_reader_constructor_template, v8::FunctionTemplate)                    \

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -288,7 +288,6 @@ Local<FunctionTemplate> HistogramBase::GetConstructorTemplate(
     tmpl = NewFunctionTemplate(isolate, New);
     Local<String> classname = FIXED_ONE_BYTE_STRING(isolate, "Histogram");
     tmpl->SetClassName(classname);
-    tmpl->Inherit(BaseObject::GetConstructorTemplate(isolate_data));
 
     tmpl->InstanceTemplate()->SetInternalFieldCount(
         HistogramBase::kInternalFieldCount);

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -768,7 +768,6 @@ void ModuleWrap::Initialize(Local<Object> target,
   Local<FunctionTemplate> tpl = NewFunctionTemplate(isolate, New);
   tpl->InstanceTemplate()->SetInternalFieldCount(
       ModuleWrap::kInternalFieldCount);
-  tpl->Inherit(BaseObject::GetConstructorTemplate(env));
 
   SetProtoMethod(isolate, tpl, "link", Link);
   SetProtoMethod(isolate, tpl, "instantiate", Instantiate);

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -565,7 +565,6 @@ void CreateInternalBindingTemplates(IsolateData* isolate_data) {
         FunctionTemplate::New(isolate_data->isolate());                        \
     templ->InstanceTemplate()->SetInternalFieldCount(                          \
         BaseObject::kInternalFieldCount);                                      \
-    templ->Inherit(BaseObject::GetConstructorTemplate(isolate_data));          \
     _register_isolate_##modname(isolate_data, templ);                          \
     isolate_data->set_##modname##_binding(templ);                              \
   } while (0);

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -131,7 +131,6 @@ Local<FunctionTemplate> Blob::GetConstructorTemplate(Environment* env) {
     tmpl = NewFunctionTemplate(isolate, nullptr);
     tmpl->InstanceTemplate()->SetInternalFieldCount(
         BaseObject::kInternalFieldCount);
-    tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
     tmpl->SetClassName(
         FIXED_ONE_BYTE_STRING(env->isolate(), "Blob"));
     SetProtoMethod(isolate, tmpl, "getReader", GetReader);
@@ -281,7 +280,6 @@ Local<FunctionTemplate> Blob::Reader::GetConstructorTemplate(Environment* env) {
     tmpl = NewFunctionTemplate(isolate, nullptr);
     tmpl->InstanceTemplate()->SetInternalFieldCount(
         BaseObject::kInternalFieldCount);
-    tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
     tmpl->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "BlobReader"));
     SetProtoMethod(env->isolate(), tmpl, "pull", Pull);
     env->set_blob_reader_constructor_template(tmpl);

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -875,7 +875,6 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   // ConverterObject
   {
     Local<FunctionTemplate> t = NewFunctionTemplate(isolate, nullptr);
-    t->Inherit(BaseObject::GetConstructorTemplate(isolate_data));
     t->InstanceTemplate()->SetInternalFieldCount(
         ConverterObject::kInternalFieldCount);
     Local<String> converter_string =

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -462,7 +462,6 @@ void Initialize(Local<Object> target,
 
   ser->InstanceTemplate()->SetInternalFieldCount(
       SerializerContext::kInternalFieldCount);
-  ser->Inherit(BaseObject::GetConstructorTemplate(env));
 
   SetProtoMethod(isolate, ser, "writeHeader", SerializerContext::WriteHeader);
   SetProtoMethod(isolate, ser, "writeValue", SerializerContext::WriteValue);
@@ -490,7 +489,6 @@ void Initialize(Local<Object> target,
 
   des->InstanceTemplate()->SetInternalFieldCount(
       DeserializerContext::kInternalFieldCount);
-  des->Inherit(BaseObject::GetConstructorTemplate(env));
 
   SetProtoMethod(isolate, des, "readHeader", DeserializerContext::ReadHeader);
   SetProtoMethod(isolate, des, "readValue", DeserializerContext::ReadValue);

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1369,18 +1369,7 @@ StartupData SerializeNodeContextInternalFields(Local<Object> holder,
   // (most importantly, BaseObject::kSlot).
   // For Node.js this design is enough for all the native binding that are
   // serializable.
-  if (index != BaseObject::kEmbedderType) {
-    return StartupData{nullptr, 0};
-  }
-
-  void* type_ptr = holder->GetAlignedPointerFromInternalField(index);
-  if (type_ptr == nullptr) {
-    return StartupData{nullptr, 0};
-  }
-
-  uint16_t type = *(static_cast<uint16_t*>(type_ptr));
-  per_process::Debug(DebugCategory::MKSNAPSHOT, "type = 0x%x\n", type);
-  if (type != kNodeEmbedderId) {
+  if (index != BaseObject::kEmbedderType || !BaseObject::IsBaseObject(holder)) {
     return StartupData{nullptr, 0};
   }
 

--- a/src/node_sockaddr.cc
+++ b/src/node_sockaddr.cc
@@ -701,7 +701,6 @@ Local<FunctionTemplate> SocketAddressBlockListWrap::GetConstructorTemplate(
     Isolate* isolate = env->isolate();
     tmpl = NewFunctionTemplate(isolate, SocketAddressBlockListWrap::New);
     tmpl->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "BlockList"));
-    tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
     tmpl->InstanceTemplate()->SetInternalFieldCount(kInternalFieldCount);
     SetProtoMethod(isolate, tmpl, "addAddress", AddAddress);
     SetProtoMethod(isolate, tmpl, "addRange", AddRange);
@@ -757,7 +756,6 @@ Local<FunctionTemplate> SocketAddressBase::GetConstructorTemplate(
     tmpl->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "SocketAddress"));
     tmpl->InstanceTemplate()->SetInternalFieldCount(
         SocketAddressBase::kInternalFieldCount);
-    tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
     SetProtoMethod(isolate, tmpl, "detail", Detail);
     SetProtoMethod(isolate, tmpl, "legacyDetail", LegacyDetail);
     SetProtoMethodNoSideEffect(isolate, tmpl, "flowlabel", GetFlowLabel);

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -137,7 +137,6 @@ void NodeCategorySet::Initialize(Local<Object> target,
       NewFunctionTemplate(isolate, NodeCategorySet::New);
   category_set->InstanceTemplate()->SetInternalFieldCount(
       NodeCategorySet::kInternalFieldCount);
-  category_set->Inherit(BaseObject::GetConstructorTemplate(env));
   SetProtoMethod(isolate, category_set, "enable", NodeCategorySet::Enable);
   SetProtoMethod(isolate, category_set, "disable", NodeCategorySet::Disable);
 

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -468,7 +468,6 @@ void Initialize(Local<Object> target,
       NewFunctionTemplate(isolate, WeakReference::New);
   weak_ref->InstanceTemplate()->SetInternalFieldCount(
       WeakReference::kInternalFieldCount);
-  weak_ref->Inherit(BaseObject::GetConstructorTemplate(env));
   SetProtoMethod(isolate, weak_ref, "get", WeakReference::Get);
   SetProtoMethod(isolate, weak_ref, "getRef", WeakReference::GetRef);
   SetProtoMethod(isolate, weak_ref, "incRef", WeakReference::IncRef);

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -1271,7 +1271,6 @@ static void InitializePreview1(Local<Object> target,
 
   Local<FunctionTemplate> tmpl = NewFunctionTemplate(isolate, WASI::New);
   tmpl->InstanceTemplate()->SetInternalFieldCount(WASI::kInternalFieldCount);
-  tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
 
 #define V(F, name)                                                             \
   SetFunction<decltype(&WASI::F), WASI::F>(WASI::F, env, name, tmpl);

--- a/src/node_wasm_web_api.cc
+++ b/src/node_wasm_web_api.cc
@@ -28,7 +28,6 @@ Local<Function> WasmStreamingObject::Initialize(Environment* env) {
 
   Isolate* isolate = env->isolate();
   Local<FunctionTemplate> t = NewFunctionTemplate(isolate, New);
-  t->Inherit(BaseObject::GetConstructorTemplate(env));
   t->InstanceTemplate()->SetInternalFieldCount(
       WasmStreamingObject::kInternalFieldCount);
 


### PR DESCRIPTION
Instead of storing the function template of BaseObject for checking if an object is BaseObject by calling HasInstance, simply checks the first internal field of the object, which is always set in the BaseObject constructor. This is simpler and faster (there is now no need to iterate over the inheritance for the check).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
