### PR TITLE
deps: set `CARES_RANDOM_FILE` for c-ares

### DIFF
--- a/deps/cares/config/aix/ares_config.h
+++ b/deps/cares/config/aix/ares_config.h
@@ -378,7 +378,7 @@
 #define PACKAGE_VERSION "1.13.0"
 
 /* a suitable file/device to read random data from */
-#define RANDOM_FILE "/dev/urandom"
+#define CARES_RANDOM_FILE "/dev/urandom"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
 #define RECVFROM_QUAL_ARG5

--- a/deps/cares/config/android/ares_config.h
+++ b/deps/cares/config/android/ares_config.h
@@ -378,7 +378,7 @@
 #define PACKAGE_VERSION "1.13.0"
 
 /* a suitable file/device to read random data from */
-#define RANDOM_FILE "/dev/urandom"
+#define CARES_RANDOM_FILE "/dev/urandom"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
 #define RECVFROM_QUAL_ARG5

--- a/deps/cares/config/cygwin/ares_config.h
+++ b/deps/cares/config/cygwin/ares_config.h
@@ -379,7 +379,7 @@
 #define PACKAGE_VERSION "1.13.0"
 
 /* a suitable file/device to read random data from */
-#define RANDOM_FILE "/dev/urandom"
+#define CARES_RANDOM_FILE "/dev/urandom"
 
 /* Define to the type of arg 1 for recvfrom. */
 #define RECVFROM_TYPE_ARG1 int

--- a/deps/cares/config/darwin/ares_config.h
+++ b/deps/cares/config/darwin/ares_config.h
@@ -378,7 +378,7 @@
 #define PACKAGE_VERSION "1.13.0"
 
 /* a suitable file/device to read random data from */
-#define RANDOM_FILE "/dev/urandom"
+#define CARES_RANDOM_FILE "/dev/urandom"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
 #define RECVFROM_QUAL_ARG5

--- a/deps/cares/config/freebsd/ares_config.h
+++ b/deps/cares/config/freebsd/ares_config.h
@@ -378,7 +378,7 @@
 #define PACKAGE_VERSION "1.13.0"
 
 /* a suitable file/device to read random data from */
-#define RANDOM_FILE "/dev/urandom"
+#define CARES_RANDOM_FILE "/dev/urandom"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
 #define RECVFROM_QUAL_ARG5

--- a/deps/cares/config/linux/ares_config.h
+++ b/deps/cares/config/linux/ares_config.h
@@ -378,7 +378,7 @@
 #define PACKAGE_VERSION "1.13.0"
 
 /* a suitable file/device to read random data from */
-#define RANDOM_FILE "/dev/urandom"
+#define CARES_RANDOM_FILE "/dev/urandom"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
 #define RECVFROM_QUAL_ARG5

--- a/deps/cares/config/netbsd/ares_config.h
+++ b/deps/cares/config/netbsd/ares_config.h
@@ -378,7 +378,7 @@
 #define PACKAGE_VERSION "1.13.0"
 
 /* a suitable file/device to read random data from */
-#define RANDOM_FILE "/dev/urandom"
+#define CARES_RANDOM_FILE "/dev/urandom"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
 #define RECVFROM_QUAL_ARG5

--- a/deps/cares/config/openbsd/ares_config.h
+++ b/deps/cares/config/openbsd/ares_config.h
@@ -378,7 +378,7 @@
 #define PACKAGE_VERSION "1.13.0"
 
 /* a suitable file/device to read random data from */
-#define RANDOM_FILE "/dev/urandom"
+#define CARES_RANDOM_FILE "/dev/urandom"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
 #define RECVFROM_QUAL_ARG5

--- a/deps/cares/config/sunos/ares_config.h
+++ b/deps/cares/config/sunos/ares_config.h
@@ -378,7 +378,7 @@
 #define PACKAGE_VERSION "1.13.0"
 
 /* a suitable file/device to read random data from */
-#define RANDOM_FILE "/dev/urandom"
+#define CARES_RANDOM_FILE "/dev/urandom"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
 #define RECVFROM_QUAL_ARG5


### PR DESCRIPTION
Upstream c-ares renamed `RANDOM_FILE` to `CARES_RANDOM_FILE` some time ago in c-ares 1.17.2.

Refs: https://github.com/c-ares/c-ares/pull/397

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
