### PR TITLE
src: allow simdutf::convert_* functions to return zero

### DIFF
--- a/src/inspector/node_string.cc
+++ b/src/inspector/node_string.cc
@@ -76,10 +76,10 @@ String StringViewToUtf8(v8_inspector::StringView view) {
   size_t utf8_length =
       simdutf::convert_utf16_to_utf8(source, view.length(), buffer.out());
   // We have that utf8_length == expected_utf8_length if and only
-  // if the input was a valid UTF-16 string.
-  if (utf8_length == 0)
-    return ""; // We had an invalid UTF-16 input.
-  CHECK_EQ(expected_utf16_length, utf16_length);
+  // if the input was a valid UTF-16 string. Otherwise, utf8_length
+  // must be zero.
+  assert(utf8_length == 0 || utf8_length == expected_utf8_length);
+  // An invalid UTF-16 input will generate the empty string:
   return String(buffer.out(), utf8_length);
 }
 
@@ -130,9 +130,11 @@ String fromUTF16(const uint16_t* data, size_t length) {
   // simdutf::convert_utf16_to_utf8 returns zero in case of error.
   size_t utf8_length =
       simdutf::convert_utf16_to_utf8(casted_data, length, buffer.out());
-  if (utf8_length == 0)
-    return ""; // We had an invalid UTF-16 input.
-  CHECK_EQ(expected_utf8_length, utf8_length);
+  // We have that utf8_length == expected_utf8_length if and only
+  // if the input was a valid UTF-16 string. Otherwise, utf8_length
+  // must be zero.
+  assert(utf8_length == 0 || utf8_length == expected_utf8_length);
+  // An invalid UTF-16 input will generate the empty string:
   return String(buffer.out(), utf8_length);
 }
 

--- a/src/inspector/node_string.cc
+++ b/src/inspector/node_string.cc
@@ -132,7 +132,7 @@ String fromUTF16(const uint16_t* data, size_t length) {
   // We have that utf8_length == expected_utf8_length if and only
   // if the input was a valid UTF-16 string. Otherwise, utf8_length
   // must be zero.
-  assert(utf8_length == 0 || utf8_length == expected_utf8_length);
+  CHECK(utf8_length == 0 || utf8_length == expected_utf8_length);
   // An invalid UTF-16 input will generate the empty string:
   return String(buffer.out(), utf8_length);
 }

--- a/src/inspector/node_string.cc
+++ b/src/inspector/node_string.cc
@@ -29,7 +29,7 @@ void builderAppendQuotedString(StringBuilder& builder,
       escapeWideStringForJSON(reinterpret_cast<const uint16_t*>(buffer.out()),
                             utf16_length,
                             &builder);
-    } // Otherwise, we had an invalid UTF-8 input.
+    }  // Otherwise, we had an invalid UTF-8 input.
   }
   builder.put('"');
 }
@@ -46,7 +46,7 @@ std::unique_ptr<Value> parseJSON(const std::string_view string) {
   // We have that utf16_length == expected_utf16_length if and only
   // if the input was a valid UTF-8 string.
   if (utf16_length == 0)
-    return nullptr; // We had an invalid UTF-8 input.
+    return nullptr;  // We had an invalid UTF-8 input.
   CHECK_EQ(expected_utf16_length, utf16_length);
   return parseJSONCharacters(reinterpret_cast<const uint16_t*>(buffer.out()),
                              utf16_length);

--- a/src/inspector/node_string.cc
+++ b/src/inspector/node_string.cc
@@ -27,8 +27,8 @@ void builderAppendQuotedString(StringBuilder& builder,
     if (utf16_length != 0) {
       CHECK_EQ(expected_utf16_length, utf16_length);
       escapeWideStringForJSON(reinterpret_cast<const uint16_t*>(buffer.out()),
-                            utf16_length,
-                            &builder);
+                              utf16_length,
+                              &builder);
     }  // Otherwise, we had an invalid UTF-8 input.
   }
   builder.put('"');
@@ -45,8 +45,7 @@ std::unique_ptr<Value> parseJSON(const std::string_view string) {
       string.data(), string.length(), buffer.out());
   // We have that utf16_length == expected_utf16_length if and only
   // if the input was a valid UTF-8 string.
-  if (utf16_length == 0)
-    return nullptr;  // We had an invalid UTF-8 input.
+  if (utf16_length == 0) return nullptr;  // We had an invalid UTF-8 input.
   CHECK_EQ(expected_utf16_length, utf16_length);
   return parseJSONCharacters(reinterpret_cast<const uint16_t*>(buffer.out()),
                              utf16_length);

--- a/src/inspector/node_string.cc
+++ b/src/inspector/node_string.cc
@@ -77,7 +77,7 @@ String StringViewToUtf8(v8_inspector::StringView view) {
   // We have that utf8_length == expected_utf8_length if and only
   // if the input was a valid UTF-16 string. Otherwise, utf8_length
   // must be zero.
-  assert(utf8_length == 0 || utf8_length == expected_utf8_length);
+  CHECK(utf8_length == 0 || utf8_length == expected_utf8_length);
   // An invalid UTF-16 input will generate the empty string:
   return String(buffer.out(), utf8_length);
 }


### PR DESCRIPTION
When transcoding with the `simdutf` library, you first scan the input to determine the size of the output (e.g., you scan the UTF-8 input to determine the size of the UTF-16 output). In a second step, you call a transcoding function. This transcoding function normally returns how many words were written. This number of words should match the size of the output computed during the first scan.

So you get three-line routines like as follow (scan, allocate, transcode):

```C++
size_t expected_utf16_length =
        simdutf::utf16_length_from_utf8(string.data(), string.length());
MaybeStackBuffer<char16_t> buffer(expected_utf16_length);
size_t utf16_length = simdutf::convert_utf8_to_utf16(
        string.data(), string.length(), buffer.out());
```


The scan to determine the size of the output does not validate the Unicode input: the validation occurs during the transcoding. For performance purposes, it will only seek to tell you how much memory you need to allocate, counting on the transcoding step to do the validation.

When the transcoding fails, the  `simdutf::convert_utf8_to_utf16` and `simdutf::convert_utf16_to_utf8`  functions return zero by convention, indicating an error. So you either have a successful transcoding (from valid Unicode to valid Unicode) in which case the transcoding function returns the number of written words, which matches exactly the expected number of output words, or you get zero, indicating that the input is invalid Unicode.


Currently, the `simdutf` library is used within `src/inspector/node_string.cc` with checks such as `CHECK_EQ(expected_utf16_length, utf16_length);`. In effect, these checks are true if and only if the inputs are valid Unicode. That should almost always be the case within Node. However, @danpeixoto reports that the check fail in their case, see https://github.com/nodejs/node/issues/47457 

I cannot reproduce @danpeixoto's issue. See my comments on the issue. Nevertheless, it seems warranted to make the code more robust in case we do have bad Unicode inputs.

This is what this PR does: it checks whether the transcoding functions return 0, and if it does, then it assumes that the input was invalid.

By convention, the routines return the empty string or a null, when the input was invalid. This could be changed to some other convention.