### PR TITLE
crypto: remove INT_MAX restriction in randomBytes

### DIFF
--- a/src/crypto/crypto_random.cc
+++ b/src/crypto/crypto_random.cc
@@ -40,7 +40,6 @@ Maybe<bool> RandomBytesTraits::AdditionalConfig(
     const FunctionCallbackInfo<Value>& args,
     unsigned int offset,
     RandomBytesConfig* params) {
-  Environment* env = Environment::GetCurrent(args);
   CHECK(IsAnyByteSource(args[offset]));  // Buffer to fill
   CHECK(args[offset + 1]->IsUint32());  // Offset
   CHECK(args[offset + 2]->IsUint32());  // Size
@@ -51,11 +50,6 @@ Maybe<bool> RandomBytesTraits::AdditionalConfig(
   const uint32_t size = args[offset + 2].As<Uint32>()->Value();
   CHECK_GE(byte_offset + size, byte_offset);  // Overflow check.
   CHECK_LE(byte_offset + size, in.size());  // Bounds check.
-
-  if (UNLIKELY(size > INT_MAX)) {
-    THROW_ERR_OUT_OF_RANGE(env, "buffer is too large");
-    return Nothing<bool>();
-  }
 
   params->buffer = in.data() + byte_offset;
   params->size = size;


### PR DESCRIPTION
This restriction was due to an implementation detail in `CSPRNG()`. Now that `CSPRNG()` properly handles lengths exceeding `INT_MAX`, remove this artificial restriction.

Refs: https://github.com/nodejs/node/pull/47515

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
