### PR TITLE
test: test streambase already has a consumer

### DIFF
--- a/test/parallel/test-whatwg-webstreams-adapters-streambase.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-streambase.js
@@ -65,3 +65,12 @@ const {
   const readable = newReadableStreamFromStreamBase(stream);
   readable.cancel().then(common.mustCall());
 }
+
+{
+  const stream = new JSStream();
+  stream.onread = common.mustCall();
+  assert.throws(() => newReadableStreamFromStreamBase(stream), {
+    code: 'ERR_INVALID_STATE'
+  });
+  stream.emitEOF();
+}

--- a/test/parallel/test-whatwg-webstreams-adapters-to-readablewritablepair.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-readablewritablepair.js
@@ -248,3 +248,9 @@ const {
   reader.closed.then(common.mustCall());
   writer.close().then(common.mustCall());
 }
+
+{
+  assert.throws(() => newReadableWritablePairFromDuplex(null), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+}

--- a/test/parallel/test-whatwg-webstreams-adapters-to-streamduplex.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-streamduplex.js
@@ -164,3 +164,21 @@ const {
 
   duplex.end();
 }
+
+{
+  const transform = { readable: {}, writable: {} };
+  assert.throws(() => newStreamDuplexFromReadableWritablePair(transform), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+}
+
+{
+  const transform = {
+    readable: new ReadableStream(),
+    writable: null
+  };
+
+  assert.throws(() => newStreamDuplexFromReadableWritablePair(transform), {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+}


### PR DESCRIPTION
* test streambase already has a consumer 
* newStreamDuplexFromReadableWritablePair doesn't have a readable prop
* newStreamDuplexFromReadableWritablePair doesn't have a writable prop
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
