### PR TITLE
src: disable concurrent sparkplug compilation

### DIFF
--- a/deps/v8/src/flags/flag-definitions.h
+++ b/deps/v8/src/flags/flag-definitions.h
@@ -761,7 +761,7 @@ DEFINE_BOOL(baseline_batch_compilation, true, "batch compile Sparkplug code")
 DEFINE_BOOL_READONLY(concurrent_sparkplug, false,
                      "compile Sparkplug code in a background thread")
 #else
-DEFINE_BOOL(concurrent_sparkplug, ENABLE_SPARKPLUG_BY_DEFAULT,
+DEFINE_BOOL(concurrent_sparkplug, false,
             "compile Sparkplug code in a background thread")
 DEFINE_WEAK_IMPLICATION(future, concurrent_sparkplug)
 DEFINE_NEG_IMPLICATION(predictable, concurrent_sparkplug)


### PR DESCRIPTION
It introduces process hangs on some platforms because Node.js doesn't tear down V8 correctly.
Disable it while we work on a solution.

Refs: https://github.com/nodejs/node/issues/47297
Refs: https://bugs.chromium.org/p/v8/issues/detail?id=13902
