### PR TITLE
deps: V8: cherry-pick 3e4952cb2a59

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.10',
+    'v8_embedder_string': '-node.11',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/test/cctest/compiler/test-operator.cc
+++ b/deps/v8/test/cctest/compiler/test-operator.cc
@@ -210,7 +210,7 @@ TEST(TestOperator1double_Equals) {
   CHECK(!op2b.Equals(&op1a));
   CHECK(!op2b.Equals(&op1b));
 
-  Operator op3(25, NONE, "Weepy", 0, 0, 0, 0, 0, 0);
+  Operator1<double> op3(25, NONE, "Weepy", 0, 0, 0, 0, 0, 0, 1.1);
 
   CHECK(!op1a.Equals(&op3));
   CHECK(!op1b.Equals(&op3));


### PR DESCRIPTION
Original commit message:

    [test] fix uninitialized error

    In op1a.Equals(&op3) call, that->parameter() is undefined.
    which triggers uninitialized error from gcc.

    Change-Id: I87f1fcba3e57adbb5a1e745a3d787c62a87fd1d3
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4307714
    Commit-Queue: Toon Verwaest <verwaest@chromium.org>
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#86267}

Refs: https://github.com/v8/v8/commit/3e4952cb2a5969e42e782a66b948dc0ee88c812e

---

Fixes the V8 CI with gcc-10 (thanks @john-yan). 
https://ci.nodejs.org/job/node-test-commit-v8-linux/5241/nodes=rhel8-s390x,v8test=v8test/console
```console
15:39:58 In file included from ../../test/cctest/compiler/test-operator.cc:8:
15:39:58 ../../src/compiler/operator.h: In function ‘void v8::internal::compiler::TestTestOperator1double_Equals()’:
15:39:58 ../../src/compiler/operator.h:185:23: error: array subscript 6 is outside array bounds of ‘v8::internal::compiler::Operator [1]’ [-Werror=array-bounds]
15:39:58   185 |     return this->pred_(this->parameter(), that->parameter());
15:39:58       |            ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
15:39:58 ../../test/cctest/compiler/test-operator.cc:213:12: note: while referencing ‘op3’
15:39:58   213 |   Operator op3(25, NONE, "Weepy", 0, 0, 0, 0, 0, 0);
15:39:58       |            ^~~
```

cc @nodejs/v8-update 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
