### PR TITLE
tools: fix race condition when npm installing

### DIFF
--- a/tools/dep_updaters/update-acorn-walk.sh
+++ b/tools/dep_updaters/update-acorn-walk.sh
@@ -33,7 +33,7 @@ rm -rf deps/acorn/acorn-walk
 
     "$NODE" "$NPM" init --yes
 
-    "$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts acorn-walk
+    "$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts "acorn-walk@$NEW_VERSION"
 )
 
 mv acorn-walk-tmp/node_modules/acorn-walk deps/acorn

--- a/tools/dep_updaters/update-acorn.sh
+++ b/tools/dep_updaters/update-acorn.sh
@@ -33,7 +33,7 @@ rm -rf deps/acorn/acorn
 
     "$NODE" "$NPM" init --yes
 
-    "$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts acorn
+    "$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts "acorn@$NEW_VERSION"
     cd node_modules/acorn
     # update this version information in src/acorn_version.h
     FILE_PATH="$ROOT/src/acorn_version.h"

--- a/tools/dep_updaters/update-cjs-module-lexer.sh
+++ b/tools/dep_updaters/update-cjs-module-lexer.sh
@@ -44,7 +44,7 @@ cd "$WORKSPACE"
 
 "$NODE" "$NPM" init --yes
 
-"$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts cjs-module-lexer
+"$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts "cjs-module-lexer@$NEW_VERSION"
 
 rm -rf "$DEPS_DIR/cjs-module-lexer"
 

--- a/tools/dep_updaters/update-eslint.sh
+++ b/tools/dep_updaters/update-eslint.sh
@@ -34,7 +34,7 @@ rm -rf ../node_modules/eslint
     --ignore-scripts \
     --install-strategy=shallow \
     --no-bin-links \
-    eslint
+    "eslint@$NEW_VERSION"
     # Uninstall plugins that we want to install so that they are removed from
     # devDependencies. Otherwise --omit=dev will cause them to be skipped.
     (

--- a/tools/dep_updaters/update-minimatch.sh
+++ b/tools/dep_updaters/update-minimatch.sh
@@ -34,7 +34,7 @@ rm -rf deps/minimatch/index.js
 
     "$NODE" "$NPM" init --yes
 
-    "$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts minimatch
+    "$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts "minimatch@$NEW_VERSION"
     cd node_modules/minimatch
     "$NODE" "$NPM" exec --package=esbuild@0.17.15 --yes -- esbuild ./dist/cjs/index.js --bundle --platform=node --outfile=minimatch.js
 )

--- a/tools/dep_updaters/update-postject.sh
+++ b/tools/dep_updaters/update-postject.sh
@@ -27,7 +27,7 @@ cd test/fixtures/postject-copy || exit
 
 "$NODE" "$NPM" init --yes
 
-"$NODE" "$NPM" install --no-bin-links --ignore-scripts postject
+"$NODE" "$NPM" install --no-bin-links --ignore-scripts "postject@$NEW_VERSION"
 
 # TODO(RaisinTen): Replace following with $WORKSPACE
 cd ../../..

--- a/tools/dep_updaters/update-undici.sh
+++ b/tools/dep_updaters/update-undici.sh
@@ -33,7 +33,7 @@ rm -f deps/undici/undici.js
 
     "$NODE" "$NPM" init --yes
 
-    "$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts undici
+    "$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts "undici@$NEW_VERSION"
     cd node_modules/undici
     "$NODE" "$NPM" run build:node
     # update this version information in src/undici_version.h


### PR DESCRIPTION
The update scripts that install dependencies from npm blindly assume that `npm install` will always install the version that was previously fetched as `dist-tags.latest`. That is not necessarily true, so instead always install the specific version that the script thinks is current.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
