### PR TITLE
stream: update readable.map test to use node:test

### DIFF
--- a/test/parallel/test-stream-map.js
+++ b/test/parallel/test-stream-map.js
@@ -7,54 +7,46 @@ const {
 const assert = require('assert');
 const { once } = require('events');
 const { setTimeout } = require('timers/promises');
+const { it } = require('node:test');
 
-{
-  // Map works on synchronous streams with a synchronous mapper
+it('Map works on synchronous streams with a synchronous mapper', async () => {
   const stream = Readable.from([1, 2, 3, 4, 5]).map((x) => x + x);
-  (async () => {
-    assert.deepStrictEqual(await stream.toArray(), [2, 4, 6, 8, 10]);
-  })().then(common.mustCall());
-}
 
-{
-  // Map works on synchronous streams with an asynchronous mapper
+  assert.deepStrictEqual(await stream.toArray(), [2, 4, 6, 8, 10]);
+});
+
+it('Map works on synchronous streams with an asynchronous mapper', async () => {
   const stream = Readable.from([1, 2, 3, 4, 5]).map(async (x) => {
     await Promise.resolve();
     return x + x;
   });
-  (async () => {
-    assert.deepStrictEqual(await stream.toArray(), [2, 4, 6, 8, 10]);
-  })().then(common.mustCall());
-}
 
-{
-  // Map works on asynchronous streams with a asynchronous mapper
+  assert.deepStrictEqual(await stream.toArray(), [2, 4, 6, 8, 10]);
+});
+
+it('Map works on asynchronous streams with a asynchronous mapper', async () => {
   const stream = Readable.from([1, 2, 3, 4, 5]).map(async (x) => {
     return x + x;
   }).map((x) => x + x);
-  (async () => {
-    assert.deepStrictEqual(await stream.toArray(), [4, 8, 12, 16, 20]);
-  })().then(common.mustCall());
-}
 
-{
-  // Map works on an infinite stream
+  assert.deepStrictEqual(await stream.toArray(), [4, 8, 12, 16, 20]);
+});
+
+it('Map works on an infinite stream', async () => {
   const stream = Readable.from(async function* () {
     while (true) yield 1;
   }()).map(common.mustCall(async (x) => {
     return x + x;
   }, 5));
-  (async () => {
-    let i = 1;
-    for await (const item of stream) {
-      assert.strictEqual(item, 2);
-      if (++i === 5) break;
-    }
-  })().then(common.mustCall());
-}
 
-{
-  // Map works on non-objectMode streams
+  let i = 1;
+  for await (const item of stream) {
+    assert.strictEqual(item, 2);
+    if (++i === 5) break;
+  }
+});
+
+it('Map works on non-objectMode streams', async () => {
   const stream = new Readable({
     read() {
       this.push(Uint8Array.from([1]));
@@ -65,15 +57,13 @@ const { setTimeout } = require('timers/promises');
     return x + x;
   }).map((x) => x + x);
   const result = [4, 8];
-  (async () => {
-    for await (const item of stream) {
-      assert.strictEqual(item, result.shift());
-    }
-  })().then(common.mustCall());
-}
 
-{
-  // Does not care about data events
+  for await (const item of stream) {
+    assert.strictEqual(item, result.shift());
+  }
+});
+
+it('Does not care about data events', async () => {
   const source = new Readable({
     read() {
       this.push(Uint8Array.from([1]));
@@ -85,15 +75,16 @@ const { setTimeout } = require('timers/promises');
   const stream = source.map(async ([x]) => {
     return x + x;
   }).map((x) => x + x);
-  const result = [4, 8];
-  (async () => {
-    for await (const item of stream) {
-      assert.strictEqual(item, result.shift());
-    }
-  })().then(common.mustCall());
-}
 
-{
+  const result = [4, 8];
+
+  for await (const item of stream) {
+    assert.strictEqual(item, result.shift());
+  }
+});
+
+
+it('Emitting an error during `map`', async () => {
   // Emitting an error during `map`
   const stream = Readable.from([1, 2, 3, 4, 5]).map(async (x) => {
     if (x === 3) {
@@ -101,89 +92,86 @@ const { setTimeout } = require('timers/promises');
     }
     return x + x;
   });
-  assert.rejects(
+  await assert.rejects(
     stream.map((x) => x + x).toArray(),
     /boom/,
-  ).then(common.mustCall());
-}
+  );
+});
 
-{
-  // Throwing an error during `map` (sync)
+it('Throwing an error during `map` (sync)', async () => {
   const stream = Readable.from([1, 2, 3, 4, 5]).map((x) => {
     if (x === 3) {
       throw new Error('boom');
     }
     return x + x;
   });
-  assert.rejects(
+
+  await assert.rejects(
     stream.map((x) => x + x).toArray(),
     /boom/,
-  ).then(common.mustCall());
-}
+  );
+});
 
-
-{
-  // Throwing an error during `map` (async)
+it('Throwing an error during `map` (async)', async () => {
   const stream = Readable.from([1, 2, 3, 4, 5]).map(async (x) => {
     if (x === 3) {
       throw new Error('boom');
     }
     return x + x;
   });
-  assert.rejects(
+
+  await assert.rejects(
     stream.map((x) => x + x).toArray(),
     /boom/,
-  ).then(common.mustCall());
-}
+  );
+});
 
-{
-  // Concurrency + AbortSignal
+it('Concurrency + AbortSignal', async () => {
   const ac = new AbortController();
   const range = Readable.from([1, 2, 3, 4, 5]);
   const stream = range.map(common.mustCall(async (_, { signal }) => {
     await once(signal, 'abort');
     throw signal.reason;
   }, 2), { signal: ac.signal, concurrency: 2 });
+
   // pump
-  assert.rejects(async () => {
+  const pr = assert.rejects(async () => {
     for await (const item of stream) {
       assert.fail('should not reach here, got ' + item);
     }
   }, {
     name: 'AbortError',
-  }).then(common.mustCall());
+  });
 
   setImmediate(() => {
     ac.abort();
   });
-}
 
-{
-  // Concurrency result order
+  await pr;
+});
+
+it('Concurrency result order', async () => {
   const stream = Readable.from([1, 2]).map(async (item, { signal }) => {
     await setTimeout(10 - item, { signal });
     return item;
   }, { concurrency: 2 });
 
-  (async () => {
-    const expected = [1, 2];
-    for await (const item of stream) {
-      assert.strictEqual(item, expected.shift());
-    }
-  })().then(common.mustCall());
-}
+  const expected = [1, 2];
+  for await (const item of stream) {
+    assert.strictEqual(item, expected.shift());
+  }
+});
 
-{
-  // Error cases
-  assert.throws(() => Readable.from([1]).map(1), /ERR_INVALID_ARG_TYPE/);
-  assert.throws(() => Readable.from([1]).map((x) => x, {
+it('Error cases', async () => {
+  await assert.throws(() => Readable.from([1]).map(1), /ERR_INVALID_ARG_TYPE/);
+  await assert.throws(() => Readable.from([1]).map((x) => x, {
     concurrency: 'Foo'
   }), /ERR_OUT_OF_RANGE/);
-  assert.throws(() => Readable.from([1]).map((x) => x, 1), /ERR_INVALID_ARG_TYPE/);
-  assert.throws(() => Readable.from([1]).map((x) => x, { signal: true }), /ERR_INVALID_ARG_TYPE/);
-}
-{
-  // Test result is a Readable
+  await assert.throws(() => Readable.from([1]).map((x) => x, 1), /ERR_INVALID_ARG_TYPE/);
+  await assert.throws(() => Readable.from([1]).map((x) => x, { signal: true }), /ERR_INVALID_ARG_TYPE/);
+});
+
+it('Test result is a Readable', () => {
   const stream = Readable.from([1, 2, 3, 4, 5]).map((x) => x);
   assert.strictEqual(stream.readable, true);
-}
+});


### PR DESCRIPTION
this is part of a bigger question: should node use its own testing?


if so, this is the first step

If speaking from DX's point of view I think it should be as the tooling is only going to get better, and you going to have an easier way of writing and executing tests IMO