### PR TITLE
test_runner: refactor coverage report output for readability

### DIFF
--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -123,7 +123,7 @@ class SpecReporter extends Transform {
       case 'test:diagnostic':
         return `${colors[type]}${this.#indent(data.nesting)}${symbols[type]}${data.message}${white}\n`;
       case 'test:coverage':
-        return getCoverageReport(this.#indent(data.nesting), data.summary, symbols['test:coverage'], blue);
+        return getCoverageReport(this.#indent(data.nesting), data.summary, symbols['test:coverage'], blue, true);
     }
   }
   _transform({ type, data }, encoding, callback) {

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -300,7 +300,7 @@ function formatLinesToRanges(values) {
       prev.push([current]);
     }
     return prev;
-  }, []), (range) => range.join('-'));
+  }, []), (range) => ArrayPrototypeJoin(range, '-'));
 }
 
 function formatUncoveredLines(lines, table) {

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -36,10 +36,10 @@ const {
 const { compose } = require('stream');
 
 const coverageColors = {
-  '__proto__': null,
-  'high': green,
-  'medium': yellow,
-  'low': red,
+  __proto__: null,
+  high: green,
+  medium: yellow,
+  low: red,
 };
 
 const kMultipleCallbackInvocations = 'multipleCallbackInvocations';

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -3,12 +3,18 @@ const {
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
   ArrayPrototypePush,
+  ArrayPrototypeReduce,
   ObjectGetOwnPropertyDescriptor,
+  MathFloor,
+  MathMax,
+  MathMin,
   NumberPrototypeToFixed,
   SafePromiseAllReturnArrayLike,
   RegExp,
   RegExpPrototypeExec,
   SafeMap,
+  StringPrototypePadStart,
+  StringPrototypePadEnd,
 } = primordials;
 
 const { basename, relative } = require('path');
@@ -26,6 +32,13 @@ const {
   kIsNodeError,
 } = require('internal/errors');
 const { compose } = require('stream');
+
+const coverageColors = {
+  '__proto__': null,
+  'high': green,
+  'medium': '\u001b[33m',
+  'low': red,
+};
 
 const kMultipleCallbackInvocations = 'multipleCallbackInvocations';
 const kRegExpPattern = /^\/(.*)\/([a-z]*)$/;
@@ -256,45 +269,130 @@ function countCompletedTest(test, harness = test.root.harness) {
 }
 
 
-function coverageThreshold(coverage, color) {
-  coverage = NumberPrototypeToFixed(coverage, 2);
-  if (color) {
-    if (coverage > 90) return `${green}${coverage}${color}`;
-    if (coverage < 50) return `${red}${coverage}${color}`;
-  }
-  return coverage;
+function addTableLine(prefix, width) {
+  return `${prefix}${'-'.repeat(width)}\n`;
 }
 
-function getCoverageReport(pad, summary, symbol, color) {
-  let report = `${color}${pad}${symbol}start of coverage report\n`;
+function truncateStart(string, width) {
+  return string.length > width ? `\u2026${string.substring(string.length - width + 1, string.length)}` : string;
+}
 
-  report += `${pad}${symbol}file | line % | branch % | funcs % | uncovered lines\n`;
+function truncateEnd(string, width) {
+  return string.length > width ? `${string.substring(0, width - 1)}\u2026` : string;
+}
 
-  for (let i = 0; i < summary.files.length; ++i) {
-    const {
-      path,
-      coveredLinePercent,
-      coveredBranchPercent,
-      coveredFunctionPercent,
-      uncoveredLineNumbers,
-    } = summary.files[i];
-    const relativePath = relative(summary.workingDirectory, path);
-    const lines = coverageThreshold(coveredLinePercent, color);
-    const branches = coverageThreshold(coveredBranchPercent, color);
-    const functions = coverageThreshold(coveredFunctionPercent, color);
-    const uncovered = ArrayPrototypeJoin(uncoveredLineNumbers, ', ');
+function formatLinesToRanges(values) {
+  return ArrayPrototypeMap(ArrayPrototypeReduce(values, (prev, current, index, array) => {
+    if ((index > 0) && ((current - array[index - 1]) === 1)) {
+      prev[prev.length - 1][1] = current;
+    } else {
+      prev.push([current]);
+    }
+    return prev;
+  }, []), (range) => range.join('-'));
+}
 
-    report += `${pad}${symbol}${relativePath} | ${lines} | ${branches} | ` +
-              `${functions} | ${uncovered}\n`;
+function formatUncoveredLines(lines, table) {
+  if (table) return ArrayPrototypeJoin(formatLinesToRanges(lines), ' ');
+  return ArrayPrototypeJoin(lines, ', ');
+}
+
+const kColumns = ['line %', 'branch %', 'funcs %'];
+const kColumnsKeys = ['coveredLinePercent', 'coveredBranchPercent', 'coveredFunctionPercent'];
+const kSeparator = ' | ';
+
+function getCoverageReport(pad, summary, symbol, color, table) {
+  const prefix = `${pad}${symbol}`;
+  let report = `${color}${prefix}start of coverage report\n`;
+
+  let filePadLength;
+  let columnPadLengths = [];
+  let uncoveredLinesPadLength;
+  let tableWidth;
+
+  if (table) {
+    // Get expected column sizes
+    filePadLength = table && ArrayPrototypeReduce(summary.files, (acc, file) =>
+      MathMax(acc, relative(summary.workingDirectory, file.path).length), 0);
+    filePadLength = MathMax(filePadLength, 'file'.length);
+    const fileWidth = filePadLength + 2;
+
+    columnPadLengths = ArrayPrototypeMap(kColumns, (column) => (table ? MathMax(column.length, 6) : 0));
+    const columnsWidth = ArrayPrototypeReduce(columnPadLengths, (acc, columnPadLength) => acc + columnPadLength + 3, 0);
+
+    uncoveredLinesPadLength = table && ArrayPrototypeReduce(summary.files, (acc, file) =>
+      MathMax(acc, formatUncoveredLines(file.uncoveredLineNumbers, table).length), 0);
+    uncoveredLinesPadLength = MathMax(uncoveredLinesPadLength, 'uncovered lines'.length);
+    const uncoveredLinesWidth = uncoveredLinesPadLength + 2;
+
+    tableWidth = fileWidth + columnsWidth + uncoveredLinesWidth;
+
+    // Fit with sensible defaults
+    const availableWidth = (process.stdout.columns || 9000) - prefix.length;
+    const columnsExtras = tableWidth - availableWidth;
+    if (table && columnsExtras > 0) {
+      // Ensure file name is sufficiently visible
+      const minFilePad = MathMin(8, filePadLength);
+      filePadLength -= MathFloor(columnsExtras * 0.2);
+      filePadLength = MathMax(filePadLength, minFilePad);
+
+      // Get rest of available space, subtracting margins
+      uncoveredLinesPadLength = MathMax(availableWidth - columnsWidth - (filePadLength + 2) - 2, 1);
+
+      // Update table width
+      tableWidth = availableWidth;
+    } else {
+      uncoveredLinesPadLength = Infinity;
+    }
   }
 
-  const { totals } = summary;
-  report += `${pad}${symbol}all files | ` +
-            `${coverageThreshold(totals.coveredLinePercent, color)} | ` +
-            `${coverageThreshold(totals.coveredBranchPercent, color)} | ` +
-            `${coverageThreshold(totals.coveredFunctionPercent, color)} |\n`;
 
-  report += `${pad}${symbol}end of coverage report\n`;
+  function getCell(string, width, { pad, truncate, coverage }) {
+    if (!table) return string;
+
+    let result = string;
+    if (pad) result = pad(result, width);
+    if (truncate) result = truncate(result, width);
+    if (color && coverage !== undefined) {
+      if (coverage > 90) return `${coverageColors.high}${result}${color}`;
+      if (coverage > 50) return `${coverageColors.medium}${result}${color}`;
+      return `${coverageColors.low}${result}${color}`;
+    }
+    return result;
+  }
+
+  // Head
+  if (table) report += addTableLine(prefix, tableWidth);
+  report += `${prefix}${getCell('file', filePadLength, { pad: StringPrototypePadEnd, truncate: truncateEnd })}${kSeparator}` +
+            `${ArrayPrototypeJoin(ArrayPrototypeMap(kColumns, (column, i) => getCell(column, columnPadLengths[i], { pad: StringPrototypePadStart })), kSeparator)}${kSeparator}` +
+            `${getCell('uncovered lines', uncoveredLinesPadLength, { truncate: truncateEnd })}\n`;
+  if (table) report += addTableLine(prefix, tableWidth);
+
+  // Body
+  for (let i = 0; i < summary.files.length; ++i) {
+    const file = summary.files[i];
+    const relativePath = relative(summary.workingDirectory, file.path);
+
+    let fileCoverage = 0;
+    const coverages = ArrayPrototypeMap(kColumnsKeys, (columnKey) => {
+      const percent = file[columnKey];
+      fileCoverage += percent;
+      return percent;
+    });
+    fileCoverage /= kColumnsKeys.length;
+
+    report += `${prefix}${getCell(relativePath, filePadLength, { pad: StringPrototypePadEnd, truncate: truncateStart, coverage: fileCoverage })}${kSeparator}` +
+              `${ArrayPrototypeJoin(ArrayPrototypeMap(coverages, (coverage, j) => getCell(NumberPrototypeToFixed(coverage, 2), columnPadLengths[j], { coverage, pad: StringPrototypePadStart })), kSeparator)}${kSeparator}` +
+              `${getCell(formatUncoveredLines(file.uncoveredLineNumbers, table), uncoveredLinesPadLength, { truncate: truncateEnd })}\n`;
+  }
+
+  // Foot
+  if (table) report += addTableLine(prefix, tableWidth);
+  report += `${prefix}${getCell('all files', filePadLength, { pad: StringPrototypePadEnd, truncate: truncateEnd })}${kSeparator}` +
+            `${ArrayPrototypeJoin(ArrayPrototypeMap(kColumnsKeys, (columnKey, j) => getCell(NumberPrototypeToFixed(summary.totals[columnKey], 2), columnPadLengths[j], { coverage: summary.totals[columnKey], pad: StringPrototypePadStart })), kSeparator)} |\n`;
+  if (table) report += addTableLine(prefix, tableWidth);
+
+  report += `${prefix}end of coverage report\n`;
   if (color) {
     report += white;
   }

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -15,6 +15,7 @@ const {
   SafeMap,
   StringPrototypePadStart,
   StringPrototypePadEnd,
+  StringPrototypeRepeat,
 } = primordials;
 
 const { basename, relative } = require('path');

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -22,7 +22,7 @@ const { createWriteStream } = require('fs');
 const { pathToFileURL } = require('internal/url');
 const { createDeferredPromise } = require('internal/util');
 const { getOptionValue } = require('internal/options');
-const { green, red, white, shouldColorize } = require('internal/util/colors');
+const { green, yellow, red, white, shouldColorize } = require('internal/util/colors');
 
 const {
   codes: {
@@ -36,7 +36,7 @@ const { compose } = require('stream');
 const coverageColors = {
   '__proto__': null,
   'high': green,
-  'medium': '\u001b[33m',
+  'medium': yellow,
   'low': red,
 };
 

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -269,8 +269,16 @@ function countCompletedTest(test, harness = test.root.harness) {
 }
 
 
+const memo = new SafeMap();
 function addTableLine(prefix, width) {
-  return `${prefix}${'-'.repeat(width)}\n`;
+  const key = `${prefix}-${width}`;
+  let value = memo.get(key);
+  if (value === undefined) {
+    value = `${prefix}${StringPrototypeRepeat('-', width)}\n`;
+    memo.set(key, value);
+  }
+
+  return value;
 }
 
 function truncateStart(string, width) {

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -358,7 +358,7 @@ function getCoverageReport(pad, summary, symbol, color, table) {
   }
 
 
-  function getCell(string, width, { pad, truncate, coverage }) {
+  function getCell(string, width, pad, truncate, coverage) {
     if (!table) return string;
 
     let result = string;
@@ -374,9 +374,9 @@ function getCoverageReport(pad, summary, symbol, color, table) {
 
   // Head
   if (table) report += addTableLine(prefix, tableWidth);
-  report += `${prefix}${getCell('file', filePadLength, { pad: StringPrototypePadEnd, truncate: truncateEnd })}${kSeparator}` +
-            `${ArrayPrototypeJoin(ArrayPrototypeMap(kColumns, (column, i) => getCell(column, columnPadLengths[i], { pad: StringPrototypePadStart })), kSeparator)}${kSeparator}` +
-            `${getCell('uncovered lines', uncoveredLinesPadLength, { truncate: truncateEnd })}\n`;
+  report += `${prefix}${getCell('file', filePadLength, StringPrototypePadEnd, truncateEnd)}${kSeparator}` +
+            `${ArrayPrototypeJoin(ArrayPrototypeMap(kColumns, (column, i) => getCell(column, columnPadLengths[i], StringPrototypePadStart)), kSeparator)}${kSeparator}` +
+            `${getCell('uncovered lines', uncoveredLinesPadLength, false, truncateEnd)}\n`;
   if (table) report += addTableLine(prefix, tableWidth);
 
   // Body
@@ -392,15 +392,15 @@ function getCoverageReport(pad, summary, symbol, color, table) {
     });
     fileCoverage /= kColumnsKeys.length;
 
-    report += `${prefix}${getCell(relativePath, filePadLength, { pad: StringPrototypePadEnd, truncate: truncateStart, coverage: fileCoverage })}${kSeparator}` +
-              `${ArrayPrototypeJoin(ArrayPrototypeMap(coverages, (coverage, j) => getCell(NumberPrototypeToFixed(coverage, 2), columnPadLengths[j], { coverage, pad: StringPrototypePadStart })), kSeparator)}${kSeparator}` +
-              `${getCell(formatUncoveredLines(file.uncoveredLineNumbers, table), uncoveredLinesPadLength, { truncate: truncateEnd })}\n`;
+    report += `${prefix}${getCell(relativePath, filePadLength, StringPrototypePadEnd, truncateStart, fileCoverage)}${kSeparator}` +
+              `${ArrayPrototypeJoin(ArrayPrototypeMap(coverages, (coverage, j) => getCell(NumberPrototypeToFixed(coverage, 2), columnPadLengths[j], StringPrototypePadStart, false, coverage)), kSeparator)}${kSeparator}` +
+              `${getCell(formatUncoveredLines(file.uncoveredLineNumbers, table), uncoveredLinesPadLength, false, truncateEnd)}\n`;
   }
 
   // Foot
   if (table) report += addTableLine(prefix, tableWidth);
-  report += `${prefix}${getCell('all files', filePadLength, { pad: StringPrototypePadEnd, truncate: truncateEnd })}${kSeparator}` +
-            `${ArrayPrototypeJoin(ArrayPrototypeMap(kColumnsKeys, (columnKey, j) => getCell(NumberPrototypeToFixed(summary.totals[columnKey], 2), columnPadLengths[j], { coverage: summary.totals[columnKey], pad: StringPrototypePadStart })), kSeparator)} |\n`;
+  report += `${prefix}${getCell('all files', filePadLength, StringPrototypePadEnd, truncateEnd)}${kSeparator}` +
+            `${ArrayPrototypeJoin(ArrayPrototypeMap(kColumnsKeys, (columnKey, j) => getCell(NumberPrototypeToFixed(summary.totals[columnKey], 2), columnPadLengths[j], StringPrototypePadStart, false, summary.totals[columnKey])), kSeparator)} |\n`;
   if (table) report += addTableLine(prefix, tableWidth);
 
   report += `${prefix}end of coverage report\n`;

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -339,7 +339,7 @@ function getCoverageReport(pad, summary, symbol, color, table) {
     tableWidth = fileWidth + columnsWidth + uncoveredLinesWidth;
 
     // Fit with sensible defaults
-    const availableWidth = (process.stdout.columns || 9000) - prefix.length;
+    const availableWidth = (process.stdout.columns || Infinity) - prefix.length;
     const columnsExtras = tableWidth - availableWidth;
     if (table && columnsExtras > 0) {
       // Ensure file name is sufficiently visible

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -282,12 +282,13 @@ function addTableLine(prefix, width) {
   return value;
 }
 
+const kHorizontalEllipsis = '\u2026';
 function truncateStart(string, width) {
-  return string.length > width ? `\u2026${string.substring(string.length - width + 1, string.length)}` : string;
+  return string.length > width ? `${kHorizontalEllipsis}${string.substring(string.length - width + 1, string.length)}` : string;
 }
 
 function truncateEnd(string, width) {
-  return string.length > width ? `${string.substring(0, width - 1)}\u2026` : string;
+  return string.length > width ? `${string.substring(0, width - 1)}${kHorizontalEllipsis}` : string;
 }
 
 function formatLinesToRanges(values) {

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -16,6 +16,7 @@ const {
   StringPrototypePadStart,
   StringPrototypePadEnd,
   StringPrototypeRepeat,
+  StringPrototypeSlice,
 } = primordials;
 
 const { basename, relative } = require('path');
@@ -284,11 +285,11 @@ function addTableLine(prefix, width) {
 
 const kHorizontalEllipsis = '\u2026';
 function truncateStart(string, width) {
-  return string.length > width ? `${kHorizontalEllipsis}${string.substring(string.length - width + 1, string.length)}` : string;
+  return string.length > width ? `${kHorizontalEllipsis}${StringPrototypeSlice(string, string.length - width + 1)}` : string;
 }
 
 function truncateEnd(string, width) {
-  return string.length > width ? `${string.substring(0, width - 1)}${kHorizontalEllipsis}` : string;
+  return string.length > width ? `${StringPrototypeSlice(string, 0, width - 1)}${kHorizontalEllipsis}` : string;
 }
 
 function formatLinesToRanges(values) {

--- a/lib/internal/util/colors.js
+++ b/lib/internal/util/colors.js
@@ -28,6 +28,7 @@ module.exports = {
       module.exports.blue = hasColors ? '\u001b[34m' : '';
       module.exports.green = hasColors ? '\u001b[32m' : '';
       module.exports.white = hasColors ? '\u001b[39m' : '';
+      module.exports.yellow = hasColors ? '\u001b[33m' : '';
       module.exports.red = hasColors ? '\u001b[31m' : '';
       module.exports.gray = hasColors ? '\u001b[90m' : '';
       module.exports.clear = hasColors ? '\u001bc' : '';

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -41,16 +41,21 @@ function getTapCoverageFixtureReport() {
 }
 
 function getSpecCoverageFixtureReport() {
+  /* eslint-disable max-len */
   const report = [
     '\u2139 start of coverage report',
-    '\u2139 file | line % | branch % | funcs % | uncovered lines',
-    '\u2139 test/fixtures/test-runner/coverage.js | 78.65 | 38.46 | 60.00 | 12, ' +
-    '13, 16, 17, 18, 19, 20, 21, 22, 27, 39, 43, 44, 61, 62, 66, 67, 71, 72',
-    '\u2139 test/fixtures/test-runner/invalid-tap.js | 100.00 | 100.00 | 100.00 | ',
-    '\u2139 test/fixtures/v8-coverage/throw.js | 71.43 | 50.00 | 100.00 | 5, 6',
-    '\u2139 all files | 78.35 | 43.75 | 60.00 |',
+    '\u2139 -------------------------------------------------------------------------------------------------------------------',
+    '\u2139 file                                     | line % | branch % | funcs % | uncovered lines',
+    '\u2139 -------------------------------------------------------------------------------------------------------------------',
+    '\u2139 test/fixtures/test-runner/coverage.js    |  78.65 |    38.46 |   60.00 | 12-13 16-22 27 39 43-44 61-62 66-67 71-72',
+    '\u2139 test/fixtures/test-runner/invalid-tap.js | 100.00 |   100.00 |  100.00 | ',
+    '\u2139 test/fixtures/v8-coverage/throw.js       |  71.43 |    50.00 |  100.00 | 5-6',
+    '\u2139 -------------------------------------------------------------------------------------------------------------------',
+    '\u2139 all files                                |  78.35 |    43.75 |   60.00 |',
+    '\u2139 -------------------------------------------------------------------------------------------------------------------',
     '\u2139 end of coverage report',
   ].join('\n');
+  /* eslint-enable max-len */
 
   if (common.isWindows) {
     return report.replaceAll('/', '\\');


### PR DESCRIPTION
Add a "table" parameter to getCoverageReport.
Keep the tap coverage output intact.
Change the output by adding padding and truncating the tables' cells. Add separation lines for table head/body/foot.
Group uncovered lines as ranges.
Add yellow color for coverage between 50 and 90.

Refs: https://github.com/nodejs/node/pull/46674

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
