### PR TITLE
doc: clarify fs permissions only affect fs module

### DIFF
--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -465,8 +465,8 @@ The available permissions are documented by the [`--experimental-permission`][]
 flag.
 
 When starting Node.js with `--experimental-permission`,
-the ability to access the file system, spawn processes, and
-use `node:worker_threads` will be restricted.
+the ability to access the file system through the `fs` module, spawn processes,
+and use `node:worker_threads` will be restricted.
 
 ```console
 $ node --experimental-permission index.js


### PR DESCRIPTION
As far as I can tell, the permission model implementation currently does not restrict all file system operations but only those through the fs module. WASI, for example, bypasses the permission model entirely.

That appears to be by design, see https://github.com/nodejs/node/pull/44004#issuecomment-1437361808.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
