### PR TITLE
src,http2: ensure cleanup if a frame is not sent

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1072,8 +1072,7 @@ int Http2Session::OnFrameNotSent(nghttp2_session* handle,
   // Do not report if the frame was not sent due to the session closing
   if (error_code == NGHTTP2_ERR_SESSION_CLOSING ||
       error_code == NGHTTP2_ERR_STREAM_CLOSED ||
-      error_code == NGHTTP2_ERR_STREAM_CLOSING ||
-      session->js_fields_->frame_error_listener_count == 0) {
+      error_code == NGHTTP2_ERR_STREAM_CLOSING) {
     // Nghttp2 contains header limit of 65536. When this value is exceeded the
     // pipeline is stopped and we should remove the current headers reference
     // to destroy the session completely.

--- a/test/parallel/test-h2-large-header-cause-client-to-hangup.js
+++ b/test/parallel/test-h2-large-header-cause-client-to-hangup.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+const assert = require('assert');
+const {
+  DEFAULT_SETTINGS_MAX_HEADER_LIST_SIZE,
+  NGHTTP2_CANCEL,
+} = http2.constants;
+
+const headerSize = DEFAULT_SETTINGS_MAX_HEADER_LIST_SIZE;
+const timeout = common.platformTimeout(2_000);
+const timer = setTimeout(() => assert.fail(`http2 client timedout
+when server can not manage to send a header of size ${headerSize}`), timeout);
+
+const server = http2.createServer((req, res) => {
+  res.setHeader('foobar', 'a'.repeat(DEFAULT_SETTINGS_MAX_HEADER_LIST_SIZE));
+  res.end();
+});
+
+server.listen(0, common.mustCall(() => {
+  const clientSession = http2.connect(`http://localhost:${server.address().port}`);
+  clientSession.on('close', common.mustCall());
+  clientSession.on('remoteSettings', send);
+
+  function send() {
+    const stream = clientSession.request({ ':path': '/' });
+    stream.on('close', common.mustCall(() => {
+      assert.strictEqual(stream.rstCode, NGHTTP2_CANCEL);
+      clearTimeout(timer);
+      server.close();
+    }));
+
+    stream.end();
+  }
+}));


### PR DESCRIPTION
Fix [41582](https://github.com/nodejs/node/issues/41582)
Call to JS and close the session if a frame is not sent even there is no frameError listener registered by user.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
