### PR TITLE
dev: merge HTTP chunks during chunked encoding

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -931,7 +931,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
   let ret;
   if (msg.chunkedEncoding && chunk.length !== 0) {
     len ??= typeof chunk === 'string' ? Buffer.byteLength(chunk, encoding) : chunk.byteLength;
-    msg._send(NumberPrototypeToString(len, 16), 'latin1', null);
+    msg._send(NumberPrototypeToString(len, 16), 'ascii', null);
     msg._send(crlf_buf, null, null);
     msg._send(chunk, encoding, null, len);
     ret = msg._send(crlf_buf, null, callback);
@@ -942,6 +942,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
   debug('write ret = ' + ret);
   return ret;
 }
+
 
 
 function connectionCorkNT(conn) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -943,8 +943,6 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
   return ret;
 }
 
-
-
 function connectionCorkNT(conn) {
   conn.uncork();
 }


### PR DESCRIPTION
Use ASCII instead of Latin1 as encoding. ASCII is a subset of Latin1 and provides better compatibility across different systems and platforms @mcollina  @ronag [#57](https://github.com/nodejs/performance/issues/57)