### PR TITLE
test,doc,sea: run SEA tests on ppc64

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -233,7 +233,7 @@ platforms:
 * Windows
 * macOS
 * Linux (all distributions [supported by Node.js][] except Alpine and all
-  architectures [supported by Node.js][] except s390x and ppc64)
+  architectures [supported by Node.js][] except s390x)
 
 This is due to a lack of better tools to generate single-executables that can be
 used to test this feature on other platforms.

--- a/test/common/sea.js
+++ b/test/common/sea.js
@@ -40,10 +40,6 @@ function skipIfSingleExecutableIsNotSupported() {
     if (process.arch === 's390x') {
       common.skip('On s390x, postject fails with `memory access out of bounds`.');
     }
-
-    if (process.arch === 'ppc64') {
-      common.skip('On ppc64, this test times out.');
-    }
   }
 }
 


### PR DESCRIPTION
The recent Postject upgrade, https://github.com/nodejs/node/pull/48072, included a performance improvement for the injection operation (see https://github.com/nodejs/postject/pull/86), so now it might be possible to run the SEA tests on the ppc64 architecture runners on Jenkins, which was previously getting timed out.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
