### PR TITLE
doc: mark signing the binary is macOS and Windows only in single-executable docs

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -47,7 +47,7 @@ tool, [postject][]:
    $ cp $(command -v node) hello
    ```
 
-5. Remove the signature of the binary:
+5. Remove the signature of the binary (macOS and Windows only):
 
    * On macOS:
 
@@ -92,7 +92,7 @@ tool, [postject][]:
          --macho-segment-name NODE_SEA
      ```
 
-7. Sign the binary:
+7. Sign the binary (macOS and Windows only):
 
    * On macOS:
 


### PR DESCRIPTION
It's a little confusing for Linux users at steps about signing the binary right now.