### PR TITLE
test: verify tracePromise does not do runStores

### DIFF
--- a/test/parallel/test-diagnostics-channel-tracing-channel-promise-run-stores.js
+++ b/test/parallel/test-diagnostics-channel-tracing-channel-promise-run-stores.js
@@ -24,7 +24,7 @@ assert.strictEqual(store.getStore(), undefined);
 channel.tracePromise(common.mustCall(async () => {
   assert.deepStrictEqual(store.getStore(), firstContext);
   await setTimeout(1);
-  // Should _not_ switch to second context as promises don't have an "afer"
+  // Should _not_ switch to second context as promises don't have an "after"
   // point at which to do a runStores.
   assert.deepStrictEqual(store.getStore(), firstContext);
 }));


### PR DESCRIPTION
Just improving the test for this slightly. Chose to do a follow-up PR so as to not tempt fate with CI so soon before release cut-off. Requesting fast-track for this.