### PR TITLE
src: throw DataCloneError on transfering untransferable objects

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -180,7 +180,7 @@ added: REPLACEME
 * `object` {any} Any JavaScript value.
 * Returns: {boolean}
 
-Check is an object is marked as not transferable with
+Check if an object is marked as not transferable with
 [`markAsUntransferable()`][].
 
 ```js

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -128,11 +128,6 @@ if (isMainThread) {
 added:
   - v14.5.0
   - v12.19.0
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/47604
-    description: An error is thrown when the untransferable object is in the
-                 transfer list.
 -->
 
 * `object` {any} Any arbitrary JavaScript value.
@@ -167,7 +162,8 @@ try {
 
 // The following line prints the contents of typedArray1 -- it still owns
 // its memory and has not been transferred. Without
-// `markAsUntransferable()`, this would print an empty Uint8Array.
+// `markAsUntransferable()`, this would print an empty Uint8Array and the
+// postMessage call would have succeeded.
 // typedArray2 is intact as well.
 console.log(typedArray1);
 console.log(typedArray2);
@@ -181,7 +177,7 @@ There is no equivalent to this API in browsers.
 added: REPLACEME
 -->
 
-* `object` {any} Any arbitrary JavaScript value.
+* `object` {any} Any JavaScript value.
 * Returns: {boolean}
 
 Check is an object is marked as not transferable with

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -128,10 +128,18 @@ if (isMainThread) {
 added:
   - v14.5.0
   - v12.19.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/47604
+    description: An error is thrown when the untransferable object is in the
+                 transfer list.
 -->
 
+* `object` {any} Any arbitrary JavaScript value.
+
 Mark an object as not transferable. If `object` occurs in the transfer list of
-a [`port.postMessage()`][] call, it is ignored.
+a [`port.postMessage()`][] call, an error is thrown. This is a no-op if
+`object` is a primitive value.
 
 In particular, this makes sense for objects that can be cloned, rather than
 transferred, and which are used by other objects on the sending side.
@@ -150,14 +158,42 @@ const typedArray2 = new Float64Array(pooledBuffer);
 markAsUntransferable(pooledBuffer);
 
 const { port1 } = new MessageChannel();
-port1.postMessage(typedArray1, [ typedArray1.buffer ]);
+try {
+  // This will throw an error, because pooledBuffer is not transferable.
+  port1.postMessage(typedArray1, [ typedArray1.buffer ]);
+} catch (error) {
+  // error.name === 'DataCloneError'
+}
 
 // The following line prints the contents of typedArray1 -- it still owns
-// its memory and has been cloned, not transferred. Without
+// its memory and has not been transferred. Without
 // `markAsUntransferable()`, this would print an empty Uint8Array.
 // typedArray2 is intact as well.
 console.log(typedArray1);
 console.log(typedArray2);
+```
+
+There is no equivalent to this API in browsers.
+
+## `worker.isMarkedAsUntransferable(object)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `object` {any} Any arbitrary JavaScript value.
+* Returns: {boolean}
+
+Check is an object is marked as not transferable with
+[`markAsUntransferable()`][].
+
+```js
+const { markAsUntransferable, isMarkedAsUntransferable } = require('node:worker_threads');
+
+const pooledBuffer = new ArrayBuffer(8);
+markAsUntransferable(pooledBuffer);
+
+isMarkedAsUntransferable(pooledBuffer);  // Returns true.
 ```
 
 There is no equivalent to this API in browsers.
@@ -568,6 +604,10 @@ are part of the channel.
 <!-- YAML
 added: v10.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/47604
+    description: An error is thrown when an untransferable object is in the
+                 transfer list.
   - version:
       - v15.14.0
       - v14.18.0

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -6,7 +6,6 @@ const {
   Float64Array,
   MathFloor,
   Number,
-  ObjectPrototypeHasOwnProperty,
   Uint8Array,
 } = primordials;
 
@@ -1055,15 +1054,12 @@ function markAsUntransferable(obj) {
 }
 
 // This simply checks if the object is marked as untransferable and doesn't
-// check the ability to be transferred.
+// check whether we are able to transfer it.
 function isMarkedAsUntransferable(obj) {
   if (obj == null)
     return false;
-  // v8::Object::HasPrivate checks own properties only.
-  if (!ObjectPrototypeHasOwnProperty(obj, untransferable_object_private_symbol)) {
-    return false;
-  }
-  return obj[untransferable_object_private_symbol] === true;
+  // Private symbols are not inherited.
+  return obj[untransferable_object_private_symbol] !== undefined;
 }
 
 // A toggle used to access the zero fill setting of the array buffer allocator

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -6,6 +6,7 @@ const {
   Float64Array,
   MathFloor,
   Number,
+  ObjectPrototypeHasOwnProperty,
   Uint8Array,
 } = primordials;
 
@@ -1056,8 +1057,12 @@ function markAsUntransferable(obj) {
 // This simply checks if the object is marked as untransferable and doesn't
 // check the ability to be transferred.
 function isMarkedAsUntransferable(obj) {
-  if ((typeof obj !== 'object' && typeof obj !== 'function') || obj === null)
+  if (obj == null)
     return false;
+  // v8::Object::HasPrivate checks own properties only.
+  if (!ObjectPrototypeHasOwnProperty(obj, untransferable_object_private_symbol)) {
+    return false;
+  }
   return obj[untransferable_object_private_symbol] === true;
 }
 

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -1053,6 +1053,14 @@ function markAsUntransferable(obj) {
   obj[untransferable_object_private_symbol] = true;
 }
 
+// This simply checks if the object is marked as untransferable and doesn't
+// check the ability to be transferred.
+function isMarkedAsUntransferable(obj) {
+  if ((typeof obj !== 'object' && typeof obj !== 'function') || obj === null)
+    return false;
+  return obj[untransferable_object_private_symbol] === true;
+}
+
 // A toggle used to access the zero fill setting of the array buffer allocator
 // in C++.
 // |zeroFill| can be undefined when running inside an isolate where we
@@ -1079,6 +1087,7 @@ module.exports = {
   FastBuffer,
   addBufferPrototypeMethods,
   markAsUntransferable,
+  isMarkedAsUntransferable,
   createUnsafeBuffer,
   readUInt16BE,
   readUInt32BE,

--- a/lib/internal/modules/esm/worker.js
+++ b/lib/internal/modules/esm/worker.js
@@ -30,13 +30,21 @@ const {
   WORKER_TO_MAIN_THREAD_NOTIFICATION,
 } = require('internal/modules/esm/shared_constants');
 const { initializeHooks } = require('internal/modules/esm/utils');
-
+const { isMarkedAsUntransferable } = require('internal/buffer');
 
 function transferArrayBuffer(hasError, source) {
   if (hasError || source == null) return;
-  if (isArrayBuffer(source)) return [source];
-  if (isTypedArray(source)) return [TypedArrayPrototypeGetBuffer(source)];
-  if (isDataView(source)) return [DataViewPrototypeGetBuffer(source)];
+  let arrayBuffer;
+  if (isArrayBuffer(source)) {
+    arrayBuffer = source;
+  } else if (isTypedArray(source)) {
+    arrayBuffer = TypedArrayPrototypeGetBuffer(source);
+  } else if (isDataView(source)) {
+    arrayBuffer = DataViewPrototypeGetBuffer(source);
+  }
+  if (arrayBuffer && !isMarkedAsUntransferable(arrayBuffer)) {
+    return [arrayBuffer];
+  }
 }
 
 function wrapMessage(status, body) {

--- a/lib/worker_threads.js
+++ b/lib/worker_threads.js
@@ -20,6 +20,7 @@ const {
 
 const {
   markAsUntransferable,
+  isMarkedAsUntransferable,
 } = require('internal/buffer');
 
 module.exports = {
@@ -27,6 +28,7 @@ module.exports = {
   MessagePort,
   MessageChannel,
   markAsUntransferable,
+  isMarkedAsUntransferable,
   moveMessagePortToContext,
   receiveMessageOnPort,
   resourceLimits,

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -66,7 +66,7 @@
   V(change_string, "change")                                                   \
   V(channel_string, "channel")                                                 \
   V(chunks_sent_since_last_write_string, "chunksSentSinceLastWrite")           \
-  V(clone_unsupported_type_str, "Cannot transfer object of unsupported type.") \
+  V(clone_unsupported_type_str, "Cannot clone object of unsupported type.")    \
   V(code_string, "code")                                                       \
   V(commonjs_string, "commonjs")                                               \
   V(config_string, "config")                                                   \
@@ -301,6 +301,8 @@
   V(time_to_first_header_string, "timeToFirstHeader")                          \
   V(tls_ticket_string, "tlsTicket")                                            \
   V(transfer_string, "transfer")                                               \
+  V(transfer_unsupported_type_str,                                             \
+    "Cannot transfer object of unsupported type.")                             \
   V(ttl_string, "ttl")                                                         \
   V(type_string, "type")                                                       \
   V(uid_string, "uid")                                                         \

--- a/test/addons/worker-buffer-callback/test.js
+++ b/test/addons/worker-buffer-callback/test.js
@@ -9,7 +9,10 @@ const { buffer } = require(`./build/${common.buildType}/binding`);
 
 const { port1 } = new MessageChannel();
 const origByteLength = buffer.byteLength;
-port1.postMessage(buffer, [buffer.buffer]);
+assert.throws(() => port1.postMessage(buffer, [buffer.buffer]), {
+  code: 25,
+  name: 'DataCloneError',
+});
 
 assert.strictEqual(buffer.byteLength, origByteLength);
 assert.notStrictEqual(buffer.byteLength, 0);

--- a/test/node-api/test_worker_buffer_callback/test.js
+++ b/test/node-api/test_worker_buffer_callback/test.js
@@ -9,7 +9,10 @@ const { buffer } = require(`./build/${common.buildType}/binding`);
 
 const { port1 } = new MessageChannel();
 const origByteLength = buffer.byteLength;
-port1.postMessage(buffer, [buffer]);
+assert.throws(() => port1.postMessage(buffer, [buffer]), {
+  code: 25,
+  name: 'DataCloneError',
+});
 
 assert.strictEqual(buffer.byteLength, origByteLength);
 assert.notStrictEqual(buffer.byteLength, 0);

--- a/test/parallel/test-buffer-pool-untransferable.js
+++ b/test/parallel/test-buffer-pool-untransferable.js
@@ -13,7 +13,10 @@ assert.strictEqual(a.buffer, b.buffer);
 const length = a.length;
 
 const { port1 } = new MessageChannel();
-port1.postMessage(a, [ a.buffer ]);
+assert.throws(() => port1.postMessage(a, [ a.buffer ]), {
+  code: 25,
+  name: 'DataCloneError',
+});
 
 // Verify that the pool ArrayBuffer has not actually been transferred:
 assert.strictEqual(a.buffer, b.buffer);

--- a/test/parallel/test-worker-message-port-arraybuffer.js
+++ b/test/parallel/test-worker-message-port-arraybuffer.js
@@ -12,6 +12,13 @@ const { MessageChannel } = require('worker_threads');
   typedArray[0] = 0x12345678;
 
   port1.postMessage(typedArray, [ arrayBuffer ]);
+  assert.strictEqual(arrayBuffer.byteLength, 0);
+  // Transferring again should throw a DataCloneError.
+  assert.throws(() => port1.postMessage(typedArray, [ arrayBuffer ]), {
+    code: 25,
+    name: 'DataCloneError',
+  });
+
   port2.on('message', common.mustCall((received) => {
     assert.strictEqual(received[0], 0x12345678);
     port2.close(common.mustCall());

--- a/test/parallel/test-worker-message-port-transfer-native.js
+++ b/test/parallel/test-worker-message-port-transfer-native.js
@@ -31,7 +31,7 @@ const { internalBinding } = require('internal/test/binding');
     port1.postMessage(nativeObject);
   }, {
     name: 'DataCloneError',
-    message: /Cannot transfer object of unsupported type\.$/
+    message: /Cannot clone object of unsupported type\.$/
   });
   port1.close();
 }

--- a/test/parallel/test-worker-message-transfer-port-mark-as-untransferable.js
+++ b/test/parallel/test-worker-message-transfer-port-mark-as-untransferable.js
@@ -9,11 +9,13 @@ const { MessageChannel, markAsUntransferable } = require('worker_threads');
   markAsUntransferable(ab);
   assert.strictEqual(ab.byteLength, 8);
 
-  const { port1, port2 } = new MessageChannel();
-  port1.postMessage(ab, [ ab ]);
+  const { port1 } = new MessageChannel();
+  assert.throws(() => port1.postMessage(ab, [ ab ]), {
+    code: 25,
+    name: 'DataCloneError',
+  });
 
   assert.strictEqual(ab.byteLength, 8);  // The AB is not detached.
-  port2.once('message', common.mustCall());
 }
 
 {
@@ -24,7 +26,10 @@ const { MessageChannel, markAsUntransferable } = require('worker_threads');
 
   assert.throws(() => {
     channel1.port1.postMessage(channel2.port1, [ channel2.port1 ]);
-  }, /was found in message but not listed in transferList/);
+  }, {
+    code: 25,
+    name: 'DataCloneError',
+  });
 
   channel2.port1.postMessage('still works, not closed/transferred');
   channel2.port2.once('message', common.mustCall());


### PR DESCRIPTION
The HTML [StructuredSerializeWithTransfer](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer) algorithm defines that when
an untransferable object is in the transfer list, a DataCloneError is
thrown.
An array buffer that is already transferred is also considered as
untransferable.

The following script throws in the browser but succeeds in Node.js:

```js
const ab = new ArrayBuffer(10)
const first = structuredClone(ab, { transfer: [ab] })
const second = structuredClone(ab, { transfer: [ab] })
```

The motivation of the PR is throwing an error prominently to avoid copy buffer
silently when it is expected to be transferred: 

```js
const buffer = Buffer.allocUnsafe(10)
// this should throw instead of falling back to copying
structuredClone(buffer, { transfer: [buffer.buffer] })
```