### PR TITLE
test: fix test-child-process-pipe-dataflow

### DIFF
--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -13,7 +13,7 @@ const MB = KB * KB;
 
 
 // Make sure process chaining allows desired data flow:
-// check cat <file> | grep 'x' | wc -c === 1MB
+// check cat <file> | grep 'x' | wc -m === 1MB
 // This helps to make sure no data is lost between pipes.
 
 {
@@ -32,7 +32,7 @@ const MB = KB * KB;
 
   cat = spawn('cat', [file]);
   grep = spawn('grep', ['x'], { stdio: [cat.stdout, 'pipe', 'pipe'] });
-  wc = spawn('wc', ['-c'], { stdio: [grep.stdout, 'pipe', 'pipe'] });
+  wc = spawn('wc', ['-m'], { stdio: [grep.stdout, 'pipe', 'pipe'] });
 
   // Extra checks: We never try to start reading data ourselves.
   cat.stdout._handle.readStart = common.mustNotCall();


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/48300

seems like something changed in the Windows machines causing wc to behave differently
changed from `wc -c` (count bytes) to `wc -m` (count characters). 