### PR TITLE
node-api: define version 9

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1220,9 +1220,8 @@ This API throws a JavaScript `RangeError` with the text provided.
 added:
   - v17.2.0
   - v16.14.0
+napiVersion: 9
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 NAPI_EXTERN napi_status node_api_throw_syntax_error(napi_env env,
@@ -1341,9 +1340,8 @@ This API returns a JavaScript `RangeError` with the text provided.
 added:
   - v17.2.0
   - v16.14.0
+napiVersion: 9
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 NAPI_EXTERN napi_status node_api_create_syntax_error(napi_env env,
@@ -2592,9 +2590,8 @@ of the ECMAScript Language Specification.
 added:
   - v17.5.0
   - v16.15.0
+napiVersion: 9
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 napi_status node_api_symbol_for(napi_env env,
@@ -6348,9 +6345,8 @@ added:
   - v15.9.0
   - v14.18.0
   - v12.22.0
+napiVersion: 9
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 NAPI_EXTERN napi_status

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -95,13 +95,13 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_create_string_utf16(napi_env env,
 NAPI_EXTERN napi_status NAPI_CDECL napi_create_symbol(napi_env env,
                                                       napi_value description,
                                                       napi_value* result);
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 9
 NAPI_EXTERN napi_status NAPI_CDECL
 node_api_symbol_for(napi_env env,
                     const char* utf8description,
                     size_t length,
                     napi_value* result);
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 9
 NAPI_EXTERN napi_status NAPI_CDECL napi_create_function(napi_env env,
                                                         const char* utf8name,
                                                         size_t length,
@@ -120,10 +120,10 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_create_range_error(napi_env env,
                                                            napi_value code,
                                                            napi_value msg,
                                                            napi_value* result);
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 9
 NAPI_EXTERN napi_status NAPI_CDECL node_api_create_syntax_error(
     napi_env env, napi_value code, napi_value msg, napi_value* result);
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 9
 
 // Methods to get the native napi_value from Primitive type
 NAPI_EXTERN napi_status NAPI_CDECL napi_typeof(napi_env env,
@@ -378,11 +378,11 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_throw_type_error(napi_env env,
 NAPI_EXTERN napi_status NAPI_CDECL napi_throw_range_error(napi_env env,
                                                           const char* code,
                                                           const char* msg);
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 9
 NAPI_EXTERN napi_status NAPI_CDECL node_api_throw_syntax_error(napi_env env,
                                                                const char* code,
                                                                const char* msg);
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 9
 NAPI_EXTERN napi_status NAPI_CDECL napi_is_error(napi_env env,
                                                  napi_value value,
                                                  bool* result);

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -673,11 +673,13 @@ node::addon_context_register_func get_node_api_context_register_func(
     const char* module_name,
     int32_t module_api_version) {
   static_assert(
-      NAPI_VERSION == 8,
+      NAPI_VERSION == 9,
       "New version of Node-API requires adding another else-if statement below "
       "for the new version and updating this assert condition.");
   if (module_api_version <= NODE_API_DEFAULT_MODULE_API_VERSION) {
     return node_api_context_register_func<NODE_API_DEFAULT_MODULE_API_VERSION>;
+  } else if (module_api_version == 9) {
+    return node_api_context_register_func<9>;
   } else if (module_api_version == NAPI_VERSION_EXPERIMENTAL) {
     return node_api_context_register_func<NAPI_VERSION_EXPERIMENTAL>;
   } else {

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -248,12 +248,12 @@ napi_remove_async_cleanup_hook(napi_async_cleanup_hook_handle remove_handle);
 
 #endif  // NAPI_VERSION >= 8
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 9
 
 NAPI_EXTERN napi_status NAPI_CDECL
 node_api_get_module_file_name(napi_env env, const char** result);
 
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 9
 
 EXTERN_C_END
 

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -93,7 +93,7 @@
 
 // The NAPI_VERSION provided by this version of the runtime. This is the version
 // which the Node binary being built supports.
-#define NAPI_VERSION 8
+#define NAPI_VERSION 9
 
 // Node API modules use NAPI_VERSION 8 by default if it is not explicitly
 // specified. It must be always 8.

--- a/test/js-native-api/test_error/test_error.c
+++ b/test/js-native-api/test_error/test_error.c
@@ -1,4 +1,4 @@
-#define NAPI_EXPERIMENTAL
+#define NAPI_VERSION 9
 #include <js_native_api.h>
 #include "../common.h"
 

--- a/test/js-native-api/test_general/test.js
+++ b/test/js-native-api/test_general/test.js
@@ -33,7 +33,7 @@ assert.notStrictEqual(test_general.testGetPrototype(baseObject),
                       test_general.testGetPrototype(extendedObject));
 
 // Test version management functions
-assert.strictEqual(test_general.testGetVersion(), 8);
+assert.strictEqual(test_general.testGetVersion(), 9);
 
 [
   123,

--- a/test/js-native-api/test_properties/test_properties.c
+++ b/test/js-native-api/test_properties/test_properties.c
@@ -1,4 +1,4 @@
-#define NAPI_EXPERIMENTAL
+#define NAPI_VERSION 9
 #include <js_native_api.h>
 #include "../common.h"
 

--- a/test/js-native-api/test_reference/test_reference.c
+++ b/test/js-native-api/test_reference/test_reference.c
@@ -1,4 +1,4 @@
-#define NAPI_EXPERIMENTAL
+#define NAPI_VERSION 9
 #include <stdlib.h>
 #include <assert.h>
 #include <js_native_api.h>

--- a/test/node-api/test_general/test_general.c
+++ b/test/node-api/test_general/test_general.c
@@ -1,4 +1,4 @@
-#define NAPI_EXPERIMENTAL
+#define NAPI_VERSION 9
 // we define NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED here to validate that it can
 // be used as a form of test itself. It is
 // not related to any of the other tests


### PR DESCRIPTION
Node-API version 9 promotes the following Node-API into stable:

- `node_api_throw_syntax_error`
- `node_api_create_syntax_error`
- `node_api_symbol_for`
- `node_api_get_module_file_name`

Runtime behavior changes introduced in https://github.com/nodejs/node/pull/47975 and https://github.com/nodejs/node/pull/47986 are still left experimental since they landed just in the past month and not backported to all LTS lines.

/cc @nodejs/node-api-implementer 
