### PR TITLE
buffer: use buffer length as max of start offset in `buf.compare`

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1698,7 +1698,9 @@ console.log(buf1.compare(buf2, 5, 6, 5));
 ```
 
 [`ERR_OUT_OF_RANGE`][] is thrown if `targetStart < 0`, `sourceStart < 0`,
-`targetEnd > target.byteLength`, or `sourceEnd > source.byteLength`.
+`targetStart > target.byteLength`, `sourceStart > source.byteLength`,
+`targetEnd < 0`, `sourceEnd < 0`, `targetEnd > target.byteLength`,
+or `sourceEnd > source.byteLength`.
 
 ### `buf.copy(target[, targetStart[, sourceStart[, sourceEnd]]])`
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -924,7 +924,7 @@ Buffer.prototype.compare = function compare(target,
   if (targetStart === undefined)
     targetStart = 0;
   else
-    validateOffset(targetStart, 'targetStart');
+    validateOffset(targetStart, 'targetStart', 0, target.length);
 
   if (targetEnd === undefined)
     targetEnd = target.length;
@@ -934,7 +934,7 @@ Buffer.prototype.compare = function compare(target,
   if (sourceStart === undefined)
     sourceStart = 0;
   else
-    validateOffset(sourceStart, 'sourceStart');
+    validateOffset(sourceStart, 'sourceStart', 0, this.length);
 
   if (sourceEnd === undefined)
     sourceEnd = this.length;

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -67,7 +67,7 @@ assert.throws(
 );
 
 // Zero length target because default for targetEnd <= targetSource
-assert.strictEqual(a.compare(b, 0xff), 1);
+assert.strictEqual(a.compare(b, 1, 0), 1);
 
 assert.throws(
   () => a.compare(b, '0xff'),
@@ -81,7 +81,9 @@ assert.throws(
 const oor = { code: 'ERR_OUT_OF_RANGE' };
 
 assert.throws(() => a.compare(b, 0, 100, 0), oor);
+assert.throws(() => a.compare(b, 100), oor);
 assert.throws(() => a.compare(b, 0, 1, 0, 100), oor);
+assert.throws(() => a.compare(b, 0, 1, 100), oor);
 assert.throws(() => a.compare(b, -1), oor);
 assert.throws(() => a.compare(b, 0, Infinity), oor);
 assert.throws(() => a.compare(b, 0, 1, -1), oor);


### PR DESCRIPTION
`targetStart` and `sourceStart` in `buf.compare` can't be greater than each buffer length like `targetEnd` and `sourceEnd`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
