### PR TITLE
test: reduce WPT concurrency

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -468,9 +468,10 @@ const limit = (concurrency) => {
 };
 
 class WPTRunner {
-  constructor(path) {
+  constructor(path, { concurrency = os.availableParallelism() - 1 || 1 } = {}) {
     this.path = path;
     this.resource = new ResourceLoader(path);
+    this.concurrency = concurrency;
 
     this.flags = [];
     this.globalThisInitScripts = [];
@@ -595,7 +596,7 @@ class WPTRunner {
   async runJsTests() {
     const queue = this.buildQueue();
 
-    const run = limit(os.availableParallelism());
+    const run = limit(this.concurrency);
 
     for (const spec of queue) {
       const content = spec.getContent();

--- a/test/wpt/test-timers.js
+++ b/test/wpt/test-timers.js
@@ -2,6 +2,6 @@
 
 const { WPTRunner } = require('../common/wpt');
 
-const runner = new WPTRunner('html/webappapis/timers');
+const runner = new WPTRunner('html/webappapis/timers', { concurrency: 1 });
 
 runner.runJsTests();

--- a/test/wpt/testcfg.py
+++ b/test/wpt/testcfg.py
@@ -3,4 +3,4 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import testpy
 
 def GetConfiguration(context, root):
-  return testpy.ParallelTestConfiguration(context, root, 'wpt')
+  return testpy.SimpleTestConfiguration(context, root, 'wpt')


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/47657#issuecomment-1532628751

Because of the flaky wpt/test-timers and sometimes crashing wpt/test-webcrypto this PR

- moves the WPT test suite back to `SimpleTestConfiguration`
- reduces the default WPT files concurrency by 1 to save one CPU for the WPTRunner itself
- introduces an option to force a given concurrency for a WPT Runner so that timing sensitive suites can be ran sequentially

cc @targos @tniessen 