### PR TITLE
test_runner: color errors only when colors are avilable

### DIFF
--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -14,10 +14,10 @@ const {
 const assert = require('assert');
 const Transform = require('internal/streams/transform');
 const { inspectWithNoCustomRetry } = require('internal/errors');
-const { green, blue, red, white, gray } = require('internal/util/colors');
+const { green, blue, red, white, gray, hasColors } = require('internal/util/colors');
 const { getCoverageReport } = require('internal/test_runner/utils');
 
-const inspectOptions = { __proto__: null, colors: true, breakLength: Infinity };
+const inspectOptions = { __proto__: null, colors: hasColors, breakLength: Infinity };
 
 const colors = {
   '__proto__': null,


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/47393