### PR TITLE
lib: use webidl DOMString converter in EventTarget

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -42,6 +42,7 @@ const {
   kEnumerableProperty,
 } = require('internal/util');
 const { inspect } = require('util');
+const webidl = require('internal/webidl');
 
 const kIsEventTarget = SymbolFor('nodejs.event_target');
 const kIsNodeEventTarget = Symbol('kIsNodeEventTarget');
@@ -598,7 +599,7 @@ class EventTarget {
       process.emitWarning(w);
       return;
     }
-    type = String(type);
+    type = webidl.converters.DOMString(type);
 
     if (signal) {
       if (signal.aborted) {
@@ -664,7 +665,7 @@ class EventTarget {
     if (!validateEventListener(listener))
       return;
 
-    type = String(type);
+    type = webidl.converters.DOMString(type);
     const capture = options?.capture === true;
 
     const root = this[kEvents].get(type);

--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -166,12 +166,10 @@ function convertToInt(name, value, bitLength, options = kEmptyObject) {
  * @returns {string}
  */
 converters.DOMString = function DOMString(V) {
-  // 2.
   if (typeof V === 'symbol') {
     throw new ERR_INVALID_ARG_VALUE('value', V);
   }
 
-  // 3.
   return String(V);
 };
 

--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -10,6 +10,7 @@ const {
   NumberIsNaN,
   NumberMAX_SAFE_INTEGER,
   NumberMIN_SAFE_INTEGER,
+  String,
 } = primordials;
 
 const {
@@ -18,6 +19,8 @@ const {
   },
 } = require('internal/errors');
 const { kEmptyObject } = require('internal/util');
+
+const converters = { __proto__: null };
 
 // https://webidl.spec.whatwg.org/#abstract-opdef-integerpart
 const integerPart = MathTrunc;
@@ -157,7 +160,22 @@ function convertToInt(name, value, bitLength, options = kEmptyObject) {
   return x;
 }
 
+/**
+ * @see https://webidl.spec.whatwg.org/#es-DOMString
+ * @param {any} V
+ */
+converters.DOMString = function DOMString(V) {
+  // 2.
+  if (typeof V === 'symbol') {
+    throw new ERR_INVALID_ARG_VALUE('value', V);
+  }
+
+  // 3.
+  return String(V);
+};
+
 module.exports = {
   convertToInt,
   evenRound,
+  converters,
 };

--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -163,6 +163,7 @@ function convertToInt(name, value, bitLength, options = kEmptyObject) {
 /**
  * @see https://webidl.spec.whatwg.org/#es-DOMString
  * @param {any} V
+ * @returns {string}
  */
 converters.DOMString = function DOMString(V) {
   // 2.

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -60,6 +60,7 @@ const expectedModules = new Set([
   'Internal Binding blob',
   'NativeModule internal/url',
   'NativeModule util',
+  'NativeModule internal/webidl',
   'Internal Binding performance',
   'Internal Binding permission',
   'NativeModule internal/perf/utils',

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -714,3 +714,15 @@ let asyncTest = Promise.resolve();
     name: 'TypeError',
   });
 }
+
+{
+  const et = new EventTarget();
+
+  throws(() => {
+    et.addEventListener(Symbol('symbol'), () => {});
+  }, TypeError);
+
+  throws(() => {
+    et.removeEventListener(Symbol('symbol'), () => {});
+  }, TypeError);
+}


### PR DESCRIPTION
This implements a webidl converter for converting a value to a webidl DOMString and uses it in EventTarget.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
