### PR TITLE
test: add and use tmpdir.hasEnoughSpace()

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -1030,6 +1030,15 @@ Avoid calling it more than once in an asynchronous context as one call
 might refresh the temporary directory of a different context, causing
 the test to fail somewhat mysteriously.
 
+### `hasEnoughSpace(size)`
+
+* `size` [\<number>][<number>] Required size, in bytes.
+
+Returns `true` if the available blocks of the file system underlying `path`
+are likely sufficient to hold a single file of `size` bytes. This is useful for
+skipping tests that require hundreds of megabytes or even gigabytes of temporary
+files, but it is inaccurate and susceptible to race conditions.
+
 ## UDP pair helper
 
 The `common/udppair` module exports a function `makeUDPPair` and a class

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -69,7 +69,13 @@ function onexit(useSpawn) {
   }
 }
 
+function hasEnoughSpace(size) {
+  const { bavail, bsize } = fs.statfsSync(tmpPath);
+  return bavail >= Math.ceil(size / bsize);
+}
+
 module.exports = {
   path: tmpPath,
   refresh,
+  hasEnoughSpace,
 };

--- a/test/pummel/test-fs-readfile-tostring-fail.js
+++ b/test/pummel/test-fs-readfile-tostring-fail.js
@@ -16,6 +16,10 @@ if (common.isAIX && (Number(cp.execSync('ulimit -f')) * 512) < kStringMaxLength)
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
+if (!tmpdir.hasEnoughSpace(kStringMaxLength)) {
+  common.skip(`Not enough space in ${tmpdir.path}`);
+}
+
 const file = path.join(tmpdir.path, 'toobig.txt');
 const stream = fs.createWriteStream(file, {
   flags: 'a',


### PR DESCRIPTION
In general, we assume that the tmpdir will provide sufficient space for most tests. Some tests, however, require hundreds of megabytes or even gigabytes of space, which often causes them to fail, especially on our macOS infrastructure. The most recent reliability report contains more than 20 related CI failures.

This change adds a new function `hasEnoughSpace()` to the `tmpdir` module that uses `statfsSync()` (thanks @SheikhSajid and @cjihrig!) to guess whether allocating a certain amount of space within the temporary directory will succeed.

This change also updates the most frequently failing tests to use the new function such that the relevant parts of the tests are skipped if tmpdir has insufficient space. Hopefully, this will significantly reduce the number of related CI failures.

Refs: https://github.com/nodejs/reliability/issues/549

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
