### PR TITLE
node-api: rename internal NAPI_VERSION definition

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -3167,7 +3167,7 @@ napi_status NAPI_CDECL napi_get_dataview_info(napi_env env,
 napi_status NAPI_CDECL napi_get_version(napi_env env, uint32_t* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
-  *result = NAPI_VERSION;
+  *result = NODE_API_SUPPORTED_VERSION_MAX;
   return napi_clear_last_error(env);
 }
 

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -82,7 +82,7 @@ Metadata::Versions::Versions() {
   ares = ARES_VERSION_STR;
   modules = NODE_STRINGIFY(NODE_MODULE_VERSION);
   nghttp2 = NGHTTP2_VERSION;
-  napi = NODE_STRINGIFY(NAPI_VERSION);
+  napi = NODE_STRINGIFY(NODE_API_SUPPORTED_VERSION_MAX);
   llhttp =
       NODE_STRINGIFY(LLHTTP_VERSION_MAJOR)
       "."

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -91,9 +91,10 @@
  */
 #define NODE_MODULE_VERSION 115
 
-// The NAPI_VERSION provided by this version of the runtime. This is the version
-// which the Node binary being built supports.
-#define NAPI_VERSION 9
+// The NAPI_VERSION supported by the runtime. This is the inclusive range of
+// versions which the Node.js binary being built supports.
+#define NODE_API_SUPPORTED_VERSION_MAX 9
+#define NODE_API_SUPPORTED_VERSION_MIN 1
 
 // Node API modules use NAPI_VERSION 8 by default if it is not explicitly
 // specified. It must be always 8.

--- a/tools/getnapibuildversion.py
+++ b/tools/getnapibuildversion.py
@@ -12,7 +12,7 @@ def get_napi_version():
 
   f = open(napi_version_h)
 
-  regex = '^#define NAPI_VERSION'
+  regex = '^#define NODE_API_SUPPORTED_VERSION_MAX'
 
   for line in f:
     if re.match(regex, line):


### PR DESCRIPTION
The `NAPI_VERSION` defined in `node_version.h` has a different meaning than the one defined in the `js_native_api.h`. The one from `node_version.h` is identical to `napi_get_version()`, indicating the highest Node-API version supported by the Node.js runtime. While the `NAPI_VERSION` defined in `js_native_api.h` indicates the Node-API version required by the addon and should be lower than or equal to the `NAPI_VERSION` of the Node.js runtime.

Rename the one defined in `node_version.h` to `NODE_API_SUPPORTED_VERSION_MAX`. This avoids unexpected duplicated definitions of `NAPI_VERSION` when both `node_version.h` and `js_native_api.h` are included.

Fixes https://github.com/nodejs/node/issues/48310