### PR TITLE
url: improve `isURL` detection

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -692,11 +692,14 @@ ObjectDefineProperties(URLSearchParams.prototype, {
  *
  * We use `href` and `protocol` as they are the only properties that are
  * easy to retrieve and calculate due to the lazy nature of the getters.
+ *
+ * We check for auth attribute to distinguish legacy url instance with
+ * WHATWG URL instance.
  * @param {*} self
  * @returns {self is URL}
  */
 function isURL(self) {
-  return Boolean(self?.href && self.protocol);
+  return Boolean(self?.href && self.protocol && self.auth === undefined);
 }
 
 class URL {

--- a/test/parallel/test-url-is-url.js
+++ b/test/parallel/test-url-is-url.js
@@ -1,0 +1,11 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+
+const { URL, parse } = require('url');
+const assert = require('assert');
+const { isURL } = require('internal/url');
+
+assert.strictEqual(isURL(new URL('https://www.nodejs.org')), true);
+assert.strictEqual(isURL(parse('https://www.nodejs.org')), false);


### PR DESCRIPTION
Previously we were checking for `protocol` and `origin` attributes, but due to the lazy-loading nature of Ada 2.0 with `url_aggregator` we shifted from checking for `origin`. This was also breaking the detection of the legacy URL parse function. This PR fixes that in the least impactful way possible, by checking if `auth` property is defined.

Fixes https://github.com/nodejs/node/issues/47624

cc @nodejs/url @Trott 