### PR TITLE
tls: accept SecureContext object in server.addContext()

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -728,9 +728,10 @@ added: v0.5.3
 -->
 
 * `hostname` {string} A SNI host name or wildcard (e.g. `'*'`)
-* `context` {Object} An object containing any of the possible properties
-  from the [`tls.createSecureContext()`][] `options` arguments (e.g. `key`,
-  `cert`, `ca`, etc).
+* `context` {Object|tls.SecureContext} An object containing any of the possible
+  properties from the [`tls.createSecureContext()`][] `options` arguments
+  (e.g. `key`, `cert`, `ca`, etc), or a TLS context object created with
+  [`tls.createSecureContext()`][] itself.
 
 The `server.addContext()` method adds a secure context that will be used if
 the client request's SNI name matches the supplied `hostname` (or wildcard).

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1476,8 +1476,10 @@ Server.prototype.addContext = function(servername, context) {
     RegExpPrototypeSymbolReplace(/([.^$+?\-\\[\]{}])/g, servername, '\\$1'),
     '*', '[^.]*',
   ) + '$');
-  ArrayPrototypePush(this._contexts,
-                     [re, tls.createSecureContext(context).context]);
+
+  const secureContext =
+    context instanceof common.SecureContext ? context : tls.createSecureContext(context);
+  ArrayPrototypePush(this._contexts, [re, secureContext.context]);
 };
 
 Server.prototype[EE.captureRejectionSymbol] = function(

--- a/test/parallel/test-tls-add-context.js
+++ b/test/parallel/test-tls-add-context.js
@@ -1,0 +1,75 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const tls = require('tls');
+
+function loadPEM(n) {
+  return fixtures.readKey(`${n}.pem`);
+}
+
+const serverOptions = {
+  key: loadPEM('agent2-key'),
+  cert: loadPEM('agent2-cert'),
+  ca: [ loadPEM('ca2-cert') ],
+  requestCert: true,
+  rejectUnauthorized: false,
+};
+
+let connections = 0;
+
+const server = tls.createServer(serverOptions, (c) => {
+  if (++connections === 3) {
+    server.close();
+  }
+  if (c.servername === 'unknowncontext') {
+    assert.strictEqual(c.authorized, false);
+    return;
+  }
+  assert.strictEqual(c.authorized, true);
+});
+
+const secureContext = {
+  key: loadPEM('agent1-key'),
+  cert: loadPEM('agent1-cert'),
+  ca: [ loadPEM('ca1-cert') ],
+};
+server.addContext('context1', secureContext);
+server.addContext('context2', tls.createSecureContext(secureContext));
+
+const clientOptionsBase = {
+  key: loadPEM('agent1-key'),
+  cert: loadPEM('agent1-cert'),
+  ca: [ loadPEM('ca1-cert') ],
+  rejectUnauthorized: false,
+};
+
+server.listen(0, common.mustCall(() => {
+  const client1 = tls.connect({
+    ...clientOptionsBase,
+    port: server.address().port,
+    servername: 'context1',
+  }, common.mustCall(() => {
+    client1.end();
+  }));
+
+  const client2 = tls.connect({
+    ...clientOptionsBase,
+    port: server.address().port,
+    servername: 'context2',
+  }, common.mustCall(() => {
+    client2.end();
+  }));
+
+  const client3 = tls.connect({
+    ...clientOptionsBase,
+    port: server.address().port,
+    servername: 'unknowncontext',
+  }, common.mustCall(() => {
+    client3.end();
+  }));
+}));


### PR DESCRIPTION
Do not call tls.createSecureContext() if the context provided is already an instance of tls.SecureContext.

Fixes: https://github.com/nodejs/node/issues/47408

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
