### PR TITLE
test_runner: emit start event when subtest starts

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -189,7 +189,7 @@ class Test extends AsyncResource {
       this.nesting = 0;
       this.only = testOnlyFlag;
       this.reporter = new TestsStream();
-      this.reporter.begin(this.nesting, kFilename, this.testNumber, this.name, "starting", "starting");
+      this.reporter.begin(this.nesting, kFilename, this.testNumber, this.name, 'starting', 'starting');
       this.runOnlySubtests = this.only;
       this.testNumber = 0;
       this.timeout = kDefaultTimeout;
@@ -783,6 +783,8 @@ class Suite extends Test {
   }
 
   async run() {
+    this.reporter.begin(this.nesting, kFilename, this.testNumber, this.name, 'starting', 'starting');
+
     const hookArgs = this.getRunArgs();
 
     try {

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -515,7 +515,6 @@ class Test extends AsyncResource {
   }
 
   async run() {
-
     if (this.parent !== null) {
       this.parent.activeSubtests++;
     }

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -189,7 +189,6 @@ class Test extends AsyncResource {
       this.nesting = 0;
       this.only = testOnlyFlag;
       this.reporter = new TestsStream();
-      // this.reporter.lifecycleRun(this.nesting, kFilename, this.testNumber, this.name, 'starting', 'starting');
       this.runOnlySubtests = this.only;
       this.testNumber = 0;
       this.timeout = kDefaultTimeout;
@@ -783,7 +782,7 @@ class Suite extends Test {
   }
 
   async run() {
-    // this.reporter.lifecycleRun(this.nesting, kFilename, this.testNumber, this.name, 'starting', 'starting');
+    
 
     const hookArgs = this.getRunArgs();
 

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -516,8 +516,6 @@ class Test extends AsyncResource {
 
   async run() {
 
-    this.reporter.start(this.nesting, kFilename, this.name + " starting... ");
-
     if (this.parent !== null) {
       this.parent.activeSubtests++;
     }

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -189,6 +189,7 @@ class Test extends AsyncResource {
       this.nesting = 0;
       this.only = testOnlyFlag;
       this.reporter = new TestsStream();
+      this.reporter.begin(this.nesting, kFilename, this.testNumber, this.name, "starting", "starting");
       this.runOnlySubtests = this.only;
       this.testNumber = 0;
       this.timeout = kDefaultTimeout;

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -515,6 +515,9 @@ class Test extends AsyncResource {
   }
 
   async run() {
+
+    this.reporter.start(this.nesting, kFilename, this.name + " starting... ");
+
     if (this.parent !== null) {
       this.parent.activeSubtests++;
     }

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -189,7 +189,7 @@ class Test extends AsyncResource {
       this.nesting = 0;
       this.only = testOnlyFlag;
       this.reporter = new TestsStream();
-      this.reporter.begin(this.nesting, kFilename, this.testNumber, this.name, 'starting', 'starting');
+      // this.reporter.lifecycleRun(this.nesting, kFilename, this.testNumber, this.name, 'starting', 'starting');
       this.runOnlySubtests = this.only;
       this.testNumber = 0;
       this.timeout = kDefaultTimeout;
@@ -479,7 +479,7 @@ class Test extends AsyncResource {
       this.parent.addPendingSubtest(deferred);
       return deferred.promise;
     }
-
+    this.reporter.lifecycleRun(this.nesting, kFilename, this.testNumber, this.name, 'starting', 'starting');
     return this.run();
   }
 
@@ -783,7 +783,7 @@ class Suite extends Test {
   }
 
   async run() {
-    this.reporter.begin(this.nesting, kFilename, this.testNumber, this.name, 'starting', 'starting');
+    // this.reporter.lifecycleRun(this.nesting, kFilename, this.testNumber, this.name, 'starting', 'starting');
 
     const hookArgs = this.getRunArgs();
 

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -29,8 +29,8 @@ class TestsStream extends Readable {
     }
   }
 
-  begin(nesting, file, testNumber, name, details, directive) {
-    this.#emit('test:lifecycle:run', { __proto__: null, name, nesting, file, testNumber, details, ...directive });
+  begin(nesting, file, testNumber, name, details) {
+    this[kEmitMessage]('test:lifecycle:run', { __proto__: null, name, nesting, file, testNumber, details });
   }
 
   fail(nesting, file, testNumber, name, details, directive) {

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -30,7 +30,7 @@ class TestsStream extends Readable {
   }
 
   begin(nesting, file, testNumber, name, details, directive) {
-    this.#emit('test:begin', { __proto__: null, name, nesting, file, testNumber, details, ...directive });
+    this.#emit('test:lifecycle:run', { __proto__: null, name, nesting, file, testNumber, details, ...directive });
   }
 
   fail(nesting, file, testNumber, name, details, directive) {

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -29,6 +29,10 @@ class TestsStream extends Readable {
     }
   }
 
+  begin(nesting, file, testNumber, name, details, directive) {
+    this.#emit('test:begin', { __proto__: null, name, nesting, file, testNumber, details, ...directive });
+  }
+
   fail(nesting, file, testNumber, name, details, directive) {
     this[kEmitMessage]('test:fail', { __proto__: null, name, nesting, file, testNumber, details, ...directive });
   }

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -29,7 +29,7 @@ class TestsStream extends Readable {
     }
   }
 
-  begin(nesting, file, testNumber, name, details) {
+  lifecycleRun(nesting, file, testNumber, name, details) {
     this[kEmitMessage]('test:lifecycle:run', { __proto__: null, name, nesting, file, testNumber, details });
   }
 

--- a/test/parallel/test-runner-reporters.js
+++ b/test/parallel/test-runner-reporters.js
@@ -97,7 +97,7 @@ describe('node:test reporters', { concurrency: true }, () => {
                                testFile]);
       assert.strictEqual(child.stderr.toString(), '');
       const stdout = child.stdout.toString();
-      assert.match(stdout, /{"test:lifecycle:run":\d+,"test:start":4,"test:pass":2,"test:fail":2,"test:plan":2,"test:diagnostic":\d+}$/);
+      assert.match(stdout, /{"test:lifecycle:run":4,"test:start":4,"test:pass":2,"test:fail":2,"test:plan":2,"test:diagnostic":\d+}$/);
       assert.strictEqual(stdout.slice(0, filename.length + 2), `${filename} {`);
     });
   });
@@ -109,7 +109,7 @@ describe('node:test reporters', { concurrency: true }, () => {
     assert.strictEqual(child.stderr.toString(), '');
     assert.match(
       child.stdout.toString(),
-      /^package: reporter-cjs{"test:lifecycle:run":\d+,"test:start":4,"test:pass":2,"test:fail":2,"test:plan":2,"test:diagnostic":\d+}$/,
+      /^package: reporter-cjs{"test:lifecycle:run":4,"test:start":4,"test:pass":2,"test:fail":2,"test:plan":2,"test:diagnostic":\d+}$/,
     );
   });
 

--- a/test/parallel/test-runner-reporters.js
+++ b/test/parallel/test-runner-reporters.js
@@ -97,7 +97,7 @@ describe('node:test reporters', { concurrency: true }, () => {
                                testFile]);
       assert.strictEqual(child.stderr.toString(), '');
       const stdout = child.stdout.toString();
-      assert.match(stdout, /{"test:start":4,"test:pass":2,"test:fail":2,"test:plan":2,"test:diagnostic":\d+}$/);
+      assert.match(stdout, /{"test:lifecycle:run":\d+,"test:start":4,"test:pass":2,"test:fail":2,"test:plan":2,"test:diagnostic":\d+}$/);
       assert.strictEqual(stdout.slice(0, filename.length + 2), `${filename} {`);
     });
   });
@@ -109,7 +109,7 @@ describe('node:test reporters', { concurrency: true }, () => {
     assert.strictEqual(child.stderr.toString(), '');
     assert.match(
       child.stdout.toString(),
-      /^package: reporter-cjs{"test:start":4,"test:pass":2,"test:fail":2,"test:plan":2,"test:diagnostic":\d+}$/,
+      /^package: reporter-cjs{"test:lifecycle:run":\d+,"test:start":4,"test:pass":2,"test:fail":2,"test:plan":2,"test:diagnostic":\d+}$/,
     );
   });
 
@@ -120,7 +120,7 @@ describe('node:test reporters', { concurrency: true }, () => {
     assert.strictEqual(child.stderr.toString(), '');
     assert.match(
       child.stdout.toString(),
-      /^package: reporter-esm{"test:start":4,"test:pass":2,"test:fail":2,"test:plan":2,"test:diagnostic":\d+}$/,
+      /^package: reporter-esm{"test:lifecycle:run":\d+,"test:start":4,"test:pass":2,"test:fail":2,"test:plan":2,"test:diagnostic":\d+}$/,
     );
   });
 


### PR DESCRIPTION
emit a start event to show message just after a test/subtest start

Fixes: https://github.com/nodejs/node/issues/46727

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
