### PR TITLE
Update github labels for benchmarks

### DIFF
--- a/.github/label-pr-config.yml
+++ b/.github/label-pr-config.yml
@@ -158,6 +158,7 @@ exlusiveLabels:
   /^benchmark\/_http/: benchmark, http
   /^benchmark\/(?:misc|fixtures)\//: benchmark
   /^benchmark\/streams\//: benchmark, stream
+  /^benchmark\/url\//: benchmark, url, whatwg-url
   /^benchmark\/([^/]+)\//: benchmark, $1
 
   /^benchmark\//: benchmark, performance

--- a/.github/label-pr-config.yml
+++ b/.github/label-pr-config.yml
@@ -160,7 +160,7 @@ exlusiveLabels:
   /^benchmark\/streams\//: benchmark, stream
   /^benchmark\/([^/]+)\//: benchmark, $1
 
-  /^benchmark\//: benchmark
+  /^benchmark\//: benchmark, performance
 
 allJsSubSystems:
   - assert


### PR DESCRIPTION
This pull request adds 2 commits:

1. Adds `performance` label to all changes inside the `benchmark` folder
2. Adds `url` and `whatwg-url` label to all changes inside `benchmark/url` folder