### PR TITLE
process: introduce codeGenerationFromString event

### DIFF
--- a/deps/v8/include/v8-callbacks.h
+++ b/deps/v8/include/v8-callbacks.h
@@ -292,12 +292,12 @@ using FailedAccessCheckCallback = void (*)(Local<Object> target,
  * the source to string if necessary. See: ModifyCodeGenerationFromStrings.
  */
 using ModifyCodeGenerationFromStringsCallback =
-    ModifyCodeGenerationFromStringsResult (*)(Local<Context> context,
-                                              Local<Value> source);
+    Maybe<ModifyCodeGenerationFromStringsResult> (*)(Local<Context> context,
+                                                     Local<Value> source);
 using ModifyCodeGenerationFromStringsCallback2 =
-    ModifyCodeGenerationFromStringsResult (*)(Local<Context> context,
-                                              Local<Value> source,
-                                              bool is_code_like);
+    Maybe<ModifyCodeGenerationFromStringsResult> (*)(Local<Context> context,
+                                                     Local<Value> source,
+                                                     bool is_code_like);
 
 // --- WebAssembly compilation callbacks ---
 using ExtensionCallback = bool (*)(const FunctionCallbackInfo<Value>&);

--- a/deps/v8/src/codegen/compiler.cc
+++ b/deps/v8/src/codegen/compiler.cc
@@ -2925,10 +2925,10 @@ bool ModifyCodeGenerationFromStrings(Isolate* isolate, Handle<Context> context,
   ModifyCodeGenerationFromStringsResult result =
       isolate->modify_code_gen_callback()
           ? isolate->modify_code_gen_callback()(v8::Utils::ToLocal(context),
-                                                v8::Utils::ToLocal(*source))
+                                                v8::Utils::ToLocal(*source)).FromJust()
           : isolate->modify_code_gen_callback2()(v8::Utils::ToLocal(context),
                                                  v8::Utils::ToLocal(*source),
-                                                 is_code_like);
+                                                 is_code_like).FromJust();
   if (result.codegen_allowed && !result.modified_source.IsEmpty()) {
     // Use the new source (which might be the same as the old source).
     *source =

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -80,6 +80,34 @@ console.log('This message is displayed first.');
 // Process exit event with code: 0
 ```
 
+### Event: `'codeGenerationFromString'`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The `'codeGenerationFromString'` event is emitted when a call is made to `eval(str)`
+or `new Function(str)`.
+
+The event handler callback will be invoked with the argument passed to `eval` or
+the `Function` constructor.
+
+The call to `eval` or `new Function` will happen after the event is emitted.
+
+```js
+process.on('codeGenerationFromString', (code) => {
+  console.log(`Generating code from string '${code}'`);
+});
+const item = { foo: 0 };
+eval('item.foo++');
+```
+
+will log
+
+```text
+Generating code from string 'item.foo++'
+```
+
 ### Event: `'disconnect'`
 
 <!-- YAML

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -335,6 +335,26 @@ process.emitWarning = emitWarning;
   // Note: only after this point are the timers effective
 }
 
+setupCodegenFromStringCallback(rawMethods);
+
+function setupCodegenFromStringCallback(bindings) {
+  if (!bindings.codeGenerationFromStringsAllowed()) {
+    // Do nothing if code generation from strings is not allowed.
+    return;
+  }
+  const eventName = 'codeGenerationFromString';
+  process.on('newListener', (event) => {
+    if (event === eventName && process.listenerCount(eventName) === 0) {
+      bindings.setEmitCodeGenFromStringEvent(true);
+    }
+  });
+  process.on('removeListener', (event) => {
+    if (event === eventName && process.listenerCount(eventName) === 0) {
+      bindings.setEmitCodeGenFromStringEvent(false);
+    }
+  });
+}
+
 function setupProcessObject() {
   const EventEmitter = require('events');
   const origProcProto = ObjectGetPrototypeOf(process);

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -480,18 +480,7 @@ static v8::ModifyCodeGenerationFromStringsResult CodeGenCallback(
     Local<Value> source,
     bool is_code_like) {
   Environment* env = Environment::GetCurrent(context);
-  TryCatchScope try_catch(env);
-
   ProcessEmit(env, "codeGenerationFromString", source);
-
-  // V8 does not expect this callback to have a scheduled exceptions once it
-  // returns, so we print them out in a best effort to do something about it
-  // without failing silently and without crashing the process.
-  if (try_catch.HasCaught() && !try_catch.HasTerminated()) {
-    Isolate* isolate = env->isolate();
-    fprintf(stderr, "Exception in codeGenerationFromString event callback:\n");
-    PrintCaughtException(isolate, env->context(), try_catch);
-  }
 
   // returning {true, val} where val.IsEmpty() makes v8
   // use the orignal value passed to `eval` which does not impact

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -468,8 +468,11 @@ static void CodeGenerationFromStringsAllowed(
                       const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Local<Context> context = env->context();
-  bool value = context->IsCodeGenerationFromStringsAllowed();
-  args.GetReturnValue().Set(value);
+  Local<Value> allow_code_gen = context->GetEmbedderData(
+      ContextEmbedderIndex::kAllowCodeGenerationFromStrings);
+  bool codegen_allowed =
+      allow_code_gen->IsUndefined() || allow_code_gen->IsTrue();
+  args.GetReturnValue().Set(codegen_allowed);
 }
 
 static v8::ModifyCodeGenerationFromStringsResult CodeGenCallback(

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -475,7 +475,7 @@ static void CodeGenerationFromStringsAllowed(
   args.GetReturnValue().Set(codegen_allowed);
 }
 
-static v8::ModifyCodeGenerationFromStringsResult CodeGenCallback(
+static v8::Maybe<v8::ModifyCodeGenerationFromStringsResult> CodeGenCallback(
     Local<Context> context,
     Local<Value> source,
     bool is_code_like) {
@@ -485,7 +485,7 @@ static v8::ModifyCodeGenerationFromStringsResult CodeGenCallback(
   // returning {true, val} where val.IsEmpty() makes v8
   // use the orignal value passed to `eval` which does not impact
   // calls as `eval({})`
-  return {true, v8::MaybeLocal<v8::String>()};
+  return v8::Just({true, v8::MaybeLocal<v8::String>()});
 }
 
 static void SetEmitCodeGenFromStringEvent(

--- a/test/parallel/test-process-codegen-from-string.js
+++ b/test/parallel/test-process-codegen-from-string.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const item = { foo: 0 };
+eval('++item.foo');
+
+assert.strictEqual(item.foo, 1);
+
+process.on('codeGenerationFromString', common.mustCall(handleError((code) => {
+  assert.strictEqual(code, 'item.foo++');
+})));
+
+eval('item.foo++');
+assert.strictEqual(item.foo, 2);
+
+process.removeAllListeners('codeGenerationFromString');
+
+process.on('codeGenerationFromString', common.mustCall(handleError((code) => {
+  assert.strictEqual(code, '(function anonymous(a,b\n) {\nreturn a + b\n})');
+})));
+
+const fct = new Function('a', 'b', 'return a + b');
+assert.strictEqual(fct(1, 2), 3);
+
+function handleError(fn) {
+  return (...args) => {
+    try {
+      fn(...args);
+    } catch (err) {
+      // The C++ code will just log the error to stderr and continue with the
+      // flow of the program. Set the exit code manually to ensure the test
+      // script fails in case of an error.
+      process.exitCode = 1;
+      throw err;
+    }
+  };
+}

--- a/test/parallel/test-process-codegen-from-string.js
+++ b/test/parallel/test-process-codegen-from-string.js
@@ -8,32 +8,22 @@ eval('++item.foo');
 
 assert.strictEqual(item.foo, 1);
 
-process.on('codeGenerationFromString', common.mustCall(handleError((code) => {
+// Basic eval() test
+process.on('codeGenerationFromString', common.mustCall((code) => {
   assert.strictEqual(code, 'item.foo++');
-})));
+}));
 
 eval('item.foo++');
 assert.strictEqual(item.foo, 2);
 
 process.removeAllListeners('codeGenerationFromString');
 
-process.on('codeGenerationFromString', common.mustCall(handleError((code) => {
+// Basic Function() test
+process.on('codeGenerationFromString', common.mustCall((code) => {
   assert.strictEqual(code, '(function anonymous(a,b\n) {\nreturn a + b\n})');
-})));
+}));
 
 const fct = new Function('a', 'b', 'return a + b');
 assert.strictEqual(fct(1, 2), 3);
 
-function handleError(fn) {
-  return (...args) => {
-    try {
-      fn(...args);
-    } catch (err) {
-      // The C++ code will just log the error to stderr and continue with the
-      // flow of the program. Set the exit code manually to ensure the test
-      // script fails in case of an error.
-      process.exitCode = 1;
-      throw err;
-    }
-  };
-}
+process.removeAllListeners('codeGenerationFromString');


### PR DESCRIPTION
In this PR I'm picking up the work from the now closed #35157. I've updated the code from #35157 to now work with the newest version of `main`.

The 'codeGenerationFromString' event is emitted on `process` when a call is made to `eval` or `Function`.

The goal is to provide a way to listen to unsafe code generation from strings as it is not possible to monkeypatch `eval`.

The event will only be emitted if there is at least one listener on it and removing all listeners on this event will result in the handler in V8 to never be called. In other words, if there is no listener on this event, there should be no performance impact on calling `eval` or the `Function` constructor.

While working on the to-do's below, I'll add WIP commits to the PR which modifies the V8 code directly. These commits are ment only as a place to discuss the V8 changes that needs to land upstream, and before marking this PR as ready for review, these commits obviously needs to be removed.

## Todo

- [ ] Figure out which code changes are needed in V8 to ensure that the callback provided to `SetModifyCodeGenerationFromStringsCallback` can safely call JavaScript code. Today, this is problematic, as an exception thrown inside of the JavaScript code might be swallowed. This is because the calling V8 C++ function doesn't expect the callback to call into JavaScript.
- [ ] Land the above mentioned V8 patch upstream in the V8 project.
- [ ] Hopefully be able to backport this patch to the version of V8 that Node.js is currently using (and back to older versions of V8 used by older versions of Node.js if we want this new `codeGenerationFromString` event to be backported to older versions of Node.js.

## Tests

Below are a few example scripts that can be used to verify if uncaught exceptions from within the event callback are swallowed or not.

❌ This script should generate an uncaught exception, but doesn't:

```js
process.on('codeGenerationFromString', (code) => {
  console.log('Hello from callback!')
  throw new Error('boom!!!') // error is silenced
})

eval('1+1')
```

✅ This script should generate an uncaught exception, and it does:

```js
process.on('codeGenerationFromString', (code) => {
  console.log('Hello from callback!')
  throw new Error('boom!!!') // error is not silenced
})

console.log('result of eval:', eval('1+1'))
```

✅ This script should generate an uncaught exception, and it does:

```js
process.on('codeGenerationFromString', (code) => {
  console.log('Hello from callback!')
  throw new Error('boom!!!') // error is not silenced
})

eval('1+1')
queueMicrotask(() => {})
```

❌ This script should generate an uncaught exception, but doesn't:

```js
process.on('codeGenerationFromString', (code) => {
  console.log('Hello from callback!')
  throw new Error('boom!!!') // error is silenced
})

eval('1+1')

process.removeAllListeners('codeGenerationFromString')
queueMicrotask(() => {})
```