### PR TITLE
http: remove useless ternary in test

### DIFF
--- a/test/parallel/test-http2-endafterheaders.js
+++ b/test/parallel/test-http2-endafterheaders.js
@@ -9,7 +9,7 @@ const Countdown = require('../common/countdown');
 
 const server = http2.createServer();
 server.on('stream', common.mustCall((stream, headers) => {
-  const check = headers[':method'] === 'GET' ? true : false;
+  const check = headers[':method'] === 'GET';
   assert.strictEqual(stream.endAfterHeaders, check);
   stream.on('data', common.mustNotCall());
   stream.on('end', common.mustCall());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

The value of check depends on whether the value of headers [': method'] is equal to "GET". The first statement uses the Ternary operation to achieve this. My change uses a simple comparison expression.