### PR TITLE
url: handle URL.canParse without base parameter

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -115,7 +115,7 @@ void BindingData::DomainToUnicode(const FunctionCallbackInfo<Value>& args) {
 
 // TODO(@anonrig): Add V8 Fast API for CanParse method
 void BindingData::CanParse(const FunctionCallbackInfo<Value>& args) {
-  CHECK_GE(args.Length(), 2);
+  CHECK_GE(args.Length(), 1);
   CHECK(args[0]->IsString());  // input
   // args[1] // base url
 

--- a/test/parallel/test-whatwg-url-canparse.js
+++ b/test/parallel/test-whatwg-url-canparse.js
@@ -1,0 +1,21 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+
+const { URL } = require('url');
+const assert = require('assert');
+
+let internalBinding;
+try {
+  internalBinding = require('internal/test/binding').internalBinding;
+} catch (e) {
+  console.log('using `test/parallel/test-whatwg-url-canparse` requires `--expose-internals`');
+  throw e;
+}
+
+const { canParse } = internalBinding('url');
+
+// It should not throw when called without a base string
+assert.strictEqual(URL.canParse('https://example.org'), true);
+assert.strictEqual(canParse('https://example.org'), true);


### PR DESCRIPTION
Fixes the bug caught by this pull request: https://github.com/nodejs/node/pull/47541

Requesting fast-track to unblock the parent pull request.

cc @nodejs/url