### PR TITLE
net: fix address iteration with autoSelectFamily

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1476,7 +1476,7 @@ function lookupAndConnectMultiple(
 
       const context = {
         socket: self,
-        addresses,
+        addresses: toAttempt,
         current: 0,
         port,
         localPort,

--- a/test/parallel/test-net-autoselectfamily.js
+++ b/test/parallel/test-net-autoselectfamily.js
@@ -117,7 +117,7 @@ function createDnsServer(ipv6Addrs, ipv4Addrs, cb) {
 // Test that only the last successful connection is established.
 {
   createDnsServer(
-    '::1',
+    ['2606:4700::6810:85e5', '2606:4700::6810:84e5', '::1'],
     ['104.20.22.46', '104.20.23.46', '127.0.0.1'],
     common.mustCall(function({ dnsServer, lookup }) {
       const ipv4Server = createServer((socket) => {
@@ -144,7 +144,14 @@ function createDnsServer(ipv6Addrs, ipv4Addrs, cb) {
         connection.on('ready', common.mustCall(() => {
           assert.deepStrictEqual(
             connection.autoSelectFamilyAttemptedAddresses,
-            [`::1:${port}`, `104.20.22.46:${port}`, `104.20.23.46:${port}`, `127.0.0.1:${port}`]
+            [
+              `2606:4700::6810:85e5:${port}`,
+              `104.20.22.46:${port}`,
+              `2606:4700::6810:84e5:${port}`,
+              `104.20.23.46:${port}`,
+              `::1:${port}`,
+              `127.0.0.1:${port}`,
+            ]
           );
         }));
 


### PR DESCRIPTION
When `autoSelectFamily` is set to `true`, `net.connect` is supposed to try connecting to both IPv4 and IPv6, interleaving the address types. Instead, it appears that the array that holds the addresses in the order they should be attempted was never used after being populated.