### PR TITLE
crypto: replace THROW with CHECK for scrypt keylen

### DIFF
--- a/src/crypto/crypto_scrypt.cc
+++ b/src/crypto/crypto_scrypt.cc
@@ -109,10 +109,7 @@ Maybe<bool> ScryptTraits::AdditionalConfig(
   }
 
   params->length = args[offset + 6].As<Int32>()->Value();
-  if (params->length < 0) {
-    THROW_ERR_OUT_OF_RANGE(env, "length must be <= %d", INT_MAX);
-    return Nothing<bool>();
-  }
+  CHECK_GE(params->length, 0);
 
   return Just(true);
 }

--- a/test/parallel/test-crypto-scrypt.js
+++ b/test/parallel/test-crypto-scrypt.js
@@ -144,7 +144,15 @@ const badargs = [
     expected: { code: 'ERR_OUT_OF_RANGE', message: /"keylen"/ },
   },
   {
+    args: ['', '', 2 ** 31],
+    expected: { code: 'ERR_OUT_OF_RANGE', message: /"keylen"/ },
+  },
+  {
     args: ['', '', 2147485780],
+    expected: { code: 'ERR_OUT_OF_RANGE', message: /"keylen"/ },
+  },
+  {
+    args: ['', '', 2 ** 32],
     expected: { code: 'ERR_OUT_OF_RANGE', message: /"keylen"/ },
   },
 ];


### PR DESCRIPTION
The JS layer already uses `validateInt32(keylen, 'keylen', 0)` to ensure that the `keylen` argument fits into a signed 32-bit integer, thus, the `THROW` statement in C++ is unreachable (unless the binding is accessed directly, of course).

https://github.com/nodejs/node/blob/af8ed0206732319c63a86ecb54d2588b953d45f2/lib/internal/crypto/scrypt.js#L85-L91

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
