### PR TITLE
test: define NAPI_VERSION before including node_api.h

### DIFF
--- a/test/cctest/test_linked_binding.cc
+++ b/test/cctest/test_linked_binding.cc
@@ -1,3 +1,7 @@
+// Include node.h first to define NAPI_VERSION built with the
+// binary.
+// The node.h should also be included first in embedder's use case.
+#include "node.h"
 #include "node_api.h"
 #include "node_test_fixture.h"
 


### PR DESCRIPTION
Include node.h first to define NAPI_VERSION that node binary is built
with. The node.h should also be included first in embedder's use case
since it is the primary header file.

Fixes https://github.com/nodejs/node/issues/48310