### PR TITLE
test_runner: omit inaccessible files from coverage

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -99,7 +99,16 @@ class TestCoverage {
       // original line endings because those characters are necessary for
       // determining offsets in the file.
       const filePath = fileURLToPath(url);
-      const source = readFileSync(filePath, 'utf8');
+      let source;
+
+      try {
+        source = readFileSync(filePath, 'utf8');
+      } catch {
+        // The file can no longer be read. It may have been deleted among
+        // other possibilities. Leave it out of the coverage report.
+        continue;
+      }
+
       const linesWithBreaks =
         RegExpPrototypeSymbolSplit(kLineSplitRegex, source);
       let ignoreCount = 0;

--- a/test/fixtures/v8-coverage/combined_coverage/third.test.js
+++ b/test/fixtures/v8-coverage/combined_coverage/third.test.js
@@ -1,4 +1,7 @@
 'use strict';
+const assert = require('node:assert');
+const { unlinkSync, writeFileSync } = require('node:fs')
+const { join } = require('node:path');
 const { test } = require('node:test');
 const common = require('./common');
 
@@ -6,3 +9,17 @@ test('third 1', () => {
   common.fnC(1, 4);
   common.fnD(99);
 });
+
+assert(process.env.NODE_TEST_TMPDIR);
+const tmpFilePath = join(process.env.NODE_TEST_TMPDIR, 'temp-module.js');
+writeFileSync(tmpFilePath, `
+  module.exports = {
+    fn() {
+      return 42;
+    }
+  };
+`);
+const tempModule = require(tmpFilePath);
+assert.strictEqual(tempModule.fn(), 42);
+// Deleted files should not be part of the coverage report.
+unlinkSync(tmpFilePath);

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -156,7 +156,7 @@ test('coverage is combined for multiple processes', skipIfNoInspector, () => {
     '| 100.00 | 100.00 | ',
     '# test/fixtures/v8-coverage/combined_coverage/third.test.js | 100.00 | ' +
     '100.00 | 100.00 | ',
-    '# all files | 90.72 | 72.73 | 88.89 |',
+    '# all files | 92.11 | 72.73 | 88.89 |',
     '# end of coverage report',
   ].join('\n');
 
@@ -168,7 +168,9 @@ test('coverage is combined for multiple processes', skipIfNoInspector, () => {
   const args = [
     '--test', '--experimental-test-coverage', '--test-reporter', 'tap', fixture,
   ];
-  const result = spawnSync(process.execPath, args);
+  const result = spawnSync(process.execPath, args, {
+    env: { ...process.env, NODE_TEST_TMPDIR: tmpdir.path }
+  });
 
   assert.strictEqual(result.stderr.toString(), '');
   assert(result.stdout.toString().includes(report));


### PR DESCRIPTION
If V8 generates code coverage for a file that is later inaccessible to the test runner, then omit that file from the coverage report.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
