### PR TITLE
url: do not use object as hashmap

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -20,6 +20,7 @@ const {
   ReflectGetOwnPropertyDescriptor,
   ReflectOwnKeys,
   RegExpPrototypeSymbolReplace,
+  SafeMap,
   StringPrototypeCharAt,
   StringPrototypeCharCodeAt,
   StringPrototypeCodePointAt,
@@ -219,7 +220,7 @@ class URLSearchParams {
       } else {
         // Record<USVString, USVString>
         // Need to use reflection APIs for full spec compliance.
-        const visited = {};
+        const visited = new SafeMap();
         const keys = ReflectOwnKeys(init);
         for (let i = 0; i < keys.length; i++) {
           const key = keys[i];
@@ -228,14 +229,14 @@ class URLSearchParams {
             const typedKey = toUSVString(key);
             const typedValue = toUSVString(init[key]);
 
-            // Two different key may result same after `toUSVString()`, we only
-            // leave the later one. Refers to WPT.
-            if (visited[typedKey] !== undefined) {
-              this[searchParams][visited[typedKey]] = typedValue;
+            // Two different keys may become the same USVString after normalization.
+            // In that case, we retain the later one. Refer to WPT.
+            if (visited.has(typedKey)) {
+              this[searchParams][visited.get(typedKey)] = typedValue;
             } else {
-              visited[typedKey] = ArrayPrototypePush(this[searchParams],
-                                                     typedKey,
-                                                     typedValue) - 1;
+              visited.set(typedKey, ArrayPrototypePush(this[searchParams],
+                                                       typedKey,
+                                                       typedValue) - 1);
             }
           }
         }

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -231,8 +231,9 @@ class URLSearchParams {
 
             // Two different keys may become the same USVString after normalization.
             // In that case, we retain the later one. Refer to WPT.
-            if (visited.has(typedKey)) {
-              this[searchParams][visited.get(typedKey)] = typedValue;
+            const keyIdx = visited.get(typedKey);
+            if (keyIdx !== undefined) {
+              this[searchParams][keyIdx] = typedValue;
             } else {
               visited.set(typedKey, ArrayPrototypePush(this[searchParams],
                                                        typedKey,

--- a/test/parallel/test-whatwg-url-custom-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-constructor.js
@@ -38,8 +38,13 @@ function makeIterableFunc(array) {
     makeIterableFunc([['key', 'val'], ['key2', 'val2']].map(makeIterableFunc))
   );
   assert.strictEqual(params.toString(), 'key=val&key2=val2');
+  params = new URLSearchParams({ hasOwnProperty: 1 });
+  assert.strictEqual(params.get('hasOwnProperty'), '1');
+  assert.strictEqual(params.toString(), 'hasOwnProperty=1');
   assert.throws(() => new URLSearchParams([[1]]), tupleError);
   assert.throws(() => new URLSearchParams([[1, 2, 3]]), tupleError);
+  assert.throws(() => new URLSearchParams({ [Symbol('test')]: 42 }),
+                TypeError);
   assert.throws(() => new URLSearchParams({ [Symbol.iterator]: 42 }),
                 iterableError);
   assert.throws(() => new URLSearchParams([{}]), tupleError);


### PR DESCRIPTION
Fixes cases like `new URLSearchParams({ hasOwnProperty: 1 })`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
