### PR TITLE
lib: fix output message when repl is used with pm

### DIFF
--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -55,7 +55,7 @@ function setupHistory(repl, historyPath, ready) {
   }
 
   if (permission.isEnabled() && permission.has('fs.write', historyPath) === false) {
-    _writeToOutput(repl, '\nAccess to FileSystemOut is restricted.\n' +
+    _writeToOutput(repl, '\nAccess to FileSystemWrite is restricted.\n' +
       'REPL session history will not be persisted.\n');
     return ready(null, repl);
   }


### PR DESCRIPTION
We use FileSytemWrite and FileSytemRead now.