### PR TITLE
lib: do not disable linter for entire files

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* eslint-disable no-use-before-define */
-
 const {
   ArrayFrom,
   ArrayIsArray,
@@ -363,6 +361,7 @@ function onSessionHeaders(handle, id, cat, flags, headers, sensitiveHeaders) {
     }
     // session[kType] can be only one of two possible values
     if (type === NGHTTP2_SESSION_SERVER) {
+      // eslint-disable-next-line no-use-before-define
       stream = new ServerHttp2Stream(session, handle, id, {}, obj);
       if (endOfStream) {
         stream.push(null);
@@ -374,6 +373,7 @@ function onSessionHeaders(handle, id, cat, flags, headers, sensitiveHeaders) {
         stream[kState].flags |= STREAM_FLAGS_HEAD_REQUEST;
       }
     } else {
+      // eslint-disable-next-line no-use-before-define
       stream = new ClientHttp2Stream(session, handle, id, {});
       if (endOfStream) {
         stream.push(null);
@@ -1788,6 +1788,7 @@ class ClientHttp2Session extends Http2Session {
 
     const headersList = mapToHeaders(headers);
 
+    // eslint-disable-next-line no-use-before-define
     const stream = new ClientHttp2Stream(this, undefined, undefined, {});
     stream[kSentHeaders] = headers;
     stream[kOrigin] = `${headers[HTTP2_HEADER_SCHEME]}://` +
@@ -3412,5 +3413,3 @@ module.exports = {
   Http2ServerRequest,
   Http2ServerResponse,
 };
-
-/* eslint-enable no-use-before-define */

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* eslint-disable no-use-before-define */
-
 const {
   ArrayBuffer,
   ArrayBufferPrototypeGetByteLength,
@@ -343,10 +341,12 @@ class ReadableStream {
     const mode = options?.mode;
 
     if (mode === undefined)
+      // eslint-disable-next-line no-use-before-define
       return new ReadableStreamDefaultReader(this);
 
     if (`${mode}` !== 'byob')
       throw new ERR_INVALID_ARG_VALUE('options.mode', mode);
+    // eslint-disable-next-line no-use-before-define
     return new ReadableStreamBYOBReader(this);
   }
 
@@ -466,6 +466,7 @@ class ReadableStream {
       preventCancel = false,
     } = options;
 
+    // eslint-disable-next-line no-use-before-define
     const reader = new ReadableStreamDefaultReader(this);
     let done = false;
     let started = false;
@@ -576,6 +577,7 @@ class ReadableStream {
       locked: this.locked,
       state: this[kState].state,
       supportsBYOB:
+        // eslint-disable-next-line no-use-before-define
         this[kState].controller instanceof ReadableByteStreamController,
     });
   }
@@ -3259,5 +3261,3 @@ module.exports = {
   setupReadableByteStreamController,
   setupReadableByteStreamControllerFromSource,
 };
-
-/* eslint-enable no-use-before-define */

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* eslint-disable no-use-before-define */
-
 const {
   ArrayPrototypePush,
   ArrayPrototypeShift,
@@ -262,6 +260,7 @@ class WritableStream {
   getWriter() {
     if (!isWritableStream(this))
       throw new ERR_INVALID_THIS('WritableStream');
+    // eslint-disable-next-line no-use-before-define
     return new WritableStreamDefaultWriter(this);
   }
 
@@ -1360,5 +1359,3 @@ module.exports = {
   setupWritableStreamDefaultControllerFromSink,
   setupWritableStreamDefaultController,
 };
-
-/* eslint-enable no-use-before-define */


### PR DESCRIPTION
Disabling linter for single lines is less error prone, disabling on the entire file can swallow errors that are easier to miss during code reviews, when one would assume the rule is enabled.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
