### PR TITLE
tools: add update script for googletest

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -23,6 +23,7 @@ on:
           - corepack
           - doc
           - eslint
+          - googletest
           - libuv
           - lint-md-dependencies
           - llhttp
@@ -232,6 +233,14 @@ jobs:
             label: dependencies
             run: |
               ./tools/dep_updaters/update-zlib.sh > temp-output
+              cat temp-output
+              tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
+              rm temp-output
+          - id: googletest
+            subsystem: deps
+            label: dependencies, test
+            run: |
+              ./tools/dep_updaters/update-googletest.sh > temp-output
               cat temp-output
               tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
               rm temp-output

--- a/tools/dep_updaters/update-googletest.sh
+++ b/tools/dep_updaters/update-googletest.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+set -e
+# Shell script to update GoogleTest in the source tree to the most recent version.
+# GoogleTest follows the Abseil Live at Head philosophy and rarely creates tags
+# or GitHub releases, so instead, we use the latest commit on the main branch.
+
+BASE_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+DEPS_DIR="$BASE_DIR/deps"
+
+NEW_UPSTREAM_SHA1=$(git ls-remote "https://github.com/google/googletest.git" HEAD | awk '{print $1}')
+NEW_VERSION=$(echo "$NEW_UPSTREAM_SHA1" | head -c 7)
+
+echo "Comparing $NEW_VERSION with current revision"
+
+git remote add googletest-upstream https://github.com/google/googletest.git
+git fetch googletest-upstream "$NEW_UPSTREAM_SHA1"
+git remote remove googletest-upstream
+
+DIFF_TREE=$(
+  git diff HEAD:deps/googletest/LICENSE "$NEW_UPSTREAM_SHA1:LICENSE"
+  git diff-tree HEAD:deps/googletest/include "$NEW_UPSTREAM_SHA1:googletest/include"
+  git diff-tree HEAD:deps/googletest/src "$NEW_UPSTREAM_SHA1:googletest/src"
+)
+
+if [ -z "$DIFF_TREE" ]; then
+  echo "Skipped because googletest is on the latest version."
+  exit 0
+fi
+
+# This is a rather arbitrary restriction. This script is assumed to run on
+# Sunday, shortly after midnight UTC. This check thus prevents pulling in the
+# most recent commits if any changes were made on Friday or Saturday (UTC).
+# Because of Google's own "Live at Head" philosophy, new bugs that are likely to
+# affect Node.js tend to be fixed quickly, so we don't want to pull in a commit
+# that was just pushed, and instead rather wait for the next week's update. If
+# no commits have been pushed in the last two days, we assume that the most
+# recent commit is stable enough to be pulled in.
+LAST_CHANGE_DATE=$(git log -1 --format=%ct "$NEW_UPSTREAM_SHA1" -- LICENSE googletest/include googletest/src)
+TWO_DAYS_AGO=$(date -d 'now - 2 days' '+%s')
+if [ "$LAST_CHANGE_DATE" -gt "$TWO_DAYS_AGO" ]; then
+  echo "Skipped because the latest version is too recent."
+  exit 0
+fi
+
+echo "Creating temporary work tree"
+
+WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
+WORKTREE="$WORKSPACE/googletest"
+
+cleanup () {
+  EXIT_CODE=$?
+  [ -d "$WORKTREE" ] && git worktree remove -f "$WORKTREE"
+  [ -d "$WORKSPACE" ] && rm -rf "$WORKSPACE"
+  exit $EXIT_CODE
+}
+
+trap cleanup INT TERM EXIT
+
+git worktree add "$WORKTREE" "$NEW_UPSTREAM_SHA1"
+
+echo "Copying LICENSE, include and src to deps/googletest"
+for p in LICENSE googletest/include googletest/src ; do
+  rm -rf "$DEPS_DIR/googletest/$(basename "$p")"
+  cp -R "$WORKTREE/$p" "$DEPS_DIR/googletest/$(basename "$p")"
+done
+
+echo "Updating googletest.gyp"
+
+NEW_GYP=$(
+  sed "/'googletest_sources': \[/q" "$DEPS_DIR/googletest/googletest.gyp"
+  for f in $( (cd deps/googletest/ && find include src -type f \( -iname '*.h' -o -iname '*.cc' \) ) | LANG=C LC_ALL=C sort --stable ); do
+    if [ "$(basename "$f")" != "gtest_main.cc" ] &&
+       [ "$(basename "$f")" != "gtest-all.cc" ] &&
+       [ "$(basename "$f")" != "gtest_prod.h" ] ; then
+      echo "      '$f',"
+    fi
+  done
+  sed -ne '/\]/,$ p' "$DEPS_DIR/googletest/googletest.gyp"
+)
+
+echo "$NEW_GYP" >"$DEPS_DIR/googletest/googletest.gyp"
+
+echo "All done!"
+echo ""
+echo "Please git stage googletest, commit the new version:"
+echo ""
+echo "$ git stage -A deps/googletest"
+echo "$ git commit -m \"deps: update googletest to $NEW_VERSION\""
+echo ""
+
+# The last line of the script should always print the new version,
+# as we need to add it to $GITHUB_ENV variable.
+echo "NEW_VERSION=$NEW_VERSION"


### PR DESCRIPTION
I haven't done one of these before, so please review carefully.

GoogleTest follows the Abseil Live at Head philosophy, and rarely creates tags or GitHub releases, so instead, follow Google's recommendation and update to the upstream HEAD every once in a while.
    
The tricky bit is properly updating googletest.gyp, and this script might fail doing so in the future.

Refs: https://github.com/nodejs/security-wg/issues/828

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
