### PR TITLE
feat: allow repl pause on exception state to be set from env

### DIFF
--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -32,10 +32,11 @@ const {
   AbortController,
 } = require('internal/abort_controller');
 
-const { 0: InspectClient, 1: createRepl } =
+const { 0: InspectClient, 1: createRepl, 2: parseArguments } =
     [
       require('internal/debugger/inspect_client'),
       require('internal/debugger/inspect_repl'),
+      require('internal/debugger/util/argument_parser')
     ];
 
 const debuglog = util.debuglog('inspect');
@@ -286,50 +287,6 @@ class NodeInspector {
   }
 }
 
-function parseArgv(args) {
-  const target = ArrayPrototypeShift(args);
-  let host = '127.0.0.1';
-  let port = 9229;
-  let isRemote = false;
-  let script = target;
-  let scriptArgs = args;
-
-  const hostMatch = RegExpPrototypeExec(/^([^:]+):(\d+)$/, target);
-  const portMatch = RegExpPrototypeExec(/^--port=(\d+)$/, target);
-
-  if (hostMatch) {
-    // Connecting to remote debugger
-    host = hostMatch[1];
-    port = Number(hostMatch[2]);
-    isRemote = true;
-    script = null;
-  } else if (portMatch) {
-    // Start on custom port
-    port = Number(portMatch[1]);
-    script = args[0];
-    scriptArgs = ArrayPrototypeSlice(args, 1);
-  } else if (args.length === 1 && RegExpPrototypeExec(/^\d+$/, args[0]) !== null &&
-             target === '-p') {
-    // Start debugger against a given pid
-    const pid = Number(args[0]);
-    try {
-      process._debugProcess(pid);
-    } catch (e) {
-      if (e.code === 'ESRCH') {
-        process.stderr.write(`Target process: ${pid} doesn't exist.\n`);
-        process.exit(kGenericUserError);
-      }
-      throw e;
-    }
-    script = null;
-    isRemote = true;
-  }
-
-  return {
-    host, port, isRemote, script, scriptArgs,
-  };
-}
-
 function startInspect(argv = ArrayPrototypeSlice(process.argv, 2),
                       stdin = process.stdin,
                       stdout = process.stdout) {
@@ -343,7 +300,7 @@ function startInspect(argv = ArrayPrototypeSlice(process.argv, 2),
     process.exit(kInvalidCommandLineArgument);
   }
 
-  const options = parseArgv(argv);
+  const options = parseArguments(argv);
   const inspector = new NodeInspector(options, stdin, stdout);
 
   stdin.resume();

--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -361,7 +361,7 @@ function aliasProperties(target, mapping) {
 }
 
 function createRepl(inspector) {
-  const { Debugger, HeapProfiler, Profiler, Runtime } = inspector;
+  const { Debugger, HeapProfiler, Profiler, Runtime, options: commandLineOptions } = inspector;
 
   let repl;
 
@@ -370,7 +370,7 @@ function createRepl(inspector) {
   const watchedExpressions = [];
   const knownBreakpoints = [];
   let heapSnapshotPromise = null;
-  let pauseOnExceptionState = process.env.NODE_INSPECT_PAUSE_ON_EXCEPTION_STATE || 'none';
+  let pauseOnExceptionState = commandLineOptions.pauseOnExceptionState || 'none';
   let lastCommand;
 
   // Things we need to reset when the app restarts
@@ -883,7 +883,7 @@ function createRepl(inspector) {
   }
 
   Debugger.on('paused', ({ callFrames, reason /* , hitBreakpoints */ }) => {
-    if (process.env.NODE_INSPECT_RESUME_ON_START === '1' &&
+    if ((process.env.NODE_INSPECT_RESUME_ON_START === '1' || commandLineOptions.inspectResumeOnStart === true) &&
         reason === 'Break on start') {
       debuglog('Paused on start, but NODE_INSPECT_RESUME_ON_START' +
               ' environment variable is set to 1, resuming');

--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -370,7 +370,7 @@ function createRepl(inspector) {
   const watchedExpressions = [];
   const knownBreakpoints = [];
   let heapSnapshotPromise = null;
-  let pauseOnExceptionState = 'none';
+  let pauseOnExceptionState = process.env.NODE_INSPECT_PAUSE_ON_EXCEPTION_STATE || 'none';
   let lastCommand;
 
   // Things we need to reset when the app restarts

--- a/lib/internal/debugger/util/argument_parser.js
+++ b/lib/internal/debugger/util/argument_parser.js
@@ -1,0 +1,111 @@
+const {
+  ArrayPrototypeShift,
+  ArrayPrototypeSplice,
+  ArrayPrototypeIncludes,
+  StringPrototypeSplit,
+  RegExpPrototypeExec,
+} = primordials;
+
+function parseBoolean(value) {
+  return value === 'true' || value === '1' || value === 'yes';
+}
+
+function validatePauseOnExceptionState(value) {
+  const validStates = ['uncaught', 'none', 'all'];
+  if (!ArrayPrototypeIncludes(validStates, value)) {
+    throw new Error(`Invalid state passed for pauseOnExceptionState: ${value}. Must be one of 'uncaught', 'none', or 'all'.`);
+  }
+  return value;
+}
+
+function parseArguments(argv) {
+  const legacyArguments = processLegacyArgs(argv)
+
+  let options = {
+    pauseOnExceptionState: undefined,
+    inspectResumeOnStart: undefined
+  }
+
+  // `NODE_INSPECT_OPTIONS` is parsed first and can be overwritten by command line arguments
+
+  if (process.env.NODE_INSPECT_OPTIONS) {
+    const envOptions = StringPrototypeSplit(process.env.NODE_INSPECT_OPTIONS, ' ');
+    for (let i = 0; i < envOptions.length; i++) {
+      switch (envOptions[i]) {
+        case '--pause-on-exception-state':
+          options.pauseOnExceptionState = validatePauseOnExceptionState(envOptions[++i]);
+          break;
+        case '--inspect-resume-on-start':
+          options.inspectResumeOnStart = parseBoolean(envOptions[++i]);
+          break;
+      }
+    }
+  }
+
+  for (let i = 0; i < argv.length;) {
+    switch (argv[i]) {
+      case '--pause-on-exception-state':
+        options.pauseOnExceptionState = validatePauseOnExceptionState(argv[i+1]);
+        ArrayPrototypeSplice(argv, i, 2);
+        break;
+      case '--inspect-resume-on-start':
+        options.inspectResumeOnStart = parseBoolean(argv[i+1]);
+        ArrayPrototypeSplice(argv, i, 2);
+        break;
+      default:
+        i++;
+        break;
+    }
+  }
+
+  return {...options, ...legacyArguments};
+}
+
+// the legacy `node inspect` options assumed the first argument was the target
+// to avoid breaking existing scripts, we maintain this behavior
+
+function processLegacyArgs(args) {
+  const target = ArrayPrototypeShift(args);
+  let host = '127.0.0.1';
+  let port = 9229;
+  let isRemote = false;
+  let script = target;
+  let scriptArgs = args;
+
+  const hostMatch = RegExpPrototypeExec(/^([^:]+):(\d+)$/, target);
+  const portMatch = RegExpPrototypeExec(/^--port=(\d+)$/, target);
+
+  if (hostMatch) {
+    // Connecting to remote debugger
+    host = hostMatch[1];
+    port = Number(hostMatch[2]);
+    isRemote = true;
+    script = null;
+  } else if (portMatch) {
+    // Start on custom port
+    port = Number(portMatch[1]);
+    script = args[0];
+    scriptArgs = ArrayPrototypeSlice(args, 1);
+  } else if (args.length === 1 && RegExpPrototypeExec(/^\d+$/, args[0]) !== null &&
+             target === '-p') {
+    // Start debugger against a given pid
+    const pid = Number(args[0]);
+    try {
+      process._debugProcess(pid);
+    } catch (e) {
+      if (e.code === 'ESRCH') {
+        process.stderr.write(`Target process: ${pid} doesn't exist.\n`);
+        process.exit(kGenericUserError);
+      }
+      throw e;
+    }
+    script = null;
+    isRemote = true;
+  }
+
+  return {
+    host, port, isRemote, script, scriptArgs,
+  };
+}
+
+module.exports = parseArguments;


### PR DESCRIPTION
Right now, it's not possible to configure the debugger to pause on uncaught exceptions
without manually configuring the pause state on each run. This change would allow the
pause state to be configured via a shell env variable to allow for faster CLI-based node
debugging.

I'm not sure if there's a reason there aren't more configuration options for `node inspect`,
so I wanted to submit this PR for discussion before writing tests and updating documentation.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
