### PR TITLE
stream: prevent pipeline hang with generator functions

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -138,9 +138,8 @@ async function pumpToNode(iterable, writable, finish, { end }) {
 
     if (end) {
       writable.end();
+      await wait();
     }
-
-    await wait();
 
     finish();
   } catch (err) {

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1627,6 +1627,7 @@ const tsp = require('timers/promises');
   });
   pipelinep(async function*() {
     yield 'hello';
+    await Promise.resolve();
     yield 'world';
   }, writable, { end: false }).then(common.mustCall(() => {
     assert.strictEqual(res, 'helloworld');

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1616,3 +1616,20 @@ const tsp = require('timers/promises');
   dup.push(null);
   dup.read();
 }
+
+{
+  let res = '';
+  const writable = new Writable({
+    write(chunk, enc, cb) {
+      res += chunk;
+      cb();
+    }
+  });
+  pipelinep(async function*() {
+    yield 'hello';
+    yield 'world';
+  }, writable, { end: false }).then(common.mustCall(() => {
+    assert.strictEqual(res, 'helloworld');
+    assert.strictEqual(writable.closed, false);
+  }));
+}


### PR DESCRIPTION
In the previous implementation 
we had 

https://github.com/nodejs/node/blob/32e478d7c37a0296b2bf616ee2e39e81e4c8d694/lib/internal/streams/pipeline.js#L126

which would have called `resume()` only when the stream ended thus resolving the promise over here

https://github.com/nodejs/node/blob/32e478d7c37a0296b2bf616ee2e39e81e4c8d694/lib/internal/streams/pipeline.js#L143

but for `end: false` eos would never call resume as the stream doesn't end, hence we `wait()` only if the stream is stated to end

Fixes: https://github.com/nodejs/node/issues/47708

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
