### PR TITLE
tools: don't gitignore base64 config.h

### DIFF
--- a/tools/dep_updaters/update-base64.sh
+++ b/tools/dep_updaters/update-base64.sh
@@ -49,7 +49,11 @@ mv "$WORKSPACE/base64" "$DEPS_DIR/base64/"
 
 # Build configuration is handled by `deps/base64/base64.gyp`, but since `config.h` has to be present for the build
 # to work, we create it and leave it empty.
-echo "// Intentionally empty" >> "$DEPS_DIR/base64/base64/lib/config.h"
+echo "// Intentionally empty" > "$DEPS_DIR/base64/base64/lib/config.h"
+
+# Clear out .gitignore, otherwise config.h is ignored. That's dangerous when
+# people check in our tarballs into source control and run `git clean`.
+echo "# Intentionally empty" > "$DEPS_DIR/base64/base64/.gitignore"
 
 echo "All done!"
 echo ""


### PR DESCRIPTION
The file is checked into git. Ignoring it causes a very non-obvious way of breaking tarball builds:

1. Download and unpack tarball
2. Check the sources into git with `git init; git add .; git commit -a`
3. Clean the source tree with `git clean -dfx`
4. Run `./configure && make`
5. Observe build failure because config.h is missing

Fixes: https://github.com/nodejs/node/issues/47638