### PR TITLE
constants: add support for sysexits.h exit codes

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -1005,6 +1005,103 @@ The following error constants are exported by `os.constants.errno`.
   </tr>
 </table>
 
+#### Legacy Unix sysexits.h codes.
+
+The following error codes are almost exclusively used on older Unix systems
+as the exit code for a process that has encountered an error.  In general,
+on modern Linux or MacOS systems, you should return 1 (EXIT\_FAILURE) for a
+generic problem.  There is no widely accepted standard for exit codes on
+newer systems, so each application must define its own set of exit codes.
+
+The following descriptions are from the FreeBSD project's sysexits.h man page.
+
+<table>
+  <tr>
+    <th>Constant</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>EX_USAGE</code></td>
+    <td>The command was used incorrectly, e.g., with the wrong number of
+    arguments, a bad flag, a bad syntax in a parameter, or whatever.</td>
+  </tr>
+  <tr>
+    <td><code>EX_DATAERR</code></td>
+    <td>The input data was incorrect in some way.  This should only be used
+    for user's data and not system files.</td>
+  </tr>
+  <tr>
+    <td><code>EX_NOINPUT</code></td>
+    <td>An input file (not a system file) did not exist or was not readable.
+    This could also include errors like "No message" to a mailer (if it cared
+    to catch it).</td>
+  </tr>
+  <tr>
+    <td><code>EX_NOUSER</code></td>
+    <td>The user specified did not exist.  This might be used for mail
+    addresses or remote logins.</td>
+  </tr>
+  <tr>
+    <td><code>EX_NOHOST</code></td>
+    <td>The host specified did not exist.  This is used in mail addresses or
+    network requests.</td>
+  </tr>
+  <tr>
+    <td><code>EX_UNAVAILABLE</code></td>
+    <td>A service is unavailable.  This can occur if a support program or file
+    does not exist.  This can also be used as a catchall message when
+    something you wanted to do doesn't work, but you don't know why.</td>
+  </tr>
+  <tr>
+    <td><code>EX_SOFTWARE</code></td>
+    <td>An internal software error has been detected.  This should be limited
+    to non-operating system related errors as possible.</td>
+  </tr>
+  <tr>
+    <td><code>EX_OSERR</code></td>
+    <td>An operating system error has been detected.  This is intended to be
+    used for such things as "cannot fork", "cannot create pipe", or the like.
+    It includes things like getuid returning a user that does not exist in the
+    passwd file.</td>
+  </tr>
+  <tr>
+    <td><code>EX_OSFILE</code></td>
+    <td>Some system file (e.g., <code>/etc/passwd</code>,
+    <code>/var/run/utmp</code>, etc.) does not exist, cannot be opened, or has
+    some sort of error (e.g., syntax error).</td>
+  </tr>
+  <tr>
+    <td><code>EX_CANTCREAT</code></td>
+    <td>A (user specified) output file cannot be created.</td>
+  </tr>
+  <tr>
+    <td><code>EX_IOERR</code></td>
+    <td>An error occurred while doing I/O on some file.</td>
+  </tr>
+  <tr>
+    <td><code>EX_TEMPFAIL</code></td>
+    <td>Temporary failure, indicating something that is not really an error.
+    In sendmail, this means that a mailer (e.g.) could not create a connection,
+    and the request should be reattempted later.</td>
+  </tr>
+  <tr>
+    <td><code>EX_PROTOCOL</code></td>
+    <td>The remote system returned something that was during a protocol
+    exchange.</td>
+  </tr>
+  <tr>
+    <td><code>EX_NOPERM</code></td>
+    <td>You did not have sufficient permission to perform the operation.  This
+    is not intended for file system problems, which should use
+    <code>EX_NOINPUT</code> or <code>EX_CANTCREAT</code>, but rather for higher
+    level permissions.</td>
+  </tr>
+  <tr>
+    <td><code>EX_CONFIG</code></td>
+    <td>Something was found in an unconfigured or misconfigured state.</td>
+  </tr>
+</table>
+
 #### Windows-specific error constants
 
 The following error codes are specific to the Windows operating system.

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -34,6 +34,7 @@ const constants = internalBinding('constants');
 ObjectAssign(exports,
              constants.os.dlopen,
              constants.os.errno,
+             constants.os.sysexits,
              constants.os.priority,
              constants.os.signals,
              constants.fs,

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -28,6 +28,7 @@
 
 #if !defined(_MSC_VER)
 #include <unistd.h>
+#include <sysexits.h>
 #endif
 
 #include <fcntl.h>
@@ -387,6 +388,68 @@ void DefineErrnoConstants(Local<Object> target) {
 
 #ifdef EXDEV
   NODE_DEFINE_CONSTANT(target, EXDEV);
+#endif
+}
+
+void DefineSysexitConstants(Local<Object> target) {
+#ifdef EX_USAGE
+  NODE_DEFINE_CONSTANT(target, EX_USAGE);
+#endif
+
+#ifdef EX_DATAERR
+  NODE_DEFINE_CONSTANT(target, EX_DATAERR);
+#endif
+
+#ifdef EX_NOINPUT
+  NODE_DEFINE_CONSTANT(target, EX_NOINPUT);
+#endif
+
+#ifdef EX_NOUSER
+  NODE_DEFINE_CONSTANT(target, EX_NOUSER);
+#endif
+
+#ifdef EX_NOHOST
+  NODE_DEFINE_CONSTANT(target, EX_NOHOST);
+#endif
+
+#ifdef EX_UNAVAILABLE
+  NODE_DEFINE_CONSTANT(target, EX_UNAVAILABLE);
+#endif
+
+#ifdef EX_SOFTWARE
+  NODE_DEFINE_CONSTANT(target, EX_SOFTWARE);
+#endif
+
+#ifdef EX_OSERR
+  NODE_DEFINE_CONSTANT(target, EX_OSERR);
+#endif
+
+#ifdef EX_OSFILE
+  NODE_DEFINE_CONSTANT(target, EX_OSFILE);
+#endif
+
+#ifdef EX_CANTCREAT
+  NODE_DEFINE_CONSTANT(target, EX_CANTCREAT);
+#endif
+
+#ifdef EX_IOERR
+  NODE_DEFINE_CONSTANT(target, EX_IOERR);
+#endif
+
+#ifdef EX_TEMPFAIL
+  NODE_DEFINE_CONSTANT(target, EX_TEMPFAIL);
+#endif
+
+#ifdef EX_PROTOCOL
+  NODE_DEFINE_CONSTANT(target, EX_PROTOCOL);
+#endif
+
+#ifdef EX_NOPERM
+  NODE_DEFINE_CONSTANT(target, EX_NOPERM);
+#endif
+
+#ifdef EX_CONFIG
+  NODE_DEFINE_CONSTANT(target, EX_CONFIG);
 #endif
 }
 
@@ -1291,6 +1354,10 @@ void CreatePerContextProperties(Local<Object> target,
   CHECK(err_constants->SetPrototype(env->context(),
                                     Null(env->isolate())).FromJust());
 
+  Local<Object> sysexit_constants = Object::New(isolate);
+  CHECK(sysexit_constants->SetPrototype(env->context(),
+                                    Null(env->isolate())).FromJust());
+
   Local<Object> sig_constants = Object::New(isolate);
   CHECK(sig_constants->SetPrototype(env->context(),
                                     Null(env->isolate())).FromJust());
@@ -1320,6 +1387,7 @@ void CreatePerContextProperties(Local<Object> target,
                                       Null(env->isolate())).FromJust());
 
   DefineErrnoConstants(err_constants);
+  DefineSysexitConstants(sysexit_constants);
   DefineWindowsErrorConstants(err_constants);
   DefineSignalConstants(sig_constants);
   DefinePriorityConstants(priority_constants);
@@ -1338,6 +1406,9 @@ void CreatePerContextProperties(Local<Object> target,
   os_constants->Set(env->context(),
                     OneByteString(isolate, "errno"),
                     err_constants).Check();
+  os_constants->Set(env->context(),
+                    OneByteString(isolate, "sysexits"),
+                    sysexit_constants).Check();
   os_constants->Set(env->context(),
                     OneByteString(isolate, "signals"),
                     sig_constants).Check();

--- a/test/parallel/test-binding-constants.js
+++ b/test/parallel/test-binding-constants.js
@@ -12,7 +12,7 @@ assert.deepStrictEqual(
 
 assert.deepStrictEqual(
   Object.keys(constants.os).sort(), ['UV_UDP_REUSEADDR', 'dlopen', 'errno',
-                                     'priority', 'signals']
+                                     'priority', 'signals', 'sysexits']
 );
 
 // Make sure all the constants objects don't inherit from Object.prototype

--- a/test/parallel/test-constants.js
+++ b/test/parallel/test-constants.js
@@ -11,6 +11,7 @@ assert.ok(binding);
 assert.ok(binding.os);
 assert.ok(binding.os.signals);
 assert.ok(binding.os.errno);
+assert.ok(binding.os.sysexits);
 assert.ok(binding.fs);
 assert.ok(binding.crypto);
 

--- a/typings/internalBinding/constants.d.ts
+++ b/typings/internalBinding/constants.d.ts
@@ -88,6 +88,23 @@ declare function InternalBinding(binding: 'constants'): {
       EWOULDBLOCK: 35;
       EXDEV: 18;
     };
+    sysexits: {
+      EX_USAGE: 64;
+      EX_DATAERR: 65;
+      EX_NOINPUT: 66;
+      EX_NOUSER: 67;
+      EX_NOHOST: 68;
+      EX_UNAVAILABLE: 69;
+      EX_SOFTWARE: 70;
+      EX_OSERR: 71;
+      EX_OSFILE: 72;
+      EX_CANTCREAT: 73;
+      EX_IOERR: 74;
+      EX_TEMPFAIL: 75;
+      EX_PROTOCOL: 76;
+      EX_NOPERM: 77;
+      EX_CONFIG: 78;
+    }
     signals: {
       SIGHUP: 1;
       SIGINT: 2;


### PR DESCRIPTION
These exit codes are still in use by process managers which inherited behavior expectations of child processes from the early days of BSD.  

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
