### PR TITLE
src: support sync 'overlapped' stdio option

### DIFF
--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -92,7 +92,6 @@ void SyncProcessOutputBuffer::set_next(SyncProcessOutputBuffer* next) {
   next_ = next;
 }
 
-
 SyncProcessStdioPipe::SyncProcessStdioPipe(SyncProcessRunner* process_handler,
                                            bool readable,
                                            bool writable,
@@ -114,7 +113,6 @@ SyncProcessStdioPipe::SyncProcessStdioPipe(SyncProcessRunner* process_handler,
       lifecycle_(kUninitialized) {
   CHECK(readable || writable);
 }
-
 
 SyncProcessStdioPipe::~SyncProcessStdioPipe() {
   CHECK(lifecycle_ == kUninitialized || lifecycle_ == kClosed);
@@ -204,11 +202,9 @@ bool SyncProcessStdioPipe::writable() const {
   return writable_;
 }
 
-
 bool SyncProcessStdioPipe::overlapped() const {
   return overlapped_;
 }
-
 
 uv_stdio_flags SyncProcessStdioPipe::uv_flags() const {
   unsigned int flags;
@@ -218,8 +214,7 @@ uv_stdio_flags SyncProcessStdioPipe::uv_flags() const {
     flags |= UV_READABLE_PIPE;
   if (writable())
     flags |= UV_WRITABLE_PIPE;
-  if (overlapped())
-    flags |= UV_OVERLAPPED_PIPE;
+  if (overlapped()) flags |= UV_OVERLAPPED_PIPE;
 
   return static_cast<uv_stdio_flags>(flags);
 }
@@ -970,7 +965,6 @@ int SyncProcessRunner::AddStdioIgnore(uint32_t child_fd) {
   return 0;
 }
 
-
 int SyncProcessRunner::AddStdioPipe(uint32_t child_fd,
                                     bool readable,
                                     bool writable,
@@ -979,12 +973,8 @@ int SyncProcessRunner::AddStdioPipe(uint32_t child_fd,
   CHECK_LT(child_fd, stdio_count_);
   CHECK(!stdio_pipes_[child_fd]);
 
-  std::unique_ptr<SyncProcessStdioPipe> h(
-      new SyncProcessStdioPipe(this,
-                               readable,
-                               writable,
-                               overlapped,
-                               input_buffer));
+  std::unique_ptr<SyncProcessStdioPipe> h(new SyncProcessStdioPipe(
+      this, readable, writable, overlapped, input_buffer));
 
   int r = h->Initialize(uv_loop_);
   if (r < 0) {
@@ -999,7 +989,6 @@ int SyncProcessRunner::AddStdioPipe(uint32_t child_fd,
 
   return 0;
 }
-
 
 int SyncProcessRunner::AddStdioInheritFD(uint32_t child_fd, int inherit_fd) {
   CHECK_LT(child_fd, stdio_count_);

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -75,6 +75,7 @@ class SyncProcessStdioPipe {
   SyncProcessStdioPipe(SyncProcessRunner* process_handler,
                        bool readable,
                        bool writable,
+                       bool overlapped,
                        uv_buf_t input_buffer);
   ~SyncProcessStdioPipe();
 
@@ -86,6 +87,7 @@ class SyncProcessStdioPipe {
 
   inline bool readable() const;
   inline bool writable() const;
+  inline bool overlapped() const;
   inline uv_stdio_flags uv_flags() const;
 
   inline uv_pipe_t* uv_pipe() const;
@@ -118,6 +120,7 @@ class SyncProcessStdioPipe {
 
   bool readable_;
   bool writable_;
+  bool overlapped_;
   uv_buf_t input_buffer_;
 
   SyncProcessOutputBuffer* first_output_buffer_;
@@ -182,6 +185,7 @@ class SyncProcessRunner {
   inline int AddStdioPipe(uint32_t child_fd,
                           bool readable,
                           bool writable,
+                          bool overlapped,
                           uv_buf_t input_buffer);
   inline int AddStdioInheritFD(uint32_t child_fd, int inherit_fd);
 

--- a/test/parallel/test-child-process-stdio-overlapped.js
+++ b/test/parallel/test-child-process-stdio-overlapped.js
@@ -37,6 +37,17 @@ if (!require('fs').existsSync(exePath)) {
   common.skip(exe + ' binary is not available');
 }
 
+// We can't synchronously write to the child (the 'input' and 'stdio' options
+// conflict) but we can at least verify it starts up normally and is then
+// terminated by the timer watchdog.
+const { error } = child_process.spawnSync(exePath, [], {
+  stdio: ['overlapped', 'pipe', 'pipe'],
+  timeout: 42,
+});
+
+assert.ok(error);
+assert.strictEqual(error.code, 'ETIMEDOUT');
+
 const child = child_process.spawn(exePath, [], {
   stdio: ['overlapped', 'pipe', 'pipe']
 });


### PR DESCRIPTION
Fix an oversight in the pull request that introduced the 'overlapped' option to the asynchronous child process methods, and also add it to the synchronous methods, like child_process.spawnSync().

Fixes: https://github.com/nodejs/node/issues/48476
Refs: https://github.com/nodejs/node/pull/29412