### PR TITLE
doc,fs: update description of fs.stat() method

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4126,7 +4126,7 @@ Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
 
 In case of an error, the `err.code` will be one of [Common System Errors][].
 
-[`fs.stat()`][] follows symbolic links, [`fs.lstat()`][] looks at the links
+[`fs.stat()`][] follows symbolic links. [`fs.lstat()`][] looks at the links
 themselves. Therefore, it is recommended to use [`fs.lstat()`][] when the links
 themselves need to be examined.
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4126,6 +4126,10 @@ Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
 
 In case of an error, the `err.code` will be one of [Common System Errors][].
 
+[`fs.stat()`][] follows symbolic links, [`fs.lstat()`][] looks at the links
+themselves. Therefore, it is recommended to use [`fs.lstat()`][] when the links
+themselves need to be examined.
+
 Using `fs.stat()` to check for the existence of a file before calling
 `fs.open()`, `fs.readFile()`, or `fs.writeFile()` is not recommended.
 Instead, user code should open/read/write the file directly and handle the

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4126,8 +4126,8 @@ Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
 
 In case of an error, the `err.code` will be one of [Common System Errors][].
 
-[`fs.stat()`][] follows symbolic links. Use [`fs.lstat()`][] to look at the links
-themselves.
+[`fs.stat()`][] follows symbolic links. Use [`fs.lstat()`][] to look at the
+links themselves.
 
 Using `fs.stat()` to check for the existence of a file before calling
 `fs.open()`, `fs.readFile()`, or `fs.writeFile()` is not recommended.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4127,8 +4127,8 @@ Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
 In case of an error, the `err.code` will be one of [Common System Errors][].
 
 [`fs.stat()`][] follows symbolic links. [`fs.lstat()`][] looks at the links
-themselves. Therefore, it is recommended to use [`fs.lstat()`][] when the links
-themselves need to be examined.
+themselves. Therefore, [`fs.lstat()`][] must be used when the links themselves
+need to be examined.
 
 Using `fs.stat()` to check for the existence of a file before calling
 `fs.open()`, `fs.readFile()`, or `fs.writeFile()` is not recommended.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4126,9 +4126,8 @@ Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
 
 In case of an error, the `err.code` will be one of [Common System Errors][].
 
-[`fs.stat()`][] follows symbolic links. [`fs.lstat()`][] looks at the links
-themselves. Therefore, [`fs.lstat()`][] must be used when the links themselves
-need to be examined.
+[`fs.stat()`][] follows symbolic links. Use [`fs.lstat()`][] to look at the links
+themselves.
 
 Using `fs.stat()` to check for the existence of a file before calling
 `fs.open()`, `fs.readFile()`, or `fs.writeFile()` is not recommended.


### PR DESCRIPTION
Hi as [mentioned](https://github.com/nodejs/node/issues/47633) in the talk, fs.stat watches the symlinks, while fs.lstat looks at the symlinks themselves. For this reason, it is recommended to use fs.lstat in cases where symlinks themselves need to be looked at. Based on this information I added that you should use fs.stat or fs.lstat depending on the type of file

Fixes: https://github.com/nodejs/node/issues/47633