### PR TITLE
deps: enable zlib AVX-512 optimizations

### DIFF
--- a/deps/zlib/cpu_features.c
+++ b/deps/zlib/cpu_features.c
@@ -141,7 +141,9 @@ static void _cpu_check_features(void)
  */
 #ifdef CRC32_SIMD_AVX512_PCLMUL
 #include <immintrin.h>
+#if !defined(_MSC_VER)
 #include <xsaveintrin.h>
+#endif
 #endif
 static void _cpu_check_features(void)
 {

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -194,7 +194,10 @@
           'conditions': [
             ['OS!="win"', {
               'cflags!': [ '-ansi' ],
-              'cflags': [ '-Wno-implicit-fallthrough' ],
+              'cflags': [
+                '-Wno-implicit-fallthrough',
+                '-mxsave',
+              ],
               'defines': [ 'HAVE_HIDDEN' ],
             }, {
               'defines': [ 'ZLIB_DLL' ]

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -198,6 +198,9 @@
                 '-Wno-implicit-fallthrough',
                 '-mxsave',
               ],
+              'xcode_settings': {
+                'OTHER_CFLAGS': [ '-mxsave' ],
+              },
               'defines': [ 'HAVE_HIDDEN' ],
             }, {
               'defines': [ 'ZLIB_DLL' ]

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -113,21 +113,31 @@
           'conditions': [
             ['OS!="win" or llvm_version!="0.0"', {
               'cflags': [
-                '-msse4.2',
+                '-mvpclmulqdq',
+                '-msse2',
+                '-mavx512f',
                 '-mpclmul',
               ],
               'xcode_settings': {
                 'OTHER_CFLAGS': [
-                  '-msse4.2',
+                  '-mvpclmulqdq',
+                  '-msse2',
+                  '-mavx512f',
                   '-mpclmul',
                 ],
               },
             }]
           ],
-          'defines': [ 'CRC32_SIMD_SSE42_PCLMUL' ],
+          'defines': [
+            'CRC32_SIMD_SSE42_PCLMUL',
+            'CRC32_SIMD_AVX512_PCLMUL',
+          ],
           'include_dirs': [ '<(ZLIB_ROOT)' ],
           'direct_dependent_settings': {
-            'defines': [ 'CRC32_SIMD_SSE42_PCLMUL' ],
+            'defines': [
+              'CRC32_SIMD_SSE42_PCLMUL',
+              'CRC32_SIMD_AVX512_PCLMUL',
+            ],
             'include_dirs': [ '<(ZLIB_ROOT)' ],
           },
           'sources': [


### PR DESCRIPTION
This enables AVX-512 optimizations as per https://chromium.googlesource.com/chromium/src/third_party/zlib/+/b890619bc2b193b8fbe9c1c053f4cd19a9791d92%5E%21/#F0. However, build fails. Any suggestion is welcome.

The first commit is from https://github.com/nodejs/node/pull/48218.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
