### PR TITLE
test_runner: handled change for exposing 'spec' reporter

### DIFF
--- a/lib/test/reporters.js
+++ b/lib/test/reporters.js
@@ -22,7 +22,7 @@ ObjectDefineProperties(module.exports, {
     configurable: true,
     enumerable: true,
     get() {
-      spec ??= (...args) => ReflectConstruct(require('internal/test_runner/reporter/spec'), args);
+      spec ??= function SpecReporter() { return ReflectConstruct(require('internal/test_runner/reporter/spec'), arguments); };
       return spec;
     },
   },

--- a/lib/test/reporters.js
+++ b/lib/test/reporters.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ObjectDefineProperties } = primordials;
+const { ObjectDefineProperties, ReflectConstruct } = primordials;
 
 let dot;
 let spec;
@@ -22,7 +22,7 @@ ObjectDefineProperties(module.exports, {
     configurable: true,
     enumerable: true,
     get() {
-      spec ??= require('internal/test_runner/reporter/spec');
+      spec ??= (...args) => ReflectConstruct(require('internal/test_runner/reporter/spec'), args);
       return spec;
     },
   },

--- a/lib/test/reporters.js
+++ b/lib/test/reporters.js
@@ -21,9 +21,8 @@ ObjectDefineProperties(module.exports, {
     __proto__: null,
     configurable: true,
     enumerable: true,
-    get() {
-      spec ??= function SpecReporter() { return ReflectConstruct(require('internal/test_runner/reporter/spec'), arguments); };
-      return spec;
+    value: spec ?? function SpecReporter() { 
+      return ReflectConstruct(require('internal/test_runner/reporter/spec'), arguments); 
     },
   },
   tap: {

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -76,8 +76,7 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
   });
 
   it('should be piped with spec', async () => {
-    const specReporter = new spec();
-    const result = await run({ files: [join(testFixtures, 'test/random.cjs')] }).compose(specReporter).toArray();
+    const result = await run({ files: [join(testFixtures, 'test/random.cjs')] }).compose(spec).toArray();
     const stringResults = result.map((bfr) => bfr.toString());
     assert.match(stringResults[0], /this should pass/);
     assert.match(stringResults[1], /tests 1/);


### PR DESCRIPTION
Fixes: [Issue#48112](https://github.com/nodejs/node/issues/48112)

Other reporters (dot, tap) by signature are a function while 'spec'
reporter is a ES6 class.

This behaviour of api spec is causing difference in semantics while
consumption since it has not been addressed anywhere in the document
(it has to be instantiated).

Instead of making changes in the signature of spec.js, i have proposed
changes where the 'spec' reporter gets exposed in reporter.js


Refs: [reporter/spec.js](https://github.com/nodejs/node/blob/main/lib/internal/test_runner/reporter/spec.js)
Refs: (@line-no:143) [test_runner/utils.js](https://github.com/nodejs/node/blob/main/lib/internal/test_runner/utils.js)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
