### PR TITLE
test_runner: fix ordering of test hooks

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -477,7 +477,6 @@ class Test extends AsyncResource {
       this.parent.addPendingSubtest(deferred);
       return deferred.promise;
     }
-
     return this.run();
   }
 
@@ -525,11 +524,7 @@ class Test extends AsyncResource {
     }
 
     const { args, ctx } = this.getRunArgs();
-    const after = runOnce(async () => {
-      if (this.hooks.after.length > 0) {
-        await this.runHook('after', { args, ctx });
-      }
-    });
+
     const afterEach = runOnce(async () => {
       if (this.parent?.hooks.afterEach.length > 0) {
         await this.parent.runHook('afterEach', { args, ctx });
@@ -537,11 +532,11 @@ class Test extends AsyncResource {
     });
 
     try {
-      if (this.parent?.hooks.beforeEach.length > 0) {
-        await this.parent.runHook('beforeEach', { args, ctx });
-      }
       if (this.parent?.hooks.before.length > 0) {
         await this.parent.runHook('before', this.parent.getRunArgs());
+      }
+      if (this.parent?.hooks.beforeEach.length > 0) {
+        await this.parent.runHook('beforeEach', { args, ctx });
       }
       const stopPromise = stopTest(this.timeout, this.signal);
       const runArgs = ArrayPrototypeSlice(args);
@@ -574,11 +569,17 @@ class Test extends AsyncResource {
         return;
       }
 
-      await after();
       await afterEach();
+      if (this.hooks.after.length > 0) {
+        await this.runHook('after', this.getRunArgs());
+      }
       this.pass();
     } catch (err) {
-      try { await after(); } catch { /* Ignore error. */ }
+      try {
+        if (this.hooks.after.length > 0) {
+          await this.runHook('after', this.getRunArgs());
+        }
+      } catch { /* Ignore error. */ }
       try { await afterEach(); } catch { /* test is already failing, let's ignore the error */ }
       if (isTestFailureError(err)) {
         if (err.failureType === kTestTimeoutFailure) {

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -477,6 +477,7 @@ class Test extends AsyncResource {
       this.parent.addPendingSubtest(deferred);
       return deferred.promise;
     }
+
     return this.run();
   }
 
@@ -524,15 +525,14 @@ class Test extends AsyncResource {
     }
 
     const { args, ctx } = this.getRunArgs();
-
-    const afterEach = runOnce(async () => {
-      if (this.parent?.hooks.afterEach.length > 0) {
-        await this.parent.runHook('afterEach', { args, ctx });
-      }
-    });
     const after = runOnce(async () => {
       if (this.hooks.after.length > 0) {
         await this.runHook('after', { args, ctx });
+      }
+    });
+    const afterEach = runOnce(async () => {
+      if (this.parent?.hooks.afterEach.length > 0) {
+        await this.parent.runHook('afterEach', { args, ctx });
       }
     });
 

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -530,6 +530,11 @@ class Test extends AsyncResource {
         await this.parent.runHook('afterEach', { args, ctx });
       }
     });
+    const after = runOnce(async () => {
+      if (this.hooks.after.length > 0) {
+        await this.runHook('after', { args, ctx });
+      }
+    });
 
     try {
       if (this.parent?.hooks.before.length > 0) {
@@ -570,16 +575,10 @@ class Test extends AsyncResource {
       }
 
       await afterEach();
-      if (this.hooks.after.length > 0) {
-        await this.runHook('after', this.getRunArgs());
-      }
+      await after();
       this.pass();
     } catch (err) {
-      try {
-        if (this.hooks.after.length > 0) {
-          await this.runHook('after', this.getRunArgs());
-        }
-      } catch { /* Ignore error. */ }
+      try { await after(); } catch { /* Ignore error. */ }
       try { await afterEach(); } catch { /* test is already failing, let's ignore the error */ }
       if (isTestFailureError(err)) {
         if (err.failureType === kTestTimeoutFailure) {

--- a/test/fixtures/test-runner/output/hooks.js
+++ b/test/fixtures/test-runner/output/hooks.js
@@ -99,6 +99,8 @@ test('test hooks', async (t) => {
   await t.test('2', () => testArr.push('2'));
 
   await t.test('nested', async (t) => {
+    t.before((t) => testArr.push('nested before ' + t.name));
+    t.after((t) => testArr.push('nested after ' + t.name));
     t.beforeEach((t) => testArr.push('nested beforeEach ' + t.name));
     t.afterEach((t) => testArr.push('nested afterEach ' + t.name));
     await t.test('nested 1', () => testArr.push('nested1'));
@@ -106,12 +108,15 @@ test('test hooks', async (t) => {
   });
 
   assert.deepStrictEqual(testArr, [
-    'beforeEach 1', 'before test hooks', '1', 'afterEach 1',
+    'before test hooks',
+    'beforeEach 1', '1', 'afterEach 1',
     'beforeEach 2', '2', 'afterEach 2',
     'beforeEach nested',
+    'nested before nested',
     'beforeEach nested 1', 'nested beforeEach nested 1', 'nested1', 'afterEach nested 1', 'nested afterEach nested 1',
     'beforeEach nested 2', 'nested beforeEach nested 2', 'nested 2', 'afterEach nested 2', 'nested afterEach nested 2',
     'afterEach nested',
+    'nested after nested',
   ]);
 });
 


### PR DESCRIPTION
For tests with subtests the before hook was being run after the beforeEach hook, which is the opposite to test suites and expectations.

Also, a function was being used to close over the after hooks, but at the point it was being run the after hooks were not yet set up.

Fixes #47915

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
