### PR TITLE
[v18.x backport] test: fix test-net-happy-eyeballs without IPv6 support

### DIFF
--- a/test/parallel/test-net-happy-eyeballs.js
+++ b/test/parallel/test-net-happy-eyeballs.js
@@ -202,6 +202,8 @@ if (common.hasIPv6) {
         if (common.hasIPv6) {
           assert.strictEqual(error.code, 'ECONNREFUSED');
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
+        } else if (error.code === 'EAFNOSUPPORT') {
+          assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
         } else {
           assert.strictEqual(error.code, 'EADDRNOTAVAIL');
           assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);


### PR DESCRIPTION
Backport of:
- https://github.com/nodejs/node/pull/45856