### PR TITLE
src: rename SKIP_CHECK_SIZE to SKIP_CHECK_STRLEN

### DIFF
--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -28,18 +28,18 @@
 #include <WinError.h>
 
 #define SKIP_CHECK_VAR "NODE_SKIP_PLATFORM_CHECK"
-#define SKIP_CHECK_SIZE 1
 #define SKIP_CHECK_VALUE "1"
+#define SKIP_CHECK_STRLEN (sizeof(SKIP_CHECK_VALUE) - 1)
 
 int wmain(int argc, wchar_t* wargv[]) {
   // Windows Server 2012 (not R2) is supported until 10/10/2023, so we allow it
   // to run in the experimental support tier.
-  char buf[SKIP_CHECK_SIZE + 1];
+  char buf[SKIP_CHECK_STRLEN + 1];
   if (!IsWindows8Point1OrGreater() &&
       !(IsWindowsServer() && IsWindows8OrGreater()) &&
       (GetEnvironmentVariableA(SKIP_CHECK_VAR, buf, sizeof(buf)) !=
-       SKIP_CHECK_SIZE ||
-       strncmp(buf, SKIP_CHECK_VALUE, SKIP_CHECK_SIZE + 1) != 0)) {
+           SKIP_CHECK_STRLEN ||
+       strncmp(buf, SKIP_CHECK_VALUE, SKIP_CHECK_STRLEN) != 0)) {
     fprintf(stderr, "Node.js is only supported on Windows 8.1, Windows "
                     "Server 2012 R2, or higher.\n"
                     "Setting the " SKIP_CHECK_VAR " environment variable "


### PR DESCRIPTION
`SKIP_CHECK_VALUE` is a string literal, so its size is the length of the string in `char`s _plus one_. The buffer `buf` is also always null-terminated, so its size should match the size of `SKIP_CHECK_VALUE`, which is _not_ `SKIP_CHECK_SIZE`.

Rename `SKIP_CHECK_SIZE` to be consistent with C/C++ terminology.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
