### PR TITLE
tools: fix notify-on-push Slack messages

### DIFF
--- a/.github/workflows/notify-on-push.yml
+++ b/.github/workflows/notify-on-push.yml
@@ -20,7 +20,7 @@ jobs:
           SLACK_ICON: https://github.com/nodejs.png?size=48
           SLACK_TITLE: ${{ github.actor }} force-pushed to ${{ github.ref }}
           SLACK_MESSAGE: |
-            @here A commit was force-pushed to <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.repository }}@${{ github.ref_name }}> by <https://github.com/${{ github.actor }}|${{ github.actor }}>
+            <!here> A commit was force-pushed to <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.repository }}@${{ github.ref_name }}> by <https://github.com/${{ github.actor }}|${{ github.actor }}>
 
             Before: <https://github.com/${{ github.repository }}/commit/${{ github.event.before }}|${{ github.event.before }}>
             After: <https://github.com/${{ github.repository }}/commit/${{ github.event.after }}|${{ github.event.after }}>
@@ -51,7 +51,7 @@ jobs:
         if: ${{ env.PR_ID }}
         run: |
           gh pr comment ${{ env.PR_ID }} --repo "${{ github.repository }}" \
-            --body "A commit referencing this Pull Request was pushed to `main` by @${{ github.actor }} without the expected commit metadata added to its message."
+            --body "A commit referencing this Pull Request was pushed to `${{ github.ref_name }}` by @${{ github.actor }} with an invalid commit message."
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Slack Notification
@@ -62,7 +62,7 @@ jobs:
           SLACK_ICON: https://github.com/nodejs.png?size=48
           SLACK_TITLE: Invalid commit was pushed to ${{ github.repository.default_branch }}
           SLACK_MESSAGE: |
-            @here A commit lacking the expected metadata was pushed to <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.repository }}@${{ github.ref_name }}> by <https://github.com/${{ github.actor }}|${{ github.actor }}>.
+            <!here> A commit with an invalid message was pushed to <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.repository }}@${{ github.ref_name }}> by <https://github.com/${{ github.actor }}|${{ github.actor }}>.
 
             Before: <https://github.com/${{ github.repository }}/commit/${{ github.event.before }}|${{ github.event.before }}>
             After: <https://github.com/${{ github.repository }}/commit/${{ github.event.after }}|${{ github.event.after }}>


### PR DESCRIPTION
The `@here` mention was not working. Also saying the commit is "lacking the expected metadata" is not always true, as lacking metadata is one of several things the workflow is checking.

Refs: https://api.slack.com/reference/surfaces/formatting#special-mentions

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
