### PR TITLE
doc: update codeowners with website team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,8 @@
 
 # website
 /doc/api @nodejs/website
+/doc/api_assets @nodejs/website
+/doc/template.html @nodejs/website
 /tools/doc @nodejs/website
 
 # streams

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,10 @@
 /LICENSE @nodejs/tsc
 /onboarding.md @nodejs/tsc
 
+# website
+/doc/api @nodejs/website
+/tools/doc @nodejs/website
+
 # streams
 
 /lib/_stream* @nodejs/streams

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,6 @@
 /onboarding.md @nodejs/tsc
 
 # website
-/doc/api @nodejs/website
 /doc/api_assets @nodejs/website
 /doc/template.html @nodejs/website
 /tools/doc @nodejs/website


### PR DESCRIPTION
This PR updates the CODEOWNERS file to manually ping the Website Team with changes to /tool/doc and /doc/api.