### PR TITLE
tools: add security-wg as dep updaters owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -160,7 +160,7 @@
 
 # Dependency Update Tools
 
-/tools/dep_updaters/* @nodejs/security-wg
 /.github/workflows/tools.yml @nodejs/security-wg
-/.github/workflows/update-v8.yml @nodejs/security-wg @nodejs/v8-update
 /.github/workflows/update-openssl.yml @nodejs/security-wg
+/.github/workflows/update-v8.yml @nodejs/security-wg @nodejs/v8-update
+/tools/dep_updaters/* @nodejs/security-wg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -162,5 +162,5 @@
 
 /tools/dep_updaters/* @nodejs/security-wg
 /.github/workflows/tools.yml @nodejs/security-wg
-/.github/workflows/update-v8.yml @nodejs/security-wg
+/.github/workflows/update-v8.yml @nodejs/security-wg @nodejs/v8-update
 /.github/workflows/update-openssl.yml @nodejs/security-wg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -157,3 +157,10 @@
 /src/permission/* @nodejs/security-wg
 /doc/api/permissions.md @nodejs/security-wg
 /lib/internal/process/permission.js @nodejs/security-wg
+
+# Dependency Update Tools
+
+/tools/dep_updaters/* @nodejs/security-wg
+/.github/workflows/tools.yml @nodejs/security-wg
+/.github/workflows/update-v8.yml @nodejs/security-wg
+/.github/workflows/update-openssl.yml @nodejs/security-wg


### PR DESCRIPTION
Refs: https://github.com/nodejs/security-wg/issues/828
Added security-wg as codeowner of dep updaters
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
