### PR TITLE
vm: fix crash when setting __proto__ on context's globalThis

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -529,11 +529,13 @@ void ContextifyContext::PropertySetterCallback(
 
   if (ctx->sandbox()->Set(context, property, value).IsNothing()) return;
 
-  Local<Value> desc;
-  if (is_declared_on_sandbox &&
-      ctx->sandbox()
-          ->GetOwnPropertyDescriptor(context, property)
-          .ToLocal(&desc)) {
+  if (is_declared_on_sandbox) {
+    Local<Value> desc;
+    bool success = ctx->sandbox()
+                       ->GetOwnPropertyDescriptor(context, property)
+                       .ToLocal(&desc);
+    if (!success || desc->IsUndefined()) return;
+
     Environment* env = Environment::GetCurrent(context);
     Local<Object> desc_obj = desc.As<Object>();
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -529,13 +529,12 @@ void ContextifyContext::PropertySetterCallback(
 
   if (ctx->sandbox()->Set(context, property, value).IsNothing()) return;
 
-  if (is_declared_on_sandbox) {
-    Local<Value> desc;
-    bool success = ctx->sandbox()
-                       ->GetOwnPropertyDescriptor(context, property)
-                       .ToLocal(&desc);
-    if (!success || desc->IsUndefined()) return;
-
+  Local<Value> desc;
+  if (is_declared_on_sandbox &&
+      ctx->sandbox()
+          ->GetOwnPropertyDescriptor(context, property)
+          .ToLocal(&desc) &&
+      !desc->IsUndefined()) {
     Environment* env = Environment::GetCurrent(context);
     Local<Object> desc_obj = desc.As<Object>();
 

--- a/test/parallel/test-vm-set-proto-null-on-globalthis.js
+++ b/test/parallel/test-vm-set-proto-null-on-globalthis.js
@@ -1,0 +1,13 @@
+'use strict';
+require('../common');
+
+// Setting __proto__ on vm context's globalThis should not causes a crash
+// Regression test for https://github.com/nodejs/node/issues/47798
+
+const vm = require('vm');
+const context = vm.createContext();
+
+const contextGlobalThis = vm.runInContext('this', context);
+
+// Should not crash.
+contextGlobalThis.__proto__ = null; // eslint-disable-line no-proto

--- a/test/parallel/test-vm-set-proto-null-on-globalthis.js
+++ b/test/parallel/test-vm-set-proto-null-on-globalthis.js
@@ -1,7 +1,7 @@
 'use strict';
 require('../common');
 
-// Setting __proto__ on vm context's globalThis should not causes a crash
+// Setting __proto__ on vm context's globalThis should not cause a crash
 // Regression test for https://github.com/nodejs/node/issues/47798
 
 const vm = require('vm');


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Add `IsUndefined()` check after `GetOwnPropertyDescriptor` to avoid crash when `desc_obj->HasOwnProperty()`

fix https://github.com/nodejs/node/issues/47798
