### PR TITLE
tools: add version to maintaining-dependencies.md dependencies list and automate the update

### DIFF
--- a/doc/contributing/maintaining/maintaining-dependencies.md
+++ b/doc/contributing/maintaining/maintaining-dependencies.md
@@ -8,29 +8,30 @@ directories to create the Node.js binaries.
 All dependencies are located within the `deps` directory.
 This a list of all the dependencies:
 
-* [acorn][]
-* [ada][]
-* [base64][]
-* [brotli][]
-* [c-ares][]
-* [cjs-module-lexer][]
+* [acorn 8.8.2][]
+* [ada 2.5.0][]
+* [base64 0.5.0][]
+* [brotli 1.0.9][]
+* [c-ares 1.19.0][]
+* [cjs-module-lexer 1.2.2][]
 * [corepack][]
 * [googletest][]
-* [histogram][]
-* [icu-small][]
-* [llhttp][]
-* [minimatch][]
-* [nghttp2][]
-* [ngtcp2][]
-* [npm][]
-* [openssl][]
-* [postject][]
-* [simdutf][]
-* [undici][]
-* [uv][]
-* [uvwasi][]
-* [V8][]
-* [zlib][]
+* [histogram 0.11.8][]
+* [icu-small 73.1][]
+* [libuv 1.44.2][]
+* [llhttp 8.1.0][]
+* [minimatch 9.0.0][]
+* [nghttp2 1.53.0][]
+* [nghttp3 0.7.0][]
+* [ngtcp2 0.8.1][]
+* [npm 9.6.7][]
+* [openssl 3.0.8][]
+* [postject 1.0.0-alpha.6][]
+* [simdutf 3.2.9][]
+* [undici 5.22.1][]
+* [uvwasi 0.0.16][]
+* [V8 11.3.244.8][]
+* [zlib 1.2.13][]
 
 Any code which meets one or more of these conditions should
 be managed as a dependency:
@@ -136,48 +137,49 @@ Most dependencies are automatically updated by
 [dependency-update-action][] that runs weekly.
 However, it is possible to manually update a dependency by running
 the corresponding script in `tools/update-deps`.
-[OpenSSL][] has its own update action: [update-openssl-action][].
+[OpenSSL](https://github.com/openssl/openssl) has its own update action:
+[update-openssl-action][].
 [npm-cli-bot](https://github.com/npm/cli/blob/latest/.github/workflows/create-node-pr.yml)
-takes care of [npm][] update, it is maintained by the npm team.
+takes care of npm update, it is maintained by the npm team.
 
 ## Dependency list
 
-### acorn
+### acorn 8.8.2
 
 The [acorn](https://github.com/acornjs/acorn) dependency is a JavaScript parser.
 [acorn-walk](https://github.com/acornjs/acorn/tree/master/acorn-walk) is
 an abstract syntax tree walker for the ESTree format.
 
-### ada
+### ada 2.5.0
 
 The [ada](https://github.com/ada-url/ada) dependency is a
 fast and spec-compliant URL parser written in C++.
 
-### base64
+### base64 0.5.0
 
 The [base64](https://github.com/aklomp/base64) dependency is a base64
 stream encoding/decoding library in C99 with SIMD and OpenMP acceleration.
 It also contains wrapper functions to encode/decode simple
 length-delimited strings.
 
-### brotli
+### brotli 1.0.9
 
 The [brotli](https://github.com/google/brotli) dependency is
 used for the homonym generic-purpose lossless compression algorithm.
 
-### c-ares
+### c-ares 1.19.0
 
 The [c-ares](https://github.com/c-ares/c-ares) is a C library
 for asynchronous DNS requests.
 
-### cjs-module-lexer
+### cjs-module-lexer 1.2.2
 
 The [cjs-module-lexer](https://github.com/nodejs/node/tree/HEAD/deps/cjs-module-lexer)
 dependency is used within the Node.js ESM implementation to detect the
 named exports of a CommonJS module.
 See [maintaining-cjs-module-lexer][] for more information.
 
-## corepack
+### corepack
 
 The [corepack](https://github.com/nodejs/corepack) dependency is a
 zero-runtime-dependency Node.js script that acts as a bridge between
@@ -192,36 +194,47 @@ by Node.js by default.
 The [googletest](https://github.com/google/googletest) dependency is Google’s
 C++ testing and mocking framework.
 
-### histogram
+### histogram 0.11.8
 
 The [histogram](https://github.com/HdrHistogram/HdrHistogram_c) dependency is
 a C port of High Dynamic Range (HDR) Histogram.
 
-### icu-small
+### icu-small 73.1
 
 The [icu](http://site.icu-project.org) is widely used set of C/C++
 and Java libraries providing Unicode and Globalization
 support for software applications.
 See [maintaining-icu][] for more informations.
 
-### llhttp
+### libuv 1.44.2
+
+The [libuv](https://github.com/libuv/libuv) dependency is a
+multi-platform support library with a focus on asynchronous I/O.
+It was primarily developed for use by Node.js.
+
+### llhttp 8.1.0
 
 The [llhttp](https://github.com/nodejs/llhttp) dependency is
 the http parser used by Node.js.
 See [maintaining-http][] for more informations.
 
-### minimatch
+### minimatch 9.0.0
 
 The [minimatch](https://github.com/isaacs/minimatch) dependency is a
 minimal matching utility.
 
-### nghttp2
+### nghttp2 1.53.0
 
 The [nghttp2](https://github.com/nghttp2/nghttp2) dependency is a C library
 implementing HTTP/2 protocol.
 See [maintaining-http][] for more informations.
 
-### ngtcp2
+### nghttp3 0.7.0
+
+The [nghttp3](https://github.com/ngtcp2/nghttp3) dependency is HTTP/3 library
+written in C. See ngtcp2 for more informations.
+
+### ngtcp2 0.8.1
 
 The ngtcp2 and nghttp3 dependencies provide the core functionality for
 QUIC and HTTP/3.
@@ -241,7 +254,7 @@ The `nghttp3` library depends on `ngtcp2`. Both should always be updated
 together. From `ngtcp2` we only want the contents of the `lib` and `crypto`
 directories; from `nghttp3` we only want the contents of the `lib` directory.
 
-### npm
+### npm 9.6.7
 
 The [npm](https://github.com/npm/cli) dependency is
 the package manager for JavaScript.
@@ -256,7 +269,7 @@ are at the discretion of the release and LTS teams.
 This process only covers full updates to new versions of npm. Cherry-picked
 changes can be reviewed and landed via the normal consensus seeking process.
 
-### openssl
+### openssl 3.0.8
 
 The [openssl](https://github.com/quictls/openssl) dependency is a
 fork of OpenSSL to enable QUIC.
@@ -268,29 +281,23 @@ the main openssl/openssl releases with the addition of APIs to support
 the QUIC protocol.
 See [maintaining-openssl][] for more informations.
 
-### postject
+### postject 1.0.0-alpha.6
 
 The [postject](https://github.com/nodejs/postject) dependency is used for the
 [Single Executable strategic initiative](https://github.com/nodejs/single-executable).
 
-### simdutf
+### simdutf 3.2.9
 
 The [simdutf](https://github.com/simdutf/simdutf) dependency is
 a C++ library for fast UTF-8 decoding and encoding.
 
-### undici
+### undici 5.22.1
 
 The [undici](https://github.com/nodejs/undici) dependency is an HTTP/1.1 client,
 written from scratch for Node.js..
 See [maintaining-http][] for more informations.
 
-### uv
-
-The [libuv](https://github.com/libuv/libuv) dependency is a
-multi-platform support library with a focus on asynchronous I/O.
-It was primarily developed for use by Node.js.
-
-### uvwasi
+### uvwasi 0.0.16
 
 The [uvwasi](https://github.com/nodejs/uvwasi) dependency implements
 the WASI system call API, so that WebAssembly runtimes can easily
@@ -298,47 +305,48 @@ implement WASI calls.
 Under the hood, uvwasi leverages libuv where possible for maximum portability.
 See [maintaining-web-assembly][] for more informations.
 
-### V8
+### V8 11.3.244.8
 
 [V8](https://chromium.googlesource.com/v8/v8.git/) is Google's open source
 high-performance JavaScript and WebAssembly engine, written in C++.
 See [maintaining-V8][] for more informations.
 
-### zlib
+### zlib 1.2.13
 
 The [zlib](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/zlib)
 dependency lossless data-compression library,
 it comes from the Chromium team's zlib fork which incorporated
 performance improvements not currently available in standard zlib.
 
-[acorn]: #acorn
-[ada]: #ada
-[base64]: #base64
-[brotli]: #brotli
-[c-ares]: #c-ares
-[cjs-module-lexer]: #cjs-module-lexer
+[acorn 8.8.2]: #acorn-882
+[ada 2.5.0]: #ada-250
+[base64 0.5.0]: #base64-050
+[brotli 1.0.9]: #brotli-109
+[c-ares 1.19.0]: #c-ares-1190
+[cjs-module-lexer 1.2.2]: #cjs-module-lexer-122
 [corepack]: #corepack
 [dependency-update-action]: ../../../.github/workflows/tools.yml
 [googletest]: #googletest
-[histogram]: #histogram
-[icu-small]: #icu-small
-[llhttp]: #llhttp
+[histogram 0.11.8]: #histogram-0118
+[icu-small 73.1]: #icu-small-731
+[libuv 1.44.2]: #libuv-1442
+[llhttp 8.1.0]: #llhttp-810
 [maintaining-V8]: ./maintaining-V8.md
 [maintaining-cjs-module-lexer]: ./maintaining-cjs-module-lexer.md
 [maintaining-http]: ./maintaining-http.md
 [maintaining-icu]: ./maintaining-icu.md
 [maintaining-openssl]: ./maintaining-openssl.md
 [maintaining-web-assembly]: ./maintaining-web-assembly.md
-[minimatch]: #minimatch
-[nghttp2]: #nghttp2
-[ngtcp2]: #ngtcp2
-[npm]: #npm
-[openssl]: #openssl
-[postject]: #postject
-[simdutf]: #simdutf
-[undici]: #undici
+[minimatch 9.0.0]: #minimatch-900
+[nghttp2 1.53.0]: #nghttp2-1530
+[nghttp3 0.7.0]: #nghttp3-070
+[ngtcp2 0.8.1]: #ngtcp2-081
+[npm 9.6.7]: #npm-967
+[openssl 3.0.8]: #openssl-308
+[postject 1.0.0-alpha.6]: #postject-100-alpha6
+[simdutf 3.2.9]: #simdutf-329
+[undici 5.22.1]: #undici-5221
 [update-openssl-action]: ../../../.github/workflows/update-openssl.yml
-[uv]: #uv
-[uvwasi]: #uvwasi
-[v8]: #v8
-[zlib]: #zlib
+[uvwasi 0.0.16]: #uvwasi-0016
+[v8 11.3.244.8]: #v8-1132448
+[zlib 1.2.13]: #zlib-1213

--- a/tools/dep_updaters/update-acorn-walk.sh
+++ b/tools/dep_updaters/update-acorn-walk.sh
@@ -12,15 +12,14 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 [ -x "$NODE" ] || NODE=$(command -v node)
 NPM="$ROOT/deps/npm/bin/npm-cli.js"
 
+# shellcheck disable=SC1091
+. "$ROOT/tools/dep_updaters/utils.sh"
+
 NEW_VERSION=$("$NODE" "$NPM" view acorn-walk dist-tags.latest)
 CURRENT_VERSION=$("$NODE" -p "require('./deps/acorn/acorn-walk/package.json').version")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because Acorn-walk is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "acorn-walk" "$NEW_VERSION" "$CURRENT_VERSION"
 
 cd "$( dirname "$0" )/../.." || exit
 

--- a/tools/dep_updaters/update-acorn.sh
+++ b/tools/dep_updaters/update-acorn.sh
@@ -12,15 +12,14 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 [ -x "$NODE" ] || NODE=$(command -v node)
 NPM="$ROOT/deps/npm/bin/npm-cli.js"
 
+# shellcheck disable=SC1091
+. "$ROOT/tools/dep_updaters/utils.sh"
+
 NEW_VERSION=$("$NODE" "$NPM" view acorn dist-tags.latest)
 CURRENT_VERSION=$("$NODE" -p "require('./deps/acorn/acorn/package.json').version")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because Acorn is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "acorn" "$NEW_VERSION" "$CURRENT_VERSION"
 
 cd "$( dirname "$0" )/../.." || exit
 
@@ -50,14 +49,7 @@ mv acorn-tmp/node_modules/acorn deps/acorn
 
 rm -rf acorn-tmp/
 
-echo "All done!"
-echo ""
-echo "Please git add acorn, commit the new version:"
-echo ""
-echo "$ git add -A deps/acorn src/acorn_version.h"
-echo "$ git commit -m \"deps: update acorn to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "acorn" "$NEW_VERSION" "src/acorn_version.h"

--- a/tools/dep_updaters/update-ada.sh
+++ b/tools/dep_updaters/update-ada.sh
@@ -25,12 +25,8 @@ EOF
 
 CURRENT_VERSION=$(grep "#define ADA_VERSION" "$DEPS_DIR/ada/ada.h" | sed -n "s/^.*VERSION \"\(.*\)\"/\1/p")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because ada is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "ada" "$NEW_VERSION" "$CURRENT_VERSION"
 
 echo "Making temporary workspace..."
 
@@ -63,14 +59,7 @@ mv "$DEPS_DIR/ada/"*.gyp "$DEPS_DIR/ada/README.md" "$WORKSPACE/"
 rm -rf "$DEPS_DIR/ada"
 mv "$WORKSPACE" "$DEPS_DIR/ada"
 
-echo "All done!"
-echo ""
-echo "Please git add ada, commit the new version:"
-echo ""
-echo "$ git add -A deps/ada"
-echo "$ git commit -m \"deps: update ada to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "ada" "$NEW_VERSION"

--- a/tools/dep_updaters/update-base64.sh
+++ b/tools/dep_updaters/update-base64.sh
@@ -26,12 +26,8 @@ EOF
 
 CURRENT_VERSION=$(grep "base64 LANGUAGES C VERSION" ./deps/base64/base64/CMakeLists.txt | sed -n "s/^.*VERSION \(.*\))/\1/p")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because base64 is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "base64" "$NEW_VERSION" "$CURRENT_VERSION"
 
 echo "Making temporary workspace"
 
@@ -78,14 +74,7 @@ cat > "$BASE_DIR/src/base64_version.h" << EOL
 #endif  // SRC_BASE64_VERSION_H_
 EOL
 
-echo "All done!"
-echo ""
-echo "Please git add base64/base64, commit the new version:"
-echo ""
-echo "$ git add -A deps/base64/base64 src/base64_version.h"
-echo "$ git commit -m \"deps: update base64 to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "base64" "$NEW_VERSION" "src/base64_version.h"

--- a/tools/dep_updaters/update-brotli.sh
+++ b/tools/dep_updaters/update-brotli.sh
@@ -31,12 +31,8 @@ minor=$(( ($VERSION_HEX >> 12) & 0xfff ))
 patch=$(( $VERSION_HEX & 0xfff ))
 CURRENT_VERSION="${major}.${minor}.${patch}"
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because brotli is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "brotli" "$NEW_VERSION" "$CURRENT_VERSION"
 
 echo "Making temporary workspace"
 
@@ -71,14 +67,7 @@ mkdir "$DEPS_DIR/brotli"
 echo "Update c and LICENSE"
 mv "$WORKSPACE/brotli/c" "$WORKSPACE/brotli/LICENSE" "$WORKSPACE/brotli/brotli.gyp" "$DEPS_DIR/brotli"
 
-echo "All done!"
-echo ""
-echo "Please git add brotli, commit the new version:"
-echo ""
-echo "$ git add -A deps/brotli"
-echo "$ git commit -m \"deps: update brotli to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "brotli" "$NEW_VERSION"

--- a/tools/dep_updaters/update-c-ares.sh
+++ b/tools/dep_updaters/update-c-ares.sh
@@ -26,12 +26,8 @@ EOF
 
 CURRENT_VERSION=$(grep "#define ARES_VERSION_STR" ./deps/cares/include/ares_version.h |  sed -n "s/^.*VERSION_STR \"\(.*\)\"/\1/p")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because c-ares is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "c-ares" "$NEW_VERSION" "$CURRENT_VERSION"
 
 echo "Making temporary workspace"
 
@@ -69,14 +65,7 @@ echo "Replacing existing c-ares"
 rm -rf "$DEPS_DIR/cares"
 mv "$WORKSPACE/cares" "$DEPS_DIR/"
 
-echo "All done!"
-echo ""
-echo "Please git add c-ares, commit the new version:"
-echo ""
-echo "$ git add -A deps/cares"
-echo "$ git commit -m \"deps: update c-ares to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "c-ares" "$NEW_VERSION"

--- a/tools/dep_updaters/update-cjs-module-lexer.sh
+++ b/tools/dep_updaters/update-cjs-module-lexer.sh
@@ -10,6 +10,9 @@ DEPS_DIR="$BASE_DIR/deps"
 
 NPM="$DEPS_DIR/npm/bin/npm-cli.js"
 
+# shellcheck disable=SC1091
+. "$BASE_DIR/tools/dep_updaters/utils.sh"
+
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
 const res = await fetch('https://api.github.com/repos/nodejs/cjs-module-lexer/tags',
   process.env.GITHUB_TOKEN && {
@@ -26,12 +29,8 @@ EOF
 
 CURRENT_VERSION=$("$NODE" -p "require('./deps/cjs-module-lexer/package.json').version")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because cjs-module-lexer is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "cjs-module-lexer" "$NEW_VERSION" "$CURRENT_VERSION"
 
 echo "Making temporary workspace"
 
@@ -65,14 +64,7 @@ cat > "$BASE_DIR/src/cjs_module_lexer_version.h" << EOL
 #endif  // SRC_CJS_MODULE_LEXER_VERSION_H_
 EOL
 
-echo "All done!"
-echo ""
-echo "Please git add cjs-module-lexer, commit the new version:"
-echo ""
-echo "$ git add -A deps/cjs-module-lexer src/cjs_module_lexer_version.h"
-echo "$ git commit -m \"deps: update cjs-module-lexer to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "cjs-module-lexer" "$NEW_VERSION" "src/cjs_module_lexer_version.h"

--- a/tools/dep_updaters/update-eslint.sh
+++ b/tools/dep_updaters/update-eslint.sh
@@ -13,15 +13,14 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 [ -x "$NODE" ] || NODE=$(command -v node)
 NPM="$ROOT/deps/npm/bin/npm-cli.js"
 
+# shellcheck disable=SC1091
+. "$ROOT/tools/dep_updaters/utils.sh"
+
 NEW_VERSION=$("$NODE" "$NPM" view eslint dist-tags.latest)
 CURRENT_VERSION=$("$NODE" -p "require('./tools/node_modules/eslint/package.json').version")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because ESlint is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "eslint" "$NEW_VERSION" "$CURRENT_VERSION"
 
 cd "$( dirname "$0" )" || exit
 rm -rf ../node_modules/eslint

--- a/tools/dep_updaters/update-googletest.sh
+++ b/tools/dep_updaters/update-googletest.sh
@@ -10,6 +10,9 @@ DEPS_DIR="$BASE_DIR/deps"
 NEW_UPSTREAM_SHA1=$(git ls-remote "https://github.com/google/googletest.git" HEAD | awk '{print $1}')
 NEW_VERSION=$(echo "$NEW_UPSTREAM_SHA1" | head -c 7)
 
+# shellcheck disable=SC1091
+. "$BASE_DIR/tools/dep_updaters/utils.sh"
+
 echo "Comparing $NEW_VERSION with current revision"
 
 git remote add googletest-upstream https://github.com/google/googletest.git
@@ -80,14 +83,7 @@ NEW_GYP=$(
 
 echo "$NEW_GYP" >"$DEPS_DIR/googletest/googletest.gyp"
 
-echo "All done!"
-echo ""
-echo "Please git stage googletest, commit the new version:"
-echo ""
-echo "$ git stage -A deps/googletest"
-echo "$ git commit -m \"deps: update googletest to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "googletest" "$NEW_VERSION"

--- a/tools/dep_updaters/update-histogram.sh
+++ b/tools/dep_updaters/update-histogram.sh
@@ -21,12 +21,8 @@ EOF
 
 CURRENT_VERSION=$(grep "#define HDR_HISTOGRAM_VERSION" ./deps/histogram/include/hdr/hdr_histogram_version.h | sed -n "s/^.*VERSION \"\(.*\)\"/\1/p")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because histogram is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "histogram" "$NEW_VERSION" "$CURRENT_VERSION"
 
 echo "Making temporary workspace"
 
@@ -60,15 +56,7 @@ cp "$WORKSPACE/histogram/include/hdr/hdr_histogram_version.h" "$WORKSPACE/histog
 
 cp "$WORKSPACE/histogram/src/hdr_atomic.h" "$WORKSPACE/histogram/src/hdr_malloc.h" "$WORKSPACE/histogram/src/hdr_tests.h" "$WORKSPACE/histogram/src/hdr_histogram.c" "$DEPS_DIR/histogram/src"
 
-
-echo "All done!"
-echo ""
-echo "Please git add histogram, commit the new version:"
-echo ""
-echo "$ git add -A deps/histogram"
-echo "$ git commit -m \"deps: update histogram to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "histogram" "$NEW_VERSION"

--- a/tools/dep_updaters/update-libuv.sh
+++ b/tools/dep_updaters/update-libuv.sh
@@ -33,12 +33,8 @@ CURRENT_SUFFIX_VERSION=$(grep "#define UV_VERSION_SUFFIX" "$VERSION_H" | sed -n 
 SUFFIX_STRING=$([ "$CURRENT_IS_RELEASE" = 1 ] || [ -z "$CURRENT_SUFFIX_VERSION" ] && echo "" || echo "-$CURRENT_SUFFIX_VERSION")
 CURRENT_VERSION="$CURRENT_MAJOR_VERSION.$CURRENT_MINOR_VERSION.$CURRENT_PATCH_VERSION$SUFFIX_STRING"
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because libuv is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "libuv" "$NEW_VERSION" "$CURRENT_VERSION"
 
 echo "Making temporary workspace..."
 
@@ -68,14 +64,7 @@ mv "$DEPS_DIR/uv/"*.gyp "$DEPS_DIR/uv/"*.gypi "$WORKSPACE/uv/"
 rm -rf "$DEPS_DIR/uv"
 mv "$WORKSPACE/uv" "$DEPS_DIR/"
 
-echo "All done!"
-echo ""
-echo "Please git add uv, commit the new version:"
-echo ""
-echo "$ git add -A deps/uv"
-echo "$ git commit -m \"deps: update libuv to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "libuv" "$NEW_VERSION"

--- a/tools/dep_updaters/update-llhttp.sh
+++ b/tools/dep_updaters/update-llhttp.sh
@@ -30,12 +30,8 @@ CURRENT_MINOR_VERSION=$(grep "#define LLHTTP_VERSION_MINOR" ./deps/llhttp/includ
 CURRENT_PATCH_VERSION=$(grep "#define LLHTTP_VERSION_PATCH" ./deps/llhttp/include/llhttp.h | sed -n "s/^.*PATCH \(.*\)/\1/p")
 CURRENT_VERSION="$CURRENT_MAJOR_VERSION.$CURRENT_MINOR_VERSION.$CURRENT_PATCH_VERSION"
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because llhttp is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "llhttp" "$NEW_VERSION" "$CURRENT_VERSION"
 
 cleanup () {
   EXIT_CODE=$?
@@ -78,15 +74,7 @@ else
   cp -a "llhttp-release-v$NEW_VERSION" "$DEPS_DIR/llhttp"
 fi
 
-echo ""
-echo "All done!"
-echo ""
-echo "Please git add llhttp, commit the new version:"
-echo ""
-echo "$ git add -A deps/llhttp"
-echo "$ git commit -m \"deps: update llhttp to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "llhttp" "$NEW_VERSION"

--- a/tools/dep_updaters/update-minimatch.sh
+++ b/tools/dep_updaters/update-minimatch.sh
@@ -12,15 +12,14 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 [ -x "$NODE" ] || NODE=$(command -v node)
 NPM="$ROOT/deps/npm/bin/npm-cli.js"
 
+# shellcheck disable=SC1091
+. "$ROOT/tools/dep_updaters/utils.sh"
+
 NEW_VERSION=$("$NODE" "$NPM" view minimatch dist-tags.latest)
 CURRENT_VERSION=$("$NODE" -p "require('./deps/minimatch/src/package.json').version")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because minimatch is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "minimatch" "$NEW_VERSION" "$CURRENT_VERSION"
 
 cd "$( dirname "$0" )/../.." || exit
 
@@ -46,14 +45,7 @@ cp deps/minimatch/src/LICENSE deps/minimatch/LICENSE
 
 rm -rf minimatch-tmp/
 
-echo "All done!"
-echo ""
-echo "Please git add minimatch, commit the new version:"
-echo ""
-echo "$ git add -A deps/minimatch"
-echo "$ git commit -m \"deps: update minimatch to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "minimatch" "$NEW_VERSION"

--- a/tools/dep_updaters/update-nghttp2.sh
+++ b/tools/dep_updaters/update-nghttp2.sh
@@ -26,12 +26,8 @@ EOF
 
 CURRENT_VERSION=$(grep "#define NGHTTP2_VERSION" ./deps/nghttp2/lib/includes/nghttp2/nghttp2ver.h | sed -n "s/^.*VERSION \"\(.*\)\"/\1/p")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because nghttp2 is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "nghttp2" "$NEW_VERSION" "$CURRENT_VERSION"
 
 echo "Making temporary workspace"
 
@@ -81,14 +77,7 @@ echo "Replacing existing nghttp2"
 rm -rf "$DEPS_DIR/nghttp2"
 mv "$WORKSPACE/nghttp2" "$DEPS_DIR/"
 
-echo "All done!"
-echo ""
-echo "Please git add nghttp2, commit the new version:"
-echo ""
-echo "$ git add -A deps/nghttp2"
-echo "$ git commit -m \"deps: update nghttp2 to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "nghttp2" "$NEW_VERSION"

--- a/tools/dep_updaters/update-nghttp3.sh
+++ b/tools/dep_updaters/update-nghttp3.sh
@@ -28,12 +28,8 @@ NGHTTP3_VERSION_H="$DEPS_DIR/ngtcp2/nghttp3/lib/includes/nghttp3/version.h"
 
 CURRENT_VERSION=$(grep "#define NGHTTP3_VERSION" "$NGHTTP3_VERSION_H" | sed -n "s/^.*VERSION \"\(.*\)\"/\1/p")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because http3 is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "nghttp3" "$NEW_VERSION" "$CURRENT_VERSION"
 
 WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
 
@@ -65,14 +61,7 @@ autoreconf -i
 
 cp -R lib/* "$DEPS_DIR/ngtcp2/nghttp3/lib/"
 
-echo "All done!"
-echo ""
-echo "Please git add nghttp3, commit the new version:"
-echo ""
-echo "$ git add -A deps/nghttp3"
-echo "$ git commit -m \"deps: update nghttp3 to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "nghttp3" "$NEW_VERSION"

--- a/tools/dep_updaters/update-ngtcp2.sh
+++ b/tools/dep_updaters/update-ngtcp2.sh
@@ -28,12 +28,8 @@ NGTCP2_VERSION_H="$DEPS_DIR/ngtcp2/ngtcp2/lib/includes/ngtcp2/version.h"
 
 CURRENT_VERSION=$(grep "#define NGTCP2_VERSION" "$NGTCP2_VERSION_H" | sed -n "s/^.*VERSION \"\(.*\)\"/\1/p")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because ngtcp2 is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "ngtcp2" "$NEW_VERSION" "$CURRENT_VERSION"
 
 WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
 
@@ -71,14 +67,7 @@ cp -R lib/* "$DEPS_DIR/ngtcp2/ngtcp2/lib/"
 
 cp -R crypto/* "$DEPS_DIR/ngtcp2/ngtcp2/crypto/"
 
-echo "All done!"
-echo ""
-echo "Please git add ngtcp2, commit the new version:"
-echo ""
-echo "$ git add -A deps/ngtcp2"
-echo "$ git commit -m \"deps: update ngtcp2 to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "ngtcp2" "$NEW_VERSION"

--- a/tools/dep_updaters/update-npm.sh
+++ b/tools/dep_updaters/update-npm.sh
@@ -47,15 +47,7 @@ mkdir "$DEPS_DIR/npm"
 
 tar zxvf "$NPM_TGZ" --strip-component=1 -C "$DEPS_DIR/npm"
 
-echo ""
-echo "All done!"
-echo ""
-echo "Please git add npm, commit the new version, and whitespace-fix:"
-echo ""
-echo "$ git add -A deps/npm"
-echo "$ git commit -m \"deps: upgrade npm to $NPM_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NPM_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "npm" "$NPM_VERSION"

--- a/tools/dep_updaters/update-openssl.sh
+++ b/tools/dep_updaters/update-openssl.sh
@@ -37,11 +37,15 @@ download() {
   rm -rf "$DEPS_DIR/openssl/openssl"
   mv "$WORKSPACE/openssl" "$DEPS_DIR/openssl/"
 
+  # Update the version number
+  update_dependency_version "openssl" "$OPENSSL_VERSION"
+
   echo "All done!"
   echo ""
   echo "Please git add openssl, and commit the new version:"
   echo ""
   echo "$ git add -A deps/openssl/openssl"
+  echo "$ git add doc/contributing/maintaining/maintaining-dependencies.md"
   echo "$ git commit -m \"deps: upgrade openssl sources to quictls/openssl-$OPENSSL_VERSION\""
   echo ""
 }

--- a/tools/dep_updaters/update-postject.sh
+++ b/tools/dep_updaters/update-postject.sh
@@ -12,15 +12,14 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 [ -x "$NODE" ] || NODE=$(command -v node)
 NPM="$ROOT/deps/npm/bin/npm-cli.js"
 
+# shellcheck disable=SC1091
+. "$ROOT/tools/dep_updaters/utils.sh"
+
 NEW_VERSION=$("$NODE" "$NPM" view postject dist-tags.latest)
 CURRENT_VERSION=$("$NODE" -p "require('./test/fixtures/postject-copy/node_modules/postject/package.json').version")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because Postject is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "postject" "$NEW_VERSION" "$CURRENT_VERSION"
 
 cd "$( dirname "$0" )/../.." || exit
 rm -rf test/fixtures/postject-copy
@@ -38,6 +37,7 @@ mkdir deps/postject
 cp test/fixtures/postject-copy/node_modules/postject/LICENSE deps/postject
 cp test/fixtures/postject-copy/node_modules/postject/dist/postject-api.h deps/postject
 
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "postject" "$NEW_VERSION"

--- a/tools/dep_updaters/update-simdutf.sh
+++ b/tools/dep_updaters/update-simdutf.sh
@@ -24,12 +24,8 @@ EOF
 )"
 CURRENT_VERSION=$(grep "#define SIMDUTF_VERSION" "$DEPS_DIR/simdutf/simdutf.h" | sed -n "s/^.*VERSION \"\(.*\)\"/\1/p")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because simdutf is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "simdutf" "$NEW_VERSION" "$CURRENT_VERSION"
 
 echo "Making temporary workspace..."
 
@@ -63,14 +59,7 @@ mv "$DEPS_DIR/simdutf/"*.gyp "$DEPS_DIR/simdutf/README.md" "$WORKSPACE/"
 rm -rf "$DEPS_DIR/simdutf"
 mv "$WORKSPACE" "$DEPS_DIR/simdutf"
 
-echo "All done!"
-echo ""
-echo "Please git add simdutf, commit the new version:"
-echo ""
-echo "$ git add -A deps/simdutf"
-echo "$ git commit -m \"deps: update simdutf to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "simdutf" "$NEW_VERSION"

--- a/tools/dep_updaters/update-undici.sh
+++ b/tools/dep_updaters/update-undici.sh
@@ -12,15 +12,14 @@ ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 [ -x "$NODE" ] || NODE=$(command -v node)
 NPM="$ROOT/deps/npm/bin/npm-cli.js"
 
+# shellcheck disable=SC1091
+. "$ROOT/tools/dep_updaters/utils.sh"
+
 NEW_VERSION=$("$NODE" "$NPM" view undici dist-tags.latest)
 CURRENT_VERSION=$("$NODE" -p "require('./deps/undici/src/package.json').version")
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because Undici is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "undici" "$NEW_VERSION" "$CURRENT_VERSION"
 
 cd "$( dirname "$0" )/../.." || exit
 rm -rf deps/undici/src
@@ -54,14 +53,7 @@ cp deps/undici/src/LICENSE deps/undici/LICENSE
 
 rm -rf undici-tmp/
 
-echo "All done!"
-echo ""
-echo "Please git add and commit the new version:"
-echo ""
-echo "$ git add -A deps/undici src/undici_version.h"
-echo "$ git commit -m \"deps: update Undici to $NEW_VERSION\""
-echo ""
-
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "undici" "$NEW_VERSION" "src/undici_version.h"

--- a/tools/dep_updaters/update-uvwasi.sh
+++ b/tools/dep_updaters/update-uvwasi.sh
@@ -29,12 +29,8 @@ CURRENT_MINOR_VERSION=$(grep "#define UVWASI_VERSION_MINOR" "$DEPS_DIR/uvwasi/in
 CURRENT_PATCH_VERSION=$(grep "#define UVWASI_VERSION_PATCH" "$DEPS_DIR/uvwasi/include/uvwasi.h" | sed -n "s/^.*PATCH \(.*\)/\1/p")
 CURRENT_VERSION="$CURRENT_MAJOR_VERSION.$CURRENT_MINOR_VERSION.$CURRENT_PATCH_VERSION"
 
-echo "Comparing $NEW_VERSION with $CURRENT_VERSION"
-
-if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-  echo "Skipped because uvwasi is on the latest version."
-  exit 0
-fi
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "uvwasi" "$NEW_VERSION" "$CURRENT_VERSION"
 
 echo "Making temporary workspace"
 
@@ -73,16 +69,10 @@ cp -r "$UVWASI_ZIP/src" "$DEPS_DIR/uvwasi/"
 cp "$UVWASI_ZIP/LICENSE" "$DEPS_DIR/uvwasi/"
 rm -rf "$UVWASI_ZIP"
 
-echo "All done!"
-echo ""
-echo "Please git add uvwasi, commit the new version:"
-echo ""
-echo "$ git add -A deps/uvwasi"
-echo "$ git commit -m \"deps: update uvwasi to $NEW_VERSION\""
-echo ""
 echo "Make sure to update the deps/uvwasi/uvwasi.gyp if any significant changes have occurred upstream"
 echo ""
 
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "acorn" "$NEW_VERSION"

--- a/tools/dep_updaters/update-v8-patch.sh
+++ b/tools/dep_updaters/update-v8-patch.sh
@@ -26,8 +26,8 @@ CURRENT_PATCH_VERSION=$(grep "#define V8_PATCH_LEVEL" "$DEPS_DIR/v8/include/v8-v
 NEW_VERSION="$CURRENT_MAJOR_VERSION.$CURRENT_MINOR_VERSION.$CURRENT_BUILD_VERSION.$CURRENT_PATCH_VERSION"
 
 
-# Update the version number. We need to call this function twice to update
-# both V8 and v8 (upper/lower case)
+# Update the version number. We have to call it twice because V8 is written
+# both in lowercase and uppdercase
 update_dependency_version "v8" "$NEW_VERSION"
 update_dependency_version "V8" "$NEW_VERSION"
 

--- a/tools/dep_updaters/update-v8-patch.sh
+++ b/tools/dep_updaters/update-v8-patch.sh
@@ -4,6 +4,9 @@ set -e
 
 BASE_DIR=$(cd "$(dirname "$0")/../.." && pwd)
 
+# shellcheck disable=SC1091
+. "$BASE_DIR/tools/dep_updaters/utils.sh"
+
 cd "$BASE_DIR"
 
 IS_UP_TO_DATE=$(git node v8 minor | grep "V8 is up-to-date")
@@ -21,6 +24,12 @@ CURRENT_BUILD_VERSION=$(grep "#define V8_BUILD_NUMBER" "$DEPS_DIR/v8/include/v8-
 CURRENT_PATCH_VERSION=$(grep "#define V8_PATCH_LEVEL" "$DEPS_DIR/v8/include/v8-version.h" | cut -d ' ' -f3)
 
 NEW_VERSION="$CURRENT_MAJOR_VERSION.$CURRENT_MINOR_VERSION.$CURRENT_BUILD_VERSION.$CURRENT_PATCH_VERSION"
+
+
+# Update the version number. We need to call this function twice to update
+# both V8 and v8 (upper/lower case)
+update_dependency_version "v8" "$NEW_VERSION"
+update_dependency_version "V8" "$NEW_VERSION"
 
 echo "All done!"
 echo ""

--- a/tools/dep_updaters/update-zlib.sh
+++ b/tools/dep_updaters/update-zlib.sh
@@ -42,7 +42,7 @@ if [ "$LAST_CHANGE_DATE" -gt "$TWO_DAYS_AGO" ]; then
   exit 0
 fi
 
-NEW_VERSION=$(git rev-parse --short=7 FETCH_HEAD)
+LATEST_COMMIT=$(git rev-parse --short=7 FETCH_HEAD)
 
 echo "Making temporary workspace..."
 
@@ -77,16 +77,11 @@ mv "$DEPS_DIR/zlib.def" "$DEPS_DIR/zlib/win32"
 
 perl -i -pe 's|^#include "chromeconf.h"|//#include "chromeconf.h"|' "$DEPS_DIR/zlib/zconf.h"
 
-echo "All done!"
-echo ""
-echo "Make sure to update the deps/zlib/zlib.gyp if any significant changes have occurred upstream"
-echo ""
-echo "Please git add zlib, commit the new version:"
-echo ""
-echo "$ git add -A deps/zlib"
-echo "$ git commit -m \"deps: update zlib to $NEW_VERSION\""
-echo ""
+VERSION_NUMBER=$(grep "#define ZLIB_VERSION" "$DEPS_DIR/zlib/zlib.h" | sed -n "s/^.*VERSION \"\(.*\)\"/\1/p")
 
-# The last line of the script should always print the new version,
-# as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$NEW_VERSION"
+NEW_VERSION="$VERSION_NUMBER-$LATEST_COMMIT"
+
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "zlib" "$NEW_VERSION"

--- a/tools/dep_updaters/utils.sh
+++ b/tools/dep_updaters/utils.sh
@@ -1,5 +1,56 @@
 #!/bin/sh
 
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# This function compare new version with current version of a depdendency and
+# exit the script if the versions are the same
+#
+# $1 is the package name e.g. 'acorn', 'ada', 'base64' etc. See the file
+# https://github.com/nodejs/node/blob/main/doc/contributing/maintaining/maintaining-dependencies.md
+# for a complete list of package name
+# $2 is the new version.
+compare_dependency_version() {
+  package_name="$1"
+  new_version="$2"
+  current_version="$3"
+  echo "Comparing $new_version with $current_version"
+  if [ "$new_version" = "$current_version" ]; then
+    echo "Skipped because $package_name is on the latest version."
+    exit 0
+  fi
+}
+
+# This function inform to commit the new version of a maintained dependency
+# and print the last line of the script "NEW_VERSION=$NEW_VERSION" as we need
+# to add it to $GITHUB_ENV variable.
+#
+# $1 is the package name e.g. 'acorn', 'ada', 'base64' etc. See the file
+# https://github.com/nodejs/node/blob/main/doc/contributing/maintaining/maintaining-dependencies.md
+# for a complete list of package name
+# $2 is the new version.
+# $3 (optional) other files to be git added apart from the deps/package_name
+finalize_version_update() {
+  package_name="$1"
+  new_version="$2"
+  extra_files="$3"
+
+  # Update the version number on maintaining-dependencies.md
+  update_dependency_version "$package_name" "$new_version"
+
+  echo "All done!"
+  echo ""
+  echo "Please git add $package_name and commit the new version:"
+  echo ""
+  echo "$ git add -A deps/$package_name $extra_files"
+  echo "$ git add doc/contributing/maintaining/maintaining-dependencies.md"
+  echo "$ git commit -m \"deps: update $package_name to $new_version\""
+  echo ""
+
+  # The last line of the script should always print the new version,
+  # as we need to add it to $GITHUB_ENV variable.
+  echo "NEW_VERSION=$new_version"
+}
+
 # This function logs the archive checksum and, if provided, compares it with
 # the deposited checksum
 #
@@ -28,4 +79,21 @@ log_and_verify_sha256sum() {
       exit 1
     fi
   fi
+}
+
+# This function update the version of a maintained dependency in
+# https://github.com/nodejs/node/blob/main/doc/contributing/maintaining/maintaining-dependencies.md
+#
+# $1 is the package name e.g. 'acorn', 'ada', 'base64' etc. See that file
+# for a complete list of package name
+# $2 is the new version.
+update_dependency_version() {
+  package_name="$1"
+  new_version="$2"
+  deps_file_path="$ROOT/doc/contributing/maintaining/maintaining-dependencies.md"
+  # Remove version dots for anchor markdown
+  version_no_dots=$(echo "$new_version" | sed -e 's/\.//g')
+  perl -i -pe 's|^\* \['"$package_name"'.*|* ['"$package_name"' '"$new_version"'][]|' "$deps_file_path"
+  perl -i -pe 's|^\['"$package_name"'.*\]: #'"$package_name"'.*|['"$package_name"' '"$new_version"']: #'"$package_name"'-'"$version_no_dots"'|' "$deps_file_path"
+  perl -i -pe 's|^### '"$package_name"'.*|### '"$package_name"' '"$new_version"'|' "$deps_file_path"
 }


### PR DESCRIPTION
Add version to `doc/contributing/maintaining/maintaining-dependencies.md` dependencies list and automate the update
Refs: https://github.com/nodejs/security-wg/issues/973

Most of the duplicated code in all the dependencies updaters has been moved in the `utils.sh` file

This is the list of all the dependencies:
- [x] acorn
- [x] ada
- [x] base64
- [x] brotli
- [x] c-ares
- [x] cjs-module-lexer
- [ ] corepack
- [x] googletest
- [x] histogram
- [x] icu-small
- [x] llhttp
- [x] minimatch
- [x] nghttp2
- [x] ngtcp2
- [x] npm
- [x] openssl
- [x] postject
- [x] simdutf
- [x] undici
- [x] uv
- [x] uvwasi
- [x] V8
- [x] zlib