### PR TITLE
doc: add performance initiative

### DIFF
--- a/doc/contributing/strategic-initiatives.md
+++ b/doc/contributing/strategic-initiatives.md
@@ -15,6 +15,7 @@ agenda to ensure they are active and have the support they need.
 | V8 Currency            | [Michaël Zasso][targos]     |                                               |
 | Next-10                | [Michael Dawson][mhdawson]  | <https://github.com/nodejs/next-10>           |
 | Single executable apps | [Darshan Sen][RaisinTen]    | <https://github.com/nodejs/node/issues/43432> |
+| Performance            | [Yagiz Nizipli][anonrig]    | <https://github.com/nodejs/performance>       |
 
 <details>
 <summary>List of completed initiatives</summary>
@@ -39,6 +40,7 @@ agenda to ensure they are active and have the support they need.
 
 [RaisinTen]: https://github.com/RaisinTen
 [aduh95]: https://github.com/aduh95
+[anonrig]: https://github.com/anonrig
 [jasnell]: https://github.com/jasnell
 [joyeecheung]: https://github.com/joyeecheung
 [legendecas]: https://github.com/legendecas


### PR DESCRIPTION
I am updating the strategic initiative document as a result of the TSC agenda.

Refs: https://github.com/nodejs/TSC/issues/1343 