### PR TITLE
Add auto to docs' contain-intrinsic-size decl, to prevent jitter/flicker

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -436,7 +436,7 @@ dd + dt.pre {
 
 #apicontent section {
   content-visibility: auto;
-  contain-intrinsic-size: 1px 5000px;
+  contain-intrinsic-size: 1px auto 5000px;
 }
 
 #apicontent .line {


### PR DESCRIPTION
This addresses a scrolling/flickering issue in the node.js docs, as viewed by Firefox versions that have 'content-visibility' support (on by default in Firefox Nightly for several releases, opt-in in about:config in release versions).

See https://bugzilla.mozilla.org/show_bug.cgi?id=1832675 for details. Before this patch, the `content-visibility:auto` and `contain-intrinsic-size:1px 5000px` styles are telling the browser to suppress rendering of offscreen sections and behave as if they're 5000px tall, though they in fact are much shorter. This causes scrolling to behave quite bizarrely and can cause troublesome oscillating issues.

By adding `auto` to the `contain-intrinsic-size` CSS, we're asking the browser to remember the last-rendered size for the element (once it's been rendered) instead of forcing the browser to treat it as being 1px by 5000px when it goes offscreen.

(In fact the spec was recently updated to require browsers to behave as if `auto` were specified like this; but this fix hasn't shipped in Firefox yet as of the time I'm writing this patch, so in the meantime it would be nice to avoid the issue directly in the Node.js styles.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
