### PR TITLE
src: prefer data accessor of string and vector

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1750,7 +1750,7 @@ void SetServers(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (err == 0)
-    err = ares_set_servers_ports(channel->cares_channel(), &servers[0]);
+    err = ares_set_servers_ports(channel->cares_channel(), servers.data());
   else
     err = ARES_EBADSTR;
 

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -147,8 +147,9 @@ static void generate_accept_string(const std::string& client_key,
   static const char ws_magic[] = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
   std::string input(client_key + ws_magic);
   char hash[SHA_DIGEST_LENGTH];
-  USE(SHA1(reinterpret_cast<const unsigned char*>(&input[0]), input.size(),
-       reinterpret_cast<unsigned char*>(hash)));
+  USE(SHA1(reinterpret_cast<const unsigned char*>(input.data()),
+           input.size(),
+           reinterpret_cast<unsigned char*>(hash)));
   node::base64_encode(hash, sizeof(hash), *buffer, sizeof(*buffer));
 }
 

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -136,7 +136,7 @@ void SendProtocolJson(InspectorSocket* socket) {
   strm.next_in = const_cast<uint8_t*>(PROTOCOL_JSON + 3);
   strm.avail_in = sizeof(PROTOCOL_JSON) - 3;
   std::string data(kDecompressedSize, '\0');
-  strm.next_out = reinterpret_cast<Byte*>(&data[0]);
+  strm.next_out = reinterpret_cast<Byte*>(data.data());
   strm.avail_out = data.size();
   CHECK_EQ(Z_STREAM_END, inflate(&strm, Z_FINISH));
   CHECK_EQ(0, strm.avail_out);

--- a/src/node.cc
+++ b/src/node.cc
@@ -733,9 +733,9 @@ static ExitCode ProcessGlobalArgsInternal(std::vector<std::string>* args,
   std::vector<char*> v8_args_as_char_ptr(v8_args.size());
   if (v8_args.size() > 0) {
     for (size_t i = 0; i < v8_args.size(); ++i)
-      v8_args_as_char_ptr[i] = &v8_args[i][0];
+      v8_args_as_char_ptr[i] = v8_args[i].data();
     int argc = v8_args.size();
-    V8::SetFlagsFromCommandLine(&argc, &v8_args_as_char_ptr[0], true);
+    V8::SetFlagsFromCommandLine(&argc, v8_args_as_char_ptr.data(), true);
     v8_args_as_char_ptr.resize(argc);
   }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1075,7 +1075,7 @@ static void InternalModuleReadJSON(const FunctionCallbackInfo<Value>& args) {
   } while (static_cast<size_t>(numchars) == kBlockSize);
 
   size_t start = 0;
-  if (offset >= 3 && 0 == memcmp(&chars[0], "\xEF\xBB\xBF", 3)) {
+  if (offset >= 3 && 0 == memcmp(chars.data(), "\xEF\xBB\xBF", 3)) {
     start = 3;  // Skip UTF-8 BOM.
   }
 

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -541,7 +541,7 @@ size_t StringBytes::hex_encode(
 std::string StringBytes::hex_encode(const char* src, size_t slen) {
   size_t dlen = slen * 2;
   std::string dst(dlen, '\0');
-  hex_encode(src, slen, &dst[0], dlen);
+  hex_encode(src, slen, dst.data(), dlen);
   return dst;
 }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -144,7 +144,7 @@ std::string GetProcessTitle(const char* default_title) {
   std::string buf(16, '\0');
 
   for (;;) {
-    const int rc = uv_get_process_title(&buf[0], buf.size());
+    const int rc = uv_get_process_title(buf.data(), buf.size());
 
     if (rc == 0)
       break;
@@ -160,7 +160,7 @@ std::string GetProcessTitle(const char* default_title) {
 
   // Strip excess trailing nul bytes. Using strlen() here is safe,
   // uv_get_process_title() always zero-terminates the result.
-  buf.resize(strlen(&buf[0]));
+  buf.resize(strlen(buf.data()));
 
   return buf;
 }

--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -764,8 +764,8 @@ TEST_F(InspectorSocketTest, Send1Mb) {
   std::string expected(EXPECTED_FRAME_HEADER, sizeof(EXPECTED_FRAME_HEADER));
   expected.append(message);
 
-  delegate->Write(&message[0], message.size());
-  expect_on_client(&expected[0], expected.size());
+  delegate->Write(message.data(), message.size());
+  expect_on_client(expected.data(), expected.size());
 
   char MASK[4] = {'W', 'h', 'O', 'a'};
 
@@ -778,8 +778,8 @@ TEST_F(InspectorSocketTest, Send1Mb) {
   outgoing.resize(outgoing.size() + message.size());
   mask_message(message, &outgoing[sizeof(FRAME_TO_SERVER_HEADER)], MASK);
 
-  do_write(&outgoing[0], outgoing.size());
-  delegate->ExpectData(&message[0], message.size());
+  do_write(outgoing.data(), outgoing.size());
+  delegate->ExpectData(message.data(), message.size());
 
   // 3. Close
   const char CLIENT_CLOSE_FRAME[] = {'\x88', '\x80', '\x2D',


### PR DESCRIPTION
The pattern of getting the address of the element at index 0 of a container is generally used to materialize a pointer to the backing data of a container, however `std::string` and `std::vector` provide a `data()` accessor to retrieve the data pointer which should be preferred.

This also ensures that in the case that the container is empty, the data pointer access does not perform an errant memory access.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
