### PR TITLE
test: skip test-runner-watch-mode on IBMi

### DIFF
--- a/test/parallel/test-runner-watch-mode.mjs
+++ b/test/parallel/test-runner-watch-mode.mjs
@@ -1,11 +1,15 @@
 // Flags: --expose-internals
-import '../common/index.mjs';
+import * as common from '../common/index.mjs';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { spawn } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import util from 'internal/util';
 import tmpdir from '../common/tmpdir.js';
+
+
+if (common.isIBMi)
+  common.skip('IBMi does not support `fs.watch()`');
 
 tmpdir.refresh();
 


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/48065
this skip exists in 21 other places: https://github.com/search?q=repo%3Anodejs%2Fnode+%22IBMi+does+not+support+%60fs.watch%28%29%60%22&type=code