### PR TITLE
stream: fix ReadableStream BYOBReader read hang on close

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1908,6 +1908,11 @@ function readableStreamClose(stream) {
     for (let n = 0; n < reader[kState].readRequests.length; n++)
       reader[kState].readRequests[n][kClose]();
     reader[kState].readRequests = [];
+  } else {
+    assert(readableStreamHasBYOBReader(stream));
+    for (let n = 0; n < reader[kState].readIntoRequests.length; n++)
+      reader[kState].readIntoRequests[n][kClose]();
+    reader[kState].readIntoRequests = [];
   }
 }
 


### PR DESCRIPTION
Fix reader.read promise not fulfilling when the controller is closed when the reader is a BYOBReader

Basically copy/pasted the relevant parts from `readableStreamError` which works correctly.

fixes: https://github.com/nodejs/node/issues/48233
