### PR TITLE
lib: reduce url getters on `makeRequireFunction`

### DIFF
--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -86,8 +86,8 @@ function makeRequireFunction(mod, redirects) {
       if (destination === true) {
         missing = false;
       } else if (destination) {
-        const href = destination.href;
-        if (destination.protocol === 'node:') {
+        const { href, protocol } = destination;
+        if (protocol === 'node:') {
           const specifier = destination.pathname;
 
           if (BuiltinModule.canBeRequiredByUsers(specifier)) {
@@ -95,11 +95,9 @@ function makeRequireFunction(mod, redirects) {
             return mod.exports;
           }
           throw new ERR_UNKNOWN_BUILTIN_MODULE(specifier);
-        } else if (destination.protocol === 'file:') {
-          let filepath;
-          if (urlToFileCache.has(href)) {
-            filepath = urlToFileCache.get(href);
-          } else {
+        } else if (protocol === 'file:') {
+          let filepath = urlToFileCache.get(href);
+          if (!filepath) {
             filepath = fileURLToPath(destination);
             urlToFileCache.set(href, filepath);
           }


### PR DESCRIPTION
Reduce calling getters of URL due to the lazy loading of URL.

Ref: https://github.com/nodejs/performance/issues/92