### PR TITLE
Revert "tools: open issue when update workflow fails"

### DIFF
--- a/.github/FAILED_DEP_UPDATE_ISSUE_TEMPLATE.md
+++ b/.github/FAILED_DEP_UPDATE_ISSUE_TEMPLATE.md
@@ -1,7 +1,0 @@
----
-title: 'deps: update {{ env.FAILED_DEP }} job failed'
-labels: dependencies
----
-This is an automatically generated issue by the {{ tools.context.action }} GitHub Action.
-The update [workflow]({{ env.JOB_URL }}) has failed for {{ tools.context.workflow }}.
-@nodejs/security-wg @nodejs/actions

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -307,14 +307,3 @@ jobs:
           labels: ${{ matrix.label }}
           title: '${{ matrix.subsystem }}: update ${{ matrix.id }} to ${{ env.NEW_VERSION }}'
           update-pull-request-title-and-body: true
-      - name: Open issue on fail
-        id: create-issue
-        if: github.event_name == 'schedule' && ${{ failure() }}
-        uses: JasonEtco/create-an-issue@e27dddc79c92bc6e4562f268fffa5ed752639abd  # 2.9.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
-          FAILED_DEP: ${{ matrix.id }}
-          JOB_URL: ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}
-        with:
-          filename: .github/FAILED_DEP_UPDATE_ISSUE_TEMPLATE.md
-          update_existing: true


### PR DESCRIPTION
This reverts commit c488558c15eb088a4b81a16fc34e5416c1d6e8d5.
the action creates an issue that dep update failed: https://github.com/nodejs/node/issues/48309 but actually worked https://github.com/nodejs/node/pull/48308, while other jobs failed

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
