### PR TITLE
fix: callback with error if SyncWriteStream writeSync failed

### DIFF
--- a/lib/internal/fs/sync_write_stream.js
+++ b/lib/internal/fs/sync_write_stream.js
@@ -23,9 +23,13 @@ ObjectSetPrototypeOf(SyncWriteStream.prototype, Writable.prototype);
 ObjectSetPrototypeOf(SyncWriteStream, Writable);
 
 SyncWriteStream.prototype._write = function(chunk, encoding, cb) {
-  writeSync(this.fd, chunk, 0, chunk.length);
+  try {
+    writeSync(this.fd, chunk, 0, chunk.length);
+  } catch (e) {
+    cb(e);
+    return;
+  }
   cb();
-  return true;
 };
 
 SyncWriteStream.prototype._destroy = function(err, cb) {

--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -74,3 +74,15 @@ const filename = path.join(tmpdir.path, 'sync-write-stream.txt');
     assert.strictEqual(stream.fd, null);
   }));
 }
+
+// Verify that an error on _write() triggers an 'error' event.
+{
+  const fd = fs.openSync(filename, 'w');
+  const stream = new SyncWriteStream(fd);
+
+  assert.strictEqual(stream.fd, fd);
+  stream._write({}, null, common.mustCall((err) => {
+    assert(err);
+    fs.closeSync(fd);
+  }));
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/47948

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
