### PR TITLE
Revert "test: unskip negative-settimeout.any.js WPT"

### DIFF
--- a/test/wpt/status/html/webappapis/timers.json
+++ b/test/wpt/status/html/webappapis/timers.json
@@ -1,1 +1,5 @@
-{}
+{
+  "negative-settimeout.any.js": {
+    "skip": "unreliable in Node.js; Refs: https://github.com/nodejs/node/issues/37672"
+  }
+}


### PR DESCRIPTION
This reverts commit 8244e6c35c0e9af3976511f31db2575bd2fc9d7a, PR #47946

https://github.com/nodejs/reliability/issues/577