### PR TITLE
lib: fix argument error of opendir while opening from Buffer

### DIFF
--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -33,6 +33,7 @@ const {
   validateFunction,
   validateUint32,
 } = require('internal/validators');
+const { Buffer } = require('buffer');
 
 const kDirHandle = Symbol('kDirHandle');
 const kDirPath = Symbol('kDirPath');
@@ -152,7 +153,7 @@ class Dir {
       ArrayPrototypePush(
         this[kDirBufferedEntries],
         getDirent(
-          pathModule.join(path, result[i]),
+          Buffer.isBuffer(path) ? Buffer.concat([path, result[i]]) : pathModule.join(path, result[i]),
           result[i],
           result[i + 1],
         ),

--- a/test/parallel/test-fs-opendir-buffer.js
+++ b/test/parallel/test-fs-opendir-buffer.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const { opendir } = require('fs/promises');
+const path = require('path');
+
+const tmpdir = require('../common/tmpdir');
+
+const testDir = tmpdir.path;
+const files = ['empty', 'files', 'for', 'just', 'testing'];
+
+// Make sure tmp directory is clean
+tmpdir.refresh();
+
+// Create the necessary files
+files.forEach(function(filename) {
+  fs.closeSync(fs.openSync(path.join(testDir, filename), 'w'));
+});
+
+// Opendir from buffer
+{
+  (async () => {
+    // open the directory
+    const dir = await opendir(Buffer.from(testDir), { encoding: 'buffer' });
+    const fileNames = [];
+
+    // Iterate and check each files are Buffer
+    for await (const dirent of dir) {
+      assert.strictEqual(Buffer.isBuffer(dirent.name), true);
+      // Convert the buffer filename to string, so that we can ensure all files are returned.
+      fileNames.push(dirent.name.toString());
+    }
+
+    assert.strictEqual(fileNames.length, files.length);
+
+    // Sort both file arrays, so that it can be compared easily
+    assert.deepStrictEqual(fileNames.sort(), files.sort());
+
+  })().then(common.mustCall());
+}


### PR DESCRIPTION
Fix and issue addressed in #47879 

Changes:
fix argument error of opendir while opening from Buffer

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
