### PR TITLE
test: mark test-http2-large-file flaky on aix

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -26,6 +26,8 @@ test-http-max-sockets: PASS, FLAKY
 [$system==aix]
 # https://github.com/nodejs/node/pull/29054
 test-buffer-creation-regression: SKIP
+# https://github.com/nodejs/node/issues/47409
+test-http2-large-file: PASS, FLAKY
 
 [$system==ibmi]
 # https://github.com/nodejs/node/pull/29054


### PR DESCRIPTION
a mitigation for https://github.com/nodejs/node/issues/47409