### PR TITLE
sea: add support for V8 bytecode-only caching

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -10,6 +10,9 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/46824
     description: Added support for "useSnapshot".
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/48191
+    description: Added support for "useCodeCache".
 -->
 
 > Stability: 1 - Experimental: This feature is being designed and will change.
@@ -174,7 +177,8 @@ The configuration currently reads the following top-level fields:
   "main": "/path/to/bundled/script.js",
   "output": "/path/to/write/the/generated/blob.blob",
   "disableExperimentalSEAWarning": true, // Default: false
-  "useSnapshot": false  // Default: false
+  "useSnapshot": false,  // Default: false
+  "useCodeCache": true // Default: false
 }
 ```
 
@@ -212,6 +216,16 @@ script when it's used to build snapshot for the single executable application,
 and the main script can use the [`v8.startupSnapshot` API][] to adapt to
 these constraints. See
 [documentation about startup snapshot support in Node.js][].
+
+### V8 code cache support
+
+When `useCodeCache` is set to `true` in the configuration, during the generation
+of the single executable preparation blob, Node.js will run the `main` script
+to generate the V8 code cache. The generated code cache would be part of the
+preparation blob and get injected into the final executable. When the single
+executable application is launched, instead of running the `main` script from
+scratch, Node.js would consume the code cache and then execute the script, which
+would improve the startup performance.
 
 ## Notes
 

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -220,9 +220,9 @@ these constraints. See
 ### V8 code cache support
 
 When `useCodeCache` is set to `true` in the configuration, during the generation
-of the single executable preparation blob, Node.js will run the `main` script
-to generate the V8 code cache. The generated code cache would be part of the
-preparation blob and get injected into the final executable. When the single
+of the single executable preparation blob, Node.js will compile the `main`
+script to generate the V8 code cache. The generated code cache would be part of
+the preparation blob and get injected into the final executable. When the single
 executable application is launched, instead of compiling the `main` script from
 scratch, Node.js would use the code cache to speed up the compilation, then
 execute the script, which would improve the startup performance.

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -223,9 +223,9 @@ When `useCodeCache` is set to `true` in the configuration, during the generation
 of the single executable preparation blob, Node.js will run the `main` script
 to generate the V8 code cache. The generated code cache would be part of the
 preparation blob and get injected into the final executable. When the single
-executable application is launched, instead of running the `main` script from
-scratch, Node.js would consume the code cache and then execute the script, which
-would improve the startup performance.
+executable application is launched, instead of compiling the `main` script from
+scratch, Node.js would use the code cache to speed up the compilation, then
+execute the script, which would improve the startup performance.
 
 ## Notes
 

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -227,6 +227,8 @@ executable application is launched, instead of compiling the `main` script from
 scratch, Node.js would use the code cache to speed up the compilation, then
 execute the script, which would improve the startup performance.
 
+**Note:** `import()` does not work when `useCodeCache` is `true`.
+
 ## Notes
 
 ### `require(id)` in the injected module is not file based

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -126,6 +126,7 @@ let hasLoadedAnyUserCJSModule = false;
 
 const {
   codes: {
+    ERR_INTERNAL_ASSERTION,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_MODULE_SPECIFIER,
     ERR_REQUIRE_ESM,
@@ -1123,7 +1124,7 @@ Module.prototype.require = function(id) {
 let resolvedArgv;
 let hasPausedEntry = false;
 let Script;
-function wrapSafe(filename, content, cjsModuleInstance) {
+function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
   if (patched) {
     const wrapper = Module.wrap(content);
     if (Script === undefined) {
@@ -1158,12 +1159,17 @@ function wrapSafe(filename, content, cjsModuleInstance) {
       '__dirname',
     ], {
       filename,
+      cachedData: codeCache,
       importModuleDynamically(specifier, _, importAssertions) {
         const cascadedLoader = getCascadedLoader();
         return cascadedLoader.import(specifier, normalizeReferrerURL(filename),
                                      importAssertions);
       },
     });
+
+    if (codeCache && result.cachedDataRejected !== false) {
+      throw new ERR_INTERNAL_ASSERTION('Code cache data rejected.');
+    }
 
     // Cache the source map for the module if present.
     if (result.sourceMapURL) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -98,7 +98,6 @@ const {
     require_private_symbol,
   },
 } = internalBinding('util');
-const { isSea } = internalBinding('sea');
 const {
   getCjsConditions,
   initializeCjsConditions,
@@ -1168,7 +1167,9 @@ function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
     });
 
     // The code cache is used for SEAs only.
-    if (codeCache && result.cachedDataRejected !== false && isSea()) {
+    if (codeCache &&
+        result.cachedDataRejected !== false &&
+        internalBinding('sea').isSea()) {
       process.emitWarning('Code cache data rejected.');
     }
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -98,6 +98,7 @@ const {
     require_private_symbol,
   },
 } = internalBinding('util');
+const { isSea } = internalBinding('sea');
 const {
   getCjsConditions,
   initializeCjsConditions,
@@ -126,7 +127,6 @@ let hasLoadedAnyUserCJSModule = false;
 
 const {
   codes: {
-    ERR_INTERNAL_ASSERTION,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_MODULE_SPECIFIER,
     ERR_REQUIRE_ESM,
@@ -1167,8 +1167,9 @@ function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
       },
     });
 
-    if (codeCache && result.cachedDataRejected !== false) {
-      throw new ERR_INTERNAL_ASSERTION('Code cache data rejected.');
+    // The code cache is used for SEAs only.
+    if (codeCache && result.cachedDataRejected !== false && isSea()) {
+      process.emitWarning('Code cache data rejected.');
     }
 
     // Cache the source map for the module if present.

--- a/lib/internal/util/embedding.js
+++ b/lib/internal/util/embedding.js
@@ -2,7 +2,7 @@
 const { BuiltinModule: { normalizeRequirableId } } = require('internal/bootstrap/realm');
 const { Module, wrapSafe } = require('internal/modules/cjs/loader');
 const { codes: { ERR_UNKNOWN_BUILTIN_MODULE } } = require('internal/errors');
-const { getCodeCache } = internalBinding('sea');
+const { getCodeCache, getCodePath } = internalBinding('sea');
 
 // This is roughly the same as:
 //
@@ -16,7 +16,8 @@ const { getCodeCache } = internalBinding('sea');
 
 function embedderRunCjs(contents) {
   const filename = process.execPath;
-  const compiledWrapper = wrapSafe(filename, contents, undefined, getCodeCache());
+  const codeCache = getCodeCache();
+  const compiledWrapper = wrapSafe(codeCache ? getCodePath() : filename, contents, undefined, codeCache);
 
   const customModule = new Module(filename, null);
   customModule.filename = filename;

--- a/lib/internal/util/embedding.js
+++ b/lib/internal/util/embedding.js
@@ -16,8 +16,11 @@ const { getCodeCache, getCodePath } = internalBinding('sea');
 
 function embedderRunCjs(contents) {
   const filename = process.execPath;
-  const codeCache = getCodeCache();
-  const compiledWrapper = wrapSafe(codeCache ? getCodePath() : filename, contents, undefined, codeCache);
+  const compiledWrapper = wrapSafe(
+    getCodePath(),
+    contents,
+    undefined,
+    getCodeCache());
 
   const customModule = new Module(filename, null);
   customModule.filename = filename;

--- a/lib/internal/util/embedding.js
+++ b/lib/internal/util/embedding.js
@@ -2,7 +2,7 @@
 const { BuiltinModule: { normalizeRequirableId } } = require('internal/bootstrap/realm');
 const { Module, wrapSafe } = require('internal/modules/cjs/loader');
 const { codes: { ERR_UNKNOWN_BUILTIN_MODULE } } = require('internal/errors');
-const { getCodeCache, getCodePath } = internalBinding('sea');
+const { getCodeCache, getCodePath, isSea } = internalBinding('sea');
 
 // This is roughly the same as:
 //
@@ -17,7 +17,7 @@ const { getCodeCache, getCodePath } = internalBinding('sea');
 function embedderRunCjs(contents) {
   const filename = process.execPath;
   const compiledWrapper = wrapSafe(
-    getCodePath(),
+    isSea() ? getCodePath() : filename,
     contents,
     undefined,
     getCodeCache());

--- a/lib/internal/util/embedding.js
+++ b/lib/internal/util/embedding.js
@@ -1,7 +1,8 @@
 'use strict';
-const { codes: { ERR_UNKNOWN_BUILTIN_MODULE } } = require('internal/errors');
 const { BuiltinModule: { normalizeRequirableId } } = require('internal/bootstrap/realm');
 const { Module, wrapSafe } = require('internal/modules/cjs/loader');
+const { codes: { ERR_UNKNOWN_BUILTIN_MODULE } } = require('internal/errors');
+const { getCodeCache } = internalBinding('sea');
 
 // This is roughly the same as:
 //
@@ -15,7 +16,7 @@ const { Module, wrapSafe } = require('internal/modules/cjs/loader');
 
 function embedderRunCjs(contents) {
   const filename = process.execPath;
-  const compiledWrapper = wrapSafe(filename, contents);
+  const compiledWrapper = wrapSafe(filename, contents, undefined, getCodeCache());
 
   const customModule = new Module(filename, null);
   customModule.filename = filename;

--- a/src/json_parser.cc
+++ b/src/json_parser.cc
@@ -4,7 +4,6 @@
 #include "util-inl.h"
 
 namespace node {
-using v8::ArrayBuffer;
 using v8::Context;
 using v8::Isolate;
 using v8::Local;
@@ -12,26 +11,8 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 
-static Isolate* NewIsolate(v8::ArrayBuffer::Allocator* allocator) {
-  Isolate* isolate = Isolate::Allocate();
-  CHECK_NOT_NULL(isolate);
-  per_process::v8_platform.Platform()->RegisterIsolate(isolate,
-                                                       uv_default_loop());
-  Isolate::CreateParams params;
-  params.array_buffer_allocator = allocator;
-  Isolate::Initialize(isolate, params);
-  return isolate;
-}
-
-void JSONParser::FreeIsolate(Isolate* isolate) {
-  per_process::v8_platform.Platform()->UnregisterIsolate(isolate);
-  isolate->Dispose();
-}
-
 JSONParser::JSONParser()
-    : allocator_(ArrayBuffer::Allocator::NewDefaultAllocator()),
-      isolate_(NewIsolate(allocator_.get())),
-      handle_scope_(isolate_.get()),
+    : handle_scope_(isolate_.get()),
       context_(isolate_.get(), Context::New(isolate_.get())),
       context_scope_(context_.Get(isolate_.get())) {}
 

--- a/src/json_parser.h
+++ b/src/json_parser.h
@@ -24,9 +24,7 @@ class JSONParser {
  private:
   // We might want a lighter-weight JSON parser for this use case. But for now
   // using V8 is good enough.
-  static void FreeIsolate(v8::Isolate* isolate);
-  std::unique_ptr<v8::ArrayBuffer::Allocator> allocator_;
-  DeleteFnPtr<v8::Isolate, FreeIsolate> isolate_;
+  RAIIIsolate isolate_;
   v8::HandleScope handle_scope_;
   v8::Global<v8::Context> context_;
   v8::Context::Scope context_scope_;

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -935,6 +935,30 @@ Maybe<bool> StoreCodeCacheResult(
   return Just(true);
 }
 
+// TODO(RaisinTen): Reuse in ContextifyContext::CompileFunction().
+MaybeLocal<Function> CompileFunction(Isolate* isolate,
+                                     Local<Context> context,
+                                     Local<String> filename,
+                                     Local<String> content,
+                                     std::vector<Local<String>> parameters) {
+  ScriptOrigin script_origin(isolate, filename, 0, 0, true);
+  ScriptCompiler::Source script_source(content, script_origin);
+
+  Local<Function> fn;
+  if (!ScriptCompiler::CompileFunction(context,
+                                       &script_source,
+                                       parameters.size(),
+                                       parameters.data(),
+                                       0,
+                                       nullptr,
+                                       ScriptCompiler::kEagerCompile)
+           .ToLocal(&fn)) {
+    return {};
+  }
+
+  return fn;
+}
+
 bool ContextifyScript::InstanceOf(Environment* env,
                                   const Local<Value>& value) {
   return !value.IsEmpty() &&

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -953,7 +953,7 @@ MaybeLocal<Function> CompileFunction(Isolate* isolate,
                                        nullptr,
                                        ScriptCompiler::kEagerCompile)
            .ToLocal(&fn)) {
-    return {};
+    return MaybeLocal<Function>();
   }
 
   return fn;

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -940,15 +940,15 @@ MaybeLocal<Function> CompileFunction(Isolate* isolate,
                                      Local<Context> context,
                                      Local<String> filename,
                                      Local<String> content,
-                                     std::vector<Local<String>> parameters) {
+                                     std::vector<Local<String>>* parameters) {
   ScriptOrigin script_origin(isolate, filename, 0, 0, true);
   ScriptCompiler::Source script_source(content, script_origin);
 
   Local<Function> fn;
   if (!ScriptCompiler::CompileFunction(context,
                                        &script_source,
-                                       parameters.size(),
-                                       parameters.data(),
+                                       parameters->size(),
+                                       parameters->data(),
                                        0,
                                        nullptr,
                                        ScriptCompiler::kEagerCompile)

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -936,12 +936,11 @@ Maybe<bool> StoreCodeCacheResult(
 }
 
 // TODO(RaisinTen): Reuse in ContextifyContext::CompileFunction().
-MaybeLocal<Function> CompileFunction(Isolate* isolate,
-                                     Local<Context> context,
+MaybeLocal<Function> CompileFunction(Local<Context> context,
                                      Local<String> filename,
                                      Local<String> content,
                                      std::vector<Local<String>>* parameters) {
-  ScriptOrigin script_origin(isolate, filename, 0, 0, true);
+  ScriptOrigin script_origin(context->GetIsolate(), filename, 0, 0, true);
   ScriptCompiler::Source script_source(content, script_origin);
 
   return ScriptCompiler::CompileFunction(context,

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -949,8 +949,7 @@ MaybeLocal<Function> CompileFunction(Isolate* isolate,
                                          parameters->size(),
                                          parameters->data(),
                                          0,
-                                         nullptr,
-                                         ScriptCompiler::kEagerCompile);
+                                         nullptr);
 }
 
 bool ContextifyScript::InstanceOf(Environment* env,

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -944,19 +944,13 @@ MaybeLocal<Function> CompileFunction(Isolate* isolate,
   ScriptOrigin script_origin(isolate, filename, 0, 0, true);
   ScriptCompiler::Source script_source(content, script_origin);
 
-  Local<Function> fn;
-  if (!ScriptCompiler::CompileFunction(context,
-                                       &script_source,
-                                       parameters->size(),
-                                       parameters->data(),
-                                       0,
-                                       nullptr,
-                                       ScriptCompiler::kEagerCompile)
-           .ToLocal(&fn)) {
-    return MaybeLocal<Function>();
-  }
-
-  return fn;
+  return ScriptCompiler::CompileFunction(context,
+                                         &script_source,
+                                         parameters->size(),
+                                         parameters->data(),
+                                         0,
+                                         nullptr,
+                                         ScriptCompiler::kEagerCompile);
 }
 
 bool ContextifyScript::InstanceOf(Environment* env,

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -211,7 +211,6 @@ v8::Maybe<bool> StoreCodeCacheResult(
     std::unique_ptr<v8::ScriptCompiler::CachedData> new_cached_data);
 
 v8::MaybeLocal<v8::Function> CompileFunction(
-    v8::Isolate* isolate,
     v8::Local<v8::Context> context,
     v8::Local<v8::String> filename,
     v8::Local<v8::String> content,

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -210,6 +210,13 @@ v8::Maybe<bool> StoreCodeCacheResult(
     bool produce_cached_data,
     std::unique_ptr<v8::ScriptCompiler::CachedData> new_cached_data);
 
+v8::MaybeLocal<v8::Function> CompileFunction(
+    v8::Isolate* isolate,
+    v8::Local<v8::Context> context,
+    v8::Local<v8::String> filename,
+    v8::Local<v8::String> content,
+    std::vector<v8::Local<v8::String>> parameters);
+
 }  // namespace contextify
 }  // namespace node
 

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -215,7 +215,7 @@ v8::MaybeLocal<v8::Function> CompileFunction(
     v8::Local<v8::Context> context,
     v8::Local<v8::String> filename,
     v8::Local<v8::String> content,
-    std::vector<v8::Local<v8::String>> parameters);
+    std::vector<v8::Local<v8::String>>* parameters);
 
 }  // namespace contextify
 }  // namespace node

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -379,7 +379,7 @@ std::optional<std::string> GenerateCodeCache(std::string_view main_path,
 
   Local<Function> fn;
   if (!contextify::CompileFunction(
-           isolate, context, filename, content, std::move(parameters))
+           isolate, context, filename, content, &parameters)
            .ToLocal(&fn)) {
     return std::nullopt;
   }

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -215,12 +215,19 @@ void GetCodeCache(const FunctionCallbackInfo<Value>& args) {
 
   SeaResource sea_resource = FindSingleExecutableResource();
 
-  Local<Object> buf =
-      Buffer::Copy(
-          env,
-          reinterpret_cast<const char*>(sea_resource.code_cache.data()),
-          sea_resource.code_cache.length())
-          .ToLocalChecked();
+  Local<Object> buf;
+  if (!Buffer::New(
+           env,
+           const_cast<char*>(sea_resource.code_cache.data()),
+           sea_resource.code_cache.length(),
+           [](char* /* data */, void* /* hint */) {
+             // We don't free the code cache data string because it is not owned
+             // by us.
+           },
+           nullptr)
+           .ToLocal(&buf)) {
+    return;
+  }
 
   args.GetReturnValue().Set(buf);
 }

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -200,6 +200,10 @@ bool IsSingleExecutable() {
   return postject_has_resource();
 }
 
+void IsSea(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(IsSingleExecutable());
+}
+
 void IsExperimentalSeaWarningNeeded(const FunctionCallbackInfo<Value>& args) {
   bool is_building_sea =
       !per_process::cli_options->experimental_sea_config.empty();
@@ -507,6 +511,7 @@ void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
                 void* priv) {
+  SetMethod(context, target, "isSea", IsSea);
   SetMethod(context,
             target,
             "isExperimentalSeaWarningNeeded",
@@ -516,6 +521,7 @@ void Initialize(Local<Object> target,
 }
 
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  registry->Register(IsSea);
   registry->Register(IsExperimentalSeaWarningNeeded);
   registry->Register(GetCodePath);
   registry->Register(GetCodeCache);

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -103,11 +103,6 @@ size_t SeaSerializer::Write(const SeaResource& sea) {
                       sea.use_snapshot() ? StringLogMode::kAddressOnly
                                          : StringLogMode::kAddressAndContent);
 
-  Debug("Write SEA resource code cache %p, size=%zu\n",
-        sea.code_cache.data(),
-        sea.code_cache.size());
-  written_total += WriteStringView(sea.code_cache, StringLogMode::kAddressOnly);
-
   if (sea.code_cache.has_value()) {
     Debug("Write SEA resource code cache %p, size=%zu\n",
           sea.code_cache->data(),

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -361,12 +361,12 @@ std::optional<std::string> GenerateCodeCache(std::string_view main_path,
 
   Local<String> filename;
   if (!String::NewFromUtf8(isolate, main_path.data()).ToLocal(&filename)) {
-    return {};
+    return std::nullopt;
   }
 
   Local<String> content;
   if (!String::NewFromUtf8(isolate, main_script.data()).ToLocal(&content)) {
-    return {};
+    return std::nullopt;
   }
 
   std::vector<Local<String>> parameters = {
@@ -381,7 +381,7 @@ std::optional<std::string> GenerateCodeCache(std::string_view main_path,
   if (!contextify::CompileFunction(
            isolate, context, filename, content, std::move(parameters))
            .ToLocal(&fn)) {
-    return {};
+    return std::nullopt;
   }
 
   std::unique_ptr<ScriptCompiler::CachedData> cache{

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -421,6 +421,9 @@ std::optional<std::string> GenerateCodeCache(std::string_view main_path,
       FIXED_ONE_BYTE_STRING(isolate, "__dirname"),
   };
 
+  // TODO(RaisinTen): Using the V8 code cache prevents us from using `import()`
+  // in the SEA code. Support it.
+  // Refs: https://github.com/nodejs/node/pull/48191#discussion_r1213271430
   Local<Function> fn;
   if (!contextify::CompileFunction(
            isolate, context, filename, content, &parameters)

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -39,6 +39,7 @@ using v8::FunctionCallbackInfo;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
+using v8::NewStringType;
 using v8::Object;
 using v8::ScriptCompiler;
 using v8::String;
@@ -275,7 +276,10 @@ void GetCodePath(const FunctionCallbackInfo<Value>& args) {
   SeaResource sea_resource = FindSingleExecutableResource();
 
   Local<String> code_path;
-  if (!String::NewFromUtf8(isolate, sea_resource.code_path.data())
+  if (!String::NewFromUtf8(isolate,
+                           sea_resource.code_path.data(),
+                           NewStringType::kNormal,
+                           sea_resource.code_path.length())
            .ToLocal(&code_path)) {
     return;
   }
@@ -429,12 +433,20 @@ std::optional<std::string> GenerateCodeCache(std::string_view main_path,
       isolate, errors::PrinterTryCatch::kPrintSourceLine);
 
   Local<String> filename;
-  if (!String::NewFromUtf8(isolate, main_path.data()).ToLocal(&filename)) {
+  if (!String::NewFromUtf8(isolate,
+                           main_path.data(),
+                           NewStringType::kNormal,
+                           main_path.length())
+           .ToLocal(&filename)) {
     return std::nullopt;
   }
 
   Local<String> content;
-  if (!String::NewFromUtf8(isolate, main_script.data()).ToLocal(&content)) {
+  if (!String::NewFromUtf8(isolate,
+                           main_script.data(),
+                           NewStringType::kNormal,
+                           main_script.length())
+           .ToLocal(&content)) {
     return std::nullopt;
   }
 

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -234,7 +234,6 @@ void GetCodeCache(const FunctionCallbackInfo<Value>& args) {
   }
 
   Isolate* isolate = args.GetIsolate();
-  HandleScope scope(isolate);
 
   SeaResource sea_resource = FindSingleExecutableResource();
 

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -258,9 +258,7 @@ void GetCodeCache(const FunctionCallbackInfo<Value>& args) {
 }
 
 void GetCodePath(const FunctionCallbackInfo<Value>& args) {
-  if (!IsSingleExecutable()) {
-    return;
-  }
+  DCHECK(IsSingleExecutable());
 
   Isolate* isolate = args.GetIsolate();
   HandleScope scope(isolate);

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -460,8 +460,7 @@ std::optional<std::string> GenerateCodeCache(std::string_view main_path,
   // in the SEA code. Support it.
   // Refs: https://github.com/nodejs/node/pull/48191#discussion_r1213271430
   Local<Function> fn;
-  if (!contextify::CompileFunction(
-           isolate, context, filename, content, &parameters)
+  if (!contextify::CompileFunction(context, filename, content, &parameters)
            .ToLocal(&fn)) {
     return std::nullopt;
   }

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -261,7 +261,6 @@ void GetCodePath(const FunctionCallbackInfo<Value>& args) {
   DCHECK(IsSingleExecutable());
 
   Isolate* isolate = args.GetIsolate();
-  HandleScope scope(isolate);
 
   SeaResource sea_resource = FindSingleExecutableResource();
 

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -238,8 +238,7 @@ void GetCodeCache(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
+  Isolate* isolate = args.GetIsolate();
   HandleScope scope(isolate);
 
   SeaResource sea_resource = FindSingleExecutableResource();
@@ -253,8 +252,8 @@ void GetCodeCache(const FunctionCallbackInfo<Value>& args) {
           static_cast<const void*>(sea_resource.code_cache->data())),
       sea_resource.code_cache->length(),
       [](void* /* data */, size_t /* length */, void* /* deleter_data */) {
-        // The code cache data string is not freed here because it is a static
-        // string which is not allocated by the BackingStore allocator.
+        // The code cache data blob is not freed here because it is a static
+        // blob which is not allocated by the BackingStore allocator.
       },
       nullptr);
   Local<ArrayBuffer> array_buffer = ArrayBuffer::New(isolate, backing_store);
@@ -269,8 +268,7 @@ void GetCodePath(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
+  Isolate* isolate = args.GetIsolate();
   HandleScope scope(isolate);
 
   SeaResource sea_resource = FindSingleExecutableResource();

--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -29,6 +29,7 @@ enum class SeaFlags : uint32_t {
 struct SeaResource {
   SeaFlags flags = SeaFlags::kDefault;
   std::string_view main_code_or_snapshot;
+  std::string_view code_cache;
 
   bool use_snapshot() const;
   static constexpr size_t kHeaderSize = sizeof(kMagic) + sizeof(SeaFlags);

--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -6,10 +6,12 @@
 #if !defined(DISABLE_SINGLE_EXECUTABLE_APPLICATION)
 
 #include <cinttypes>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <tuple>
 #include <vector>
+
 #include "node_exit_code.h"
 
 namespace node {
@@ -24,6 +26,7 @@ enum class SeaFlags : uint32_t {
   kDefault = 0,
   kDisableExperimentalSeaWarning = 1 << 0,
   kUseSnapshot = 1 << 1,
+  kUseCodeCache = 1 << 2,
 };
 
 struct SeaResource {
@@ -31,6 +34,7 @@ struct SeaResource {
   std::string_view code_path;
   std::string_view main_code_or_snapshot;
   std::string_view code_cache;
+  std::optional<std::string_view> code_cache;
 
   bool use_snapshot() const;
   static constexpr size_t kHeaderSize = sizeof(kMagic) + sizeof(SeaFlags);

--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -28,6 +28,7 @@ enum class SeaFlags : uint32_t {
 
 struct SeaResource {
   SeaFlags flags = SeaFlags::kDefault;
+  std::string_view code_path;
   std::string_view main_code_or_snapshot;
   std::string_view code_cache;
 

--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -33,7 +33,6 @@ struct SeaResource {
   SeaFlags flags = SeaFlags::kDefault;
   std::string_view code_path;
   std::string_view main_code_or_snapshot;
-  std::string_view code_cache;
   std::optional<std::string_view> code_cache;
 
   bool use_snapshot() const;

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1267,7 +1267,7 @@ void CompileSerializeMain(const FunctionCallbackInfo<Value>& args) {
   };
   Local<Function> fn;
   if (contextify::CompileFunction(
-          isolate, context, filename, source, std::move(parameters))
+          isolate, context, filename, source, &parameters)
           .ToLocal(&fn)) {
     args.GetReturnValue().Set(fn);
   }

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -42,7 +42,6 @@ using v8::MaybeLocal;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::ScriptCompiler;
-using v8::ScriptOrigin;
 using v8::SnapshotCreator;
 using v8::StartupData;
 using v8::String;
@@ -1259,7 +1258,6 @@ void CompileSerializeMain(const FunctionCallbackInfo<Value>& args) {
   Local<String> source = args[1].As<String>();
   Isolate* isolate = args.GetIsolate();
   Local<Context> context = isolate->GetCurrentContext();
-  ScriptOrigin origin(isolate, filename, 0, 0, true);
   // TODO(joyeecheung): do we need all of these? Maybe we would want a less
   // internal version of them.
   std::vector<Local<String>> parameters = {
@@ -1267,15 +1265,9 @@ void CompileSerializeMain(const FunctionCallbackInfo<Value>& args) {
       FIXED_ONE_BYTE_STRING(isolate, "__filename"),
       FIXED_ONE_BYTE_STRING(isolate, "__dirname"),
   };
-  ScriptCompiler::Source script_source(source, origin);
   Local<Function> fn;
-  if (ScriptCompiler::CompileFunction(context,
-                                      &script_source,
-                                      parameters.size(),
-                                      parameters.data(),
-                                      0,
-                                      nullptr,
-                                      ScriptCompiler::kNoCompileOptions)
+  if (contextify::CompileFunction(
+          isolate, context, filename, source, std::move(parameters))
           .ToLocal(&fn)) {
     args.GetReturnValue().Set(fn);
   }

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1266,8 +1266,7 @@ void CompileSerializeMain(const FunctionCallbackInfo<Value>& args) {
       FIXED_ONE_BYTE_STRING(isolate, "__dirname"),
   };
   Local<Function> fn;
-  if (contextify::CompileFunction(
-          isolate, context, filename, source, &parameters)
+  if (contextify::CompileFunction(context, filename, source, &parameters)
           .ToLocal(&fn)) {
     args.GetReturnValue().Set(fn);
   }

--- a/src/util.h
+++ b/src/util.h
@@ -958,6 +958,19 @@ void SetConstructorFunction(v8::Isolate* isolate,
                             SetConstructorFunctionFlag flag =
                                 SetConstructorFunctionFlag::SET_CLASS_NAME);
 
+// Simple RAII class to spin up a v8::Isolate instance.
+class RAIIIsolate {
+ public:
+  RAIIIsolate();
+  ~RAIIIsolate();
+
+  v8::Isolate* get() const { return isolate_; }
+
+ private:
+  std::unique_ptr<v8::ArrayBuffer::Allocator> allocator_;
+  v8::Isolate* isolate_;
+};
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/test/fixtures/errors/force_colors.snapshot
+++ b/test/fixtures/errors/force_colors.snapshot
@@ -4,10 +4,10 @@ throw new Error('Should include grayed stack trace')
 
 Error: Should include grayed stack trace
     at Object.<anonymous> [90m(/[39mtest*force_colors.js:1:7[90m)[39m
-[90m    at Module._compile (node:internal*modules*cjs*loader:1233:14)[39m
-[90m    at Module._extensions..js (node:internal*modules*cjs*loader:1287:10)[39m
-[90m    at Module.load (node:internal*modules*cjs*loader:1091:32)[39m
-[90m    at Module._load (node:internal*modules*cjs*loader:938:12)[39m
+[90m    at Module._compile (node:internal*modules*cjs*loader:1240:14)[39m
+[90m    at Module._extensions..js (node:internal*modules*cjs*loader:1294:10)[39m
+[90m    at Module.load (node:internal*modules*cjs*loader:1092:32)[39m
+[90m    at Module._load (node:internal*modules*cjs*loader:939:12)[39m
 [90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:83:12)[39m
 [90m    at node:internal*main*run_main_module:23:47[39m
 

--- a/test/fixtures/errors/force_colors.snapshot
+++ b/test/fixtures/errors/force_colors.snapshot
@@ -4,10 +4,10 @@ throw new Error('Should include grayed stack trace')
 
 Error: Should include grayed stack trace
     at Object.<anonymous> [90m(/[39mtest*force_colors.js:1:7[90m)[39m
-[90m    at Module._compile (node:internal*modules*cjs*loader:1240:14)[39m
-[90m    at Module._extensions..js (node:internal*modules*cjs*loader:1294:10)[39m
-[90m    at Module.load (node:internal*modules*cjs*loader:1092:32)[39m
-[90m    at Module._load (node:internal*modules*cjs*loader:939:12)[39m
+[90m    at Module._compile (node:internal*modules*cjs*loader:1241:14)[39m
+[90m    at Module._extensions..js (node:internal*modules*cjs*loader:1295:10)[39m
+[90m    at Module.load (node:internal*modules*cjs*loader:1091:32)[39m
+[90m    at Module._load (node:internal*modules*cjs*loader:938:12)[39m
 [90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:83:12)[39m
 [90m    at node:internal*main*run_main_module:23:47[39m
 

--- a/test/fixtures/sea.js
+++ b/test/fixtures/sea.js
@@ -18,6 +18,9 @@ if (createdRequire('./sea-config.json').disableExperimentalSEAWarning) {
 const { deepStrictEqual, strictEqual, throws } = require('assert');
 const { dirname } = require('node:path');
 
+// Checks that the source filename is used in the error stack trace.
+strictEqual(new Error('lol').stack.split('\n')[1], '    at sea.js:22:13');
+
 // Should be possible to require a core module that requires using the "node:"
 // scheme.
 {

--- a/test/fixtures/sea.js
+++ b/test/fixtures/sea.js
@@ -5,12 +5,15 @@ const createdRequire = createRequire(__filename);
 // because we set NODE_TEST_DIR=/Users/iojs/node-tmp on Jenkins CI.
 const { expectWarning, mustNotCall } = createdRequire(process.env.COMMON_DIRECTORY);
 
+// This additionally makes sure that no unexpected warnings are emitted.
 if (createdRequire('./sea-config.json').disableExperimentalSEAWarning) {
   process.on('warning', mustNotCall());
 } else {
   expectWarning('ExperimentalWarning',
                 'Single executable application is an experimental feature and ' +
                 'might change at any time');
+  // Any unexpected warning would throw this error:
+  // https://github.com/nodejs/node/blob/c301404105a7256b79a0b8c4522ce47af96dfa17/test/common/index.js#L697-L700.
 }
 
 // Should be possible to require core modules that optionally require the
@@ -19,7 +22,7 @@ const { deepStrictEqual, strictEqual, throws } = require('assert');
 const { dirname } = require('node:path');
 
 // Checks that the source filename is used in the error stack trace.
-strictEqual(new Error('lol').stack.split('\n')[1], '    at sea.js:22:13');
+strictEqual(new Error('lol').stack.split('\n')[1], '    at sea.js:25:13');
 
 // Should be possible to require a core module that requires using the "node:"
 // scheme.

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -39,7 +39,6 @@ const expectedModules = new Set([
   'Internal Binding messaging',
   'NativeModule internal/worker/js_transferable',
   'Internal Binding process_methods',
-  'Internal Binding sea',
   'NativeModule internal/process/per_thread',
   'Internal Binding credentials',
   'NativeModule internal/process/promises',

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -39,6 +39,7 @@ const expectedModules = new Set([
   'Internal Binding messaging',
   'NativeModule internal/worker/js_transferable',
   'Internal Binding process_methods',
+  'Internal Binding sea',
   'NativeModule internal/process/per_thread',
   'Internal Binding credentials',
   'NativeModule internal/process/promises',

--- a/test/sequential/test-single-executable-application-use-code-cache.js
+++ b/test/sequential/test-single-executable-application-use-code-cache.js
@@ -1,0 +1,60 @@
+'use strict';
+
+require('../common');
+
+const {
+  injectAndCodeSign,
+  skipIfSingleExecutableIsNotSupported,
+} = require('../common/sea');
+
+skipIfSingleExecutableIsNotSupported();
+
+// This tests the creation of a single executable application which uses the
+// V8 code cache.
+
+const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
+const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const { execFileSync } = require('child_process');
+const { join } = require('path');
+const { strictEqual } = require('assert');
+const assert = require('assert');
+
+const inputFile = fixtures.path('sea.js');
+const requirableFile = join(tmpdir.path, 'requirable.js');
+const configFile = join(tmpdir.path, 'sea-config.json');
+const seaPrepBlob = join(tmpdir.path, 'sea-prep.blob');
+const outputFile = join(tmpdir.path, process.platform === 'win32' ? 'sea.exe' : 'sea');
+
+tmpdir.refresh();
+
+writeFileSync(requirableFile, `
+module.exports = {
+  hello: 'world',
+};
+`);
+
+writeFileSync(configFile, `
+{
+  "main": "sea.js",
+  "output": "sea-prep.blob",
+  "useCodeCache": true
+}
+`);
+
+// Copy input to working directory
+copyFileSync(inputFile, join(tmpdir.path, 'sea.js'));
+execFileSync(process.execPath, ['--experimental-sea-config', 'sea-config.json'], {
+  cwd: tmpdir.path
+});
+
+assert(existsSync(seaPrepBlob));
+
+copyFileSync(process.execPath, outputFile);
+injectAndCodeSign(outputFile, seaPrepBlob);
+
+const singleExecutableApplicationOutput = execFileSync(
+  outputFile,
+  [ '-a', '--b=c', 'd' ],
+  { env: { COMMON_DIRECTORY: join(__dirname, '..', 'common') } });
+strictEqual(singleExecutableApplicationOutput.toString(), 'Hello, world! 😊\n');


### PR DESCRIPTION
This improves the startup performance of SEAs.

For example, the comparison of the startup performance benchmarks of a Node.js SEA built using the CJS bundle of Yarn's source code shows a 24% improvement on my `x86_64` macOS:
```js
$ hyperfine -N -w 30 -L cmd 'with_code_cache/yarn help','without_code_cache/yarn help' '{cmd}'
Benchmark 1: with_code_cache/yarn help
  Time (mean ± σ):     210.8 ms ±   1.3 ms    [User: 224.0 ms, System: 25.2 ms]
  Range (min … max):   209.0 ms … 213.4 ms    14 runs

Benchmark 2: without_code_cache/yarn help
  Time (mean ± σ):     279.1 ms ±   2.3 ms    [User: 284.9 ms, System: 30.1 ms]
  Range (min … max):   276.6 ms … 284.4 ms    10 runs

Summary
  'with_code_cache/yarn help' ran
    1.32 ± 0.01 times faster than 'without_code_cache/yarn help'
```

Fixes: https://github.com/nodejs/single-executable/issues/73

cc @kvakil 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
