### PR TITLE
dns: call `ada::idna::to_ascii` directly from c++

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -28,7 +28,6 @@ const {
 } = primordials;
 
 const cares = internalBinding('cares_wrap');
-const { toASCII } = require('internal/idna');
 const { isIP } = require('internal/net');
 const { customPromisifyArgs } = require('internal/util');
 const errors = require('internal/errors');
@@ -220,7 +219,7 @@ function lookup(hostname, options, callback) {
   req.oncomplete = all ? onlookupall : onlookup;
 
   const err = cares.getaddrinfo(
-    req, toASCII(hostname), family, hints, verbatim,
+    req, hostname, family, hints, verbatim,
   );
   if (err) {
     process.nextTick(callback, dnsException(err, 'getaddrinfo', hostname));

--- a/lib/internal/dns/callback_resolver.js
+++ b/lib/internal/dns/callback_resolver.js
@@ -7,8 +7,6 @@ const {
   Symbol,
 } = primordials;
 
-const { toASCII } = require('internal/idna');
-
 const {
   codes: {
     ERR_INVALID_ARG_TYPE,
@@ -70,7 +68,7 @@ function resolver(bindingName) {
     req.hostname = name;
     req.oncomplete = onresolve;
     req.ttl = !!(options && options.ttl);
-    const err = this._handle[bindingName](req, toASCII(name));
+    const err = this._handle[bindingName](req, name);
     if (err) throw dnsException(err, bindingName, name);
     if (hasObserver('dns')) {
       startPerf(req, kPerfHooksDnsLookupResolveContext, {

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -46,7 +46,6 @@ const {
   CANCELLED,
 } = dnsErrorCodes;
 const { codes, dnsException } = require('internal/errors');
-const { toASCII } = require('internal/idna');
 const { isIP } = require('internal/net');
 const {
   getaddrinfo,
@@ -138,7 +137,7 @@ function createLookupPromise(family, hostname, all, hints, verbatim) {
     req.resolve = resolve;
     req.reject = reject;
 
-    const err = getaddrinfo(req, toASCII(hostname), family, hints, verbatim);
+    const err = getaddrinfo(req, hostname, family, hints, verbatim);
 
     if (err) {
       reject(dnsException(err, 'getaddrinfo', hostname));
@@ -274,7 +273,7 @@ function createResolverPromise(resolver, bindingName, hostname, ttl) {
     req.reject = reject;
     req.ttl = ttl;
 
-    const err = resolver._handle[bindingName](req, toASCII(hostname));
+    const err = resolver._handle[bindingName](req, hostname);
 
     if (err)
       reject(dnsException(err, bindingName, hostname));


### PR DESCRIPTION
Reduces the C++/JS bridge crosses by calling `toASCII` directly from C++.

Fixes: https://github.com/nodejs/performance/issues/77

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1335/