### PR TITLE
lib: use const instead of cmd identifiers in the SocketListSend

### DIFF
--- a/lib/internal/socket_list.js
+++ b/lib/internal/socket_list.js
@@ -4,6 +4,11 @@ const { ERR_CHILD_CLOSED_BEFORE_REPLY } = require('internal/errors').codes;
 
 const EventEmitter = require('events');
 
+const NODE_SOCKET_COUNT = 'NODE_SOCKET_COUNT';
+const NODE_SOCKET_GET_COUNT = 'NODE_SOCKET_GET_COUNT';
+const NODE_SOCKET_ALL_CLOSED = 'NODE_SOCKET_ALL_CLOSED';
+const NODE_SOCKET_NOTIFY_CLOSE = 'NODE_SOCKET_NOTIFY_CLOSE';
+
 // This object keeps track of the sockets that are sent
 class SocketListSend extends EventEmitter {
   constructor(child, key) {
@@ -38,16 +43,16 @@ class SocketListSend extends EventEmitter {
 
   close(callback) {
     this._request({
-      cmd: 'NODE_SOCKET_NOTIFY_CLOSE',
+      cmd: NODE_SOCKET_NOTIFY_CLOSE,
       key: this.key,
-    }, 'NODE_SOCKET_ALL_CLOSED', true, callback);
+    }, NODE_SOCKET_ALL_CLOSED, true, callback);
   }
 
   getConnections(callback) {
     this._request({
-      cmd: 'NODE_SOCKET_GET_COUNT',
+      cmd: NODE_SOCKET_GET_COUNT,
       key: this.key,
-    }, 'NODE_SOCKET_COUNT', false, (err, msg) => {
+    }, NODE_SOCKET_COUNT, false, (err, msg) => {
       if (err) return callback(err);
       callback(null, msg.count);
     });
@@ -68,7 +73,7 @@ class SocketListReceive extends EventEmitter {
       if (!self.child.connected) return;
 
       self.child._send({
-        cmd: 'NODE_SOCKET_ALL_CLOSED',
+        cmd: NODE_SOCKET_ALL_CLOSED,
         key: self.key,
       }, undefined, true);
     }
@@ -76,16 +81,16 @@ class SocketListReceive extends EventEmitter {
     this.child.on('internalMessage', (msg) => {
       if (msg.key !== this.key) return;
 
-      if (msg.cmd === 'NODE_SOCKET_NOTIFY_CLOSE') {
+      if (msg.cmd === NODE_SOCKET_NOTIFY_CLOSE) {
         // Already empty
         if (this.connections === 0) return onempty(this);
 
         // Wait for sockets to get closed
         this.once('empty', onempty);
-      } else if (msg.cmd === 'NODE_SOCKET_GET_COUNT') {
+      } else if (msg.cmd === NODE_SOCKET_GET_COUNT) {
         if (!this.child.connected) return;
         this.child._send({
-          cmd: 'NODE_SOCKET_COUNT',
+          cmd: NODE_SOCKET_COUNT,
           key: this.key,
           count: this.connections,
         });


### PR DESCRIPTION
**Description of change**

use const instead of cmd identifiers in the SocketListSend

**Checklist**
 
- [x] make -j4 test (UNIX), or vcbuild test (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines)
