### PR TITLE
test: skip flaky wpt/test-timers

### DIFF
--- a/test/wpt/status/html/webappapis/timers.json
+++ b/test/wpt/status/html/webappapis/timers.json
@@ -1,5 +1,8 @@
 {
   "negative-settimeout.any.js": {
     "skip": "unreliable in Node.js; Refs: https://github.com/nodejs/node/issues/37672"
+  },
+  "type-long-setinterval.any.js": {
+    "skip": "unreliable in Node.js; Refs: https://github.com/nodejs/node/issues/37672"
   }
 }


### PR DESCRIPTION
This has been flaky ever since re-enabling parallelism on WPTs. If more become flaky over time I would recommend dropping wpt/test-timers completely and instead moving the few tests there into sequential (if they're not already there).