### PR TITLE
fs: change default mode to COPYFILE_FICLONE

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -924,7 +924,7 @@ changes:
   operation. It is possible to create a mask consisting of the bitwise OR of
   two or more values (e.g.
   `fs.constants.COPYFILE_EXCL | fs.constants.COPYFILE_FICLONE`)
-  **Default:** `0`.
+  **Default:** `fs.constants.COPYFILE_FICLONE`.
   * `fs.constants.COPYFILE_EXCL`: The copy operation will fail if `dest`
     already exists.
   * `fs.constants.COPYFILE_FICLONE`: The copy operation will attempt to create
@@ -5187,7 +5187,7 @@ changes:
 
 * `src` {string|Buffer|URL} source filename to copy
 * `dest` {string|Buffer|URL} destination filename of the copy operation
-* `mode` {integer} modifiers for copy operation. **Default:** `0`.
+* `mode` {integer} modifiers for copy operation. **Default:** `fs.constants.COPYFILE_FICLONE`.
 
 Synchronously copies `src` to `dest`. By default, `dest` is overwritten if it
 already exists. Returns `undefined`. Node.js makes no guarantees about the

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -92,6 +92,7 @@ const {
 } = require('internal/util');
 const {
   constants: {
+    kDefaultCopyMode,
     kIoMaxLength,
     kMaxUserId,
   },
@@ -2942,7 +2943,7 @@ function mkdtempSync(prefix, options) {
 function copyFile(src, dest, mode, callback) {
   if (typeof mode === 'function') {
     callback = mode;
-    mode = 0;
+    mode = kDefaultCopyMode;
   }
 
   src = getValidatedPath(src, 'src');

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -112,16 +112,11 @@ const {
 const kMinimumAccessMode = MathMin(F_OK, W_OK, R_OK, X_OK);
 const kMaximumAccessMode = F_OK | W_OK | R_OK | X_OK;
 
-const kDefaultCopyMode = 0;
+const kDefaultCopyMode = COPYFILE_FICLONE;
 // The copy modes can be any of COPYFILE_EXCL, COPYFILE_FICLONE or
 // COPYFILE_FICLONE_FORCE. They can be used in combination as well
 // (COPYFILE_EXCL | COPYFILE_FICLONE | COPYFILE_FICLONE_FORCE).
-const kMinimumCopyMode = MathMin(
-  kDefaultCopyMode,
-  COPYFILE_EXCL,
-  COPYFILE_FICLONE,
-  COPYFILE_FICLONE_FORCE,
-);
+const kMinimumCopyMode = 0;
 const kMaximumCopyMode = COPYFILE_EXCL |
                          COPYFILE_FICLONE |
                          COPYFILE_FICLONE_FORCE;
@@ -927,6 +922,7 @@ const validatePosition = hideStackFrames((position, name) => {
 
 module.exports = {
   constants: {
+    kDefaultCopyMode,
     kIoMaxLength,
     kMaxUserId,
     kReadFileBufferLength,

--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -6,6 +6,7 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
 const { internalBinding } = require('internal/test/binding');
+const { getValidMode } = require('internal/fs/utils');
 const {
   UV_ENOENT,
   UV_EEXIST
@@ -60,6 +61,9 @@ verify(src, dest);
 fs.unlinkSync(dest);
 fs.copyFileSync(src, dest, UV_FS_COPYFILE_FICLONE);
 verify(src, dest);
+
+// Verify that default mode is COPYFILE_FICLONE.
+assert.strictEqual(getValidMode(null, 'copyFile'), COPYFILE_FICLONE);
 
 // Verify that COPYFILE_FICLONE_FORCE can be used.
 try {


### PR DESCRIPTION
Change default value of mode to `COPYFILE_FICLONE` in
`fs.copyFile` and `fs.copyFileSync`.

If copy-on-write is not supported, fallback copy mechanism
will be used.

Fixes: https://github.com/nodejs/node/issues/47861

I am aware that the discussion is still very nascent. If we are not going to do this or if we are going in different direction, feel free to close this PR.

TODO:
- Update commit message

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
