### PR TITLE
meta: add mailmap entry for KhafraDev

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -343,6 +343,7 @@ Matteo Collina <matteo.collina@gmail.com> <hello@matteocollina.com>
 Matthew Lye <muddletoes@hotmail.com>
 Matthew Turner <matty_t47@hotmail.com> <ramesius@users.noreply.github.com>
 Matthias Bastian <dev@matthias-bastian.de> <piepmatz@users.noreply.github.com>
+Matthew Aitken <maitken033380023@gmail.com>
 Maurice Hayward <mauricehayward1@gmail.com>
 Maya Lekova <apokalyptra@gmail.com> <mslekova@chromium.org>
 Mestery <mestery@protonmail.com> <mestery@pm.me>


### PR DESCRIPTION
This will make `git log` entries for KhafraDev show up using the name in the README, which is required so that find-inactive-collaborators.mjs doesn't incorrectly flag him for removal.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
