### PR TITLE
build: add node-core-utils to setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,7 @@
 # Ref: https://github.com/gitpod-io/gitpod/issues/6283#issuecomment-1001043454
 tasks:
   - init: ./configure && timeout 50m make -j16 || true
+  - init: pnpm i -g node-core-utils
 
 # Ref: https://www.gitpod.io/docs/prebuilds#github-specific-configuration
 github:


### PR DESCRIPTION
should be more easy when landing PR and do v8 backport