### PR TITLE
test: fix flaky test-runner-watch-mode

### DIFF
--- a/test/fixtures/test-runner/dependency.js
+++ b/test/fixtures/test-runner/dependency.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/test/fixtures/test-runner/dependency.mjs
+++ b/test/fixtures/test-runner/dependency.mjs
@@ -1,1 +1,0 @@
-export const a = 1;

--- a/test/fixtures/test-runner/dependent.js
+++ b/test/fixtures/test-runner/dependent.js
@@ -1,5 +1,0 @@
-const test = require('node:test');
-require('./dependency.js');
-import('./dependency.mjs');
-import('data:text/javascript,');
-test('test has ran');

--- a/test/parallel/test-runner-watch-mode.mjs
+++ b/test/parallel/test-runner-watch-mode.mjs
@@ -1,33 +1,37 @@
 // Flags: --expose-internals
 import '../common/index.mjs';
+import path from 'node:path';
 import { describe, it } from 'node:test';
 import { spawn } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import util from 'internal/util';
-import * as fixtures from '../common/fixtures.mjs';
+import tmpdir from '../common/tmpdir.js';
+
+tmpdir.refresh();
 
 // This test updates these files repeatedly,
 // Reading them from disk is unreliable due to race conditions.
 const fixtureContent = {
-  [fixtures.path('test-runner/dependent.js')]:
-`const test = require('node:test');
+  'dependency.js': 'module.exports = {};',
+  'dependency.mjs': 'export const a = 1;',
+  'dependent.js': `
+const test = require('node:test');
 require('./dependency.js');
 import('./dependency.mjs');
 import('data:text/javascript,');
-test('test has ran');
-`,
-  [fixtures.path('test-runner/dependency.js')]:
-`module.exports = {};
-`,
-  [fixtures.path('test-runner/dependency.mjs')]:
-`export const a = 1;
-`,
+test('test has ran');`,
 };
+const fixturePaths = Object.keys(fixtureContent)
+  .reduce((acc, file) => ({ ...acc, [file]: path.join(tmpdir.path, file) }), {});
+Object.entries(fixtureContent)
+  .forEach(([file, content]) => writeFileSync(fixturePaths[file], content));
 
-async function testWatch({ files, fileToUpdate }) {
+async function testWatch({ fileToUpdate }) {
   const ran1 = util.createDeferredPromise();
   const ran2 = util.createDeferredPromise();
-  const child = spawn(process.execPath, ['--watch', '--test', '--no-warnings', ...files], { encoding: 'utf8' });
+  const child = spawn(process.execPath,
+                      ['--watch', '--test', '--no-warnings', fixturePaths['dependent.js']],
+                      { encoding: 'utf8', stdio: 'pipe' });
   let stdout = '';
 
   child.stdout.on('data', (data) => {
@@ -39,7 +43,11 @@ async function testWatch({ files, fileToUpdate }) {
 
   await ran1.promise;
   const content = fixtureContent[fileToUpdate];
-  const interval = setInterval(() => writeFileSync(fileToUpdate, content), 10);
+  const path = fixturePaths[fileToUpdate];
+  const interval = setInterval(() => {
+    console.log(`Updating ${path}`);
+    writeFileSync(path, content);
+  }, 50);
   await ran2.promise;
   clearInterval(interval);
   child.kill();
@@ -47,22 +55,14 @@ async function testWatch({ files, fileToUpdate }) {
 
 describe('test runner watch mode', () => {
   it('should run tests repeatedly', async () => {
-    const file1 = fixtures.path('test-runner/index.test.js');
-    const file2 = fixtures.path('test-runner/dependent.js');
-    await testWatch({ files: [file1, file2], fileToUpdate: file2 });
+    await testWatch({ fileToUpdate: 'dependent.js' });
   });
 
   it('should run tests with dependency repeatedly', async () => {
-    const file1 = fixtures.path('test-runner/index.test.js');
-    const dependent = fixtures.path('test-runner/dependent.js');
-    const dependency = fixtures.path('test-runner/dependency.js');
-    await testWatch({ files: [file1, dependent], fileToUpdate: dependency });
+    await testWatch({ fileToUpdate: 'dependency.js' });
   });
 
   it('should run tests with ESM dependency', async () => {
-    const file1 = fixtures.path('test-runner/index.test.js');
-    const dependent = fixtures.path('test-runner/dependent.js');
-    const dependency = fixtures.path('test-runner/dependency.mjs');
-    await testWatch({ files: [file1, dependent], fileToUpdate: dependency });
+    await testWatch({ fileToUpdate: 'dependency.mjs' });
   });
 });


### PR DESCRIPTION
I was able to reproduce the fluke with `tools/test.py -J --timeout=10 --repeat=1500 test/parallel/test-runner-watch-mode` and validate this fixes it