### PR TITLE
esm: avoid accessing lazy getters for urls

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -899,16 +899,20 @@ function resolveAsCommonJS(specifier, parentURL) {
 // TODO(@JakobJingleheimer): de-dupe `specifier` & `parsed`
 function checkIfDisallowedImport(specifier, parsed, parsedParentURL) {
   if (parsedParentURL) {
+    // Avoid accessing the `protocol` property due to the lazy getters.
+    const parentProtocol = parsedParentURL.protocol;
     if (
-      parsedParentURL.protocol === 'http:' ||
-      parsedParentURL.protocol === 'https:'
+      parentProtocol === 'http:' ||
+      parentProtocol === 'https:'
     ) {
       if (shouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
+        // Avoid accessing the `protocol` property due to the lazy getters.
+        const parsedProtocol = parsed?.protocol;
         // data: and blob: disallowed due to allowing file: access via
         // indirection
-        if (parsed &&
-          parsed.protocol !== 'https:' &&
-          parsed.protocol !== 'http:'
+        if (parsedProtocol &&
+          parsedProtocol !== 'https:' &&
+          parsedProtocol !== 'http:'
         ) {
           throw new ERR_NETWORK_IMPORT_DISALLOWED(
             specifier,
@@ -949,22 +953,26 @@ function throwIfInvalidParentURL(parentURL) {
 }
 
 function throwIfUnsupportedURLProtocol(url) {
-  if (url.protocol !== 'file:' && url.protocol !== 'data:' &&
-      url.protocol !== 'node:') {
+  // Avoid accessing the `protocol` property due to the lazy getters.
+  const protocol = url.protocol;
+  if (protocol !== 'file:' && protocol !== 'data:' &&
+      protocol !== 'node:') {
     throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(url);
   }
 }
 
 function throwIfUnsupportedURLScheme(parsed, experimentalNetworkImports) {
+  // Avoid accessing the `protocol` property due to the lazy getters.
+  const protocol = parsed?.protocol;
   if (
-    parsed &&
-    parsed.protocol !== 'file:' &&
-    parsed.protocol !== 'data:' &&
+    protocol &&
+    protocol !== 'file:' &&
+    protocol !== 'data:' &&
     (
       !experimentalNetworkImports ||
       (
-        parsed.protocol !== 'https:' &&
-        parsed.protocol !== 'http:'
+        protocol !== 'https:' &&
+        protocol !== 'http:'
       )
     )
   ) {
@@ -1021,11 +1029,13 @@ function defaultResolve(specifier, context = {}) {
       parsed = new URL(specifier);
     }
 
-    if (parsed.protocol === 'data:' ||
+    // Avoid accessing the `protocol` property due to the lazy getters.
+    const protocol = parsed.protocol;
+    if (protocol === 'data:' ||
       (experimentalNetworkImports &&
         (
-          parsed.protocol === 'https:' ||
-          parsed.protocol === 'http:'
+          protocol === 'https:' ||
+          protocol === 'http:'
         )
       )
     ) {


### PR DESCRIPTION
This pull request avoids multiple calls to the `protocol` getter of the URL. Previor to Ada version 2, `url.protocol` was always returned an already allocated string, but right now, it slices a new string for each call. Storing it in a variable and access it, would make some improvement in terms of performance.

cc @nodejs/url 