### PR TITLE
http2: improve nghttp2 error callback

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -843,11 +843,11 @@ class Http2Session : public AsyncWrap,
       const nghttp2_frame* frame,
       size_t maxPayloadLen,
       void* user_data);
-  static int OnNghttpError(
-      nghttp2_session* session,
-      const char* message,
-      size_t len,
-      void* user_data);
+  static int OnNghttpError(nghttp2_session* session,
+                           int lib_error_code,
+                           const char* message,
+                           size_t len,
+                           void* user_data);
   static int OnSendData(
       nghttp2_session* session,
       nghttp2_frame* frame,


### PR DESCRIPTION
The http2 implementation uses the deprecated function `nghttp2_session_callbacks_set_error_callback`, which does not supply an error code but only an error message. This so far forced node's error callback to rely on the error message in order to distinguish between different errors, which is fragile and inefficient.

Use the newer `nghttp2_session_callbacks_set_error_callback2` function instead, which is not deprecated and which provides the exact error code to node's error callback.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
