### PR TITLE
doc: clarify tty.isRaw

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -51,7 +51,11 @@ added: v0.7.7
 -->
 
 A `boolean` that is `true` if the TTY is currently configured to operate as a
-raw device. Defaults to `false`.
+raw device.
+
+This flag is always `false` when a process starts, even if the terminal is
+operating in raw mode. Its value will change with subsequent calls to
+`setRawMode`.
 
 ### `readStream.isTTY`
 


### PR DESCRIPTION
This clarifies the behavior of [tty.ReadStream.isRaw](https://nodejs.org/api/tty.html#readstreamisraw), which is not quite explicitly spelled out and is kind of surprising IMO. For more context, see the discussion in https://github.com/nodejs/node/issues/47938

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
