### PR TITLE
test_runner: remove redundant check from coverage

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -377,10 +377,13 @@ function mergeCoverage(merged, coverage) {
     const newScript = coverage[i];
     const { url } = newScript;
 
-    // Filter out core modules and the node_modules/ directory from results.
-    if (StringPrototypeStartsWith(url, 'node:') ||
-        StringPrototypeIncludes(url, '/node_modules/') ||
-        // On Windows some generated coverages are invalid.
+    // The first part of this check filters out the node_modules/ directory
+    // from the results. This filter is applied first because most real world
+    // applications will be dominated by third party dependencies. The second
+    // part of the check filters out core modules, which start with 'node:' in
+    // coverage reports, as well as any invalid coverages which have been
+    // observed on Windows.
+    if (StringPrototypeIncludes(url, '/node_modules/') ||
         !StringPrototypeStartsWith(url, 'file:')) {
       continue;
     }


### PR DESCRIPTION
The code coverage reporting logic already filters out URLs that don't start with 'file:', so there is no need to also filter out URLs that start with 'node:'.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
