### PR TITLE
doc: add a note about os.cpus() returning an empty list

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -76,6 +76,8 @@ added: v0.3.3
 * Returns: {Object\[]}
 
 Returns an array of objects containing information about each logical CPU core.
+The array will be empty if no CPU information is available, such as if the
+`/proc` file system is unavailable.
 
 The properties included on each object include:
 


### PR DESCRIPTION
It is not obvious that in some cases cpus() returns an empty list and this has caused a bug before: https://github.com/isaacs/promise-call-limit/pull/11

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
