### PR TITLE
doc: clarify array args to Buffer.from()

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1118,6 +1118,12 @@ const { Buffer } = require('node:buffer');
 const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 ```
 
+Note that if `array` is an `Array`-like object (that is, one with a `length`
+property of type `number`) it is treated as if it is an array, unless it is a
+`Buffer` or a `Uint8Array`. This means all other `TypedArray` variants get
+treated as `Array`. To create a `Buffer` from the underlying `ArrayBuffer`, use
+the `.buffer` property directly.
+
 A `TypeError` will be thrown if `array` is not an `Array` or another type
 appropriate for `Buffer.from()` variants.
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1119,10 +1119,10 @@ const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 ```
 
 If `array` is an `Array`-like object (that is, one with a `length` property of
-type `number`), it is treated as if it is an array, unless it is a `Buffer` or a
-`Uint8Array`. This means all other `TypedArray` variants get treated as an
-`Array`. To create a `Buffer` from the underlying `ArrayBuffer`, use the
-`.buffer` property directly.
+type `number`), it is treated as if it is an array, unless it is a `Buffer` or
+a `Uint8Array`. This means all other `TypedArray` variants get treated as an
+`Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use
+[`Buffer.copyBytesFrom()`][].
 
 A `TypeError` will be thrown if `array` is not an `Array` or another type
 appropriate for `Buffer.from()` variants.
@@ -5496,6 +5496,7 @@ introducing security vulnerabilities into an application.
 [`Buffer.allocUnsafe()`]: #static-method-bufferallocunsafesize
 [`Buffer.allocUnsafeSlow()`]: #static-method-bufferallocunsafeslowsize
 [`Buffer.concat()`]: #static-method-bufferconcatlist-totallength
+[`Buffer.copyBytesFrom()`]: #static-method-buffercopybytesfromview-offset-length
 [`Buffer.from(array)`]: #static-method-bufferfromarray
 [`Buffer.from(arrayBuf)`]: #static-method-bufferfromarraybuffer-byteoffset-length
 [`Buffer.from(buffer)`]: #static-method-bufferfrombuffer

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1118,11 +1118,11 @@ const { Buffer } = require('node:buffer');
 const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 ```
 
-Note that if `array` is an `Array`-like object (that is, one with a `length`
-property of type `number`) it is treated as if it is an array, unless it is a
-`Buffer` or a `Uint8Array`. This means all other `TypedArray` variants get
-treated as `Array`. To create a `Buffer` from the underlying `ArrayBuffer`, use
-the `.buffer` property directly.
+If `array` is an `Array`-like object (that is, one with a `length` property of
+type `number`), it is treated as if it is an array, unless it is a `Buffer` or a
+`Uint8Array`. This means all other `TypedArray` variants get treated as an
+`Array`. To create a `Buffer` from the underlying `ArrayBuffer`, use the
+`.buffer` property directly.
 
 A `TypeError` will be thrown if `array` is not an `Array` or another type
 appropriate for `Buffer.from()` variants.


### PR DESCRIPTION
The code for Buffer.from() treats non-Buffer and non-Uint8Array Array-likes as Arrays. This creates some confusion when passing various TypedArrays to Buffer.from(). The documentation now reflects the actual behavior.

Fixes: https://github.com/nodejs/node/issues/28725

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
