### PR TITLE
fs: make recursive readdir algorithms iterative

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1454,10 +1454,8 @@ function readdirSyncRecursive(basePath, options) {
     }
   }
 
-  while (pathsQueue.length > 0) {
-    const path = ArrayPrototypeShift(pathsQueue);
-    read(path);
-  }
+  while (pathsQueue.length > 0)
+    read(ArrayPrototypeShift(pathsQueue));
 
   return readdirResults;
 }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -26,6 +26,7 @@
 
 const {
   ArrayPrototypePush,
+  ArrayPrototypeShift,
   BigIntPrototypeToString,
   MathMax,
   Number,
@@ -140,7 +141,6 @@ const {
   validateObject,
   validateString,
 } = require('internal/validators');
-
 let truncateWarn = true;
 let fs;
 
@@ -1404,34 +1404,64 @@ function mkdirSync(path, options) {
   }
 }
 
-// TODO(Ethan-Arrowood): Make this iterative too
-function readdirSyncRecursive(path, origPath, options) {
-  nullCheck(path, 'path', true);
-  const ctx = { path };
-  const result = binding.readdir(pathModule.toNamespacedPath(path),
-                                 options.encoding, !!options.withFileTypes, undefined, ctx);
-  handleErrorFromBinding(ctx);
-  return options.withFileTypes ?
-    getDirents(path, result).flatMap((dirent) => {
-      return [
-        dirent,
-        ...(dirent.isDirectory() ?
-          readdirSyncRecursive(
-            pathModule.join(path, dirent.name),
-            origPath,
-            options,
-          ) : []),
-      ];
-    }) :
-    result.flatMap((ent) => {
-      const innerPath = pathModule.join(path, ent);
-      const relativePath = pathModule.relative(origPath, innerPath);
-      const stat = binding.internalModuleStat(innerPath);
-      return [
-        relativePath,
-        ...(stat === 1 ? readdirSyncRecursive(innerPath, origPath, options) : []),
-      ];
-    });
+/**
+ * An iterative algorithm for reading the entire contents of the `basePath` directory.
+ * This function does not validate `basePath` as a directory. It is passed directly to
+ * `binding.readdir` after a `nullCheck`.
+ * @param {string} basePath
+ * @param {{ encoding: string, withFileTypes: boolean }} options
+ * @returns {Array<string> | Array<Dirent>}
+ */
+function readdirSyncRecursive(basePath, options) {
+  nullCheck(basePath, 'path', true);
+
+  const results = [];
+  const opsQueue = [];
+
+  function _read(_path) {
+    const ctx = { _path };
+    const result = binding.readdir(
+      pathModule.toNamespacedPath(_path),
+      options.encoding,
+      !!options.withFileTypes,
+      undefined,
+      ctx,
+    );
+    handleErrorFromBinding(ctx);
+
+    if (options.withFileTypes) {
+      const dirents = getDirents(_path, result);
+      for (let i = 0; i < dirents.length; i++) {
+        const dirent = dirents[i];
+        ArrayPrototypePush(results, dirent);
+        if (dirent.isDirectory()) {
+          ArrayPrototypePush(opsQueue, curryRead(pathModule.join(dirent.path, dirent.name)));
+        }
+      }
+    } else {
+      for (let i = 0; i < result.length; i++) {
+        const ent = result[i];
+        const innerPath = pathModule.join(_path, ent);
+        const relativePath = pathModule.relative(basePath, innerPath);
+        const stat = binding.internalModuleStat(innerPath);
+        ArrayPrototypePush(results, relativePath);
+        if (stat === 1) {
+          ArrayPrototypePush(opsQueue, curryRead(innerPath));
+        }
+      }
+    }
+  }
+
+  const curryRead = (p) => () => _read(p);
+
+  ArrayPrototypePush(opsQueue, curryRead(basePath));
+
+  while (opsQueue.length !== 0) {
+    const op = ArrayPrototypeShift(opsQueue);
+    op();
+  }
+
+  return results;
 }
 
 /**
@@ -1456,7 +1486,7 @@ function readdir(path, options, callback) {
   }
 
   if (options.recursive) {
-    callback(null, readdirSyncRecursive(path, path, options));
+    callback(null, readdirSyncRecursive(path, options));
     return;
   }
 
@@ -1494,7 +1524,7 @@ function readdirSync(path, options) {
   }
 
   if (options.recursive) {
-    return readdirSyncRecursive(path, path, options);
+    return readdirSyncRecursive(path, options);
   }
 
   const ctx = { path };

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -98,6 +98,7 @@ const {
   copyObject,
   Dirent,
   emitRecursiveRmdirWarning,
+  getDirent,
   getDirents,
   getOptions,
   getValidatedFd,
@@ -1416,31 +1417,32 @@ function mkdirSync(path, options) {
 function readdirSyncRecursive(basePath, options) {
   nullCheck(basePath, 'path', true);
 
+  const withFileTypes = Boolean(options.withFileTypes);
+  const encoding = options.encoding;
+
   const readdirResults = [];
   const pathsQueue = [basePath];
 
+  const ctx = { path: basePath };
   function read(path) {
-    const ctx = { path };
+    ctx.path = path;
     const readdirResult = binding.readdir(
       pathModule.toNamespacedPath(path),
-      options.encoding,
-      Boolean(options.withFileTypes),
+      encoding,
+      withFileTypes,
       undefined,
       ctx,
     );
     handleErrorFromBinding(ctx);
 
-    if (options.withFileTypes) {
-      const dirents = getDirents(path, readdirResult);
-      for (let i = 0; i < dirents.length; i++) {
-        const dirent = dirents[i];
+    for (let i = 0; i < readdirResult.length; i++) {
+      if (withFileTypes) {
+        const dirent = getDirent(path, readdirResult[0][i], readdirResult[1][i]);
         ArrayPrototypePush(readdirResults, dirent);
         if (dirent.isDirectory()) {
           ArrayPrototypePush(pathsQueue, pathModule.join(dirent.path, dirent.name));
         }
-      }
-    } else {
-      for (let i = 0; i < readdirResult.length; i++) {
+      } else {
         const resultPath = pathModule.join(path, readdirResult[i]);
         const relativeResultPath = pathModule.relative(basePath, resultPath);
         const stat = binding.internalModuleStat(resultPath);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1454,8 +1454,9 @@ function readdirSyncRecursive(basePath, options) {
     }
   }
 
-  while (pathsQueue.length > 0)
-    read(ArrayPrototypeShift(pathsQueue));
+  for (let i = 0; i < pathsQueue.length; i++) {
+    read(pathsQueue[i]);
+  }
 
   return readdirResults;
 }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -28,6 +28,7 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeShift,
   BigIntPrototypeToString,
+  Boolean,
   MathMax,
   Number,
   ObjectDefineProperties,
@@ -141,6 +142,7 @@ const {
   validateObject,
   validateString,
 } = require('internal/validators');
+
 let truncateWarn = true;
 let fs;
 
@@ -1410,58 +1412,54 @@ function mkdirSync(path, options) {
  * `binding.readdir` after a `nullCheck`.
  * @param {string} basePath
  * @param {{ encoding: string, withFileTypes: boolean }} options
- * @returns {Array<string> | Array<Dirent>}
+ * @returns {string[] | Dirent[]}
  */
 function readdirSyncRecursive(basePath, options) {
   nullCheck(basePath, 'path', true);
 
-  const results = [];
-  const opsQueue = [];
+  const readdirResults = [];
+  const pathsQueue = [basePath];
 
-  function _read(_path) {
-    const ctx = { _path };
-    const result = binding.readdir(
-      pathModule.toNamespacedPath(_path),
+  function read(path) {
+    const ctx = { path };
+    const readdirResult = binding.readdir(
+      pathModule.toNamespacedPath(path),
       options.encoding,
-      !!options.withFileTypes,
+      Boolean(options.withFileTypes),
       undefined,
       ctx,
     );
     handleErrorFromBinding(ctx);
 
     if (options.withFileTypes) {
-      const dirents = getDirents(_path, result);
+      const dirents = getDirents(path, readdirResult);
       for (let i = 0; i < dirents.length; i++) {
         const dirent = dirents[i];
-        ArrayPrototypePush(results, dirent);
+        ArrayPrototypePush(readdirResults, dirent);
         if (dirent.isDirectory()) {
-          ArrayPrototypePush(opsQueue, curryRead(pathModule.join(dirent.path, dirent.name)));
+          ArrayPrototypePush(pathsQueue, pathModule.join(dirent.path, dirent.name));
         }
       }
     } else {
-      for (let i = 0; i < result.length; i++) {
-        const ent = result[i];
-        const innerPath = pathModule.join(_path, ent);
-        const relativePath = pathModule.relative(basePath, innerPath);
-        const stat = binding.internalModuleStat(innerPath);
-        ArrayPrototypePush(results, relativePath);
+      for (let i = 0; i < readdirResult.length; i++) {
+        const resultPath = pathModule.join(path, readdirResult[i]);
+        const relativeResultPath = pathModule.relative(basePath, resultPath);
+        const stat = binding.internalModuleStat(resultPath);
+        ArrayPrototypePush(readdirResults, relativeResultPath);
+        // 1 indicates directory
         if (stat === 1) {
-          ArrayPrototypePush(opsQueue, curryRead(innerPath));
+          ArrayPrototypePush(pathsQueue, resultPath);
         }
       }
     }
   }
 
-  const curryRead = (p) => () => _read(p);
-
-  ArrayPrototypePush(opsQueue, curryRead(basePath));
-
-  while (opsQueue.length !== 0) {
-    const op = ArrayPrototypeShift(opsQueue);
-    op();
+  while (pathsQueue.length > 0) {
+    const path = ArrayPrototypeShift(pathsQueue);
+    read(path);
   }
 
-  return results;
+  return readdirResults;
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -26,7 +26,6 @@
 
 const {
   ArrayPrototypePush,
-  ArrayPrototypeShift,
   BigIntPrototypeToString,
   Boolean,
   MathMax,

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -160,8 +160,6 @@ class Dir {
     }
   }
 
-  // TODO(Ethan-Arrowood): Review this implementation. Make it iterative.
-  // Can we better leverage the `kDirOperationQueue`?
   readSyncRecursive(dirent) {
     const ctx = { path: dirent.path };
     const handle = dirBinding.opendir(


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR updates the new `readdir` recursive algorithm to be iterative. This helps avoid potential callstack issues for very large directories. 