### PR TITLE
fix: harden check for non-module in vm.modules linker

### DIFF
--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -303,7 +303,7 @@ class SourceTextModule extends Module {
 
       const promises = this[kWrap].link(async (identifier, assert) => {
         const module = await linker(identifier, this, { assert });
-        if (module === undefined || module[kWrap] === undefined) {
+        if (module?.[kWrap] === undefined) {
           throw new ERR_VM_MODULE_NOT_MODULE();
         }
         if (module.context !== this.context) {

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -303,7 +303,7 @@ class SourceTextModule extends Module {
 
       const promises = this[kWrap].link(async (identifier, assert) => {
         const module = await linker(identifier, this, { assert });
-        if (module[kWrap] === undefined) {
+        if (module === undefined || module[kWrap] === undefined) {
           throw new ERR_VM_MODULE_NOT_MODULE();
         }
         if (module.context !== this.context) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

```
(node:528088) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
node:internal/vm/module:306
        if (module[kWrap] === undefined) {
                  ^

TypeError: Cannot read properties of undefined (reading 'Symbol(kWrap)')
    at ModuleWrap.<anonymous> (node:internal/vm/module:306:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v19.9.0
```

Repro case:

```js
const vm = require('node:vm');

async function main() {
  const myObj = { myProp: '' };
  const context = vm.createContext(myObj);
  const module = new vm.SourceTextModule('import * as bug from "bug";', { identifier: 'bug', context });
  await module.link(function(a,b,c){return});
}

main();
```