### PR TITLE
test: unskip negative-settimeout.any.js WPT

### DIFF
--- a/test/wpt/status/html/webappapis/timers.json
+++ b/test/wpt/status/html/webappapis/timers.json
@@ -1,5 +1,1 @@
-{
-  "negative-settimeout.any.js": {
-    "skip": "unreliable in Node.js; Refs: https://github.com/nodejs/node/issues/37672"
-  }
-}
+{}


### PR DESCRIPTION
#47834 resolved the concurrency issues of wpt/test-timers so I believe this skip is no longer needed.