### PR TITLE
src: track ShadowRealm native objects correctly in the heap snapshot

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -64,6 +64,9 @@
 
 namespace node {
 
+namespace shadow_realm {
+class ShadowRealm;
+}
 namespace contextify {
 class ContextifyScript;
 class CompiledFnEntry;
@@ -643,6 +646,8 @@ class Environment : public MemoryRetainer {
                        const ContextInfo& info);
   void TrackContext(v8::Local<v8::Context> context);
   void UntrackContext(v8::Local<v8::Context> context);
+  void TrackShadowRealm(shadow_realm::ShadowRealm* realm);
+  void UntrackShadowRealm(shadow_realm::ShadowRealm* realm);
 
   void StartProfilerIdleNotifier();
 
@@ -1020,6 +1025,7 @@ class Environment : public MemoryRetainer {
 
   size_t async_callback_scope_depth_ = 0;
   std::vector<double> destroy_async_id_list_;
+  std::unordered_set<shadow_realm::ShadowRealm*> shadow_realms_;
 
 #if HAVE_INSPECTOR
   std::unique_ptr<profiler::V8CoverageConnection> coverage_connection_;

--- a/src/node_realm.cc
+++ b/src/node_realm.cc
@@ -33,7 +33,6 @@ void Realm::MemoryInfo(MemoryTracker* tracker) const {
   PER_REALM_STRONG_PERSISTENT_VALUES(V)
 #undef V
 
-  tracker->TrackField("env", env_);
   tracker->TrackField("cleanup_queue", cleanup_queue_);
   tracker->TrackField("builtins_with_cache", builtins_with_cache);
   tracker->TrackField("builtins_without_cache", builtins_without_cache);
@@ -299,10 +298,6 @@ PrincipalRealm::PrincipalRealm(Environment* env,
   if (realm_info == nullptr) {
     CreateProperties();
   }
-}
-
-void PrincipalRealm::MemoryInfo(MemoryTracker* tracker) const {
-  Realm::MemoryInfo(tracker);
 }
 
 MaybeLocal<Value> PrincipalRealm::BootstrapRealm() {

--- a/src/node_realm.h
+++ b/src/node_realm.h
@@ -165,7 +165,6 @@ class PrincipalRealm : public Realm {
 
   SET_MEMORY_INFO_NAME(PrincipalRealm)
   SET_SELF_SIZE(PrincipalRealm)
-  void MemoryInfo(MemoryTracker* tracker) const override;
 
 #define V(PropertyName, TypeName)                                              \
   v8::Local<TypeName> PropertyName() const override;                           \

--- a/src/node_shadow_realm.h
+++ b/src/node_shadow_realm.h
@@ -15,7 +15,6 @@ class ShadowRealm : public Realm {
 
   SET_MEMORY_INFO_NAME(ShadowRealm)
   SET_SELF_SIZE(ShadowRealm)
-  void MemoryInfo(MemoryTracker* tracker) const override;
 
   v8::Local<v8::Context> context() const override;
 
@@ -24,6 +23,8 @@ class ShadowRealm : public Realm {
   void set_##PropertyName(v8::Local<TypeName> value) override;
   PER_REALM_STRONG_PERSISTENT_VALUES(V)
 #undef V
+
+  void OnEnvironmentDestruct();
 
  protected:
   v8::MaybeLocal<v8::Value> BootstrapRealm() override;


### PR DESCRIPTION
Previously the native ShadowRealm objects were never actually tracked in the heap snapshot - the tracking starts with the Environment, we don't call the tracking methods unless it's reachable natively from the Environment. This patch adds a set in the Environment for tracking shadow realms in the heap snapshot.

Drive-by: remove redundant MemoryInfo() overrides from the derived classes of Realm and remove the tracking of `env` from `Realm::MemoryInfo()` because the realms don't hold the Environment alive (even for the principal realm, it's the other way around).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
