### PR TITLE
tools: use shasum instead of sha256sum

### DIFF
--- a/tools/dep_updaters/utils.sh
+++ b/tools/dep_updaters/utils.sh
@@ -12,11 +12,11 @@ log_and_verify_sha256sum() {
   package_name="$1"
   archive="$2"
   checksum="$3"
-  bsd_formatted_checksum=$(sha256sum --tag "$archive")
+  bsd_formatted_checksum=$(shasum -a 256 --tag "$archive")
   if [ -z "$3" ]; then
     echo "$bsd_formatted_checksum"
   else
-    archive_checksum=$(sha256sum "$archive")
+    archive_checksum=$(shasum -a 256 "$archive")
     if [ "$checksum" = "$archive_checksum" ]; then
       echo "Valid $package_name checksum"
       echo "$bsd_formatted_checksum"


### PR DESCRIPTION
By default, there is no sha256sum command in macOS.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
