### PR TITLE
readline: fix issue with newline-less last line

### DIFF
--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -1324,21 +1324,19 @@ class Interface extends InterfaceConstructor {
           if (typeof s === 'string' && s) {
             // Erase state of previous searches.
             lineEnding.lastIndex = 0;
-            let nextMatch = RegExpPrototypeExec(lineEnding, s);
-            // If no line endings are found, just insert the string as is.
-            if (nextMatch === null) {
-              this[kInsertString](s);
-            } else {
-              // Keep track of the end of the last match.
-              let lastIndex = 0;
-              do {
-                this[kInsertString](StringPrototypeSlice(s, lastIndex, nextMatch.index));
-                ({ lastIndex } = lineEnding);
-                this[kLine]();
-                // Restore lastIndex as the call to kLine could have mutated it.
-                lineEnding.lastIndex = lastIndex;
-              } while ((nextMatch = RegExpPrototypeExec(lineEnding, s)) !== null);
+            let nextMatch;
+            // Keep track of the end of the last match.
+            let lastIndex = 0;
+            while ((nextMatch = RegExpPrototypeExec(lineEnding, s)) !== null) {
+              this[kInsertString](StringPrototypeSlice(s, lastIndex, nextMatch.index));
+              ({ lastIndex } = lineEnding);
+              this[kLine]();
+              // Restore lastIndex as the call to kLine could have mutated it.
+              lineEnding.lastIndex = lastIndex;
             }
+            // This ensures that the last line is written if it doesn't end in a newline.
+            // Note that the last line may be the first line, in which case this still works.
+            this[kInsertString](StringPrototypeSlice(s, lastIndex));
           }
       }
     }

--- a/test/fixtures/repl-load-multiline-no-trailing-newline.js
+++ b/test/fixtures/repl-load-multiline-no-trailing-newline.js
@@ -1,0 +1,6 @@
+const getLunch = () =>
+  placeOrder('tacos')
+    .then(eat);
+
+const placeOrder = (order) => Promise.resolve(order);
+const eat = (food) => '<nom nom nom>';

--- a/test/fixtures/repl-load-multiline-no-trailing-newline.js
+++ b/test/fixtures/repl-load-multiline-no-trailing-newline.js
@@ -1,3 +1,4 @@
+// The lack of a newline at the end of this file is intentional.
 const getLunch = () =>
   placeOrder('tacos')
     .then(eat);

--- a/test/parallel/test-readline-interface-no-trailing-newline.js
+++ b/test/parallel/test-readline-interface-no-trailing-newline.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const ArrayStream = require('../common/arraystream');
+const assert = require('assert');
+
+common.skipIfDumbTerminal();
+
+const readline = require('readline');
+const rli = new readline.Interface({
+  terminal: true,
+  input: new ArrayStream(),
+  output: new ArrayStream(),
+});
+
+// Minimal reproduction for #47305
+const testInput = '{\n}';
+
+let accum = '';
+
+rli.output.write = data => accum += data.replace('\r', '');
+
+rli.write(testInput);
+
+assert.strictEqual(accum, testInput);

--- a/test/parallel/test-readline-interface-no-trailing-newline.js
+++ b/test/parallel/test-readline-interface-no-trailing-newline.js
@@ -17,7 +17,7 @@ const testInput = '{\n}';
 
 let accum = '';
 
-rli.output.write = data => accum += data.replace('\r', '');
+rli.output.write = (data) => accum += data.replace('\r', '');
 
 rli.write(testInput);
 

--- a/test/parallel/test-repl-load-multiline-no-trailing-newline.js
+++ b/test/parallel/test-repl-load-multiline-no-trailing-newline.js
@@ -12,6 +12,7 @@ const terminalCode = '\u001b[1G\u001b[0J \u001b[1G';
 const terminalCodeRegex = new RegExp(terminalCode.replace(/\[/g, '\\['), 'g');
 
 const expected = `${command}
+// The lack of a newline at the end of this file is intentional.
 const getLunch = () =>
   placeOrder('tacos')
     .then(eat);

--- a/test/parallel/test-repl-load-multiline-no-trailing-newline.js
+++ b/test/parallel/test-repl-load-multiline-no-trailing-newline.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const ArrayStream = require('../common/arraystream');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const repl = require('repl');
+
+common.skipIfDumbTerminal();
+
+const command = `.load ${fixtures.path('repl-load-multiline-no-trailing-newline.js')}`;
+const terminalCode = '\u001b[1G\u001b[0J \u001b[1G';
+const terminalCodeRegex = new RegExp(terminalCode.replace(/\[/g, '\\['), 'g');
+
+const expected = `${command}
+const getLunch = () =>
+  placeOrder('tacos')
+    .then(eat);
+
+const placeOrder = (order) => Promise.resolve(order);
+const eat = (food) => '<nom nom nom>';
+undefined
+`;
+
+let accum = '';
+
+const inputStream = new ArrayStream();
+const outputStream = new ArrayStream();
+
+outputStream.write = (data) => accum += data.replace('\r', '');
+
+const r = repl.start({
+  prompt: '',
+  input: inputStream,
+  output: outputStream,
+  terminal: true,
+  useColors: false
+});
+
+r.write(`${command}\n`);
+assert.strictEqual(accum.replace(terminalCodeRegex, ''), expected);
+r.close();


### PR DESCRIPTION
The logic for reading lines was slightly flawed, in that it assumed there would be a final new line. It handled the case where there are no new lines, but this then broke if there were some new lines.

The fix in logic is basically removing the special case where there are no new lines by changing it to always read the final line with no new lines. This works because if a file contains no new lines, the final line is the first line, and all is well.

There is some subtlety in this functioning, however. If the last line contains no new lines, then `lastIndex` will be the start of the last line, and `kInsertString` will be called from that point. If it does contain a new line, `lastIndex` will be equal to `s.length`, so the slice will be the empty string.

Fixes: https://github.com/nodejs/node/issues/47305

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
