### PR TITLE
http: ServerResponse.assignSocket should not throw an internal error

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1438,6 +1438,12 @@ Status code was outside the regular status code range (100-999).
 
 The client has not sent the entire request within the allowed time.
 
+<a id="ERR_HTTP_SOCKET_ASSIGNED"></a>
+
+### `ERR_HTTP_SOCKET_ASSIGNED`
+
+The given [`ServerResponse`][] was already assigned a socket.
+
 <a id="ERR_HTTP_SOCKET_ENCODING"></a>
 
 ### `ERR_HTTP_SOCKET_ENCODING`
@@ -3590,6 +3596,7 @@ The native call from `process.cpuUsage` could not be processed.
 [`Object.getPrototypeOf`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf
 [`Object.setPrototypeOf`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
 [`REPL`]: repl.md
+[`ServerResponse`]: http.md#class-httpserverresponse
 [`Writable`]: stream.md#class-streamwritable
 [`child_process`]: child_process.md
 [`cipher.getAuthTag()`]: crypto.md#ciphergetauthtag

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -75,6 +75,7 @@ const {
   ERR_HTTP_HEADERS_SENT,
   ERR_HTTP_INVALID_STATUS_CODE,
   ERR_HTTP_SOCKET_ENCODING,
+  ERR_HTTP_SOCKET_ASSIGNED,
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CHAR,
 } = codes;
@@ -276,7 +277,9 @@ function onServerResponseClose() {
 }
 
 ServerResponse.prototype.assignSocket = function assignSocket(socket) {
-  assert(!socket._httpMessage);
+  if (socket._httpMessage) {
+    throw new ERR_HTTP_SOCKET_ASSIGNED();
+  }
   socket._httpMessage = this;
   socket.on('close', onServerResponseClose);
   this.socket = socket;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1167,6 +1167,8 @@ E('ERR_HTTP_INVALID_HEADER_VALUE',
   'Invalid value "%s" for header "%s"', TypeError);
 E('ERR_HTTP_INVALID_STATUS_CODE', 'Invalid status code: %s', RangeError);
 E('ERR_HTTP_REQUEST_TIMEOUT', 'Request timeout', Error);
+E('ERR_HTTP_SOCKET_ASSIGNED',
+  'ServerResponse has an already assigned socket', Error);
 E('ERR_HTTP_SOCKET_ENCODING',
   'Changing the socket encoding is not allowed per RFC7230 Section 3.', Error);
 E('ERR_HTTP_TRAILER_INVALID',

--- a/test/parallel/test-http-server-response-standalone.js
+++ b/test/parallel/test-http-server-response-standalone.js
@@ -31,4 +31,10 @@ const ws = new Writable({
 
 res.assignSocket(ws);
 
+assert.throws(function() {
+  res.assignSocket(ws);
+}, {
+  code: 'ERR_HTTP_SOCKET_ASSIGNED'
+});
+
 res.end('hello world');


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Via https://github.com/fastify/fastify-websocket/issues/249, I found out that calling `assignSocket` multiple times could lead to `ERR_INTERNAL_ASSERTION`, which is confusing for users, as this is a user mistake and not an internals bug.
