### PR TITLE
doc: ntfs junction points must link to directories

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1596,7 +1596,8 @@ The `type` argument is only used on Windows platforms and can be one of `'dir'`,
 autodetect `target` type and use `'file'` or `'dir'`. If the `target` does not
 exist, `'file'` will be used. Windows junction points require the destination
 path to be absolute. When using `'junction'`, the `target` argument will
-automatically be normalized to absolute path.
+automatically be normalized to absolute path. Junction points on NTFS volumes
+can only point to directories.
 
 ### `fsPromises.truncate(path[, len])`
 
@@ -4265,7 +4266,8 @@ It can be set to `'dir'`, `'file'`, or `'junction'`. If the `type` argument is
 not a string, Node.js will autodetect `target` type and use `'file'` or `'dir'`.
 If the `target` does not exist, `'file'` will be used. Windows junction points
 require the destination path to be absolute. When using `'junction'`, the
-`target` argument will automatically be normalized to absolute path.
+`target` argument will automatically be normalized to absolute path. Junction
+points on NTFS volumes can only point to directories.
 
 Relative targets are relative to the link's parent directory.
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/40184