### PR TITLE
sea: allow requiring core modules with the "node:" prefix

### DIFF
--- a/lib/internal/util/embedding.js
+++ b/lib/internal/util/embedding.js
@@ -36,12 +36,18 @@ function embedderRunCjs(contents) {
     customDirname);
 }
 
+let embedderRequireInternal;
+
 function embedderRequire(path) {
   if (!Module.isBuiltin(path)) {
     throw new ERR_UNKNOWN_BUILTIN_MODULE(path);
   }
 
-  return require(path);
+  if (!embedderRequireInternal) {
+    embedderRequireInternal = Module.createRequire(process.execPath);
+  }
+
+  return embedderRequireInternal(path);
 }
 
 module.exports = { embedderRequire, embedderRunCjs };

--- a/test/fixtures/sea.js
+++ b/test/fixtures/sea.js
@@ -10,7 +10,7 @@ expectWarning('ExperimentalWarning',
               'might change at any time');
 
 const { deepStrictEqual, strictEqual, throws } = require('assert');
-const { dirname } = require('path');
+const { dirname } = require('node:path');
 
 deepStrictEqual(process.argv, [process.execPath, process.execPath, '-a', '--b=c', 'd']);
 


### PR DESCRIPTION
Previously, the `require()` function exposed to the embedded SEA code was calling the internal `require()` function if the module name belonged to the list of public core modules but the internal `require()` function does not support loading modules with the "node:" prefix, so this change forwards the calls to another `require()` function that supports this.

Fixes: https://github.com/nodejs/single-executable/issues/69

cc @nodejs/single-executable

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
