### PR TITLE
src: make AliasedBuffers in the binding data weak

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -59,9 +59,6 @@ const {
 const pathModule = require('path');
 const { isArrayBufferView } = require('internal/util/types');
 
-// We need to get the statValues from the binding at the callsite since
-// it's re-initialized after deserialization.
-
 const binding = internalBinding('fs');
 
 const { createBlobFromFilePath } = require('internal/blob');
@@ -78,7 +75,10 @@ const {
   uvException,
 } = require('internal/errors');
 
-const { FSReqCallback } = binding;
+const {
+  FSReqCallback,
+  statValues,
+} = binding;
 const { toPathIfFileURL } = require('internal/url');
 const {
   customPromisifyArgs: kCustomPromisifyArgsSymbol,
@@ -2569,8 +2569,8 @@ function realpathSync(p, options) {
 
     // Continue if not a symlink, break if a pipe/socket
     if (knownHard.has(base) || cache?.get(base) === base) {
-      if (isFileType(binding.statValues, S_IFIFO) ||
-          isFileType(binding.statValues, S_IFSOCK)) {
+      if (isFileType(statValues, S_IFIFO) ||
+          isFileType(statValues, S_IFSOCK)) {
         break;
       }
       continue;
@@ -2727,8 +2727,8 @@ function realpath(p, options, callback) {
 
     // Continue if not a symlink, break if a pipe/socket
     if (knownHard.has(base)) {
-      if (isFileType(binding.statValues, S_IFIFO) ||
-          isFileType(binding.statValues, S_IFSOCK)) {
+      if (isFileType(statValues, S_IFIFO) ||
+          isFileType(statValues, S_IFSOCK)) {
         return callback(null, encodeRealpathResult(p, options));
       }
       return process.nextTick(LOOP);

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -51,6 +51,7 @@ const {
 const binding = internalBinding('encoding_binding');
 const {
   encodeInto,
+  encodeIntoResults,
   encodeUtf8String,
   decodeUTF8,
 } = binding;
@@ -341,7 +342,7 @@ class TextEncoder {
     encodeInto(src, dest);
     // We need to read from the binding here since the buffer gets refreshed
     // from the snapshot.
-    const { 0: read, 1: written } = binding.encodeIntoResults;
+    const { 0: read, 1: written } = encodeIntoResults;
     return { read, written };
   }
 

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -139,6 +139,10 @@ const {
   kBytecodeAndMetadataSizeIndex,
   kExternalScriptSourceSizeIndex,
   kCPUProfilerMetaDataSizeIndex,
+
+  heapStatisticsBuffer,
+  heapCodeStatisticsBuffer,
+  heapSpaceStatisticsBuffer,
 } = binding;
 
 const kNumberOfHeapSpaces = kHeapSpaces.length;
@@ -170,7 +174,7 @@ function setFlagsFromString(flags) {
  *   }}
  */
 function getHeapStatistics() {
-  const buffer = binding.heapStatisticsBuffer;
+  const buffer = heapStatisticsBuffer;
 
   updateHeapStatisticsBuffer();
 
@@ -204,7 +208,7 @@ function getHeapStatistics() {
  */
 function getHeapSpaceStatistics() {
   const heapSpaceStatistics = new Array(kNumberOfHeapSpaces);
-  const buffer = binding.heapSpaceStatisticsBuffer;
+  const buffer = heapSpaceStatisticsBuffer;
 
   for (let i = 0; i < kNumberOfHeapSpaces; i++) {
     updateHeapSpaceStatisticsBuffer(i);
@@ -230,7 +234,7 @@ function getHeapSpaceStatistics() {
  *   }}
  */
 function getHeapCodeStatistics() {
-  const buffer = binding.heapCodeStatisticsBuffer;
+  const buffer = heapCodeStatisticsBuffer;
 
   updateHeapCodeStatisticsBuffer();
   return {

--- a/src/aliased_buffer-inl.h
+++ b/src/aliased_buffer-inl.h
@@ -70,14 +70,14 @@ AliasedBufferBase<NativeT, V8T>::AliasedBufferBase(
       count_(that.count_),
       byte_offset_(that.byte_offset_),
       buffer_(that.buffer_) {
-  DCHECK_NULL(index_);
+  DCHECK(is_valid());
   js_array_ = v8::Global<V8T>(that.isolate_, that.GetJSArray());
 }
 
 template <typename NativeT, typename V8T>
 AliasedBufferIndex AliasedBufferBase<NativeT, V8T>::Serialize(
     v8::Local<v8::Context> context, v8::SnapshotCreator* creator) {
-  DCHECK_NULL(index_);
+  DCHECK(is_valid());
   return creator->AddData(context, GetJSArray());
 }
 
@@ -100,7 +100,7 @@ inline void AliasedBufferBase<NativeT, V8T>::Deserialize(
 template <typename NativeT, typename V8T>
 AliasedBufferBase<NativeT, V8T>& AliasedBufferBase<NativeT, V8T>::operator=(
     AliasedBufferBase<NativeT, V8T>&& that) noexcept {
-  DCHECK_NULL(index_);
+  DCHECK(is_valid());
   this->~AliasedBufferBase();
   isolate_ = that.isolate_;
   count_ = that.count_;
@@ -116,7 +116,7 @@ AliasedBufferBase<NativeT, V8T>& AliasedBufferBase<NativeT, V8T>::operator=(
 
 template <typename NativeT, typename V8T>
 v8::Local<V8T> AliasedBufferBase<NativeT, V8T>::GetJSArray() const {
-  DCHECK_NULL(index_);
+  DCHECK(is_valid());
   return js_array_.Get(isolate_);
 }
 
@@ -127,6 +127,21 @@ void AliasedBufferBase<NativeT, V8T>::Release() {
 }
 
 template <typename NativeT, typename V8T>
+inline void AliasedBufferBase<NativeT, V8T>::WeakCallback(
+    const v8::WeakCallbackInfo<AliasedBufferBase<NativeT, V8T>>& data) {
+  AliasedBufferBase<NativeT, V8T>* buffer = data.GetParameter();
+  DCHECK(buffer->is_valid());
+  buffer->cleared_ = true;
+  buffer->js_array_.Reset();
+}
+
+template <typename NativeT, typename V8T>
+inline void AliasedBufferBase<NativeT, V8T>::MakeWeak() {
+  DCHECK(is_valid());
+  js_array_.SetWeak(this, WeakCallback, v8::WeakCallbackType::kParameter);
+}
+
+template <typename NativeT, typename V8T>
 v8::Local<v8::ArrayBuffer> AliasedBufferBase<NativeT, V8T>::GetArrayBuffer()
     const {
   return GetJSArray()->Buffer();
@@ -134,7 +149,7 @@ v8::Local<v8::ArrayBuffer> AliasedBufferBase<NativeT, V8T>::GetArrayBuffer()
 
 template <typename NativeT, typename V8T>
 inline const NativeT* AliasedBufferBase<NativeT, V8T>::GetNativeBuffer() const {
-  DCHECK_NULL(index_);
+  DCHECK(is_valid());
   return buffer_;
 }
 
@@ -147,14 +162,14 @@ template <typename NativeT, typename V8T>
 inline void AliasedBufferBase<NativeT, V8T>::SetValue(const size_t index,
                                                       NativeT value) {
   DCHECK_LT(index, count_);
-  DCHECK_NULL(index_);
+  DCHECK(is_valid());
   buffer_[index] = value;
 }
 
 template <typename NativeT, typename V8T>
 inline const NativeT AliasedBufferBase<NativeT, V8T>::GetValue(
     const size_t index) const {
-  DCHECK_NULL(index_);
+  DCHECK(is_valid());
   DCHECK_LT(index, count_);
   return buffer_[index];
 }
@@ -162,7 +177,7 @@ inline const NativeT AliasedBufferBase<NativeT, V8T>::GetValue(
 template <typename NativeT, typename V8T>
 typename AliasedBufferBase<NativeT, V8T>::Reference
 AliasedBufferBase<NativeT, V8T>::operator[](size_t index) {
-  DCHECK_NULL(index_);
+  DCHECK(is_valid());
   return Reference(this, index);
 }
 
@@ -178,7 +193,7 @@ size_t AliasedBufferBase<NativeT, V8T>::Length() const {
 
 template <typename NativeT, typename V8T>
 void AliasedBufferBase<NativeT, V8T>::reserve(size_t new_capacity) {
-  DCHECK_NULL(index_);
+  DCHECK(is_valid());
   DCHECK_GE(new_capacity, count_);
   DCHECK_EQ(byte_offset_, 0);
   const v8::HandleScope handle_scope(isolate_);
@@ -204,6 +219,11 @@ void AliasedBufferBase<NativeT, V8T>::reserve(size_t new_capacity) {
 
   buffer_ = new_buffer;
   count_ = new_capacity;
+}
+
+template <typename NativeT, typename V8T>
+inline bool AliasedBufferBase<NativeT, V8T>::is_valid() const {
+  return index_ == nullptr && !cleared_;
 }
 
 template <typename NativeT, typename V8T>

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -118,6 +118,14 @@ class AliasedBufferBase : public MemoryRetainer {
   void Release();
 
   /**
+   * Make the global reference to the typed array weak. The caller must make
+   * sure that no operation can be done on the AliasedBuffer when the typed
+   * array becomes unreachable. Usually this means the caller must maintain
+   * a JS reference to the typed array from JS object.
+   */
+  inline void MakeWeak();
+
+  /**
   *  Get the underlying v8::ArrayBuffer underlying the TypedArray and
   *  overlaying the native buffer
   */
@@ -164,11 +172,15 @@ class AliasedBufferBase : public MemoryRetainer {
   inline void MemoryInfo(node::MemoryTracker* tracker) const override;
 
  private:
+  inline bool is_valid() const;
+  static inline void WeakCallback(
+      const v8::WeakCallbackInfo<AliasedBufferBase<NativeT, V8T>>& data);
   v8::Isolate* isolate_ = nullptr;
   size_t count_ = 0;
   size_t byte_offset_ = 0;
   NativeT* buffer_ = nullptr;
   v8::Global<V8T> js_array_;
+  bool cleared_ = false;
 
   // Deserialize data
   const AliasedBufferIndex* index_ = nullptr;

--- a/src/encoding_binding.h
+++ b/src/encoding_binding.h
@@ -14,10 +14,13 @@ class ExternalReferenceRegistry;
 namespace encoding_binding {
 class BindingData : public SnapshotableObject {
  public:
-  BindingData(Realm* realm, v8::Local<v8::Object> obj);
+  struct InternalFieldInfo : public node::InternalFieldInfoBase {
+    AliasedBufferIndex encode_into_results_buffer;
+  };
 
-  using InternalFieldInfo = InternalFieldInfoBase;
-
+  BindingData(Realm* realm,
+              v8::Local<v8::Object> obj,
+              InternalFieldInfo* info = nullptr);
   SERIALIZABLE_OBJECT_METHODS()
   SET_BINDING_ID(encoding_binding_data)
 
@@ -39,6 +42,7 @@ class BindingData : public SnapshotableObject {
  private:
   static constexpr size_t kEncodeIntoResultsLength = 2;
   AliasedUint32Array encode_into_results_buffer_;
+  InternalFieldInfo* internal_field_info_ = nullptr;
 };
 
 }  // namespace encoding_binding

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -57,7 +57,15 @@ constexpr size_t kFsStatFsBufferLength =
 
 class BindingData : public SnapshotableObject {
  public:
-  explicit BindingData(Realm* realm, v8::Local<v8::Object> wrap);
+  struct InternalFieldInfo : public node::InternalFieldInfoBase {
+    AliasedBufferIndex stats_field_array;
+    AliasedBufferIndex stats_field_bigint_array;
+    AliasedBufferIndex statfs_field_array;
+    AliasedBufferIndex statfs_field_bigint_array;
+  };
+  explicit BindingData(Realm* realm,
+                       v8::Local<v8::Object> wrap,
+                       InternalFieldInfo* info = nullptr);
 
   AliasedFloat64Array stats_field_array;
   AliasedBigInt64Array stats_field_bigint_array;
@@ -68,13 +76,15 @@ class BindingData : public SnapshotableObject {
   std::vector<BaseObjectPtr<FileHandleReadWrap>>
       file_handle_read_wrap_freelist;
 
-  using InternalFieldInfo = InternalFieldInfoBase;
   SERIALIZABLE_OBJECT_METHODS()
   SET_BINDING_ID(fs_binding_data)
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_SELF_SIZE(BindingData)
   SET_MEMORY_INFO_NAME(BindingData)
+
+ private:
+  InternalFieldInfo* internal_field_info_ = nullptr;
 };
 
 // structure used to store state during a complex operation, e.g., mkdirp.

--- a/src/node_realm-inl.h
+++ b/src/node_realm-inl.h
@@ -80,12 +80,14 @@ inline T* Realm::GetBindingData(v8::Local<v8::Context> context) {
   return result;
 }
 
-template <typename T>
+template <typename T, typename... Args>
 inline T* Realm::AddBindingData(v8::Local<v8::Context> context,
-                                v8::Local<v8::Object> target) {
+                                v8::Local<v8::Object> target,
+                                Args&&... args) {
   DCHECK_EQ(GetCurrent(context), this);
   // This won't compile if T is not a BaseObject subclass.
-  BaseObjectPtr<T> item = MakeDetachedBaseObject<T>(this, target);
+  BaseObjectPtr<T> item =
+      MakeDetachedBaseObject<T>(this, target, std::forward<Args>(args)...);
   BindingDataStore* map =
       static_cast<BindingDataStore*>(context->GetAlignedPointerFromEmbedderData(
           ContextEmbedderIndex::kBindingDataStoreIndex));

--- a/src/node_realm.h
+++ b/src/node_realm.h
@@ -92,9 +92,10 @@ class Realm : public MemoryRetainer {
   // Methods created using SetMethod(), SetPrototypeMethod(), etc. inside
   // this scope can access the created T* object using
   // GetBindingData<T>(args) later.
-  template <typename T>
+  template <typename T, typename... Args>
   T* AddBindingData(v8::Local<v8::Context> context,
-                    v8::Local<v8::Object> target);
+                    v8::Local<v8::Object> target,
+                    Args&&... args);
   template <typename T, typename U>
   static inline T* GetBindingData(const v8::PropertyCallbackInfo<U>& info);
   template <typename T>

--- a/src/node_v8.h
+++ b/src/node_v8.h
@@ -18,9 +18,14 @@ struct InternalFieldInfoBase;
 namespace v8_utils {
 class BindingData : public SnapshotableObject {
  public:
-  BindingData(Realm* realm, v8::Local<v8::Object> obj);
-
-  using InternalFieldInfo = InternalFieldInfoBase;
+  struct InternalFieldInfo : public node::InternalFieldInfoBase {
+    AliasedBufferIndex heap_statistics_buffer;
+    AliasedBufferIndex heap_space_statistics_buffer;
+    AliasedBufferIndex heap_code_statistics_buffer;
+  };
+  BindingData(Realm* realm,
+              v8::Local<v8::Object> obj,
+              InternalFieldInfo* info = nullptr);
 
   SERIALIZABLE_OBJECT_METHODS()
   SET_BINDING_ID(v8_binding_data)
@@ -32,6 +37,9 @@ class BindingData : public SnapshotableObject {
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_SELF_SIZE(BindingData)
   SET_MEMORY_INFO_NAME(BindingData)
+
+ private:
+  InternalFieldInfo* internal_field_info_ = nullptr;
 };
 
 class GCProfiler : public BaseObject {


### PR DESCRIPTION
src: make AliasedBuffers in the binding data weak

The binding data holds references to the AliasedBuffers directly
from their wrappers which already ensures that the AliasedBuffers
won't be accessed when the wrappers are GC'ed. So we can just
make the global references to the AliasedBuffers weak. This way
we can simply deserialize the typed arrays when deserialize the
binding data and avoid the extra Object::Set() calls. It also
eliminates the caveat in the JS land where aliased buffers must
be dynamically read from the binding.

Refs: https://github.com/nodejs/node/issues/47353

(This doesn't fix https://github.com/nodejs/node/pull/47353, but it makes sense on its own, and at least reduces the number of unnecessary global references...)
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
