### PR TITLE
http: sendfile

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -88,6 +88,7 @@ const {
   validateObject,
 } = require('internal/validators');
 const Buffer = require('buffer').Buffer;
+const { pipeline } = require('stream');
 const { setInterval, clearInterval } = require('timers');
 let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
   debug = fn;
@@ -224,6 +225,30 @@ function ServerResponse(req) {
 }
 ObjectSetPrototypeOf(ServerResponse.prototype, OutgoingMessage.prototype);
 ObjectSetPrototypeOf(ServerResponse, OutgoingMessage);
+
+ServerResponse.prototype.sendFile = function(file, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
+  validateObject(options, 'options');
+  validateCallback(callback, 'callback');
+
+  const { start, end, highWaterMark } = options;
+
+  let path
+  let fd
+
+  if (file instanceof FileHandle || Number.isInteger(file)) {
+    fd = file
+  } else {
+    path = file
+  }
+
+  // TODO (perf): Optimize this...
+  pipeline(fs.createReadStream(path, { fd, start, end, highWaterMark }), callback);
+};
 
 ServerResponse.prototype._finish = function _finish() {
   if (this[kServerResponseStatistics] && hasObserver('http')) {


### PR DESCRIPTION
Sending files is a common usage of the http api's. We could make a specialised path for this that is more optimised, e.g. we could totally skip all streams boilerplate and directly read buffers through the fs api and write to the response. Further steps could be to move the whole thing into native land. The recent ioring optimisation in libuv also adds some interesting possibilities.

This currently only contains a stub as a suggestion for anyone that wants to pick it up.