### PR TITLE
test_runner: move coverage collection to root.postRun()

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -1,6 +1,7 @@
 'use strict';
 const {
   ArrayPrototypeForEach,
+  FunctionPrototypeBind,
   PromiseResolve,
   SafeMap,
 } = primordials;
@@ -140,7 +141,6 @@ function setup(root) {
     createProcessEventHandler('unhandledRejection', root);
   const coverage = configureCoverage(root, globalOptions);
   const exitHandler = () => {
-    root.harness.coverage = collectCoverage(root, coverage);
     root.postRun(new ERR_TEST_FAILURE(
       'Promise resolution is still pending but the event loop has already resolved',
       kCancelledByParent));
@@ -167,7 +167,7 @@ function setup(root) {
   root.harness = {
     __proto__: null,
     bootstrapComplete: false,
-    coverage: null,
+    coverage: FunctionPrototypeBind(collectCoverage, null, root, coverage),
     counters: {
       __proto__: null,
       all: 0,

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -644,8 +644,10 @@ class Test extends AsyncResource {
       this.reporter.diagnostic(this.nesting, kFilename, `todo ${this.root.harness.counters.todo}`);
       this.reporter.diagnostic(this.nesting, kFilename, `duration_ms ${this.#duration()}`);
 
-      if (this.harness?.coverage) {
-        this.reporter.coverage(this.nesting, kFilename, this.harness.coverage);
+      const coverage = this.harness.coverage();
+
+      if (coverage) {
+        this.reporter.coverage(this.nesting, kFilename, coverage);
       }
 
       this.reporter.push(null);


### PR DESCRIPTION
This commit moves code coverage collection from the test harness exit handler to the `postRun()` function of the root test.

This is necessary preparatory work for supporting code coverage with `--test`. The reason is that `--test` is implemented on top of `run()`, and that function calls the root test's `postRun()` function, which outputs the test summary. This happens before the harness exit handler.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
