### PR TITLE
src: support V8 experimental shared values in messaging

### DIFF
--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -88,6 +88,9 @@ class Message : public MemoryRetainer {
   // Internal method of Message that is called when a new WebAssembly.Module
   // object is encountered in the incoming value's structure.
   uint32_t AddWASMModule(v8::CompiledWasmModule&& mod);
+  // Internal method of Message that is called when a shared value is
+  // encountered for the first time in the incoming value's structure.
+  void AdoptSharedValueConveyor(v8::SharedValueConveyor&& conveyor);
 
   // The host objects that will be transferred, as recorded by Serialize()
   // (e.g. MessagePorts).
@@ -114,6 +117,7 @@ class Message : public MemoryRetainer {
   std::vector<std::shared_ptr<v8::BackingStore>> shared_array_buffers_;
   std::vector<std::unique_ptr<TransferData>> transferables_;
   std::vector<v8::CompiledWasmModule> wasm_modules_;
+  std::optional<v8::SharedValueConveyor> shared_value_conveyor_;
 
   friend class MessagePort;
 };

--- a/test/parallel/test-experimental-shared-value-conveyor.js
+++ b/test/parallel/test-experimental-shared-value-conveyor.js
@@ -6,7 +6,9 @@ const common = require('../common');
 const assert = require('assert');
 const { Worker, isMainThread, parentPort } = require('worker_threads');
 
-if (isMainThread) {
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
   const m = new globalThis.SharedArray(16);
 
   const worker = new Worker(__filename);

--- a/test/parallel/test-experimental-shared-value-conveyor.js
+++ b/test/parallel/test-experimental-shared-value-conveyor.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Flags: --harmony-struct
+
+const common = require('../common');
+const assert = require('assert');
+const { Worker, isMainThread, parentPort } = require('worker_threads');
+
+if (isMainThread) {
+  let m = new globalThis.SharedArray(16);
+
+  let worker = new Worker(__filename);
+  worker.once('message', common.mustCall((message) => {
+    assert.strictEqual(message, m);
+  }));
+
+  worker.postMessage(m);
+} else {
+  parentPort.once('message', common.mustCall((message) => {
+    // Simple echo.
+    parentPort.postMessage(message);
+  }));
+}

--- a/test/parallel/test-experimental-shared-value-conveyor.js
+++ b/test/parallel/test-experimental-shared-value-conveyor.js
@@ -4,7 +4,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { Worker, isMainThread, parentPort } = require('worker_threads');
+const { Worker, parentPort } = require('worker_threads');
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {

--- a/test/parallel/test-experimental-shared-value-conveyor.js
+++ b/test/parallel/test-experimental-shared-value-conveyor.js
@@ -7,9 +7,9 @@ const assert = require('assert');
 const { Worker, isMainThread, parentPort } = require('worker_threads');
 
 if (isMainThread) {
-  let m = new globalThis.SharedArray(16);
+  const m = new globalThis.SharedArray(16);
 
-  let worker = new Worker(__filename);
+  const worker = new Worker(__filename);
   worker.once('message', common.mustCall((message) => {
     assert.strictEqual(message, m);
   }));


### PR DESCRIPTION
This adds the missing integration support for the V8 experimental shared structs feature (`--harmony-struct`). There is no observable difference to node if `--harmony-struct` is not passed. The flag is false by default.

This experimental feature is for proving out shared memory in JS. The standards side is tracked by https://github.com/tc39/proposal-structs, though the current experiment, for the sake of ease of experimentation, does not include syntax. The features in experiment is documented [here](https://github.com/tc39/proposal-structs/blob/main/CHROMIUM-DEV-TRIAL.md).

I also intentionally did not add any tests because the features are experimental and volatile. Here is an illustrative example though:

```javascript
'use strict';
const { Worker, isMainThread, parentPort } = require('worker_threads');

if (isMainThread) {
  let Box = new SharedStructType(['payload']);
  let b = new Box();
  b.payload = "hello shared memory world";

  let worker = new Worker(__filename);
  worker.on('message', (message) => {
    console.log(b.payload);
    console.log(message === b);
  });

  worker.postMessage(b);
} else {
  parentPort.on('message', (message) => {
    // Simple echo.
    parentPort.postMessage(message);
  });
}
```