### PR TITLE
test: mark test_cannot_run_js as flaky

### DIFF
--- a/test/root.status
+++ b/test/root.status
@@ -1,3 +1,6 @@
+[true]
+js-native-api/test_cannot_run_js/test: PASS,FLAKY
+
 [$mode==debug]
 async-hooks/test-callback-error: SLOW
 async-hooks/test-emit-init: SLOW


### PR DESCRIPTION
This test has been failing occasionally since it was introduced ~5 days ago. It was the number one failing JS test in the most recent reliability report. Mark it as flaky.

Fixes: https://github.com/nodejs/node/issues/48180
Refs: https://github.com/nodejs/node/pull/47986
Refs: https://github.com/nodejs/reliability/issues/576