### PR TITLE
v8: fix ERR_NOT_BUILDING_SNAPSHOT is not a constructor

### DIFF
--- a/lib/internal/v8/startup_snapshot.js
+++ b/lib/internal/v8/startup_snapshot.js
@@ -4,8 +4,10 @@ const {
   validateFunction,
 } = require('internal/validators');
 const {
-  ERR_NOT_BUILDING_SNAPSHOT,
-  ERR_DUPLICATE_STARTUP_SNAPSHOT_MAIN_FUNCTION,
+  codes: {
+    ERR_NOT_BUILDING_SNAPSHOT,
+    ERR_DUPLICATE_STARTUP_SNAPSHOT_MAIN_FUNCTION,
+  },
 } = require('internal/errors');
 
 const {

--- a/test/fixtures/snapshot/v8-startup-snapshot-api.js
+++ b/test/fixtures/snapshot/v8-startup-snapshot-api.js
@@ -30,3 +30,8 @@ addDeserializeCallback(({ filePath }) => {
 setDeserializeMainFunction(({ filePath }) => {
   console.log(storage[filePath].toString());
 }, { filePath });
+assert.throws(() => setDeserializeMainFunction(() => {
+  assert.fail('unreachable duplicated main function');
+}), {
+  code: 'ERR_DUPLICATE_STARTUP_SNAPSHOT_MAIN_FUNCTION',
+});

--- a/test/parallel/test-v8-startup-snapshot-api.js
+++ b/test/parallel/test-v8-startup-snapshot-api.js
@@ -1,0 +1,26 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const {
+  isBuildingSnapshot,
+  addSerializeCallback,
+  addDeserializeCallback,
+  setDeserializeMainFunction
+} = require('v8').startupSnapshot;
+
+// This test verifies that the v8.startupSnapshot APIs are not available when
+// it is not building snapshot.
+
+assert(!isBuildingSnapshot());
+
+assert.throws(() => addSerializeCallback(() => {}), {
+  code: 'ERR_NOT_BUILDING_SNAPSHOT',
+});
+assert.throws(() => addDeserializeCallback(() => {}), {
+  code: 'ERR_NOT_BUILDING_SNAPSHOT',
+});
+assert.throws(() => setDeserializeMainFunction(() => {}), {
+  code: 'ERR_NOT_BUILDING_SNAPSHOT',
+});


### PR DESCRIPTION
Adds a regression test verifying that the error is correctly constructed.