### PR TITLE
build, deps, tools: avoid excessive LTO

### DIFF
--- a/deps/openssl/openssl-cli.gypi
+++ b/deps/openssl/openssl-cli.gypi
@@ -21,5 +21,9 @@
         ],
       },
     }],
+    # Avoid excessive LTO
+    ['enable_lto=="true"', {
+      'ldflags': [ '-fno-lto' ],
+    }],
   ],
 }

--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -79,6 +79,10 @@
         }, {
           'includes': ['./openssl-cl_asm.gypi'],
         }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
      ]
     }, {
       # openssl-fipsmodule target

--- a/node.gyp
+++ b/node.gyp
@@ -966,6 +966,10 @@
         [ 'OS!="linux" or ossfuzz!="true"', {
           'type': 'none',
         }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
       ],
     }, # fuzz_env
     {
@@ -1067,6 +1071,10 @@
             'Ws2_32.lib',
           ],
         }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
       ],
     }, # cctest
 
@@ -1120,6 +1128,10 @@
             'Ws2_32.lib',
           ],
         }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
       ],
     }, # embedtest
 
@@ -1137,6 +1149,10 @@
           'sources': [
             'test/overlapped-checker/main_unix.c'
           ],
+        }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
         }],
       ]
     }, # overlapped-checker
@@ -1193,6 +1209,10 @@
             'winmm.lib',
             'Ws2_32.lib',
           ],
+        }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
         }],
       ],
     }, # node_mksnapshot

--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -428,6 +428,12 @@
         '<@(icu_src_derb)',
         'no-op.cc',
       ],
+      'conditions': [
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
+      ],
     },
     # This tool is used to rebuild res_index.res manifests
     {
@@ -438,6 +444,12 @@
       'sources': [
         'iculslocs.cc',
         'no-op.cc',
+      ],
+      'conditions': [
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
       ],
     },
     # This tool is used to package, unpackage, repackage .dat files
@@ -451,6 +463,12 @@
         '<@(icu_src_icupkg)',
         'no-op.cc',
       ],
+      'conditions': [
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
+      ],
     },
     # this is used to convert .dat directly into .obj
     {
@@ -461,6 +479,12 @@
       'sources': [
         '<@(icu_src_genccode)',
         'no-op.cc',
+      ],
+      'conditions': [
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
       ],
     },
   ],

--- a/tools/v8_gypfiles/d8.gyp
+++ b/tools/v8_gypfiles/d8.gyp
@@ -69,6 +69,10 @@
             '<(icu_gyp_path):icudata',
           ],
         }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
       ],
     },
   ],

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1397,6 +1397,10 @@
         ['want_separate_host_toolset', {
           'toolsets': ['host'],
         }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
       ],
       'defines!': [
         'BUILDING_V8_SHARED=1',
@@ -1441,6 +1445,10 @@
             '<(_msvs_precompiled_source)',
           ],
         }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
       ],
     },  # mksnapshot
     {
@@ -1453,6 +1461,10 @@
       'conditions': [
         ['want_separate_host_toolset', {
           'toolsets': ['host'],
+        }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
         }],
       ],
       'defines!': [
@@ -1488,6 +1500,10 @@
         ['want_separate_host_toolset', {
           'toolsets': ['host'],
         }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
       ],
       'dependencies': [
         'torque_base',
@@ -1520,6 +1536,10 @@
         ['want_separate_host_toolset', {
           'toolsets': ['host'],
         }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
+        }],
       ],
       'sources': [
         "<(V8_ROOT)/src/regexp/gen-regexp-special-case.cc",
@@ -1535,6 +1555,10 @@
           'dependencies': ['gen-regexp-special-case#host'],
         }, {
           'dependencies': ['gen-regexp-special-case#target'],
+        }],
+        # Avoid excessive LTO
+        ['enable_lto=="true"', {
+          'ldflags': [ '-fno-lto' ],
         }],
       ],
       'actions': [


### PR DESCRIPTION
Don't link intermediate executables with LTO in order to speed up overall build time.

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>