### PR TITLE
module: refactor to use `normalizeRequirableId` in the CJS module loader

### DIFF
--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -286,17 +286,16 @@ class BuiltinModule {
   }
 
   static normalizeRequirableId(id) {
-    let normalizedId = id;
     if (StringPrototypeStartsWith(id, 'node:')) {
-      normalizedId = StringPrototypeSlice(id, 5);
+      const normalizedId = StringPrototypeSlice(id, 5);
+      if (BuiltinModule.canBeRequiredByUsers(normalizedId)) {
+        return normalizedId;
+      }
+    } else if (BuiltinModule.canBeRequiredWithoutScheme(id)) {
+      return id;
     }
 
-    if (!BuiltinModule.canBeRequiredByUsers(normalizedId) ||
-        (id === normalizedId && !BuiltinModule.canBeRequiredWithoutScheme(normalizedId))) {
-      return undefined;
-    }
-
-    return normalizedId;
+    return undefined;
   }
 
   static isBuiltin(id) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -792,12 +792,7 @@ if (isWindows) {
 }
 
 Module._resolveLookupPaths = function(request, parent) {
-  if ((
-    StringPrototypeStartsWith(request, 'node:') &&
-    BuiltinModule.canBeRequiredByUsers(StringPrototypeSlice(request, 5))
-  ) || (
-    BuiltinModule.canBeRequiredWithoutScheme(request)
-  )) {
+  if (BuiltinModule.normalizeRequirableId(request)) {
     debug('looking for %j in []', request);
     return null;
   }
@@ -989,14 +984,7 @@ Module._load = function(request, parent, isMain) {
 };
 
 Module._resolveFilename = function(request, parent, isMain, options) {
-  if (
-    (
-      StringPrototypeStartsWith(request, 'node:') &&
-      BuiltinModule.canBeRequiredByUsers(StringPrototypeSlice(request, 5))
-    ) || (
-      BuiltinModule.canBeRequiredWithoutScheme(request)
-    )
-  ) {
+  if (BuiltinModule.normalizeRequirableId(request)) {
     return request;
   }
 


### PR DESCRIPTION
`BuiltinModule.normalizeRequirableId()` was introduced in https://github.com/nodejs/node/pull/47779 to fix a bug in the require function of SEAs and Snapshots, so that built-in modules with the `node:` scheme could be required correctly. This change makes more use of this API instead of `BuiltinModule.canBeRequiredByUsers()` and `BuiltinModule.canBeRequiredWithoutScheme()` to reduce chances of such bugs.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
