### PR TITLE
lib: use const kIpv4 and kIpv6 in the SocketAddress

### DIFF
--- a/lib/internal/socketaddress.js
+++ b/lib/internal/socketaddress.js
@@ -40,6 +40,9 @@ const {
 const kHandle = Symbol('kHandle');
 const kDetail = Symbol('kDetail');
 
+const kIpv4 = 'ipv4';
+const kIpv6 = 'ipv6';
+
 class SocketAddress extends JSTransferable {
   static isSocketAddress(value) {
     return value?.[kHandle] !== undefined;
@@ -48,9 +51,9 @@ class SocketAddress extends JSTransferable {
   constructor(options = kEmptyObject) {
     super();
     validateObject(options, 'options');
-    let { family = 'ipv4' } = options;
+    let { family = kIpv4 } = options;
     const {
-      address = (family === 'ipv4' ? '127.0.0.1' : '::'),
+      address = (family === kIpv4 ? '127.0.0.1' : '::'),
       port = 0,
       flowlabel = 0,
     } = options;
@@ -59,10 +62,10 @@ class SocketAddress extends JSTransferable {
     if (typeof family?.toLowerCase === 'function')
       family = family.toLowerCase();
     switch (family) {
-      case 'ipv4':
+      case kIpv4:
         type = AF_INET;
         break;
-      case 'ipv6':
+      case kIpv6:
         type = AF_INET6;
         break;
       default:
@@ -91,7 +94,7 @@ class SocketAddress extends JSTransferable {
   }
 
   get family() {
-    return this[kDetail].family === AF_INET ? 'ipv4' : 'ipv6';
+    return this[kDetail].family === AF_INET ? kIpv4 : kIpv6;
   }
 
   get flowlabel() {


### PR DESCRIPTION
**Description of change**

use const kIpv4 and kIpv6 in socketaddress.js

**Checklist**
 
- [x] make -j4 test (UNIX), or vcbuild test (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines)
