### PR TITLE
net: only defer _final call when connecting

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -507,7 +507,7 @@ Socket.prototype._unrefTimer = function _unrefTimer() {
 // sent out to the other side.
 Socket.prototype._final = function(cb) {
   // If still connecting - defer handling `_final` until 'connect' will happen
-  if (this.pending) {
+  if (this.connecting) {
     debug('_final: not yet connected');
     return this.once('connect', () => this._final(cb));
   }

--- a/test/parallel/test-net-end-without-connect.js
+++ b/test/parallel/test-net-end-without-connect.js
@@ -20,8 +20,11 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const net = require('net');
+const assert = require('assert');
 
 const sock = new net.Socket();
-sock.end();  // Should not throw.
+sock.end(common.mustCall(() => {
+  assert.strictEqual(sock.writable, false);
+}));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/47322

`pending` potentially covers these 2 stages:
- constructed, haven't done any connection
- connecting

It is possible sockets at first stage simply want to get destroyed without any attempt of connecting.
Thus, it's more appropriate to defer the final call only when the socket has started connecting but not yet connected.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
