### PR TITLE
test: handle EUNATCH

### DIFF
--- a/test/parallel/test-net-autoselectfamily-commandline-option.js
+++ b/test/parallel/test-net-autoselectfamily-commandline-option.js
@@ -87,9 +87,8 @@ function createDnsServer(ipv6Addr, ipv4Addr, cb) {
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
         } else if (error.code === 'EAFNOSUPPORT') {
           assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
-        } else {
-          assert.strictEqual(error.code, 'EADDRNOTAVAIL');
-          assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);
+        } else if (error.code === 'EADDRNOTAVAIL' || error.code === 'EUNATCH') {
+          assert.strictEqual(error.message, `connect ${error.code} ::1:${port} - Local (:::0)`);
         }
 
         ipv4Server.close();

--- a/test/parallel/test-net-autoselectfamily-commandline-option.js
+++ b/test/parallel/test-net-autoselectfamily-commandline-option.js
@@ -87,8 +87,11 @@ function createDnsServer(ipv6Addr, ipv4Addr, cb) {
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
         } else if (error.code === 'EAFNOSUPPORT') {
           assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
-        } else if (error.code === 'EADDRNOTAVAIL' || error.code === 'EUNATCH') {
-          assert.strictEqual(error.message, `connect ${error.code} ::1:${port} - Local (:::0)`);
+        } else if (error.code === 'EUNATCH') {
+          assert.strictEqual(error.message, `connect EUNATCH ::1:${port} - Local (:::0)`);
+        } else {
+          assert.strictEqual(error.code, 'EADDRNOTAVAIL');
+          assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);
         }
 
         ipv4Server.close();

--- a/test/parallel/test-net-autoselectfamily-default.js
+++ b/test/parallel/test-net-autoselectfamily-default.js
@@ -125,13 +125,8 @@ function createDnsServer(ipv6Addr, ipv4Addr, cb) {
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
         } else if (error.code === 'EAFNOSUPPORT') {
           assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
-        } else if (common.isIBMi) {
-          // IBMi returns EUNATCH (ERRNO 42) when IPv6 is disabled
-          // keep this errno assertion until EUNATCH is recognized by libuv
-          assert.strictEqual(error.errno, -42);
-        } else {
-          assert.strictEqual(error.code, 'EADDRNOTAVAIL');
-          assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);
+        } else if (error.code === 'EADDRNOTAVAIL' || error.code === 'EUNATCH') {
+          assert.strictEqual(error.message, `connect ${error.code} ::1:${port} - Local (:::0)`);
         }
 
         ipv4Server.close();

--- a/test/parallel/test-net-autoselectfamily-default.js
+++ b/test/parallel/test-net-autoselectfamily-default.js
@@ -125,8 +125,11 @@ function createDnsServer(ipv6Addr, ipv4Addr, cb) {
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
         } else if (error.code === 'EAFNOSUPPORT') {
           assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
-        } else if (error.code === 'EADDRNOTAVAIL' || error.code === 'EUNATCH') {
-          assert.strictEqual(error.message, `connect ${error.code} ::1:${port} - Local (:::0)`);
+        } else if (error.code === 'EUNATCH') {
+          assert.strictEqual(error.message, `connect EUNATCH ::1:${port} - Local (:::0)`);
+        } else {
+          assert.strictEqual(error.code, 'EADDRNOTAVAIL');
+          assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);
         }
 
         ipv4Server.close();

--- a/test/parallel/test-net-autoselectfamily.js
+++ b/test/parallel/test-net-autoselectfamily.js
@@ -282,13 +282,8 @@ if (common.hasIPv6) {
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
         } else if (error.code === 'EAFNOSUPPORT') {
           assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
-        } else if (common.isIBMi) {
-          // IBMi returns EUNATCH (ERRNO 42) when IPv6 is disabled
-          // keep this errno assertion until EUNATCH is recognized by libuv
-          assert.strictEqual(error.errno, -42);
-        } else {
-          assert.strictEqual(error.code, 'EADDRNOTAVAIL');
-          assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);
+        } else if (error.code === 'EADDRNOTAVAIL' || error.code === 'EUNATCH') {
+          assert.strictEqual(error.message, `connect ${error.code} ::1:${port} - Local (:::0)`);
         }
 
         ipv4Server.close();

--- a/test/parallel/test-net-autoselectfamily.js
+++ b/test/parallel/test-net-autoselectfamily.js
@@ -282,8 +282,11 @@ if (common.hasIPv6) {
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
         } else if (error.code === 'EAFNOSUPPORT') {
           assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
-        } else if (error.code === 'EADDRNOTAVAIL' || error.code === 'EUNATCH') {
-          assert.strictEqual(error.message, `connect ${error.code} ::1:${port} - Local (:::0)`);
+        } else if (error.code === 'EUNATCH') {
+          assert.strictEqual(error.message, `connect EUNATCH ::1:${port} - Local (:::0)`);
+        } else {
+          assert.strictEqual(error.code, 'EADDRNOTAVAIL');
+          assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);
         }
 
         ipv4Server.close();


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/48049
Refs: https://github.com/nodejs/node/pull/46546

When IPv6 is disabled IBM i returns EUNATCH (errno 42)
instead of EADDRNOTAVAIL.

libuv 1.46.0 adds EUNATCH errno

We can now use error.code to refer to EUNATCH
in node versions that use libuv 1.46.0.

CC @richardlau 
CC @nodejs/platform-ibmi 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
