### PR TITLE
benchmark: add bar.R

### DIFF
--- a/benchmark/bar.R
+++ b/benchmark/bar.R
@@ -1,0 +1,36 @@
+#!/usr/bin/env Rscript
+library(ggplot2);
+library(plyr);
+
+# get __dirname and load ./_cli.R
+args = commandArgs(trailingOnly = F);
+dirname = dirname(sub("--file=", "", args[grep("--file", args)]));
+source(paste0(dirname, '/_cli.R'), chdir=T);
+
+if (!is.null(args.options$help) ||
+   (!is.null(args.options$plot) && args.options$plot == TRUE)) {
+  stop("usage: cat file.csv | Rscript bar.R
+  --help           show this message
+  --plot filename  save plot to filename");
+}
+
+plot.filename = args.options$plot;
+
+dat = read.csv(
+  file('stdin'),
+  colClasses=c('character', 'character', 'character', 'numeric', 'numeric')
+);
+dat = data.frame(dat);
+
+dat$nameTwoLines = paste0(dat$filename, '\n', dat$configuration);
+dat$name = paste0(dat$filename, ' ', dat$configuration);
+
+# Create a box plot
+if (!is.null(plot.filename)) {
+  p = ggplot(data=dat, aes(x=nameTwoLines, y=rate, fill=binary));
+  p = p + geom_bar(stat="summary", position=position_dodge());
+  p = p + ylab("rate of operations (higher is better)");
+  p = p + xlab("benchmark");
+  p = p + theme(axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5));
+  ggsave(plot.filename, p);
+}

--- a/doc/contributing/writing-and-running-benchmarks.md
+++ b/doc/contributing/writing-and-running-benchmarks.md
@@ -293,7 +293,10 @@ module, you can use the `--filter` option:_
 ```
 
 For analyzing the benchmark results, use [node-benchmark-compare][] or the R
-script `benchmark/compare.R`.
+scripts:
+
+* `benchmark/compare.R`
+* `benchmark/bar.R`
 
 ```console
 $ node-benchmark-compare compare-pr-5134.csv # or cat compare-pr-5134.csv | Rscript benchmark/compare.R


### PR DESCRIPTION
I'm working on a few Node.js benchmarks and generating a barplot is quite helpful for comparisons when the standard deviation is slight. I'm using the `bar.R` in my next report and I thought would be good to have it available in the benchmark folder.

Example:

![image](https://user-images.githubusercontent.com/26234614/234618215-89217d8a-bdd5-4bed-ad84-df608b65b878.png)
