### PR TITLE
tools:  automate openssl update on v16

### DIFF
--- a/.github/workflows/update-openssl.yml
+++ b/.github/workflows/update-openssl.yml
@@ -10,35 +10,23 @@ permissions:
   contents: read
 
 jobs:
-  openssl-update:
+  openssl-v3-update:
     if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
         with:
           persist-credentials: false
-      - name: Check if update branch already exists
-        run: |
-          BRANCH_EXISTS=$(git ls-remote --heads origin actions/tools-update-openssl)
-          echo "BRANCH_EXISTS=$BRANCH_EXISTS" >> $GITHUB_ENV
       - name: Check and download new OpenSSL version
-        # Only run rest of the workflow if the update branch does not yet exist
-        if: ${{ env.BRANCH_EXISTS == '' }}
         run: |
-          NEW_VERSION=$(gh api repos/quictls/openssl/releases -q '.[].tag_name|select(contains("openssl-3"))|ltrimstr("openssl-")' | head -n1)
-          NEW_VERSION_NO_RELEASE_1=$(case $NEW_VERSION in *quic1) echo ${NEW_VERSION%1};; *) echo $NEW_VERSION;; esac)
-          VERSION_H="./deps/openssl/config/archs/linux-x86_64/asm/include/openssl/opensslv.h"
-          CURRENT_VERSION=$(grep "OPENSSL_FULL_VERSION_STR" $VERSION_H | sed -n "s/^.*VERSION_STR \"\(.*\)\"/\1/p" | sed 's/+/-/g')
-          echo "comparing current version: $CURRENT_VERSION with $NEW_VERSION_NO_RELEASE_1"
-          if [ "$NEW_VERSION_NO_RELEASE_1" != "$CURRENT_VERSION" ]; then
-            echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-            echo "HAS_UPDATE=true" >> $GITHUB_ENV
-            ./tools/dep_updaters/update-openssl.sh download "$NEW_VERSION"
-          fi
+          ./tools/dep_updaters/update-openssl.sh download_v3 > temp-output
+          cat temp-output
+          tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
+          rm temp-output
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
       - name: Create PR with first commit
-        if: env.HAS_UPDATE
+        if: env.NEW_VERSION
         uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
         # Creates a PR with the new OpenSSL source code committed
         env:
@@ -53,7 +41,7 @@ jobs:
           path: deps/openssl
           update-pull-request-title-and-body: true
       - name: Regenerate platform specific files
-        if: env.HAS_UPDATE
+        if: env.NEW_VERSION
         run: |
           sudo apt install -y nasm libtext-template-perl
           ./tools/dep_updaters/update-openssl.sh regenerate
@@ -61,12 +49,61 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
       - name: Add second commit
         # Adds a second commit to the PR with the generated platform-dependent files
-        if: env.HAS_UPDATE
+        if: env.NEW_VERSION
         uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
         with:
           author: Node.js GitHub Bot <github-bot@iojs.org>
           branch: actions/tools-update-openssl  # Custom branch *just* for this Action.
+          commit-message: 'deps: update archs files for openssl-${{ env.NEW_VERSION }}'
+          path: deps/openssl
+  openssl-v1-update:
+    if: github.repository == 'nodejs/node'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
+        with:
+          persist-credentials: false
+          ref: v16.x-staging
+      - name: Check and download new OpenSSL version
+        run: |
+          ./tools/dep_updaters/update-openssl.sh download_v1 > temp-output
+          cat temp-output
+          tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
+          rm temp-output
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+      - name: Create PR with first commit
+        if: env.NEW_VERSION
+        uses: gr2m/create-or-update-pull-request-action@df20b2c073090271599a08c55ae26e0c3522b329  # v1.9.2
+        # Creates a PR with the new OpenSSL source code committed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+        with:
+          author: Node.js GitHub Bot <github-bot@iojs.org>
+          body: This is an automated update of OpenSSL to ${{ env.NEW_VERSION }}.
+          branch: actions/tools-update-openssl-v1  # Custom branch *just* for this Action.
+          commit-message: 'deps: upgrade openssl sources to quictls/openssl-${{ env.NEW_VERSION }}'
+          labels: dependencies
+          title: '[v16.x] deps: update OpenSSL to ${{ env.NEW_VERSION }}'
+          path: deps/openssl
+          update-pull-request-title-and-body: true
+      - name: Regenerate platform specific files
+        if: env.NEW_VERSION
+        run: |
+          sudo apt install -y nasm libtext-template-perl
+          ./tools/dep_updaters/update-openssl.sh regenerate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+      - name: Add second commit
+        # Adds a second commit to the PR with the generated platform-dependent files
+        if: env.NEW_VERSION
+        uses: gr2m/create-or-update-pull-request-action@df20b2c073090271599a08c55ae26e0c3522b329  # v1.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+        with:
+          author: Node.js GitHub Bot <github-bot@iojs.org>
+          branch: actions/tools-update-openssl-v1  # Custom branch *just* for this Action.
           commit-message: 'deps: update archs files for openssl-${{ env.NEW_VERSION }}'
           path: deps/openssl

--- a/tools/dep_updaters/update-openssl.sh
+++ b/tools/dep_updaters/update-openssl.sh
@@ -65,12 +65,12 @@ EOF
 
 download_v3() {
   LATEST_V3_TAG_NAME="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/quictls/openssl/releases');
+const res = await fetch('https://api.github.com/repos/quictls/openssl/tags');
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const releases = await res.json()
-const latest = releases.find(({ tag_name }) => tag_name.includes('openssl-3.0'));
+const latest = releases.find(({ name }) => name.includes('openssl-3.0') && name.includes('quic'));
 if(!latest) throw new Error(`Could not find latest release for v3.0`);
-console.log(latest.tag_name);
+console.log(latest.name);
 EOF
 )"
   NEW_VERSION_V3=$(echo "$LATEST_V3_TAG_NAME" | sed 's/openssl-//;s/-/+/g')

--- a/tools/dep_updaters/update-openssl.sh
+++ b/tools/dep_updaters/update-openssl.sh
@@ -11,12 +11,12 @@ cleanup() {
 
 download_v1() {
   LATEST_V1_TAG_NAME="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/quictls/openssl/releases');
+const res = await fetch('https://api.github.com/repos/quictls/openssl/git/matching-refs/tags/OpenSSL_1');
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const releases = await res.json()
-const latest = releases.find(({ tag_name }) => tag_name.includes('OpenSSL_1'));
+const latest = releases.findLast(({ ref }) => ref.includes('quic'));
 if(!latest) throw new Error(`Could not find latest release for v1`);
-console.log(latest.tag_name);
+console.log(latest.ref.replace('refs/tags/',''));
 EOF
 )"
 
@@ -65,12 +65,12 @@ EOF
 
 download_v3() {
   LATEST_V3_TAG_NAME="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/quictls/openssl/tags');
+const res = await fetch('https://api.github.com/repos/quictls/openssl/git/matching-refs/tags/openssl-3.0');
 if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
 const releases = await res.json()
-const latest = releases.find(({ name }) => name.includes('openssl-3.0') && name.includes('quic'));
+const latest = releases.findLast(({ ref }) => ref.includes('quic'));
 if(!latest) throw new Error(`Could not find latest release for v3.0`);
-console.log(latest.name);
+console.log(latest.ref.replace('refs/tags/',''));
 EOF
 )"
   NEW_VERSION_V3=$(echo "$LATEST_V3_TAG_NAME" | sed 's/openssl-//;s/-/+/g')

--- a/tools/dep_updaters/update-openssl.sh
+++ b/tools/dep_updaters/update-openssl.sh
@@ -9,45 +9,115 @@ cleanup() {
   exit $EXIT_CODE
 }
 
-download() {
-  if [ -z "$1" ]; then
-    echo "Error: please provide an OpenSSL version to update to"
-    echo "	e.g. ./$0 download 3.0.7+quic1"
-    exit 1
-  fi
+download_v1() {
+  LATEST_V1_TAG_NAME="$("$NODE" --input-type=module <<'EOF'
+const res = await fetch('https://api.github.com/repos/quictls/openssl/releases');
+if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
+const releases = await res.json()
+const latest = releases.find(({ tag_name }) => tag_name.includes('OpenSSL_1'));
+if(!latest) throw new Error(`Could not find latest release for v1`);
+console.log(latest.tag_name);
+EOF
+)"
 
-  OPENSSL_VERSION=$1
+  NEW_VERSION_V1=$(echo "$LATEST_V1_TAG_NAME" | sed 's/OpenSSL_//;s/_/./g;s/-/+/g')
+
+  case "$NEW_VERSION_V1" in
+    *quic1) NEW_VERSION_V1_NO_RELEASE="${NEW_VERSION_V1%1}" ;;
+    *) NEW_VERSION_V1_NO_RELEASE="$NEW_VERSION_V1" ;;
+  esac
+
+  VERSION_H="$DEPS_DIR/openssl/openssl/include/openssl/opensslv.h"
+  CURRENT_VERSION=$(grep "OPENSSL_VERSION_TEXT" "$VERSION_H" | sed -n "s/.*OpenSSL \([^\"]*\).*/\1/p" | cut -d ' ' -f 1)
+
+  # This function exit with 0 if new version and current version are the same
+  compare_dependency_version "openssl" "$NEW_VERSION_V1_NO_RELEASE" "$CURRENT_VERSION"
+
   echo "Making temporary workspace..."
   WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
-
-  # shellcheck disable=SC1091
-  . "$BASE_DIR/tools/dep_updaters/utils.sh"
-
   cd "$WORKSPACE"
 
   echo "Fetching OpenSSL source archive..."
-  OPENSSL_TARBALL="openssl-v$OPENSSL_VERSION.tar.gz"
-  curl -sL -o "$OPENSSL_TARBALL" "https://api.github.com/repos/quictls/openssl/tarball/openssl-$OPENSSL_VERSION"
+  OPENSSL_TARBALL="openssl.tar.gz"
+  curl -sL -o "$OPENSSL_TARBALL" "https://api.github.com/repos/quictls/openssl/tarball/$LATEST_V1_TAG_NAME"
   log_and_verify_sha256sum "openssl" "$OPENSSL_TARBALL"
   gzip -dc "$OPENSSL_TARBALL" | tar xf -
   rm "$OPENSSL_TARBALL"
+
   mv quictls-openssl-* openssl
 
   echo "Replacing existing OpenSSL..."
   rm -rf "$DEPS_DIR/openssl/openssl"
   mv "$WORKSPACE/openssl" "$DEPS_DIR/openssl/"
-
-  # Update the version number
-  update_dependency_version "openssl" "$OPENSSL_VERSION"
-
+  
   echo "All done!"
   echo ""
   echo "Please git add openssl, and commit the new version:"
   echo ""
   echo "$ git add -A deps/openssl/openssl"
   echo "$ git add doc/contributing/maintaining/maintaining-dependencies.md"
-  echo "$ git commit -m \"deps: upgrade openssl sources to quictls/openssl-$OPENSSL_VERSION\""
+  echo "$ git commit -m \"deps: upgrade openssl sources to quictls/openssl-$NEW_VERSION_V1\""
   echo ""
+  # The last line of the script should always print the new version,
+  # as we need to add it to $GITHUB_ENV variable.
+  echo "NEW_VERSION=$NEW_VERSION_V1"
+}
+
+download_v3() {
+  LATEST_V3_TAG_NAME="$("$NODE" --input-type=module <<'EOF'
+const res = await fetch('https://api.github.com/repos/quictls/openssl/releases');
+if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
+const releases = await res.json()
+const latest = releases.find(({ tag_name }) => tag_name.includes('openssl-3.0'));
+if(!latest) throw new Error(`Could not find latest release for v3.0`);
+console.log(latest.tag_name);
+EOF
+)"
+  NEW_VERSION_V3=$(echo "$LATEST_V3_TAG_NAME" | sed 's/openssl-//;s/-/+/g')
+
+  case "$NEW_VERSION_V3" in
+    *quic1) NEW_VERSION_V3_NO_RELEASE="${NEW_VERSION_V3%1}" ;;
+    *) NEW_VERSION_V3_NO_RELEASE="$NEW_VERSION_V3" ;;
+  esac
+  VERSION_H="./deps/openssl/config/archs/linux-x86_64/asm/include/openssl/opensslv.h"
+  CURRENT_VERSION=$(grep "OPENSSL_FULL_VERSION_STR" $VERSION_H | sed -n "s/^.*VERSION_STR \"\(.*\)\"/\1/p")
+  # This function exit with 0 if new version and current version are the same
+  compare_dependency_version "openssl" "$NEW_VERSION_V3_NO_RELEASE" "$CURRENT_VERSION"
+
+  echo "Making temporary workspace..."
+
+  WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
+
+  cd "$WORKSPACE"
+  echo "Fetching OpenSSL source archive..."
+
+  OPENSSL_TARBALL="openssl.tar.gz"
+
+  curl -sL -o "$OPENSSL_TARBALL" "https://api.github.com/repos/quictls/openssl/tarball/$LATEST_V3_TAG_NAME"
+
+  log_and_verify_sha256sum "openssl" "$OPENSSL_TARBALL"
+
+  gzip -dc "$OPENSSL_TARBALL" | tar xf -
+
+  rm "$OPENSSL_TARBALL"
+  mv quictls-openssl-* openssl
+  echo "Replacing existing OpenSSL..."
+  rm -rf "$DEPS_DIR/openssl/openssl"
+  mv "$WORKSPACE/openssl" "$DEPS_DIR/openssl/"
+
+  # Update the version number
+  update_dependency_version "openssl" "$NEW_VERSION_V3"
+  echo "All done!"
+  echo ""
+  echo "Please git add openssl, and commit the new version:"
+  echo ""
+  echo "$ git add -A deps/openssl/openssl"
+  echo "$ git add doc/contributing/maintaining/maintaining-dependencies.md"
+  echo "$ git commit -m \"deps: upgrade openssl sources to quictls/openssl-$NEW_VERSION_V3\""
+  echo ""
+  # The last line of the script should always print the new version,
+  # as we need to add it to $GITHUB_ENV variable.
+  echo "NEW_VERSION=$NEW_VERSION_V3"
 }
 
 regenerate() {
@@ -94,8 +164,14 @@ main() {
   BASE_DIR=$(cd "$(dirname "$0")/../.." && pwd)
   DEPS_DIR="$BASE_DIR/deps"
 
+  [ -z "$NODE" ] && NODE="$BASE_DIR/out/Release/node"
+  [ -x "$NODE" ] || NODE=$(command -v node)
+
+    # shellcheck disable=SC1091
+  . "$BASE_DIR/tools/dep_updaters/utils.sh"
+
   case ${1} in
-    help | download | regenerate )
+    help | regenerate | download_v1 | download_v3 )
       $1 "${2}"
     ;;
     * )


### PR DESCRIPTION
This PR allows updating openssl 1 on v16, for this to work the scripts (also utils.sh) need to be backported to v16
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
