### PR TITLE
doc: unnest `mime` and `MIMEParams` from MIMEType constructor

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1080,7 +1080,7 @@ console.log(String(myMIME));
 // Prints: text/plain
 ```
 
-#### `mime.type`
+### `mime.type`
 
 * {string}
 
@@ -1112,7 +1112,7 @@ console.log(String(myMIME));
 // Prints: application/javascript
 ```
 
-#### `mime.subtype`
+### `mime.subtype`
 
 * {string}
 
@@ -1144,7 +1144,7 @@ console.log(String(myMIME));
 // Prints: text/javascript
 ```
 
-#### `mime.essence`
+### `mime.essence`
 
 * {string}
 
@@ -1177,7 +1177,7 @@ console.log(String(myMIME));
 // Prints: application/javascript;key=value
 ```
 
-#### `mime.params`
+### `mime.params`
 
 * {MIMEParams}
 
@@ -1185,7 +1185,7 @@ Gets the [`MIMEParams`][] object representing the
 parameters of the MIME. This property is read-only. See
 [`MIMEParams`][] documentation for details.
 
-#### `mime.toString()`
+### `mime.toString()`
 
 * Returns: {string}
 
@@ -1194,7 +1194,7 @@ The `toString()` method on the `MIMEType` object returns the serialized MIME.
 Because of the need for standard compliance, this method does not allow users
 to customize the serialization process of the MIME.
 
-#### `mime.toJSON()`
+### `mime.toJSON()`
 
 * Returns: {string}
 
@@ -1225,7 +1225,7 @@ console.log(JSON.stringify(myMIMES));
 // Prints: ["image/png", "image/gif"]
 ```
 
-### Class: `util.MIMEParams`
+## Class: `util.MIMEParams`
 
 <!-- YAML
 added:
@@ -1236,7 +1236,7 @@ added:
 The `MIMEParams` API provides read and write access to the parameters of a
 `MIMEType`.
 
-#### Constructor: `new MIMEParams()`
+### Constructor: `new MIMEParams()`
 
 Creates a new `MIMEParams` object by with empty parameters
 
@@ -1252,13 +1252,13 @@ const { MIMEParams } = require('node:util');
 const myParams = new MIMEParams();
 ```
 
-#### `mimeParams.delete(name)`
+### `mimeParams.delete(name)`
 
 * `name` {string}
 
 Remove all name-value pairs whose name is `name`.
 
-#### `mimeParams.entries()`
+### `mimeParams.entries()`
 
 * Returns: {Iterator}
 
@@ -1266,7 +1266,7 @@ Returns an iterator over each of the name-value pairs in the parameters.
 Each item of the iterator is a JavaScript `Array`. The first item of the array
 is the `name`, the second item of the array is the `value`.
 
-#### `mimeParams.get(name)`
+### `mimeParams.get(name)`
 
 * `name` {string}
 * Returns: {string} or `null` if there is no name-value pair with the given
@@ -1275,14 +1275,14 @@ is the `name`, the second item of the array is the `value`.
 Returns the value of the first name-value pair whose name is `name`. If there
 are no such pairs, `null` is returned.
 
-#### `mimeParams.has(name)`
+### `mimeParams.has(name)`
 
 * `name` {string}
 * Returns: {boolean}
 
 Returns `true` if there is at least one name-value pair whose name is `name`.
 
-#### `mimeParams.keys()`
+### `mimeParams.keys()`
 
 * Returns: {Iterator}
 
@@ -1312,7 +1312,7 @@ for (const name of params.keys()) {
 //   bar
 ```
 
-#### `mimeParams.set(name, value)`
+### `mimeParams.set(name, value)`
 
 * `name` {string}
 * `value` {string}
@@ -1341,13 +1341,13 @@ console.log(params.toString());
 // Prints: foo=def&bar=1&baz=xyz
 ```
 
-#### `mimeParams.values()`
+### `mimeParams.values()`
 
 * Returns: {Iterator}
 
 Returns an iterator over the values of each name-value pair.
 
-#### `mimeParams[@@iterator]()`
+### `mimeParams[@@iterator]()`
 
 * Returns: {Iterator}
 


### PR DESCRIPTION
This change is needed for the correct processing `json` files generated from doc.