### PR TITLE
src: avoid prototype access in binding templates

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -353,9 +353,8 @@ Local<FunctionTemplate> AsyncWrap::GetConstructorTemplate(
 }
 
 void AsyncWrap::CreatePerIsolateProperties(IsolateData* isolate_data,
-                                           Local<FunctionTemplate> ctor) {
+                                           Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> target = ctor->InstanceTemplate();
 
   SetMethod(isolate, target, "setupHooks", SetupHooks);
   SetMethod(isolate, target, "setCallbackTrampoline", SetCallbackTrampoline);

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -151,8 +151,8 @@ class AsyncWrap : public BaseObject {
                                          v8::Local<v8::Value> unused,
                                          v8::Local<v8::Context> context,
                                          void* priv);
-  static void CreatePerIsolateProperties(
-      IsolateData* isolate_data, v8::Local<v8::FunctionTemplate> target);
+  static void CreatePerIsolateProperties(IsolateData* isolate_data,
+                                         v8::Local<v8::ObjectTemplate> target);
 
   static void GetAsyncId(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void PushAsyncContext(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -16,7 +16,6 @@ using v8::ArrayBuffer;
 using v8::BackingStore;
 using v8::Context;
 using v8::FunctionCallbackInfo;
-using v8::FunctionTemplate;
 using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
@@ -219,9 +218,8 @@ void BindingData::ToUnicode(const v8::FunctionCallbackInfo<v8::Value>& args) {
 }
 
 void BindingData::CreatePerIsolateProperties(IsolateData* isolate_data,
-                                             Local<FunctionTemplate> ctor) {
+                                             Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> target = ctor->InstanceTemplate();
   SetMethod(isolate, target, "encodeInto", EncodeInto);
   SetMethodNoSideEffect(isolate, target, "encodeUtf8String", EncodeUtf8String);
   SetMethodNoSideEffect(isolate, target, "decodeUTF8", DecodeUTF8);

--- a/src/encoding_binding.h
+++ b/src/encoding_binding.h
@@ -36,7 +36,7 @@ class BindingData : public SnapshotableObject {
   static void ToUnicode(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                         v8::Local<v8::FunctionTemplate> ctor);
+                                         v8::Local<v8::ObjectTemplate> target);
   static void CreatePerContextProperties(v8::Local<v8::Object> target,
                                          v8::Local<v8::Value> unused,
                                          v8::Local<v8::Context> context,

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -807,7 +807,7 @@ void Environment::set_process_exit_handler(
 #undef VY
 #undef VP
 
-#define VM(PropertyName) V(PropertyName##_binding, v8::FunctionTemplate)
+#define VM(PropertyName) V(PropertyName##_binding_template, v8::ObjectTemplate)
 #define V(PropertyName, TypeName)                                              \
   inline v8::Local<TypeName> IsolateData::PropertyName() const {               \
     return PropertyName##_.Get(isolate_);                                      \

--- a/src/env.cc
+++ b/src/env.cc
@@ -38,7 +38,6 @@ using v8::Context;
 using v8::EmbedderGraph;
 using v8::EscapableHandleScope;
 using v8::Function;
-using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::HeapProfiler;
 using v8::HeapSpaceStatistics;
@@ -49,6 +48,7 @@ using v8::MaybeLocal;
 using v8::NewStringType;
 using v8::Number;
 using v8::Object;
+using v8::ObjectTemplate;
 using v8::Private;
 using v8::Script;
 using v8::SnapshotCreator;
@@ -326,7 +326,7 @@ IsolateDataSerializeInfo IsolateData::Serialize(SnapshotCreator* creator) {
     info.primitive_values.push_back(creator->AddData(async_wrap_provider(i)));
 
   uint32_t id = 0;
-#define VM(PropertyName) V(PropertyName##_binding, FunctionTemplate)
+#define VM(PropertyName) V(PropertyName##_binding_template, ObjectTemplate)
 #define V(PropertyName, TypeName)                                              \
   do {                                                                         \
     Local<TypeName> field = PropertyName();                                    \
@@ -390,7 +390,7 @@ void IsolateData::DeserializeProperties(const IsolateDataSerializeInfo* info) {
   const std::vector<PropInfo>& values = info->template_values;
   i = 0;  // index to the array
   uint32_t id = 0;
-#define VM(PropertyName) V(PropertyName##_binding, FunctionTemplate)
+#define VM(PropertyName) V(PropertyName##_binding_template, ObjectTemplate)
 #define V(PropertyName, TypeName)                                              \
   do {                                                                         \
     if (values.size() > i && id == values[i].id) {                             \
@@ -491,10 +491,9 @@ void IsolateData::CreateProperties() {
   NODE_ASYNC_PROVIDER_TYPES(V)
 #undef V
 
-  Local<FunctionTemplate> templ = FunctionTemplate::New(isolate());
-  templ->InstanceTemplate()->SetInternalFieldCount(
-      BaseObject::kInternalFieldCount);
-  set_binding_data_ctor_template(templ);
+  Local<ObjectTemplate> templ = ObjectTemplate::New(isolate());
+  templ->SetInternalFieldCount(BaseObject::kInternalFieldCount);
+  set_binding_data_default_template(templ);
   binding::CreateInternalBindingTemplates(this);
 
   contextify::ContextifyContext::InitializeGlobalTemplates(this);

--- a/src/env.h
+++ b/src/env.h
@@ -163,7 +163,7 @@ class NODE_EXTERN_PRIVATE IsolateData : public MemoryRetainer {
 #undef VS
 #undef VP
 
-#define VM(PropertyName) V(PropertyName##_binding, v8::FunctionTemplate)
+#define VM(PropertyName) V(PropertyName##_binding_template, v8::ObjectTemplate)
 #define V(PropertyName, TypeName)                                              \
   inline v8::Local<TypeName> PropertyName() const;                             \
   inline void set_##PropertyName(v8::Local<TypeName> value);
@@ -191,7 +191,7 @@ class NODE_EXTERN_PRIVATE IsolateData : public MemoryRetainer {
 #define VY(PropertyName, StringValue) V(v8::Symbol, PropertyName)
 #define VS(PropertyName, StringValue) V(v8::String, PropertyName)
 #define VR(PropertyName, TypeName) V(v8::Private, per_realm_##PropertyName)
-#define VM(PropertyName) V(v8::FunctionTemplate, PropertyName##_binding)
+#define VM(PropertyName) V(v8::ObjectTemplate, PropertyName##_binding_template)
 #define VT(PropertyName, TypeName) V(TypeName, PropertyName)
 #define V(TypeName, PropertyName)                                             \
   v8::Eternal<TypeName> PropertyName ## _;

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -333,7 +333,7 @@
 #define PER_ISOLATE_TEMPLATE_PROPERTIES(V)                                     \
   V(async_wrap_ctor_template, v8::FunctionTemplate)                            \
   V(async_wrap_object_ctor_template, v8::FunctionTemplate)                     \
-  V(binding_data_ctor_template, v8::FunctionTemplate)                          \
+  V(binding_data_default_template, v8::ObjectTemplate)                         \
   V(blob_constructor_template, v8::FunctionTemplate)                           \
   V(blob_reader_constructor_template, v8::FunctionTemplate)                    \
   V(blocklist_constructor_template, v8::FunctionTemplate)                      \

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -101,7 +101,7 @@ NODE_BUILTIN_BINDINGS(V)
 
 #define V(modname)                                                             \
   void _register_isolate_##modname(node::IsolateData* isolate_data,            \
-                                   v8::Local<v8::FunctionTemplate> target);
+                                   v8::Local<v8::ObjectTemplate> target);
 NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V)
 #undef V
 
@@ -235,11 +235,11 @@ using v8::Context;
 using v8::EscapableHandleScope;
 using v8::Exception;
 using v8::FunctionCallbackInfo;
-using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
+using v8::ObjectTemplate;
 using v8::String;
 using v8::Value;
 
@@ -572,12 +572,11 @@ inline struct node_module* FindModule(struct node_module* list,
 void CreateInternalBindingTemplates(IsolateData* isolate_data) {
 #define V(modname)                                                             \
   do {                                                                         \
-    Local<FunctionTemplate> templ =                                            \
-        FunctionTemplate::New(isolate_data->isolate());                        \
-    templ->InstanceTemplate()->SetInternalFieldCount(                          \
-        BaseObject::kInternalFieldCount);                                      \
+    Local<ObjectTemplate> templ =                                              \
+        ObjectTemplate::New(isolate_data->isolate());                          \
+    templ->SetInternalFieldCount(BaseObject::kInternalFieldCount);             \
     _register_isolate_##modname(isolate_data, templ);                          \
-    isolate_data->set_##modname##_binding(templ);                              \
+    isolate_data->set_##modname##_binding_template(templ);                     \
   } while (0);
   NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V)
 #undef V
@@ -586,21 +585,20 @@ void CreateInternalBindingTemplates(IsolateData* isolate_data) {
 static Local<Object> GetInternalBindingExportObject(IsolateData* isolate_data,
                                                     const char* mod_name,
                                                     Local<Context> context) {
-  Local<FunctionTemplate> ctor;
+  Local<ObjectTemplate> templ;
+
 #define V(name)                                                                \
   if (strcmp(mod_name, #name) == 0) {                                          \
-    ctor = isolate_data->name##_binding();                                     \
+    templ = isolate_data->name##_binding_template();                           \
   } else  // NOLINT(readability/braces)
   NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V)
 #undef V
   {
-    ctor = isolate_data->binding_data_ctor_template();
+    // Default template.
+    templ = isolate_data->binding_data_default_template();
   }
 
-  Local<Object> obj = ctor->GetFunction(context)
-                          .ToLocalChecked()
-                          ->NewInstance(context)
-                          .ToLocalChecked();
+  Local<Object> obj = templ->NewInstance(context).ToLocalChecked();
   return obj;
 }
 

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -83,7 +83,7 @@ namespace node {
 // list.
 #define NODE_BINDING_PER_ISOLATE_INIT(modname, per_isolate_func)               \
   void _register_isolate_##modname(node::IsolateData* isolate_data,            \
-                                   v8::Local<v8::FunctionTemplate> target) {   \
+                                   v8::Local<v8::ObjectTemplate> target) {     \
     per_isolate_func(isolate_data, target);                                    \
   }
 

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -109,9 +109,8 @@ void BlobFromFilePath(const FunctionCallbackInfo<Value>& args) {
 }  // namespace
 
 void Blob::CreatePerIsolateProperties(IsolateData* isolate_data,
-                                      Local<FunctionTemplate> ctor) {
+                                      Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> target = ctor->InstanceTemplate();
 
   SetMethod(isolate, target, "createBlob", New);
   SetMethod(isolate, target, "storeDataObject", StoreDataObject);

--- a/src/node_blob.h
+++ b/src/node_blob.h
@@ -27,7 +27,7 @@ class Blob : public BaseObject {
       ExternalReferenceRegistry* registry);
 
   static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                         v8::Local<v8::FunctionTemplate> ctor);
+                                         v8::Local<v8::ObjectTemplate> target);
   static void CreatePerContextProperties(v8::Local<v8::Object> target,
                                          v8::Local<v8::Value> unused,
                                          v8::Local<v8::Context> context,

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -15,7 +15,6 @@ using v8::DEFAULT;
 using v8::EscapableHandleScope;
 using v8::Function;
 using v8::FunctionCallbackInfo;
-using v8::FunctionTemplate;
 using v8::IntegrityLevel;
 using v8::Isolate;
 using v8::Local;
@@ -663,38 +662,37 @@ void BuiltinLoader::CopySourceAndCodeCacheReferenceFrom(
 }
 
 void BuiltinLoader::CreatePerIsolateProperties(IsolateData* isolate_data,
-                                               Local<FunctionTemplate> target) {
+                                               Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> proto = target->PrototypeTemplate();
 
-  proto->SetAccessor(isolate_data->config_string(),
-                     ConfigStringGetter,
-                     nullptr,
-                     Local<Value>(),
-                     DEFAULT,
-                     None,
-                     SideEffectType::kHasNoSideEffect);
+  target->SetAccessor(isolate_data->config_string(),
+                      ConfigStringGetter,
+                      nullptr,
+                      Local<Value>(),
+                      DEFAULT,
+                      None,
+                      SideEffectType::kHasNoSideEffect);
 
-  proto->SetAccessor(FIXED_ONE_BYTE_STRING(isolate, "builtinIds"),
-                     BuiltinIdsGetter,
-                     nullptr,
-                     Local<Value>(),
-                     DEFAULT,
-                     None,
-                     SideEffectType::kHasNoSideEffect);
+  target->SetAccessor(FIXED_ONE_BYTE_STRING(isolate, "builtinIds"),
+                      BuiltinIdsGetter,
+                      nullptr,
+                      Local<Value>(),
+                      DEFAULT,
+                      None,
+                      SideEffectType::kHasNoSideEffect);
 
-  proto->SetAccessor(FIXED_ONE_BYTE_STRING(isolate, "builtinCategories"),
-                     GetBuiltinCategories,
-                     nullptr,
-                     Local<Value>(),
-                     DEFAULT,
-                     None,
-                     SideEffectType::kHasNoSideEffect);
+  target->SetAccessor(FIXED_ONE_BYTE_STRING(isolate, "builtinCategories"),
+                      GetBuiltinCategories,
+                      nullptr,
+                      Local<Value>(),
+                      DEFAULT,
+                      None,
+                      SideEffectType::kHasNoSideEffect);
 
-  SetMethod(isolate, proto, "getCacheUsage", BuiltinLoader::GetCacheUsage);
-  SetMethod(isolate, proto, "compileFunction", BuiltinLoader::CompileFunction);
-  SetMethod(isolate, proto, "hasCachedBuiltins", HasCachedBuiltins);
-  SetMethod(isolate, proto, "setInternalLoaders", SetInternalLoaders);
+  SetMethod(isolate, target, "getCacheUsage", BuiltinLoader::GetCacheUsage);
+  SetMethod(isolate, target, "compileFunction", BuiltinLoader::CompileFunction);
+  SetMethod(isolate, target, "hasCachedBuiltins", HasCachedBuiltins);
+  SetMethod(isolate, target, "setInternalLoaders", SetInternalLoaders);
 }
 
 void BuiltinLoader::CreatePerContextProperties(Local<Object> target,

--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -84,8 +84,8 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
   BuiltinLoader& operator=(const BuiltinLoader&) = delete;
 
   static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
-  static void CreatePerIsolateProperties(
-      IsolateData* isolate_data, v8::Local<v8::FunctionTemplate> target);
+  static void CreatePerIsolateProperties(IsolateData* isolate_data,
+                                         v8::Local<v8::ObjectTemplate> target);
   static void CreatePerContextProperties(v8::Local<v8::Object> target,
                                          v8::Local<v8::Value> unused,
                                          v8::Local<v8::Context> context,

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1393,9 +1393,9 @@ void MicrotaskQueueWrap::RegisterExternalReferences(
 }
 
 void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                Local<FunctionTemplate> ctor) {
+                                Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> target = ctor->InstanceTemplate();
+
   ContextifyContext::CreatePerIsolateProperties(isolate_data, target);
   ContextifyScript::CreatePerIsolateProperties(isolate_data, target);
   MicrotaskQueueWrap::CreatePerIsolateProperties(isolate_data, target);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2827,9 +2827,8 @@ InternalFieldInfoBase* BindingData::Serialize(int index) {
 }
 
 static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                       Local<FunctionTemplate> ctor) {
+                                       Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> target = ctor->InstanceTemplate();
 
   SetMethod(isolate, target, "access", Access);
   SetMethod(isolate, target, "close", Close);
@@ -2873,7 +2872,7 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
 
   SetMethod(isolate, target, "mkdtemp", Mkdtemp);
 
-  StatWatcher::CreatePerIsolateProperties(isolate_data, ctor);
+  StatWatcher::CreatePerIsolateProperties(isolate_data, target);
 
   target->Set(
       FIXED_ONE_BYTE_STRING(isolate, "kFsStatsFieldsNumber"),

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -860,17 +860,16 @@ static void GetStringWidth(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                       Local<FunctionTemplate> target) {
+                                       Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> proto = target->PrototypeTemplate();
 
-  SetMethod(isolate, proto, "toUnicode", ToUnicode);
-  SetMethod(isolate, proto, "toASCII", ToASCII);
-  SetMethod(isolate, proto, "getStringWidth", GetStringWidth);
+  SetMethod(isolate, target, "toUnicode", ToUnicode);
+  SetMethod(isolate, target, "toASCII", ToASCII);
+  SetMethod(isolate, target, "getStringWidth", GetStringWidth);
 
   // One-shot converters
-  SetMethod(isolate, proto, "icuErrName", ICUErrorName);
-  SetMethod(isolate, proto, "transcode", Transcode);
+  SetMethod(isolate, target, "icuErrName", ICUErrorName);
+  SetMethod(isolate, target, "transcode", Transcode);
 
   // ConverterObject
   {
@@ -883,9 +882,9 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
     isolate_data->set_i18n_converter_template(t->InstanceTemplate());
   }
 
-  SetMethod(isolate, proto, "getConverter", ConverterObject::Create);
-  SetMethod(isolate, proto, "decode", ConverterObject::Decode);
-  SetMethod(isolate, proto, "hasConverter", ConverterObject::Has);
+  SetMethod(isolate, target, "getConverter", ConverterObject::Create);
+  SetMethod(isolate, target, "decode", ConverterObject::Decode);
+  SetMethod(isolate, target, "hasConverter", ConverterObject::Has);
 }
 
 void CreatePerContextProperties(Local<Object> target,

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -18,7 +18,6 @@ using v8::Context;
 using v8::DontDelete;
 using v8::Function;
 using v8::FunctionCallbackInfo;
-using v8::FunctionTemplate;
 using v8::GCCallbackFlags;
 using v8::GCType;
 using v8::Int32;
@@ -296,28 +295,27 @@ void MarkBootstrapComplete(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                       Local<FunctionTemplate> target) {
+                                       Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> proto = target->PrototypeTemplate();
 
-  HistogramBase::Initialize(isolate_data, proto);
+  HistogramBase::Initialize(isolate_data, target);
 
-  SetMethod(isolate, proto, "markMilestone", MarkMilestone);
-  SetMethod(isolate, proto, "setupObservers", SetupPerformanceObservers);
+  SetMethod(isolate, target, "markMilestone", MarkMilestone);
+  SetMethod(isolate, target, "setupObservers", SetupPerformanceObservers);
   SetMethod(isolate,
-            proto,
+            target,
             "installGarbageCollectionTracking",
             InstallGarbageCollectionTracking);
   SetMethod(isolate,
-            proto,
+            target,
             "removeGarbageCollectionTracking",
             RemoveGarbageCollectionTracking);
-  SetMethod(isolate, proto, "notify", Notify);
-  SetMethod(isolate, proto, "loopIdleTime", LoopIdleTime);
-  SetMethod(isolate, proto, "getTimeOrigin", GetTimeOrigin);
-  SetMethod(isolate, proto, "getTimeOriginTimestamp", GetTimeOriginTimeStamp);
-  SetMethod(isolate, proto, "createELDHistogram", CreateELDHistogram);
-  SetMethod(isolate, proto, "markBootstrapComplete", MarkBootstrapComplete);
+  SetMethod(isolate, target, "notify", Notify);
+  SetMethod(isolate, target, "loopIdleTime", LoopIdleTime);
+  SetMethod(isolate, target, "getTimeOrigin", GetTimeOrigin);
+  SetMethod(isolate, target, "getTimeOriginTimestamp", GetTimeOriginTimeStamp);
+  SetMethod(isolate, target, "createELDHistogram", CreateELDHistogram);
+  SetMethod(isolate, target, "markBootstrapComplete", MarkBootstrapComplete);
 }
 
 void CreatePerContextProperties(Local<Object> target,

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -41,7 +41,6 @@ using v8::CFunction;
 using v8::Context;
 using v8::Float64Array;
 using v8::FunctionCallbackInfo;
-using v8::FunctionTemplate;
 using v8::HeapStatistics;
 using v8::Integer;
 using v8::Isolate;
@@ -572,9 +571,8 @@ void BindingData::Deserialize(Local<Context> context,
 }
 
 static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                       Local<FunctionTemplate> ctor) {
+                                       Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> target = ctor->InstanceTemplate();
 
   BindingData::AddMethods(isolate, target);
   // define various internal methods

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -45,9 +45,8 @@ using v8::Uint32;
 using v8::Value;
 
 void StatWatcher::CreatePerIsolateProperties(IsolateData* isolate_data,
-                                             Local<FunctionTemplate> ctor) {
+                                             Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> target = ctor->InstanceTemplate();
 
   Local<FunctionTemplate> t = NewFunctionTemplate(isolate, StatWatcher::New);
   t->InstanceTemplate()->SetInternalFieldCount(

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -40,7 +40,7 @@ class ExternalReferenceRegistry;
 class StatWatcher : public HandleWrap {
  public:
   static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                         v8::Local<v8::FunctionTemplate> ctor);
+                                         v8::Local<v8::ObjectTemplate> ctor);
   static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
 
  protected:

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -19,7 +19,6 @@ using v8::CFunction;
 using v8::Context;
 using v8::FastOneByteString;
 using v8::FunctionCallbackInfo;
-using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
@@ -318,9 +317,8 @@ void BindingData::UpdateComponents(const ada::url_components& components,
 }
 
 void BindingData::CreatePerIsolateProperties(IsolateData* isolate_data,
-                                             Local<FunctionTemplate> ctor) {
+                                             Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> target = ctor->InstanceTemplate();
   SetMethodNoSideEffect(isolate, target, "domainToASCII", DomainToASCII);
   SetMethodNoSideEffect(isolate, target, "domainToUnicode", DomainToUnicode);
   SetMethodNoSideEffect(isolate, target, "format", Format);

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -57,7 +57,7 @@ class BindingData : public SnapshotableObject {
   static void Update(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                         v8::Local<v8::FunctionTemplate> ctor);
+                                         v8::Local<v8::ObjectTemplate> ctor);
   static void CreatePerContextProperties(v8::Local<v8::Object> target,
                                          v8::Local<v8::Value> unused,
                                          v8::Local<v8::Context> context,

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -900,9 +900,8 @@ void GetEnvMessagePort(const FunctionCallbackInfo<Value>& args) {
 }
 
 void CreateWorkerPerIsolateProperties(IsolateData* isolate_data,
-                                      Local<FunctionTemplate> target) {
+                                      Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> proto = target->PrototypeTemplate();
 
   {
     Local<FunctionTemplate> w = NewFunctionTemplate(isolate, Worker::New);
@@ -921,7 +920,7 @@ void CreateWorkerPerIsolateProperties(IsolateData* isolate_data,
     SetProtoMethod(isolate, w, "loopIdleTime", Worker::LoopIdleTime);
     SetProtoMethod(isolate, w, "loopStartTime", Worker::LoopStartTime);
 
-    SetConstructorFunction(isolate, proto, "Worker", w);
+    SetConstructorFunction(isolate, target, "Worker", w);
   }
 
   {
@@ -938,7 +937,7 @@ void CreateWorkerPerIsolateProperties(IsolateData* isolate_data,
         wst->InstanceTemplate());
   }
 
-  SetMethod(isolate, proto, "getEnvMessagePort", GetEnvMessagePort);
+  SetMethod(isolate, target, "getEnvMessagePort", GetEnvMessagePort);
 }
 
 void CreateWorkerPerContextProperties(Local<Object> target,

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -12,7 +12,6 @@ namespace timers {
 using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
-using v8::FunctionTemplate;
 using v8::Isolate;
 using v8::Local;
 using v8::Number;
@@ -123,9 +122,8 @@ v8::CFunction BindingData::fast_toggle_immediate_ref_(
     v8::CFunction::Make(FastToggleImmediateRef));
 
 void BindingData::CreatePerIsolateProperties(IsolateData* isolate_data,
-                                             Local<FunctionTemplate> ctor) {
+                                             Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  Local<ObjectTemplate> target = ctor->InstanceTemplate();
 
   SetMethod(isolate, target, "setupTimers", SetupTimers);
   SetFastMethod(

--- a/src/timers.h
+++ b/src/timers.h
@@ -46,7 +46,7 @@ class BindingData : public SnapshotableObject {
   static void ToggleImmediateRefImpl(BindingData* data, bool ref);
 
   static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                         v8::Local<v8::FunctionTemplate> ctor);
+                                         v8::Local<v8::ObjectTemplate> target);
   static void CreatePerContextProperties(v8::Local<v8::Object> target,
                                          v8::Local<v8::Value> unused,
                                          v8::Local<v8::Context> context,


### PR DESCRIPTION
This patch makes the binding templates ObjectTemplates, since we don't actually need the constructor function. This also avoids setting the properties on prototype, and instead initializes them directly on the object template.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
