### PR TITLE
buffer: make `Buffer.from` throw on `DataView`

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -533,7 +533,7 @@ function fromArrayLike(obj) {
 }
 
 function fromObject(obj) {
-  if (obj.length !== undefined || isAnyArrayBuffer(obj.buffer)) {
+  if (obj.length !== undefined) {
     if (typeof obj.length !== 'number') {
       return new FastBuffer();
     }

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1097,6 +1097,18 @@ assert.throws(() => Buffer.from(null), {
   message: 'The first argument must be of type string or an instance of ' +
   'Buffer, ArrayBuffer, or Array or an Array-like Object. Received null'
 });
+assert.throws(() => Buffer.from({ buffer: new ArrayBuffer(4) }), {
+  name: 'TypeError',
+  message: 'The first argument must be of type string or an instance of ' +
+  'Buffer, ArrayBuffer, or Array or an Array-like Object. ' +
+  'Received an instance of Object'
+});
+assert.throws(() => Buffer.from(new DataView(new ArrayBuffer(4))), {
+  name: 'TypeError',
+  message: 'The first argument must be of type string or an instance of ' +
+  'Buffer, ArrayBuffer, or Array or an Array-like Object. ' +
+  'Received an instance of DataView'
+});
 
 // Test prototype getters don't throw
 assert.strictEqual(Buffer.prototype.parent, undefined);
@@ -1150,7 +1162,7 @@ Buffer.from(new ArrayBuffer());
 // Test that ArrayBuffer from a different context is detected correctly.
 const arrayBuf = vm.runInNewContext('new ArrayBuffer()');
 Buffer.from(arrayBuf);
-Buffer.from({ buffer: arrayBuf });
+Buffer.from(new Uint8Array(arrayBuf));
 
 assert.throws(() => Buffer.alloc({ valueOf: () => 1 }),
               /"size" argument must be of type number/);

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -1087,27 +1087,23 @@ assert.throws(
              'Uint8Array. Received undefined'
   });
 
+// The first argument must be of type string or an instance of:
+// Buffer, ArrayBuffer, or Array or an Array-like Object.
 assert.throws(() => Buffer.from(), {
+  code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The first argument must be of type string or an instance of ' +
-  'Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined'
 });
 assert.throws(() => Buffer.from(null), {
+  code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The first argument must be of type string or an instance of ' +
-  'Buffer, ArrayBuffer, or Array or an Array-like Object. Received null'
 });
 assert.throws(() => Buffer.from({ buffer: new ArrayBuffer(4) }), {
+  code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The first argument must be of type string or an instance of ' +
-  'Buffer, ArrayBuffer, or Array or an Array-like Object. ' +
-  'Received an instance of Object'
 });
 assert.throws(() => Buffer.from(new DataView(new ArrayBuffer(4))), {
+  code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The first argument must be of type string or an instance of ' +
-  'Buffer, ArrayBuffer, or Array or an Array-like Object. ' +
-  'Received an instance of DataView'
 });
 
 // Test prototype getters don't throw

--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -24,4 +24,6 @@ assert.deepStrictEqual(arr_buf, ar_buf);
 // Checks for calling Buffer.byteLength on a SharedArrayBuffer.
 assert.strictEqual(Buffer.byteLength(sab), sab.byteLength);
 
-Buffer.from({ buffer: sab }); // Should not throw.
+// Should not throw.
+Buffer.from(sab);
+Buffer.from(new Uint8Array(sab));


### PR DESCRIPTION
Passing `DataView` instance or arbitrary object with any ArrayBuffer in its `buffer` property and without numeric `length` property results in a new empty `Buffer`.

This behaviour isn't documented, and is confusing since `buffer` property is checked but not used.