### PR TITLE
src: replace static const string_view by static constexpr

### DIFF
--- a/src/json_utils.cc
+++ b/src/json_utils.cc
@@ -3,7 +3,10 @@
 namespace node {
 
 std::string EscapeJsonChars(std::string_view str) {
-  static const std::string_view control_symbols[0x20] = {
+  // 'static constexpr' is slightly better than static const
+  // since the initialization occurs at compile time.
+  // See https://lemire.me/blog/I3Cah
+  static constexpr std::string_view control_symbols[0x20] = {
       "\\u0000", "\\u0001", "\\u0002", "\\u0003", "\\u0004", "\\u0005",
       "\\u0006", "\\u0007", "\\b",     "\\t",     "\\n",     "\\u000b",
       "\\f",     "\\r",     "\\u000e", "\\u000f", "\\u0010", "\\u0011",


### PR DESCRIPTION
It is slightly better to use `static constexpr std::string_view` compared to `static const std::string_view`. See https://lemire.me/blog/2023/04/12/consider-using-constexpr-static-function-variables-for-performance/ for details.

It is a micro-optimization: you are unlikely to be able to measure the difference, but it should generate less bloat.