### PR TITLE
quic: do not dereference shared_ptr after move

### DIFF
--- a/src/quic/data.cc
+++ b/src/quic/data.cc
@@ -38,16 +38,16 @@ Store::Store(std::shared_ptr<v8::BackingStore> store,
              size_t length,
              size_t offset)
     : store_(std::move(store)), length_(length), offset_(offset) {
-  CHECK_LE(offset_, store->ByteLength());
-  CHECK_LE(length_, store->ByteLength() - offset_);
+  CHECK_LE(offset_, store_->ByteLength());
+  CHECK_LE(length_, store_->ByteLength() - offset_);
 }
 
 Store::Store(std::unique_ptr<v8::BackingStore> store,
              size_t length,
              size_t offset)
     : store_(std::move(store)), length_(length), offset_(offset) {
-  CHECK_LE(offset_, store->ByteLength());
-  CHECK_LE(length_, store->ByteLength() - offset_);
+  CHECK_LE(offset_, store_->ByteLength());
+  CHECK_LE(length_, store_->ByteLength() - offset_);
 }
 
 Store::Store(v8::Local<v8::ArrayBuffer> buffer, Option option)


### PR DESCRIPTION
The stored pointer is assumed to be `nullptr` after `std::move`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
