### PR TITLE
src: get and set all V8 flags from V8 (WIP)

### DIFF
--- a/deps/v8/include/v8-initialization.h
+++ b/deps/v8/include/v8-initialization.h
@@ -89,6 +89,11 @@ class V8_EXPORT V8 {
   static void SetFlagsFromCommandLine(int* argc, char** argv,
                                       bool remove_flags);
 
+  /**
+   * Gets V8 flags names and stores them in the provided vector.
+   */
+  static std::vector<const char*> GetFlagsNames();
+
   /** Get the version string. */
   static const char* GetVersion();
 

--- a/deps/v8/include/v8-initialization.h
+++ b/deps/v8/include/v8-initialization.h
@@ -7,6 +7,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string>
 
 #include "v8-callbacks.h"  // NOLINT(build/include_directory)
 #include "v8-internal.h"   // NOLINT(build/include_directory)
@@ -92,7 +93,12 @@ class V8_EXPORT V8 {
   /**
    * Gets V8 flags names and stores them in the provided vector.
    */
-  static std::vector<const char*> GetFlagsNames();
+  static std::vector<std::string> GetFlagsNames();
+
+  /**
+   * Gets a V8 flag comment
+   */
+  static const char* GetFlagComment(const char* flag_name);
 
   /** Get the version string. */
   static const char* GetVersion();

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -45,6 +45,7 @@
 #include "src/common/globals.h"
 #include "src/compiler-dispatcher/lazy-compile-dispatcher.h"
 #include "src/date/date.h"
+#include "src/flags/flags.h"
 #include "src/objects/primitive-heap-object.h"
 #if V8_ENABLE_WEBASSEMBLY
 #include "src/debug/debug-wasm-objects.h"
@@ -687,8 +688,12 @@ void V8::SetFlagsFromCommandLine(int* argc, char** argv, bool remove_flags) {
                                        HelpOptions(HelpOptions::kDontExit));
 }
 
-std::vector<const char*> V8::GetFlagsNames() {
+std::vector<std::string> V8::GetFlagsNames() {
   return i::FlagList::GetNames();
+}
+
+const char* V8::GetFlagComment(const char* flag_name) {
+  return i::FlagList::GetFlagComment(flag_name);
 }
 
 RegisteredExtension* RegisteredExtension::first_extension_ = nullptr;

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -687,6 +687,10 @@ void V8::SetFlagsFromCommandLine(int* argc, char** argv, bool remove_flags) {
                                        HelpOptions(HelpOptions::kDontExit));
 }
 
+std::vector<const char*> V8::GetFlagsNames() {
+  return i::FlagList::GetNames();
+}
+
 RegisteredExtension* RegisteredExtension::first_extension_ = nullptr;
 
 RegisteredExtension::RegisteredExtension(std::unique_ptr<Extension> extension)
@@ -6326,7 +6330,7 @@ void v8::V8::InitializeExternalStartupDataFromFile(const char* snapshot_blob) {
   i::InitializeExternalStartupDataFromFile(snapshot_blob);
 }
 
-const char* v8::V8::GetVersion() { return i::Version::GetVersion(); }
+const char* V8::GetVersion() { return i::Version::GetVersion(); }
 
 #ifdef V8_ENABLE_SANDBOX
 VirtualAddressSpace* v8::V8::GetSandboxAddressSpace() {

--- a/deps/v8/src/flags/flags.cc
+++ b/deps/v8/src/flags/flags.cc
@@ -104,6 +104,15 @@ struct Flag {
 
   const char* name() const { return name_; }
 
+  std::string normalized_name() const {
+    std::string normalized_name_;
+    for (const char* p = name(); *p; ++p) {
+      normalized_name_ += NormalizeChar(*p);
+    }
+
+    return normalized_name_;
+  }
+
   const char* comment() const { return cmt_; }
 
   bool PointsTo(const void* ptr) const { return valptr_ == ptr; }
@@ -411,6 +420,13 @@ bool EqualNames(const char* a, const char* b) {
 Flag* FindFlagByName(const char* name) {
   for (size_t i = 0; i < kNumFlags; ++i) {
     if (EqualNames(name, flags[i].name())) return &flags[i];
+  }
+  return nullptr;
+}
+
+const char* FindFlagComment(const char* name) {
+  for (size_t i = 0; i < kNumFlags; ++i) {
+    if (EqualNames(name, flags[i].name())) return flags[i].comment();
   }
   return nullptr;
 }
@@ -834,15 +850,17 @@ void FlagList::PrintValues() {
 }
 
 // static
-std::vector<const char*> FlagList::GetNames() {
-  std::vector<const char*> stor;
-  for (const Flag& f : flags) {
-    std::string parsed_name;
-    FlagName flag_name = FlagName{f.name()};
-    for (const char* p = flag_name.name; *p; ++p) parsed_name += NormalizeChar(*p);
-    stor.push_back(parsed_name.c_str());
+std::vector<std::string> FlagList::GetNames() {
+  std::vector<std::string> stor;
+  for (Flag& flag : flags) {
+    stor.push_back(flag.normalized_name());
   }
+
   return stor;
+}
+
+const char* FlagList::GetFlagComment(const char* flag_name) {
+  return FindFlagComment(flag_name);
 }
 
 namespace {

--- a/deps/v8/src/flags/flags.cc
+++ b/deps/v8/src/flags/flags.cc
@@ -833,6 +833,18 @@ void FlagList::PrintValues() {
   }
 }
 
+// static
+std::vector<const char*> FlagList::GetNames() {
+  std::vector<const char*> stor;
+  for (const Flag& f : flags) {
+    std::string parsed_name;
+    FlagName flag_name = FlagName{f.name()};
+    for (const char* p = flag_name.name; *p; ++p) parsed_name += NormalizeChar(*p);
+    stor.push_back(parsed_name.c_str());
+  }
+  return stor;
+}
+
 namespace {
 
 class ImplicationProcessor {

--- a/deps/v8/src/flags/flags.h
+++ b/deps/v8/src/flags/flags.h
@@ -133,7 +133,10 @@ class V8_EXPORT_PRIVATE FlagList {
   static void PrintValues();
 
   // Get all the flags names and store them in the privided vector.
-  static std::vector<const char*> GetNames();
+  static std::vector<std::string> GetNames();
+
+  // Get the flag comment
+  static const char* GetFlagComment(const char*);
 
   // Set flags as consequence of being implied by another flag.
   static void EnforceFlagImplications();

--- a/deps/v8/src/flags/flags.h
+++ b/deps/v8/src/flags/flags.h
@@ -132,6 +132,9 @@ class V8_EXPORT_PRIVATE FlagList {
 
   static void PrintValues();
 
+  // Get all the flags names and store them in the privided vector.
+  static std::vector<const char*> GetNames();
+
   // Set flags as consequence of being implied by another flag.
   static void EnforceFlagImplications();
 

--- a/deps/v8/test/unittests/flags/flags-getters-setters.cc
+++ b/deps/v8/test/unittests/flags/flags-getters-setters.cc
@@ -1,0 +1,25 @@
+// Copyright 2023 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include <vector>
+#include <string>
+
+#include "include/v8-initialization.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+std::vector<std::string> v8_available_flags = v8::V8::GetFlagsNames();
+
+TEST(FlagGetterTest, FlagsGetter) {
+  // All flags should be normalized (using '-' instead of '_')
+  for (std::string& flag : v8_available_flags) {
+    EXPECT_EQ(flag.find('_'), std::string::npos);
+  }
+}
+
+TEST(FlagGetterTest, FlagsComment) {
+  // All flags should be normalized (using '-' instead of '_')
+  std::vector<std::string> v8_available_flags = v8::V8::GetFlagsNames();
+  for (std::string& flag : v8_available_flags) {
+    ASSERT_NE(v8::V8::GetFlagComment(flag.c_str()), nullptr);
+  }
+}

--- a/src/node.cc
+++ b/src/node.cc
@@ -927,6 +927,15 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
       return result;
     }
 
+    std::vector<std::string> v8_available_flags = v8::V8::GetFlagsNames();
+
+    for (size_t i = 0; i < v8_available_flags.size(); ++i) {
+      fprintf(stdout, "THE V8 FLAG IS: %s\n", v8_available_flags[i].c_str());
+      fprintf(stdout, "THE V8 FLAG comment: %s\n", v8::V8::GetFlagComment(v8_available_flags[i].c_str()));
+    }
+
+
+
     if (per_process::cli_options->print_v8_help) {
       V8::SetFlagsFromString("--help", static_cast<size_t>(6));
       result->exit_code_ = ExitCode::kNoFailure;

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -6,6 +6,7 @@
 #include "node_external_reference.h"
 #include "node_internals.h"
 #include "node_sea.h"
+#include "v8.h"
 #if HAVE_OPENSSL
 #include "openssl/opensslv.h"
 #endif
@@ -738,6 +739,14 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
 
 PerIsolateOptionsParser::PerIsolateOptionsParser(
   const EnvironmentOptionsParser& eop) {
+
+  std::vector<const char*> v8_available_flags = v8::V8::GetFlagsNames();
+  for (size_t i = 0; i < v8_available_flags.size(); ++i) {
+    std::string v8Opt = "--";
+    v8Opt.append(v8_available_flags[i]);
+    AddOption(v8Opt.c_str(), "", V8Option{}, kAllowedInEnvvar);
+  }
+
   AddOption("--track-heap-objects",
             "track heap object allocations for heap snapshots",
             &PerIsolateOptions::track_heap_objects,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -740,11 +740,13 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
 PerIsolateOptionsParser::PerIsolateOptionsParser(
   const EnvironmentOptionsParser& eop) {
 
-  std::vector<const char*> v8_available_flags = v8::V8::GetFlagsNames();
-  for (size_t i = 0; i < v8_available_flags.size(); ++i) {
-    std::string v8Opt = "--";
-    v8Opt.append(v8_available_flags[i]);
-    AddOption(v8Opt.c_str(), "", V8Option{}, kAllowedInEnvvar);
+  std::vector<std::string> v8_available_flags = v8::V8::GetFlagsNames();
+  for (std::string& flag : v8_available_flags) {
+    std::string flagName = "--" + flag;
+    AddOption(flagName.c_str(),
+              v8::V8::GetFlagComment(flag.c_str()),
+              V8Option{},
+              kAllowedInEnvvar);
   }
 
   AddOption("--track-heap-objects",


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/46339

I will send the V8 changes to the V8 team, they will probably change some things :)
Anyway, this is just a PoC; please let me know if this is what we want in Node.js

V8 issue: https://bugs.chromium.org/p/v8/issues/detail?id=13900
V8 CL: https://chromium-review.googlesource.com/c/v8/v8/+/4393070
<details>
<summary>These are the printfs in the `node.cc` code</summary>

```console
THE V8 FLAG IS: abort-on-contradictory-flags
THE V8 FLAG comment: Disallow flags or implications overriding each other.
THE V8 FLAG IS: exit-on-contradictory-flags
THE V8 FLAG comment: Exit with return code 0 on contradictory flags.
THE V8 FLAG IS: allow-overwriting-for-next-flag
THE V8 FLAG comment: temporary disable flag contradiction to allow overwriting just the next flag
THE V8 FLAG IS: use-strict
THE V8 FLAG comment: enforce strict mode
THE V8 FLAG IS: trace-temporal
THE V8 FLAG comment: trace temporal code
THE V8 FLAG IS: harmony
THE V8 FLAG comment: enable all completed harmony features
THE V8 FLAG IS: harmony-shipping
THE V8 FLAG comment: enable all shipped harmony features
THE V8 FLAG IS: harmony-weak-refs-with-cleanup-some
THE V8 FLAG comment: enable "harmony weak references with FinalizationRegistry.prototype.cleanupSome" (in progress)
THE V8 FLAG IS: harmony-temporal
THE V8 FLAG comment: enable "Temporal" (in progress)
THE V8 FLAG IS: harmony-shadow-realm
THE V8 FLAG comment: enable "harmony ShadowRealm" (in progress)
THE V8 FLAG IS: harmony-struct
THE V8 FLAG comment: enable "harmony structs, shared structs, and shared arrays" (in progress)
THE V8 FLAG IS: harmony-regexp-unicode-sets
THE V8 FLAG comment: enable "harmony RegExp Unicode Sets" (in progress)
THE V8 FLAG IS: harmony-json-parse-with-source
THE V8 FLAG comment: enable "harmony json parse with source" (in progress)
THE V8 FLAG IS: harmony-intl-best-fit-matcher
THE V8 FLAG comment: enable "Intl BestFitMatcher" (in progress)
THE V8 FLAG IS: harmony-intl-duration-format
THE V8 FLAG comment: enable "Intl DurationFormat API" (in progress)
THE V8 FLAG IS: harmony-rab-gsab
THE V8 FLAG comment: enable "harmony ResizableArrayBuffer / GrowableSharedArrayBuffer"
THE V8 FLAG IS: harmony-array-grouping
THE V8 FLAG comment: enable "harmony array grouping"
THE V8 FLAG IS: harmony-change-array-by-copy
THE V8 FLAG comment: enable "harmony change-Array-by-copy"
THE V8 FLAG IS: harmony-sharedarraybuffer
THE V8 FLAG comment: enable "harmony sharedarraybuffer"
THE V8 FLAG IS: harmony-atomics
THE V8 FLAG comment: enable "harmony atomics"
THE V8 FLAG IS: harmony-class-static-blocks
THE V8 FLAG comment: enable "harmony static initializer blocks"
THE V8 FLAG IS: harmony-array-find-last
THE V8 FLAG comment: enable "harmony array find last helpers"
THE V8 FLAG IS: harmony-import-assertions
THE V8 FLAG comment: enable "harmony import assertions"
THE V8 FLAG IS: harmony-symbol-as-weakmap-key
THE V8 FLAG comment: enable "harmony symbols as weakmap keys"
THE V8 FLAG IS: harmony-intl-number-format-v3
THE V8 FLAG comment: enable "Intl.NumberFormat v3"
THE V8 FLAG IS: builtin-subclassing
THE V8 FLAG comment: subclassing support in built-in methods
THE V8 FLAG IS: enable-sharedarraybuffer-per-context
THE V8 FLAG comment: enable the SharedArrayBuffer constructor per context
THE V8 FLAG IS: icu-timezone-data
THE V8 FLAG comment: get information about timezones from ICU
THE V8 FLAG IS: stress-snapshot
THE V8 FLAG comment: disables sharing of the read-only heap for testing
THE V8 FLAG IS: lite-mode
THE V8 FLAG comment: enables trade-off of performance for memory savings
THE V8 FLAG IS: future
THE V8 FLAG comment: Implies all staged features that we want to ship in the not-too-far future
THE V8 FLAG IS: lower-tier-as-toptier
THE V8 FLAG comment: remove tier-up logic from the top tier
THE V8 FLAG IS: maglev-filter
THE V8 FLAG comment: optimization filter for the maglev compiler
THE V8 FLAG IS: maglev-assert
THE V8 FLAG comment: insert extra assertion in maglev code
THE V8 FLAG IS: maglev-break-on-entry
THE V8 FLAG comment: insert an int3 on maglev entries
THE V8 FLAG IS: print-maglev-graph
THE V8 FLAG comment: print maglev graph
THE V8 FLAG IS: print-maglev-code
THE V8 FLAG comment: print maglev code
THE V8 FLAG IS: trace-maglev-graph-building
THE V8 FLAG comment: trace maglev graph building
THE V8 FLAG IS: trace-maglev-regalloc
THE V8 FLAG comment: trace maglev register allocation
THE V8 FLAG IS: maglev-function-context-specialization
THE V8 FLAG comment: enable function context specialization in maglev
THE V8 FLAG IS: maglev-ool-prologue
THE V8 FLAG comment: use the Maglev out of line prologue
THE V8 FLAG IS: max-opt
THE V8 FLAG comment: Set the maximal optimisation tier: > 3 == any, 0 == ignition/interpreter, 1 == sparkplug/baseline, 2 == maglev, 3 == turbofan
THE V8 FLAG IS: wasm-trace-native
THE V8 FLAG comment: Select which native code sequence to use for wasm trace instruction: default or cpuid
THE V8 FLAG IS: jitless
THE V8 FLAG comment: Disable runtime allocation of executable memory.
THE V8 FLAG IS: assert-types
THE V8 FLAG comment: generate runtime type assertions to test the typer
THE V8 FLAG IS: verify-simplified-lowering
THE V8 FLAG comment: verify graph generated by simplified lowering
THE V8 FLAG IS: trace-compilation-dependencies
THE V8 FLAG comment: trace code dependencies
THE V8 FLAG IS: allocation-site-pretenuring
THE V8 FLAG comment: pretenure with allocation sites
THE V8 FLAG IS: page-promotion
THE V8 FLAG comment: promote pages based on utilization
THE V8 FLAG IS: page-promotion-threshold
THE V8 FLAG comment: min percentage of live bytes on a page to enable fast evacuation
THE V8 FLAG IS: trace-pretenuring
THE V8 FLAG comment: trace pretenuring decisions of HAllocate instructions
THE V8 FLAG IS: trace-pretenuring-statistics
THE V8 FLAG comment: trace allocation site pretenuring statistics
THE V8 FLAG IS: track-field-types
THE V8 FLAG comment: track field types
THE V8 FLAG IS: trace-block-coverage
THE V8 FLAG comment: trace collected block coverage information
THE V8 FLAG IS: trace-protector-invalidation
THE V8 FLAG comment: trace protector cell invalidations
THE V8 FLAG IS: trace-web-snapshot
THE V8 FLAG comment: trace web snapshot deserialization
THE V8 FLAG IS: feedback-normalization
THE V8 FLAG comment: feed back normalization to constructors
THE V8 FLAG IS: unbox-double-arrays
THE V8 FLAG comment: automatically unbox arrays of doubles
THE V8 FLAG IS: interrupt-budget-for-feedback-allocation
THE V8 FLAG comment: The fixed interrupt budget (in bytecode size) for allocating feedback vectors
THE V8 FLAG IS: interrupt-budget-factor-for-feedback-allocation
THE V8 FLAG comment: The interrupt budget factor (applied to bytecode size) for allocating feedback vectors, used when bytecode size is known
THE V8 FLAG IS: interrupt-budget-for-maglev
THE V8 FLAG comment: interrupt budget which should be used for the profiler counter
THE V8 FLAG IS: interrupt-budget
THE V8 FLAG comment: interrupt budget which should be used for the profiler counter
THE V8 FLAG IS: ticks-before-optimization
THE V8 FLAG comment: the number of times we have to go through the interrupt budget before considering this function for optimization
THE V8 FLAG IS: bytecode-size-allowance-per-tick
THE V8 FLAG comment: increases the number of ticks required for optimization by bytecode.length/X
THE V8 FLAG IS: max-bytecode-size-for-early-opt
THE V8 FLAG comment: Maximum bytecode length for a function to be optimized on the first tick
THE V8 FLAG IS: use-ic
THE V8 FLAG comment: use inline caching
THE V8 FLAG IS: lazy-feedback-allocation
THE V8 FLAG comment: Allocate feedback vectors lazily
THE V8 FLAG IS: ignition-elide-noneffectful-bytecodes
THE V8 FLAG comment: elide bytecodes which won't have any external effect
THE V8 FLAG IS: ignition-reo
THE V8 FLAG comment: use ignition register equivalence optimizer
THE V8 FLAG IS: ignition-filter-expression-positions
THE V8 FLAG comment: filter expression positions before the bytecode pipeline
THE V8 FLAG IS: ignition-share-named-property-feedback
THE V8 FLAG comment: share feedback slots when loading the same named property from the same object
THE V8 FLAG IS: print-bytecode
THE V8 FLAG comment: print bytecode generated by ignition interpreter
THE V8 FLAG IS: enable-lazy-source-positions
THE V8 FLAG comment: skip generating source positions during initial compile but regenerate when actually required
THE V8 FLAG IS: stress-lazy-source-positions
THE V8 FLAG comment: collect lazy source positions immediately after lazy compile
THE V8 FLAG IS: print-bytecode-filter
THE V8 FLAG comment: filter for selecting which functions to print bytecode
THE V8 FLAG IS: omit-default-ctors
THE V8 FLAG comment: omit calling default ctors in bytecode
THE V8 FLAG IS: trace-ignition-codegen
THE V8 FLAG comment: trace the codegen of ignition interpreter bytecode handlers
THE V8 FLAG IS: trace-ignition-dispatches-output-file
THE V8 FLAG comment: write the bytecode handler dispatch table to the specified file (d8 only) (requires building with v8_enable_ignition_dispatch_counting)
THE V8 FLAG IS: trace-track-allocation-sites
THE V8 FLAG comment: trace the tracking of allocation sites
THE V8 FLAG IS: trace-migration
THE V8 FLAG comment: trace object migration
THE V8 FLAG IS: trace-generalization
THE V8 FLAG comment: trace map generalization
THE V8 FLAG IS: sparkplug
THE V8 FLAG comment: enable Sparkplug baseline compiler
THE V8 FLAG IS: always-sparkplug
THE V8 FLAG comment: directly tier up to Sparkplug code
THE V8 FLAG IS: baseline-batch-compilation
THE V8 FLAG comment: batch compile Sparkplug code
THE V8 FLAG IS: concurrent-sparkplug
THE V8 FLAG comment: compile Sparkplug code in a background thread
THE V8 FLAG IS: concurrent-sparkplug-max-threads
THE V8 FLAG comment: max number of threads that concurrent Sparkplug can use (0 for unbounded)
THE V8 FLAG IS: concurrent-sparkplug-high-priority-threads
THE V8 FLAG comment: use high priority compiler threads for concurrent Sparkplug
THE V8 FLAG IS: sparkplug-filter
THE V8 FLAG comment: filter for Sparkplug baseline compiler
THE V8 FLAG IS: sparkplug-needs-short-builtins
THE V8 FLAG comment: only enable Sparkplug baseline compiler when --short-builtin-calls are also enabled
THE V8 FLAG IS: baseline-batch-compilation-threshold
THE V8 FLAG comment: the estimated instruction size of a batch to trigger compilation
THE V8 FLAG IS: trace-baseline
THE V8 FLAG comment: trace baseline compilation
THE V8 FLAG IS: trace-baseline-batch-compilation
THE V8 FLAG comment: trace baseline batch compilation
THE V8 FLAG IS: trace-baseline-concurrent-compilation
THE V8 FLAG comment: trace baseline concurrent compilation
THE V8 FLAG IS: shared-string-table
THE V8 FLAG comment: internalize strings into shared table
THE V8 FLAG IS: always-use-string-forwarding-table
THE V8 FLAG comment: use string forwarding table instead of thin strings for all strings
THE V8 FLAG IS: initial-shared-heap-size
THE V8 FLAG comment: initial size of the shared heap (in Mbytes); other heap size flags (e.g. initial_heap_size) take precedence
THE V8 FLAG IS: max-shared-heap-size
THE V8 FLAG comment: max size of the shared heap (in Mbytes); other heap size flags (e.g. max_shared_heap_size) take precedence
THE V8 FLAG IS: write-code-using-rwx
THE V8 FLAG comment: flip permissions to rwx to write page instead of rw
THE V8 FLAG IS: concurrent-recompilation
THE V8 FLAG comment: optimizing hot functions asynchronously on a separate thread
THE V8 FLAG IS: trace-concurrent-recompilation
THE V8 FLAG comment: track concurrent recompilation
THE V8 FLAG IS: concurrent-recompilation-queue-length
THE V8 FLAG comment: the length of the concurrent compilation queue
THE V8 FLAG IS: concurrent-recompilation-delay
THE V8 FLAG comment: artificial compilation delay in ms
THE V8 FLAG IS: stress-concurrent-inlining
THE V8 FLAG comment: create additional concurrent optimization jobs but throw away result
THE V8 FLAG IS: maglev-overwrite-budget
THE V8 FLAG comment: whether maglev resets the interrupt budget
THE V8 FLAG IS: stress-concurrent-inlining-attach-code
THE V8 FLAG comment: create additional concurrent optimization jobs
THE V8 FLAG IS: max-serializer-nesting
THE V8 FLAG comment: maximum levels for nesting child serializers
THE V8 FLAG IS: trace-heap-broker-verbose
THE V8 FLAG comment: trace the heap broker verbosely (all reports)
THE V8 FLAG IS: trace-heap-broker-memory
THE V8 FLAG comment: trace the heap broker memory (refs analysis and zone numbers)
THE V8 FLAG IS: trace-heap-broker
THE V8 FLAG comment: trace the heap broker (reports on missing data only)
THE V8 FLAG IS: stress-runs
THE V8 FLAG comment: number of stress runs
THE V8 FLAG IS: deopt-every-n-times
THE V8 FLAG comment: deoptimize every n times a deopt point is passed
THE V8 FLAG IS: print-deopt-stress
THE V8 FLAG comment: print number of possible deopt points
THE V8 FLAG IS: turbofan
THE V8 FLAG comment: use the Turbofan optimizing compiler
THE V8 FLAG IS: opt
THE V8 FLAG comment: alias for --turbofan
THE V8 FLAG IS: turbo-sp-frame-access
THE V8 FLAG comment: use stack pointer-relative access to frame wherever possible
THE V8 FLAG IS: stress-turbo-late-spilling
THE V8 FLAG comment: optimize placement of all spill instructions, not just loop-top phis
THE V8 FLAG IS: turbo-filter
THE V8 FLAG comment: optimization filter for TurboFan compiler
THE V8 FLAG IS: trace-turbo
THE V8 FLAG comment: trace generated TurboFan IR
THE V8 FLAG IS: trace-turbo-path
THE V8 FLAG comment: directory to dump generated TurboFan IR to
THE V8 FLAG IS: trace-turbo-filter
THE V8 FLAG comment: filter for tracing turbofan compilation
THE V8 FLAG IS: trace-turbo-graph
THE V8 FLAG comment: trace generated TurboFan graphs
THE V8 FLAG IS: trace-turbo-scheduled
THE V8 FLAG comment: trace TurboFan IR with schedule
THE V8 FLAG IS: trace-turbo-file-prefix
THE V8 FLAG comment: trace turbo graph to a file with given prefix
THE V8 FLAG IS: trace-turbo-cfg-file
THE V8 FLAG comment: trace turbo cfg graph (for C1 visualizer) to a given file name
THE V8 FLAG IS: trace-turbo-types
THE V8 FLAG comment: trace TurboFan's types
THE V8 FLAG IS: trace-turbo-scheduler
THE V8 FLAG comment: trace TurboFan's scheduler
THE V8 FLAG IS: trace-turbo-reduction
THE V8 FLAG comment: trace TurboFan's various reducers
THE V8 FLAG IS: trace-turbo-trimming
THE V8 FLAG comment: trace TurboFan's graph trimmer
THE V8 FLAG IS: trace-turbo-jt
THE V8 FLAG comment: trace TurboFan's jump threading
THE V8 FLAG IS: trace-turbo-ceq
THE V8 FLAG comment: trace TurboFan's control equivalence
THE V8 FLAG IS: trace-turbo-loop
THE V8 FLAG comment: trace TurboFan's loop optimizations
THE V8 FLAG IS: trace-turbo-alloc
THE V8 FLAG comment: trace TurboFan's register allocator
THE V8 FLAG IS: trace-all-uses
THE V8 FLAG comment: trace all use positions
THE V8 FLAG IS: trace-representation
THE V8 FLAG comment: trace representation types
THE V8 FLAG IS: trace-turbo-stack-accesses
THE V8 FLAG comment: trace stack load/store counters for optimized code in run-time (x64 only)
THE V8 FLAG IS: turbo-verify
THE V8 FLAG comment: verify TurboFan graphs at each phase
THE V8 FLAG IS: turbo-verify-machine-graph
THE V8 FLAG comment: verify TurboFan machine graph before instruction selection
THE V8 FLAG IS: trace-verify-csa
THE V8 FLAG comment: trace code stubs verification
THE V8 FLAG IS: csa-trap-on-node
THE V8 FLAG comment: trigger break point when a node with given id is created in given stub. The format is: StubName,NodeId
THE V8 FLAG IS: turbo-stats
THE V8 FLAG comment: print TurboFan statistics
THE V8 FLAG IS: turbo-stats-nvp
THE V8 FLAG comment: print TurboFan statistics in machine-readable format
THE V8 FLAG IS: turbo-stats-wasm
THE V8 FLAG comment: print TurboFan statistics of wasm compilations
THE V8 FLAG IS: turbo-splitting
THE V8 FLAG comment: split nodes during scheduling in TurboFan
THE V8 FLAG IS: turbo-inlining
THE V8 FLAG comment: enable inlining in TurboFan
THE V8 FLAG IS: max-inlined-bytecode-size
THE V8 FLAG comment: maximum size of bytecode for a single inlining
THE V8 FLAG IS: max-inlined-bytecode-size-cumulative
THE V8 FLAG comment: maximum cumulative size of bytecode considered for inlining
THE V8 FLAG IS: max-inlined-bytecode-size-absolute
THE V8 FLAG comment: maximum absolute size of bytecode considered for inlining
THE V8 FLAG IS: reserve-inline-budget-scale-factor
THE V8 FLAG comment: scale factor of bytecode size used to calculate the inlining budget
THE V8 FLAG IS: max-inlined-bytecode-size-small
THE V8 FLAG comment: maximum size of bytecode considered for small function inlining
THE V8 FLAG IS: max-optimized-bytecode-size
THE V8 FLAG comment: maximum bytecode size to be considered for optimization; too high values may cause the compiler to hit (release) assertions
THE V8 FLAG IS: min-inlining-frequency
THE V8 FLAG comment: minimum frequency for inlining
THE V8 FLAG IS: polymorphic-inlining
THE V8 FLAG comment: polymorphic inlining
THE V8 FLAG IS: stress-inline
THE V8 FLAG comment: set high thresholds for inlining to inline as much as possible
THE V8 FLAG IS: trace-turbo-inlining
THE V8 FLAG comment: trace TurboFan inlining
THE V8 FLAG IS: turbo-inline-array-builtins
THE V8 FLAG comment: inline array builtins in TurboFan code
THE V8 FLAG IS: use-osr
THE V8 FLAG comment: use on-stack replacement
THE V8 FLAG IS: concurrent-osr
THE V8 FLAG comment: enable concurrent OSR
THE V8 FLAG IS: trace-osr
THE V8 FLAG comment: trace on-stack replacement
THE V8 FLAG IS: log-or-trace-osr
THE V8 FLAG comment: internal helper flag, please use --trace-osr instead.
THE V8 FLAG IS: analyze-environment-liveness
THE V8 FLAG comment: analyze liveness of environment slots and zap dead values
THE V8 FLAG IS: trace-environment-liveness
THE V8 FLAG comment: trace liveness of local variable slots
THE V8 FLAG IS: turbo-load-elimination
THE V8 FLAG comment: enable load elimination in TurboFan
THE V8 FLAG IS: trace-turbo-load-elimination
THE V8 FLAG comment: trace TurboFan load elimination
THE V8 FLAG IS: turbo-profiling
THE V8 FLAG comment: enable basic block profiling in TurboFan
THE V8 FLAG IS: turbo-profiling-verbose
THE V8 FLAG comment: enable basic block profiling in TurboFan, and include each function's schedule and disassembly in the output
THE V8 FLAG IS: turbo-profiling-output
THE V8 FLAG comment: emit data about basic block usage in builtins to this file (requires that V8 was built with v8_enable_builtins_profiling=true)
THE V8 FLAG IS: warn-about-builtin-profile-data
THE V8 FLAG comment: flag for mksnapshot, emit warnings when applying builtin profile data
THE V8 FLAG IS: turbo-verify-allocation
THE V8 FLAG comment: verify register allocation in TurboFan
THE V8 FLAG IS: turbo-move-optimization
THE V8 FLAG comment: optimize gap moves in TurboFan
THE V8 FLAG IS: turbo-jt
THE V8 FLAG comment: enable jump threading in TurboFan
THE V8 FLAG IS: turbo-loop-peeling
THE V8 FLAG comment: TurboFan loop peeling
THE V8 FLAG IS: turbo-loop-variable
THE V8 FLAG comment: TurboFan loop variable optimization
THE V8 FLAG IS: turbo-loop-rotation
THE V8 FLAG comment: TurboFan loop rotation
THE V8 FLAG IS: turbo-cf-optimization
THE V8 FLAG comment: optimize control flow in TurboFan
THE V8 FLAG IS: turbo-escape
THE V8 FLAG comment: enable escape analysis
THE V8 FLAG IS: turbo-allocation-folding
THE V8 FLAG comment: TurboFan allocation folding
THE V8 FLAG IS: turbo-instruction-scheduling
THE V8 FLAG comment: enable instruction scheduling in TurboFan
THE V8 FLAG IS: turbo-stress-instruction-scheduling
THE V8 FLAG comment: randomly schedule instructions to stress dependency tracking
THE V8 FLAG IS: turbo-store-elimination
THE V8 FLAG comment: enable store-store elimination in TurboFan
THE V8 FLAG IS: trace-store-elimination
THE V8 FLAG comment: trace store elimination
THE V8 FLAG IS: turbo-rewrite-far-jumps
THE V8 FLAG comment: rewrite far to near jumps (ia32,x64)
THE V8 FLAG IS: turbo-rab-gsab
THE V8 FLAG comment: optimize ResizableArrayBuffer / GrowableSharedArrayBuffer in TurboFan
THE V8 FLAG IS: stress-gc-during-compilation
THE V8 FLAG comment: simulate GC/compiler thread race related to https://crbug.com/v8/8520
THE V8 FLAG IS: turbo-fast-api-calls
THE V8 FLAG comment: enable fast API calls from TurboFan
THE V8 FLAG IS: turbo-compress-translation-arrays
THE V8 FLAG comment: compress translation arrays (experimental)
THE V8 FLAG IS: turbo-inline-js-wasm-calls
THE V8 FLAG comment: inline JS->Wasm calls
THE V8 FLAG IS: turbo-use-mid-tier-regalloc-for-huge-functions
THE V8 FLAG comment: fall back to the mid-tier register allocator for huge functions
THE V8 FLAG IS: turbo-force-mid-tier-regalloc
THE V8 FLAG comment: always use the mid-tier register allocator (for testing)
THE V8 FLAG IS: turbo-optimize-apply
THE V8 FLAG comment: optimize Function.prototype.apply
THE V8 FLAG IS: turbo-optimize-math-minmax
THE V8 FLAG comment: optimize call math.min/max with double array
THE V8 FLAG IS: turbo-collect-feedback-in-generic-lowering
THE V8 FLAG comment: enable experimental feedback collection in generic lowering.
THE V8 FLAG IS: isolate-script-cache-ageing
THE V8 FLAG comment: enable ageing of the isolate script cache.
THE V8 FLAG IS: script-delay
THE V8 FLAG comment: busy wait [ms] on every Script::Run
THE V8 FLAG IS: script-delay-once
THE V8 FLAG comment: busy wait [ms] on the first Script::Run
THE V8 FLAG IS: script-delay-fraction
THE V8 FLAG comment: busy wait after each Script::Run by the given fraction of the run's duration
THE V8 FLAG IS: turboshaft
THE V8 FLAG comment: enable TurboFan's Turboshaft phases for JS
THE V8 FLAG IS: turboshaft-trace-reduction
THE V8 FLAG comment: trace individual Turboshaft reduction steps
THE V8 FLAG IS: turboshaft-wasm
THE V8 FLAG comment: enable TurboFan's Turboshaft phases for wasm
THE V8 FLAG IS: optimize-for-size
THE V8 FLAG comment: Enables optimizations which favor memory size over execution speed
THE V8 FLAG IS: wasm-generic-wrapper
THE V8 FLAG comment: allow use of the generic js-to-wasm wrapper instead of per-signature wrappers
THE V8 FLAG IS: enable-wasm-arm64-generic-wrapper
THE V8 FLAG comment: allow use of the generic js-to-wasm wrapper instead of per-signature wrappers on arm64
THE V8 FLAG IS: expose-wasm
THE V8 FLAG comment: expose wasm interface to JavaScript
THE V8 FLAG IS: wasm-num-compilation-tasks
THE V8 FLAG comment: maximum number of parallel compilation tasks for wasm
THE V8 FLAG IS: wasm-write-protect-code-memory
THE V8 FLAG comment: write protect code memory on the wasm native heap with mprotect
THE V8 FLAG IS: wasm-memory-protection-keys
THE V8 FLAG comment: protect wasm code memory with PKU if available (takes precedence over --wasm-write-protect-code-memory)
THE V8 FLAG IS: wasm-async-compilation
THE V8 FLAG comment: enable actual asynchronous compilation for WebAssembly.compile
THE V8 FLAG IS: wasm-test-streaming
THE V8 FLAG comment: use streaming compilation instead of async compilation for tests
THE V8 FLAG IS: wasm-native-module-cache-enabled
THE V8 FLAG comment: enable the native module cache
THE V8 FLAG IS: wasm-max-mem-pages
THE V8 FLAG comment: maximum number of 64KiB memory pages per wasm memory
THE V8 FLAG IS: wasm-max-table-size
THE V8 FLAG comment: maximum table size of a wasm instance
THE V8 FLAG IS: wasm-max-code-space
THE V8 FLAG comment: maximum committed code space for wasm (in MB)
THE V8 FLAG IS: wasm-tier-up
THE V8 FLAG comment: enable tier up to the optimizing compiler (requires --liftoff to have an effect)
THE V8 FLAG IS: wasm-dynamic-tiering
THE V8 FLAG comment: enable dynamic tier up to the optimizing compiler
THE V8 FLAG IS: wasm-tiering-budget
THE V8 FLAG comment: budget for dynamic tiering (rough approximation of bytes executed
THE V8 FLAG IS: wasm-caching-threshold
THE V8 FLAG comment: the amount of wasm top tier code that triggers the next caching event
THE V8 FLAG IS: trace-wasm-compilation-times
THE V8 FLAG comment: print how long it took to compile each wasm function
THE V8 FLAG IS: wasm-tier-up-filter
THE V8 FLAG comment: only tier-up function with this index
THE V8 FLAG IS: wasm-stack-switching-stack-size
THE V8 FLAG comment: default size of stacks for wasm stack-switching (in kB)
THE V8 FLAG IS: liftoff
THE V8 FLAG comment: enable Liftoff, the baseline compiler for WebAssembly
THE V8 FLAG IS: liftoff-only
THE V8 FLAG comment: disallow TurboFan compilation for WebAssembly (for testing)
THE V8 FLAG IS: trace-wasm-memory
THE V8 FLAG comment: print all memory updates performed in wasm code
THE V8 FLAG IS: wasm-tier-mask-for-testing
THE V8 FLAG comment: bitmask of functions to compile with TurboFan instead of Liftoff
THE V8 FLAG IS: wasm-debug-mask-for-testing
THE V8 FLAG comment: bitmask of functions to compile for debugging, only applies if the tier is Liftoff
THE V8 FLAG IS: experimental-wasm-pgo-to-file
THE V8 FLAG comment: experimental: dump Wasm PGO information to a local file (for testing)
THE V8 FLAG IS: experimental-wasm-pgo-from-file
THE V8 FLAG comment: experimental: read and use Wasm PGO data from a local file (for testing)
THE V8 FLAG IS: validate-asm
THE V8 FLAG comment: validate asm.js modules before compiling
THE V8 FLAG IS: suppress-asm-messages
THE V8 FLAG comment: don't emit asm.js related messages (for golden file testing)
THE V8 FLAG IS: trace-asm-time
THE V8 FLAG comment: print asm.js timing info to the console
THE V8 FLAG IS: trace-asm-scanner
THE V8 FLAG comment: print tokens encountered by asm.js scanner
THE V8 FLAG IS: trace-asm-parser
THE V8 FLAG comment: verbose logging of asm.js parse failures
THE V8 FLAG IS: stress-validate-asm
THE V8 FLAG comment: try to validate everything as asm.js
THE V8 FLAG IS: dump-wasm-module-path
THE V8 FLAG comment: directory to dump wasm modules to
THE V8 FLAG IS: experimental-wasm-compilation-hints
THE V8 FLAG comment: enable prototype compilation hints section for wasm
THE V8 FLAG IS: experimental-wasm-instruction-tracing
THE V8 FLAG comment: enable prototype instruction tracing section for wasm
THE V8 FLAG IS: experimental-wasm-gc
THE V8 FLAG comment: enable prototype garbage collection for wasm
THE V8 FLAG IS: experimental-wasm-assume-ref-cast-succeeds
THE V8 FLAG comment: enable prototype assume ref.cast always succeeds and skip the related type check (unsafe) for wasm
THE V8 FLAG IS: experimental-wasm-ref-cast-nop
THE V8 FLAG comment: enable prototype enable unsafe ref.cast_nop instruction for wasm
THE V8 FLAG IS: experimental-wasm-skip-null-checks
THE V8 FLAG comment: enable prototype skip null checks for call.ref and array and struct operations (unsafe) for wasm
THE V8 FLAG IS: experimental-wasm-skip-bounds-checks
THE V8 FLAG comment: enable prototype skip array bounds checks (unsafe) for wasm
THE V8 FLAG IS: experimental-wasm-typed-funcref
THE V8 FLAG comment: enable prototype typed function references for wasm
THE V8 FLAG IS: experimental-wasm-memory64
THE V8 FLAG comment: enable prototype memory64 for wasm
THE V8 FLAG IS: experimental-wasm-relaxed-simd
THE V8 FLAG comment: enable prototype relaxed simd for wasm
THE V8 FLAG IS: experimental-wasm-branch-hinting
THE V8 FLAG comment: enable prototype branch hinting for wasm
THE V8 FLAG IS: experimental-wasm-stack-switching
THE V8 FLAG comment: enable prototype stack switching for wasm
THE V8 FLAG IS: experimental-wasm-extended-const
THE V8 FLAG comment: enable prototype extended constant expressions for wasm
THE V8 FLAG IS: experimental-wasm-stringref
THE V8 FLAG comment: enable prototype reference-typed strings for wasm
THE V8 FLAG IS: experimental-wasm-return-call
THE V8 FLAG comment: enable prototype return call opcodes for wasm
THE V8 FLAG IS: experimental-wasm-type-reflection
THE V8 FLAG comment: enable prototype wasm type reflection in JS for wasm
THE V8 FLAG IS: wasm-gc-structref-as-dataref
THE V8 FLAG comment: compatibility mode: Treat structref as dataref
THE V8 FLAG IS: wasm-staging
THE V8 FLAG comment: enable staged wasm features
THE V8 FLAG IS: wasm-opt
THE V8 FLAG comment: enable wasm optimization
THE V8 FLAG IS: wasm-bounds-checks
THE V8 FLAG comment: enable bounds checks (disable for performance testing only)
THE V8 FLAG IS: wasm-stack-checks
THE V8 FLAG comment: enable stack checks (disable for performance testing only)
THE V8 FLAG IS: wasm-enforce-bounds-checks
THE V8 FLAG comment: enforce explicit bounds check even if the trap handler is available
THE V8 FLAG IS: wasm-math-intrinsics
THE V8 FLAG comment: intrinsify some Math imports into wasm
THE V8 FLAG IS: wasm-inlining
THE V8 FLAG comment: enable inlining of wasm functions into wasm functions (experimental)
THE V8 FLAG IS: wasm-inlining-budget
THE V8 FLAG comment: maximum graph size (in TF nodes) that allows inlining more
THE V8 FLAG IS: wasm-speculative-inlining
THE V8 FLAG comment: enable speculative inlining of call_ref targets (experimental)
THE V8 FLAG IS: trace-wasm-inlining
THE V8 FLAG comment: trace wasm inlining
THE V8 FLAG IS: trace-wasm-speculative-inlining
THE V8 FLAG comment: trace wasm speculative inlining
THE V8 FLAG IS: trace-wasm-typer
THE V8 FLAG comment: trace wasm typer
THE V8 FLAG IS: wasm-loop-unrolling
THE V8 FLAG comment: enable loop unrolling for wasm functions
THE V8 FLAG IS: wasm-loop-peeling
THE V8 FLAG comment: enable loop peeling for wasm functions
THE V8 FLAG IS: wasm-loop-peeling-max-size
THE V8 FLAG comment: maximum size for peeling
THE V8 FLAG IS: wasm-fuzzer-gen-test
THE V8 FLAG comment: generate a test case when running a wasm fuzzer
THE V8 FLAG IS: print-wasm-code
THE V8 FLAG comment: print WebAssembly code
THE V8 FLAG IS: print-wasm-code-function-index
THE V8 FLAG comment: print WebAssembly code for function at index
THE V8 FLAG IS: print-wasm-stub-code
THE V8 FLAG comment: print WebAssembly stub code
THE V8 FLAG IS: asm-wasm-lazy-compilation
THE V8 FLAG comment: enable lazy compilation for asm-wasm modules
THE V8 FLAG IS: wasm-lazy-compilation
THE V8 FLAG comment: enable lazy compilation for all wasm modules
THE V8 FLAG IS: wasm-lazy-validation
THE V8 FLAG comment: enable lazy validation for lazily compiled wasm functions
THE V8 FLAG IS: wasm-simd-ssse3-codegen
THE V8 FLAG comment: allow wasm SIMD SSSE3 codegen
THE V8 FLAG IS: wasm-code-gc
THE V8 FLAG comment: enable garbage collection of wasm code
THE V8 FLAG IS: trace-wasm-code-gc
THE V8 FLAG comment: trace garbage collection of wasm code
THE V8 FLAG IS: stress-wasm-code-gc
THE V8 FLAG comment: stress test garbage collection of wasm code
THE V8 FLAG IS: wasm-max-initial-code-space-reservation
THE V8 FLAG comment: maximum size of the initial wasm code space reservation (in MB)
THE V8 FLAG IS: wasm-max-module-size
THE V8 FLAG comment: maximum allowed size of wasm modules
THE V8 FLAG IS: wasm-disassembly-max-mb
THE V8 FLAG comment: maximum size of produced disassembly (in MB, approximate)
THE V8 FLAG IS: trace-wasm
THE V8 FLAG comment: trace wasm function calls
THE V8 FLAG IS: stress-sampling-allocation-profiler
THE V8 FLAG comment: Enables sampling allocation profiler with X as a sample interval
THE V8 FLAG IS: lazy-new-space-shrinking
THE V8 FLAG comment: Enables the lazy new space shrinking strategy
THE V8 FLAG IS: min-semi-space-size
THE V8 FLAG comment: min size of a semi-space (in MBytes), the new space consists of two semi-spaces
THE V8 FLAG IS: max-semi-space-size
THE V8 FLAG comment: max size of a semi-space (in MBytes), the new space consists of two semi-spaces
THE V8 FLAG IS: semi-space-growth-factor
THE V8 FLAG comment: factor by which to grow the new space
THE V8 FLAG IS: max-old-space-size
THE V8 FLAG comment: max size of the old space (in Mbytes)
THE V8 FLAG IS: max-heap-size
THE V8 FLAG comment: max size of the heap (in Mbytes) both max_semi_space_size and max_old_space_size take precedence. All three flags cannot be specified at the same time.
THE V8 FLAG IS: initial-heap-size
THE V8 FLAG comment: initial size of the heap (in Mbytes)
THE V8 FLAG IS: huge-max-old-generation-size
THE V8 FLAG comment: Increase max size of the old space to 4 GB for x64 systems withthe physical memory bigger than 16 GB
THE V8 FLAG IS: initial-old-space-size
THE V8 FLAG comment: initial old space size (in Mbytes)
THE V8 FLAG IS: separate-gc-phases
THE V8 FLAG comment: young and full garbage collection phases are not overlapping
THE V8 FLAG IS: global-gc-scheduling
THE V8 FLAG comment: enable GC scheduling based on global memory
THE V8 FLAG IS: gc-global
THE V8 FLAG comment: always perform global GCs
THE V8 FLAG IS: shared-space
THE V8 FLAG comment: Implement shared heap as shared space on a main isolate.
THE V8 FLAG IS: random-gc-interval
THE V8 FLAG comment: Collect garbage after random(0, X) allocations. It overrides gc_interval.
THE V8 FLAG IS: gc-interval
THE V8 FLAG comment: garbage collect after <n> allocations
THE V8 FLAG IS: retain-maps-for-n-gc
THE V8 FLAG comment: keeps maps alive for <n> old space garbage collections
THE V8 FLAG IS: trace-gc
THE V8 FLAG comment: print one trace line following each garbage collection
THE V8 FLAG IS: trace-gc-nvp
THE V8 FLAG comment: print one detailed trace line in name=value format after each garbage collection
THE V8 FLAG IS: trace-gc-ignore-scavenger
THE V8 FLAG comment: do not print trace line after scavenger collection
THE V8 FLAG IS: trace-idle-notification
THE V8 FLAG comment: print one trace line following each idle notification
THE V8 FLAG IS: trace-idle-notification-verbose
THE V8 FLAG comment: prints the heap state used by the idle notification
THE V8 FLAG IS: trace-gc-verbose
THE V8 FLAG comment: print more details following each garbage collection
THE V8 FLAG IS: trace-gc-freelists
THE V8 FLAG comment: prints details of each freelist before and after each major garbage collection
THE V8 FLAG IS: trace-gc-freelists-verbose
THE V8 FLAG comment: prints details of freelists of each page before and after each major garbage collection
THE V8 FLAG IS: trace-gc-heap-layout
THE V8 FLAG comment: print layout of pages in heap before and after gc
THE V8 FLAG IS: trace-gc-heap-layout-ignore-minor-gc
THE V8 FLAG comment: do not print trace line before and after minor-gc
THE V8 FLAG IS: trace-evacuation-candidates
THE V8 FLAG comment: Show statistics about the pages evacuation by the compaction
THE V8 FLAG IS: trace-allocations-origins
THE V8 FLAG comment: Show statistics about the origins of allocations. Combine with --no-inline-new to track allocations from generated code
THE V8 FLAG IS: trace-pending-allocations
THE V8 FLAG comment: trace calls to Heap::IsAllocationPending that return true
THE V8 FLAG IS: trace-allocation-stack-interval
THE V8 FLAG comment: print stack trace after <n> free-list allocations
THE V8 FLAG IS: trace-duplicate-threshold-kb
THE V8 FLAG comment: print duplicate objects in the heap if their size is more than given threshold
THE V8 FLAG IS: trace-fragmentation
THE V8 FLAG comment: report fragmentation for old space
THE V8 FLAG IS: trace-fragmentation-verbose
THE V8 FLAG comment: report fragmentation for old space (detailed)
THE V8 FLAG IS: minor-mc-trace-fragmentation
THE V8 FLAG comment: trace fragmentation after marking
THE V8 FLAG IS: trace-evacuation
THE V8 FLAG comment: report evacuation statistics
THE V8 FLAG IS: trace-mutator-utilization
THE V8 FLAG comment: print mutator utilization, allocation speed, gc speed
THE V8 FLAG IS: incremental-marking
THE V8 FLAG comment: use incremental marking
THE V8 FLAG IS: incremental-marking-wrappers
THE V8 FLAG comment: use incremental marking for marking wrappers
THE V8 FLAG IS: incremental-marking-task
THE V8 FLAG comment: use tasks for incremental marking
THE V8 FLAG IS: incremental-marking-soft-trigger
THE V8 FLAG comment: threshold for starting incremental marking via a task in percent of available space: limit - size
THE V8 FLAG IS: fast-forward-schedule
THE V8 FLAG comment: Fast forwards marking schedule
THE V8 FLAG IS: incremental-marking-hard-trigger
THE V8 FLAG comment: threshold for starting incremental marking immediately in percent of available space: limit - size
THE V8 FLAG IS: trace-unmapper
THE V8 FLAG comment: Trace the unmapping
THE V8 FLAG IS: minor-mc-task-trigger
THE V8 FLAG comment: minormc task trigger in percent of the current heap limit
THE V8 FLAG IS: parallel-scavenge
THE V8 FLAG comment: parallel scavenge
THE V8 FLAG IS: scavenge-task
THE V8 FLAG comment: schedule scavenge tasks
THE V8 FLAG IS: scavenge-task-trigger
THE V8 FLAG comment: scavenge task trigger in percent of the current heap limit
THE V8 FLAG IS: scavenge-separate-stack-scanning
THE V8 FLAG comment: use a separate phase for stack scanning in scavenge
THE V8 FLAG IS: trace-parallel-scavenge
THE V8 FLAG comment: trace parallel scavenge
THE V8 FLAG IS: cppgc-young-generation
THE V8 FLAG comment: run young generation garbage collections in Oilpan
THE V8 FLAG IS: write-protect-code-memory
THE V8 FLAG comment: write protect code memory
THE V8 FLAG IS: concurrent-marking
THE V8 FLAG comment: use concurrent marking
THE V8 FLAG IS: concurrent-marking-max-worker-num
THE V8 FLAG comment: max worker number of concurrent marking, 0 for NumberOfWorkerThreads
THE V8 FLAG IS: concurrent-array-buffer-sweeping
THE V8 FLAG comment: concurrently sweep array buffers
THE V8 FLAG IS: stress-concurrent-allocation
THE V8 FLAG comment: start background threads that allocate memory
THE V8 FLAG IS: parallel-marking
THE V8 FLAG comment: use parallel marking in atomic pause
THE V8 FLAG IS: ephemeron-fixpoint-iterations
THE V8 FLAG comment: number of fixpoint iterations it takes to switch to linear ephemeron algorithm
THE V8 FLAG IS: trace-concurrent-marking
THE V8 FLAG comment: trace concurrent marking
THE V8 FLAG IS: concurrent-sweeping
THE V8 FLAG comment: use concurrent sweeping
THE V8 FLAG IS: parallel-compaction
THE V8 FLAG comment: use parallel compaction
THE V8 FLAG IS: parallel-pointer-update
THE V8 FLAG comment: use parallel pointer update during compaction
THE V8 FLAG IS: detect-ineffective-gcs-near-heap-limit
THE V8 FLAG comment: trigger out-of-memory failure to avoid GC storm near heap limit
THE V8 FLAG IS: trace-incremental-marking
THE V8 FLAG comment: trace progress of the incremental marking
THE V8 FLAG IS: trace-stress-marking
THE V8 FLAG comment: trace stress marking progress
THE V8 FLAG IS: trace-stress-scavenge
THE V8 FLAG comment: trace stress scavenge progress
THE V8 FLAG IS: track-gc-object-stats
THE V8 FLAG comment: track object counts and memory usage
THE V8 FLAG IS: trace-gc-object-stats
THE V8 FLAG comment: trace object counts and memory usage
THE V8 FLAG IS: trace-zone-stats
THE V8 FLAG comment: trace zone memory usage
THE V8 FLAG IS: zone-stats-tolerance
THE V8 FLAG comment: report a tick only when allocated zone memory changes by this amount
THE V8 FLAG IS: trace-zone-type-stats
THE V8 FLAG comment: trace per-type zone memory usage
THE V8 FLAG IS: track-retaining-path
THE V8 FLAG comment: enable support for tracking retaining path
THE V8 FLAG IS: gc-stats
THE V8 FLAG comment: Used by tracing internally to enable gc statistics
THE V8 FLAG IS: track-detached-contexts
THE V8 FLAG comment: track native contexts that are expected to be garbage collected
THE V8 FLAG IS: trace-detached-contexts
THE V8 FLAG comment: trace native contexts that are expected to be garbage collected
THE V8 FLAG IS: move-object-start
THE V8 FLAG comment: enable moving of object starts
THE V8 FLAG IS: memory-reducer
THE V8 FLAG comment: use memory reducer
THE V8 FLAG IS: memory-reducer-for-small-heaps
THE V8 FLAG comment: use memory reducer for small heaps
THE V8 FLAG IS: heap-growing-percent
THE V8 FLAG comment: specifies heap growing factor as (1 + heap_growing_percent/100)
THE V8 FLAG IS: v8-os-page-size
THE V8 FLAG comment: override OS page size (in KBytes)
THE V8 FLAG IS: allocation-buffer-parking
THE V8 FLAG comment: allocation buffer parking
THE V8 FLAG IS: compact
THE V8 FLAG comment: Perform compaction on full GCs based on V8's default heuristics
THE V8 FLAG IS: compact-code-space
THE V8 FLAG comment: Perform code space compaction on full collections.
THE V8 FLAG IS: compact-on-every-full-gc
THE V8 FLAG comment: Perform compaction on every full GC
THE V8 FLAG IS: compact-with-stack
THE V8 FLAG comment: Perform compaction when finalizing a full GC with stack
THE V8 FLAG IS: compact-code-space-with-stack
THE V8 FLAG comment: Perform code space compaction when finalizing a full GC with stack
THE V8 FLAG IS: stress-compaction
THE V8 FLAG comment: Stress GC compaction to flush out bugs (implies --force_marking_deque_overflows)
THE V8 FLAG IS: stress-compaction-random
THE V8 FLAG comment: Stress GC compaction by selecting random percent of pages as evacuation candidates. Overrides stress_compaction.
THE V8 FLAG IS: flush-baseline-code
THE V8 FLAG comment: flush of baseline code when it has not been executed recently
THE V8 FLAG IS: flush-bytecode
THE V8 FLAG comment: flush of bytecode when it has not been executed recently
THE V8 FLAG IS: bytecode-old-age
THE V8 FLAG comment: number of gcs before we flush code
THE V8 FLAG IS: stress-flush-code
THE V8 FLAG comment: stress code flushing
THE V8 FLAG IS: trace-flush-bytecode
THE V8 FLAG comment: trace bytecode flushing
THE V8 FLAG IS: use-marking-progress-bar
THE V8 FLAG comment: Use a progress bar to scan large objects in increments when incremental marking is active.
THE V8 FLAG IS: stress-per-context-marking-worklist
THE V8 FLAG comment: Use per-context worklist for marking
THE V8 FLAG IS: force-marking-deque-overflows
THE V8 FLAG comment: force overflows of marking deque by reducing it's size to 64 words
THE V8 FLAG IS: stress-incremental-marking
THE V8 FLAG comment: force incremental marking for small heaps and run it more often
THE V8 FLAG IS: fuzzer-gc-analysis
THE V8 FLAG comment: prints number of allocations and enables analysis mode for gc fuzz testing, e.g. --stress-marking, --stress-scavenge
THE V8 FLAG IS: stress-marking
THE V8 FLAG comment: force marking at random points between 0 and X (inclusive) percent of the regular marking start limit
THE V8 FLAG IS: stress-scavenge
THE V8 FLAG comment: force scavenge at random points between 0 and X (inclusive) percent of the new space capacity
THE V8 FLAG IS: reclaim-unmodified-wrappers
THE V8 FLAG comment: reclaim otherwise unreachable unmodified wrapper objects when possible
THE V8 FLAG IS: gc-experiment-less-compaction
THE V8 FLAG comment: less compaction in non-memory reducing mode
THE V8 FLAG IS: gc-memory-reducer-start-delay-ms
THE V8 FLAG comment: Delay before memory reducer start
THE V8 FLAG IS: disable-abortjs
THE V8 FLAG comment: disables AbortJS runtime function
THE V8 FLAG IS: randomize-all-allocations
THE V8 FLAG comment: randomize virtual memory reservations by ignoring any hints passed when allocating pages
THE V8 FLAG IS: manual-evacuation-candidates-selection
THE V8 FLAG comment: Test mode only flag. It allows an unit test to select evacuation candidates pages (requires --stress_compaction).
THE V8 FLAG IS: clear-free-memory
THE V8 FLAG comment: initialize free memory with 0
THE V8 FLAG IS: crash-on-aborted-evacuation
THE V8 FLAG comment: crash when evacuation of page fails
THE V8 FLAG IS: cppheap-incremental-marking
THE V8 FLAG comment: use incremental marking for CppHeap
THE V8 FLAG IS: cppheap-concurrent-marking
THE V8 FLAG comment: use concurrent marking for CppHeap
THE V8 FLAG IS: enable-sse3
THE V8 FLAG comment: enable use of SSE3 instructions if available
THE V8 FLAG IS: enable-ssse3
THE V8 FLAG comment: enable use of SSSE3 instructions if available
THE V8 FLAG IS: enable-sse4-1
THE V8 FLAG comment: enable use of SSE4.1 instructions if available
THE V8 FLAG IS: enable-sse4-2
THE V8 FLAG comment: enable use of SSE4.2 instructions if available
THE V8 FLAG IS: enable-sahf
THE V8 FLAG comment: enable use of SAHF instruction if available (X64 only)
THE V8 FLAG IS: enable-avx
THE V8 FLAG comment: enable use of AVX instructions if available
THE V8 FLAG IS: enable-avx2
THE V8 FLAG comment: enable use of AVX2 instructions if available
THE V8 FLAG IS: enable-fma3
THE V8 FLAG comment: enable use of FMA3 instructions if available
THE V8 FLAG IS: enable-bmi1
THE V8 FLAG comment: enable use of BMI1 instructions if available
THE V8 FLAG IS: enable-bmi2
THE V8 FLAG comment: enable use of BMI2 instructions if available
THE V8 FLAG IS: enable-lzcnt
THE V8 FLAG comment: enable use of LZCNT instruction if available
THE V8 FLAG IS: enable-popcnt
THE V8 FLAG comment: enable use of POPCNT instruction if available
THE V8 FLAG IS: arm-arch
THE V8 FLAG comment: generate instructions for the selected ARM architecture if available: armv6, armv7, armv7+sudiv or armv8
THE V8 FLAG IS: force-long-branches
THE V8 FLAG comment: force all emitted branches to be in long mode (MIPS/PPC only)
THE V8 FLAG IS: mcpu
THE V8 FLAG comment: enable optimization for specific cpu
THE V8 FLAG IS: partial-constant-pool
THE V8 FLAG comment: enable use of partial constant pools (X64 only)
THE V8 FLAG IS: sim-arm64-optional-features
THE V8 FLAG comment: enable optional features on the simulator for testing: none or all
THE V8 FLAG IS: enable-source-at-csa-bind
THE V8 FLAG comment: Include source information in the binary at CSA bind locations.
THE V8 FLAG IS: enable-armv7
THE V8 FLAG comment: deprecated (use --arm_arch instead)
THE V8 FLAG IS: enable-vfp3
THE V8 FLAG comment: deprecated (use --arm_arch instead)
THE V8 FLAG IS: enable-32dregs
THE V8 FLAG comment: deprecated (use --arm_arch instead)
THE V8 FLAG IS: enable-neon
THE V8 FLAG comment: deprecated (use --arm_arch instead)
THE V8 FLAG IS: enable-sudiv
THE V8 FLAG comment: deprecated (use --arm_arch instead)
THE V8 FLAG IS: enable-armv8
THE V8 FLAG comment: deprecated (use --arm_arch instead)
THE V8 FLAG IS: enable-regexp-unaligned-accesses
THE V8 FLAG comment: enable unaligned accesses for the regexp engine
THE V8 FLAG IS: script-streaming
THE V8 FLAG comment: enable parsing on background
THE V8 FLAG IS: stress-background-compile
THE V8 FLAG comment: stress test parsing on background
THE V8 FLAG IS: concurrent-cache-deserialization
THE V8 FLAG comment: enable deserializing code caches on background
THE V8 FLAG IS: merge-background-deserialized-script-with-compilation-cache
THE V8 FLAG comment: After deserializing code cache data on a background thread, merge it into an existing Script if one is found in the Isolate compilation cache
THE V8 FLAG IS: disable-old-api-accessors
THE V8 FLAG comment: Disable old-style API accessors whose setters trigger through the prototype chain
THE V8 FLAG IS: embedder-instance-types
THE V8 FLAG comment: enable type checks based on instance types provided by the embedder
THE V8 FLAG IS: expose-gc
THE V8 FLAG comment: expose gc extension
THE V8 FLAG IS: expose-gc-as
THE V8 FLAG comment: expose gc extension under the specified name
THE V8 FLAG IS: expose-externalize-string
THE V8 FLAG comment: expose externalize string extension
THE V8 FLAG IS: expose-statistics
THE V8 FLAG comment: expose statistics extension
THE V8 FLAG IS: expose-trigger-failure
THE V8 FLAG comment: expose trigger-failure extension
THE V8 FLAG IS: expose-ignition-statistics
THE V8 FLAG comment: expose ignition-statistics extension (requires building with v8_enable_ignition_dispatch_counting)
THE V8 FLAG IS: stack-trace-limit
THE V8 FLAG comment: number of stack frames to capture
THE V8 FLAG IS: builtins-in-stack-traces
THE V8 FLAG comment: show built-in functions in stack traces
THE V8 FLAG IS: experimental-stack-trace-frames
THE V8 FLAG comment: enable experimental frames (API/Builtins) and stack trace layout
THE V8 FLAG IS: disallow-code-generation-from-strings
THE V8 FLAG comment: disallow eval and friends
THE V8 FLAG IS: expose-async-hooks
THE V8 FLAG comment: expose async_hooks object
THE V8 FLAG IS: expose-cputracemark-as
THE V8 FLAG comment: expose cputracemark extension under the specified name
THE V8 FLAG IS: allow-unsafe-function-constructor
THE V8 FLAG comment: allow invoking the function constructor without security checks
THE V8 FLAG IS: force-slow-path
THE V8 FLAG comment: always take the slow path for builtins
THE V8 FLAG IS: test-small-max-function-context-stub-size
THE V8 FLAG comment: enable testing the function context size overflow path by making the maximum size smaller
THE V8 FLAG IS: inline-new
THE V8 FLAG comment: use fast inline allocation
THE V8 FLAG IS: switch-table-spread-threshold
THE V8 FLAG comment: allow the jump table used for switch statements to span a range of integers roughly equal to this number times the number of clauses in the switch
THE V8 FLAG IS: switch-table-min-cases
THE V8 FLAG comment: the number of Smi integer cases present in the switch statement before using the jump table optimization
THE V8 FLAG IS: trace
THE V8 FLAG comment: trace javascript function calls
THE V8 FLAG IS: lazy
THE V8 FLAG comment: use lazy compilation
THE V8 FLAG IS: lazy-eval
THE V8 FLAG comment: use lazy compilation during eval
THE V8 FLAG IS: lazy-streaming
THE V8 FLAG comment: use lazy compilation during streaming compilation
THE V8 FLAG IS: max-lazy
THE V8 FLAG comment: ignore eager compilation hints
THE V8 FLAG IS: trace-opt
THE V8 FLAG comment: trace optimized compilation
THE V8 FLAG IS: trace-opt-verbose
THE V8 FLAG comment: extra verbose optimized compilation tracing
THE V8 FLAG IS: trace-opt-stats
THE V8 FLAG comment: trace optimized compilation statistics
THE V8 FLAG IS: trace-deopt
THE V8 FLAG comment: trace deoptimization
THE V8 FLAG IS: log-deopt
THE V8 FLAG comment: log deoptimization
THE V8 FLAG IS: trace-deopt-verbose
THE V8 FLAG comment: extra verbose deoptimization tracing
THE V8 FLAG IS: trace-file-names
THE V8 FLAG comment: include file names in trace-opt/trace-deopt output
THE V8 FLAG IS: always-turbofan
THE V8 FLAG comment: always try to optimize functions
THE V8 FLAG IS: always-osr
THE V8 FLAG comment: always try to OSR functions
THE V8 FLAG IS: prepare-always-turbofan
THE V8 FLAG comment: prepare for turning on always opt
THE V8 FLAG IS: deopt-to-baseline
THE V8 FLAG comment: deoptimize to baseline code when available
THE V8 FLAG IS: trace-serializer
THE V8 FLAG comment: print code serializer trace
THE V8 FLAG IS: compilation-cache
THE V8 FLAG comment: enable compilation cache
THE V8 FLAG IS: cache-prototype-transitions
THE V8 FLAG comment: cache prototype transitions
THE V8 FLAG IS: lazy-compile-dispatcher
THE V8 FLAG comment: enable compiler dispatcher
THE V8 FLAG IS: lazy-compile-dispatcher-max-threads
THE V8 FLAG comment: max threads for compiler dispatcher (0 for unbounded)
THE V8 FLAG IS: trace-compiler-dispatcher
THE V8 FLAG comment: trace compiler dispatcher activity
THE V8 FLAG IS: parallel-compile-tasks-for-eager-toplevel
THE V8 FLAG comment: spawn parallel compile tasks for eagerly compiled, top-level functions
THE V8 FLAG IS: parallel-compile-tasks-for-lazy
THE V8 FLAG comment: spawn parallel compile tasks for all lazily compiled functions
THE V8 FLAG IS: cpu-profiler-sampling-interval
THE V8 FLAG comment: CPU profiler sampling interval in microseconds
THE V8 FLAG IS: trace-side-effect-free-debug-evaluate
THE V8 FLAG comment: print debug messages for side-effect-free debug-evaluate for testing
THE V8 FLAG IS: hard-abort
THE V8 FLAG comment: abort by crashing
THE V8 FLAG IS: experimental-value-unavailable
THE V8 FLAG comment: enable experimental <value unavailable> in scopes
THE V8 FLAG IS: experimental-reuse-locals-blocklists
THE V8 FLAG comment: enable reuse of local blocklists across multiple debug-evaluates
THE V8 FLAG IS: experimental-remove-internal-scopes-property
THE V8 FLAG comment: don't report the artificial [[Scopes]] property for functions
THE V8 FLAG IS: log-colour
THE V8 FLAG comment: When logging, try to use coloured output.
THE V8 FLAG IS: expose-inspector-scripts
THE V8 FLAG comment: expose injected-script-source.js for debugging
THE V8 FLAG IS: stack-size
THE V8 FLAG comment: default size of stack region v8 is allowed to use (in kBytes)
THE V8 FLAG IS: max-stack-trace-source-length
THE V8 FLAG comment: maximum length of function source code printed in a stack trace.
THE V8 FLAG IS: clear-exceptions-on-js-entry
THE V8 FLAG comment: clear pending exceptions when entering JavaScript
THE V8 FLAG IS: histogram-interval
THE V8 FLAG comment: time interval in ms for aggregating memory histograms
THE V8 FLAG IS: heap-profiler-trace-objects
THE V8 FLAG comment: Dump heap object allocations/movements/size_updates
THE V8 FLAG IS: heap-profiler-use-embedder-graph
THE V8 FLAG comment: Use the new EmbedderGraph API to get embedder nodes
THE V8 FLAG IS: heap-snapshot-string-limit
THE V8 FLAG comment: truncate strings to this length in the heap snapshot
THE V8 FLAG IS: heap-profiler-show-hidden-objects
THE V8 FLAG comment: use 'native' rather than 'hidden' node type in snapshot
THE V8 FLAG IS: sampling-heap-profiler-suppress-randomness
THE V8 FLAG comment: Use constant sample intervals to eliminate test flakiness
THE V8 FLAG IS: use-idle-notification
THE V8 FLAG comment: Use idle notification to reduce memory footprint.
THE V8 FLAG IS: log-ic
THE V8 FLAG comment: Log inline cache state transitions for tools/ic-processor
THE V8 FLAG IS: max-valid-polymorphic-map-count
THE V8 FLAG comment: maximum number of valid maps to track in POLYMORPHIC state
THE V8 FLAG IS: native-code-counters
THE V8 FLAG comment: generate extra code for manipulating stats counters
THE V8 FLAG IS: super-ic
THE V8 FLAG comment: use an IC for super property loads
THE V8 FLAG IS: enable-mega-dom-ic
THE V8 FLAG comment: use MegaDOM IC state for API objects
THE V8 FLAG IS: trace-prototype-users
THE V8 FLAG comment: Trace updates to prototype user tracking
THE V8 FLAG IS: trace-for-in-enumerate
THE V8 FLAG comment: Trace for-in enumerate slow-paths
THE V8 FLAG IS: log-maps
THE V8 FLAG comment: Log map creation
THE V8 FLAG IS: log-maps-details
THE V8 FLAG comment: Also log map details
THE V8 FLAG IS: allow-natives-syntax
THE V8 FLAG comment: allow natives syntax
THE V8 FLAG IS: allow-natives-for-differential-fuzzing
THE V8 FLAG comment: allow only natives explicitly allowlisted for differential fuzzers
THE V8 FLAG IS: parse-only
THE V8 FLAG comment: only parse the sources
THE V8 FLAG IS: async-stack-traces
THE V8 FLAG comment: include async stack traces in Error.stack
THE V8 FLAG IS: stack-trace-on-illegal
THE V8 FLAG comment: print stack trace when an illegal exception is thrown
THE V8 FLAG IS: abort-on-uncaught-exception
THE V8 FLAG comment: abort program (dump core) when an uncaught exception is thrown
THE V8 FLAG IS: correctness-fuzzer-suppressions
THE V8 FLAG comment: Suppress certain unspecified behaviors to ease correctness fuzzing: Abort program when the stack overflows or a string exceeds maximum length (as opposed to throwing RangeError). Use a fixed suppression string for error messages.
THE V8 FLAG IS: rehash-snapshot
THE V8 FLAG comment: rehash strings from the snapshot to override the baked-in seed
THE V8 FLAG IS: hash-seed
THE V8 FLAG comment: Fixed seed to use to hash property keys (0 means random)(with snapshots this option cannot override the baked-in seed)
THE V8 FLAG IS: random-seed
THE V8 FLAG comment: Default seed for initializing random generator (0, the default, means to use system random).
THE V8 FLAG IS: fuzzer-random-seed
THE V8 FLAG comment: Default seed for initializing fuzzer random generator (0, the default, means to use v8's random number generator seed).
THE V8 FLAG IS: trace-rail
THE V8 FLAG comment: trace RAIL mode
THE V8 FLAG IS: print-all-exceptions
THE V8 FLAG comment: print exception object and stack trace on each thrown exception
THE V8 FLAG IS: detailed-error-stack-trace
THE V8 FLAG comment: includes arguments for each function call in the error stack frames array
THE V8 FLAG IS: adjust-os-scheduling-parameters
THE V8 FLAG comment: adjust OS specific scheduling params for the isolate
THE V8 FLAG IS: experimental-flush-embedded-blob-icache
THE V8 FLAG comment: Used in an experiment to evaluate icache flushing on certain CPUs
THE V8 FLAG IS: short-builtin-calls
THE V8 FLAG comment: Put embedded builtins code into the code range for shorter builtin calls/jumps if system has >=4GB memory
THE V8 FLAG IS: runtime-call-stats
THE V8 FLAG comment: report runtime call counts and times
THE V8 FLAG IS: rcs
THE V8 FLAG comment: report runtime call counts and times
THE V8 FLAG IS: rcs-cpu-time
THE V8 FLAG comment: report runtime times in cpu time (the default is wall time)
THE V8 FLAG IS: verify-snapshot-checksum
THE V8 FLAG comment: Verify snapshot checksums when deserializing snapshots. Enable checksum creation and verification for code caches. Enabled by default in debug builds and once per process for Android.
THE V8 FLAG IS: profile-deserialization
THE V8 FLAG comment: Print the time it takes to deserialize the snapshot.
THE V8 FLAG IS: serialization-statistics
THE V8 FLAG comment: Collect statistics on serialized objects.
THE V8 FLAG IS: regexp-optimization
THE V8 FLAG comment: generate optimized regexp code
THE V8 FLAG IS: regexp-interpret-all
THE V8 FLAG comment: interpret all regexp code
THE V8 FLAG IS: regexp-tier-up
THE V8 FLAG comment: enable regexp interpreter and tier up to the compiler after the number of executions set by the tier up ticks flag
THE V8 FLAG IS: regexp-tier-up-ticks
THE V8 FLAG comment: set the number of executions for the regexp interpreter before tiering-up to the compiler
THE V8 FLAG IS: regexp-peephole-optimization
THE V8 FLAG comment: enable peephole optimization for regexp bytecode
THE V8 FLAG IS: trace-regexp-peephole-optimization
THE V8 FLAG comment: trace regexp bytecode peephole optimization
THE V8 FLAG IS: trace-regexp-bytecodes
THE V8 FLAG comment: trace regexp bytecode execution
THE V8 FLAG IS: trace-regexp-assembler
THE V8 FLAG comment: trace regexp macro assembler calls.
THE V8 FLAG IS: trace-regexp-parser
THE V8 FLAG comment: trace regexp parsing
THE V8 FLAG IS: trace-regexp-tier-up
THE V8 FLAG comment: trace regexp tiering up execution
THE V8 FLAG IS: trace-regexp-graph
THE V8 FLAG comment: trace the regexp graph
THE V8 FLAG IS: enable-experimental-regexp-engine
THE V8 FLAG comment: recognize regexps with 'l' flag, run them on experimental engine
THE V8 FLAG IS: default-to-experimental-regexp-engine
THE V8 FLAG comment: run regexps with the experimental engine where possible
THE V8 FLAG IS: trace-experimental-regexp-engine
THE V8 FLAG comment: trace execution of experimental regexp engine
THE V8 FLAG IS: enable-experimental-regexp-engine-on-excessive-backtracks
THE V8 FLAG comment: fall back to a breadth-first regexp engine on excessive backtracking
THE V8 FLAG IS: regexp-backtracks-before-fallback
THE V8 FLAG comment: number of backtracks during regexp execution before fall back to experimental engine if enable_experimental_regexp_engine_on_excessive_backtracks is set
THE V8 FLAG IS: testing-bool-flag
THE V8 FLAG comment: testing_bool_flag
THE V8 FLAG IS: testing-maybe-bool-flag
THE V8 FLAG comment: testing_maybe_bool_flag
THE V8 FLAG IS: testing-int-flag
THE V8 FLAG comment: testing_int_flag
THE V8 FLAG IS: testing-float-flag
THE V8 FLAG comment: float-flag
THE V8 FLAG IS: testing-string-flag
THE V8 FLAG comment: string-flag
THE V8 FLAG IS: testing-prng-seed
THE V8 FLAG comment: Seed used for threading test randomness
THE V8 FLAG IS: testing-d8-test-runner
THE V8 FLAG comment: test runner turns on this flag to enable a check that the function was prepared for optimization before marking it for optimization
THE V8 FLAG IS: fuzzing
THE V8 FLAG comment: Fuzzers use this flag to signal that they are ... fuzzing. This causes intrinsics to fail silently (e.g. return undefined) on invalid usage.
THE V8 FLAG IS: freeze-flags-after-init
THE V8 FLAG comment: Disallow changes to flag values after initializing V8
THE V8 FLAG IS: embedded-src
THE V8 FLAG comment: Path for the generated embedded data file. (mksnapshot only)
THE V8 FLAG IS: embedded-variant
THE V8 FLAG comment: Label to disambiguate symbols in embedded data file. (mksnapshot only)
THE V8 FLAG IS: startup-src
THE V8 FLAG comment: Write V8 startup as C++ src. (mksnapshot only)
THE V8 FLAG IS: startup-blob
THE V8 FLAG comment: Write V8 startup blob file. (mksnapshot only)
THE V8 FLAG IS: target-arch
THE V8 FLAG comment: The mksnapshot target arch. (mksnapshot only)
THE V8 FLAG IS: target-os
THE V8 FLAG comment: The mksnapshot target os. (mksnapshot only)
THE V8 FLAG IS: target-is-simulator
THE V8 FLAG comment: Instruct mksnapshot that the target is meant to run in the simulator and it can generate simulator-specific instructions. (mksnapshot only)
THE V8 FLAG IS: turbo-profiling-input
THE V8 FLAG comment: Path of the input file containing basic block counters for builtins. (mksnapshot only)
THE V8 FLAG IS: text-is-readable
THE V8 FLAG comment: Whether the .text section of binary can be read
THE V8 FLAG IS: trace-minor-mc-parallel-marking
THE V8 FLAG comment: trace parallel marking for the young generation
THE V8 FLAG IS: minor-mc
THE V8 FLAG comment: perform young generation mark compact GCs
THE V8 FLAG IS: concurrent-minor-mc-marking
THE V8 FLAG comment: perform young generation marking concurrently
THE V8 FLAG IS: help
THE V8 FLAG comment: Print usage message, including flags, on console
THE V8 FLAG IS: print-flag-values
THE V8 FLAG comment: Print all flag values of V8
THE V8 FLAG IS: slow-histograms
THE V8 FLAG comment: Enable slow histograms with more overhead.
THE V8 FLAG IS: use-external-strings
THE V8 FLAG comment: Use external strings for source code
THE V8 FLAG IS: map-counters
THE V8 FLAG comment: Map counters to a file
THE V8 FLAG IS: mock-arraybuffer-allocator
THE V8 FLAG comment: Use a mock ArrayBuffer allocator for testing.
THE V8 FLAG IS: mock-arraybuffer-allocator-limit
THE V8 FLAG comment: Memory limit for mock ArrayBuffer allocator used to simulate OOM for testing.
THE V8 FLAG IS: logfile
THE V8 FLAG comment: Specify the name of the log file, use '-' for console, '+' for a temporary file.
THE V8 FLAG IS: logfile-per-isolate
THE V8 FLAG comment: Separate log files for each isolate.
THE V8 FLAG IS: log
THE V8 FLAG comment: Minimal logging (no API, code, GC, suspect, or handles samples).
THE V8 FLAG IS: log-all
THE V8 FLAG comment: Log all events to the log file.
THE V8 FLAG IS: log-source-code
THE V8 FLAG comment: Log source code.
THE V8 FLAG IS: log-source-position
THE V8 FLAG comment: Log detailed source information.
THE V8 FLAG IS: log-code
THE V8 FLAG comment: Log code events to the log file without profiling.
THE V8 FLAG IS: log-feedback-vector
THE V8 FLAG comment: Log FeedbackVectors on first creation
THE V8 FLAG IS: log-code-disassemble
THE V8 FLAG comment: Log all disassembled code to the log file.
THE V8 FLAG IS: log-function-events
THE V8 FLAG comment: Log function events (parse, compile, execute) separately.
THE V8 FLAG IS: detailed-line-info
THE V8 FLAG comment: Always generate detailed line information for CPU profiling.
THE V8 FLAG IS: prof-sampling-interval
THE V8 FLAG comment: Interval for --prof samples (in microseconds).
THE V8 FLAG IS: prof-cpp
THE V8 FLAG comment: Like --prof, but ignore generated code.
THE V8 FLAG IS: prof-browser-mode
THE V8 FLAG comment: Used with --prof, turns on browser-compatible mode for profiling.
THE V8 FLAG IS: prof
THE V8 FLAG comment: Log statistical profiling information (implies --log-code).
THE V8 FLAG IS: ll-prof
THE V8 FLAG comment: Enable low-level linux profiler.
THE V8 FLAG IS: gc-fake-mmap
THE V8 FLAG comment: Specify the name of the file for fake gc mmap used in ll_prof
THE V8 FLAG IS: log-internal-timer-events
THE V8 FLAG comment: Time internal events.
THE V8 FLAG IS: redirect-code-traces
THE V8 FLAG comment: output deopt information and disassembly into file code-<pid>-<isolate id>.asm
THE V8 FLAG IS: redirect-code-traces-to
THE V8 FLAG comment: output deopt information and disassembly into the given file
THE V8 FLAG IS: print-opt-source
THE V8 FLAG comment: print source code of optimized and inlined functions
THE V8 FLAG IS: vtune-prof-annotate-wasm
THE V8 FLAG comment: Used when v8_enable_vtunejit is enabled, load wasm source map and provide annotate support (experimental).
THE V8 FLAG IS: win64-unwinding-info
THE V8 FLAG comment: Enable unwinding info for Windows/x64
THE V8 FLAG IS: interpreted-frames-native-stack
THE V8 FLAG comment: Show interpreted frames on the native stack (useful for external profilers).
THE V8 FLAG IS: trace-elements-transitions
THE V8 FLAG comment: trace elements transitions
THE V8 FLAG IS: trace-creation-allocation-sites
THE V8 FLAG comment: trace the creation of allocation sites
THE V8 FLAG IS: print-code
THE V8 FLAG comment: print generated code
THE V8 FLAG IS: print-opt-code
THE V8 FLAG comment: print optimized code
THE V8 FLAG IS: print-opt-code-filter
THE V8 FLAG comment: filter for printing optimized code
THE V8 FLAG IS: print-code-verbose
THE V8 FLAG comment: print more information for code
THE V8 FLAG IS: print-builtin-code
THE V8 FLAG comment: print generated code for builtins
THE V8 FLAG IS: print-builtin-code-filter
THE V8 FLAG comment: filter for printing builtin code
THE V8 FLAG IS: print-regexp-code
THE V8 FLAG comment: print generated regexp code
THE V8 FLAG IS: print-regexp-bytecode
THE V8 FLAG comment: print generated regexp bytecode
THE V8 FLAG IS: print-builtin-size
THE V8 FLAG comment: print code size for builtins
THE V8 FLAG IS: print-all-code
THE V8 FLAG comment: enable all flags related to printing code
THE V8 FLAG IS: predictable
THE V8 FLAG comment: enable predictable mode
THE V8 FLAG IS: predictable-gc-schedule
THE V8 FLAG comment: Predictable garbage collection schedule. Fixes heap growing, idle, and memory reducing behavior.
THE V8 FLAG IS: single-threaded
THE V8 FLAG comment: disable the use of background tasks
THE V8 FLAG IS: single-threaded-gc
THE V8 FLAG comment: disable the use of background gc tasks
THE V8 FLAG IS: experimental-web-snapshots
THE V8 FLAG comment: enable Web Snapshots
Welcome to Node.js v20.0.0-pre.
Type ".help" for more information.

```

</details> 

cc @joyeecheung @bnoordhuis