### PR TITLE
https: fix connection checking interval not clearing on server close

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -507,6 +507,11 @@ function setupConnectionsTracking(server) {
     setInterval(checkConnections.bind(server), server.connectionsCheckingInterval).unref();
 }
 
+function httpServerPreClose(server) {
+  server.closeIdleConnections();
+  clearInterval(server[kConnectionsCheckingInterval]);
+}
+
 function Server(options, requestListener) {
   if (!(this instanceof Server)) return new Server(options, requestListener);
 
@@ -548,8 +553,7 @@ ObjectSetPrototypeOf(Server.prototype, net.Server.prototype);
 ObjectSetPrototypeOf(Server, net.Server);
 
 Server.prototype.close = function() {
-  this.closeIdleConnections();
-  clearInterval(this[kConnectionsCheckingInterval]);
+  httpServerPreClose(this);
   ReflectApply(net.Server.prototype.close, this, arguments);
 };
 
@@ -1193,4 +1197,5 @@ module.exports = {
   storeHTTPOptions,
   _connectionListener: connectionListener,
   kServerResponse,
+  httpServerPreClose,
 };

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -1198,4 +1198,5 @@ module.exports = {
   _connectionListener: connectionListener,
   kServerResponse,
   httpServerPreClose,
+  kConnectionsCheckingInterval,
 };

--- a/lib/https.js
+++ b/lib/https.js
@@ -31,6 +31,7 @@ const {
   JSONStringify,
   ObjectAssign,
   ObjectSetPrototypeOf,
+  ReflectApply,
   ReflectConstruct,
 } = primordials;
 
@@ -43,6 +44,7 @@ assertCrypto();
 const tls = require('tls');
 const { Agent: HttpAgent } = require('_http_agent');
 const {
+  httpServerPreClose,
   Server: HttpServer,
   setupConnectionsTracking,
   storeHTTPOptions,
@@ -102,6 +104,11 @@ Server.prototype.closeAllConnections = HttpServer.prototype.closeAllConnections;
 Server.prototype.closeIdleConnections = HttpServer.prototype.closeIdleConnections;
 
 Server.prototype.setTimeout = HttpServer.prototype.setTimeout;
+
+Server.prototype.close = function() {
+  httpServerPreClose(this);
+  ReflectApply(tls.Server.prototype.close, this, arguments);
+};
 
 /**
  * Creates a new `https.Server` instance.

--- a/test/parallel/test-http-server-close-destroy-timeout.js
+++ b/test/parallel/test-http-server-close-destroy-timeout.js
@@ -1,0 +1,13 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { createServer } = require('http');
+const { kConnectionsCheckingInterval } = require('_http_server');
+
+const server = createServer(function(req, res) {});
+server.listen(0, common.mustCall(function() {
+  assert.strictEqual(server[kConnectionsCheckingInterval]._destroyed, false);
+  server.close(common.mustCall(() => {
+    assert(server[kConnectionsCheckingInterval]._destroyed);
+  }));
+}));

--- a/test/parallel/test-http-server-close-idle.js
+++ b/test/parallel/test-http-server-close-idle.js
@@ -42,7 +42,6 @@ server.listen(0, function() {
         assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));
         assert.strictEqual(connections, 2);
 
-        server.closeIdleConnections();
         server.close(common.mustCall());
 
         // Check that only the idle connection got closed

--- a/test/parallel/test-https-server-close-destroy-timeout.js
+++ b/test/parallel/test-https-server-close-destroy-timeout.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+const { createServer } = require('https');
+const { kConnectionsCheckingInterval } = require('_http_server');
+
+const fixtures = require('../common/fixtures');
+
+const options = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+};
+
+const server = createServer(options, function(req, res) {});
+server.listen(0, common.mustCall(function() {
+  assert.strictEqual(server[kConnectionsCheckingInterval]._destroyed, false);
+  server.close(common.mustCall(() => {
+    assert(server[kConnectionsCheckingInterval]._destroyed);
+  }));
+}));

--- a/test/parallel/test-https-server-close-idle.js
+++ b/test/parallel/test-https-server-close-idle.js
@@ -52,7 +52,6 @@ server.listen(0, function() {
         assert(response.startsWith('HTTP/1.1 200 OK\r\nConnection: keep-alive'));
         assert.strictEqual(connections, 2);
 
-        server.closeIdleConnections();
         server.close(common.mustCall());
 
         // Check that only the idle connection got closed


### PR DESCRIPTION
The connection checking interval should get cleared when `https.Server.close` is called similarly to how it gets cleared when `http.Server.close` is called. Note that this also adds a call to `closeIdleConnections()` to `https.server.close`.

Fixes https://github.com/nodejs/node/issues/48373