### PR TITLE
build: update action to close stale PRs

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -1,4 +1,4 @@
-name: Close stale feature requests
+name: Close stale pull requests
 on:
   workflow_dispatch:
     inputs:
@@ -6,9 +6,6 @@ on:
         description: stop processing PRs after this date
         required: false
         type: string
-  schedule:
-    # Run every day at 1:00 AM UTC.
-    - cron: 0 1 * * *
 
 # yamllint disable rule:empty-lines
 env:
@@ -51,7 +48,6 @@ jobs:
           end-date: ${{ env.END_DATE }}
           days-before-issue-stale: -1
           days-before-issue-close: -1
-          only-labels: test-stale-pr
           days-before-stale: 150
           days-before-close: 30
           stale-issue-label: stale


### PR DESCRIPTION
My original plan of adding a lable to limit those initially process as outlined in https://github.com/nodejs/node/pull/48051 does not work I think because adding a lable updates the last update time.

- Removing the need for the lable
- Remove the cron scheduling so that it only runs when I run it manually
- Fix the display name for the action as I missed updating that after cut and paste from existing action

The plan will be to find stop dates that should only affect a reasonable number of PRs at a time and then run in batches using that instead.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
