### PR TITLE
tools: simplify update-openssl workflow

### DIFF
--- a/.github/workflows/update-openssl.yml
+++ b/.github/workflows/update-openssl.yml
@@ -17,28 +17,16 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
         with:
           persist-credentials: false
-      - name: Check if update branch already exists
-        run: |
-          BRANCH_EXISTS=$(git ls-remote --heads origin actions/tools-update-openssl)
-          echo "BRANCH_EXISTS=$BRANCH_EXISTS" >> $GITHUB_ENV
       - name: Check and download new OpenSSL version
-        # Only run rest of the workflow if the update branch does not yet exist
-        if: ${{ env.BRANCH_EXISTS == '' }}
         run: |
-          NEW_VERSION=$(gh api repos/quictls/openssl/releases -q '.[].tag_name|select(contains("openssl-3"))|ltrimstr("openssl-")' | head -n1)
-          NEW_VERSION_NO_RELEASE_1=$(case $NEW_VERSION in *quic1) echo ${NEW_VERSION%1};; *) echo $NEW_VERSION;; esac)
-          VERSION_H="./deps/openssl/config/archs/linux-x86_64/asm/include/openssl/opensslv.h"
-          CURRENT_VERSION=$(grep "OPENSSL_FULL_VERSION_STR" $VERSION_H | sed -n "s/^.*VERSION_STR \"\(.*\)\"/\1/p" | sed 's/+/-/g')
-          echo "comparing current version: $CURRENT_VERSION with $NEW_VERSION_NO_RELEASE_1"
-          if [ "$NEW_VERSION_NO_RELEASE_1" != "$CURRENT_VERSION" ]; then
-            echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-            echo "HAS_UPDATE=true" >> $GITHUB_ENV
-            ./tools/dep_updaters/update-openssl.sh download "$NEW_VERSION"
-          fi
+          ./tools/dep_updaters/update-openssl.sh download > temp-output
+          cat temp-output
+          tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
+          rm temp-output
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
       - name: Create PR with first commit
-        if: env.HAS_UPDATE
+        if: env.NEW_VERSION
         uses: gr2m/create-or-update-pull-request-action@df20b2c073090271599a08c55ae26e0c3522b329  # v1.9.2
         # Creates a PR with the new OpenSSL source code committed
         env:
@@ -53,7 +41,7 @@ jobs:
           path: deps/openssl
           update-pull-request-title-and-body: true
       - name: Regenerate platform specific files
-        if: env.HAS_UPDATE
+        if: env.NEW_VERSION
         run: |
           sudo apt install -y nasm libtext-template-perl
           ./tools/dep_updaters/update-openssl.sh regenerate
@@ -61,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
       - name: Add second commit
         # Adds a second commit to the PR with the generated platform-dependent files
-        if: env.HAS_UPDATE
+        if: env.NEW_VERSION
         uses: gr2m/create-or-update-pull-request-action@df20b2c073090271599a08c55ae26e0c3522b329  # v1.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}

--- a/tools/dep_updaters/update-openssl.sh
+++ b/tools/dep_updaters/update-openssl.sh
@@ -18,7 +18,7 @@ download() {
 const res = await fetch('https://api.github.com/repos/quictls/openssl/releases');
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const releases = await res.json()
-const latest = releases.find(({ tag_name }) => tag_name.contains('openssl-3.0'));
+const latest = releases.find(({ tag_name }) => tag_name.includes('openssl-3.0'));
 if(!latest) throw new Error(`Could not find latest release for 3.0`);
 console.log(latest.tag_name.replace('openssl-', ''));
 EOF

--- a/tools/dep_updaters/update-openssl.sh
+++ b/tools/dep_updaters/update-openssl.sh
@@ -18,8 +18,9 @@ download() {
 const res = await fetch('https://api.github.com/repos/quictls/openssl/releases');
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const releases = await res.json()
-const { tag_name } = releases.at(0);
-console.log(tag_name.replace('openssl-', ''));
+const latest = releases.find(({ tag_name }) => tag_name.contains('openssl-3.0'));
+if(!latest) throw new Error(`Could not find latest release for 3.0`);
+console.log(latest.tag_name.replace('openssl-', ''));
 EOF
 )"
 


### PR DESCRIPTION
This removes a lot of noise from the github action and allows to run the update script without specifying a version.
Unlike other dependencies we want to keep the update with the specified target version for backporting security patches to v16 which is no longer compatible with the version on main.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
