### PR TITLE
Do not drain worker tasks on main thread

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -462,6 +462,8 @@ void NodePlatform::DrainTasks(Isolate* isolate) {
   std::shared_ptr<PerIsolatePlatformData> per_isolate = ForNodeIsolate(isolate);
   if (!per_isolate) return;
 
+  // Worker tasks aren't associated with an Isolate.
+  worker_thread_task_runner_->BlockingDrain();
   // Drain foreground tasks but not worker tasks as this may cause deadlocks
   // and v8::Isolate::Dispose will join V8's worker tasks for that isolate.
   while (per_isolate->FlushForegroundTasksInternal()) {

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -464,7 +464,8 @@ void NodePlatform::DrainTasks(Isolate* isolate) {
 
   // Drain foreground tasks but not worker tasks as this may cause deadlocks
   // and v8::Isolate::Dispose will join V8's worker tasks for that isolate.
-  while (per_isolate->FlushForegroundTasksInternal());
+  while (per_isolate->FlushForegroundTasksInternal()) {
+  }
 }
 
 bool PerIsolatePlatformData::FlushForegroundTasksInternal() {

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -462,10 +462,9 @@ void NodePlatform::DrainTasks(Isolate* isolate) {
   std::shared_ptr<PerIsolatePlatformData> per_isolate = ForNodeIsolate(isolate);
   if (!per_isolate) return;
 
-  do {
-    // Worker tasks aren't associated with an Isolate.
-    worker_thread_task_runner_->BlockingDrain();
-  } while (per_isolate->FlushForegroundTasksInternal());
+  // Drain foreground tasks but not worker tasks as this may cause deadlocks
+  // and v8::Isolate::Dispose will join V8's worker tasks for that isolate.
+  while (per_isolate->FlushForegroundTasksInternal());
 }
 
 bool PerIsolatePlatformData::FlushForegroundTasksInternal() {


### PR DESCRIPTION
Hi!

This PR stops draining worker tasks on the main thread. I believe it's not necessary since V8 will join its own worker tasks as part of v8::Isolate::Dispose. It may also cause deadlocks now that those worker tasks may ask the main thread to perform a GC, see the discussion in this [V8 issue](https://bugs.chromium.org/p/v8/issues/detail?id=13902) here. This should help enable concurrent sparkplug again, which will get/is disabled with this [PR](https://github.com/nodejs/node/pull/47450).

Do you know why Node is draining worker tasks here? Am I seeing right that NodePlatform::DrainTasks is also invoked from the event loop [here](https://github.com/nodejs/node/blob/main/src/api/embed_helpers.cc#L44)? If so, this might be a problem for performance as we block the main thread until those worker tasks are finished when the event loop is empty.

I have to admit that I didn't run tests yet for that PR and it may require V8 patches as well (see the V8 issue linked above) but I opened the PR already to discuss this.