### PR TITLE
doc: add missing setEncoding call in ESM example

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1058,6 +1058,7 @@ export function load(url, context, nextLoad) {
     return new Promise((resolve, reject) => {
       get(url, (res) => {
         let data = '';
+        res.setEncoding('utf8');
         res.on('data', (chunk) => data += chunk);
         res.on('end', () => resolve({
           // This example assumes all network-provided JavaScript is ES module


### PR DESCRIPTION
Adding `setEncoding()` ensures that the example handles characters split across chunk boundaries well.