### PR TITLE
doc: change offset of example in `Buffer.copyBytesFrom`

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -581,7 +581,7 @@ contained by the `Blob` is copied only when the `arrayBuffer()` or `text()`
 methods are called.
 
 ```mjs
-import { Blob, Buffer } from 'node:buffer';
+import { Blob } from 'node:buffer';
 import { setTimeout as delay } from 'node:timers/promises';
 
 const blob = new Blob(['hello there']);
@@ -608,7 +608,7 @@ blob.text().then(console.log);
 ```
 
 ```cjs
-const { Blob, Buffer } = require('node:buffer');
+const { Blob } = require('node:buffer');
 const { setTimeout: delay } = require('node:timers/promises');
 
 const blob = new Blob(['hello there']);
@@ -1075,7 +1075,7 @@ Copies the underlying memory of `view` into a new `Buffer`.
 
 ```js
 const u16 = new Uint16Array([0, 0xffff]);
-const buf = Buffer.copyBytesFrom(u16, 0, 1);
+const buf = Buffer.copyBytesFrom(u16, 1, 1);
 u16[1] = 0;
 console.log(buf.length); // 2
 console.log(buf[0]); // 255


### PR DESCRIPTION
Actual output is different from expected output if offset is 0.
Plus, removed unused importing `Buffer`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
