### PR TITLE
test_runner: delegate stderr and stdout formatting to reporter

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1521,6 +1521,24 @@ Emitted when all subtests have completed for a given test.
 
 Emitted when a test starts.
 
+### Event: `'test:stderr'`
+
+* `data` {Object}
+  * `file` {string} The path of the test file.
+  * `message` {string} The message written to `stderr`.
+
+Emitted when a running test writes to `stderr`.
+This event is only emitted if `--test` flag is passed.
+
+### Event: `'test:stdout'`
+
+* `data` {Object}
+  * `file` {string} The path of the test file.
+  * `message` {string} The message written to `stdout`.
+
+Emitted when a running test writes to `stdout`.
+This event is only emitted if `--test` flag is passed.
+
 ## Class: `TestContext`
 
 <!-- YAML

--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -117,6 +117,9 @@ class SpecReporter extends Transform {
       case 'test:start':
         ArrayPrototypeUnshift(this.#stack, { __proto__: null, data, type });
         break;
+      case 'test:stderr':
+      case 'test:stdout':
+        return `${data.message}\n`;
       case 'test:diagnostic':
         return `${colors[type]}${this.#indent(data.nesting)}${symbols[type]}${data.message}${white}\n`;
       case 'test:coverage':

--- a/lib/internal/test_runner/reporter/tap.js
+++ b/lib/internal/test_runner/reporter/tap.js
@@ -45,6 +45,8 @@ async function * tapReporter(source) {
       case 'test:start':
         yield `${indent(data.nesting)}# Subtest: ${tapEscape(data.name)}\n`;
         break;
+      case 'test:stderr':
+      case 'test:stdout':
       case 'test:diagnostic':
         yield `${indent(data.nesting)}# ${tapEscape(data.message)}\n`;
         break;

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -285,8 +285,8 @@ class FileTest extends Test {
         const message = messages[i];
         this.addToReport({
           __proto__: null,
-          type: 'test:diagnostic',
-          data: { __proto__: null, nesting: 0, file: this.name, message },
+          type: 'test:stdout',
+          data: { __proto__: null, file: this.name, message },
         });
       }
     }
@@ -357,13 +357,12 @@ function runTestFile(path, root, inspectPort, filesWatcher, testNamePatterns) {
       }
 
       // stderr cannot be treated as TAP, per the spec. However, we want to
-      // surface stderr lines as TAP diagnostics to improve the DX. Inject
-      // each line into the test output as an unknown token as if it came
-      // from the TAP parser.
+      // surface stderr lines to improve the DX. Inject each line into the
+      // test output as an unknown token as if it came from the TAP parser.
       subtest.addToReport({
         __proto__: null,
-        type: 'test:diagnostic',
-        data: { __proto__: null, nesting: 0, file: path, message: line },
+        type: 'test:stderr',
+        data: { __proto__: null, file: path, message: line },
       });
     });
 

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -57,6 +57,14 @@ class TestsStream extends Readable {
     this[kEmitMessage]('test:diagnostic', { __proto__: null, nesting, file, message });
   }
 
+  stderr(file, message) {
+    this[kEmitMessage]('test:stderr', { __proto__: null, file, message });
+  }
+
+  stdout(file, message) {
+    this[kEmitMessage]('test:stdout', { __proto__: null, file, message });
+  }
+
   coverage(nesting, file, summary) {
     this[kEmitMessage]('test:coverage', { __proto__: null, nesting, file, summary });
   }


### PR DESCRIPTION
Introduce new `TestsStream` events `test:stderr` and `test:stdout`
to delegate `stderr` and `stdout` (e.g. `console.log()`) formatting
to the reporter. And patch existing reporters to:
- Spec: output the message as it is
- TAP: stay the same with existing `test:diagnostic`

Fixes: https://github.com/nodejs/node/issues/48011

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
