### PR TITLE
Revert "net: enable autoSelectFamily by default"

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -464,7 +464,7 @@ added: v6.0.0
 Enable FIPS-compliant crypto at startup. (Requires Node.js to be built
 against FIPS-compatible OpenSSL.)
 
-### `--no-network-family-autoselection`
+### `--enable-network-family-autoselection`
 
 <!-- YAML
 added: v19.4.0
@@ -476,8 +476,8 @@ changes:
                  an alias.
 -->
 
-Disables the family autoselection algorithm unless connection options explicitly
-enables it.
+Enables the family autoselection algorithm unless connection options explicitly
+disables it.
 
 ### `--enable-source-maps`
 
@@ -2151,7 +2151,6 @@ Node.js options that are allowed are:
 * `--no-extra-info-on-fatal-exception`
 * `--no-force-async-hooks-checks`
 * `--no-global-search-paths`
-* `--no-network-family-autoselection`
 * `--no-warnings`
 * `--node-memory-debug`
 * `--openssl-config`

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2612,13 +2612,6 @@ An attempt was made to operate on an already closed socket.
 When calling [`net.Socket.write()`][] on a connecting socket and the socket was
 closed before the connection was established.
 
-<a id="ERR_SOCKET_CONNECTION_TIMEOUT"></a>
-
-### `ERR_SOCKET_CONNECTION_TIMEOUT`
-
-The socket was unable to connect to any address returned by the DNS within the
-allowed timeout when using the family autoselection algorithm.
-
 <a id="ERR_SOCKET_DGRAM_IS_CONNECTED"></a>
 
 ### `ERR_SOCKET_DGRAM_IS_CONNECTED`

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -870,6 +870,10 @@ behavior.
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: REPLACEME
+    pr-url: TBD
+    description: The default value for the autoSelectFamily option is now false,
+                 as the change was too unstable.
   - version: v20.0.0
     pr-url: https://github.com/nodejs/node/pull/46790
     description: The default value for the autoSelectFamily option is now true.
@@ -942,12 +946,12 @@ For TCP connections, available `options` are:
   option before timing out and trying the next address.
   Ignored if the `family` option is not `0` or if `localAddress` is set.
   Connection errors are not emitted if at least one connection succeeds.
-  If all connections attempts fails, a single `AggregateError` with all failed attempts is emitted.
-  **Default:** [`net.getDefaultAutoSelectFamily()`][]
+  **Default:** initially `false`, but it can be changed at runtime using [`net.setDefaultAutoSelectFamily(value)`][]
+  or via the command line option `--enable-network-family-autoselection`.
 * `autoSelectFamilyAttemptTimeout` {number}: The amount of time in milliseconds to wait
   for a connection attempt to finish before trying the next address when using the `autoSelectFamily` option.
   If set to a positive integer less than `10`, then the value `10` will be used instead.
-  **Default:** [`net.getDefaultAutoSelectFamilyAttemptTimeout()`][]
+  **Default:** initially `250`, but it can be changed at runtime using [`net.setDefaultAutoSelectFamilyAttemptTimeout(value)`][]
 
 For [IPC][] connections, available `options` are:
 
@@ -1643,8 +1647,6 @@ added: v19.4.0
 -->
 
 Gets the current default value of the `autoSelectFamily` option of [`socket.connect(options)`][].
-The initial default value is `true`, unless the command line option
-`--no-network-family-autoselection` is provided.
 
 * Returns: {boolean} The current default value of the `autoSelectFamily` option.
 
@@ -1665,7 +1667,6 @@ added: v19.8.0
 -->
 
 Gets the current default value of the `autoSelectFamilyAttemptTimeout` option of [`socket.connect(options)`][].
-The initial default value is `250`.
 
 * Returns: {number} The current default value of the `autoSelectFamilyAttemptTimeout` option.
 
@@ -1764,8 +1765,8 @@ net.isIPv6('fhqwhgads'); // returns false
 [`net.createConnection(path)`]: #netcreateconnectionpath-connectlistener
 [`net.createConnection(port, host)`]: #netcreateconnectionport-host-connectlistener
 [`net.createServer()`]: #netcreateserveroptions-connectionlistener
-[`net.getDefaultAutoSelectFamily()`]: #netgetdefaultautoselectfamily
-[`net.getDefaultAutoSelectFamilyAttemptTimeout()`]: #netgetdefaultautoselectfamilyattempttimeout
+[`net.setDefaultAutoSelectFamily(value)`]: #netsetdefaultautoselectfamilyvalue
+[`net.setDefaultAutoSelectFamilyAttemptTimeout(value)`]: #netsetdefaultautoselectfamilyattempttimeoutvalue
 [`new net.Socket(options)`]: #new-netsocketoptions
 [`readable.setEncoding()`]: stream.md#readablesetencodingencoding
 [`server.close()`]: #serverclosecallback

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1571,8 +1571,6 @@ E('ERR_SOCKET_CLOSED', 'Socket is closed', Error);
 E('ERR_SOCKET_CLOSED_BEFORE_CONNECTION',
   'Socket closed before the connection was established',
   Error);
-E('ERR_SOCKET_CONNECTION_TIMEOUT',
-  'Socket connection timeout', Error);
 E('ERR_SOCKET_DGRAM_IS_CONNECTED', 'Already connected', Error);
 E('ERR_SOCKET_DGRAM_NOT_CONNECTED', 'Not connected', Error);
 E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running', Error);

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -67,7 +67,7 @@ function makeSyncWrite(fd) {
 }
 
 module.exports = {
-  kReinitializeHandle: Symbol('kReinitializeHandle'),
+  kReinitializeHandle: Symbol('reinitializeHandle'),
   isIP,
   isIPv4,
   isIPv6,

--- a/lib/net.js
+++ b/lib/net.js
@@ -23,7 +23,6 @@
 
 const {
   ArrayIsArray,
-  ArrayPrototypeIncludes,
   ArrayPrototypeIndexOf,
   ArrayPrototypePush,
   Boolean,
@@ -98,7 +97,6 @@ const {
     ERR_INVALID_HANDLE_TYPE,
     ERR_SERVER_ALREADY_LISTEN,
     ERR_SERVER_NOT_RUNNING,
-    ERR_SOCKET_CONNECTION_TIMEOUT,
     ERR_SOCKET_CLOSED,
     ERR_SOCKET_CLOSED_BEFORE_CONNECTION,
     ERR_MISSING_ARGS,
@@ -129,7 +127,7 @@ let cluster;
 let dns;
 let BlockList;
 let SocketAddress;
-let autoSelectFamilyDefault = getOptionValue('--network-family-autoselection');
+let autoSelectFamilyDefault = getOptionValue('--enable-network-family-autoselection');
 let autoSelectFamilyAttemptTimeoutDefault = 250;
 
 const { clearTimeout, setTimeout } = require('timers');
@@ -1094,11 +1092,6 @@ function internalConnectMultiple(context, canceled) {
 
   // All connections have been tried without success, destroy with error
   if (canceled || context.current === context.addresses.length) {
-    if (context.errors.length === 0) {
-      self.destroy(new ERR_SOCKET_CONNECTION_TIMEOUT());
-      return;
-    }
-
     self.destroy(aggregateErrors(context.errors));
     return;
   }
@@ -1334,7 +1327,6 @@ function lookupAndConnect(self, options) {
         options,
         dnsopts,
         port,
-        localAddress,
         localPort,
         autoSelectFamilyAttemptTimeout,
       );
@@ -1377,9 +1369,7 @@ function lookupAndConnect(self, options) {
   });
 }
 
-function lookupAndConnectMultiple(
-  self, async_id_symbol, lookup, host, options, dnsopts, port, localAddress, localPort, timeout,
-) {
+function lookupAndConnectMultiple(self, async_id_symbol, lookup, host, options, dnsopts, port, localPort, timeout) {
   defaultTriggerAsyncIdScope(self[async_id_symbol], function emitLookup() {
     lookup(host, dnsopts, function emitLookup(err, addresses) {
       // It's possible we were destroyed while looking this up.
@@ -1400,7 +1390,6 @@ function lookupAndConnectMultiple(
       // Filter addresses by only keeping the one which are either IPv4 or IPV6.
       // The first valid address determines which group has preference on the
       // alternate family sorting which happens later.
-      const validAddresses = [[], []];
       const validIps = [[], []];
       let destinations;
       for (let i = 0, l = addresses.length; i < l; i++) {
@@ -1413,19 +1402,12 @@ function lookupAndConnectMultiple(
             destinations = addressType === 6 ? { 6: 0, 4: 1 } : { 4: 0, 6: 1 };
           }
 
-          const destination = destinations[addressType];
-
-          // Only try an address once
-          if (!ArrayPrototypeIncludes(validIps[destination], ip)) {
-            ArrayPrototypePush(validAddresses[destination], address);
-            ArrayPrototypePush(validIps[destination], ip);
-          }
+          ArrayPrototypePush(validIps[destinations[addressType]], address);
         }
       }
 
-
       // When no AAAA or A records are available, fail on the first one
-      if (!validAddresses[0].length && !validAddresses[1].length) {
+      if (!validIps[0].length && !validIps[1].length) {
         const { address: firstIp, family: firstAddressType } = addresses[0];
 
         if (!isIP(firstIp)) {
@@ -1443,36 +1425,16 @@ function lookupAndConnectMultiple(
 
       // Sort addresses alternating families
       const toAttempt = [];
-      for (let i = 0, l = MathMax(validAddresses[0].length, validAddresses[1].length); i < l; i++) {
-        if (i in validAddresses[0]) {
-          ArrayPrototypePush(toAttempt, validAddresses[0][i]);
+      for (let i = 0, l = MathMax(validIps[0].length, validIps[1].length); i < l; i++) {
+        if (i in validIps[0]) {
+          ArrayPrototypePush(toAttempt, validIps[0][i]);
         }
-        if (i in validAddresses[1]) {
-          ArrayPrototypePush(toAttempt, validAddresses[1][i]);
+        if (i in validIps[1]) {
+          ArrayPrototypePush(toAttempt, validIps[1][i]);
         }
-      }
-
-      if (toAttempt.length === 1) {
-        debug('connect/multiple: only one address found, switching back to single connection');
-        const { address: ip, family: addressType } = toAttempt[0];
-
-        self._unrefTimer();
-        defaultTriggerAsyncIdScope(
-          self[async_id_symbol],
-          internalConnect,
-          self,
-          ip,
-          port,
-          addressType,
-          localAddress,
-          localPort,
-        );
-
-        return;
       }
 
       self.autoSelectFamilyAttemptedAddresses = [];
-      debug('connect/multiple: will try the following addresses', toAttempt);
 
       const context = {
         socket: self,
@@ -1618,6 +1580,13 @@ function afterConnectMultiple(context, current, status, handle, req, readable, w
 
     // Try the next address
     internalConnectMultiple(context, status === UV_ECANCELED);
+    return;
+  }
+
+  // One of the connection has completed and correctly dispatched but after timeout, ignore this one
+  if (context[kTimeoutTriggered]) {
+    debug('connect/multiple: ignoring successful but timedout connection to %s:%s', req.address, req.port);
+    handle.close();
     return;
   }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -351,13 +351,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "returned)",
             &EnvironmentOptions::dns_result_order,
             kAllowedInEnvvar);
-  AddOption("--network-family-autoselection",
-            "Disable network address family autodetection algorithm",
-            &EnvironmentOptions::network_family_autoselection,
-            kAllowedInEnvvar,
-            true);
-  AddAlias("--enable-network-family-autoselection",
-           "--network-family-autoselection");
+  AddOption("--enable-network-family-autoselection",
+            "Enable network address family autodetection algorithm",
+            &EnvironmentOptions::enable_network_family_autoselection,
+            kAllowedInEnvvar);
   AddOption("--enable-source-maps",
             "Source Map V3 support for stack traces",
             &EnvironmentOptions::enable_source_maps,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -132,7 +132,7 @@ class EnvironmentOptions : public Options {
   bool frozen_intrinsics = false;
   int64_t heap_snapshot_near_heap_limit = 0;
   std::string heap_snapshot_signal;
-  bool network_family_autoselection = true;
+  bool enable_network_family_autoselection = false;
   uint64_t max_http_header_size = 16 * 1024;
   bool deprecation = true;
   bool force_async_hooks_checks = true;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -26,7 +26,6 @@ const process = global.process;  // Some tests tamper with the process global.
 const assert = require('assert');
 const { exec, execSync, spawn, spawnSync } = require('child_process');
 const fs = require('fs');
-const net = require('net');
 // Do not require 'os' until needed so that test-os-checked-function can
 // monkey patch it. If 'os' is required here, that test will fail.
 const path = require('path');
@@ -145,14 +144,6 @@ const isPi = (() => {
 })();
 
 const isDumbTerminal = process.env.TERM === 'dumb';
-
-// When using high concurrency or in the CI we need much more time for each connection attempt
-const defaultAutoSelectFamilyAttemptTimeout = platformTimeout(2500);
-// Since this is also used by tools outside of the test suite,
-// make sure setDefaultAutoSelectFamilyAttemptTimeout
-if (typeof net.setDefaultAutoSelectFamilyAttemptTimeout === 'function') {
-  net.setDefaultAutoSelectFamilyAttemptTimeout(platformTimeout(defaultAutoSelectFamilyAttemptTimeout));
-}
 
 const buildType = process.config.target_defaults ?
   process.config.target_defaults.default_configuration :
@@ -903,7 +894,6 @@ const common = {
   canCreateSymLink,
   childShouldThrowAndAbort,
   createZeroFilledFile,
-  defaultAutoSelectFamilyAttemptTimeout,
   expectsError,
   expectWarning,
   gcUntil,

--- a/test/internet/test-tls-autoselectfamily-servername.js
+++ b/test/internet/test-tls-autoselectfamily-servername.js
@@ -7,7 +7,11 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
 }
 
+const { setDefaultAutoSelectFamilyAttemptTimeout } = require('net');
 const { connect } = require('tls');
+
+// Some of the windows machines in the CI need more time to establish connection
+setDefaultAutoSelectFamilyAttemptTimeout(common.platformTimeout(common.isWindows ? 1500 : 250));
 
 // Test that TLS connecting works without autoSelectFamily
 {

--- a/test/parallel/test-http-autoselectfamily.js
+++ b/test/parallel/test-http-autoselectfamily.js
@@ -7,8 +7,12 @@ const assert = require('assert');
 const dgram = require('dgram');
 const { Resolver } = require('dns');
 const { request, createServer } = require('http');
+const { setDefaultAutoSelectFamilyAttemptTimeout } = require('net');
 
 // Test that happy eyeballs algorithm is properly implemented when using HTTP.
+
+// Some of the windows machines in the CI need more time to establish connection
+setDefaultAutoSelectFamilyAttemptTimeout(common.platformTimeout(common.isWindows ? 1500 : 250));
 
 function _lookup(resolver, hostname, options, cb) {
   resolver.resolve(hostname, 'ANY', (err, replies) => {

--- a/test/parallel/test-http2-ping-settings-heapdump.js
+++ b/test/parallel/test-http2-ping-settings-heapdump.js
@@ -11,6 +11,14 @@ const v8 = require('v8');
 // after it is destroyed, either because they are detached from it or have been
 // destroyed themselves.
 
+// We use an higher autoSelectFamilyAttemptTimeout in this test as the v8.getHeapSnapshot().resume()
+// will slow the connection flow and we don't want the second connection attempt to start.
+let autoSelectFamilyAttemptTimeout = common.platformTimeout(1000);
+if (common.isWindows) {
+  // Some of the windows machines in the CI need more time to establish connection
+  autoSelectFamilyAttemptTimeout = common.platformTimeout(10000);
+}
+
 for (const variant of ['ping', 'settings']) {
   const server = http2.createServer();
   server.on('session', common.mustCall((session) => {
@@ -30,7 +38,8 @@ for (const variant of ['ping', 'settings']) {
   }));
 
   server.listen(0, common.mustCall(() => {
-    const client = http2.connect(`http://localhost:${server.address().port}`, common.mustCall());
+    const client = http2.connect(`http://localhost:${server.address().port}`, { autoSelectFamilyAttemptTimeout },
+                                 common.mustCall());
     client.on('error', (err) => {
       // We destroy the session so it's possible to get ECONNRESET here.
       if (err.code !== 'ECONNRESET')

--- a/test/parallel/test-https-autoselectfamily.js
+++ b/test/parallel/test-https-autoselectfamily.js
@@ -13,6 +13,7 @@ const assert = require('assert');
 const dgram = require('dgram');
 const { Resolver } = require('dns');
 const { request, createServer } = require('https');
+const { setDefaultAutoSelectFamilyAttemptTimeout } = require('net');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -23,6 +24,9 @@ const options = {
 };
 
 // Test that happy eyeballs algorithm is properly implemented when using HTTP.
+
+// Some of the windows machines in the CI need more time to establish connection
+setDefaultAutoSelectFamilyAttemptTimeout(common.platformTimeout(common.isWindows ? 1500 : 250));
 
 function _lookup(resolver, hostname, options, cb) {
   resolver.resolve(hostname, 'ANY', (err, replies) => {

--- a/test/parallel/test-net-autoselectfamily-commandline-option.js
+++ b/test/parallel/test-net-autoselectfamily-commandline-option.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Flags: --no-network-family-autoselection
+// Flags: --enable-network-family-autoselection
 
 const common = require('../common');
 const { parseDNSPacket, writeDNSPacket } = require('../common/dns');
@@ -8,9 +8,12 @@ const { parseDNSPacket, writeDNSPacket } = require('../common/dns');
 const assert = require('assert');
 const dgram = require('dgram');
 const { Resolver } = require('dns');
-const { createConnection, createServer } = require('net');
+const { createConnection, createServer, setDefaultAutoSelectFamilyAttemptTimeout } = require('net');
 
 // Test that happy eyeballs algorithm can be enable from command line.
+
+// Some of the windows machines in the CI need more time to establish connection
+setDefaultAutoSelectFamilyAttemptTimeout(common.platformTimeout(common.isWindows ? 1500 : 250));
 
 function _lookup(resolver, hostname, options, cb) {
   resolver.resolve(hostname, 'ANY', (err, replies) => {
@@ -59,7 +62,7 @@ function createDnsServer(ipv6Addr, ipv4Addr, cb) {
   });
 }
 
-// Test that IPV4 is NOT reached if IPV6 is not reachable and the option has been disabled via command line
+// Test that IPV4 is reached if IPV6 is not reachable
 {
   createDnsServer('::1', '127.0.0.1', common.mustCall(function({ dnsServer, lookup }) {
     const ipv4Server = createServer((socket) => {
@@ -78,10 +81,10 @@ function createDnsServer(ipv6Addr, ipv4Addr, cb) {
         lookup,
       });
 
+
       connection.on('ready', common.mustNotCall());
       connection.on('error', common.mustCall((error) => {
         assert.strictEqual(connection.autoSelectFamilyAttemptedAddresses, undefined);
-
         if (common.hasIPv6) {
           assert.strictEqual(error.code, 'ECONNREFUSED');
           assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);

--- a/test/parallel/test-net-autoselectfamily-ipv4first.js
+++ b/test/parallel/test-net-autoselectfamily-ipv4first.js
@@ -6,9 +6,12 @@ const { parseDNSPacket, writeDNSPacket } = require('../common/dns');
 const assert = require('assert');
 const dgram = require('dgram');
 const { Resolver } = require('dns');
-const { createConnection, createServer } = require('net');
+const { createConnection, createServer, setDefaultAutoSelectFamilyAttemptTimeout } = require('net');
 
 // Test that happy eyeballs algorithm is properly implemented when a A record is returned first.
+
+// Some of the windows machines in the CI need more time to establish connection
+setDefaultAutoSelectFamilyAttemptTimeout(common.platformTimeout(common.isWindows ? 1500 : 250));
 
 function _lookup(resolver, hostname, options, cb) {
   resolver.resolve(hostname, 'ANY', (err, replies) => {

--- a/test/parallel/test-net-autoselectfamily.js
+++ b/test/parallel/test-net-autoselectfamily.js
@@ -13,8 +13,8 @@ const { createConnection, createServer } = require('net');
 // Purposely not using setDefaultAutoSelectFamilyAttemptTimeout here to test the
 // parameter is correctly used in options.
 //
-// Some of the machines in the CI need more time to establish connection
-const autoSelectFamilyAttemptTimeout = common.defaultAutoSelectFamilyAttemptTimeout;
+// Some of the windows machines in the CI need more time to establish connection
+const autoSelectFamilyAttemptTimeout = common.platformTimeout(common.isWindows ? 1500 : 250);
 
 function _lookup(resolver, hostname, options, cb) {
   resolver.resolve(hostname, 'ANY', (err, replies) => {

--- a/test/parallel/test-net-autoselectfamilydefault.js
+++ b/test/parallel/test-net-autoselectfamilydefault.js
@@ -10,7 +10,11 @@ const { createConnection, createServer, setDefaultAutoSelectFamily } = require('
 
 // Test that the default for happy eyeballs algorithm is properly respected.
 
-const autoSelectFamilyAttemptTimeout = common.defaultAutoSelectFamilyAttemptTimeout;
+let autoSelectFamilyAttemptTimeout = common.platformTimeout(250);
+if (common.isWindows) {
+  // Some of the windows machines in the CI need more time to establish connection
+  autoSelectFamilyAttemptTimeout = common.platformTimeout(1500);
+}
 
 function _lookup(resolver, hostname, options, cb) {
   resolver.resolve(hostname, 'ANY', (err, replies) => {

--- a/test/parallel/test-tls-connect-hints-option.js
+++ b/test/parallel/test-tls-connect-hints-option.js
@@ -25,7 +25,7 @@ tls.connect({
   port: 42,
   lookup: common.mustCall((host, options) => {
     assert.strictEqual(host, 'localhost');
-    assert.deepStrictEqual(options, { family: undefined, hints, all: true });
+    assert.deepStrictEqual(options, { family: undefined, hints });
   }),
   hints
 });

--- a/test/sequential/test-http-econnrefused.js
+++ b/test/sequential/test-http-econnrefused.js
@@ -32,6 +32,7 @@ const common = require('../common');
 const http = require('http');
 const assert = require('assert');
 
+
 const server = http.createServer(function(req, res) {
   let body = '';
 
@@ -134,10 +135,7 @@ function ping() {
     console.log(`Error making ping req: ${error}`);
     hadError = true;
     assert.ok(!gotEnd);
-
-    // Family autoselection might be skipped if only a single address is returned by DNS.
-    const actualError = Array.isArray(error.errors) ? error.errors[0] : error;
-    afterPing(actualError.message);
+    afterPing(error.message);
   });
 }
 

--- a/test/sequential/test-net-better-error-messages-port.js
+++ b/test/sequential/test-net-better-error-messages-port.js
@@ -7,11 +7,8 @@ const c = net.createConnection(common.PORT);
 
 c.on('connect', common.mustNotCall());
 
-c.on('error', common.mustCall(function(error) {
-  // Family autoselection might be skipped if only a single address is returned by DNS.
-  const failedAttempt = Array.isArray(error.errors) ? error.errors[0] : error;
-
-  assert.strictEqual(failedAttempt.code, 'ECONNREFUSED');
-  assert.strictEqual(failedAttempt.port, common.PORT);
-  assert.match(failedAttempt.address, /^(127\.0\.0\.1|::1)$/);
+c.on('error', common.mustCall(function(e) {
+  assert.strictEqual(e.code, 'ECONNREFUSED');
+  assert.strictEqual(e.port, common.PORT);
+  assert.match(e.address, /^(127\.0\.0\.1|::1)$/);
 }));

--- a/test/sequential/test-net-connect-econnrefused.js
+++ b/test/sequential/test-net-connect-econnrefused.js
@@ -40,12 +40,9 @@ const server = net.createServer().listen(0, common.mustCall(() => {
 function pummel() {
   let pending;
   for (pending = 0; pending < ATTEMPTS_PER_ROUND; pending++) {
-    net.createConnection({ port, autoSelectFamily: false }).on('error', function(error) {
-      // Family autoselection might be skipped if only a single address is returned by DNS.
-      const actualError = Array.isArray(error.errors) ? error.errors[0] : error;
-
+    net.createConnection(port).on('error', function(err) {
       console.log('pending', pending, 'rounds', rounds);
-      assert.strictEqual(actualError.code, 'ECONNREFUSED');
+      assert.strictEqual(err.code, 'ECONNREFUSED');
       if (--pending > 0) return;
       if (rounds === ROUNDS) return check();
       rounds++;

--- a/test/sequential/test-net-reconnect-error.js
+++ b/test/sequential/test-net-reconnect-error.js
@@ -30,11 +30,8 @@ const c = net.createConnection(common.PORT);
 
 c.on('connect', common.mustNotCall('client should not have connected'));
 
-c.on('error', common.mustCall((error) => {
-  // Family autoselection might be skipped if only a single address is returned by DNS.
-  const actualError = Array.isArray(error.errors) ? error.errors[0] : error;
-
-  assert.strictEqual(actualError.code, 'ECONNREFUSED');
+c.on('error', common.mustCall((e) => {
+  assert.strictEqual(e.code, 'ECONNREFUSED');
 }, N + 1));
 
 c.on('close', common.mustCall(() => {


### PR DESCRIPTION
This reverts commit 8b51c1a8696ae263141d18b39cbd144d2866f7c7.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

I think we were too eager to turn this on. In the Fastify community, we have been trying to get our tests to pass on Node v20 for a month and a half with minimal luck. The only solution was to use `NODE_OPTIONS=no-network-family-autoselection`.

Note that tests spuriously fail even with v20.3.0, so the fixes are not complete. I was not able to reproduce the problem individually. My 2 cents is that there is a race condition somewhere triggered by many open sockets in a short period of time.