### PR TITLE
doc: add copy node executable guide on windows

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -50,10 +50,18 @@ tool, [postject][]:
    $ cp $(command -v node) hello
    ```
 
-   * On Windows with PowerShell:
+   * On Windows:
+
+   Using PowerShell:
 
    ```console
    $ cp (Get-Command node).Source hello.exe
+   ```
+   
+   Using CMD:
+   
+   ```console
+   for /F "tokens=*" %n IN ('where.exe node') DO @(copy "%n" hello.exe)
    ```
 
    The `.exe` extension is necessary.

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -72,13 +72,13 @@ tool, [postject][]:
    skipped, ignore any signature-related warning from postject.
 
    ```console
-   $ signtool remove /s hello
+   $ signtool remove /s hello.exe
    ```
 
 6. Inject the blob into the copied binary by running `postject` with
    the following options:
 
-   * `hello` - The name of the copy of the `node` executable created in step 2.
+   * `hello` / `hello.exe` - The name of the copy of the `node` executable created in step 2.
    * `NODE_SEA_BLOB` - The name of the resource / note / section in the binary
      where the contents of the blob will be stored.
    * `sea-prep.blob` - The name of the blob created in step 1.
@@ -90,9 +90,15 @@ tool, [postject][]:
 
    To summarize, here is the required command for each platform:
 
-   * On systems other than macOS:
+   * On Linux:
      ```console
      $ npx postject hello NODE_SEA_BLOB sea-prep.blob \
+         --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+     ```
+
+   * On Windows:
+     ```console
+     $ npx postject hello.exe NODE_SEA_BLOB sea-prep.blob \
          --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
      ```
 
@@ -117,12 +123,22 @@ tool, [postject][]:
    binary would still be runnable.
 
    ```console
-   $ signtool sign /fd SHA256 hello
+   $ signtool sign /fd SHA256 hello.exe
    ```
 
 8. Run the binary:
+
+   * On systems other than Windows
+
    ```console
    $ ./hello world
+   Hello, world!
+   ```
+
+   * On Windows
+
+   ```console
+   $ .\hello.exe world
    Hello, world!
    ```
 

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -53,7 +53,7 @@ tool, [postject][]:
    * On Windows with PowerShell:
 
    ```console
-   $ cp (Get-Command node).source hello.exe
+   $ cp (Get-Command node).Source hello.exe
    ```
 
    The `.exe` extension is necessary.

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -78,7 +78,8 @@ tool, [postject][]:
 6. Inject the blob into the copied binary by running `postject` with
    the following options:
 
-   * `hello` / `hello.exe` - The name of the copy of the `node` executable created in step 4.
+   * `hello` / `hello.exe` - The name of the copy of the `node` executable
+     created in step 4.
    * `NODE_SEA_BLOB` - The name of the resource / note / section in the binary
      where the contents of the blob will be stored.
    * `sea-prep.blob` - The name of the blob created in step 1.

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -56,7 +56,7 @@ tool, [postject][]:
    $ cp (Get-Command node).source hello.exe
    ```
 
-   Note that `.exe` extension is necessary.
+   The `.exe` extension is necessary.
 
 5. Remove the signature of the binary (macOS and Windows only):
 

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -50,7 +50,7 @@ tool, [postject][]:
    $ cp $(command -v node) hello
    ```
    
-   * On Windows with powershell:
+   * On Windows with PowerShell:
 
    ```console
    $ cp (Get-Command node).source hello.exe

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -43,9 +43,20 @@ tool, [postject][]:
    ```
 
 4. Create a copy of the `node` executable and name it according to your needs:
+   
+   * On systems other than Windows:
+
    ```console
    $ cp $(command -v node) hello
    ```
+   
+   * On Windows with powershell:
+
+   ```console
+   $ cp (Get-Command node).source hello.exe
+   ```
+   
+   Note that `.exe` extension is necessary.
 
 5. Remove the signature of the binary (macOS and Windows only):
 

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -57,9 +57,9 @@ tool, [postject][]:
    ```console
    $ cp (Get-Command node).Source hello.exe
    ```
-   
+
    Using CMD:
-   
+
    ```console
    for /F "tokens=*" %n IN ('where.exe node') DO @(copy "%n" hello.exe)
    ```

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -58,10 +58,10 @@ tool, [postject][]:
    $ cp (Get-Command node).Source hello.exe
    ```
 
-   Using CMD:
+   Using Command Prompt:
 
    ```console
-   for /F "tokens=*" %n IN ('where.exe node') DO @(copy "%n" hello.exe)
+   $ for /F "tokens=*" %n IN ('where.exe node') DO @(copy "%n" hello.exe)
    ```
 
    The `.exe` extension is necessary.

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -78,7 +78,7 @@ tool, [postject][]:
 6. Inject the blob into the copied binary by running `postject` with
    the following options:
 
-   * `hello` / `hello.exe` - The name of the copy of the `node` executable created in step 2.
+   * `hello` / `hello.exe` - The name of the copy of the `node` executable created in step 4.
    * `NODE_SEA_BLOB` - The name of the resource / note / section in the binary
      where the contents of the blob will be stored.
    * `sea-prep.blob` - The name of the blob created in step 1.

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -43,19 +43,19 @@ tool, [postject][]:
    ```
 
 4. Create a copy of the `node` executable and name it according to your needs:
-   
+
    * On systems other than Windows:
 
    ```console
    $ cp $(command -v node) hello
    ```
-   
+
    * On Windows with PowerShell:
 
    ```console
    $ cp (Get-Command node).source hello.exe
    ```
-   
+
    Note that `.exe` extension is necessary.
 
 5. Remove the signature of the binary (macOS and Windows only):


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Hello.

In single-executable, copyied node executable on windows should be named with extension .exe, this PR added some guides about it.

Related discussion https://github.com/nodejs/single-executable/discussions/65

---

Sorry for reopen this PR so many times for that I made some mistakes when rebasing and not sure how to recover :(
