### PR TITLE
deps: V8: cherry-pick 1b471b796022

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.6',
+    'v8_embedder_string': '-node.7',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
+++ b/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
@@ -3976,8 +3976,12 @@ bool MacroAssembler::BranchShortHelper(int32_t offset, Label* L, Condition cond,
   BlockTrampolinePoolScope block_trampoline_pool(this);
   Register scratch = no_reg;
   if (!rt.is_reg()) {
-    scratch = temps.Acquire();
-    li(scratch, rt);
+    if (rt.immediate() == 0) {
+      scratch = zero_reg;
+    } else {
+      scratch = temps.Acquire();
+      li(scratch, rt);
+    }
   } else {
     scratch = rt.rm();
   }

--- a/deps/v8/src/regexp/riscv/regexp-macro-assembler-riscv.cc
+++ b/deps/v8/src/regexp/riscv/regexp-macro-assembler-riscv.cc
@@ -24,7 +24,7 @@ namespace internal {
  * - s5 : Currently loaded character. Must be loaded using
  *        LoadCurrentCharacter before using any of the dispatch methods.
  * - s6 : Points to tip of backtrack stack
- * - s7 : End of input (points to byte after last character in input).
+ * - s8 : End of input (points to byte after last character in input).
  * - fp : Frame pointer. Used to access arguments, local variables and
  *        RegExp registers.
  * - sp : Points to tip of C stack.
@@ -38,7 +38,7 @@ namespace internal {
  *  --- sp when called ---
  *  - fp[72]  ra                  Return from RegExp code (ra).                  kReturnAddress
  *  - fp[64]  old-fp              Old fp, callee saved(s9).
- *  - fp[0..63]  s1..s78          Callee-saved registers fp..s7.
+ *  - fp[0..63]  s1..s11          Callee-saved registers fp..s11.
  *  --- frame pointer ----
  *  - fp[-8]  frame marker
  *  - fp[-16]  Isolate* isolate   (address of the current isolate)               kIsolate
@@ -672,8 +672,8 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
     // Order here should correspond to order of offset constants in header file.
     // TODO(plind): we save fp..s11, but ONLY use s3 here - use the regs
     // or dont save.
-    RegList registers_to_retain = {fp, s1, s2, s3, s4,
-                                   s5, s6, s7, s8 /*, s9, s10, s11*/};
+    RegList registers_to_retain = {fp, s1, s2, s3, s4,  s5,
+                                   s6, s7, s8, s9, s10, s11};
     DCHECK(registers_to_retain.Count() == kNumCalleeRegsToRetain);
 
     // The remaining arguments are passed in registers, e.g.by calling the code
@@ -717,7 +717,7 @@ Handle<HeapObject> RegExpMacroAssemblerRISCV::GetCode(Handle<String> source) {
 
     // Initialize backtrack stack pointer. It must not be clobbered from here
     // on. Note the backtrack_stackpointer is callee-saved.
-    static_assert(backtrack_stackpointer() == s7);
+    static_assert(backtrack_stackpointer() == s8);
     LoadRegExpStackPointerFromMemory(backtrack_stackpointer());
     // Store the regexp base pointer - we'll later restore it / write it to
     // memory when returning from this irregexp code object.

--- a/deps/v8/src/regexp/riscv/regexp-macro-assembler-riscv.h
+++ b/deps/v8/src/regexp/riscv/regexp-macro-assembler-riscv.h
@@ -104,8 +104,8 @@ class V8_EXPORT_PRIVATE RegExpMacroAssemblerRISCV
   static constexpr int kStoredRegistersOffset = kFramePointerOffset;
   // Return address (stored from link register, read into pc on return).
 
-  // This 9 is 8 s-regs (s1..s8) plus fp.
-  static constexpr int kNumCalleeRegsToRetain = 9;
+  // This 9 is 8 s-regs (s1..s11) plus fp.
+  static constexpr int kNumCalleeRegsToRetain = 12;
   static constexpr int kReturnAddressOffset =
       kStoredRegistersOffset + kNumCalleeRegsToRetain * kSystemPointerSize;
 
@@ -187,7 +187,9 @@ class V8_EXPORT_PRIVATE RegExpMacroAssemblerRISCV
 
   // The register containing the backtrack stack top. Provides a meaningful
   // name to the register.
-  static constexpr Register backtrack_stackpointer() { return s7; }
+  // s7 should not be used here because baseline sparkplug uses s7 as context
+  // register.
+  static constexpr Register backtrack_stackpointer() { return s8; }
 
   // Register holding pointer to the current code object.
   static constexpr Register code_pointer() { return s1; }


### PR DESCRIPTION
Original commit message:

    [riscv] Using s8 as backtrack_stackpointer reg and optimize BranchShortHelper

    1. Fix incorrect backtrack_stackpointer reg.
    2. Optimize BranchShortHelper when comparing zero immediate.
    3. This is a workaround CL fix v8:13836

    Bug: v8:13836

    Change-Id: I4cfc9df92fcd38ecd448a41ee87d1e251efd4ad9
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4394942
    Auto-Submit: Yahan Lu <yahan@iscas.ac.cn>
    Reviewed-by: Ji Qiu <qiuji@iscas.ac.cn>
    Commit-Queue: Ji Qiu <qiuji@iscas.ac.cn>
    Cr-Commit-Position: refs/heads/main@{#86889}

Refs: https://github.com/v8/v8/commit/1b471b79602235c13202b5b52eeb34603cee7a91

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
