### PR TITLE
doc: remove Vladimir de Turckheim from Security release stewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,8 +806,6 @@ releases on a rotation basis as outlined in the
 * Datadog
   * [bengl](https://github.com/bengl) -
     **Bryan English** <<bryan@bryanenglish.com>> (he/him)
-  * [vdeturckheim](https://github.com/vdeturckheim) -
-    **Vladimir de Turckheim** <<vlad2t@hotmail.com>> (he/him)
 * NearForm
   * [RafaelGSS](https://github.com/RafaelGSS) -
     **Rafael Gonzaga** <<rafael.nunu@hotmail.com>> (he/him)

--- a/doc/contributing/security-release-process.md
+++ b/doc/contributing/security-release-process.md
@@ -32,7 +32,6 @@ The current security stewards are documented in the main Node.js
 | Datadog      | Bryan           |              |
 | IBM          | Joe             |              |
 | NearForm     | Rafael          |              |
-| Datadog      | Vladimir        |              |
 | NodeSource   | Juan            |              |
 | Red Hat      | Michael         |              |
 
@@ -109,7 +108,7 @@ The current security stewards are documented in the main Node.js
   For more information see: https://nodejs.org/en/blog/vulnerability/month-year-security-releases/
   ```
   (Get access from existing manager: Matteo Collina, Rodd Vagg, Michael Dawson,
-  Bryan English, Vladimir de Turckheim)
+  Bryan English)
 
 * [ ] CC `oss-security@lists.openwall.com` on pre-release
 


### PR DESCRIPTION
As announced internally a couple weeks ago, I am leaving Datadog tomorrow and will step down from Security release stewardship for the time being.