### PR TITLE
src: optimizing watchdog performance

### DIFF
--- a/src/node_watchdog.cc
+++ b/src/node_watchdog.cc
@@ -39,65 +39,100 @@ using v8::Local;
 using v8::Object;
 using v8::Value;
 
-Watchdog::Watchdog(v8::Isolate* isolate, uint64_t ms, bool* timed_out)
-    : isolate_(isolate), timed_out_(timed_out) {
+void WatchdogService::Init() {
+  if (!initialized_) {
+    initialized_ = true;
+    sleep_until_hrtime_ = std::numeric_limits<uint64_t>::max();
 
-  int rc;
-  rc = uv_loop_init(&loop_);
-  if (rc != 0) {
-    UNREACHABLE("Failed to initialize uv loop.");
+    int rc = uv_mutex_init(&mutex_);
+    CHECK_EQ(0, rc);
+
+    rc = uv_cond_init(&cond_);
+    CHECK_EQ(0, rc);
+
+    rc = uv_thread_create(&thread_, &WatchdogService::Run, this);
+    CHECK_EQ(0, rc);
   }
-
-  rc = uv_async_init(&loop_, &async_, [](uv_async_t* signal) {
-    Watchdog* w = ContainerOf(&Watchdog::async_, signal);
-    uv_stop(&w->loop_);
-  });
-
-  CHECK_EQ(0, rc);
-
-  rc = uv_timer_init(&loop_, &timer_);
-  CHECK_EQ(0, rc);
-
-  rc = uv_timer_start(&timer_, &Watchdog::Timer, ms, 0);
-  CHECK_EQ(0, rc);
-
-  rc = uv_thread_create(&thread_, &Watchdog::Run, this);
-  CHECK_EQ(0, rc);
 }
 
+void WatchdogService::Run(void* arg) {
+  WatchdogService* ws = static_cast<WatchdogService*>(arg);
+
+  uv_mutex_lock(&ws->mutex_);
+  while (!ws->should_destroy_) {
+    const uint64_t hrtime = uv_hrtime();
+    while (!ws->watchdog_timers_.empty() &&
+           ws->watchdog_timers_.begin()->first <= hrtime) {
+      auto element = ws->watchdog_timers_.begin();
+      WatchdogTimer* watchdog_timer = element->second;
+      ws->watchdog_timers_.erase(element);
+
+      *watchdog_timer->timed_out = true;
+      watchdog_timer->isolate->TerminateExecution();
+    }
+
+    ws->sleep_until_hrtime_ = std::numeric_limits<uint64_t>::max();
+    if (!ws->watchdog_timers_.empty()) {
+      ws->sleep_until_hrtime_ = ws->watchdog_timers_.begin()->first;
+    }
+
+    uint64_t sleep_nanos = ws->sleep_until_hrtime_ - hrtime;
+    uv_cond_timedwait(&ws->cond_, &ws->mutex_, sleep_nanos);
+  }
+  uv_mutex_unlock(&ws->mutex_);
+}
+
+void WatchdogService::SetTimer(WatchdogTimer* watchdog_timer) {
+  Init();
+  uv_mutex_lock(&mutex_);
+  watchdog_timers_.insert({watchdog_timer->expires_at_hrtime, watchdog_timer});
+  if (sleep_until_hrtime_ > watchdog_timer->expires_at_hrtime) {
+    uv_cond_signal(&cond_);
+  }
+  uv_mutex_unlock(&mutex_);
+}
+
+void WatchdogService::ClearTimer(WatchdogTimer* watchdog_timer) {
+  Init();
+  uv_mutex_lock(&mutex_);
+  auto bucket = watchdog_timers_.equal_range(watchdog_timer->expires_at_hrtime);
+  for (auto it = bucket.first; it != bucket.second; it++) {
+    if (it->second == watchdog_timer) {
+      watchdog_timers_.erase(it);
+      break;
+    }
+  }
+  uv_mutex_unlock(&mutex_);
+}
+
+WatchdogService::~WatchdogService() {
+  if (initialized_) {
+    uv_mutex_lock(&mutex_);
+    should_destroy_ = true;
+    uv_cond_signal(&cond_);
+    uv_mutex_unlock(&mutex_);
+    uv_thread_join(&thread_);
+    uv_cond_destroy(&cond_);
+    uv_mutex_destroy(&mutex_);
+    initialized_ = false;
+  }
+}
+
+thread_local WatchdogService watchdog_service;
+
+Watchdog::Watchdog(v8::Isolate* isolate, uint64_t ms, bool* timed_out) {
+  watchdog_timer_ = new WatchdogTimer();
+  watchdog_timer_->isolate = isolate;
+  watchdog_timer_->timed_out = timed_out;
+  watchdog_timer_->expires_at_hrtime = uv_hrtime() + ms * 1000000;
+
+  watchdog_service.SetTimer(watchdog_timer_);
+}
 
 Watchdog::~Watchdog() {
-  uv_async_send(&async_);
-  uv_thread_join(&thread_);
-
-  uv_close(reinterpret_cast<uv_handle_t*>(&async_), nullptr);
-
-  // UV_RUN_DEFAULT so that libuv has a chance to clean up.
-  uv_run(&loop_, UV_RUN_DEFAULT);
-
-  CheckedUvLoopClose(&loop_);
+  watchdog_service.ClearTimer(watchdog_timer_);
+  delete watchdog_timer_;
 }
-
-
-void Watchdog::Run(void* arg) {
-  Watchdog* wd = static_cast<Watchdog*>(arg);
-
-  // UV_RUN_DEFAULT the loop will be stopped either by the async or the
-  // timer handle.
-  uv_run(&wd->loop_, UV_RUN_DEFAULT);
-
-  // Loop ref count reaches zero when both handles are closed.
-  // Close the timer handle on this side and let ~Watchdog() close async_
-  uv_close(reinterpret_cast<uv_handle_t*>(&wd->timer_), nullptr);
-}
-
-void Watchdog::Timer(uv_timer_t* timer) {
-  Watchdog* w = ContainerOf(&Watchdog::timer_, timer);
-  *w->timed_out_ = true;
-  w->isolate()->TerminateExecution();
-  uv_stop(&w->loop_);
-}
-
 
 SigintWatchdog::SigintWatchdog(
   v8::Isolate* isolate, bool* received_signal)

--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -42,24 +42,40 @@ enum class SignalPropagation {
   kStopPropagation,
 };
 
+struct WatchdogTimer {
+  v8::Isolate* isolate;
+  uint64_t expires_at_hrtime;
+  bool* timed_out;
+};
+
+class WatchdogService {
+ public:
+  ~WatchdogService();
+  void SetTimer(WatchdogTimer* watchdog_timer);
+  void ClearTimer(WatchdogTimer* watchdog_timer);
+
+ private:
+  std::multimap<uint64_t, WatchdogTimer*> watchdog_timers_;
+  uint64_t sleep_until_hrtime_;
+  uv_mutex_t mutex_;
+  uv_cond_t cond_;
+  uv_thread_t thread_;
+  bool initialized_;
+  bool should_destroy_;
+  void Init();
+  static void Run(void* arg);
+};
+
 class Watchdog {
  public:
   explicit Watchdog(v8::Isolate* isolate,
                     uint64_t ms,
                     bool* timed_out = nullptr);
   ~Watchdog();
-  v8::Isolate* isolate() { return isolate_; }
+  v8::Isolate* isolate() { return watchdog_timer_->isolate; }
 
  private:
-  static void Run(void* arg);
-  static void Timer(uv_timer_t* timer);
-
-  v8::Isolate* isolate_;
-  uv_thread_t thread_;
-  uv_loop_t loop_;
-  uv_async_t async_;
-  uv_timer_t timer_;
-  bool* timed_out_;
+  WatchdogTimer* watchdog_timer_;
 };
 
 class SigintWatchdogBase {

--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -51,11 +51,11 @@ struct WatchdogTimer {
 class WatchdogService {
  public:
   ~WatchdogService();
-  void SetTimer(WatchdogTimer* watchdog_timer);
-  void ClearTimer(WatchdogTimer* watchdog_timer);
+  void SetTimer(std::shared_ptr<WatchdogTimer> watchdog_timer);
+  void ClearTimer(std::shared_ptr<WatchdogTimer> watchdog_timer);
 
  private:
-  std::multimap<uint64_t, WatchdogTimer*> watchdog_timers_;
+  std::multimap<uint64_t, std::shared_ptr<WatchdogTimer>> watchdog_timers_;
   uint64_t sleep_until_hrtime_;
   uv_mutex_t mutex_;
   uv_cond_t cond_;
@@ -75,7 +75,7 @@ class Watchdog {
   v8::Isolate* isolate() { return watchdog_timer_->isolate; }
 
  private:
-  WatchdogTimer* watchdog_timer_;
+  std::shared_ptr<WatchdogTimer> watchdog_timer_;
 };
 
 class SigintWatchdogBase {


### PR DESCRIPTION
Performance of vm.Script's runInContext for small and/or quick scripts can be much slower when the optional execution timeout parameter is set - over 30 times slower in edge cases.

The root issue is the constant creation and destruction of threads. Each timeout is enforced with a parallel uv loop that contains a timer and for this a new uv thread is created and later destroyed.

For applications that utilize the vm for sandboxing it is often the case that the optional timeout will be frequently, if not always, set.

This is a small rework of the watchdog that will transform the uv loop into a single parallel thread for each execution thread.

Instead of spawning a thread for each watchdog instance a thread-local WatchdogService is used to execute the timer logic for all timeouts from the given execution thread. The WatchdogService is lazy-initialized the first time a watchdog is requested from an execution thread.

The uv_loop and uv_timers used by the Watchdog have been replaced by a multimap-based priority queue of WatchdogTimer objects. Timekeeping is done using uv_hrtime,

The WatchdogService::Run loop sleeps until the closest timeout is about to expire, or forever if there are no timers set. A conditional wait is used to notify the run loop of a new timer only if its expiration time is shorter than the current time the run loop is about to awaken.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
