### PR TITLE
src: avoid strcmp() with Utf8Value

### DIFF
--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -840,8 +840,7 @@ void SecureContext::SetECDHCurve(const FunctionCallbackInfo<Value>& args) {
 
   Utf8Value curve(env->isolate(), args[0]);
 
-  if (strcmp(*curve, "auto") != 0 &&
-      !SSL_CTX_set1_curves_list(sc->ctx_.get(), *curve)) {
+  if (curve != "auto" && !SSL_CTX_set1_curves_list(sc->ctx_.get(), *curve)) {
     return THROW_ERR_CRYPTO_OPERATION_FAILED(env, "Failed to set ECDH curve");
   }
 }

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -1350,8 +1350,7 @@ unsigned int TLSWrap::PskServerCallback(
 
   // Make sure there are no utf8 replacement symbols.
   Utf8Value identity_utf8(env->isolate(), identity_str);
-  if (strcmp(*identity_utf8, identity) != 0)
-    return 0;
+  if (identity_utf8 != identity) return 0;
 
   Local<Value> argv[] = {
     identity_str,

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -401,7 +401,7 @@ static void PrintJavaScriptErrorProperties(JSONWriter* writer,
         continue;
       }
       node::Utf8Value k(isolate, key);
-      if (!strcmp(*k, "stack") || !strcmp(*k, "message")) continue;
+      if (k == "stack" || k == "message") continue;
       node::Utf8Value v(isolate, value_string);
       writer->json_keyvalue(k.ToStringView(), v.ToStringView());
     }

--- a/src/util.h
+++ b/src/util.h
@@ -531,9 +531,8 @@ class Utf8Value : public MaybeStackBuffer<char> {
     return std::string_view(out(), length());
   }
 
-  inline bool operator==(const char* a) const {
-    return strcmp(out(), a) == 0;
-  }
+  inline bool operator==(const char* a) const { return strcmp(out(), a) == 0; }
+  inline bool operator!=(const char* a) const { return !(*this == a); }
 };
 
 class TwoByteValue : public MaybeStackBuffer<uint16_t> {


### PR DESCRIPTION
Having `Utf8Value::operator==()` without `operator!=()` is awkward in C++17, so add the negated equality operator. Then, use either instead of `strcmp()` where appropriate.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
