### PR TITLE
[v19.x backport] deps: V8: cherry-pick cb30b8e17429

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/base/platform/platform.h
+++ b/deps/v8/src/base/platform/platform.h
@@ -654,9 +654,9 @@ class V8_BASE_EXPORT Stack {
     constexpr size_t kAsanRealFrameOffsetBytes = 32;
     void* real_frame = __asan_addr_is_in_fake_stack(
         __asan_get_current_fake_stack(), slot, nullptr, nullptr);
-    return real_frame
-               ? (static_cast<char*>(real_frame) + kAsanRealFrameOffsetBytes)
-               : slot;
+    return real_frame ? StackSlot(static_cast<char*>(real_frame) +
+                                  kAsanRealFrameOffsetBytes)
+                      : slot;
 #endif  // V8_USE_ADDRESS_SANITIZER
     return slot;
   }


### PR DESCRIPTION
Original commit message:

    Fix compilation error in platform.h for ASAN
    The last two operands of the conditional expression needs to be
    of the same type to compile.

    Change-Id: Ib6cba4acb1238394910c650c776a7fd1ee93721e
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4306802
    Commit-Queue: Joyee Cheung <joyee@igalia.com>
    Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#86235}

Refs: https://github.com/v8/v8/commit/cb30b8e1742938dff0a24470f24d649b1664f0c2
Refs: https://github.com/nodejs/node/issues/43370

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
