### PR TITLE
lib: reuse default DOMException in AbortController

### DIFF
--- a/benchmark/events/abortcontroller-abort.js
+++ b/benchmark/events/abortcontroller-abort.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [1e6],
+});
+
+function main({ n }) {
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    const ac = new AbortController();
+    ac.signal.addEventListener('abort', () => {});
+    ac.abort();
+  }
+  bench.end(n);
+}

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -30,6 +30,7 @@ const {
   customInspectSymbol,
   kEmptyObject,
   kEnumerableProperty,
+  SideEffectFreeRegExpPrototypeSymbolReplace,
 } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
 const {
@@ -63,10 +64,13 @@ const {
 
 let _MessageChannel;
 let makeTransferable;
+let defaultDOMException;
 
 // Loading the MessageChannel and makeTransferable have to be done lazily
 // because otherwise we'll end up with a require cycle that ends up with
 // an incomplete initialization of abort_controller.
+
+const userModuleRegExp = /^ {4}at (?:[^/\\(]+ \()(?!node:(.+):\d+:\d+\)$).*/gm;
 
 function lazyMessageChannel() {
   _MessageChannel ??= require('internal/worker/io').MessageChannel;
@@ -77,6 +81,21 @@ function lazyMakeTransferable(obj) {
   makeTransferable ??=
     require('internal/worker/js_transferable').makeTransferable;
   return makeTransferable(obj);
+}
+
+function lazyDOMException() {
+  if (defaultDOMException) {
+    return defaultDOMException;
+  }
+
+  defaultDOMException = new DOMException('This operation was aborted', 'AbortError');
+
+  // Avoid V8 leak and remove userland stackstrace
+  defaultDOMException.stack = SideEffectFreeRegExpPrototypeSymbolReplace(
+    userModuleRegExp,
+    defaultDOMException.stack,
+    '');
+  return defaultDOMException;
 }
 
 const clearTimeoutRegistry = new SafeFinalizationRegistry(clearTimeout);
@@ -166,8 +185,10 @@ class AbortSignal extends EventTarget {
    * @param {any} [reason]
    * @returns {AbortSignal}
    */
-  static abort(
-    reason = new DOMException('This operation was aborted', 'AbortError')) {
+  static abort(reason) {
+    if (reason === undefined) {
+      reason = lazyDOMException();
+    }
     return createAbortSignal({ aborted: true, reason });
   }
 
@@ -328,7 +349,10 @@ class AbortController {
   /**
    * @param {any} [reason]
    */
-  abort(reason = new DOMException('This operation was aborted', 'AbortError')) {
+  abort(reason) {
+    if (reason === undefined) {
+      reason = lazyDOMException();
+    }
     abortSignal(this.#signal ??= createAbortSignal(), reason);
   }
 

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -4,6 +4,7 @@
 // in https://github.com/mysticatea/abort-controller (MIT license)
 
 const {
+  ErrorCaptureStackTrace,
   ObjectAssign,
   ObjectDefineProperties,
   ObjectSetPrototypeOf,
@@ -30,7 +31,6 @@ const {
   customInspectSymbol,
   kEmptyObject,
   kEnumerableProperty,
-  SideEffectFreeRegExpPrototypeSymbolReplace,
 } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
 const {
@@ -70,8 +70,6 @@ let defaultDOMException;
 // because otherwise we'll end up with a require cycle that ends up with
 // an incomplete initialization of abort_controller.
 
-const userModuleRegExp = /^ {4}at (?:[^/\\(]+ \()(?!node:(.+):\d+:\d+\)$).*/gm;
-
 function lazyMessageChannel() {
   _MessageChannel ??= require('internal/worker/io').MessageChannel;
   return new _MessageChannel();
@@ -90,11 +88,9 @@ function lazyDOMException() {
 
   defaultDOMException = new DOMException('This operation was aborted', 'AbortError');
 
-  // Avoid V8 leak and remove userland stackstrace
-  defaultDOMException.stack = SideEffectFreeRegExpPrototypeSymbolReplace(
-    userModuleRegExp,
-    defaultDOMException.stack,
-    '');
+  // Avoid V8 leak
+  // eslint-disable-next-line no-unused-vars
+  const dummy = defaultDOMException.stack;
   return defaultDOMException;
 }
 
@@ -185,9 +181,10 @@ class AbortSignal extends EventTarget {
    * @param {any} [reason]
    * @returns {AbortSignal}
    */
-  static abort(reason) {
+  static abort(reason = undefined) {
     if (reason === undefined) {
       reason = lazyDOMException();
+      ErrorCaptureStackTrace(reason);
     }
     return createAbortSignal({ aborted: true, reason });
   }
@@ -352,6 +349,7 @@ class AbortController {
   abort(reason) {
     if (reason === undefined) {
       reason = lazyDOMException();
+      ErrorCaptureStackTrace(reason);
     }
     abortSignal(this.#signal ??= createAbortSignal(), reason);
   }


### PR DESCRIPTION
Similar to https://github.com/nodejs/node/pull/46086 have reused the default DOMException we throw when calling `ac.abort()`, so far the tests dont break and the benchmark added in this PR show good improvement

Benchmark results:
```console
                                          confidence improvement accuracy (*)   (**)  (***)
events/abortcontroller-abort.js n=1000000        ***    148.36 %       ±2.47% ±3.30% ±4.33%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 1 comparisons, you can thus expect the following amount of false-positive results:
  0.05 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.01 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

Refs: https://github.com/nodejs/node/pull/46086
Refs: https://github.com/nodejs/performance/issues/44

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
