### PR TITLE
meta: ping security-wg team on permission model changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -150,3 +150,7 @@
 /test/fixtures/postject-copy @nodejs/single-executable
 /test/parallel/test-single-executable-* @nodejs/single-executable
 /tools/dep_updaters/update-postject.sh @nodejs/single-executable
+
+# Permission Model
+/src/permission/* @nodejs/security-wg
+/doc/api/permissions.md @nodejs/security-wg


### PR DESCRIPTION
Since the Permission Model is a SecurityWG initiative I think rather than creating a `permission-model` team, we could use the security-wg for now.

cc: @nodejs/security-wg 