### PR TITLE
http: send implicit headers on HEAD with no body

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -887,17 +887,6 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     err = new ERR_STREAM_DESTROYED('write');
   }
 
-  if (!msg._hasBody) {
-    if (msg[kRejectNonStandardBodyWrites]) {
-      throw new ERR_HTTP_BODY_NOT_ALLOWED();
-    } else {
-      debug('This type of response MUST NOT have a body. ' +
-        'Ignoring write() calls.');
-      process.nextTick(callback);
-      return true;
-    }
-  }
-
   if (err) {
     if (!msg.destroyed) {
       onError(msg, err, callback);
@@ -928,6 +917,17 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
       msg._contentLength = len;
     }
     msg._implicitHeader();
+  }
+
+  if (!msg._hasBody) {
+    if (msg[kRejectNonStandardBodyWrites]) {
+      throw new ERR_HTTP_BODY_NOT_ALLOWED();
+    } else {
+      debug('This type of response MUST NOT have a body. ' +
+        'Ignoring write() calls.');
+      process.nextTick(callback);
+      return true;
+    }
   }
 
   if (!fromEnd && msg.socket && !msg.socket.writableCorked) {

--- a/test/parallel/test-http-head-response-has-no-body-end-implicit-headers.js
+++ b/test/parallel/test-http-head-response-has-no-body-end-implicit-headers.js
@@ -1,24 +1,3 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 'use strict';
 const common = require('../common');
 const http = require('http');

--- a/test/parallel/test-http-head-response-has-no-body-end-implicit-headers.js
+++ b/test/parallel/test-http-head-response-has-no-body-end-implicit-headers.js
@@ -25,10 +25,10 @@ const http = require('http');
 
 // This test is to make sure that when the HTTP server
 // responds to a HEAD request with data to res.end,
-// it does not send any body.
+// it does not send any body but the response is sent
+// anyway.
 
 const server = http.createServer(function(req, res) {
-  res.writeHead(200);
   res.end('FAIL'); // broken: sends FAIL from hot path.
 });
 server.listen(0);


### PR DESCRIPTION
If we respond to a HEAD request with a body, we ignore all writes. However, we must still include all implicit headers.

Fixes a regressions introduced in
https://github.com/nodejs/node/pull/47732.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
