### PR TITLE
url: reduce revokeObjectURL cpp calls

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -24,7 +24,6 @@ const {
   StringPrototypeIncludes,
   StringPrototypeIndexOf,
   StringPrototypeSlice,
-  StringPrototypeSplit,
   StringPrototypeStartsWith,
   Symbol,
   SymbolIterator,
@@ -1024,10 +1023,7 @@ ObjectDefineProperties(URL, {
 });
 
 function installObjectURLMethods() {
-  const {
-    storeDataObject,
-    revokeDataObject,
-  } = internalBinding('blob');
+  const bindingBlob = internalBinding('blob');
 
   function createObjectURL(obj) {
     const cryptoRandom = lazyCryptoRandom();
@@ -1040,22 +1036,13 @@ function installObjectURLMethods() {
 
     const id = cryptoRandom.randomUUID();
 
-    storeDataObject(id, obj[blob.kHandle], obj.size, obj.type);
+    bindingBlob.storeDataObject(id, obj[blob.kHandle], obj.size, obj.type);
 
     return `blob:nodedata:${id}`;
   }
 
   function revokeObjectURL(url) {
-    url = `${url}`;
-    try {
-      // TODO(@anonrig): Remove this try/catch by calling `parse` directly.
-      const parsed = new URL(url);
-      const split = StringPrototypeSplit(parsed.pathname, ':');
-      if (split.length === 2)
-        revokeDataObject(split[1]);
-    } catch {
-      // If there's an error, it's ignored.
-    }
+    bindingBlob.revokeObjectURL(`${url}`);
   }
 
   ObjectDefineProperties(URL, {

--- a/src/node_blob.h
+++ b/src/node_blob.h
@@ -37,7 +37,7 @@ class Blob : public BaseObject {
   static void ToSlice(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void StoreDataObject(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetDataObject(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void RevokeDataObject(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void RevokeObjectURL(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
       Environment* env);


### PR DESCRIPTION
Resolving a pending TODO. This pull request mainly reduces the C++ calls in revokeObjectURL function while removing the `try/catch` block.

cc @nodejs/url