### PR TITLE
bootstrap: do not expand process.argv[1] for snapshot entry points

### DIFF
--- a/lib/internal/v8/startup_snapshot.js
+++ b/lib/internal/v8/startup_snapshot.js
@@ -90,7 +90,8 @@ function setDeserializeMainFunction(callback, data) {
 
     // This should be in sync with run_main_module.js until we make that
     // a built-in main function.
-    prepareMainThreadExecution(true);
+    // TODO(joyeecheung): make a copy of argv[0] and insert it as argv[1].
+    prepareMainThreadExecution(false);
     markBootstrapComplete();
     callback(data);
   });

--- a/test/parallel/test-snapshot-argv1.js
+++ b/test/parallel/test-snapshot-argv1.js
@@ -1,0 +1,58 @@
+'use strict';
+
+// This tests snapshot JS API using the example in the docs.
+
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const tmpdir = require('../common/tmpdir');
+const path = require('path');
+const fs = require('fs');
+
+tmpdir.refresh();
+const blobPath = path.join(tmpdir.path, 'snapshot.blob');
+const code = `
+require('v8').startupSnapshot.setDeserializeMainFunction(() => {
+  console.log(JSON.stringify(process.argv));
+});
+`;
+{
+  fs.writeFileSync(path.join(tmpdir.path, 'entry.js'), code, 'utf8');
+  const child = spawnSync(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot',
+    'entry.js',
+  ], {
+    cwd: tmpdir.path
+  });
+  if (child.status !== 0) {
+    console.log(child.stderr.toString());
+    console.log(child.stdout.toString());
+    assert.strictEqual(child.status, 0);
+  }
+  const stats = fs.statSync(path.join(tmpdir.path, 'snapshot.blob'));
+  assert(stats.isFile());
+}
+
+{
+  const child = spawnSync(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    'argv1',
+    'argv2',
+  ], {
+    cwd: tmpdir.path,
+    env: {
+      ...process.env,
+    }
+  });
+
+  const stdout = JSON.parse(child.stdout.toString().trim());
+  assert.deepStrictEqual(stdout, [
+    process.execPath,
+    'argv1',
+    'argv2',
+  ]);
+  assert.strictEqual(child.status, 0);
+}


### PR DESCRIPTION
In applications with entry points deserialized from snapshots, they don't need an additional CLI argument for the entry point script so process.argv[1] is going to be other user-defiend arguments. We could consider copying process.argv[0] as process.argv[1] like what we do for single executable applications, but for now just don't exapnd it so it's easier to backport to previous releases.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
