### PR TITLE
watch: fix watch path with equals

### DIFF
--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -6,6 +6,7 @@ const {
   ArrayPrototypeMap,
   ArrayPrototypePushApply,
   ArrayPrototypeSlice,
+  StringPrototypeStartsWith,
 } = primordials;
 
 const {
@@ -38,7 +39,9 @@ const kPreserveOutput = getOptionValue('--watch-preserve-output');
 const kCommand = ArrayPrototypeSlice(process.argv, 1);
 const kCommandStr = inspect(ArrayPrototypeJoin(kCommand, ' '));
 const args = ArrayPrototypeFilter(process.execArgv, (arg, i, arr) =>
-  arg !== '--watch-path' && arr[i - 1] !== '--watch-path' && arg !== '--watch' && arg !== '--watch-preserve-output');
+  !StringPrototypeStartsWith(arg, '--watch-path') &&
+  (!arr[i - 1] || !StringPrototypeStartsWith(arr[i - 1], '--watch-path')) &&
+  arg !== '--watch' && arg !== '--watch-preserve-output');
 ArrayPrototypePushApply(args, kCommand);
 
 const watcher = new FilesWatcher({ throttle: 500, mode: kShouldFilterModules ? 'filter' : 'all' });
@@ -50,7 +53,7 @@ let exited;
 
 function start() {
   exited = false;
-  const stdio = kShouldFilterModules ? ['inherit', 'inherit', 'inherit', 'ipc'] : undefined;
+  const stdio = kShouldFilterModules ? ['inherit', 'inherit', 'inherit', 'ipc'] : 'inherit';
   child = spawn(process.execPath, args, { stdio, env: { ...process.env, WATCH_REPORT_DEPENDENCIES: '1' } });
   watcher.watchChildProcessModules(child);
   child.once('exit', (code) => {

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -137,6 +137,23 @@ describe('watch mode', { concurrency: false, timeout: 60_000 }, () => {
     });
   });
 
+  it('should watch changes to a file with watch-path', {
+    skip: !supportsRecursive,
+  }, async () => {
+    const file = createTmpFile();
+    const watchedFile = fixtures.path('watch-mode/subdir/file.js');
+    const { stderr, stdout } = await spawnWithRestarts({
+      file,
+      watchedFile,
+      args: ['--watch-path', fixtures.path('./watch-mode/subdir'), file],
+    });
+    assert.strictEqual(stderr, '');
+    assertRestartedCorrectly({
+      stdout,
+      messages: { inner: 'running', completed: `Completed running ${inspect(file)}`, restarted: `Restarting ${inspect(file)}` },
+    });
+  });
+
   it('should watch when running an non-existing file - when specified under --watch-path', {
     skip: !supportsRecursive
   }, async () => {

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -148,7 +148,28 @@ describe('watch mode', { concurrency: false, timeout: 60_000 }, () => {
       args: ['--watch-path', fixtures.path('./watch-mode/subdir/'), file],
     });
 
-    assert.strictEqual(stderr, '');
+    assert.match(stderr, /Error: Cannot find module/);
+    assert(stderr.match(/Error: Cannot find module/g).length >= 2);
+
+    assertRestartedCorrectly({
+      stdout,
+      messages: { completed: `Failed running ${inspect(file)}`, restarted: `Restarting ${inspect(file)}` },
+    });
+  });
+
+  it('should watch when running an non-existing file - when specified under --watch-path with equals', {
+    skip: !supportsRecursive
+  }, async () => {
+    const file = fixtures.path('watch-mode/subdir/non-existing.js');
+    const watchedFile = fixtures.path('watch-mode/subdir/file.js');
+    const { stderr, stdout } = await spawnWithRestarts({
+      file,
+      watchedFile,
+      args: [`--watch-path=${fixtures.path('./watch-mode/subdir/')}`, file],
+    });
+
+    assert.match(stderr, /Error: Cannot find module/);
+    assert(stderr.match(/Error: Cannot find module/g).length >= 2);
     assertRestartedCorrectly({
       stdout,
       messages: { completed: `Failed running ${inspect(file)}`, restarted: `Restarting ${inspect(file)}` },


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/47296

prior to this fix `node --watch-path path.js` worked but `node --watch-path=path.js` did not