### PR TITLE
buffer: add SIMD Neon optimization for `byteLength`

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -121,6 +121,7 @@
       'src/node_report_utils.cc',
       'src/node_sea.cc',
       'src/node_serdes.cc',
+      'src/node_simd.cc',
       'src/node_shadow_realm.cc',
       'src/node_snapshotable.cc',
       'src/node_sockaddr.cc',

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -26,6 +26,7 @@
 #include "node_external_reference.h"
 #include "node_i18n.h"
 #include "node_internals.h"
+#include "node_simd.h"
 
 #include "env-inl.h"
 #include "simdutf.h"
@@ -743,14 +744,8 @@ void SlowByteLengthUtf8(const FunctionCallbackInfo<Value>& args) {
 
 uint32_t FastByteLengthUtf8(Local<Value> receiver,
                             const v8::FastOneByteString& source) {
-  uint32_t result = 0;
-  uint32_t length = source.length;
-  const uint8_t* data = reinterpret_cast<const uint8_t*>(source.data);
-  for (uint32_t i = 0; i < length; ++i) {
-    result += (data[i] >> 7);
-  }
-  result += length;
-  return result;
+  return node::simd::utf8_byte_length(
+      reinterpret_cast<const uint8_t*>(source.data), source.length);
 }
 
 static v8::CFunction fast_byte_length_utf8(

--- a/src/node_simd.cc
+++ b/src/node_simd.cc
@@ -1,0 +1,60 @@
+#include "node_simd.h"
+
+#include <string_view>
+
+#if NODE_HAS_SIMD_NEON
+#include <arm_neon.h>
+#endif
+
+namespace node {
+namespace simd {
+
+#if NODE_HAS_SIMD_NEON
+uint32_t utf8_byte_length(const uint8_t* data, size_t length) {
+  uint64_t result{0};
+
+  const int lanes = sizeof(uint8x16_t);
+  const int max_sra_count = 256 / lanes;  // Avoid overflowing vaddvq_u8.
+  const int unrolls = max_sra_count;
+  const int unrolled_lanes = lanes * unrolls;
+
+  const uint8_t* unroll_end = data + (length / unrolled_lanes) * unrolled_lanes;
+  uint32_t length_after_unroll = length % unrolled_lanes;
+  for (; data < unroll_end;) {
+    uint8x16_t acc = {};
+    for (int i = 0; i < unrolls; ++i, data += lanes) {
+      uint8x16_t chunk = vld1q_u8(data);
+      acc = vsraq_n_u8(acc, chunk, 7);
+    }
+    result += vaddvq_u8(acc);
+  }
+
+  const uint8_t* simd_end = data + (length_after_unroll / lanes) * lanes;
+  uint32_t length_after_simd = length % lanes;
+  uint8x16_t acc = {};
+  for (; data < simd_end; data += lanes) {
+    uint8x16_t chunk = vld1q_u8(data);
+    acc = vsraq_n_u8(acc, chunk, 7);
+  }
+  result += vaddvq_u8(acc);
+
+  const uint8_t* scalar_end = data + length_after_simd;
+  for (; data < scalar_end; data += 1) {
+    result += *data >> 7;
+  }
+
+  return result + length;
+}
+#else
+uint32_t utf8_byte_length(const uint8_t* data, size_t length) {
+  uint32_t result = 0;
+  for (uint32_t i = 0; i < length; ++i) {
+    result += (data[i] >> 7);
+  }
+  result += length;
+  return result;
+}
+#endif
+
+}  // namespace simd
+}  // namespace node

--- a/src/node_simd.h
+++ b/src/node_simd.h
@@ -1,0 +1,22 @@
+#ifndef SRC_NODE_SIMD_H_
+#define SRC_NODE_SIMD_H_
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#define NODE_HAS_SIMD_NEON 1
+#endif
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include <string_view>
+
+namespace node {
+namespace simd {
+
+uint32_t utf8_byte_length(const uint8_t* input, size_t length);
+
+}  // namespace simd
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_NODE_SIMD_H_


### PR DESCRIPTION
Ref https://github.com/nodejs/performance/issues/52

Since, benchmark CI does not have ARM processor, here's the benchmark results from my local:

```
node benchmark/compare.js --old ./node-main --new ./out/Release/node --filter buffer-bytelength buffers > bytelength.csv && node-benchmark-compare bytelength.csv
[00:18:29|% 100| 2/2 files | 60/60 runs | 32/32 configs]: Done
                                                                                               confidence improvement accuracy (*)   (**)  (***)
buffers/buffer-bytelength-buffer.js n=4000000 len=16                                                          0.39 %       ±0.77% ±1.03% ±1.35%
buffers/buffer-bytelength-buffer.js n=4000000 len=2                                                          -0.02 %       ±0.45% ±0.60% ±0.78%
buffers/buffer-bytelength-buffer.js n=4000000 len=256                                                         1.97 %       ±3.41% ±4.60% ±6.10%
buffers/buffer-bytelength-string.js n=1000000 repeat=1 encoding='base64' type='four_bytes'                    1.71 %       ±3.63% ±4.84% ±6.31%
buffers/buffer-bytelength-string.js n=1000000 repeat=1 encoding='base64' type='one_byte'                      0.03 %       ±0.68% ±0.90% ±1.17%
buffers/buffer-bytelength-string.js n=1000000 repeat=1 encoding='base64' type='three_bytes'                   2.16 %       ±2.97% ±3.98% ±5.24%
buffers/buffer-bytelength-string.js n=1000000 repeat=1 encoding='base64' type='two_bytes'                    -1.08 %       ±2.05% ±2.76% ±3.65%
buffers/buffer-bytelength-string.js n=1000000 repeat=1 encoding='utf8' type='four_bytes'                     -0.13 %       ±0.96% ±1.28% ±1.67%
buffers/buffer-bytelength-string.js n=1000000 repeat=1 encoding='utf8' type='one_byte'               ***      4.59 %       ±0.77% ±1.02% ±1.33%
buffers/buffer-bytelength-string.js n=1000000 repeat=1 encoding='utf8' type='three_bytes'                     0.21 %       ±0.61% ±0.82% ±1.07%
buffers/buffer-bytelength-string.js n=1000000 repeat=1 encoding='utf8' type='two_bytes'                      -0.30 %       ±0.43% ±0.57% ±0.74%
buffers/buffer-bytelength-string.js n=1000000 repeat=16 encoding='base64' type='four_bytes'                  -0.68 %       ±3.18% ±4.24% ±5.53%
buffers/buffer-bytelength-string.js n=1000000 repeat=16 encoding='base64' type='one_byte'                     0.65 %       ±2.05% ±2.75% ±3.61%
buffers/buffer-bytelength-string.js n=1000000 repeat=16 encoding='base64' type='three_bytes'                 -0.89 %       ±1.98% ±2.66% ±3.51%
buffers/buffer-bytelength-string.js n=1000000 repeat=16 encoding='base64' type='two_bytes'                    0.10 %       ±1.44% ±1.92% ±2.50%
buffers/buffer-bytelength-string.js n=1000000 repeat=16 encoding='utf8' type='four_bytes'                    -1.39 %       ±2.75% ±3.70% ±4.91%
buffers/buffer-bytelength-string.js n=1000000 repeat=16 encoding='utf8' type='one_byte'                      -0.97 %       ±1.35% ±1.82% ±2.40%
buffers/buffer-bytelength-string.js n=1000000 repeat=16 encoding='utf8' type='three_bytes'                    0.94 %       ±1.67% ±2.25% ±2.98%
buffers/buffer-bytelength-string.js n=1000000 repeat=16 encoding='utf8' type='two_bytes'                      0.19 %       ±0.47% ±0.63% ±0.83%
buffers/buffer-bytelength-string.js n=1000000 repeat=2 encoding='base64' type='four_bytes'                   -1.67 %       ±2.60% ±3.50% ±4.63%
buffers/buffer-bytelength-string.js n=1000000 repeat=2 encoding='base64' type='one_byte'                      0.77 %       ±1.95% ±2.63% ±3.48%
buffers/buffer-bytelength-string.js n=1000000 repeat=2 encoding='base64' type='three_bytes'                   2.70 %       ±3.23% ±4.34% ±5.73%
buffers/buffer-bytelength-string.js n=1000000 repeat=2 encoding='base64' type='two_bytes'                     0.02 %       ±1.06% ±1.41% ±1.83%
buffers/buffer-bytelength-string.js n=1000000 repeat=2 encoding='utf8' type='four_bytes'                      0.24 %       ±0.61% ±0.81% ±1.06%
buffers/buffer-bytelength-string.js n=1000000 repeat=2 encoding='utf8' type='one_byte'                        0.04 %       ±2.03% ±2.70% ±3.53%
buffers/buffer-bytelength-string.js n=1000000 repeat=2 encoding='utf8' type='three_bytes'                     1.33 %       ±2.73% ±3.67% ±4.87%
buffers/buffer-bytelength-string.js n=1000000 repeat=2 encoding='utf8' type='two_bytes'                       0.10 %       ±0.40% ±0.53% ±0.69%
buffers/buffer-bytelength-string.js n=1000000 repeat=256 encoding='base64' type='four_bytes'                 -0.16 %       ±3.65% ±4.85% ±6.32%
buffers/buffer-bytelength-string.js n=1000000 repeat=256 encoding='base64' type='one_byte'                    0.47 %       ±2.66% ±3.54% ±4.60%
buffers/buffer-bytelength-string.js n=1000000 repeat=256 encoding='base64' type='three_bytes'                -0.51 %       ±0.78% ±1.04% ±1.37%
buffers/buffer-bytelength-string.js n=1000000 repeat=256 encoding='base64' type='two_bytes'                  -1.66 %       ±2.60% ±3.49% ±4.62%
buffers/buffer-bytelength-string.js n=1000000 repeat=256 encoding='utf8' type='four_bytes'                   -0.42 %       ±0.54% ±0.72% ±0.94%
buffers/buffer-bytelength-string.js n=1000000 repeat=256 encoding='utf8' type='one_byte'                     -0.07 %       ±0.32% ±0.43% ±0.56%
buffers/buffer-bytelength-string.js n=1000000 repeat=256 encoding='utf8' type='three_bytes'                  -0.49 %       ±0.69% ±0.93% ±1.21%
buffers/buffer-bytelength-string.js n=1000000 repeat=256 encoding='utf8' type='two_bytes'              *     -0.53 %       ±0.49% ±0.65% ±0.85%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 35 comparisons, you can thus expect the following amount of false-positive results:
  1.75 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.35 false positives, when considering a   1% risk acceptance (**, ***),
  0.04 false positives, when considering a 0.1% risk acceptance (***)
```