### PR TITLE
lib: disallow file-backed blob cloning

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -56,6 +56,7 @@ const {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_THIS,
+    ERR_INVALID_STATE,
     ERR_BUFFER_TOO_LARGE,
   },
 } = require('internal/errors');
@@ -72,6 +73,7 @@ const {
 const kHandle = Symbol('kHandle');
 const kType = Symbol('kType');
 const kLength = Symbol('kLength');
+const kNotCloneable = Symbol('kNotCloneable');
 
 const disallowedTypeCharacters = /[^\u{0020}-\u{007E}]/u;
 
@@ -184,6 +186,11 @@ class Blob {
   }
 
   [kClone]() {
+    if (this[kNotCloneable]) {
+      // We do not currently allow file-backed Blobs to be cloned or passed across
+      // worker threads.
+      throw new ERR_INVALID_STATE.TypeError('File-backed Blobs are not cloneable');
+    }
     const handle = this[kHandle];
     const type = this[kType];
     const length = this[kLength];
@@ -436,7 +443,9 @@ function createBlobFromFilePath(path, options) {
     return lazyDOMException('The blob could not be read', 'NotReadableError');
   }
   const { 0: blob, 1: length } = maybeBlob;
-  return createBlob(blob, length, options?.type);
+  const res = createBlob(blob, length, options?.type);
+  res[kNotCloneable] = true;
+  return res;
 }
 
 module.exports = {

--- a/test/parallel/test-blob-file-backed.js
+++ b/test/parallel/test-blob-file-backed.js
@@ -4,6 +4,7 @@ const common = require('../common');
 const {
   strictEqual,
   rejects,
+  throws,
 } = require('assert');
 const { TextDecoder } = require('util');
 const {
@@ -98,4 +99,15 @@ writeFileSync(testfile3, '');
   const stream = blob.stream();
   const reader = stream.getReader();
   await rejects(() => reader.read(), { name: 'NotReadableError' });
+})().then(common.mustCall());
+
+(async () => {
+  // We currently do not allow File-backed blobs to be cloned or transfered
+  // across worker threads. This is largely because the underlying FdEntry
+  // is bound to the Environment/Realm under which is was created.
+  const blob = await openAsBlob(__filename);
+  throws(() => structuredClone(blob), {
+    code: 'ERR_INVALID_STATE',
+    message: 'Invalid state: File-backed Blobs are not cloneable'
+  });
 })().then(common.mustCall());


### PR DESCRIPTION
Disallow cloning of file-backed Blobs. If necessary, we can enable this later but for now we disable it. The reason is because the underlying FdEntry ends up bound to the Environment/Realm under which is was created and transfering across worker threads ends up failing.

Fixes: https://github.com/nodejs/node/issues/47334