### PR TITLE
crypto: remove OPENSSL_FIPS guard for OpenSSL 3

### DIFF
--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -253,7 +253,6 @@ void TestFipsCrypto(const v8::FunctionCallbackInfo<v8::Value>& args) {
   Mutex::ScopedLock lock(per_process::cli_options_mutex);
   Mutex::ScopedLock fips_lock(fips_mutex);
 
-#ifdef OPENSSL_FIPS
 #if OPENSSL_VERSION_MAJOR >= 3
   OSSL_PROVIDER* fips_provider = nullptr;
   if (OSSL_PROVIDER_available(nullptr, "fips")) {
@@ -262,11 +261,12 @@ void TestFipsCrypto(const v8::FunctionCallbackInfo<v8::Value>& args) {
   const auto enabled = fips_provider == nullptr ? 0 :
       OSSL_PROVIDER_self_test(fips_provider) ? 1 : 0;
 #else
+#ifdef OPENSSL_FIPS
   const auto enabled = FIPS_selftest() ? 1 : 0;
-#endif
 #else  // OPENSSL_FIPS
   const auto enabled = 0;
 #endif  // OPENSSL_FIPS
+#endif
 
   args.GetReturnValue().Set(enabled);
 }


### PR DESCRIPTION
The OPENSSL_FIPS guard is only needed for versions of OpenSSL earlier than 3.0.

Removing the guard for OpenSSL 3 fixes `parallel/test-crypto-fips` when run with a FIPS enabled OpenSSL 3 configuration.

Refs: https://github.com/nodejs/node/issues/48379

cc @nodejs/crypto 

--- 

## Test failure on `main` (https://github.com/nodejs/node/commit/9dc2d1b964db5ff96e8dbffe0a8ac9d3e3ae6488)

- https://ci.nodejs.org/job/richardlau-node-test-commit-linux-containered/15/nodes=ubuntu2204_sharedlibs_openssl30fips_x64/testReport/junit/(root)/parallel/test_crypto_fips/
- https://ci.nodejs.org/job/richardlau-node-test-commit-linux-containered/15/nodes=ubuntu2204_sharedlibs_openssl30fips_x64/consoleFull
```console
13:27:29 not ok 640 parallel/test-crypto-fips
13:27:29   ---
13:27:29   duration_ms: 303.07300
13:27:29   severity: fail
13:27:29   exitcode: 1
13:27:29   stack: |-
13:27:29     Spawned child [pid:2304732] with cmd 'process.versions' expect "OpenSSL error when trying to enable FIPS:" with args '--enable-fips' OPENSSL_CONF="/opt/openssl-3.0.8-fips/ssl/openssl.cnf"
13:27:29     node:assert:125
13:27:29       throw new AssertionError(obj);
13:27:29       ^
13:27:29     
13:27:29     AssertionError [ERR_ASSERTION]: Expected "actual" to be strictly unequal to: 0
13:27:29         at responseHandler (/home/iojs/build/workspace/richardlau-node-test-commit-linux-containered/test/parallel/test-crypto-fips.js:48:12)
13:27:29         at testHelper (/home/iojs/build/workspace/richardlau-node-test-commit-linux-containered/test/parallel/test-crypto-fips.js:61:3)
13:27:29         at Object.<anonymous> (/home/iojs/build/workspace/richardlau-node-test-commit-linux-containered/test/parallel/test-crypto-fips.js:65:1)
13:27:29         at Module._compile (node:internal/modules/cjs/loader:1255:14)
13:27:29         at Module._extensions..js (node:internal/modules/cjs/loader:1309:10)
13:27:29         at Module.load (node:internal/modules/cjs/loader:1113:32)
13:27:29         at Module._load (node:internal/modules/cjs/loader:960:12)
13:27:29         at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
13:27:29         at node:internal/main/run_main_module:23:47 {
13:27:29       generatedMessage: true,
13:27:29       code: 'ERR_ASSERTION',
13:27:29       actual: 0,
13:27:29       expected: 0,
13:27:29       operator: 'notStrictEqual'
13:27:29     }
13:27:29     
13:27:29     Node.js v21.0.0-pre
13:27:29   ...
```

## Passing with this PR (https://github.com/nodejs/node/commit/84a33d6aa69f5b742373644caff290775f90d9f5)
- https://ci.nodejs.org/job/richardlau-node-test-commit-linux-containered/16/nodes=ubuntu2204_sharedlibs_openssl30fips_x64/testReport/(root)/parallel/test_crypto_fips/
- https://ci.nodejs.org/job/richardlau-node-test-commit-linux-containered/16/nodes=ubuntu2204_sharedlibs_openssl30fips_x64/consoleFull

```console
15:39:50 ok 638 parallel/test-crypto-fips
15:39:50   ---
15:39:50   duration_ms: 752.46200
15:39:50   ...
```