### PR TITLE
lib: remove duplicated requires in check_syntax

### DIFF
--- a/lib/internal/main/check_syntax.js
+++ b/lib/internal/main/check_syntax.js
@@ -4,7 +4,7 @@
 // instead of actually running the file.
 
 const { getOptionValue } = require('internal/options');
-const { URL } = require('internal/url');
+const { URL, pathToFileURL } = require('internal/url');
 const {
   prepareMainThreadExecution,
   markBootstrapComplete,
@@ -13,8 +13,6 @@ const {
 const {
   readStdin,
 } = require('internal/process/execution');
-
-const { pathToFileURL } = require('url');
 
 const {
   Module: {
@@ -49,7 +47,6 @@ if (process.argv[1] && process.argv[1] !== '-') {
 }
 
 function loadESMIfNeeded(cb) {
-  const { getOptionValue } = require('internal/options');
   const hasModulePreImport = getOptionValue('--import').length > 0;
 
   if (hasModulePreImport) {


### PR DESCRIPTION
Removes the duplicated require in `url` and `internal/url` as well as `internal/options`