### PR TITLE
test: fix parsing test flags

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -82,7 +82,6 @@ function parseTestFlags(filename = process.argv[1]) {
   }
   return source
     .substring(flagStart, flagEnd)
-    .replace(/_/g, '-')
     .split(/\s+/)
     .filter(Boolean);
 }
@@ -98,9 +97,8 @@ if (process.argv.length === 2 &&
     require('cluster').isPrimary &&
     fs.existsSync(process.argv[1])) {
   const flags = parseTestFlags();
-  const args = process.execArgv.map((arg) => arg.replace(/_/g, '-'));
   for (const flag of flags) {
-    if (!args.includes(flag) &&
+    if (!process.execArgv.includes(flag) &&
         // If the binary is build without `intl` the inspect option is
         // invalid. The test itself should handle this case.
         (process.features.inspector || !flag.startsWith('--inspect'))) {


### PR DESCRIPTION
This does not replace `_` with `-` when parsing flags.

I believe that it was added for a certain purpose, but it doesn't seem to be needed anymore. Currently, the cli options are not passed as intended in the following cases:

```js
// Flags: --diagnostic-dir=~/PATH_HAS_UNDERSCORES
```
```console
NOTE: The test started as a child_process using these flags: [ 
  '--diagnostic-dir=~/PATH-HAS-UNDERSCORES' <--
]
```

```js
// Flags: --experimental-permission --allow-fs-read=~/PATH_HAS_UNDERSCORES
```

```console
The test started as a child_process using these flags: [
  '--experimental-permission',
  '--allow-fs-read=~/PATH-HAS-UNDERSCORES'  <--
] 
```
Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
