### PR TITLE
node-api: remove unused mark_arraybuffer_as_untransferable

### DIFF
--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -66,10 +66,6 @@ struct napi_env__ {
   }
 
   virtual bool can_call_into_js() const { return true; }
-  virtual v8::Maybe<bool> mark_arraybuffer_as_untransferable(
-      v8::Local<v8::ArrayBuffer> ab) const {
-    return v8::Just(true);
-  }
 
   static inline void HandleThrow(napi_env env, v8::Local<v8::Value> value) {
     if (env->terminatedOrTerminating()) {

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -35,13 +35,6 @@ bool node_napi_env__::can_call_into_js() const {
   return node_env()->can_call_into_js();
 }
 
-v8::Maybe<bool> node_napi_env__::mark_arraybuffer_as_untransferable(
-    v8::Local<v8::ArrayBuffer> ab) const {
-  return ab->SetPrivate(context(),
-                        node_env()->untransferable_object_private_symbol(),
-                        v8::True(isolate));
-}
-
 void node_napi_env__::CallFinalizer(napi_finalize cb, void* data, void* hint) {
   CallFinalizer<true>(cb, data, hint);
 }

--- a/src/node_api_internals.h
+++ b/src/node_api_internals.h
@@ -13,8 +13,6 @@ struct node_napi_env__ : public napi_env__ {
                   const std::string& module_filename);
 
   bool can_call_into_js() const override;
-  v8::Maybe<bool> mark_arraybuffer_as_untransferable(
-      v8::Local<v8::ArrayBuffer> ab) const override;
   void CallFinalizer(napi_finalize cb, void* data, void* hint) override;
   template <bool enforceUncaughtExceptionPolicy>
   void CallFinalizer(napi_finalize cb, void* data, void* hint);


### PR DESCRIPTION
`napi_create_external_arraybuffer` creates the arraybuffer with
`node::Buffer`, which already marks the buffer as untransferable.
The `napi_env__::mark_arraybuffer_as_untransferable` is not used
anymore.