### PR TITLE
test_runner: avoid reporting parents of failing tests in summary

### DIFF
--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -15,6 +15,7 @@ const assert = require('assert');
 const Transform = require('internal/streams/transform');
 const { inspectWithNoCustomRetry } = require('internal/errors');
 const { green, blue, red, white, gray, hasColors } = require('internal/util/colors');
+const { kSubtestsFailed } = require('internal/test_runner/test');
 const { getCoverageReport } = require('internal/test_runner/utils');
 
 const inspectOptions = { __proto__: null, colors: hasColors, breakLength: Infinity };
@@ -107,7 +108,9 @@ class SpecReporter extends Transform {
   #handleEvent({ type, data }) {
     switch (type) {
       case 'test:fail':
-        ArrayPrototypePush(this.#failedTests, data);
+        if (data.details?.error?.failureType !== kSubtestsFailed) {
+          ArrayPrototypePush(this.#failedTests, data);
+        }
         return this.#handleTestReportEvent(type, data);
       case 'test:pass':
         return this.#handleTestReportEvent(type, data);

--- a/test/fixtures/test-runner/output/spec_reporter.snapshot
+++ b/test/fixtures/test-runner/output/spec_reporter.snapshot
@@ -399,17 +399,11 @@
       *
       *
 
- subtest sync throw fail (*ms)
-  '1 subtest failed'
-
  sync throw non-error fail (*ms)
   Symbol(thrown symbol from sync throw non-error fail)
 
  +long running (*ms)
   'test did not finish before its parent and was cancelled'
-
- top level (*ms)
-  '1 subtest failed'
 
  sync skip option is false fail (*ms)
   Error: this should be executed
@@ -486,9 +480,6 @@
       *
       *
       *
-
- subtest sync throw fails (*ms)
-  '2 subtests failed'
 
  timed out async test (*ms)
   'test timed out after *ms'

--- a/test/fixtures/test-runner/output/spec_reporter_cli.snapshot
+++ b/test/fixtures/test-runner/output/spec_reporter_cli.snapshot
@@ -408,20 +408,12 @@
       *
       *
 
- subtest sync throw fail (*ms)
-  [Error: 1 subtest failed
-  ]
-
  sync throw non-error fail (*ms)
   [Error: Symbol(thrown symbol from sync throw non-error fail)
   ]
 
  +long running (*ms)
   [Error: test did not finish before its parent and was cancelled
-  ]
-
- top level (*ms)
-  [Error: 1 subtest failed
   ]
 
  sync skip option is false fail (*ms)
@@ -503,10 +495,6 @@
       *
       *
       *
-
- subtest sync throw fails (*ms)
-  [Error: 2 subtests failed
-  ]
 
  timed out async test (*ms)
   [Error: test timed out after *ms

--- a/test/pseudo-tty/test_runner_default_reporter.out
+++ b/test/pseudo-tty/test_runner_default_reporter.out
@@ -55,6 +55,3 @@
 
 [31m* should pass but parent fail [90m(*ms)[39m[39m
   [32m'test did not finish before its parent and was cancelled'[39m
-
-[31m* parent [90m(*ms)[39m[39m
-  [32m'2 subtests failed'[39m


### PR DESCRIPTION
it is a little distracting that the summary of failures includes both failing tests and their parents