### PR TITLE
bootstrap: put is_building_snapshot state in IsolateData and introduce ERR_NOT_SUPPORTED_IN_SNAPSHOT

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2414,6 +2414,13 @@ error indicates that the idle loop has failed to stop.
 An attempt was made to use operations that can only be used when building
 V8 startup snapshot even though Node.js isn't building one.
 
+<a id="ERR_NOT_SUPPORTED_IN_SNAPSHOT"></a>
+
+### `ERR_NOT_SUPPORTED_IN_SNAPSHOT`
+
+An attempt was made to perform operations that are not supported in the
+snapshot.
+
 <a id="ERR_NO_CRYPTO"></a>
 
 ### `ERR_NO_CRYPTO`

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2418,8 +2418,8 @@ V8 startup snapshot even though Node.js isn't building one.
 
 ### `ERR_NOT_SUPPORTED_IN_SNAPSHOT`
 
-An attempt was made to perform operations that are not supported in the
-snapshot.
+An attempt was made to perform operations that are not supported when
+building a startup snapshot.
 
 <a id="ERR_NO_CRYPTO"></a>
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1464,6 +1464,8 @@ E('ERR_NETWORK_IMPORT_DISALLOWED',
   "import of '%s' by %s is not supported: %s", Error);
 E('ERR_NOT_BUILDING_SNAPSHOT',
   'Operation cannot be invoked when not building startup snapshot', Error);
+E('ERR_NOT_SUPPORTED_IN_SNAPSHOT',
+  '%s is not supported in startup snapshot', Error);
 E('ERR_NO_CRYPTO',
   'Node.js is not compiled with OpenSSL crypto support', Error);
 E('ERR_NO_ICU',

--- a/lib/internal/v8/startup_snapshot.js
+++ b/lib/internal/v8/startup_snapshot.js
@@ -6,6 +6,7 @@ const {
 const {
   codes: {
     ERR_NOT_BUILDING_SNAPSHOT,
+    ERR_NOT_SUPPORTED_IN_SNAPSHOT,
     ERR_DUPLICATE_STARTUP_SNAPSHOT_MAIN_FUNCTION,
   },
 } = require('internal/errors');
@@ -14,7 +15,7 @@ const {
   setSerializeCallback,
   setDeserializeCallback,
   setDeserializeMainFunction: _setDeserializeMainFunction,
-  isBuildingSnapshotBuffer
+  isBuildingSnapshotBuffer,
 } = internalBinding('mksnapshot');
 
 function isBuildingSnapshot() {
@@ -24,6 +25,12 @@ function isBuildingSnapshot() {
 function throwIfNotBuildingSnapshot() {
   if (!isBuildingSnapshot()) {
     throw new ERR_NOT_BUILDING_SNAPSHOT();
+  }
+}
+
+function throwIfBuildingSnapshot(reason) {
+  if (isBuildingSnapshot()) {
+    throw new ERR_NOT_SUPPORTED_IN_SNAPSHOT(reason);
   }
 }
 
@@ -102,6 +109,7 @@ function setDeserializeMainFunction(callback, data) {
 module.exports = {
   initializeCallbacks,
   runDeserializeCallbacks,
+  throwIfBuildingSnapshot,
   // Exposed to require('v8').startupSnapshot
   namespace: {
     addDeserializeCallback,

--- a/lib/internal/v8/startup_snapshot.js
+++ b/lib/internal/v8/startup_snapshot.js
@@ -14,11 +14,11 @@ const {
   setSerializeCallback,
   setDeserializeCallback,
   setDeserializeMainFunction: _setDeserializeMainFunction,
+  isBuildingSnapshotBuffer
 } = internalBinding('mksnapshot');
 
 function isBuildingSnapshot() {
-  // For now this is the only way to build a snapshot.
-  return require('internal/options').getOptionValue('--build-snapshot');
+  return isBuildingSnapshotBuffer[0];
 }
 
 function throwIfNotBuildingSnapshot() {

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -60,7 +60,9 @@ const { deserializeError } = require('internal/error_serdes');
 const { fileURLToPath, isURL, pathToFileURL } = require('internal/url');
 const { kEmptyObject } = require('internal/util');
 const { validateArray, validateString } = require('internal/validators');
-
+const {
+  throwIfBuildingSnapshot,
+} = require('internal/v8/startup_snapshot');
 const {
   ownsProcessState,
   isMainThread,
@@ -129,6 +131,7 @@ function assignEnvironmentData(data) {
 
 class Worker extends EventEmitter {
   constructor(filename, options = kEmptyObject) {
+    throwIfBuildingSnapshot('Creating workers');
     super();
     const isInternal = arguments[2] === kIsInternal;
     debug(

--- a/src/api/embed_helpers.cc
+++ b/src/api/embed_helpers.cc
@@ -142,8 +142,8 @@ CommonEnvironmentSetup::CommonEnvironmentSetup(
 
     impl_->isolate_data.reset(CreateIsolateData(
         isolate, loop, platform, impl_->allocator.get(), snapshot_data));
-    impl_->isolate_data->options()->build_snapshot =
-        impl_->snapshot_creator.has_value();
+    impl_->isolate_data->set_is_building_snapshot(
+        impl_->snapshot_creator.has_value());
 
     if (snapshot_data) {
       impl_->env.reset(make_env(this));

--- a/src/base_object_types.h
+++ b/src/base_object_types.h
@@ -12,6 +12,7 @@ namespace node {
 #define SERIALIZABLE_BINDING_TYPES(V)                                          \
   V(encoding_binding_data, encoding_binding::BindingData)                      \
   V(fs_binding_data, fs::BindingData)                                          \
+  V(mksnapshot_binding_data, mksnapshot::BindingData)                          \
   V(v8_binding_data, v8_utils::BindingData)                                    \
   V(blob_binding_data, BlobBindingData)                                        \
   V(process_binding_data, process::BindingData)                                \

--- a/src/env.h
+++ b/src/env.h
@@ -136,6 +136,9 @@ class NODE_EXTERN_PRIVATE IsolateData : public MemoryRetainer {
   void MemoryInfo(MemoryTracker* tracker) const override;
   IsolateDataSerializeInfo Serialize(v8::SnapshotCreator* creator);
 
+  bool is_building_snapshot() const { return is_building_snapshot_; }
+  void set_is_building_snapshot(bool value) { is_building_snapshot_ = value; }
+
   inline uv_loop_t* event_loop() const;
   inline MultiIsolatePlatform* platform() const;
   inline const SnapshotData* snapshot_data() const;
@@ -219,6 +222,7 @@ class NODE_EXTERN_PRIVATE IsolateData : public MemoryRetainer {
   const SnapshotData* snapshot_data_;
   std::shared_ptr<PerIsolateOptions> options_;
   worker::Worker* worker_context_ = nullptr;
+  bool is_building_snapshot_ = false;
 };
 
 struct ContextInfo {

--- a/src/node.cc
+++ b/src/node.cc
@@ -283,7 +283,7 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
     auto reset_entry_point =
         OnScopeLeave([&]() { env->set_embedder_entry_point({}); });
 
-    const char* entry = env->isolate_data()->options()->build_snapshot
+    const char* entry = env->isolate_data()->is_building_snapshot()
                             ? "internal/main/mksnapshot"
                             : "internal/main/embedding";
 
@@ -311,7 +311,7 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
     return StartExecution(env, "internal/main/inspect");
   }
 
-  if (env->isolate_data()->options()->build_snapshot) {
+  if (env->isolate_data()->is_building_snapshot()) {
     return StartExecution(env, "internal/main/mksnapshot");
   }
 

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -37,6 +37,7 @@ static_assert(static_cast<int>(NM_F_LINKED) ==
   V(contextify)                                                                \
   V(encoding_binding)                                                          \
   V(fs)                                                                        \
+  V(mksnapshot)                                                                \
   V(timers)                                                                    \
   V(process_methods)                                                           \
   V(performance)                                                               \

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -56,6 +56,8 @@ NodeMainInstance::NodeMainInstance(const SnapshotData* snapshot_data,
                         platform,
                         array_buffer_allocator_.get(),
                         snapshot_data->AsEmbedderWrapper().get()));
+  isolate_data_->set_is_building_snapshot(
+      per_process::cli_options->per_isolate->build_snapshot);
 
   isolate_data_->max_young_gen_size =
       isolate_params_->constraints.max_young_generation_size_in_bytes();

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -4,6 +4,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include "aliased_buffer.h"
 #include "base_object.h"
 #include "util.h"
 
@@ -121,6 +122,31 @@ void DeserializeNodeInternalFields(v8::Local<v8::Object> holder,
 void SerializeSnapshotableObjects(Realm* realm,
                                   v8::SnapshotCreator* creator,
                                   RealmSerializeInfo* info);
+
+namespace mksnapshot {
+class BindingData : public SnapshotableObject {
+ public:
+  struct InternalFieldInfo : public node::InternalFieldInfoBase {
+    AliasedBufferIndex is_building_snapshot_buffer;
+  };
+
+  BindingData(Realm* realm,
+              v8::Local<v8::Object> obj,
+              InternalFieldInfo* info = nullptr);
+  SET_BINDING_ID(mksnapshot_binding_data)
+  SERIALIZABLE_OBJECT_METHODS()
+
+  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_SELF_SIZE(BindingData)
+  SET_MEMORY_INFO_NAME(BindingData)
+
+ private:
+  AliasedUint8Array is_building_snapshot_buffer_;
+  InternalFieldInfo* internal_field_info_ = nullptr;
+};
+
+}  // namespace mksnapshot
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -186,6 +186,7 @@ class WorkerThreadData {
                             allocator.get(),
                             w->snapshot_data()->AsEmbedderWrapper().get()));
       CHECK(isolate_data_);
+      CHECK(!isolate_data_->is_building_snapshot());
       if (w_->per_isolate_opts_)
         isolate_data_->set_options(std::move(w_->per_isolate_opts_));
       isolate_data_->set_worker_context(w_);
@@ -481,6 +482,7 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
     THROW_ERR_MISSING_PLATFORM_FOR_WORKER(env);
     return;
   }
+  CHECK(!env->isolate_data()->is_building_snapshot());
 
   std::string url;
   std::string name;

--- a/test/fixtures/snapshot/worker.js
+++ b/test/fixtures/snapshot/worker.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { Worker } = require('worker_threads');
+
+new Worker('1', { eval: true });

--- a/test/parallel/test-snapshot-worker.js
+++ b/test/parallel/test-snapshot-worker.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// This tests snapshot JS API using the example in the docs.
+
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const path = require('path');
+const fs = require('fs');
+
+tmpdir.refresh();
+const blobPath = path.join(tmpdir.path, 'snapshot.blob');
+const entry = fixtures.path('snapshot', 'worker.js');
+{
+  const child = spawnSync(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot',
+    entry,
+  ], {
+    cwd: tmpdir.path
+  });
+  const stderr = child.stderr.toString();
+  assert.match(
+    stderr,
+    /Error: Creating workers is not supported in startup snapshot/);
+  assert.match(
+    stderr,
+    /ERR_NOT_SUPPORTED_IN_SNAPSHOT/);
+  assert.strictEqual(child.status, 1);
+  assert(!fs.existsSync(blobPath));
+}


### PR DESCRIPTION
#### bootstrap: put is_building_snapshot state in IsolateData

Previously we modify the CLI options store to indicate whether the
isolate is created for building snapshot, which is a bit hacky and
makes it difficult to tell whether the snapshot is built from the
command line or through other APIs. This patch adds
is_building_snapshot to IsolateData and use this instead when we
need to know whether the isolate is created for building snapshot
(but do not care about where that request is coming from).

#### bootstrap: throw ERR_NOT_SUPPORTED_IN_SNAPSHOT in unsupported operation

This patch adds a new ERR_NOT_SUPPORTED_IN_SNAPSHOT error and throw
it in the worker constructor.


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
