### PR TITLE
doc: update output of example in AbortController

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -43,7 +43,7 @@ ac.signal.addEventListener('abort', () => console.log('Aborted!'),
 
 ac.abort();
 
-console.log(ac.signal.aborted);  // Prints True
+console.log(ac.signal.aborted);  // Prints true
 ```
 
 ### `abortController.abort([reason])`
@@ -196,7 +196,7 @@ An optional reason specified when the `AbortSignal` was triggered.
 ```js
 const ac = new AbortController();
 ac.abort(new Error('boom!'));
-console.log(ac.signal.reason);  // Error('boom!');
+console.log(ac.signal.reason);  // Error: boom!
 ```
 
 #### `abortSignal.throwIfAborted()`

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -163,7 +163,7 @@ class AbortSignal extends EventTarget {
   }
 
   /**
-   * @param {any} reason
+   * @param {any} [reason]
    * @returns {AbortSignal}
    */
   static abort(
@@ -326,7 +326,7 @@ class AbortController {
   }
 
   /**
-   * @param {any} reason
+   * @param {any} [reason]
    */
   abort(reason = new DOMException('This operation was aborted', 'AbortError')) {
     abortSignal(this.#signal ??= createAbortSignal(), reason);


### PR DESCRIPTION
Actual output of example in AbortController is mismatched. Plus, make `reason` parameter as optional in JSDoc.

Refs: https://github.com/nodejs/node/blob/main/doc/api/globals.md#abortcontrollerabortreason
Refs: https://github.com/nodejs/node/blob/main/doc/api/globals.md#static-method-abortsignalabortreason

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
