### PR TITLE
test: use lower security level in s_client

### DIFF
--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -65,7 +65,7 @@ function test(dhparam, keylen, expectedCipher) {
 
   server.listen(0, '127.0.0.1', common.mustCall(() => {
     const args = ['s_client', '-connect', `127.0.0.1:${server.address().port}`,
-                  '-cipher', ciphers];
+                  '-cipher', `${ciphers}:@SECLEVEL=1`];
 
     execFile(common.opensslCli, args, common.mustSucceed((stdout) => {
       assert(keylen === null ||


### PR DESCRIPTION
With the default security level (SECLEVEL=2), the following error

```
40E72B52DB7F0000:error:0A00018A:SSL routines:tls_process_ske_dhe:dh key
too small:../deps/openssl/openssl/ssl/statem/statem_clnt.c:2100
```

is raised on on Ubuntu 22.04 on WSL2.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
