### PR TITLE
permission: fix chmod,chown improve fs coverage

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1338,8 +1338,18 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
   BufferValue src(isolate, args[0]);
   CHECK_NOT_NULL(*src);
 
+  const auto src_view = src.ToStringView();
+  // To avoid bypass the link target should be allowed to read and write
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemRead, src_view);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, src_view);
+
   BufferValue dest(isolate, args[1]);
   CHECK_NOT_NULL(*dest);
+  const auto dest_view = dest.ToStringView();
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, dest_view);
 
   FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // link(src, dest, req)
@@ -2422,6 +2432,8 @@ static void Chmod(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
 
   CHECK(args[1]->IsInt32());
   int mode = args[1].As<Int32>()->Value();
@@ -2485,6 +2497,8 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
 
   CHECK(IsSafeJsInt(args[1]));
   const uv_uid_t uid = static_cast<uv_uid_t>(args[1].As<Integer>()->Value());
@@ -2551,6 +2565,8 @@ static void LChown(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
 
   CHECK(IsSafeJsInt(args[1]));
   const uv_uid_t uid = static_cast<uv_uid_t>(args[1].As<Integer>()->Value());
@@ -2646,6 +2662,8 @@ static void LUTimes(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
 
   CHECK(args[1]->IsNumber());
   const double atime = args[1].As<Number>()->Value();

--- a/test/fixtures/permission/fs-read.js
+++ b/test/fixtures/permission/fs-read.js
@@ -5,14 +5,11 @@ const common = require('../../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
 
 const blockedFile = process.env.BLOCKEDFILE;
 const blockedFolder = process.env.BLOCKEDFOLDER;
 const allowedFolder = process.env.ALLOWEDFOLDER;
 const regularFile = __filename;
-const uid = os.userInfo().uid;
-const gid = os.userInfo().gid;
 
 // fs.readFile
 {
@@ -104,19 +101,6 @@ const gid = os.userInfo().gid;
   fs.access(regularFile, fs.constants.R_OK, (err) => {
     assert.ifError(err);
   });
-}
-
-// fs.chownSync (should not bypass)
-{
-  assert.throws(() => {
-    // This operation will work fine
-    fs.chownSync(blockedFile, uid, gid);
-    fs.readFileSync(blockedFile);
-  }, common.expectsError({
-    code: 'ERR_ACCESS_DENIED',
-    permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
-  }));
 }
 
 // fs.copyFile

--- a/test/fixtures/permission/fs-symlink.js
+++ b/test/fixtures/permission/fs-symlink.js
@@ -80,10 +80,26 @@ const symlinkFromBlockedFile = process.env.EXISTINGSYMLINK;
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
   }));
+  assert.throws(() => {
+    fs.link(regularFile, blockedFolder + '/asdf', (err) => {
+      assert.ifError(err);
+    });
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  }));
 
   // App won't be able to symlink BLOCKEDFILE to REGULARDIR
   assert.throws(() => {
     fs.symlink(blockedFile, path.join(__dirname, '/asdf'), 'file', (err) => {
+      assert.ifError(err);
+    });
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+  }));
+  assert.throws(() => {
+    fs.link(blockedFile, path.join(__dirname, '/asdf'), (err) => {
       assert.ifError(err);
     });
   }, common.expectsError({

--- a/test/fixtures/permission/fs-write.js
+++ b/test/fixtures/permission/fs-write.js
@@ -108,6 +108,17 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
   }));
 }
 
+// fs.lutimes
+{
+  assert.throws(() => {
+    fs.lutimes(blockedFile, new Date(), new Date(), () => {});
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
+}
+
 // fs.mkdir
 {
   assert.throws(() => {
@@ -269,4 +280,102 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
       permission: 'FileSystemWrite'
     });
   }
+}
+
+// fs.chmod
+{
+  assert.throws(() => {
+    fs.chmod(blockedFile, 0o755, common.mustNotCall());
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  });
+  assert.rejects(async () => {
+    await fs.promises.chmod(blockedFile, 0o755);
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  });
+}
+
+// fs.lchmod
+{
+  if (common.isOSX) {
+    assert.throws(() => {
+      fs.lchmod(blockedFile, 0o755, common.mustNotCall());
+    }, {
+      code: 'ERR_ACCESS_DENIED',
+      permission: 'FileSystemWrite',
+    });
+    assert.rejects(async () => {
+      await fs.promises.lchmod(blockedFile, 0o755);
+    }, {
+      code: 'ERR_ACCESS_DENIED',
+      permission: 'FileSystemWrite',
+    });
+  }
+}
+
+// fs.appendFile
+{
+  assert.throws(() => {
+    fs.appendFile(blockedFile, 'new data', common.mustNotCall());
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  });
+  assert.rejects(async () => {
+    await fs.promises.appendFile(blockedFile, 'new data');
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  });
+}
+
+// fs.chown
+{
+  assert.throws(() => {
+    fs.chown(blockedFile, 1541, 999, common.mustNotCall());
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  });
+  assert.rejects(async () => {
+    await fs.promises.chown(blockedFile, 1541, 999);
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  });
+}
+
+// fs.lchown
+{
+  assert.throws(() => {
+    fs.lchown(blockedFile, 1541, 999, common.mustNotCall());
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  });
+  assert.rejects(async () => {
+    await fs.promises.lchown(blockedFile, 1541, 999);
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  });
+}
+
+// fs.link
+{
+  assert.throws(() => {
+    fs.link(blockedFile, path.join(blockedFolder, '/linked'), common.mustNotCall());
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  });
+  assert.rejects(async () => {
+    await fs.promises.link(blockedFile, path.join(blockedFolder, '/linked'));
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  });
 }


### PR DESCRIPTION
`fs.chmod` and `fs.chown` wasn't handled properly by the permission model. This PR fixes it and increase the coverage of all file system API using permission model