### PR TITLE
esm: protect against removal of `"beforeExit"` event handler

### DIFF
--- a/lib/internal/modules/esm/worker.js
+++ b/lib/internal/modules/esm/worker.js
@@ -125,7 +125,7 @@ async function customizedModuleWorker(lock, syncCommPort, errorHandler) {
 
   const unsettledResponsePorts = new SafeSet();
 
-  process.on('beforeExit', () => {
+  function beforeExitHandler() {
     for (const port of unsettledResponsePorts) {
       port.postMessage(wrapMessage('never-settle'));
     }
@@ -143,6 +143,12 @@ async function customizedModuleWorker(lock, syncCommPort, errorHandler) {
     clearImmediate(immediate);
     // Add some work for next tick so the worker cannot exit.
     setImmediate(() => {});
+  }
+  process.on('beforeExit', beforeExitHandler);
+  process.on('removeListener', function removeListenerHandler(type, fn) {
+    if (type === 'beforeExit' && fn === beforeExitHandler) {
+      process.on('beforeExit', beforeExitHandler);
+    }
   });
 
   async function handleMessage({ method, args, port }) {

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -68,6 +68,22 @@ describe('Loader hooks', { concurrency: true }, () => {
       assert.strictEqual(signal, null);
     });
 
+    it('top-level await of a race of never-settling hooks with loader removing core event handlers', async () => {
+      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+        '--no-warnings',
+        '--experimental-loader',
+        'data:text/javascript,setInterval(()=>process.removeAllListeners("beforeExit"),1).unref()',
+        '--experimental-loader',
+        fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+        fixtures.path('es-module-loaders/never-settling-resolve-step/race.mjs'),
+      ]);
+
+      assert.strictEqual(stderr, '');
+      assert.match(stdout, /^true\r?\n$/);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(signal, null);
+    });
+
     it('import.meta.resolve of a never-settling resolve', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
         '--no-warnings',
@@ -117,6 +133,22 @@ describe('Loader hooks', { concurrency: true }, () => {
     it('race of never-settling hooks', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
         '--no-warnings',
+        '--experimental-loader',
+        fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
+        fixtures.path('es-module-loaders/never-settling-resolve-step/race.cjs'),
+      ]);
+
+      assert.strictEqual(stderr, '');
+      assert.match(stdout, /^true\r?\n$/);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(signal, null);
+    });
+
+    it('race of never-settling hooks with loader removing listeners', async () => {
+      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+        '--no-warnings',
+        '--experimental-loader',
+        'data:text/javascript,setInterval(()=>process.removeAllListeners("beforeExit"),1).unref()',
         '--experimental-loader',
         fixtures.fileURL('es-module-loaders/never-settling-resolve-step/loader.mjs'),
         fixtures.path('es-module-loaders/never-settling-resolve-step/race.cjs'),

--- a/test/fixtures/es-module-loaders/never-settling-resolve-step/race.mjs
+++ b/test/fixtures/es-module-loaders/never-settling-resolve-step/race.mjs
@@ -4,4 +4,6 @@ const result = await Promise.race([
     import('node:process'),
 ]);
 
+await import('data:text/javascript,');
+
 console.log(result.default === process);


### PR DESCRIPTION
tbh I'm not sure if that's a good idea, it's still quite brittle because hooks authors could still remove the `removeListener` listener (e.g. by calling `process.removeAllListeners())`, and at some point there's no way around it – or at least, I didn't find a way. I'm opening this in case someone has a better solution they'd want to share.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
