### PR TITLE
doc: add missing deprecated blocks to cluster

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -850,6 +850,8 @@ added: v0.8.1
 deprecated: v16.0.0
 -->
 
+> Stability: 0 - Deprecated
+
 Deprecated alias for [`cluster.isPrimary`][].
 
 ## `cluster.isPrimary`
@@ -958,6 +960,8 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/7838
     description: The `stdio` option is supported now.
 -->
+
+> Stability: 0 - Deprecated
 
 Deprecated alias for [`.setupPrimary()`][].
 


### PR DESCRIPTION
I believe that these are required so that the respective APIs are marked as deprecated in the table of contents.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
