### PR TITLE
worker: support more cases when (de)serializing errors

### DIFF
--- a/lib/internal/error_serdes.js
+++ b/lib/internal/error_serdes.js
@@ -18,11 +18,15 @@ const {
   RangeError,
   ReferenceError,
   SafeSet,
+  StringFromCharCode,
   StringPrototypeSubstring,
   SymbolToStringTag,
   SyntaxError,
   SymbolFor,
   TypeError,
+  TypedArrayPrototypeGetBuffer,
+  TypedArrayPrototypeGetByteOffset,
+  TypedArrayPrototypeGetByteLength,
   URIError,
 } = primordials;
 const { inspect: { custom: customInspectSymbol } } = require('util');
@@ -50,6 +54,7 @@ function TryGetAllProperties(object, target = object) {
   ArrayPrototypeForEach(keys, (key) => {
     let descriptor;
     try {
+      // TODO: create a null-prototype descriptor with needed properties only
       descriptor = ObjectGetOwnPropertyDescriptor(object, key);
     } catch { return; }
     const getter = descriptor.get;
@@ -108,8 +113,7 @@ let serialize;
 function serializeError(error) {
   if (!serialize) serialize = require('v8').serialize;
   if (typeof error === 'symbol') {
-    return Buffer.concat([Buffer.from([kInspectedSymbol]),
-                          Buffer.from(inspect(error), 'utf8')]);
+    return Buffer.from(StringFromCharCode(kInspectedSymbol) + inspect(error), 'utf8');
   }
   try {
     if (typeof error === 'object' &&
@@ -132,8 +136,7 @@ function serializeError(error) {
   try {
     if (error != null &&
       ObjectPrototypeHasOwnProperty(error, customInspectSymbol)) {
-      return Buffer.concat([Buffer.from([kCustomInspectedObject]),
-                            Buffer.from(inspect(error), 'utf8')]);
+      return Buffer.from(StringFromCharCode(kCustomInspectedObject) + inspect(error), 'utf8');
     }
   } catch {
     // Continue regardless of error.
@@ -144,14 +147,13 @@ function serializeError(error) {
   } catch {
     // Continue regardless of error.
   }
-  return Buffer.concat([Buffer.from([kInspectedError]),
-                        Buffer.from(inspect(error), 'utf8')]);
+  return Buffer.from(StringFromCharCode(kInspectedError) + inspect(error), 'utf8');
 }
 
 function fromBuffer(error) {
-  return Buffer.from(error.buffer,
-                     error.byteOffset + 1,
-                     error.byteLength - 1);
+  return Buffer.from(TypedArrayPrototypeGetBuffer(error),
+                     TypedArrayPrototypeGetByteOffset(error) + 1,
+                     TypedArrayPrototypeGetByteLength(error) - 1);
 }
 
 let deserialize;

--- a/lib/internal/error_serdes.js
+++ b/lib/internal/error_serdes.js
@@ -56,19 +56,17 @@ function TryGetAllProperties(object, target = object) {
     if (getter && key !== '__proto__') {
       try {
         descriptor.value = FunctionPrototypeCall(getter, target);
+        delete descriptor.get;
+        delete descriptor.set;
       } catch {
         // Continue regardless of error.
       }
     }
     if (key === 'cause') {
-      delete descriptor.get;
-      delete descriptor.set;
       descriptor.value = serializeError(descriptor.value);
       all[key] = descriptor;
     } else if ('value' in descriptor &&
             typeof descriptor.value !== 'function' && typeof descriptor.value !== 'symbol') {
-      delete descriptor.get;
-      delete descriptor.set;
       all[key] = descriptor;
     }
   });

--- a/lib/internal/error_serdes.js
+++ b/lib/internal/error_serdes.js
@@ -13,19 +13,27 @@ const {
   ObjectGetOwnPropertyNames,
   ObjectGetPrototypeOf,
   ObjectKeys,
+  ObjectPrototypeHasOwnProperty,
   ObjectPrototypeToString,
   RangeError,
   ReferenceError,
   SafeSet,
+  StringPrototypeSubstring,
   SymbolToStringTag,
   SyntaxError,
+  SymbolFor,
   TypeError,
   URIError,
 } = primordials;
+const { inspect: { custom: customInspectSymbol } } = require('util');
 
 const kSerializedError = 0;
 const kSerializedObject = 1;
 const kInspectedError = 2;
+const kInspectedSymbol = 3;
+const kCustomInspectedObject = 4;
+
+const kSymbolStringLength = 'Symbol('.length;
 
 const errors = {
   Error, TypeError, RangeError, URIError, SyntaxError, ReferenceError, EvalError,
@@ -52,7 +60,13 @@ function TryGetAllProperties(object, target = object) {
         // Continue regardless of error.
       }
     }
-    if ('value' in descriptor && typeof descriptor.value !== 'function') {
+    if (key === 'cause') {
+      delete descriptor.get;
+      delete descriptor.set;
+      descriptor.value = serializeError(descriptor.value);
+      all[key] = descriptor;
+    } else if ('value' in descriptor &&
+            typeof descriptor.value !== 'function' && typeof descriptor.value !== 'symbol') {
       delete descriptor.get;
       delete descriptor.set;
       all[key] = descriptor;
@@ -95,6 +109,10 @@ function inspect(...args) {
 let serialize;
 function serializeError(error) {
   if (!serialize) serialize = require('v8').serialize;
+  if (typeof error === 'symbol') {
+    return Buffer.concat([Buffer.from([kInspectedSymbol]),
+                          Buffer.from(inspect(error), 'utf8')]);
+  }
   try {
     if (typeof error === 'object' &&
         ObjectPrototypeToString(error) === '[object Error]') {
@@ -114,6 +132,15 @@ function serializeError(error) {
     // Continue regardless of error.
   }
   try {
+    if (error != null &&
+      ObjectPrototypeHasOwnProperty(error, customInspectSymbol)) {
+      return Buffer.concat([Buffer.from([kCustomInspectedObject]),
+                            Buffer.from(inspect(error), 'utf8')]);
+    }
+  } catch {
+    // Continue regardless of error.
+  }
+  try {
     const serialized = serialize(error);
     return Buffer.concat([Buffer.from([kSerializedObject]), serialized]);
   } catch {
@@ -121,6 +148,12 @@ function serializeError(error) {
   }
   return Buffer.concat([Buffer.from([kInspectedError]),
                         Buffer.from(inspect(error), 'utf8')]);
+}
+
+function fromBuffer(error) {
+  return Buffer.from(error.buffer,
+                     error.byteOffset + 1,
+                     error.byteLength - 1);
 }
 
 let deserialize;
@@ -132,19 +165,27 @@ function deserializeError(error) {
       const ctor = errors[constructor];
       ObjectDefineProperty(properties, SymbolToStringTag, {
         __proto__: null,
-        value: { value: 'Error', configurable: true },
+        value: { __proto__: null, value: 'Error', configurable: true },
         enumerable: true,
       });
+      if ('cause' in properties && 'value' in properties.cause) {
+        properties.cause.value = deserializeError(properties.cause.value);
+      }
       return ObjectCreate(ctor.prototype, properties);
     }
     case kSerializedObject:
       return deserialize(error.subarray(1));
-    case kInspectedError: {
-      const buf = Buffer.from(error.buffer,
-                              error.byteOffset + 1,
-                              error.byteLength - 1);
-      return buf.toString('utf8');
+    case kInspectedError:
+      return fromBuffer(error).toString('utf8');
+    case kInspectedSymbol: {
+      const buf = fromBuffer(error);
+      return SymbolFor(StringPrototypeSubstring(buf.toString('utf8'), kSymbolStringLength, buf.length - 1));
     }
+    case kCustomInspectedObject:
+      return {
+        __proto__: null,
+        [customInspectSymbol]: () => fromBuffer(error).toString('utf8'),
+      };
   }
   require('assert').fail('This should not happen');
 }

--- a/test/parallel/test-error-serdes.js
+++ b/test/parallel/test-error-serdes.js
@@ -53,6 +53,7 @@ assert.strictEqual(cycle(new Error('Error with cause', { cause: -1 })).cause, -1
 assert.strictEqual(cycle(new Error('Error with cause', { cause: 1.4 })).cause, 1.4);
 assert.strictEqual(cycle(new Error('Error with cause', { cause: null })).cause, null);
 assert.strictEqual(cycle(new Error('Error with cause', { cause: undefined })).cause, undefined);
+assert.strictEqual(Object.hasOwn(cycle(new Error('Error with cause', { cause: undefined })), 'cause'), true);
 assert.strictEqual(cycle(new Error('Error with cause', { cause: 'foo' })).cause, 'foo');
 assert.deepStrictEqual(cycle(new Error('Error with cause', { cause: new Error('err') })).cause, new Error('err'));
 class ErrorWithCause extends Error {
@@ -61,7 +62,13 @@ class ErrorWithCause extends Error {
   }
 }
 assert.deepStrictEqual(cycle(new ErrorWithCause('Error with cause')).cause, new Error('err'));
-
+class ErrorWithThowingCause extends Error {
+  get cause() {
+    throw new Error('err');
+  }
+}
+assert.strictEqual(cycle(new ErrorWithThowingCause('Error with cause')).cause, undefined);
+assert.strictEqual(Object.hasOwn(cycle(new ErrorWithThowingCause('Error with cause')), 'cause'), false);
 
 {
   const err = new ERR_INVALID_ARG_TYPE('object', 'Object', 42);

--- a/test/parallel/test-error-serdes.js
+++ b/test/parallel/test-error-serdes.js
@@ -55,6 +55,12 @@ assert.strictEqual(cycle(new Error('Error with cause', { cause: null })).cause, 
 assert.strictEqual(cycle(new Error('Error with cause', { cause: undefined })).cause, undefined);
 assert.strictEqual(cycle(new Error('Error with cause', { cause: 'foo' })).cause, 'foo');
 assert.deepStrictEqual(cycle(new Error('Error with cause', { cause: new Error('err') })).cause, new Error('err'));
+class ErrorWithCause extends Error {
+  get cause() {
+    return new Error('err');
+  }
+}
+assert.deepStrictEqual(cycle(new ErrorWithCause('Error with cause')).cause, new Error('err'));
 
 
 {


### PR DESCRIPTION
extracted from https://github.com/nodejs/node/pull/47867: 
the motivation of this change is for the test runner (which runs across multiple processes) to communicate with the main process via v8 serialization instead of TAP - so we want to better serialize a wider range of (edge?) cases