### PR TITLE
build: fix building when there is only python3

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2121,6 +2121,10 @@ write('config.mk', do_not_edit + config_str)
 gyp_args = ['--no-parallel', '-Dconfiguring_node=1']
 gyp_args += ['-Dbuild_type=' + config['BUILDTYPE']]
 
+# always set 'python' variable, otherwise environments that only have python3
+# will fail to run python scripts
+gyp_args += ['-Dpython=' + sys.executable]
+
 if options.use_ninja:
   gyp_args += ['-f', 'ninja-' + flavor]
 elif flavor == 'win' and sys.platform != 'msys':
@@ -2132,10 +2136,6 @@ if options.compile_commands_json:
   gyp_args += ['-f', 'compile_commands_json']
   os.path.islink('./compile_commands.json') and os.unlink('./compile_commands.json')
   os.symlink('./out/' + config['BUILDTYPE'] + '/compile_commands.json', './compile_commands.json')
-
-# override the variable `python` defined in common.gypi
-if bin_override is not None:
-  gyp_args += ['-Dpython=' + sys.executable]
 
 # pass the leftover non-whitespace positional arguments to GYP
 gyp_args += [arg for arg in args if not str.isspace(arg)]

--- a/configure.py
+++ b/configure.py
@@ -2121,9 +2121,16 @@ write('config.mk', do_not_edit + config_str)
 gyp_args = ['--no-parallel', '-Dconfiguring_node=1']
 gyp_args += ['-Dbuild_type=' + config['BUILDTYPE']]
 
-# always set 'python' variable, otherwise environments that only have python3
-# will fail to run python scripts
-gyp_args += ['-Dpython=' + sys.executable]
+# Remove the trailing .exe from the executable name, otherwise the python.exe
+# would be rewrote as python_host.exe due to hack in GYP for supporting cross
+# compilation on Windows.
+# See https://github.com/nodejs/node/pull/32867 for related change.
+python = sys.executable
+if flavor == 'win' and python.lower().endswith('.exe'):
+  python = python[:-4]
+# Always set 'python' variable, otherwise environments that only have python3
+# will fail to run python scripts.
+gyp_args += ['-Dpython=' + python]
 
 if options.use_ninja:
   gyp_args += ['-f', 'ninja-' + flavor]

--- a/node.gyp
+++ b/node.gyp
@@ -762,7 +762,7 @@
                 '<(fipsmodule)',
               ],
               'action': [
-                'python', 'tools/copyfile.py',
+                '<(python)', 'tools/copyfile.py',
                 '<(fipsmodule_internal)',
                 '<(fipsmodule)',
               ],
@@ -772,7 +772,7 @@
               'inputs': [ '<(opensslconfig)', ],
               'outputs': [ '<(opensslconfig_internal)', ],
               'action': [
-                'python', 'tools/enable_fips_include.py',
+                '<(python)', 'tools/enable_fips_include.py',
                 '<(opensslconfig)',
                 '<(opensslconfig_internal)',
                 '<(fipsconfig)',

--- a/tools/gyp/pylib/gyp/generator/msvs.py
+++ b/tools/gyp/pylib/gyp/generator/msvs.py
@@ -438,6 +438,7 @@ def _BuildCommandLineForRuleRaw(
             # Support a mode for using cmd directly.
             # Convert any paths to native form (first element is used directly).
             # TODO(quote):  regularize quoting path names throughout the module
+            command[1] = '"%s"' % command[1]
             arguments = ['"%s"' % i for i in arguments]
         # Collapse into a single command.
         return input_dir_preamble + " ".join(command + arguments)

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -41,7 +41,7 @@
     'has_valgrind%': 0,
     'coverage%': 0,
     'v8_target_arch%': '<(target_arch)',
-    'v8_host_byteorder%': '<!(<(python) -c "import sys; print(sys.byteorder)")',
+    'v8_host_byteorder%': '<!("<(python)" -c "import sys; print(sys.byteorder)")',
     'force_dynamic_crt%': 0,
 
     # Setting 'v8_can_use_vfp32dregs' to 'true' will cause V8 to use the VFP

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -41,7 +41,7 @@
     'has_valgrind%': 0,
     'coverage%': 0,
     'v8_target_arch%': '<(target_arch)',
-    'v8_host_byteorder%': '<!(python -c "import sys; print(sys.byteorder)")',
+    'v8_host_byteorder%': '<!(<(python) -c "import sys; print(sys.byteorder)")',
     'force_dynamic_crt%': 0,
 
     # Setting 'v8_can_use_vfp32dregs' to 'true' will cause V8 to use the VFP


### PR DESCRIPTION
On some environments, especially macOS, there is only `python3` and no `python`, replacing the `python` to `<(python)` can make gyp use the correct python.