### PR TITLE
doc: use secure key length for HMAC generateKey

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3648,7 +3648,7 @@ const {
   generateKey,
 } = await import('node:crypto');
 
-generateKey('hmac', { length: 64 }, (err, key) => {
+generateKey('hmac', { length: 512 }, (err, key) => {
   if (err) throw err;
   console.log(key.export().toString('hex'));  // 46e..........620
 });
@@ -3659,7 +3659,7 @@ const {
   generateKey,
 } = require('node:crypto');
 
-generateKey('hmac', { length: 64 }, (err, key) => {
+generateKey('hmac', { length: 512 }, (err, key) => {
   if (err) throw err;
   console.log(key.export().toString('hex'));  // 46e..........620
 });
@@ -3922,7 +3922,7 @@ const {
   generateKeySync,
 } = await import('node:crypto');
 
-const key = generateKeySync('hmac', { length: 64 });
+const key = generateKeySync('hmac', { length: 512 });
 console.log(key.export().toString('hex'));  // e89..........41e
 ```
 
@@ -3931,7 +3931,7 @@ const {
   generateKeySync,
 } = require('node:crypto');
 
-const key = generateKeySync('hmac', { length: 64 });
+const key = generateKeySync('hmac', { length: 512 });
 console.log(key.export().toString('hex'));  // e89..........41e
 ```
 


### PR DESCRIPTION
The examples for `generateKey()` and `generateKeySync()` generate 64-bit HMAC keys. That is inadequate for virtually any HMAC instance. As per common NIST recommendations, the minimum should be roughly 112 bits, or more commonly 128 bits.

Due to the [design of HMAC itself](https://en.wikipedia.org/wiki/HMAC), it is not unreasonable to choose the underlying hash function's block size as the key length. For many popular hash functions (SHA-256, SHA-224, SHA-1, MD5, ...) this happens to be 64 bytes (bytes, not bits!). This is consistent with the [HMAC implementation in .NET](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hmacsha256.-ctor?view=net-7.0), for example, even though it provides virtually no benefit over a 256-bit key.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
