### PR TITLE
Revert "util: reduce javascript call for ToUSVString"

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -69,8 +69,16 @@ const experimentalWarnings = new SafeSet();
 
 const colorRegExp = /\u001b\[\d\d?m/g; // eslint-disable-line no-control-regex
 
+const unpairedSurrogateRe =
+  /(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
 function toUSVString(val) {
-  return _toUSVString(`${val}`);
+  const str = `${val}`;
+  // As of V8 5.5, `str.search()` (and `unpairedSurrogateRe[@@search]()`) are
+  // slower than `unpairedSurrogateRe.exec()`.
+  const match = RegExpPrototypeExec(unpairedSurrogateRe, str);
+  if (!match)
+    return str;
+  return _toUSVString(str, match.index);
 }
 
 let uvBinding;

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -322,12 +322,16 @@ static void GuessHandleType(const FunctionCallbackInfo<Value>& args) {
 
 static void ToUSVString(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  CHECK_GE(args.Length(), 1);
+  CHECK_GE(args.Length(), 2);
   CHECK(args[0]->IsString());
+  CHECK(args[1]->IsNumber());
 
   TwoByteValue value(env->isolate(), args[0]);
 
-  for (size_t i = 0; i < value.length(); i++) {
+  int64_t start = args[1]->IntegerValue(env->context()).FromJust();
+  CHECK_GE(start, 0);
+
+  for (size_t i = start; i < value.length(); i++) {
     char16_t c = value[i];
     if (!IsUnicodeSurrogate(c)) {
       continue;


### PR DESCRIPTION
This PR reverts https://github.com/nodejs/node/pull/47192 due to https://github.com/nodejs/node/issues/47328. This change causes huge performance regression. Even though we have `dont-land` label on the PR, it is meddling with our benchmark results.

Fixes https://github.com/nodejs/node/issues/47328

cc @mscdex @targos 