### PR TITLE
crypto: fix setEngine() when OPENSSL_NO_ENGINE set

### DIFF
--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -44,6 +44,7 @@ const normalizeHashName = require('internal/crypto/hashnames');
 const {
   hideStackFrames,
   codes: {
+    ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED,
     ERR_CRYPTO_ENGINE_UNKNOWN,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
@@ -105,6 +106,8 @@ function setEngine(id, flags) {
   if (flags === 0)
     flags = ENGINE_METHOD_ALL;
 
+  if (typeof _setEngine !== 'function')
+    throw new ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED();
   if (!_setEngine(id, flags))
     throw new ERR_CRYPTO_ENGINE_UNKNOWN(id);
 }


### PR DESCRIPTION
When OpenSSL is configured with `OPENSSL_NO_ENGINE`, `setEngine()` currently throws an internal error because the C++ binding does not export the relevant function, which causes `_setEngine()` to be undefined within JS.

Instead, match the behavior of `tls/secure-context.js` and throw the existing error code `ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED` when OpenSSL has been configured with `OPENSSL_NO_ENGINE`.

For reference:

https://github.com/nodejs/node/blob/7984af69a090dd6d1f60ffe7e194d5e69bce0c20/lib/internal/tls/secure-context.js#L202-L205

https://github.com/nodejs/node/blob/7984af69a090dd6d1f60ffe7e194d5e69bce0c20/lib/internal/tls/secure-context.js#L285-L288

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
