### PR TITLE
test: skip test-wasm-web-api on ARM

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -32,6 +32,8 @@ test-http-server-request-timeouts-mixed: PASS,FLAKY
 # https://github.com/nodejs/node/pull/31178
 test-crypto-dh-stateless: SKIP
 test-crypto-keygen: SKIP
+# https://github.com/nodejs/node/issues/47297
+test-wasm-web-api: SKIP
 
 [$system==solaris] # Also applies to SmartOS
 # https://github.com/nodejs/node/issues/43457


### PR DESCRIPTION
This test is flaky on ARM with V8 >= 11.2.
Skip it so we can update V8 before the release of Nodejs 20.0.0.

Refs: https://github.com/nodejs/node/pull/47251