### PR TITLE
test: make IsolateData per-isolate in cctest

### DIFF
--- a/test/cctest/node_test_fixture.cc
+++ b/test/cctest/node_test_fixture.cc
@@ -6,7 +6,8 @@ uv_loop_t NodeZeroIsolateTestFixture::current_loop;
 NodePlatformUniquePtr NodeZeroIsolateTestFixture::platform;
 TracingAgentUniquePtr NodeZeroIsolateTestFixture::tracing_agent;
 bool NodeZeroIsolateTestFixture::node_initialized = false;
-
+v8::Isolate* NodeTestFixture::isolate_ = nullptr;
+node::IsolateData* EnvironmentTestFixture::isolate_data_ = nullptr;
 
 void NodeTestEnvironment::SetUp() {
   NodeZeroIsolateTestFixture::tracing_agent =

--- a/test/cctest/test_node_api.cc
+++ b/test/cctest/test_node_api.cc
@@ -16,7 +16,7 @@ class NodeApiTest : public EnvironmentTestFixture {
  private:
   void SetUp() override { EnvironmentTestFixture::SetUp(); }
 
-  void TearDown() override { NodeTestFixture::TearDown(); }
+  void TearDown() override { EnvironmentTestFixture::TearDown(); }
 };
 
 TEST_F(NodeApiTest, CreateNodeApiEnv) {

--- a/test/cctest/test_report.cc
+++ b/test/cctest/test_report.cc
@@ -20,7 +20,7 @@ bool report_callback_called = false;
 class ReportTest : public EnvironmentTestFixture {
  private:
   void TearDown() override {
-    NodeTestFixture::TearDown();
+    EnvironmentTestFixture::TearDown();
     report_callback_called = false;
   }
 };


### PR DESCRIPTION
This ensures that we only create one IsolateData for each isolate inthe cctest, since IsolateData are meant to be per-isolate. We need to make the isolate and isolate_data static in the test fixtures as a result, similar to how the event loops and array buffer allocators are managed in the
NodeZeroIsolateTestFixture but it is fine because gtest ensures that the Setup() and TearDown() of the fixtures are always run in order and would never overlap in one process.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
