### PR TITLE
test: fix output tests when path includes node version

### DIFF
--- a/test/parallel/test-node-output-console.mjs
+++ b/test/parallel/test-node-output-console.mjs
@@ -3,17 +3,14 @@ import * as fixtures from '../common/fixtures.mjs';
 import * as snapshot from '../common/assertSnapshot.js';
 import { describe, it } from 'node:test';
 
-function replaceNodeVersion(str) {
-  return str.replaceAll(process.version, '*');
-}
 
 function replaceStackTrace(str) {
   return snapshot.replaceStackTrace(str, '$1at *$7\n');
 }
 
 describe('console output', { concurrency: true }, () => {
-  function stackTrace(str) {
-    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '').replaceAll('/', '*').replaceAll(/\d+/g, '*');
+  function normalize(str) {
+    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '').replaceAll('/', '*').replaceAll(process.version, '*').replaceAll(/\d+/g, '*');
   }
   const tests = [
     { name: 'console/2100bytes.js' },
@@ -23,7 +20,7 @@ describe('console output', { concurrency: true }, () => {
     {
       name: 'console/stack_overflow.js',
       transform: snapshot
-        .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, replaceNodeVersion, stackTrace)
+        .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, normalize)
     },
   ];
   const defaultTransform = snapshot

--- a/test/parallel/test-node-output-errors.mjs
+++ b/test/parallel/test-node-output-errors.mjs
@@ -20,10 +20,10 @@ describe('errors output', { concurrency: true }, () => {
     return normalize(str).replaceAll(/\d+:\d+/g, '*:*').replaceAll(/:\d+/g, ':*').replaceAll('*fixtures*message*', '*');
   }
   const common = snapshot
-    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, replaceNodeVersion);
-  const defaultTransform = snapshot.transform(common, normalize);
-  const errTransform = snapshot.transform(common, normalizeNoNumbers);
-  const promiseTransform = snapshot.transform(common, replaceStackTrace, normalizeNoNumbers);
+    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths);
+  const defaultTransform = snapshot.transform(common, normalize, replaceNodeVersion);
+  const errTransform = snapshot.transform(common, normalizeNoNumbers, replaceNodeVersion);
+  const promiseTransform = snapshot.transform(common, replaceStackTrace, normalizeNoNumbers, replaceNodeVersion);
 
   const tests = [
     { name: 'errors/async_error_eval_cjs.js' },

--- a/test/parallel/test-node-output-sourcemaps.mjs
+++ b/test/parallel/test-node-output-sourcemaps.mjs
@@ -25,7 +25,7 @@ describe('sourcemaps output', { concurrency: true }, () => {
     return result;
   }
   const defaultTransform = snapshot
-    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, replaceNodeVersion, normalize);
+    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, normalize, replaceNodeVersion);
 
   const tests = [
     { name: 'source-map/output/source_map_disabled_by_api.js' },

--- a/test/parallel/test-node-output-vm.mjs
+++ b/test/parallel/test-node-output-vm.mjs
@@ -13,7 +13,7 @@ describe('vm output', { concurrency: true }, () => {
   }
 
   const defaultTransform = snapshot
-    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, replaceNodeVersion, normalize);
+    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, normalize, replaceNodeVersion);
 
   const tests = [
     { name: 'vm/vm_caught_custom_runtime_error.js' },


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/47498#issuecomment-1532508231

sometimes `process.cwd()` has the node version included in it - so we must first normalize `process.cwd()` and only then normalize `process.version`.