### PR TITLE
tools: update create-or-update-pull-request-action

### DIFF
--- a/.github/workflows/update-openssl.yml
+++ b/.github/workflows/update-openssl.yml
@@ -39,7 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
       - name: Create PR with first commit
         if: env.HAS_UPDATE
-        uses: gr2m/create-or-update-pull-request-action@df20b2c073090271599a08c55ae26e0c3522b329  # v1.9.2
+        uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
         # Creates a PR with the new OpenSSL source code committed
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
       - name: Add second commit
         # Adds a second commit to the PR with the generated platform-dependent files
         if: env.HAS_UPDATE
-        uses: gr2m/create-or-update-pull-request-action@df20b2c073090271599a08c55ae26e0c3522b329  # v1.9.2
+        uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
         with:


### PR DESCRIPTION
Use the same commit SHA for this action as used in our other workflows.

Refs: https://github.com/nodejs/node/pull/46169
Refs: https://github.com/nodejs/node/pull/45022#issuecomment-1290397901

---

The workflow is currently failing: https://github.com/nodejs/node/actions/runs/5215729249/jobs/9413680952

```console
Run gr2m/create-or-update-pull-request-action@df20b2c073090271599a08c55ae26e0c3522b329
Error: File not found: '/home/runner/work/_actions/gr2m/create-or-update-pull-request-action/df20b2c073090271599a08c55ae26e0c3522b329/dist/index.js'
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
