### PR TITLE
src: expose node.http trace flag by array

### DIFF
--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -8,7 +8,10 @@ const {
 } = primordials;
 
 const { setUnrefTimeout } = require('internal/timers');
-const { trace, isTraceCategoryEnabled } = internalBinding('trace_events');
+// The trace variable must not be destructured
+// because it might break node snapshot serialization
+// ref: https://github.com/nodejs/node/pull/48142#discussion_r1204128367
+const trace_events = internalBinding('trace_events');
 const {
   CHAR_LOWERCASE_B,
   CHAR_LOWERCASE_E,
@@ -38,17 +41,17 @@ function getNextTraceEventId() {
 }
 
 function isTraceHTTPEnabled() {
-  return isTraceCategoryEnabled('node.http');
+  return trace_events.tracingCategories[0] > 0;
 }
 
 const traceEventCategory = 'node,node.http';
 
 function traceBegin(...args) {
-  trace(CHAR_LOWERCASE_B, traceEventCategory, ...args);
+  trace_events.trace(CHAR_LOWERCASE_B, traceEventCategory, ...args);
 }
 
 function traceEnd(...args) {
-  trace(CHAR_LOWERCASE_E, traceEventCategory, ...args);
+  trace_events.trace(CHAR_LOWERCASE_E, traceEventCategory, ...args);
 }
 
 module.exports = {

--- a/src/base_object_types.h
+++ b/src/base_object_types.h
@@ -17,7 +17,8 @@ namespace node {
   V(blob_binding_data, BlobBindingData)                                        \
   V(process_binding_data, process::BindingData)                                \
   V(timers_binding_data, timers::BindingData)                                  \
-  V(url_binding_data, url::BindingData)
+  V(url_binding_data, url::BindingData)                                        \
+  V(trace_events_binding_data, trace_events::BindingData)
 
 #define UNSERIALIZABLE_BINDING_TYPES(V)                                        \
   V(http2_binding_data, http2::BindingData)                                    \

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -20,6 +20,7 @@
 #include "node_metadata.h"
 #include "node_process.h"
 #include "node_snapshot_builder.h"
+#include "node_trace_events.h"
 #include "node_url.h"
 #include "node_util.h"
 #include "node_v8.h"

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -26,7 +26,6 @@ using v8::Isolate;
 using v8::Local;
 using v8::NewStringType;
 using v8::Object;
-using v8::ObjectTemplate;
 using v8::String;
 using v8::Uint8Array;
 using v8::Value;
@@ -171,8 +170,6 @@ void NodeCategorySet::RegisterExternalReferences(
 
 namespace trace_events {
 
-void BindingData::MemoryInfo(MemoryTracker* tracker) const {}
-
 BindingData::BindingData(Realm* realm, v8::Local<v8::Object> object)
     : SnapshotableObject(realm, object, type_int) {
   // Get the pointer of the memory for the flag that
@@ -220,23 +217,12 @@ void BindingData::Deserialize(v8::Local<v8::Context> context,
   CHECK_NOT_NULL(binding);
 }
 
-void BindingData::CreatePerIsolateProperties(IsolateData* isolate_data,
-                                             Local<ObjectTemplate> ctor) {}
-
 void BindingData::CreatePerContextProperties(Local<Object> target,
                                              Local<Value> unused,
                                              Local<Context> context,
                                              void* priv) {
   Realm* realm = Realm::GetCurrent(context);
   realm->AddBindingData<BindingData>(context, target);
-}
-
-void BindingData::RegisterExternalReferences(
-    ExternalReferenceRegistry* registry) {}
-
-static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                       Local<ObjectTemplate> ctor) {
-  BindingData::CreatePerIsolateProperties(isolate_data, ctor);
 }
 
 static void CreatePerContextProperties(Local<Object> target,
@@ -248,18 +234,11 @@ static void CreatePerContextProperties(Local<Object> target,
   NodeCategorySet::Initialize(target, unused, context, priv);
 }
 
-void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
-  NodeCategorySet::RegisterExternalReferences(registry);
-  BindingData::RegisterExternalReferences(registry);
-}
-
 }  // namespace trace_events
 
 }  // namespace node
 
 NODE_BINDING_CONTEXT_AWARE_INTERNAL(
     trace_events, node::trace_events::CreatePerContextProperties)
-NODE_BINDING_PER_ISOLATE_INIT(trace_events,
-                              node::trace_events::CreatePerIsolateProperties)
-NODE_BINDING_EXTERNAL_REFERENCE(trace_events,
-                                node::trace_events::RegisterExternalReferences)
+NODE_BINDING_EXTERNAL_REFERENCE(
+    trace_events, node::NodeCategorySet::RegisterExternalReferences)

--- a/src/node_trace_events.h
+++ b/src/node_trace_events.h
@@ -24,18 +24,14 @@ class BindingData : public SnapshotableObject {
 
   SERIALIZABLE_OBJECT_METHODS()
   SET_BINDING_ID(trace_events_binding_data)
-
-  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_NO_MEMORY_INFO()
   SET_SELF_SIZE(BindingData)
   SET_MEMORY_INFO_NAME(BindingData)
 
-  static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                         v8::Local<v8::ObjectTemplate> ctor);
   static void CreatePerContextProperties(v8::Local<v8::Object> target,
                                          v8::Local<v8::Value> unused,
                                          v8::Local<v8::Context> context,
                                          void* priv);
-  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
 };
 
 }  // namespace trace_events

--- a/src/node_trace_events.h
+++ b/src/node_trace_events.h
@@ -1,0 +1,45 @@
+#ifndef SRC_NODE_TRACE_EVENTS_H_
+#define SRC_NODE_TRACE_EVENTS_H_
+
+#include <cinttypes>
+#include "aliased_buffer.h"
+#include "node.h"
+#include "node_snapshotable.h"
+#include "util.h"
+#include "v8-fast-api-calls.h"
+#include "v8.h"
+
+#include <string>
+
+namespace node {
+class ExternalReferenceRegistry;
+
+namespace trace_events {
+
+class BindingData : public SnapshotableObject {
+ public:
+  BindingData(Realm* realm, v8::Local<v8::Object> obj);
+
+  using InternalFieldInfo = InternalFieldInfoBase;
+
+  SERIALIZABLE_OBJECT_METHODS()
+  SET_BINDING_ID(trace_events_binding_data)
+
+  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_SELF_SIZE(BindingData)
+  SET_MEMORY_INFO_NAME(BindingData)
+
+  static void CreatePerIsolateProperties(IsolateData* isolate_data,
+                                         v8::Local<v8::ObjectTemplate> ctor);
+  static void CreatePerContextProperties(v8::Local<v8::Object> target,
+                                         v8::Local<v8::Value> unused,
+                                         v8::Local<v8::Context> context,
+                                         void* priv);
+  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
+};
+
+}  // namespace trace_events
+
+}  // namespace node
+
+#endif  // SRC_NODE_TRACE_EVENTS_H_


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR aims to fix the issue raised on NodeJS Performance: https://github.com/nodejs/performance/issues/81

The function `isTraceHTTPEnable` is a little bit expensive, in general, that function should not even appear in the stack trace since is just to check if the trace is enabled.

The solution was inspired by https://github.com/nodejs/performance/issues/81#issuecomment-1547615298 and it basically exposes the C++ pointer of the flag that tells if the HTTP trace is enabled or not by using an array.

## To Reviewers

Some interesting files that could be looked to review this code:

- Built-in Trace Function: https://github.com/nodejs/node/blob/300f68e9d0fcee9f50dd124000b2027b24592c8a/deps/v8/src/builtins/builtins-trace.cc#L107-L123
- The implementation of GetCategoryGroupEnabled: https://github.com/nodejs/node/blob/300f68e9d0fcee9f50dd124000b2027b24592c8a/deps/v8/src/libplatform/tracing/tracing-controller.cc#L295-L344
- The defined function used to get the current category pointer: https://github.com/nodejs/node/blob/300f68e9d0fcee9f50dd124000b2027b24592c8a/src/tracing/trace_event.h#L62-L73
