### PR TITLE
buffer: combine checking range of sourceStart in `buf.copy`

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -222,8 +222,8 @@ function _copy(source, target, targetStart, sourceStart, sourceEnd) {
     sourceStart = 0;
   } else {
     sourceStart = toInteger(sourceStart, 0);
-    if (sourceStart < 0)
-      throw new ERR_OUT_OF_RANGE('sourceStart', '>= 0', sourceStart);
+    if (sourceStart < 0 || sourceStart > source.length)
+      throw new ERR_OUT_OF_RANGE('sourceStart', `>= 0 && <= ${source.length}`, sourceStart);
   }
 
   if (sourceEnd === undefined) {
@@ -236,12 +236,6 @@ function _copy(source, target, targetStart, sourceStart, sourceEnd) {
 
   if (targetStart >= target.length || sourceStart >= sourceEnd)
     return 0;
-
-  if (sourceStart > source.length) {
-    throw new ERR_OUT_OF_RANGE('sourceStart',
-                               `<= ${source.length}`,
-                               sourceStart);
-  }
 
   return _copyActual(source, target, targetStart, sourceStart, sourceEnd);
 }

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -124,7 +124,7 @@ b.copy(Buffer.alloc(0), 1, 1, 1);
 b.copy(Buffer.alloc(1), 1, 1, 1);
 
 // Try to copy 0 bytes from past the end of the source buffer
-b.copy(Buffer.alloc(1), 0, 2048, 2048);
+b.copy(Buffer.alloc(1), 0, 1024, 1024);
 
 // Testing for smart defaults and ability to pass string values as offset
 {

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -155,8 +155,15 @@ assert.throws(
   {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "sourceStart" is out of range. ' +
-             'It must be >= 0. Received -1'
+  }
+);
+
+// Copy throws if sourceStart is greater than length of source
+assert.throws(
+  () => Buffer.allocUnsafe(5).copy(Buffer.allocUnsafe(5), 0, 100),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError',
   }
 );
 


### PR DESCRIPTION
Merging 2 checking range of sourceStart into 1. Plus, add test case to increase coverage if sourceStart is greater than length of source.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
