### PR TITLE
module: use symbol in weakmap to maintain lifetime of modules' host defined options

### DIFF
--- a/lib/internal/modules/esm/create_dynamic_module.js
+++ b/lib/internal/modules/esm/create_dynamic_module.js
@@ -45,8 +45,9 @@ import.meta.done();
 
   if (imports.length)
     reflect.imports = { __proto__: null };
-  const { setCallbackForWrap } = require('internal/modules/esm/utils');
-  setCallbackForWrap(m, {
+  const { registerModule } = require('internal/modules/esm/utils');
+  registerModule(m, {
+    __proto__: null,
     initializeImportMeta: (meta, wrap) => {
       meta.exports = reflect.exports;
       if (reflect.imports)

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -180,9 +180,10 @@ class ModuleLoader {
   ) {
     const evalInstance = (url) => {
       const { ModuleWrap } = internalBinding('module_wrap');
-      const { setCallbackForWrap } = require('internal/modules/esm/utils');
+      const { registerModule } = require('internal/modules/esm/utils');
       const module = new ModuleWrap(url, undefined, source, 0, 0);
-      setCallbackForWrap(module, {
+      registerModule(module, {
+        __proto__: null,
         initializeImportMeta: (meta, wrap) => this.importMetaInitialize(meta, { url }),
         importModuleDynamically: (specifier, { url }, importAssertions) => {
           return this.import(specifier, url, importAssertions);

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -116,8 +116,9 @@ translators.set('module', async function moduleStrategy(url, source, isMain) {
   maybeCacheSourceMap(url, source);
   debug(`Translating StandardModule ${url}`);
   const module = new ModuleWrap(url, undefined, source, 0, 0);
-  const { setCallbackForWrap } = require('internal/modules/esm/utils');
-  setCallbackForWrap(module, {
+  const { registerModule } = require('internal/modules/esm/utils');
+  registerModule(module, {
+    __proto__: null,
     initializeImportMeta: (meta, wrap) => this.importMetaInitialize(meta, { url }),
     importModuleDynamically,
   });

--- a/lib/internal/modules/esm/utils.js
+++ b/lib/internal/modules/esm/utils.js
@@ -8,6 +8,11 @@ const {
 } = primordials;
 
 const {
+  privateSymbols: {
+    host_defined_option_symbol,
+  },
+} = internalBinding('util');
+const {
   ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING,
   ERR_INVALID_ARG_VALUE,
 } = require('internal/errors').codes;
@@ -21,15 +26,7 @@ const {
   setImportModuleDynamicallyCallback,
   setInitializeImportMetaObjectCallback,
 } = internalBinding('module_wrap');
-const {
-  getModuleFromWrap,
-} = require('internal/vm/module');
 const assert = require('internal/assert');
-
-const callbackMap = new SafeWeakMap();
-function setCallbackForWrap(wrap, data) {
-  callbackMap.set(wrap, data);
-}
 
 let defaultConditions;
 function getDefaultConditions() {
@@ -73,21 +70,75 @@ function getConditionsSet(conditions) {
   return getDefaultConditionsSet();
 }
 
-function initializeImportMetaObject(wrap, meta) {
-  if (callbackMap.has(wrap)) {
-    const { initializeImportMeta } = callbackMap.get(wrap);
+/**
+ * @callback ImportModuleDynamicallyCallback
+ * @param {string} specifier
+ * @param {ModuleWrap|ContextifyScript|Function|vm.Module} callbackReferrer
+ * @param {object} assertions
+ * @returns { Promise<void> }
+ */
+
+/**
+ * @callback InitializeImportMetaCallback
+ * @param {object} meta
+ * @param {ModuleWrap|ContextifyScript|Function|vm.Module} callbackReferrer
+ */
+
+/**
+ * @typedef {{
+ *   callbackReferrer: ModuleWrap|ContextifyScript|Function|vm.Module
+ *   initializeImportMeta? : InitializeImportMetaCallback,
+ *   importModuleDynamically? : ImportModuleDynamicallyCallback
+ * }} ModuleRegistry
+ */
+
+/**
+ * @type {WeakMap<symbol, ModuleRegistry>}
+ */
+const moduleRegistries = new SafeWeakMap();
+
+/**
+ * V8 would make sure that as long as import() can still be initiated from
+ * the referrer, the symbol referenced by |host_defined_option_symbol| should
+ * be alive, which in term would keep the settings object alive through the
+ * WeakMap, and in turn that keeps the referrer object alive, which would be
+ * passed into the callbacks.
+ * The reference goes like this:
+ * [v8::internal::Script] (via host defined options) ----1--> [idSymbol]
+ * [callbackReferrer] (via host_defined_option_symbol) ------2------^  |
+ *                                 ^----------3---- (via WeakMap)------
+ * 1+3 makes sure that as long as import() can still be initiated, the
+ * referrer wrap is still around and can be passed into the callbacks.
+ * 2 is only there so that we can get the id symbol to configure the
+ * weak map.
+ * @param {ModuleWrap|ContextifyScript|Function} referrer The referrer to
+ *   get the id symbol from. This is different from callbackReferrer which
+ *   could be set by the caller.
+ * @param {ModuleRegistry} registry
+ */
+function registerModule(referrer, registry) {
+  const idSymbol = referrer[host_defined_option_symbol];
+  // To prevent it from being GC'ed.
+  registry.callbackReferrer ??= referrer;
+  moduleRegistries.set(idSymbol, registry);
+}
+
+// The native callback
+function initializeImportMetaObject(symbol, meta) {
+  if (moduleRegistries.has(symbol)) {
+    const { initializeImportMeta, callbackReferrer } = moduleRegistries.get(symbol);
     if (initializeImportMeta !== undefined) {
-      meta = initializeImportMeta(meta, getModuleFromWrap(wrap) || wrap);
+      meta = initializeImportMeta(meta, callbackReferrer);
     }
   }
 }
 
-async function importModuleDynamicallyCallback(wrap, specifier, assertions) {
-  if (callbackMap.has(wrap)) {
-    const { importModuleDynamically } = callbackMap.get(wrap);
+// The native callback
+async function importModuleDynamicallyCallback(symbol, specifier, assertions) {
+  if (moduleRegistries.has(symbol)) {
+    const { importModuleDynamically, callbackReferrer } = moduleRegistries.get(symbol);
     if (importModuleDynamically !== undefined) {
-      return importModuleDynamically(
-        specifier, getModuleFromWrap(wrap) || wrap, assertions);
+      return importModuleDynamically(specifier, callbackReferrer, assertions);
     }
   }
   throw new ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING();
@@ -149,7 +200,7 @@ async function initializeHooks() {
 }
 
 module.exports = {
-  setCallbackForWrap,
+  registerModule,
   initializeESM,
   initializeHooks,
   getDefaultConditions,

--- a/lib/internal/vm.js
+++ b/lib/internal/vm.js
@@ -100,9 +100,10 @@ function internalCompileFunction(code, params, options) {
     const { importModuleDynamicallyWrap } = require('internal/vm/module');
     const wrapped = importModuleDynamicallyWrap(importModuleDynamically);
     const func = result.function;
-    const { setCallbackForWrap } = require('internal/modules/esm/utils');
-    setCallbackForWrap(result.cacheKey, {
-      importModuleDynamically: (s, _k, i) => wrapped(s, func, i),
+    const { registerModule } = require('internal/modules/esm/utils');
+    registerModule(func, {
+      __proto__: null,
+      importModuleDynamically: wrapped,
     });
   }
 

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -11,7 +11,6 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
   SafePromiseAllReturnVoid,
-  SafeWeakMap,
   Symbol,
   SymbolToStringTag,
   TypeError,
@@ -69,7 +68,6 @@ const STATUS_MAP = {
 
 let globalModuleId = 0;
 const defaultModuleName = 'vm:module';
-const wrapToModuleMap = new SafeWeakMap();
 
 const kWrap = Symbol('kWrap');
 const kContext = Symbol('kContext');
@@ -120,17 +118,18 @@ class Module {
       });
     }
 
+    let registry = { __proto__: null };
     if (sourceText !== undefined) {
       this[kWrap] = new ModuleWrap(identifier, context, sourceText,
                                    options.lineOffset, options.columnOffset,
                                    options.cachedData);
-      const { setCallbackForWrap } = require('internal/modules/esm/utils');
-      setCallbackForWrap(this[kWrap], {
+      registry = {
+        __proto__: null,
         initializeImportMeta: options.initializeImportMeta,
         importModuleDynamically: options.importModuleDynamically ?
           importModuleDynamicallyWrap(options.importModuleDynamically) :
           undefined,
-      });
+      };
     } else {
       assert(syntheticEvaluationSteps);
       this[kWrap] = new ModuleWrap(identifier, context,
@@ -138,7 +137,11 @@ class Module {
                                    syntheticEvaluationSteps);
     }
 
-    wrapToModuleMap.set(this[kWrap], this);
+    // This will take precedence over the referrer as the object being
+    // passed into the callbacks.
+    registry.callbackReferrer = this;
+    const { registerModule } = require('internal/modules/esm/utils');
+    registerModule(this[kWrap], registry);
 
     this[kContext] = context;
   }
@@ -445,5 +448,4 @@ module.exports = {
   SourceTextModule,
   SyntheticModule,
   importModuleDynamicallyWrap,
-  getModuleFromWrap: (wrap) => wrapToModuleMap.get(wrap),
 };

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -105,8 +105,9 @@ class Script extends ContextifyScript {
       validateFunction(importModuleDynamically,
                        'options.importModuleDynamically');
       const { importModuleDynamicallyWrap } = require('internal/vm/module');
-      const { setCallbackForWrap } = require('internal/modules/esm/utils');
-      setCallbackForWrap(this, {
+      const { registerModule } = require('internal/modules/esm/utils');
+      registerModule(this, {
+        __proto__: null,
         importModuleDynamically:
           importModuleDynamicallyWrap(importModuleDynamically),
       });

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -393,16 +393,6 @@ inline AliasedInt32Array& Environment::stream_base_state() {
   return stream_base_state_;
 }
 
-inline uint32_t Environment::get_next_module_id() {
-  return module_id_counter_++;
-}
-inline uint32_t Environment::get_next_script_id() {
-  return script_id_counter_++;
-}
-inline uint32_t Environment::get_next_function_id() {
-  return function_id_counter_++;
-}
-
 ShouldNotAbortOnUncaughtScope::ShouldNotAbortOnUncaughtScope(
     Environment* env)
     : env_(env) {

--- a/src/env.h
+++ b/src/env.h
@@ -746,14 +746,6 @@ class Environment : public MemoryRetainer {
   builtins::BuiltinLoader* builtin_loader();
 
   std::unordered_multimap<int, loader::ModuleWrap*> hash_to_module_map;
-  std::unordered_map<uint32_t, loader::ModuleWrap*> id_to_module_map;
-  std::unordered_map<uint32_t, contextify::ContextifyScript*>
-      id_to_script_map;
-  std::unordered_map<uint32_t, contextify::CompiledFnEntry*> id_to_function_map;
-
-  inline uint32_t get_next_module_id();
-  inline uint32_t get_next_script_id();
-  inline uint32_t get_next_function_id();
 
   EnabledDebugList* enabled_debug_list() { return &enabled_debug_list_; }
 

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -22,6 +22,7 @@
   V(contextify_context_private_symbol, "node:contextify:context")              \
   V(decorated_private_symbol, "node:decorated")                                \
   V(transfer_mode_private_symbol, "node:transfer_mode")                        \
+  V(host_defined_option_symbol, "node:host_defined_option_symbol")             \
   V(js_transferable_wrapper_private_symbol, "node:js_transferable_wrapper")    \
   V(napi_type_tag, "node:napi:type_tag")                                       \
   V(napi_wrapper, "node:napi:wrapper")                                         \
@@ -342,7 +343,6 @@
   V(blocklist_constructor_template, v8::FunctionTemplate)                      \
   V(contextify_global_template, v8::ObjectTemplate)                            \
   V(contextify_wrapper_template, v8::ObjectTemplate)                           \
-  V(compiled_fn_entry_template, v8::ObjectTemplate)                            \
   V(crypto_key_object_handle_constructor, v8::FunctionTemplate)                \
   V(env_proxy_template, v8::ObjectTemplate)                                    \
   V(env_proxy_ctor_template, v8::FunctionTemplate)                             \

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -64,6 +64,7 @@ ModuleWrap::ModuleWrap(Environment* env,
   if (!synthetic_evaluation_step->IsUndefined()) {
     synthetic_ = true;
   }
+  MakeWeak();
 }
 
 ModuleWrap::~ModuleWrap() {

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -55,7 +55,10 @@ ModuleWrap::ModuleWrap(Environment* env,
                        Local<String> url,
                        Local<Object> context_object,
                        Local<Value> synthetic_evaluation_step)
-    : BaseObject(env, object), module_(env->isolate(), module) {
+    : BaseObject(env, object),
+      module_(env->isolate(), module),
+      module_hash_(module->GetIdentityHash()) {
+  object->SetInternalField(kModuleSlot, module);
   object->SetInternalField(kURLSlot, url);
   object->SetInternalField(kSyntheticEvaluationStepsSlot,
                            synthetic_evaluation_step);
@@ -65,12 +68,12 @@ ModuleWrap::ModuleWrap(Environment* env,
     synthetic_ = true;
   }
   MakeWeak();
+  module_.SetWeak();
 }
 
 ModuleWrap::~ModuleWrap() {
   HandleScope scope(env()->isolate());
-  Local<Module> module = module_.Get(env()->isolate());
-  auto range = env()->hash_to_module_map.equal_range(module->GetIdentityHash());
+  auto range = env()->hash_to_module_map.equal_range(module_hash_);
   for (auto it = range.first; it != range.second; ++it) {
     if (it->second == this) {
       env()->hash_to_module_map.erase(it);

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -33,7 +33,7 @@ enum HostDefinedOptions : int {
 class ModuleWrap : public BaseObject {
  public:
   enum InternalFields {
-    kModuleWrapBaseField = BaseObject::kInternalFieldCount,
+    kModuleSlot = BaseObject::kInternalFieldCount,
     kURLSlot,
     kSyntheticEvaluationStepsSlot,
     kContextObjectSlot,  // Object whose creation context is the target Context
@@ -106,6 +106,7 @@ class ModuleWrap : public BaseObject {
   contextify::ContextifyContext* contextify_context_ = nullptr;
   bool synthetic_ = false;
   bool linked_ = false;
+  int module_hash_;
 };
 
 }  // namespace loader

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -26,9 +26,8 @@ enum ScriptType : int {
 };
 
 enum HostDefinedOptions : int {
-  kType = 8,
-  kID = 9,
-  kLength = 10,
+  kID = 8,
+  kLength = 9,
 };
 
 class ModuleWrap : public BaseObject {
@@ -55,9 +54,7 @@ class ModuleWrap : public BaseObject {
     tracker->TrackField("resolve_cache", resolve_cache_);
   }
 
-  inline uint32_t id() { return id_; }
   v8::Local<v8::Context> context() const;
-  static ModuleWrap* GetFromID(node::Environment*, uint32_t id);
 
   SET_MEMORY_INFO_NAME(ModuleWrap)
   SET_SELF_SIZE(ModuleWrap)
@@ -109,7 +106,6 @@ class ModuleWrap : public BaseObject {
   contextify::ContextifyContext* contextify_context_ = nullptr;
   bool synthetic_ = false;
   bool linked_ = false;
-  uint32_t id_;
 };
 
 }  // namespace loader

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -855,7 +855,10 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
                      "ContextifyScript::New");
     return;
   }
+
   contextify_script->script_.Reset(isolate, v8_script);
+  contextify_script->script_.SetWeak();
+  contextify_script->object()->SetInternalField(kUnboundScriptSlot, v8_script);
 
   std::unique_ptr<ScriptCompiler::CachedData> new_cached_data;
   if (produce_cached_data) {

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -128,6 +128,11 @@ class ContextifyContext : public BaseObject {
 
 class ContextifyScript : public BaseObject {
  public:
+  enum InternalFields {
+    kUnboundScriptSlot = BaseObject::kInternalFieldCount,
+    kInternalFieldCount
+  };
+
   SET_NO_MEMORY_INFO()
   SET_MEMORY_INFO_NAME(ContextifyScript)
   SET_SELF_SIZE(ContextifyScript)

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -151,32 +151,8 @@ class ContextifyScript : public BaseObject {
                           v8::MicrotaskQueue* microtask_queue,
                           const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  inline uint32_t id() { return id_; }
-
  private:
   v8::Global<v8::UnboundScript> script_;
-  uint32_t id_;
-};
-
-class CompiledFnEntry final : public BaseObject {
- public:
-  SET_NO_MEMORY_INFO()
-  SET_MEMORY_INFO_NAME(CompiledFnEntry)
-  SET_SELF_SIZE(CompiledFnEntry)
-
-  CompiledFnEntry(Environment* env,
-                  v8::Local<v8::Object> object,
-                  uint32_t id,
-                  v8::Local<v8::Function> fn);
-  ~CompiledFnEntry();
-
-  bool IsNotIndicativeOfMemoryLeakAtExit() const override { return true; }
-
- private:
-  uint32_t id_;
-  v8::Global<v8::Function> fn_;
-
-  static void WeakCallback(const v8::WeakCallbackInfo<CompiledFnEntry>& data);
 };
 
 v8::Maybe<bool> StoreCodeCacheResult(

--- a/test/es-module/test-dynamic-import-script-lifetime.js
+++ b/test/es-module/test-dynamic-import-script-lifetime.js
@@ -1,0 +1,32 @@
+// Flags: --expose-gc --experimental-vm-modules
+
+'use strict';
+
+// This tests that vm.Script would not get GC'ed while the script can still
+// initiate dynamic import.
+// See https://github.com/nodejs/node/issues/43205.
+
+require('../common');
+const vm = require('vm');
+
+const code = `
+new Promise(resolve => {
+  setTimeout(() => {
+    gc();  // vm.Script should not be GC'ed while the script is alive.
+    resolve();
+  }, 1);
+}).then(() => import('foo'));`;
+
+// vm.runInThisContext creates a vm.Script underneath, which should not be GC'ed
+// while import() can still be initiated.
+vm.runInThisContext(code, {
+  async importModuleDynamically() {
+    const m = new vm.SyntheticModule(['bar'], () => {
+      m.setExport('bar', 1);
+    });
+
+    await m.link(() => {});
+    await m.evaluate();
+    return m;
+  }
+});

--- a/test/es-module/test-vm-compile-function-leak.js
+++ b/test/es-module/test-vm-compile-function-leak.js
@@ -1,0 +1,19 @@
+// Flags: --max-old-space-size=16 --trace-gc
+'use strict';
+
+// This tests that vm.compileFunction with dynamic import callback does not leak.
+// See https://github.com/nodejs/node/issues/44211
+require('../common');
+const vm = require('vm');
+let count = 0;
+
+function main() {
+  // Try to reach the maximum old space size.
+  vm.compileFunction(`"${Math.random().toString().repeat(512)}"`, [], {
+    async importModuleDynamically() {},
+  });
+  if (count++ < 2048) {
+    setTimeout(main, 1);
+  }
+}
+main();

--- a/test/es-module/test-vm-contextified-script-leak.js
+++ b/test/es-module/test-vm-contextified-script-leak.js
@@ -1,0 +1,19 @@
+// Flags: --max-old-space-size=16 --trace-gc
+'use strict';
+
+// This tests that vm.Script with dynamic import callback does not leak.
+// See: https://github.com/nodejs/node/issues/33439
+require('../common');
+const vm = require('vm');
+let count = 0;
+
+function main() {
+  // Try to reach the maximum old space size.
+  new vm.Script(`"${Math.random().toString().repeat(512)}";`, {
+    async importModuleDynamically() {},
+  });
+  if (count++ < 2 * 1024) {
+    setTimeout(main, 1);
+  }
+}
+main();

--- a/test/es-module/test-vm-source-text-module-leak.js
+++ b/test/es-module/test-vm-source-text-module-leak.js
@@ -1,0 +1,23 @@
+// Flags: --experimental-vm-modules --max-old-space-size=16 --trace-gc
+'use strict';
+
+// This tests that vm.SourceTextModule() does not leak.
+// See: https://github.com/nodejs/node/issues/33439
+require('../common');
+
+const vm = require('vm');
+let count = 0;
+async function createModule() {
+  // Try to reach the maximum old space size.
+  const m = new vm.SourceTextModule(`
+  const bar = new Array(512).fill("----");
+  export { bar };
+`);
+  await m.link(() => {});
+  await m.evaluate();
+  if (count++ < 4096) {
+    setTimeout(createModule, 1);
+  }
+  return m;
+}
+createModule();

--- a/test/es-module/test-vm-synthetic-module-leak.js
+++ b/test/es-module/test-vm-synthetic-module-leak.js
@@ -1,0 +1,23 @@
+// Flags: --experimental-vm-modules --max-old-space-size=16
+'use strict';
+
+// This tests that vm.SyntheticModule does not leak.
+// See https://github.com/nodejs/node/issues/44211
+require('../common');
+const vm = require('vm');
+
+let count = 0;
+async function createModule() {
+  // Try to reach the maximum old space size.
+  const m = new vm.SyntheticModule(['bar'], () => {
+    m.setExport('bar', new Array(512).fill('----'));
+  });
+  await m.link(() => {});
+  await m.evaluate();
+  if (count++ < 4 * 1024) {
+    setTimeout(createModule, 1);
+  }
+  return m;
+}
+
+createModule();


### PR DESCRIPTION
This PR (hopefully) fixes a bunch of memory leaks & use-after-free surrounding `vm.Script`, `vm.compileFunction`, `vm.SyntheticModule` and `vm.SourceTextModule` when dynamic import is used (see the issues referenced below) and makes it possible for people to upgrade from older versions of Node.js.

This cannot land as-is on v20.x as it depends on https://github.com/nodejs/node/pull/49491 and https://github.com/nodejs/node/pull/49419 which break the ABI on v20x. If this proves to fix the issues in the wild without causing regressions, we'll need to do an exceptional breakage of ABI on v20.x to backport it (hopefully before it goes LTS and before v21.x is cut). It might be already too late to break the ABI on v18.x, however.

#### module: use symbol in WeakMap to manage host defined options

Previously when managing the importModuleDynamically callback of
vm.compileFunction(), we use an ID number as the host defined option
and maintain a per-Environment ID -> CompiledFnEntry map to retain
the top-level referrer function returned by vm.compileFunction() in
order to pass it back to the callback, but it would leak because with
how we used v8::Persistent to maintain this reference, V8 would not
be able to understand the cycle and would just think that the
CompiledFnEntry was supposed to live forever. We made an attempt
to make that reference known to V8 by making the CompiledFnEntry weak
and using a private symbol to make CompiledFnEntry strongly
references the top-level referrer function in
https://github.com/nodejs/node/pull/46785, but that turned out to be
unsound, because the there's no guarantee that the top-level function
must be alive while import() can still be initiated from that
function, since V8 could discard the top-level function and only keep
inner functions alive, so relying on the top-level function to keep
the CompiledFnEntry alive could result in use-after-free which caused
a revert of that fix.

With this patch we use a symbol in the host defined options instead of
a number, because with the stage-3 symbol-as-weakmap-keys proposal
we could directly use that symbol to keep the referrer alive using a
WeakMap. As a bonus this also keeps the other kinds of referrers
alive as long as import() can still be initiated from that
Script/Module, so this also fixes the long-standing crash caused by
vm.Script being GC'ed too early when its importModuleDynamically
callback still needs it.

#### module: fix leak of vm.SyntheticModule

Previously we maintain a strong persistent reference to the
ModuleWrap to retrieve the ID-to-ModuleWrap mapping from
the HostImportModuleDynamicallyCallback using the number ID
stored in the host-defined options. As a result the ModuleWrap
would be kept alive until the Environment is shut down, which
would be a leak for user code. With the new symbol-based
host-defined option we can just get the ModuleWrap from the
JS-land WeakMap so there's now no need to maintain this
strong reference. This would at least fix the leak for
vm.SyntheticModule. vm.SourceTextModule is still leaking
due to the strong persistent reference to the v8::Module.

#### module: fix the leak in SourceTextModule and ContextifySript
Replace the persistent handles to v8::Module and
v8::UnboundScript with an internal reference that V8's GC is
aware of to fix the leaks.

Refs: https://github.com/nodejs/node/issues/44211
Refs: https://github.com/nodejs/node/issues/42080
Refs: https://github.com/nodejs/node/issues/47096
Refs: https://github.com/nodejs/node/issues/43205
Refs: https://github.com/nodejs/node/issues/38695

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
