### PR TITLE
src: fix bug prone forwarding reference moves

### DIFF
--- a/src/callback_queue-inl.h
+++ b/src/callback_queue-inl.h
@@ -11,7 +11,7 @@ template <typename R, typename... Args>
 template <typename Fn>
 std::unique_ptr<typename CallbackQueue<R, Args...>::Callback>
 CallbackQueue<R, Args...>::CreateCallback(Fn&& fn, CallbackFlags::Flags flags) {
-  return std::make_unique<CallbackImpl<Fn>>(std::move(fn), flags);
+  return std::make_unique<CallbackImpl<Fn>>(std::forward<Fn>(fn), flags);
 }
 
 template <typename R, typename... Args>

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -559,7 +559,8 @@ inline void IsolateData::set_options(
 
 template <typename Fn>
 void Environment::SetImmediate(Fn&& cb, CallbackFlags::Flags flags) {
-  auto callback = native_immediates_.CreateCallback(std::move(cb), flags);
+  auto callback =
+      native_immediates_.CreateCallback(std::forward<Fn>(cb), flags);
   native_immediates_.Push(std::move(callback));
 
   if (flags & CallbackFlags::kRefed) {
@@ -571,8 +572,8 @@ void Environment::SetImmediate(Fn&& cb, CallbackFlags::Flags flags) {
 
 template <typename Fn>
 void Environment::SetImmediateThreadsafe(Fn&& cb, CallbackFlags::Flags flags) {
-  auto callback = native_immediates_threadsafe_.CreateCallback(
-      std::move(cb), flags);
+  auto callback =
+      native_immediates_threadsafe_.CreateCallback(std::forward<Fn>(cb), flags);
   {
     Mutex::ScopedLock lock(native_immediates_threadsafe_mutex_);
     native_immediates_threadsafe_.Push(std::move(callback));
@@ -584,7 +585,7 @@ void Environment::SetImmediateThreadsafe(Fn&& cb, CallbackFlags::Flags flags) {
 template <typename Fn>
 void Environment::RequestInterrupt(Fn&& cb) {
   auto callback = native_immediates_interrupts_.CreateCallback(
-      std::move(cb), CallbackFlags::kRefed);
+      std::forward<Fn>(cb), CallbackFlags::kRefed);
   {
     Mutex::ScopedLock lock(native_immediates_threadsafe_mutex_);
     native_immediates_interrupts_.Push(std::move(callback));

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -138,7 +138,7 @@ template <typename Fn>
 bool Worker::RequestInterrupt(Fn&& cb) {
   Mutex::ScopedLock lock(mutex_);
   if (env_ == nullptr) return false;
-  env_->RequestInterrupt(std::move(cb));
+  env_->RequestInterrupt(std::forward<Fn>(cb));
   return true;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -592,7 +592,7 @@ struct OnScopeLeaveImpl {
 // });
 template <typename Fn>
 inline MUST_USE_RESULT OnScopeLeaveImpl<Fn> OnScopeLeave(Fn&& fn) {
-  return OnScopeLeaveImpl<Fn>{std::move(fn)};
+  return OnScopeLeaveImpl<Fn>{std::forward<Fn>(fn)};
 }
 
 // Simple RAII wrapper for contiguous data that uses malloc()/free().


### PR DESCRIPTION
Forwarding references should typically be passed to `std::forward` instead of `std::move`.

The general expectation is that `T&&` will always end up as an rvalue no matter what the deduced type for `T` is, and therefore it's not possible to pass an lvalue to the function, however that's not true.

The passed value can be left in an intermediate state after being moved which is bug prone, use `std::forward` to avoid this potential problem.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
