### PR TITLE
test: ignore helper files in WPTs

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -411,7 +411,7 @@ class StatusLoader {
         const list = this.grep(filepath);
         result = result.concat(list);
       } else {
-        if (!(/\.\w+\.js$/.test(filepath))) {
+        if (!(/\.\w+\.js$/.test(filepath)) || filepath.endsWith('.helper.js')) {
           continue;
         }
         result.push(filepath);


### PR DESCRIPTION
Because daily WPT report started timing out on these helper files. These are not test entrypoints so we're not losing any coverage.