### PR TITLE
v8: isBuildingSnapshotBuffer out of bound fix

### DIFF
--- a/lib/internal/v8/startup_snapshot.js
+++ b/lib/internal/v8/startup_snapshot.js
@@ -19,7 +19,7 @@ const {
 } = internalBinding('mksnapshot');
 
 function isBuildingSnapshot() {
-  return isBuildingSnapshotBuffer[0];
+  return isBuildingSnapshotBuffer?[0];
 }
 
 function throwIfNotBuildingSnapshot() {


### PR DESCRIPTION
```sh
❯ ./out/Release/node
node:internal/v8/startup_snapshot:22
  return isBuildingSnapshotBuffer[0];
                                 ^

TypeError: Cannot read properties of undefined (reading '0')
    at isBuildingSnapshot (node:internal/v8/startup_snapshot:22:34)
    at initializeGlobalConsole (node:internal/console/constructor:701:51)
    at patchProcessObject (node:internal/process/pre_execution:169:3)
    at prepareExecution (node:internal/process/pre_execution:64:3)
    at prepareMainThreadExecution (node:internal/process/pre_execution:42:3)
    at node: internal/main/repl:21:1

Node.js v21.0.0-pre
```
Was noticing this issue and fixing the array access made sense.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
