### PR TITLE
src: check node_extra_ca_certs after openssl config

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -961,11 +961,6 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
       return ret;
     };
 
-    {
-      std::string extra_ca_certs;
-      if (credentials::SafeGetenv("NODE_EXTRA_CA_CERTS", &extra_ca_certs))
-        crypto::UseExtraCaCerts(extra_ca_certs);
-    }
     // In the case of FIPS builds we should make sure
     // the random source is properly initialized first.
 #if OPENSSL_VERSION_MAJOR >= 3
@@ -1052,6 +1047,12 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
       CHECK(crypto::CSPRNG(buffer, length).is_ok());
       return true;
     });
+
+    {
+      std::string extra_ca_certs;
+      if (credentials::SafeGetenv("NODE_EXTRA_CA_CERTS", &extra_ca_certs))
+        crypto::UseExtraCaCerts(extra_ca_certs);
+    }
 #endif  // HAVE_OPENSSL && !defined(OPENSSL_IS_BORINGSSL)
   }
 


### PR DESCRIPTION
I recently discovered that the custom NodeJS specific OpenSSL config section in openssl.cnf would not be respected, if the environment variable `NODE_EXTRA_CA_CERTS` was set.

This happens even if it contains an invalid value, i.e no actual certs are read.

[Someone suggested](https://github.com/nodejs/node/issues/48143#issuecomment-1560570740) moving the checking of extra ca certs to after the OpenSSL config is read, and this seems to work.

I wasn't sure how to add a test for this directly into the repo, but as part of my bug report, I had constructed a test which attempts to make a TLS connection to the offending server with a custom OpenSSL config, once with `NODE_EXTRA_CA_CERTS` set to `""` , and once with a dummy value (e.g `/dev/null`)

To test this change, I build node with the patch and made published it as a container (you can see dockerfile & patch here: https://github.com/ckcr4lyf/no-rfc5746/tree/master/patched_node)

I then updated my tests to load the custom SSL config into this patched node and try the same test, and it passes both cases now!

An example run can be found here: https://github.com/ckcr4lyf/no-rfc5746/actions/runs/5071123450

Note: I am testing the node's usage of the custom SSL config by providing a non-default legacy renegotiation option, and then connecting to a mocked server [where I handcraft this insecure ServerHello](https://github.com/ckcr4lyf/no-rfc5746/blob/8e2106c2f33607364f1dbd9949ce5a0e3b74f06a/server.mjs#L15). 

Fixes #48143 