### PR TITLE
net: fix family autoselection SSL connection handling

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -634,8 +634,8 @@ TLSSocket.prototype._wrapHandle = function(wrap, handle) {
 };
 
 TLSSocket.prototype[kReinitializeHandle] = function reinitializeHandle(handle) {
-  const originalServername = this._handle.getServername();
-  const originalSession = this._handle.getSession();
+  const originalServername = this.ssl ? this._handle.getServername() : null;
+  const originalSession = this.ssl ? this._handle.getSession() : null;
 
   this.handle = this._wrapHandle(null, handle);
   this.ssl = this._handle;

--- a/test/internet/test-https-autoselectfamily-slow-timeout.js
+++ b/test/internet/test-https-autoselectfamily-slow-timeout.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common');
+const { addresses } = require('../common/internet');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -9,7 +10,7 @@ const assert = require('assert');
 const { request } = require('https');
 
 request(
-  'https://nodejs.org/en',
+  `https://${addresses.INET_HOST}/en`,
   // Purposely set this to false because we want all connection but the last to fail
   { autoSelectFamily: true, autoSelectFamilyAttemptTimeout: 10 },
   (res) => {

--- a/test/parallel/test-http-remove-connection-header-persists-connection.js
+++ b/test/parallel/test-http-remove-connection-header-persists-connection.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const net = require('net');
@@ -52,7 +52,7 @@ function makeHttp10Request(cb) {
 
     setTimeout(function() {
       cb(socket);
-    }, 10);
+    }, common.platformTimeout(50));
   });
 }
 

--- a/test/parallel/test-https-autoselectfamily-slow-timeout.js
+++ b/test/parallel/test-https-autoselectfamily-slow-timeout.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { request } = require('https');
+
+request(
+  'https://nodejs.org/en',
+  // Purposely set this to false because we want all connection but the last to fail
+  { autoSelectFamily: true, autoSelectFamilyAttemptTimeout: 10 },
+  (res) => {
+    assert.strictEqual(res.statusCode, 200);
+    res.resume();
+  },
+).end();


### PR DESCRIPTION
This PR fixes SSL connection attempts by not attempting to restore SSL information (like server name) if such informations are not available anymore.

Fixes #48000.