### PR TITLE
workflows: run timezone-update.yml everyday

### DIFF
--- a/.github/workflows/timezone-update.yml
+++ b/.github/workflows/timezone-update.yml
@@ -1,8 +1,8 @@
 name: Timezone update
 on:
   schedule:
-    # Run once a week at 00:05 AM UTC on Sunday.
-    - cron: 5 0 * * 0
+    # Run everyday at 00:05 AM UTC.
+    - cron: 5 0 * * *
 
   workflow_dispatch:
 


### PR DESCRIPTION
Updated [.github/workflows/timezone-update.yml](https://github.com/nodejs/node/blob/main/.github/workflows/timezone-update.yml) to run everyday.

This is needed to ensure that the tzdata updates can get merged into node quickly.