### PR TITLE
bootstrap: support namespaced builtins in snapshot scripts

### DIFF
--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -7,6 +7,8 @@ const {
   ObjectSetPrototypeOf,
   SafeArrayIterator,
   SafeSet,
+  StringPrototypeStartsWith,
+  StringPrototypeSlice,
 } = primordials;
 
 const binding = internalBinding('mksnapshot');
@@ -96,7 +98,13 @@ function supportedInUserSnapshot(id) {
 }
 
 function requireForUserSnapshot(id) {
-  if (!BuiltinModule.canBeRequiredByUsers(id)) {
+  let normalizedId = id;
+  if (StringPrototypeStartsWith(id, 'node:')) {
+    normalizedId = StringPrototypeSlice(id, 5);
+  }
+  if (!BuiltinModule.canBeRequiredByUsers(normalizedId) ||
+      (id !== normalizedId &&
+        !BuiltinModule.canBeRequiredWithoutScheme(normalizedId))) {
     // eslint-disable-next-line no-restricted-syntax
     const err = new Error(
       `Cannot find module '${id}'. `,
@@ -104,15 +112,15 @@ function requireForUserSnapshot(id) {
     err.code = 'MODULE_NOT_FOUND';
     throw err;
   }
-  if (!supportedInUserSnapshot(id)) {
-    if (!warnedModules.has(id)) {
+  if (!supportedInUserSnapshot(normalizedId)) {
+    if (!warnedModules.has(normalizedId)) {
       process.emitWarning(
         `built-in module ${id} is not yet supported in user snapshots`);
-      warnedModules.add(id);
+      warnedModules.add(normalizedId);
     }
   }
 
-  return require(id);
+  return require(normalizedId);
 }
 
 function main() {

--- a/test/parallel/test-snapshot-namespaced-builtin.js
+++ b/test/parallel/test-snapshot-namespaced-builtin.js
@@ -1,0 +1,42 @@
+'use strict';
+
+// This tests snapshot JS API using the example in the docs.
+
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const tmpdir = require('../common/tmpdir');
+const path = require('path');
+const fs = require('fs');
+
+tmpdir.refresh();
+const blobPath = path.join(tmpdir.path, 'snapshot.blob');
+{
+  // The list of modules supported in the snapshot is unstable, so just check
+  // a few that are known to work.
+  const code = `
+    require("node:v8");
+    require("node:fs");
+    require("node:fs/promises");
+  `;
+  fs.writeFileSync(
+    path.join(tmpdir.path, 'entry.js'),
+    code,
+    'utf8'
+  );
+  const child = spawnSync(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot',
+    'entry.js',
+  ], {
+    cwd: tmpdir.path
+  });
+  if (child.status !== 0) {
+    console.log(child.stderr.toString());
+    console.log(child.stdout.toString());
+    assert.strictEqual(child.status, 0);
+  }
+  const stats = fs.statSync(path.join(tmpdir.path, 'snapshot.blob'));
+  assert(stats.isFile());
+}


### PR DESCRIPTION
This enables e.g. `require('node:fs')` in the snapshot scripts (which is done by our doc example, but didn't actually work without this patch).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
