### PR TITLE
diagnostics_channel: fix ref counting bug when reaching zero subscribers

### DIFF
--- a/lib/diagnostics_channel.js
+++ b/lib/diagnostics_channel.js
@@ -5,6 +5,7 @@ const {
   ArrayPrototypeIndexOf,
   ArrayPrototypePush,
   ArrayPrototypeSplice,
+  SafeFinalizationRegistry,
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
   Promise,
@@ -29,14 +30,29 @@ const { triggerUncaughtException } = internalBinding('errors');
 
 const { WeakReference } = internalBinding('util');
 
-function decRef(channel) {
-  if (channels.get(channel.name).decRef() === 0) {
-    channels.delete(channel.name);
-  }
-}
+// Can't delete when weakref count reaches 0 as it could increment again.
+// Only GC can be used as a valid time to clean up the channels map.
+class WeakRefMap extends SafeMap {
+  #finalizers = new SafeFinalizationRegistry((key) => {
+    this.delete(key);
+  });
 
-function incRef(channel) {
-  channels.get(channel.name).incRef();
+  set(key, value) {
+    this.#finalizers.register(value, key);
+    return super.set(key, new WeakReference(value));
+  }
+
+  get(key) {
+    return super.get(key)?.get();
+  }
+
+  incRef(key) {
+    return super.get(key)?.incRef();
+  }
+
+  decRef(key) {
+    return super.get(key)?.decRef();
+  }
 }
 
 function markActive(channel) {
@@ -81,7 +97,7 @@ class ActiveChannel {
   subscribe(subscription) {
     validateFunction(subscription, 'subscription');
     ArrayPrototypePush(this._subscribers, subscription);
-    incRef(this);
+    channels.incRef(this.name);
   }
 
   unsubscribe(subscription) {
@@ -90,7 +106,7 @@ class ActiveChannel {
 
     ArrayPrototypeSplice(this._subscribers, index, 1);
 
-    decRef(this);
+    channels.decRef(this.name);
     maybeMarkInactive(this);
 
     return true;
@@ -98,7 +114,7 @@ class ActiveChannel {
 
   bindStore(store, transform) {
     const replacing = this._stores.has(store);
-    if (!replacing) incRef(this);
+    if (!replacing) channels.incRef(this.name);
     this._stores.set(store, transform);
   }
 
@@ -109,7 +125,7 @@ class ActiveChannel {
 
     this._stores.delete(store);
 
-    decRef(this);
+    channels.decRef(this.name);
     maybeMarkInactive(this);
 
     return true;
@@ -154,7 +170,7 @@ class Channel {
     this._stores = undefined;
     this.name = name;
 
-    channels.set(name, new WeakReference(this));
+    channels.set(name, this);
   }
 
   static [SymbolHasInstance](instance) {
@@ -192,12 +208,10 @@ class Channel {
   }
 }
 
-const channels = new SafeMap();
+const channels = new WeakRefMap();
 
 function channel(name) {
-  let channel;
-  const ref = channels.get(name);
-  if (ref) channel = ref.get();
+  const channel = channels.get(name);
   if (channel) return channel;
 
   if (typeof name !== 'string' && typeof name !== 'symbol') {
@@ -216,12 +230,8 @@ function unsubscribe(name, subscription) {
 }
 
 function hasSubscribers(name) {
-  let channel;
-  const ref = channels.get(name);
-  if (ref) channel = ref.get();
-  if (!channel) {
-    return false;
-  }
+  const channel = channels.get(name);
+  if (!channel) return false;
 
   return channel.hasSubscribers;
 }

--- a/test/parallel/test-diagnostics-channel-pub-sub.js
+++ b/test/parallel/test-diagnostics-channel-pub-sub.js
@@ -42,3 +42,10 @@ assert.ok(!dc.unsubscribe(name, subscriber));
 assert.throws(() => {
   dc.subscribe(name, null);
 }, { code: 'ERR_INVALID_ARG_TYPE' });
+
+// Reaching zero subscribers should not delete from the channels map as there
+// will be no more weakref to incRef if another subscribe happens while the
+// channel object itself exists.
+channel.subscribe(subscriber);
+channel.unsubscribe(subscriber);
+channel.subscribe(subscriber);


### PR DESCRIPTION
I discovered a bug in some of the changes I landed with TracingChannel. Technically the bug existed before, but we've been discouraging use of `channel.subscribe(...)` and `channel.unsubscribe(...)`. With the TracingChannel changes I included a fix for the GC issue that allows `channel.subscribe(...)` and `channel.unsubscribe(...)` to work as they were originally intended, and some simplifications were made to make the top-level functions delegate to those. Unfortunately, there was an unnoticed issue where if the subscriber count ever dropped to zero the weakref would be deleted from the channels map but channel objects could still be held and therefore could still have subscribers added which would attempt an incRef on a weakref that's not there anymore. To handle that safely the delete actually has to happen only when there are no more strong refs, meaning when GC happens, so I've changed it to use `FinalizationRegistry` instead.