### PR TITLE
test: remove unnecessary status check on test-release-npm

### DIFF
--- a/test/parallel/test-release-npm.js
+++ b/test/parallel/test-release-npm.js
@@ -17,7 +17,6 @@ if (!releaseReg.test(process.version) || !common.hasCrypto) {
 
   const npmCli = path.join(__dirname, '../../deps/npm/bin/npm-cli.js');
   const npmExec = child_process.spawnSync(process.execPath, [npmCli]);
-  assert.strictEqual(npmExec.status, 1);
 
   const stderr = npmExec.stderr.toString();
   assert.strictEqual(stderr.length, 0, 'npm is not ready for this release ' +


### PR DESCRIPTION
`test-release-npm` is failing on #47381 and it seems related to https://github.com/nodejs/node/pull/43716. However, this asserting seems unnecesary, so rather than adjust it (either on `npm` side or node.js) sounds reasonable to remove that check.

However, it doesn't mean there's no bug in that change. It seems `process.exitCode` isn't considered when `process.exit()` is called with `undefined`. cc: @daeyeon