### PR TITLE
lib: add `navigator.hardwareConcurrency`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -328,6 +328,7 @@ module.exports = {
     DecompressionStream: 'readable',
     fetch: 'readable',
     FormData: 'readable',
+    navigator: 'readable',
     ReadableStream: 'readable',
     ReadableStreamDefaultReader: 'readable',
     ReadableStreamBYOBReader: 'readable',

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -591,8 +591,17 @@ added: REPLACEME
 
 > Stability: 1 - Experimental
 
-An implementation of the [Navigator API][]. Similar to [`window.navigator`][]
-in browsers.
+An implementation of the [Navigator API][].
+
+## `navigator`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+An implementation of [`window.navigator`][].
 
 ### `navigator.hardwareConcurrency`
 

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -583,6 +583,32 @@ The `MessagePort` class. See [`MessagePort`][] for more details.
 
 This variable may appear to be global but is not. See [`module`][].
 
+## `Navigator`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+An implementation of the [Navigator API][]. Similar to [`window.navigator`][]
+in browsers.
+
+### `navigator.hardwareConcurrency`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+The `navigator.hardwareConcurrency` read-only property returns the number of
+logical processors available to the current Node.js instance.
+
+```js
+console.log(`This process is running on ${navigator.hardwareConcurrency}`);
+```
+
 ## `PerformanceEntry`
 
 <!-- YAML
@@ -998,6 +1024,7 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 
 [CommonJS module]: modules.md
 [ECMAScript module]: esm.md
+[Navigator API]: https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
 [Web Crypto API]: webcrypto.md
 [`--no-experimental-fetch`]: cli.md#--no-experimental-fetch
 [`--no-experimental-global-customevent`]: cli.md#--no-experimental-global-customevent
@@ -1057,6 +1084,7 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 [`setInterval`]: timers.md#setintervalcallback-delay-args
 [`setTimeout`]: timers.md#settimeoutcallback-delay-args
 [`structuredClone`]: https://developer.mozilla.org/en-US/docs/Web/API/structuredClone
+[`window.navigator`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator
 [buffer section]: buffer.md
 [built-in objects]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 [module system documentation]: modules.md

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -75,6 +75,10 @@ rules:
       message: Use `const { MessageEvent } = require('internal/worker/io');` instead of the global.
     - name: MessagePort
       message: Use `const { MessagePort } = require('internal/worker/io');` instead of the global.
+    - name: Navigator
+      message: Use `const { Navigator } = require('internal/navigator');` instead of the global.
+    - name: navigator
+      message: Use `const { navigator } = require('internal/navigator');` instead of the global.
     - name: PerformanceEntry
       message: Use `const { PerformanceEntry } = require('perf_hooks');` instead of the global.
     - name: PerformanceMark

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -56,7 +56,8 @@ exposeLazyInterfaces(globalThis, 'perf_hooks', [
 defineReplaceableLazyAttribute(globalThis, 'perf_hooks', ['performance']);
 
 // https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
-exposeLazyInterfaces(globalThis, 'internal/navigator', ['Navigator', 'navigator']);
+exposeLazyInterfaces(globalThis, 'internal/navigator', ['Navigator']);
+defineReplaceableLazyAttribute(globalThis, 'internal/navigator', ['navigator'], false);
 
 // https://w3c.github.io/FileAPI/#creating-revoking
 const { installObjectURLMethods } = require('internal/url');

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -2,7 +2,7 @@
 
 /**
  * This file exposes web interfaces that is defined with the WebIDL
- * Exposed=(Window,Worker) extended attribute or exposed in
+ * Exposed=Window + Exposed=(Window,Worker) extended attribute or exposed in
  * WindowOrWorkerGlobalScope mixin.
  * See more details at https://webidl.spec.whatwg.org/#Exposed and
  * https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope.

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -55,6 +55,9 @@ exposeLazyInterfaces(globalThis, 'perf_hooks', [
 
 defineReplaceableLazyAttribute(globalThis, 'perf_hooks', ['performance']);
 
+// https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
+exposeLazyInterfaces(globalThis, 'internal/navigator', ['Navigator', 'navigator']);
+
 // https://w3c.github.io/FileAPI/#creating-revoking
 const { installObjectURLMethods } = require('internal/url');
 installObjectURLMethods();

--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -18,6 +18,9 @@ const {
 } = internalBinding('os');
 
 class Navigator {
+  // Private properties are used to avoid brand validations.
+  #availableParallelism;
+
   constructor() {
     throw ERR_ILLEGAL_CONSTRUCTOR();
   }
@@ -26,7 +29,8 @@ class Navigator {
    * @return {number}
    */
   get hardwareConcurrency() {
-    return getAvailableParallelism();
+    this.#availableParallelism ??= getAvailableParallelism();
+    return this.#availableParallelism;
   }
 }
 

--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -2,7 +2,7 @@
 
 const {
   ObjectDefineProperties,
-  ReflectConstruct,
+  Symbol,
 } = primordials;
 
 const {
@@ -17,11 +17,16 @@ const {
   getAvailableParallelism,
 } = internalBinding('os');
 
+const kInitialize = Symbol('kInitialize');
+
 class Navigator {
   // Private properties are used to avoid brand validations.
   #availableParallelism;
 
   constructor() {
+    if (arguments[0] === kInitialize) {
+      return;
+    }
     throw ERR_ILLEGAL_CONSTRUCTOR();
   }
 
@@ -39,6 +44,6 @@ ObjectDefineProperties(Navigator.prototype, {
 });
 
 module.exports = {
-  navigator: ReflectConstruct(function() {}, [], Navigator),
+  navigator: new Navigator(kInitialize),
   Navigator,
 };

--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const {
+  ObjectDefineProperties,
+  ObjectSetPrototypeOf,
+} = primordials;
+
+const {
+  ERR_ILLEGAL_CONSTRUCTOR,
+} = require('internal/errors').codes;
+
+const {
+  getAvailableParallelism,
+} = internalBinding('os');
+
+class Navigator {
+  constructor() {
+    throw ERR_ILLEGAL_CONSTRUCTOR();
+  }
+}
+
+class InternalNavigator {}
+InternalNavigator.prototype.constructor = Navigator.prototype.constructor;
+ObjectSetPrototypeOf(InternalNavigator.prototype, Navigator.prototype);
+
+ObjectDefineProperties(Navigator.prototype, {
+  hardwareConcurrency: {
+    __proto__: null,
+    configurable: true,
+    enumerable: true,
+    get() {
+      return getAvailableParallelism();
+    },
+  },
+});
+
+module.exports = {
+  navigator: new InternalNavigator(),
+  Navigator,
+};

--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -2,12 +2,16 @@
 
 const {
   ObjectDefineProperties,
-  ObjectSetPrototypeOf,
+  ReflectConstruct,
 } = primordials;
 
 const {
   ERR_ILLEGAL_CONSTRUCTOR,
 } = require('internal/errors').codes;
+
+const {
+  kEnumerableProperty,
+} = require('internal/util');
 
 const {
   getAvailableParallelism,
@@ -17,24 +21,20 @@ class Navigator {
   constructor() {
     throw ERR_ILLEGAL_CONSTRUCTOR();
   }
+
+  /**
+   * @return {number}
+   */
+  get hardwareConcurrency() {
+    return getAvailableParallelism();
+  }
 }
 
-class InternalNavigator {}
-InternalNavigator.prototype.constructor = Navigator.prototype.constructor;
-ObjectSetPrototypeOf(InternalNavigator.prototype, Navigator.prototype);
-
 ObjectDefineProperties(Navigator.prototype, {
-  hardwareConcurrency: {
-    __proto__: null,
-    configurable: true,
-    enumerable: true,
-    get() {
-      return getAvailableParallelism();
-    },
-  },
+  hardwareConcurrency: kEnumerableProperty,
 });
 
 module.exports = {
-  navigator: new InternalNavigator(),
+  navigator: ReflectConstruct(function() {}, [], Navigator),
   Navigator,
 };

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -309,6 +309,14 @@ if (global.gc) {
   knownGlobals.push(global.gc);
 }
 
+if (global.navigator) {
+  knownGlobals.push(global.navigator);
+}
+
+if (global.Navigator) {
+  knownGlobals.push(global.Navigator);
+}
+
 if (global.Performance) {
   knownGlobals.push(global.Performance);
 }

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -46,6 +46,8 @@ const expectedModules = new Set([
   'NativeModule async_hooks',
   'NativeModule internal/process/task_queues',
   'NativeModule timers',
+  'Internal Binding os',
+  'NativeModule internal/navigator',
   'Internal Binding trace_events',
   'NativeModule internal/constants',
   'NativeModule path',

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -46,8 +46,6 @@ const expectedModules = new Set([
   'NativeModule async_hooks',
   'NativeModule internal/process/task_queues',
   'NativeModule timers',
-  'Internal Binding os',
-  'NativeModule internal/navigator',
   'Internal Binding trace_events',
   'NativeModule internal/constants',
   'NativeModule path',

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -58,6 +58,7 @@ builtinModules.forEach((moduleName) => {
     'structuredClone',
     'fetch',
     'crypto',
+    'navigator',
   ];
   assert.deepStrictEqual(new Set(Object.keys(global)), new Set(expected));
 }

--- a/test/parallel/test-navigator.js
+++ b/test/parallel/test-navigator.js
@@ -1,0 +1,15 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const is = {
+  number: (value, key) => {
+    assert(!Number.isNaN(value), `${key} should not be NaN`);
+    assert.strictEqual(typeof value, 'number');
+  },
+};
+
+is.number(+navigator.hardwareConcurrency, 'hardwareConcurrency');
+is.number(navigator.hardwareConcurrency, 'hardwareConcurrency');
+assert.ok(navigator.hardwareConcurrency > 0);


### PR DESCRIPTION
I'm following up on an abandoned pull request, and adding authors as the co-author to this pull request. 

I've simplified and only added `navigator.hardwareConcurrency` right now, to receive feedback, understand any blockers before investing more time on it.

Referencing issue: https://github.com/nodejs/node/issues/39540
Follow up of the pull request: https://github.com/nodejs/node/pull/39581