### PR TITLE
lib: fix http get Inheritance issues

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -109,6 +109,7 @@ function request(url, options, cb) {
  * @returns {ClientRequest}
  */
 function get(url, options, cb) {
+  options = {...options, method: 'GET'};
   const req = request(url, options, cb);
   req.end();
   return req;

--- a/lib/http.js
+++ b/lib/http.js
@@ -109,8 +109,7 @@ function request(url, options, cb) {
  * @returns {ClientRequest}
  */
 function get(url, options, cb) {
-  options = {...options, method: 'GET'};
-
+  options = { ...options, method: 'GET' };
   const req = request(url, options, cb);
   req.end();
   return req;

--- a/lib/http.js
+++ b/lib/http.js
@@ -110,6 +110,7 @@ function request(url, options, cb) {
  */
 function get(url, options, cb) {
   options = {...options, method: 'GET'};
+
   const req = request(url, options, cb);
   req.end();
   return req;


### PR DESCRIPTION
The original get method will inherit the value of the method in the prototype, resulting in the sent request method not being GET