### PR TITLE
tools: ensure failed daily wpt run still generates a report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -592,7 +592,7 @@ test-wpt: all
 test-wpt-report:
 	$(RM) -r out/wpt
 	mkdir -p out/wpt
-	WPT_REPORT=1 $(PYTHON) tools/test.py --shell $(NODE) $(PARALLEL_ARGS) wpt
+	-WPT_REPORT=1 $(PYTHON) tools/test.py --shell $(NODE) $(PARALLEL_ARGS) wpt
 	$(NODE) "$$PWD/tools/merge-wpt-reports.mjs"
 
 .PHONY: test-internet


### PR DESCRIPTION
This fixes a regression to the daily wpt run (only nightly runs at the moment) introduced in #47283.

When this lands the `dont-land-*` labels on #47283 may be removed.