### PR TITLE
src: fix creating an ArrayBuffer from a Blob created with `openAsBlob`

### DIFF
--- a/src/dataqueue/queue.cc
+++ b/src/dataqueue/queue.cc
@@ -817,7 +817,7 @@ class FdEntry final : public EntryImpl {
     uint64_t new_start = start_ + start;
     uint64_t new_end = end_;
     if (end.has_value()) {
-      new_end = std::min(end.value() + start, new_end);
+      new_end = std::min(end.value(), end_);
     }
 
     CHECK(new_start >= start_);
@@ -881,7 +881,7 @@ class FdEntry final : public EntryImpl {
               file,
               Local<Object>(),
               entry->start_,
-              entry->end_)),
+              entry->end_ - entry->start_)),
           entry);
     }
 

--- a/test/parallel/test-blob-file-backed.js
+++ b/test/parallel/test-blob-file-backed.js
@@ -68,6 +68,23 @@ writeFileSync(testfile3, '');
 })().then(common.mustCall());
 
 (async () => {
+  // Refs: https://github.com/nodejs/node/issues/47683
+  const blob = await openAsBlob(testfile);
+  const res = blob.slice(10, 20);
+  const ab = await res.arrayBuffer();
+  strictEqual(res.size, ab.byteLength);
+
+  let length = 0;
+  const stream = await res.stream();
+  for await (const chunk of stream)
+    length += chunk.length;
+  strictEqual(res.size, length);
+
+  const res1 = blob.slice(995, 1005);
+  strictEqual(await res1.text(), data.slice(995, 1005));
+})().then(common.mustCall());
+
+(async () => {
   const blob = await openAsBlob(testfile2);
   const stream = blob.stream();
   const read = async () => {


### PR DESCRIPTION
Fixes: #47683

This fixes creating an `ArrayBuffer` from a Blob sliced from a Blob created with `fs.openAsBlob`.

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
