### PR TITLE
test: refactor to use `getEventListeners` in timers

### DIFF
--- a/test/parallel/test-timers-immediate-promisified.js
+++ b/test/parallel/test-timers-immediate-promisified.js
@@ -6,7 +6,7 @@ const timers = require('timers');
 const { promisify } = require('util');
 const child_process = require('child_process');
 
-// TODO(benjamingr) - refactor to use getEventListeners when #35991 lands
+const { getEventListeners } = require('events');
 const { NodeEventTarget } = require('internal/event_target');
 
 const timerPromises = require('timers/promises');
@@ -60,7 +60,7 @@ process.on('multipleResolves', common.mustNotCall());
   const signal = new NodeEventTarget();
   signal.aborted = false;
   setPromiseImmediate(0, { signal }).finally(common.mustCall(() => {
-    assert.strictEqual(signal.listenerCount('abort'), 0);
+    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
   }));
 }
 

--- a/test/parallel/test-timers-interval-promisified.js
+++ b/test/parallel/test-timers-interval-promisified.js
@@ -6,7 +6,7 @@ const timers = require('timers');
 const { promisify } = require('util');
 const child_process = require('child_process');
 
-// TODO(benjamingr) - refactor to use getEventListeners when #35991 lands
+const { getEventListeners } = require('events');
 const { NodeEventTarget } = require('internal/event_target');
 
 const timerPromises = require('timers/promises');
@@ -122,10 +122,10 @@ process.on('multipleResolves', common.mustNotCall());
   signal.aborted = false;
   const iterator = setInterval(1, undefined, { signal });
   iterator.next().then(common.mustCall(() => {
-    assert.strictEqual(signal.listenerCount('abort'), 1);
+    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
     iterator.return();
   })).finally(common.mustCall(() => {
-    assert.strictEqual(signal.listenerCount('abort'), 0);
+    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
   }));
 }
 
@@ -139,7 +139,7 @@ process.on('multipleResolves', common.mustNotCall());
     // eslint-disable-next-line no-unused-vars
     for await (const _ of iterator) {
       if (i === 0) {
-        assert.strictEqual(signal.listenerCount('abort'), 1);
+        assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
       }
       i++;
       if (i === 2) {
@@ -147,7 +147,7 @@ process.on('multipleResolves', common.mustNotCall());
       }
     }
     assert.strictEqual(i, 2);
-    assert.strictEqual(signal.listenerCount('abort'), 0);
+    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
   }
 
   tryBreak().then(common.mustCall());

--- a/test/parallel/test-timers-timeout-promisified.js
+++ b/test/parallel/test-timers-timeout-promisified.js
@@ -6,7 +6,7 @@ const timers = require('timers');
 const { promisify } = require('util');
 const child_process = require('child_process');
 
-// TODO(benjamingr) - refactor to use getEventListeners when #35991 lands
+const { getEventListeners } = require('events');
 const { NodeEventTarget } = require('internal/event_target');
 
 const timerPromises = require('timers/promises');
@@ -60,7 +60,7 @@ process.on('multipleResolves', common.mustNotCall());
   const signal = new NodeEventTarget();
   signal.aborted = false;
   setPromiseTimeout(0, null, { signal }).finally(common.mustCall(() => {
-    assert.strictEqual(signal.listenerCount('abort'), 0);
+    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
   }));
 }
 


### PR DESCRIPTION
Use `getEventListeners` instead of `listenerCount` because #35991 was landed.

Refs: https://github.com/nodejs/node/pull/35991
Refs: https://github.com/nodejs/node/pull/36006

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
