### PR TITLE
[v18.x] esm: fix `--specifier-resolution=node` not preserving symlinks

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -310,7 +310,8 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
       }
     }
 
-    path = file;
+    resolved = file;
+    path = fileURLToPath(resolved);
   }
 
   const stats = tryStatSync(StringPrototypeEndsWith(path, '/') ?

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -309,7 +309,7 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
           resolved.pathname, fileURLToPath(base), 'module');
       }
     }
-    // if preserveSymlinks is false resolved is returned and path
+    // If `preserveSymlinks` is false, `resolved` is returned and `path`
     // is used only to check that the resolved path exists.
     resolved = file;
     path = fileURLToPath(resolved);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -309,7 +309,8 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
           resolved.pathname, fileURLToPath(base), 'module');
       }
     }
-
+    // if preserveSymlinks is false resolved is returned and path
+    // is used only to check that the resolved path exists
     resolved = file;
     path = fileURLToPath(resolved);
   }

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -310,7 +310,7 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
       }
     }
     // if preserveSymlinks is false resolved is returned and path
-    // is used only to check that the resolved path exists
+    // is used only to check that the resolved path exists.
     resolved = file;
     path = fileURLToPath(resolved);
   }

--- a/test/es-module/test-esm-specifiers.mjs
+++ b/test/es-module/test-esm-specifiers.mjs
@@ -36,6 +36,37 @@ describe('ESM: specifier-resolution=node', { concurrency: true }, () => {
     strictEqual(stdout, '');
     strictEqual(code, 0);
   });
+  it('should work with --preserve-symlinks', async () => {
+    const { code, stderr, stdout } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-specifier-resolution=node',
+      '--preserve-symlinks',
+      '--input-type=module',
+      '--eval',
+      [
+        'import { strictEqual } from "node:assert";',
+        // CommonJS index.js
+        `import commonjs from ${JSON.stringify(fixtures.fileURL('es-module-specifiers/package-type-commonjs'))};`,
+        // ESM index.js
+        `import module from ${JSON.stringify(fixtures.fileURL('es-module-specifiers/package-type-module'))};`,
+        // Directory entry with main.js
+        `import main from ${JSON.stringify(fixtures.fileURL('es-module-specifiers/dir-with-main'))};`,
+        // Notice the trailing slash
+        `import success, { explicit, implicit, implicitModule } from ${JSON.stringify(fixtures.fileURL('es-module-specifiers/'))};`,
+        'strictEqual(commonjs, "commonjs");',
+        'strictEqual(module, "module");',
+        'strictEqual(main, "main");',
+        'strictEqual(success, "success");',
+        'strictEqual(explicit, "esm");',
+        'strictEqual(implicit, "cjs");',
+        'strictEqual(implicitModule, "cjs");',
+      ].join('\n'),
+    ]);
+
+    strictEqual(stderr, '');
+    strictEqual(stdout, '');
+    strictEqual(code, 0);
+  });
 
   it('should throw when the file doesn\'t exist', async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/47649

When you combine `--experimental-specifier-resolution=node` and `--preserve-symlinks` imports that were valid in node 14 fail.

While I recognise that this behaviour is experimental, and indeed removed in node 19, swapping to a loader for the simple case of  appending `.js` is quite a bit of effort - even if that effort will eventually need to be made.