### PR TITLE
url: call `ada::can_parse` directly

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -125,32 +125,25 @@ void BindingData::CanParse(const FunctionCallbackInfo<Value>& args) {
 
   Environment* env = Environment::GetCurrent(args);
   HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
 
   Utf8Value input(env->isolate(), args[0]);
-  ada::result<ada::url_aggregator> base;
-  ada::url_aggregator* base_pointer = nullptr;
-  if (args[1]->IsString()) {
-    base = ada::parse<ada::url_aggregator>(
-        Utf8Value(env->isolate(), args[1]).ToString());
-    if (!base) {
-      return args.GetReturnValue().Set(false);
-    }
-    base_pointer = &base.value();
-  }
-  auto out =
-      ada::parse<ada::url_aggregator>(input.ToStringView(), base_pointer);
+  std::string_view input_view = input.ToStringView();
 
-  args.GetReturnValue().Set(out.has_value());
+  bool can_parse{};
+  if (args[1]->IsString()) {
+    Utf8Value base(env->isolate(), args[1]);
+    std::string_view base_view = base.ToStringView();
+    can_parse = ada::can_parse(input_view, &base_view);
+  } else {
+    can_parse = ada::can_parse(input_view);
+  }
+
+  args.GetReturnValue().Set(can_parse);
 }
 
 bool BindingData::FastCanParse(Local<Value> receiver,
                                const FastOneByteString& input) {
-  std::string_view input_view(input.data, input.length);
-
-  auto output = ada::parse<ada::url_aggregator>(input_view);
-
-  return output.has_value();
+  return ada::can_parse(std::string_view(input.data, input.length));
 }
 
 CFunction BindingData::fast_can_parse_(CFunction::Make(FastCanParse));


### PR DESCRIPTION
We're planning on improving the performance of `ada::can_parse` and added this function in `2.3.1` release. This would make things a lot easier and more readable for Node.js.

cc @KhafraDev @nodejs/url