### PR TITLE
src: implement constants and natives binding directly

### DIFF
--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -78,11 +78,13 @@ ObjectDefineProperty(process, 'moduleLoadList', {
 });
 
 
-// internalBindingAllowlist contains the name of internalBinding modules
-// that are allowed for access via process.binding()... This is used
-// to provide a transition path for modules that are being moved over to
-// internalBinding.
-const internalBindingAllowlist = new SafeSet([
+// processBindingAllowList contains the name of bindings that are allowed
+// for access via process.binding(). This is used to provide a transition
+// path for modules that are being moved over to internalBinding.
+// Certain bindings may not actually correspond to an internalBinding any
+// more, we just implement them as legacy wrappers instead. See the
+// legacyWrapperList.
+const processBindingAllowList = new SafeSet([
   'async_wrap',
   'buffer',
   'cares_wrap',
@@ -124,6 +126,7 @@ const runtimeDeprecatedList = new SafeSet([
 ]);
 
 const legacyWrapperList = new SafeSet([
+  'natives',
   'util',
 ]);
 
@@ -145,7 +148,7 @@ const experimentalModuleList = new SafeSet();
     module = String(module);
     // Deprecated specific process.binding() modules, but not all, allow
     // selective fallback to internalBinding for the deprecated ones.
-    if (internalBindingAllowlist.has(module)) {
+    if (processBindingAllowList.has(module)) {
       if (runtimeDeprecatedList.has(module)) {
         runtimeDeprecatedList.delete(module);
         process.emitWarning(

--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -118,16 +118,12 @@ function extractFunctionName(description) {
   return fnNameMatch ? `: ${fnNameMatch[1]}` : '';
 }
 
-const {
-  builtinIds: PUBLIC_BUILTINS,
-} = internalBinding('builtins');
-const NATIVES = internalBinding('natives');
+const { builtinIds } = internalBinding('builtins');
 function isNativeUrl(url) {
   url = SideEffectFreeRegExpPrototypeSymbolReplace(/\.js$/, url, '');
 
   return StringPrototypeStartsWith(url, 'node:internal/') ||
-         ArrayPrototypeIncludes(PUBLIC_BUILTINS, url) ||
-         url in NATIVES || url === 'bootstrap_node';
+         ArrayPrototypeIncludes(builtinIds, url);
 }
 
 function getRelativePath(filenameOrURL) {

--- a/lib/internal/legacy/processbinding.js
+++ b/lib/internal/legacy/processbinding.js
@@ -36,7 +36,8 @@ module.exports = {
   natives() {
     const { natives: result, configs } = internalBinding('builtins');
     // Legacy feature: process.binding('natives').config contains stringified
-    // config.gypi
+    // config.gypi. We do not use this object internally so it's fine to mutate
+    // it.
     result.configs = configs;
     return result;
   },

--- a/lib/internal/legacy/processbinding.js
+++ b/lib/internal/legacy/processbinding.js
@@ -33,4 +33,11 @@ module.exports = {
         ], key);
       })));
   },
+  natives() {
+    const { natives: result, configs } = internalBinding('builtins');
+    // Legacy feature: process.binding('natives').config contains stringified
+    // config.gypi
+    result.configs = configs;
+    return result;
+  },
 };

--- a/lib/internal/v8_prof_processor.js
+++ b/lib/internal/v8_prof_processor.js
@@ -12,7 +12,7 @@ const console = require('internal/console/global');
 const vm = require('vm');
 const { SourceTextModule } = require('internal/vm/module');
 
-const natives = internalBinding('natives');
+const { natives } = internalBinding('builtins');
 
 async function linker(specifier, referencingModule) {
   // Transform "./file.mjs" to "file"

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -635,15 +635,6 @@ void GetInternalBinding(const FunctionCallbackInfo<Value>& args) {
     exports = Object::New(isolate);
     CHECK(exports->SetPrototype(context, Null(isolate)).FromJust());
     DefineConstants(isolate, exports);
-  } else if (!strcmp(*module_v, "natives")) {
-    exports = realm->env()->builtin_loader()->GetSourceObject(context);
-    // Legacy feature: process.binding('natives').config contains stringified
-    // config.gypi
-    CHECK(exports
-              ->Set(context,
-                    realm->isolate_data()->config_string(),
-                    realm->env()->builtin_loader()->GetConfigString(isolate))
-              .FromJust());
   } else {
     return THROW_ERR_INVALID_MODULE(isolate, "No such binding: %s", *module_v);
   }

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -34,6 +34,7 @@
   V(builtins)                                                                  \
   V(cares_wrap)                                                                \
   V(config)                                                                    \
+  V(constants)                                                                 \
   V(contextify)                                                                \
   V(credentials)                                                               \
   V(encoding_binding)                                                          \
@@ -619,7 +620,6 @@ void GetInternalBinding(const FunctionCallbackInfo<Value>& args) {
   Realm* realm = Realm::GetCurrent(args);
   Isolate* isolate = realm->isolate();
   HandleScope scope(isolate);
-  Local<Context> context = realm->context();
 
   CHECK(args[0]->IsString());
 
@@ -631,10 +631,6 @@ void GetInternalBinding(const FunctionCallbackInfo<Value>& args) {
   if (mod != nullptr) {
     exports = InitInternalBinding(realm, mod);
     realm->internal_bindings.insert(mod);
-  } else if (!strcmp(*module_v, "constants")) {
-    exports = Object::New(isolate);
-    CHECK(exports->SetPrototype(context, Null(isolate)).FromJust());
-    DefineConstants(isolate, exports);
   } else {
     return THROW_ERR_INVALID_MODULE(isolate, "No such binding: %s", *module_v);
   }

--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -107,7 +107,6 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
                                            const char* id,
                                            Realm* realm);
 
-  v8::Local<v8::Object> GetSourceObject(v8::Local<v8::Context> context);
   // Returns config.gypi as a JSON string
   v8::Local<v8::String> GetConfigString(v8::Isolate* isolate);
   bool Exists(const char* id);
@@ -169,6 +168,9 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
   static void CompileFunction(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void HasCachedBuiltins(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  // For legacy process.binding('natives')
+  static void GetNatives(v8::Local<v8::Name> property,
+                         const v8::PropertyCallbackInfo<v8::Value>& info);
 
   void AddExternalizedBuiltin(const char* id, const char* filename);
 

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -63,10 +63,14 @@
 
 namespace node {
 
+using v8::Context;
+using v8::Isolate;
 using v8::Local;
+using v8::Null;
 using v8::Object;
+using v8::Value;
 
-namespace {
+namespace constants {
 
 void DefineErrnoConstants(Local<Object> target) {
 #ifdef E2BIG
@@ -1270,10 +1274,14 @@ void DefineTraceConstants(Local<Object> target) {
   NODE_DEFINE_CONSTANT(target, TRACE_EVENT_PHASE_LINK_IDS);
 }
 
-}  // anonymous namespace
+void CreatePerContextProperties(Local<Object> target,
+                                Local<Value> unused,
+                                Local<Context> context,
+                                void* priv) {
+  Isolate* isolate = context->GetIsolate();
+  Environment* env = Environment::GetCurrent(context);
 
-void DefineConstants(v8::Isolate* isolate, Local<Object> target) {
-  Environment* env = Environment::GetCurrent(isolate);
+  CHECK(target->SetPrototype(env->context(), Null(env->isolate())).FromJust());
 
   Local<Object> os_constants = Object::New(isolate);
   CHECK(os_constants->SetPrototype(env->context(),
@@ -1353,4 +1361,8 @@ void DefineConstants(v8::Isolate* isolate, Local<Object> target) {
               trace_constants).Check();
 }
 
+}  // namespace constants
 }  // namespace node
+
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(constants,
+                                    node::constants::CreatePerContextProperties)

--- a/src/node_constants.h
+++ b/src/node_constants.h
@@ -74,11 +74,6 @@
 #endif  // NODE_OPENSSL_DEFAULT_CIPHER_LIST
 #endif  // HAVE_OPENSSL
 
-namespace node {
-
-void DefineConstants(v8::Isolate* isolate, v8::Local<v8::Object> target);
-}  // namespace node
-
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #endif  // SRC_NODE_CONSTANTS_H_

--- a/test/es-module/test-loaders-hidden-from-users.js
+++ b/test/es-module/test-loaders-hidden-from-users.js
@@ -17,8 +17,9 @@ assert.throws(
 assert.throws(
   () => {
     const source = 'module.exports = require("internal/bootstrap/realm")';
-    const { internalBinding } = require('internal/test/binding');
-    internalBinding('natives').owo = source;
+    // This needs to be process.binding() to mimic what's normally available
+    // in the user land.
+    process.binding('natives').owo = source;
     require('owo');
   }, {
     code: 'MODULE_NOT_FOUND',


### PR DESCRIPTION
### src: implement natives binding without special casing

This patch removes special case in the internal binding loader
for natives, and implements it using the builtins internal
binding. Internally we do not actually need the natives binding,
so implement it as a legacy wrapper instead.

### src: implement constants binding directly

Instead of adding a special case for it in the internal binding
loader, just implement it as usual using a per-context property
initializer.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
