### PR TITLE
Policy required flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1116,6 +1116,16 @@ Instructs Node.js to error prior to running any code if the policy does not have
 the specified integrity. It expects a [Subresource Integrity][] string as a
 parameter.
 
+### `--policy-required`
+
+<!-- YAML
+added: FIXME
+-->
+
+> Stability: 1 - Experimental
+
+Instructs Node.js to error prior to running any code if no policy is supplied.
+
 ### `--preserve-symlinks`
 
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1119,7 +1119,7 @@ parameter.
 ### `--policy-required`
 
 <!-- YAML
-added: FIXME
+added: REPLACEME
 -->
 
 > Stability: 1 - Experimental

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2161,6 +2161,7 @@ Node.js options that are allowed are:
 * `--openssl-shared-config`
 * `--pending-deprecation`
 * `--policy-integrity`
+* `--policy-required`
 * `--preserve-symlinks-main`
 * `--preserve-symlinks`
 * `--prof-process`

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -60,7 +60,9 @@ node --experimental-policy=policy.json app.js
 ```
 
 The policy manifest will be used to enforce constraints on code loaded by
-Node.js.
+Node.js. It is possible to require a policy be supplied using
+`--policy-required` to prevent running without a policy. `--policy-required`
+can be set in the [`NODE_OPTIONS`][] environment variable.
 
 To mitigate tampering with policy files on disk, an integrity for
 the policy file itself may be provided via `--policy-integrity`.
@@ -553,6 +555,7 @@ There are constraints you need to know before using this system:
 [`--allow-fs-write`]: cli.md#--allow-fs-write
 [`--allow-worker`]: cli.md#--allow-worker
 [`--experimental-permission`]: cli.md#--experimental-permission
+[`NODE_OPTIONS`]: cli.md#node_optionsoptions
 [`permission.has()`]: process.md#processpermissionhasscope-reference
 [import maps]: https://url.spec.whatwg.org/#relative-url-with-fragment-string
 [relative-url string]: https://url.spec.whatwg.org/#relative-url-with-fragment-string

--- a/doc/node.1
+++ b/doc/node.1
@@ -338,6 +338,9 @@ Emit pending deprecation warnings.
 .It Fl -policy-integrity Ns = Ns Ar sri
 Instructs Node.js to error prior to running any code if the policy does not have the specified integrity. It expects a Subresource Integrity string as a parameter.
 .
+.It Fl -policy-required
+Instructs Node.js to error prior to running any code if no policy is supplied.
+.
 .It Fl -preserve-symlinks
 Instructs the module loader to preserve symbolic links when resolving and caching modules other than the main module.
 .

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -104,6 +104,11 @@ void PerIsolateOptions::CheckOptions(std::vector<std::string>* errors,
 
 void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors,
                                       std::vector<std::string>* argv) {
+  if (experimental_policy_required && experimental_policy.empty()) {
+    errors->push_back("--policy-required requires "
+                      "--experimental-policy be enabled");
+  }
+
   if (has_policy_integrity_string && experimental_policy.empty()) {
     errors->push_back("--policy-integrity requires "
                       "--experimental-policy be enabled");
@@ -423,6 +428,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::experimental_policy_integrity,
             kAllowedInEnvvar);
   Implies("--policy-integrity", "[has_policy_integrity_string]");
+  AddOption("--policy-required",
+            "throw an error if no policy is specified",
+            &EnvironmentOptions::experimental_policy_required,
+            kAllowedInEnvvar);
   AddOption("--allow-fs-read",
             "allow permissions to read the filesystem",
             &EnvironmentOptions::allow_fs_read,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -119,6 +119,7 @@ class EnvironmentOptions : public Options {
   std::string module_type;
   std::string experimental_policy;
   std::string experimental_policy_integrity;
+  bool experimental_policy_required = false;
   bool has_policy_integrity_string = false;
   bool experimental_permission = false;
   std::string allow_fs_read;

--- a/test/parallel/test-policy-required-flag.js
+++ b/test/parallel/test-policy-required-flag.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+common.requireNoPackageJSONAbove();
+
+const fixtures = require('../common/fixtures');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const depPolicy = fixtures.path('policy', 'dep-policy.json');
+const dep = fixtures.path('policy', 'dep.js');
+
+{
+  const { status, stderr } = spawnSync(
+    process.execPath,
+    [
+      '--policy-required',
+      '--experimental-policy', depPolicy, dep,
+    ]
+  );
+
+  assert.strictEqual(status, 0, `status: ${status}\nstderr: ${stderr}`);
+}
+{
+  const { status, stderr } = spawnSync(
+    process.execPath,
+    [
+      '--policy-required',
+      dep,
+    ]
+  );
+
+  assert.strictEqual(status, 9, `status: ${status}\nstderr: ${stderr}`);
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This allows enforcing that any `node` invocation has a policy associated with it, it is the first step of https://github.com/nodejs/security-wg/issues/856 . 2 follow on PRs are separately useful to accomplish the full user story, but this flag is able to stand alone in utility.

CC: @nodejs/security 