### PR TITLE
test: fix `test-net-autoselectfamily` for kernel without IPv6 support

### DIFF
--- a/test/parallel/test-net-autoselectfamily-commandline-option.js
+++ b/test/parallel/test-net-autoselectfamily-commandline-option.js
@@ -85,6 +85,8 @@ function createDnsServer(ipv6Addr, ipv4Addr, cb) {
         if (common.hasIPv6) {
           assert.strictEqual(error.code, 'ECONNREFUSED');
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
+        } else if (error.code === 'EAFNOSUPPORT') {
+          assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
         } else {
           assert.strictEqual(error.code, 'EADDRNOTAVAIL');
           assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);


### PR DESCRIPTION
If `CONFIG_IPV6` is disabled, the observed error on some platforms is `EAFNOSUPPORT` instead of `EADDRNOTAVAIL`.