### PR TITLE
lib: mark URL/URLSearchParams as uncloneable and untransferable

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -48,6 +48,10 @@ const {
 } = require('internal/util');
 
 const {
+  markTransferMode,
+} = require('internal/worker/js_transferable');
+
+const {
   codes: {
     ERR_ARG_NOT_ITERABLE,
     ERR_INVALID_ARG_TYPE,
@@ -326,6 +330,8 @@ class URLSearchParams {
   // Default parameter is necessary to keep URLSearchParams.length === 0 in
   // accordance with Web IDL spec.
   constructor(init = undefined) {
+    markTransferMode(this, false, false);
+
     if (init == null) {
       // Do nothing
     } else if (typeof init === 'object' || typeof init === 'function') {
@@ -761,6 +767,8 @@ class URL {
   #searchParams;
 
   constructor(input, base = undefined) {
+    markTransferMode(this, false, false);
+
     if (arguments.length === 0) {
       throw new ERR_MISSING_ARGS('url');
     }

--- a/test/wpt/status/url.json
+++ b/test/wpt/status/url.json
@@ -6,9 +6,7 @@
     "fail": {
       "note": "We are faking location with a URL object for the sake of the testharness and it has searchParams.",
       "expected": [
-        "searchParams on location object",
-        "URL: no structured serialize/deserialize support",
-        "URLSearchParams: no structured serialize/deserialize support"
+        "searchParams on location object"
       ]
     }
   },


### PR DESCRIPTION
Mark URL/URLSearchParams as uncloneable and untransferable to reject
them in `structuredClone` and `port.postMessage`.

Refs: https://github.com/nodejs/node/pull/47214

/cc @anonrig 