### PR TITLE
lib: remove multiple `noop` definition

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -80,6 +80,7 @@ const {
 } = codes;
 const {
   kEmptyObject,
+  noop,
 } = require('internal/util');
 const {
   validateInteger,
@@ -809,7 +810,6 @@ function onParserTimeout(server, socket) {
     socket.destroy();
 }
 
-const noop = () => {};
 const badRequestResponse = Buffer.from(
   `HTTP/1.1 400 ${STATUS_CODES[400]}\r\n` +
   'Connection: close\r\n\r\n', 'ascii',

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -25,7 +25,6 @@ const {
   ArrayPrototypeForEach,
   ArrayPrototypeJoin,
   ArrayPrototypePush,
-  FunctionPrototype,
   ObjectAssign,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
@@ -43,6 +42,7 @@ const {
   assertCrypto,
   deprecate,
   kEmptyObject,
+  noop,
 } = require('internal/util');
 
 assertCrypto();
@@ -113,8 +113,6 @@ const kPskCallback = Symbol('pskcallback');
 const kPskIdentityHint = Symbol('pskidentityhint');
 const kPendingSession = Symbol('pendingSession');
 const kIsVerified = Symbol('verified');
-
-const noop = FunctionPrototype;
 
 let ipServernameWarned = false;
 let tlsTracingWarned = false;

--- a/lib/internal/assert/calltracker.js
+++ b/lib/internal/assert/calltracker.js
@@ -4,7 +4,6 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeSlice,
   Error,
-  FunctionPrototype,
   ObjectFreeze,
   Proxy,
   ReflectApply,
@@ -19,11 +18,10 @@ const {
   },
 } = require('internal/errors');
 const AssertionError = require('internal/assert/assertion_error');
+const { noop } = require('internal/util');
 const {
   validateUint32,
 } = require('internal/validators');
-
-const noop = FunctionPrototype;
 
 class CallTrackerContext {
   #expected;

--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -2,7 +2,6 @@
 
 const {
   ArrayPrototypeJoin,
-  FunctionPrototype,
   ObjectAssign,
   ReflectApply,
   SafeMap,
@@ -17,12 +16,12 @@ const Worker = require('internal/cluster/worker');
 const { internal, sendHelper } = require('internal/cluster/utils');
 const { exitCodes: { kNoFailure } } = internalBinding('errors');
 const { TIMEOUT_MAX } = require('internal/timers');
+const { noop } = require('internal/util');
 const { setInterval, clearInterval } = require('timers');
 
 const cluster = new EventEmitter();
 const handles = new SafeMap();
 const indexes = new SafeMap();
-const noop = FunctionPrototype;
 
 module.exports = cluster;
 

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -4,7 +4,6 @@ const {
   ArrayPrototypeJoin,
   ArrayPrototypePush,
   ArrayPrototypeSome,
-  FunctionPrototype,
   ObjectSetPrototypeOf,
   PromiseResolve,
   PromisePrototypeThen,
@@ -21,14 +20,15 @@ const {
 
 const { ModuleWrap } = internalBinding('module_wrap');
 
-const { decorateErrorStack } = require('internal/util');
+const {
+  decorateErrorStack,
+  noop,
+} = require('internal/util');
 const {
   getSourceMapsEnabled,
 } = require('internal/source_map/source_map_cache');
 const assert = require('internal/assert');
 const resolvedPromise = PromiseResolve();
-
-const noop = FunctionPrototype;
 
 let hasPausedEntry = false;
 

--- a/lib/internal/repl/await.js
+++ b/lib/internal/repl/await.js
@@ -6,7 +6,6 @@ const {
   ArrayPrototypeJoin,
   ArrayPrototypePop,
   ArrayPrototypePush,
-  FunctionPrototype,
   ObjectKeys,
   RegExpPrototypeSymbolReplace,
   StringPrototypeEndsWith,
@@ -21,12 +20,12 @@ const {
 const parser = require('internal/deps/acorn/acorn/dist/acorn').Parser;
 const walk = require('internal/deps/acorn/acorn-walk/dist/walk');
 const { Recoverable } = require('internal/repl');
+const { noop } = require('internal/util');
 
 function isTopLevelDeclaration(state) {
   return state.ancestors[state.ancestors.length - 2] === state.body;
 }
 
-const noop = FunctionPrototype;
 const visitorsWithoutAncestors = {
   ClassDeclaration(node, state, c) {
     if (isTopLevelDeclaration(state)) {

--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -3,7 +3,6 @@
 const {
   ArrayPrototypeJoin,
   Boolean,
-  FunctionPrototype,
   RegExpPrototypeSymbolSplit,
   StringPrototypeTrim,
 } = primordials;
@@ -16,9 +15,8 @@ let debug = require('internal/util/debuglog').debuglog('repl', (fn) => {
   debug = fn;
 });
 const permission = require('internal/process/permission');
+const { noop } = require('internal/util');
 const { clearTimeout, setTimeout } = require('timers');
-
-const noop = FunctionPrototype;
 
 // XXX(chrisdickinson): The 15ms debounce value is somewhat arbitrary.
 // The debounce is to guard against code pasted into the REPL.

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -6,7 +6,6 @@ const {
   ArrayPrototypeSlice,
   ArrayPrototypeSome,
   ArrayPrototypeUnshift,
-  FunctionPrototype,
   MathMax,
   Number,
   ObjectSeal,
@@ -41,6 +40,7 @@ const {
 const {
   createDeferredPromise,
   kEmptyObject,
+  noop,
   once: runOnce,
 } = require('internal/util');
 const { isPromise } = require('internal/util/types');
@@ -63,7 +63,6 @@ const kTestCodeFailure = 'testCodeFailure';
 const kTestTimeoutFailure = 'testTimeoutFailure';
 const kHookFailure = 'hookFailed';
 const kDefaultTimeout = null;
-const noop = FunctionPrototype;
 const kShouldAbort = Symbol('kShouldAbort');
 const kFilename = process.argv?.[1];
 const kHookNames = ObjectSeal(['before', 'after', 'beforeEach', 'afterEach']);

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -8,6 +8,7 @@ const {
   ArrayPrototypeSlice,
   ArrayPrototypeSort,
   Error,
+  FunctionPrototype,
   FunctionPrototypeCall,
   ObjectDefineProperties,
   ObjectDefineProperty,
@@ -64,6 +65,8 @@ const {
 const { isNativeError } = internalBinding('types');
 
 const noCrypto = !process.versions.openssl;
+
+const noop = FunctionPrototype;
 
 const experimentalWarnings = new SafeSet();
 
@@ -777,6 +780,7 @@ module.exports = {
   join,
   lazyDOMException,
   lazyDOMExceptionClass,
+  noop,
   normalizeEncoding,
   once,
   promisify,

--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -9,6 +9,7 @@ const {
   StringPrototypeToUpperCase,
 } = primordials;
 
+const { noop } = require('internal/util');
 const { inspect, format, formatWithOptions } = require('internal/util/inspect');
 
 // `debugImpls` and `testEnabled` are deliberately not initialized so any call
@@ -42,8 +43,6 @@ function emitWarningIfNeeded(set) {
       'in the resulting log.');
   }
 }
-
-const noop = () => {};
 
 function debuglogImpl(enabled, set) {
   if (debugImpls[set] === undefined) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -109,7 +109,10 @@ const {
 } = require('internal/errors');
 const { isUint8Array } = require('internal/util/types');
 const { queueMicrotask } = require('internal/process/task_queues');
-const { kEmptyObject } = require('internal/util');
+const {
+  kEmptyObject,
+  noop,
+} = require('internal/util');
 const {
   validateAbortSignal,
   validateBoolean,
@@ -138,8 +141,6 @@ const DEFAULT_IPV4_ADDR = '0.0.0.0';
 const DEFAULT_IPV6_ADDR = '::';
 
 const isWindows = process.platform === 'win32';
-
-const noop = () => {};
 
 const kPerfHooksNetConnectContext = Symbol('kPerfHooksNetConnectContext');
 


### PR DESCRIPTION
Define `noop` in `internal/util`. And use it elsewhere.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
