### PR TITLE
test: run doctool tests in parallel

### DIFF
--- a/test/doctool/testcfg.py
+++ b/test/doctool/testcfg.py
@@ -4,4 +4,4 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import testpy
 
 def GetConfiguration(context, root):
-    return testpy.SimpleTestConfiguration(context, root, 'doctool')
+    return testpy.ParallelTestConfiguration(context, root, 'doctool')


### PR DESCRIPTION
I don't see why we can't run doctool tests and wpt in parallel, so make them run in parallel.

About other non-parallel tests:

- benchmark: needs some refactoring in net and tls benchmarks to stop using common.PORT
- embedding: there is only one test, so making it run in parallel doesn't add much
- internet: needs refactoring to stop using common.PORT
- known-issues: usually not run anyway
- tick-processor: this does not even work locally for me?
- pummel: takes a long time to run anyway, which is its point, and I am not sure if it can actually be run in parallel

Refs: https://github.com/nodejs/node/issues/47146

EDIT: removed the WPT changes in favor of https://github.com/nodejs/node/pull/47283

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
