### PR TITLE
stream: dont emit error on operator finish

### DIFF
--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -219,6 +219,7 @@ function asIndexedPairs(options = undefined) {
 
 async function some(fn, options = undefined) {
   for await (const unused of filter.call(this, fn, options)) {
+    this.destroy(null);
     return true;
   }
   return false;
@@ -237,6 +238,7 @@ async function every(fn, options = undefined) {
 
 async function find(fn, options) {
   for await (const result of filter.call(this, fn, options)) {
+    this.destroy(null);
     return result;
   }
   return undefined;
@@ -413,6 +415,7 @@ function take(number, options = undefined) {
 
       // Don't get another item from iterator in case we reached the end
       if (number <= 0) {
+        this.destroy(null);
         return;
       }
     }

--- a/test/parallel/test-stream-drop-take.js
+++ b/test/parallel/test-stream-drop-take.js
@@ -5,6 +5,7 @@ const {
   Readable,
 } = require('stream');
 const { deepStrictEqual, rejects, throws, strictEqual } = require('assert');
+const {it} = require("node:test");
 
 const { from } = Readable;
 
@@ -47,6 +48,18 @@ const naturals = () => from(async function*() {
     deepStrictEqual(await naturals().drop(10).take(10).toArray(), next10);
     deepStrictEqual(await naturals().take(5).take(1).toArray(), [1]);
   })().then(common.mustCall());
+}
+
+{
+  // Don't emit error on take finish
+  (async () => {
+    const originalStream = from([1, 2, 3, 4, 5]);
+
+    originalStream.on('error', common.mustNotCall())
+
+    const firstItem = await originalStream.take(1).toArray();
+    deepStrictEqual(firstItem, [1]);
+  })().then(common.mustCall())
 }
 
 

--- a/test/parallel/test-stream-some-find-every.mjs
+++ b/test/parallel/test-stream-some-find-every.mjs
@@ -116,6 +116,40 @@ function oneTo5Async() {
 }
 
 {
+  // Don't emit error on find finish
+  (async () => {
+    const originalStream = Readable.from([1, 2, 3, 4, 5]);
+
+    originalStream.on('error', common.mustNotCall())
+
+    const firstItem = await originalStream.find(() => true);
+    assert.strictEqual(firstItem, 1);
+  })().then(common.mustCall())
+}
+{
+  // Don't emit error on some finish
+  (async () => {
+    const originalStream = Readable.from([1, 2, 3, 4, 5]);
+
+    originalStream.on('error', common.mustNotCall())
+
+    const result = await originalStream.some(() => true);
+    assert.strictEqual(result, true);
+  })().then(common.mustCall())
+}
+{
+  // Don't emit error on some finish
+  (async () => {
+    const originalStream = Readable.from([1, 2, 3, 4, 5]);
+
+    originalStream.on('error', common.mustNotCall())
+
+    const result = await originalStream.every(() => false);
+    assert.strictEqual(result, false);
+  })().then(common.mustCall())
+}
+
+{
   // Support for AbortSignal
   for (const op of ['some', 'every', 'find']) {
     {


### PR DESCRIPTION
currently when finding some data, the error event emit because we use the async iterator and on return before the stream actually completed it destroys with AbortError