### PR TITLE
test: add missing <algorithm> include for std::find

### DIFF
--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -3,6 +3,7 @@
 #endif
 #include "node.h"
 #include "uv.h"
+#include <algorithm>
 #include <assert.h>
 
 // Note: This file is being referred to from doc/api/embedding.md, and excerpts


### PR DESCRIPTION
GCC 14 drops some transitive includes within libstdc++. Explicitly include <algorithm> for std::find.

Signed-off-by: Sam James <sam@gentoo.org>