### PR TITLE
lib: move web global bootstrapping to the expected file

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -70,7 +70,6 @@ const internalTimers = require('internal/timers');
 const {
   defineOperation,
   deprecate,
-  defineLazyProperties,
 } = require('internal/util');
 const {
   validateInteger,
@@ -208,21 +207,11 @@ internalBinding('async_wrap').setupHooks(nativeHooks);
 
 const {
   setupTaskQueue,
-  queueMicrotask,
 } = require('internal/process/task_queues');
-
-// Non-standard extensions:
-defineOperation(globalThis, 'queueMicrotask', queueMicrotask);
-
 const timers = require('timers');
+// Non-standard extensions:
 defineOperation(globalThis, 'clearImmediate', timers.clearImmediate);
 defineOperation(globalThis, 'setImmediate', timers.setImmediate);
-
-defineLazyProperties(
-  globalThis,
-  'internal/structured_clone',
-  ['structuredClone'],
-);
 
 // Set the per-Environment callback that will be called
 // when the TrackingTraceStateObserver updates trace state.

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -374,7 +374,6 @@ function setupBuffer() {
   // Only after this point can C++ use Buffer::New()
   bufferBinding.setBufferPrototype(Buffer.prototype);
   delete bufferBinding.setBufferPrototype;
-  delete bufferBinding.zeroFill;
 
   // Create global.Buffer as getters so that we have a
   // deprecation path for these in ES Modules.

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -26,12 +26,23 @@ defineOperation(globalThis, 'clearTimeout', timers.clearTimeout);
 defineOperation(globalThis, 'setInterval', timers.setInterval);
 defineOperation(globalThis, 'setTimeout', timers.setTimeout);
 
+const {
+  queueMicrotask,
+} = require('internal/process/task_queues');
+defineOperation(globalThis, 'queueMicrotask', queueMicrotask);
+
+defineLazyProperties(
+  globalThis,
+  'internal/structured_clone',
+  ['structuredClone'],
+);
+defineLazyProperties(globalThis, 'buffer', ['atob', 'btoa']);
+
 // https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts
 exposeLazyInterfaces(globalThis, 'internal/worker/io', ['BroadcastChannel']);
 exposeLazyInterfaces(globalThis, 'internal/worker/io', [
   'MessageChannel', 'MessagePort', 'MessageEvent',
 ]);
-defineLazyProperties(globalThis, 'buffer', ['atob', 'btoa']);
 // https://www.w3.org/TR/FileAPI/#dfn-Blob
 exposeLazyInterfaces(globalThis, 'internal/blob', ['Blob']);
 // https://www.w3.org/TR/FileAPI/#dfn-file


### PR DESCRIPTION
Moves the definition of `queueMicrotask` and `structuredClone` to `internal/bootstrap/web/exposed-window-or-worker.js` as they are defined in HTML `WindowOrWorkerGlobalScope`. This also suggests they can be disabled with the option `--no-browser--globals`.

Also, remove the obsolete deletion `bufferBinding.zeroFill`.