### PR TITLE
bootstrap: unify snapshot builder and embedder entry points

### DIFF
--- a/lib/internal/main/embedding.js
+++ b/lib/internal/main/embedding.js
@@ -6,7 +6,7 @@ const {
 const { isExperimentalSeaWarningNeeded } = internalBinding('sea');
 const { emitExperimentalWarning } = require('internal/util');
 const { embedderRequire, embedderRunCjs } = require('internal/util/embedding');
-const { getEmbedderEntryFunction } = internalBinding('mksnapshot');
+const { runEmbedderEntryPoint } = internalBinding('mksnapshot');
 
 prepareMainThreadExecution(false, true);
 markBootstrapComplete();
@@ -15,4 +15,4 @@ if (isExperimentalSeaWarningNeeded()) {
   emitExperimentalWarning('Single executable application');
 }
 
-return getEmbedderEntryFunction()(embedderRequire, embedderRunCjs);
+return runEmbedderEntryPoint(process, embedderRequire, embedderRunCjs);

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -9,20 +9,30 @@ const {
   SafeSet,
 } = primordials;
 
-const binding = internalBinding('mksnapshot');
 const { BuiltinModule: { normalizeRequirableId } } = require('internal/bootstrap/realm');
 const {
-  getEmbedderEntryFunction,
+  runEmbedderEntryPoint,
   compileSerializeMain,
-} = binding;
+  anonymousMainPath,
+} = internalBinding('mksnapshot');
 
 const {
   getOptionValue,
 } = require('internal/options');
 
 const {
-  readFileSync,
-} = require('fs');
+  initializeCallbacks,
+  namespace: {
+    addSerializeCallback,
+    addDeserializeCallback,
+  },
+} = require('internal/v8/startup_snapshot');
+
+const {
+  prepareMainThreadExecution,
+} = require('internal/process/pre_execution');
+
+const path = require('path');
 
 const supportedModules = new SafeSet(new SafeArrayIterator([
   // '_http_agent',
@@ -117,42 +127,7 @@ function requireForUserSnapshot(id) {
 }
 
 function main() {
-  const {
-    prepareMainThreadExecution,
-  } = require('internal/process/pre_execution');
-  const path = require('path');
-
-  let serializeMainFunction = getEmbedderEntryFunction();
-  const serializeMainArgs = [requireForUserSnapshot];
-
-  if (serializeMainFunction) { // embedded case
-    prepareMainThreadExecution(false, false);
-    // TODO(addaleax): Make this `embedderRunCjs` once require('module')
-    // is supported in snapshots.
-    const filename = process.execPath;
-    const dirname = path.dirname(filename);
-    function minimalRunCjs(source) {
-      const fn = compileSerializeMain(filename, source);
-      return fn(requireForUserSnapshot, filename, dirname);
-    }
-    serializeMainArgs.push(minimalRunCjs);
-  } else {
-    prepareMainThreadExecution(true, false);
-    const file = process.argv[1];
-    const filename = path.resolve(file);
-    const dirname = path.dirname(filename);
-    const source = readFileSync(file, 'utf-8');
-    serializeMainFunction = compileSerializeMain(filename, source);
-    serializeMainArgs.push(filename, dirname);
-  }
-
-  const {
-    initializeCallbacks,
-    namespace: {
-      addSerializeCallback,
-      addDeserializeCallback,
-    },
-  } = require('internal/v8/startup_snapshot');
+  prepareMainThreadExecution(true, false);
   initializeCallbacks();
 
   let stackTraceLimitDesc;
@@ -161,14 +136,6 @@ function main() {
       ObjectDefineProperty(Error, 'stackTraceLimit', stackTraceLimitDesc);
     }
   });
-
-  if (getOptionValue('--inspect-brk')) {
-    internalBinding('inspector').callAndPauseOnStart(
-      serializeMainFunction, undefined, ...serializeMainArgs);
-  } else {
-    serializeMainFunction(...serializeMainArgs);
-  }
-
   addSerializeCallback(() => {
     stackTraceLimitDesc = ObjectGetOwnPropertyDescriptor(Error, 'stackTraceLimit');
 
@@ -181,6 +148,31 @@ function main() {
       delete Error.stackTraceLimit;
     }
   });
+
+  // TODO(addaleax): Make this `embedderRunCjs` once require('module')
+  // is supported in snapshots.
+  function minimalRunCjs(source) {
+    let filename;
+    let dirname;
+    if (process.argv[1] === anonymousMainPath) {
+      filename = dirname = process.argv[1];
+    } else {
+      filename = path.resolve(process.argv[1]);
+      dirname = path.dirname(filename);
+    }
+
+    const fn = compileSerializeMain(filename, source);
+    return fn(requireForUserSnapshot, filename, dirname);
+  }
+
+  const serializeMainArgs = [process, requireForUserSnapshot, minimalRunCjs];
+
+  if (getOptionValue('--inspect-brk')) {
+    internalBinding('inspector').callAndPauseOnStart(
+      runEmbedderEntryPoint, undefined, ...serializeMainArgs);
+  } else {
+    runEmbedderEntryPoint(...serializeMainArgs);
+  }
 }
 
 main();

--- a/src/node.h
+++ b/src/node.h
@@ -816,6 +816,8 @@ NODE_EXTERN struct uv_loop_s* GetCurrentEventLoop(v8::Isolate* isolate);
 // This function only works if `env` has an associated `MultiIsolatePlatform`.
 NODE_EXTERN v8::Maybe<int> SpinEventLoop(Environment* env);
 
+NODE_EXTERN std::string GetAnonymousMainPath();
+
 class NODE_EXTERN CommonEnvironmentSetup {
  public:
   ~CommonEnvironmentSetup();
@@ -847,6 +849,13 @@ class NODE_EXTERN CommonEnvironmentSetup {
   // Not all Node.js APIs are supported in this case. Currently, there is
   // no support for native/host objects other than Node.js builtins
   // in the snapshot.
+  //
+  // If the embedder wants to use LoadEnvironment() later to run a snapshot
+  // builder script they should make sure args[1] contains the path of the
+  // snapshot script, which will be used to create __filename and __dirname
+  // in the context where the builder script is run. If they do not want to
+  // include the build-time paths into the snapshot, use the string returned
+  // by GetAnonymousMainPath() as args[1] to anonymize the script.
   //
   // Snapshots are an *experimental* feature. In particular, the embedder API
   // exposed through this class is subject to change or removal between Node.js
@@ -909,6 +918,7 @@ std::unique_ptr<CommonEnvironmentSetup> CommonEnvironmentSetup::Create(
   if (!errors->empty()) ret.reset();
   return ret;
 }
+
 // Implementation for ::CreateFromSnapshot -- the ::Create() method
 // could call this with a nullptr snapshot_data in a major version.
 template <typename... EnvironmentArgs>

--- a/src/node_snapshot_builder.h
+++ b/src/node_snapshot_builder.h
@@ -19,14 +19,14 @@ struct SnapshotData;
 class NODE_EXTERN_PRIVATE SnapshotBuilder {
  public:
   static ExitCode Generate(std::ostream& out,
-                           const std::vector<std::string> args,
-                           const std::vector<std::string> exec_args,
+                           const std::vector<std::string>& args,
+                           const std::vector<std::string>& exec_args,
                            std::optional<std::string_view> main_script);
 
   // Generate the snapshot into out.
   static ExitCode Generate(SnapshotData* out,
-                           const std::vector<std::string> args,
-                           const std::vector<std::string> exec_args,
+                           const std::vector<std::string>& args,
+                           const std::vector<std::string>& exec_args,
                            std::optional<std::string_view> main_script);
 
   // If nullptr is returned, the binary is not built with embedded

--- a/src/node_snapshot_builder.h
+++ b/src/node_snapshot_builder.h
@@ -5,6 +5,8 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include <cstdint>
+#include <optional>
+#include <string_view>
 #include "node_exit_code.h"
 #include "node_mutex.h"
 #include "v8.h"
@@ -18,12 +20,14 @@ class NODE_EXTERN_PRIVATE SnapshotBuilder {
  public:
   static ExitCode Generate(std::ostream& out,
                            const std::vector<std::string> args,
-                           const std::vector<std::string> exec_args);
+                           const std::vector<std::string> exec_args,
+                           std::optional<std::string_view> main_script);
 
   // Generate the snapshot into out.
   static ExitCode Generate(SnapshotData* out,
                            const std::vector<std::string> args,
-                           const std::vector<std::string> exec_args);
+                           const std::vector<std::string> exec_args,
+                           std::optional<std::string_view> main_script);
 
   // If nullptr is returned, the binary is not built with embedded
   // snapshot.

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -848,8 +848,8 @@ void SnapshotBuilder::InitializeIsolateParams(const SnapshotData* data,
 
 ExitCode SnapshotBuilder::Generate(
     SnapshotData* out,
-    const std::vector<std::string> args,
-    const std::vector<std::string> exec_args,
+    const std::vector<std::string>& args,
+    const std::vector<std::string>& exec_args,
     std::optional<std::string_view> main_script) {
   // The default snapshot is meant to be runtime-independent and has more
   // restrictions. We do not enable the inspector and do not run the event
@@ -1020,8 +1020,8 @@ ExitCode SnapshotBuilder::CreateSnapshot(SnapshotData* out,
 
 ExitCode SnapshotBuilder::Generate(
     std::ostream& out,
-    const std::vector<std::string> args,
-    const std::vector<std::string> exec_args,
+    const std::vector<std::string>& args,
+    const std::vector<std::string>& exec_args,
     std::optional<std::string_view> main_script) {
   SnapshotData data;
   ExitCode exit_code = Generate(&data, args, exec_args, main_script);

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -846,9 +846,20 @@ void SnapshotBuilder::InitializeIsolateParams(const SnapshotData* data,
       const_cast<v8::StartupData*>(&(data->v8_snapshot_blob_data));
 }
 
-ExitCode SnapshotBuilder::Generate(SnapshotData* out,
-                                   const std::vector<std::string> args,
-                                   const std::vector<std::string> exec_args) {
+ExitCode SnapshotBuilder::Generate(
+    SnapshotData* out,
+    const std::vector<std::string> args,
+    const std::vector<std::string> exec_args,
+    std::optional<std::string_view> main_script) {
+  // The default snapshot is meant to be runtime-independent and has more
+  // restrictions. We do not enable the inspector and do not run the event
+  // loop when building the default snapshot to avoid inconsistencies, but
+  // we do for the fully customized one, and they are expected to fixup the
+  // inconsistencies using v8.startupSnapshot callbacks.
+  SnapshotMetadata::Type snapshot_type =
+      main_script.has_value() ? SnapshotMetadata::Type::kFullyCustomized
+                              : SnapshotMetadata::Type::kDefault;
+
   std::vector<std::string> errors;
   auto setup = CommonEnvironmentSetup::CreateForSnapshotting(
       per_process::v8_platform.Platform(), &errors, args, exec_args);
@@ -858,12 +869,6 @@ ExitCode SnapshotBuilder::Generate(SnapshotData* out,
     return ExitCode::kBootstrapFailure;
   }
   Isolate* isolate = setup->isolate();
-
-  // It's only possible to be kDefault in node_mksnapshot.
-  SnapshotMetadata::Type snapshot_type =
-      per_process::cli_options->per_isolate->build_snapshot
-          ? SnapshotMetadata::Type::kFullyCustomized
-          : SnapshotMetadata::Type::kDefault;
 
   {
     HandleScope scope(isolate);
@@ -876,32 +881,25 @@ ExitCode SnapshotBuilder::Generate(SnapshotData* out,
       }
     });
 
-    // Initialize the main instance context.
-    {
+    // Run the custom main script for fully customized snapshots.
+    if (snapshot_type == SnapshotMetadata::Type::kFullyCustomized) {
       Context::Scope context_scope(setup->context());
       Environment* env = setup->env();
-
-      // If --build-snapshot is true, lib/internal/main/mksnapshot.js would be
-      // loaded via LoadEnvironment() to execute process.argv[1] as the entry
-      // point (we currently only support this kind of entry point, but we
-      // could also explore snapshotting other kinds of execution modes
-      // in the future).
-      if (snapshot_type == SnapshotMetadata::Type::kFullyCustomized) {
 #if HAVE_INSPECTOR
         env->InitializeInspector({});
 #endif
-        if (LoadEnvironment(env, StartExecutionCallback{}).IsEmpty()) {
+        if (LoadEnvironment(env, main_script.value()).IsEmpty()) {
           return ExitCode::kGenericUserError;
         }
+
         // FIXME(joyeecheung): right now running the loop in the snapshot
-        // builder seems to introduces inconsistencies in JS land that need to
+        // builder might introduce inconsistencies in JS land that need to
         // be synchronized again after snapshot restoration.
         ExitCode exit_code =
             SpinEventLoopInternal(env).FromMaybe(ExitCode::kGenericUserError);
         if (exit_code != ExitCode::kNoFailure) {
           return exit_code;
         }
-      }
     }
   }
 
@@ -1020,11 +1018,13 @@ ExitCode SnapshotBuilder::CreateSnapshot(SnapshotData* out,
   return ExitCode::kNoFailure;
 }
 
-ExitCode SnapshotBuilder::Generate(std::ostream& out,
-                                   const std::vector<std::string> args,
-                                   const std::vector<std::string> exec_args) {
+ExitCode SnapshotBuilder::Generate(
+    std::ostream& out,
+    const std::vector<std::string> args,
+    const std::vector<std::string> exec_args,
+    std::optional<std::string_view> main_script) {
   SnapshotData data;
-  ExitCode exit_code = Generate(&data, args, exec_args);
+  ExitCode exit_code = Generate(&data, args, exec_args, main_script);
   if (exit_code != ExitCode::kNoFailure) {
     return exit_code;
   }
@@ -1178,27 +1178,23 @@ void SerializeSnapshotableObjects(Realm* realm,
   });
 }
 
-// NB: This is also used by the regular embedding codepath.
-void GetEmbedderEntryFunction(const FunctionCallbackInfo<Value>& args) {
+static void RunEmbedderEntryPoint(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
-  if (!env->embedder_entry_point()) return;
-  MaybeLocal<Function> jsfn =
-      Function::New(isolate->GetCurrentContext(),
-                    [](const FunctionCallbackInfo<Value>& args) {
-                      Environment* env = Environment::GetCurrent(args);
-                      Local<Value> require_fn = args[0];
-                      Local<Value> runcjs_fn = args[1];
-                      CHECK(require_fn->IsFunction());
-                      CHECK(runcjs_fn->IsFunction());
-                      MaybeLocal<Value> retval = env->embedder_entry_point()(
-                          {env->process_object(),
-                           require_fn.As<Function>(),
-                           runcjs_fn.As<Function>()});
-                      if (!retval.IsEmpty())
-                        args.GetReturnValue().Set(retval.ToLocalChecked());
-                    });
-  if (!jsfn.IsEmpty()) args.GetReturnValue().Set(jsfn.ToLocalChecked());
+  Local<Value> process_obj = args[0];
+  Local<Value> require_fn = args[1];
+  Local<Value> runcjs_fn = args[2];
+  CHECK(process_obj->IsObject());
+  CHECK(require_fn->IsFunction());
+  CHECK(runcjs_fn->IsFunction());
+
+  const node::StartExecutionCallback& callback = env->embedder_entry_point();
+  node::StartExecutionCallbackInfo info{process_obj.As<Object>(),
+                                        require_fn.As<Function>(),
+                                        runcjs_fn.As<Function>()};
+  MaybeLocal<Value> retval = callback(info);
+  if (!retval.IsEmpty()) {
+    args.GetReturnValue().Set(retval.ToLocalChecked());
+  }
 }
 
 void CompileSerializeMain(const FunctionCallbackInfo<Value>& args) {
@@ -1248,6 +1244,12 @@ void SetDeserializeMainFunction(const FunctionCallbackInfo<Value>& args) {
   CHECK(env->snapshot_deserialize_main().IsEmpty());
   CHECK(args[0]->IsFunction());
   env->set_snapshot_deserialize_main(args[0].As<Function>());
+}
+
+constexpr const char* kAnonymousMainPath = "__node_anonymous_main";
+
+std::string GetAnonymousMainPath() {
+  return kAnonymousMainPath;
 }
 
 namespace mksnapshot {
@@ -1326,8 +1328,7 @@ void CreatePerContextProperties(Local<Object> target,
 void CreatePerIsolateProperties(IsolateData* isolate_data,
                                 Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  SetMethod(
-      isolate, target, "getEmbedderEntryFunction", GetEmbedderEntryFunction);
+  SetMethod(isolate, target, "runEmbedderEntryPoint", RunEmbedderEntryPoint);
   SetMethod(isolate, target, "compileSerializeMain", CompileSerializeMain);
   SetMethod(isolate, target, "setSerializeCallback", SetSerializeCallback);
   SetMethod(isolate, target, "setDeserializeCallback", SetDeserializeCallback);
@@ -1335,10 +1336,12 @@ void CreatePerIsolateProperties(IsolateData* isolate_data,
             target,
             "setDeserializeMainFunction",
             SetDeserializeMainFunction);
+  target->Set(FIXED_ONE_BYTE_STRING(isolate, "anonymousMainPath"),
+              OneByteString(isolate, kAnonymousMainPath));
 }
 
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
-  registry->Register(GetEmbedderEntryFunction);
+  registry->Register(RunEmbedderEntryPoint);
   registry->Register(CompileSerializeMain);
   registry->Register(SetSerializeCallback);
   registry->Register(SetDeserializeCallback);

--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -60,23 +60,49 @@ int RunNodeInstance(MultiIsolatePlatform* platform,
                     const std::vector<std::string>& exec_args) {
   int exit_code = 0;
 
+  // Format of the arguments of this binary:
+  // Building snapshot:
+  // embedtest js_code_to_eval arg1 arg2... \
+  //           --embedder-snapshot-blob blob-path \
+  //           --embedder-snapshot-create
+  //           [--embedder-snapshot-as-file]
+  // Running snapshot:
+  // embedtest --embedder-snapshot-blob blob-path \
+  //           [--embedder-snapshot-as-file]
+  //           arg1 arg2...
+  // No snapshot:
+  // embedtest arg1 arg2...
   node::EmbedderSnapshotData::Pointer snapshot;
-  auto snapshot_build_mode_it =
-      std::find(args.begin(), args.end(), "--embedder-snapshot-create");
-  auto snapshot_arg_it =
-      std::find(args.begin(), args.end(), "--embedder-snapshot-blob");
-  auto snapshot_as_file_it =
-      std::find(args.begin(), args.end(), "--embedder-snapshot-as-file");
-  if (snapshot_arg_it < args.end() - 1 &&
-      snapshot_build_mode_it == args.end()) {
-    const char* filename = (snapshot_arg_it + 1)->c_str();
-    FILE* fp = fopen(filename, "r");
+
+  std::string binary_path = args[0];
+  std::vector<std::string> filtered_args;
+  bool is_building_snapshot = false;
+  bool snapshot_as_file = false;
+  std::string snapshot_blob_path;
+  for (size_t i = 0; i < args.size(); ++i) {
+    const std::string& arg = args[i];
+    if (arg == "--embedder-snapshot-create") {
+      is_building_snapshot = true;
+    } else if (arg == "--embedder-snapshot-as-file") {
+      snapshot_as_file = true;
+    } else if (arg == "--embedder-snapshot-blob") {
+      assert(i + 1 < args.size());
+      snapshot_blob_path = args[i + i];
+      i++;
+    } else {
+      filtered_args.push_back(arg);
+    }
+  }
+
+  if (!snapshot_blob_path.empty() && !is_building_snapshot) {
+    FILE* fp = fopen(snapshot_blob_path.c_str(), "r");
     assert(fp != nullptr);
-    if (snapshot_as_file_it != args.end()) {
+    if (snapshot_as_file) {
       snapshot = node::EmbedderSnapshotData::FromFile(fp);
     } else {
       uv_fs_t req = uv_fs_t();
-      int statret = uv_fs_stat(nullptr, &req, filename, nullptr);
+      int statret =
+          uv_fs_stat(nullptr, &req, snapshot_blob_path.c_str(), nullptr);
       assert(statret == 0);
       size_t filesize = req.statbuf.st_size;
       uv_fs_req_cleanup(&req);
@@ -91,17 +117,27 @@ int RunNodeInstance(MultiIsolatePlatform* platform,
     assert(ret == 0);
   }
 
+  if (is_building_snapshot) {
+    // It contains at least the binary path, the code to snapshot,
+    // and --embedder-snapshot-create. Insert an anonymous filename
+    // as process.argv[1].
+    assert(filtered_args.size() >= 3);
+    filtered_args.insert(filtered_args.begin() + 1,
+                         node::GetAnonymousMainPath());
+  }
+
   std::vector<std::string> errors;
   std::unique_ptr<CommonEnvironmentSetup> setup =
-      snapshot ? CommonEnvironmentSetup::CreateFromSnapshot(
-                     platform, &errors, snapshot.get(), args, exec_args)
-      : snapshot_build_mode_it != args.end()
-          ? CommonEnvironmentSetup::CreateForSnapshotting(
-                platform, &errors, args, exec_args)
-          : CommonEnvironmentSetup::Create(platform, &errors, args, exec_args);
+      snapshot
+          ? CommonEnvironmentSetup::CreateFromSnapshot(
+                platform, &errors, snapshot.get(), filtered_args, exec_args)
+      : is_building_snapshot ? CommonEnvironmentSetup::CreateForSnapshotting(
+                                   platform, &errors, filtered_args, exec_args)
+                             : CommonEnvironmentSetup::Create(
+                                   platform, &errors, filtered_args, exec_args);
   if (!setup) {
     for (const std::string& err : errors)
-      fprintf(stderr, "%s: %s\n", args[0].c_str(), err.c_str());
+      fprintf(stderr, "%s: %s\n", binary_path.c_str(), err.c_str());
     return 1;
   }
 
@@ -127,7 +163,7 @@ int RunNodeInstance(MultiIsolatePlatform* platform,
           "  globalThis.require = publicRequire;"
           "} else globalThis.require = require;"
           "globalThis.embedVars = { nön_ascıı: '🏳️‍🌈' };"
-          "require('vm').runInThisContext(process.argv[1]);");
+          "require('vm').runInThisContext(process.argv[2]);");
     }
 
     if (loadenv_ret.IsEmpty())  // There has been a JS exception.
@@ -136,14 +172,13 @@ int RunNodeInstance(MultiIsolatePlatform* platform,
     exit_code = node::SpinEventLoop(env).FromMaybe(1);
   }
 
-  if (snapshot_arg_it < args.end() - 1 &&
-      snapshot_build_mode_it != args.end()) {
+  if (!snapshot_blob_path.empty() && is_building_snapshot) {
     snapshot = setup->CreateSnapshot();
     assert(snapshot);
 
-    FILE* fp = fopen((snapshot_arg_it + 1)->c_str(), "w");
+    FILE* fp = fopen(snapshot_blob_path.c_str(), "w");
     assert(fp != nullptr);
-    if (snapshot_as_file_it != args.end()) {
+    if (snapshot_as_file) {
       snapshot->ToFile(fp);
     } else {
       const std::vector<char> vec = snapshot->ToBlob();

--- a/test/embedding/test-embedding.js
+++ b/test/embedding/test-embedding.js
@@ -74,11 +74,16 @@ for (const extraSnapshotArgs of [[], ['--embedder-snapshot-as-file']]) {
   ];
 
   fs.rmSync(blobPath, { force: true });
-  assert.strictEqual(child_process.spawnSync(binary, [
+  const child = child_process.spawnSync(binary, [
     '--', ...buildSnapshotArgs,
   ], {
     cwd: tmpdir.path,
-  }).status, 0);
+  });
+  if (child.status !== 0) {
+    console.log(child.stderr.toString());
+    console.log(child.stdout.toString());
+  }
+  assert.strictEqual(child.status, 0);
   const spawnResult = child_process.spawnSync(binary, ['--', ...runEmbeddedArgs]);
   assert.deepStrictEqual(JSON.parse(spawnResult.stdout), {
     originalArgv: [binary, ...buildSnapshotArgs],

--- a/tools/snapshot/node_mksnapshot.cc
+++ b/tools/snapshot/node_mksnapshot.cc
@@ -87,7 +87,7 @@ int BuildSnapshot(int argc, char* argv[]) {
   node::ExitCode exit_code = node::ExitCode::kNoFailure;
   {
     exit_code = node::SnapshotBuilder::Generate(
-        out, result->args(), result->exec_args());
+        out, result->args(), result->exec_args(), std::nullopt);
     if (exit_code == node::ExitCode::kNoFailure) {
       if (!out) {
         std::cerr << "Failed to write " << out_path << "\n";


### PR DESCRIPTION
- Run the embedder entry point directly through runEmbedderEntryPoint(), instead of going through another JS -> C++ trip through the function returned by getEmbedderEntryFunction()
- For --build-snapshot, read the snapshot script code directly in C++ and pass it to SnapshotBuilder::Generate(), this makes the entry point more explicit instead of hiding it in JS land, and also makes it possible to invoke SnapshotBuilder::Generate() internally to create a custom snapshot.
- Previously we used process.execPath for the embedder to create __filename and __dirname in the snapshot builder script while using process.argv[1] for --build-snapshot (where it's always set) which results in inconsistencies. We now require the embedder to also set args[1] when creating the Environment if they intend to run snapshot scripts with a context that contains __filename and __dirname, which would be derived from args[1]. If they prefer not to include build-time paths in the snapshot, we now provide node::GetAnonymousMainPath() as an alternative.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
