### PR TITLE
src: clarify the parameter name in `Permission::Apply`

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -796,10 +796,10 @@ Environment::Environment(IsolateData* isolate_data,
     // spawn/worker nor use addons unless explicitly allowed by the user
     if (!options_->allow_fs_read.empty() || !options_->allow_fs_write.empty()) {
       options_->allow_native_addons = false;
-      if (options_->allow_child_process) {
+      if (!options_->allow_child_process) {
         permission()->Apply("*", permission::PermissionScope::kChildProcess);
       }
-      if (options_->allow_worker_threads) {
+      if (!options_->allow_worker_threads) {
         permission()->Apply("*", permission::PermissionScope::kWorkerThreads);
       }
     }

--- a/src/env.cc
+++ b/src/env.cc
@@ -796,10 +796,10 @@ Environment::Environment(IsolateData* isolate_data,
     // spawn/worker nor use addons unless explicitly allowed by the user
     if (!options_->allow_fs_read.empty() || !options_->allow_fs_write.empty()) {
       options_->allow_native_addons = false;
-      if (!options_->allow_child_process) {
+      if (options_->allow_child_process) {
         permission()->Apply("*", permission::PermissionScope::kChildProcess);
       }
-      if (!options_->allow_worker_threads) {
+      if (options_->allow_worker_threads) {
         permission()->Apply("*", permission::PermissionScope::kWorkerThreads);
       }
     }

--- a/src/permission/child_process_permission.cc
+++ b/src/permission/child_process_permission.cc
@@ -11,12 +11,12 @@ namespace permission {
 // Once denied, it's always denied
 void ChildProcessPermission::Apply(const std::string& allow,
                                    PermissionScope scope) {
-  deny_all_ = true;
+  is_all_allowed_ = true;
 }
 
 bool ChildProcessPermission::is_granted(PermissionScope perm,
                                         const std::string_view& param) {
-  return deny_all_ == false;
+  return is_all_allowed_;
 }
 
 }  // namespace permission

--- a/src/permission/child_process_permission.cc
+++ b/src/permission/child_process_permission.cc
@@ -9,7 +9,7 @@ namespace permission {
 
 // Currently, ChildProcess manage a single state
 // Once denied, it's always denied
-void ChildProcessPermission::Apply(const std::string& deny,
+void ChildProcessPermission::Apply(const std::string& allow,
                                    PermissionScope scope) {
   deny_all_ = true;
 }

--- a/src/permission/child_process_permission.cc
+++ b/src/permission/child_process_permission.cc
@@ -11,12 +11,12 @@ namespace permission {
 // Once denied, it's always denied
 void ChildProcessPermission::Apply(const std::string& allow,
                                    PermissionScope scope) {
-  is_all_allowed_ = true;
+  deny_all_ = true;
 }
 
 bool ChildProcessPermission::is_granted(PermissionScope perm,
                                         const std::string_view& param) {
-  return is_all_allowed_;
+  return deny_all_ == false;
 }
 
 }  // namespace permission

--- a/src/permission/child_process_permission.h
+++ b/src/permission/child_process_permission.h
@@ -17,7 +17,7 @@ class ChildProcessPermission final : public PermissionBase {
                   const std::string_view& param = "") override;
 
  private:
-  bool is_all_allowed_{false};
+  bool deny_all_;
 };
 
 }  // namespace permission

--- a/src/permission/child_process_permission.h
+++ b/src/permission/child_process_permission.h
@@ -12,7 +12,7 @@ namespace permission {
 
 class ChildProcessPermission final : public PermissionBase {
  public:
-  void Apply(const std::string& deny, PermissionScope scope) override;
+  void Apply(const std::string& allow, PermissionScope scope) override;
   bool is_granted(PermissionScope perm,
                   const std::string_view& param = "") override;
 

--- a/src/permission/child_process_permission.h
+++ b/src/permission/child_process_permission.h
@@ -17,7 +17,7 @@ class ChildProcessPermission final : public PermissionBase {
                   const std::string_view& param = "") override;
 
  private:
-  bool deny_all_;
+  bool is_all_allowed_{false};
 };
 
 }  // namespace permission

--- a/src/permission/fs_permission.h
+++ b/src/permission/fs_permission.h
@@ -16,7 +16,7 @@ namespace permission {
 
 class FSPermission final : public PermissionBase {
  public:
-  void Apply(const std::string& deny, PermissionScope scope) override;
+  void Apply(const std::string& allow, PermissionScope scope) override;
   bool is_granted(PermissionScope perm, const std::string_view& param) override;
 
   // For debugging purposes, use the gist function to print the whole tree

--- a/src/permission/permission.h
+++ b/src/permission/permission.h
@@ -46,7 +46,7 @@ class Permission {
                                 const std::string_view& res);
 
   // CLI Call
-  void Apply(const std::string& deny, PermissionScope scope);
+  void Apply(const std::string& allow, PermissionScope scope);
   void EnablePermissions();
 
  private:

--- a/src/permission/permission_base.h
+++ b/src/permission/permission_base.h
@@ -36,7 +36,7 @@ enum class PermissionScope {
 
 class PermissionBase {
  public:
-  virtual void Apply(const std::string& deny, PermissionScope scope) = 0;
+  virtual void Apply(const std::string& allow, PermissionScope scope) = 0;
   virtual bool is_granted(PermissionScope perm,
                           const std::string_view& param = "") = 0;
 };

--- a/src/permission/worker_permission.cc
+++ b/src/permission/worker_permission.cc
@@ -9,7 +9,7 @@ namespace permission {
 
 // Currently, PolicyDenyWorker manage a single state
 // Once denied, it's always denied
-void WorkerPermission::Apply(const std::string& deny, PermissionScope scope) {
+void WorkerPermission::Apply(const std::string& allow, PermissionScope scope) {
   deny_all_ = true;
 }
 

--- a/src/permission/worker_permission.cc
+++ b/src/permission/worker_permission.cc
@@ -10,12 +10,12 @@ namespace permission {
 // Currently, PolicyDenyWorker manage a single state
 // Once denied, it's always denied
 void WorkerPermission::Apply(const std::string& allow, PermissionScope scope) {
-  is_all_allowed_ = true;
+  deny_all_ = true;
 }
 
 bool WorkerPermission::is_granted(PermissionScope perm,
                                   const std::string_view& param) {
-  return is_all_allowed_;
+  return deny_all_ == false;
 }
 
 }  // namespace permission

--- a/src/permission/worker_permission.cc
+++ b/src/permission/worker_permission.cc
@@ -10,12 +10,12 @@ namespace permission {
 // Currently, PolicyDenyWorker manage a single state
 // Once denied, it's always denied
 void WorkerPermission::Apply(const std::string& allow, PermissionScope scope) {
-  deny_all_ = true;
+  is_all_allowed_ = true;
 }
 
 bool WorkerPermission::is_granted(PermissionScope perm,
                                   const std::string_view& param) {
-  return deny_all_ == false;
+  return is_all_allowed_;
 }
 
 }  // namespace permission

--- a/src/permission/worker_permission.h
+++ b/src/permission/worker_permission.h
@@ -12,7 +12,7 @@ namespace permission {
 
 class WorkerPermission final : public PermissionBase {
  public:
-  void Apply(const std::string& deny, PermissionScope scope) override;
+  void Apply(const std::string& allow, PermissionScope scope) override;
   bool is_granted(PermissionScope perm,
                   const std::string_view& param = "") override;
 

--- a/src/permission/worker_permission.h
+++ b/src/permission/worker_permission.h
@@ -17,7 +17,7 @@ class WorkerPermission final : public PermissionBase {
                   const std::string_view& param = "") override;
 
  private:
-  bool deny_all_;
+  bool is_all_allowed_{false};
 };
 
 }  // namespace permission

--- a/src/permission/worker_permission.h
+++ b/src/permission/worker_permission.h
@@ -17,7 +17,7 @@ class WorkerPermission final : public PermissionBase {
                   const std::string_view& param = "") override;
 
  private:
-  bool is_all_allowed_{false};
+  bool deny_all_;
 };
 
 }  // namespace permission


### PR DESCRIPTION
The first parameter is to set allow-permission, but its name declaration is `deny`. This removes any confusion.

/cc @RafaelGSS 

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
