### PR TITLE
test: add missing <algorithm> include for std::find

### DIFF
--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -5,6 +5,8 @@
 #include "uv.h"
 #include <assert.h>
 
+#include <algorithm>
+
 // Note: This file is being referred to from doc/api/embedding.md, and excerpts
 // from it are included in the documentation. Try to keep these in sync.
 // Snapshot support is not part of the embedder API docs yet due to its


### PR DESCRIPTION
GCC 14 drops some transitive includes within libstdc++. Explicitly include <algorithm> for std::find.

Signed-off-by: Sam James <sam@gentoo.org>