### PR TITLE
buffer: use size_t instead of uint32_t to avoid segmentation fault

### DIFF
--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -633,7 +633,6 @@ size_t StringBytes::hex_encode(
   CHECK(dlen >= slen * 2 &&
       "not enough space provided for hex encode");
 
-
   dlen = slen * 2;
   for (size_t i = 0, k = 0; k < dlen; i += 1, k += 2) {
     static const char hex[] = "0123456789abcdef";

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -628,7 +628,7 @@ size_t StringBytes::hex_encode(
     size_t dlen) {
   // We know how much we'll write, just make sure that there's space.
   CHECK(dlen >= MultiplyWithOverflowCheck<size_t>(slen, 2u) &&
-      "not enough space provided for hex encode");
+        "not enough space provided for hex encode");
 
   dlen = slen * 2;
   for (size_t i = 0, k = 0; k < dlen; i += 1, k += 2) {

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -626,9 +626,13 @@ size_t StringBytes::hex_encode(
     size_t slen,
     char* dst,
     size_t dlen) {
+
+  CHECK(slen * 2 >= slen && "overflow in hex encode");
+
   // We know how much we'll write, just make sure that there's space.
   CHECK(dlen >= slen * 2 &&
       "not enough space provided for hex encode");
+
 
   dlen = slen * 2;
   for (size_t i = 0, k = 0; k < dlen; i += 1, k += 2) {

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -626,10 +626,8 @@ size_t StringBytes::hex_encode(
     size_t slen,
     char* dst,
     size_t dlen) {
-  CHECK(slen * 2 >= slen && "overflow in hex encode");
-
   // We know how much we'll write, just make sure that there's space.
-  CHECK(dlen >= slen * 2 &&
+  CHECK(dlen >= MultiplyWithOverflowCheck<size_t>(slen, 2u) &&
       "not enough space provided for hex encode");
 
   dlen = slen * 2;

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -631,7 +631,7 @@ size_t StringBytes::hex_encode(
       "not enough space provided for hex encode");
 
   dlen = slen * 2;
-  for (uint32_t i = 0, k = 0; k < dlen; i += 1, k += 2) {
+  for (size_t i = 0, k = 0; k < dlen; i += 1, k += 2) {
     static const char hex[] = "0123456789abcdef";
     uint8_t val = static_cast<uint8_t>(src[i]);
     dst[k + 0] = hex[val >> 4];

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -626,7 +626,6 @@ size_t StringBytes::hex_encode(
     size_t slen,
     char* dst,
     size_t dlen) {
-
   CHECK(slen * 2 >= slen && "overflow in hex encode");
 
   // We know how much we'll write, just make sure that there's space.


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/46836

If tests are needed for this, I'll need some guidance about how to do it as I don't know how to test if something produce a segfault or not.