### PR TITLE
Upgrading Windows on ARM64 to a tier 2 platform

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -113,7 +113,7 @@ platforms. This is true regardless of entries in the table below.
 | Windows          | x64, x86 (WoW64) | >= Windows 10/Server 2016         | Tier 1                                          | [^2],[^3]                            |
 | Windows          | x86 (native)     | >= Windows 10/Server 2016         | Tier 1 (running) / Experimental (compiling)[^4] |                                      |
 | Windows          | x64, x86         | Windows 8.1/Server 2012           | Experimental                                    |                                      |
-| Windows          | arm64            | >= Windows 10                     | Tier 2 (compiling) / Experimental (running)     |                                      |
+| Windows          | arm64            | >= Windows 10                     | Tier 2                                          |                                      |
 | macOS            | x64              | >= 10.15                          | Tier 1                                          | For notes about compilation see [^5] |
 | macOS            | arm64            | >= 11                             | Tier 1                                          |                                      |
 | SmartOS          | x64              | >= 18                             | Tier 2                                          |                                      |


### PR DESCRIPTION
Official support for ARM64 Windows is something many people have been looking forward to for years. We recently added test machines to Jenkins, and tests are being run for every PR. We would like to move forward and move ARM64 Windows to tier 2.

@nodejs/build if this PR is approved, @joaocgreis and I will add arm64 to the release Jenkins to start producing releases.

This should land on v19. Node v18 and prior versions have failing tests.

cc @nodejs/tsc 

Refs: https://github.com/nodejs/build/issues/3046
Refs: https://github.com/nodejs/build/issues/2540
Fixes: https://github.com/nodejs/node/issues/25998