### PR TITLE
deps: V8: cherry-pick c5ab3e4f0c5a

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.4',
+    'v8_embedder_string': '-node.5',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/codegen/tnode.h
+++ b/deps/v8/src/codegen/tnode.h
@@ -269,8 +269,9 @@ using BuiltinPtr = Smi;
 template <class T, class U>
 struct is_subtype {
   static const bool value =
-      std::is_base_of<U, T>::value || (std::is_same<U, MaybeObject>::value &&
-                                       std::is_convertible<T, Object>::value);
+      std::disjunction<std::is_base_of<U, T>,
+                       std::conjunction<std::is_same<U, MaybeObject>,
+                                        std::is_convertible<T, Object>>>::value;
 };
 template <class T1, class T2, class U>
 struct is_subtype<UnionT<T1, T2>, U> {


### PR DESCRIPTION
Original commit message:

    libstdc++: fix incomplete type in v8::internal::is_subtype<T, U>

    Using std::convertible with incomplete types is UB. However, till
    GCC 12 it was accepted and std::convertible returned false.
    This fails now for e.g. v8::internal::WasmArray. Use
    std::disjunction and std::conjunction instead which are short-
    circuiting, because std::is_base_of<T, T> is already true.

    Bug: chromium:957519
    Change-Id: Ia26643dbdf0fb00d5586c71ae6b18e8d0f3cf96e
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4394663
    Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
    Reviewed-by: Clemens Backes <clemensb@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#86904}

Refs: https://github.com/v8/v8/commit/c5ab3e4f0c5a3ce880941184ef8447c27cd19a93
Fixes: https://github.com/nodejs/node/issues/47623
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
