### PR TITLE
Fix test-child-process-exec-cwd for Windows on ARM64

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -16,7 +16,6 @@ test-fs-rmdir-recursive: PASS, FLAKY
 
 # Windows on ARM
 [$system==win32 && $arch==arm64]
-test-child-process-exec-cwd: SKIP
 
 [$system==linux]
 # https://github.com/nodejs/node/issues/39368

--- a/test/parallel/test-child-process-exec-cwd.js
+++ b/test/parallel/test-child-process-exec-cwd.js
@@ -35,5 +35,5 @@ if (common.isWindows) {
 }
 
 exec(pwdcommand, { cwd: dir }, common.mustSucceed((stdout, stderr) => {
-  assert(stdout.startsWith(dir));
+  assert(stdout.toLowerCase().startsWith(dir));
 }));


### PR DESCRIPTION
This PR fixes the previously skipped `test-child-process-exec-cwd` on Windows on ARM64. The issue was the casing of stdout for that platform.

cc: @targos (https://github.com/nodejs/node/pull/47020#discussion_r1142306028) @nodejs/platform-windows-arm

Refs: https://github.com/nodejs/node/pull/47020
Refs: https://github.com/nodejs/build/issues/3046