### PR TITLE
tools: authenticate github api request to avoid rate limit

### DIFF
--- a/tools/dep_updaters/update-ada.sh
+++ b/tools/dep_updaters/update-ada.sh
@@ -11,7 +11,11 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/ada-url/ada/releases/latest');
+const res = await fetch('https://api.github.com/repos/ada-url/ada/releases/latest', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-ada.sh
+++ b/tools/dep_updaters/update-ada.sh
@@ -11,7 +11,7 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/ada-url/ada/releases/latest', {
+const res = await fetch('https://api.github.com/repos/ada-url/ada/releases/latest', process.env.GITHUB_TOKEN && {
   headers: {
     "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
   },

--- a/tools/dep_updaters/update-ada.sh
+++ b/tools/dep_updaters/update-ada.sh
@@ -11,11 +11,12 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/ada-url/ada/releases/latest', process.env.GITHUB_TOKEN && {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/ada-url/ada/releases/latest',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-base64.sh
+++ b/tools/dep_updaters/update-base64.sh
@@ -12,11 +12,12 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/aklomp/base64/releases/latest', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/aklomp/base64/releases/latest',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-base64.sh
+++ b/tools/dep_updaters/update-base64.sh
@@ -12,7 +12,11 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/aklomp/base64/releases/latest');
+const res = await fetch('https://api.github.com/repos/aklomp/base64/releases/latest', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-brotli.sh
+++ b/tools/dep_updaters/update-brotli.sh
@@ -12,11 +12,12 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/google/brotli/releases/latest', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/google/brotli/releases/latest',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-brotli.sh
+++ b/tools/dep_updaters/update-brotli.sh
@@ -12,7 +12,11 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/google/brotli/releases/latest');
+const res = await fetch('https://api.github.com/repos/google/brotli/releases/latest', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-c-ares.sh
+++ b/tools/dep_updaters/update-c-ares.sh
@@ -12,7 +12,11 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/c-ares/c-ares/releases/latest');
+const res = await fetch('https://api.github.com/repos/c-ares/c-ares/releases/latest', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('cares-', '').replaceAll('_', '.'));

--- a/tools/dep_updaters/update-c-ares.sh
+++ b/tools/dep_updaters/update-c-ares.sh
@@ -12,11 +12,12 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/c-ares/c-ares/releases/latest', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/c-ares/c-ares/releases/latest',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('cares-', '').replaceAll('_', '.'));

--- a/tools/dep_updaters/update-cjs-module-lexer.sh
+++ b/tools/dep_updaters/update-cjs-module-lexer.sh
@@ -11,7 +11,11 @@ DEPS_DIR="$BASE_DIR/deps"
 NPM="$DEPS_DIR/npm/bin/npm-cli.js"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/nodejs/cjs-module-lexer/tags');
+const res = await fetch('https://api.github.com/repos/nodejs/cjs-module-lexer/tags', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const tags = await res.json();
 const { name } = tags.at(0)

--- a/tools/dep_updaters/update-cjs-module-lexer.sh
+++ b/tools/dep_updaters/update-cjs-module-lexer.sh
@@ -11,11 +11,12 @@ DEPS_DIR="$BASE_DIR/deps"
 NPM="$DEPS_DIR/npm/bin/npm-cli.js"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/nodejs/cjs-module-lexer/tags', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/nodejs/cjs-module-lexer/tags',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const tags = await res.json();
 const { name } = tags.at(0)

--- a/tools/dep_updaters/update-icu.sh
+++ b/tools/dep_updaters/update-icu.sh
@@ -10,7 +10,11 @@ TOOLS_DIR="$BASE_DIR/tools"
 [ -x "$NODE" ] || NODE=$(command -v node)
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/unicode-org/icu/releases/latest');
+const res = await fetch('https://api.github.com/repos/unicode-org/icu/releases/latest', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('release-', '').replace('-','.'));

--- a/tools/dep_updaters/update-icu.sh
+++ b/tools/dep_updaters/update-icu.sh
@@ -10,11 +10,12 @@ TOOLS_DIR="$BASE_DIR/tools"
 [ -x "$NODE" ] || NODE=$(command -v node)
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/unicode-org/icu/releases/latest', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/unicode-org/icu/releases/latest',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('release-', '').replace('-','.'));

--- a/tools/dep_updaters/update-libuv.sh
+++ b/tools/dep_updaters/update-libuv.sh
@@ -12,11 +12,12 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/libuv/libuv/releases/latest', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/libuv/libuv/releases/latest',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-libuv.sh
+++ b/tools/dep_updaters/update-libuv.sh
@@ -12,7 +12,11 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/libuv/libuv/releases/latest');
+const res = await fetch('https://api.github.com/repos/libuv/libuv/releases/latest', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-llhttp.sh
+++ b/tools/dep_updaters/update-llhttp.sh
@@ -13,11 +13,12 @@ DEPS_DIR="${BASE_DIR}/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/nodejs/llhttp/releases/latest', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/nodejs/llhttp/releases/latest',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('release/v', ''));

--- a/tools/dep_updaters/update-llhttp.sh
+++ b/tools/dep_updaters/update-llhttp.sh
@@ -13,7 +13,11 @@ DEPS_DIR="${BASE_DIR}/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/nodejs/llhttp/releases/latest');
+const res = await fetch('https://api.github.com/repos/nodejs/llhttp/releases/latest', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('release/v', ''));

--- a/tools/dep_updaters/update-nghttp2.sh
+++ b/tools/dep_updaters/update-nghttp2.sh
@@ -12,7 +12,11 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/nghttp2/nghttp2/releases/latest');
+const res = await fetch('https://api.github.com/repos/nghttp2/nghttp2/releases/latest', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-nghttp2.sh
+++ b/tools/dep_updaters/update-nghttp2.sh
@@ -12,11 +12,12 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/nghttp2/nghttp2/releases/latest', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/nghttp2/nghttp2/releases/latest',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-nghttp3.sh
+++ b/tools/dep_updaters/update-nghttp3.sh
@@ -11,11 +11,12 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/ngtcp2/nghttp3/releases', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/ngtcp2/nghttp3/releases',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const releases = await res.json()
 const { tag_name } = releases.at(0);

--- a/tools/dep_updaters/update-nghttp3.sh
+++ b/tools/dep_updaters/update-nghttp3.sh
@@ -11,7 +11,11 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/ngtcp2/nghttp3/releases');
+const res = await fetch('https://api.github.com/repos/ngtcp2/nghttp3/releases', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const releases = await res.json()
 const { tag_name } = releases.at(0);

--- a/tools/dep_updaters/update-ngtcp2.sh
+++ b/tools/dep_updaters/update-ngtcp2.sh
@@ -11,7 +11,11 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/ngtcp2/ngtcp2/releases');
+const res = await fetch('https://api.github.com/repos/ngtcp2/ngtcp2/releases', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const releases = await res.json()
 const { tag_name } = releases.at(0);

--- a/tools/dep_updaters/update-ngtcp2.sh
+++ b/tools/dep_updaters/update-ngtcp2.sh
@@ -11,11 +11,12 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/ngtcp2/ngtcp2/releases', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/ngtcp2/ngtcp2/releases',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const releases = await res.json()
 const { tag_name } = releases.at(0);

--- a/tools/dep_updaters/update-simdutf.sh
+++ b/tools/dep_updaters/update-simdutf.sh
@@ -11,11 +11,12 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/simdutf/simdutf/releases/latest', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/simdutf/simdutf/releases/latest',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-simdutf.sh
+++ b/tools/dep_updaters/update-simdutf.sh
@@ -11,7 +11,11 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/simdutf/simdutf/releases/latest');
+const res = await fetch('https://api.github.com/repos/simdutf/simdutf/releases/latest', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-uvwasi.sh
+++ b/tools/dep_updaters/update-uvwasi.sh
@@ -12,7 +12,11 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/nodejs/uvwasi/releases/latest');
+const res = await fetch('https://api.github.com/repos/nodejs/uvwasi/releases/latest', {
+  headers: {
+    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+  },
+});
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));

--- a/tools/dep_updaters/update-uvwasi.sh
+++ b/tools/dep_updaters/update-uvwasi.sh
@@ -12,11 +12,12 @@ DEPS_DIR="$BASE_DIR/deps"
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/nodejs/uvwasi/releases/latest', {
-  headers: {
-    "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-  },
-});
+const res = await fetch('https://api.github.com/repos/nodejs/uvwasi/releases/latest',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const { tag_name } = await res.json();
 console.log(tag_name.replace('v', ''));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/48119
Refs: https://github.com/nodejs/security-wg/issues/973

Added `authorization` header to authenticate Github api requests in the dependency update workflow
