### PR TITLE
build: fix `configure --link-module`

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1411,7 +1411,7 @@ def configure_node(o):
   o['variables']['shlib_suffix'] = shlib_suffix
 
   if options.linked_module:
-    o['variables']['library_files'] = options.linked_module
+    o['variables']['linked_module_files'] = options.linked_module
 
   o['variables']['asan'] = int(options.enable_asan or 0)
 

--- a/node.gyp
+++ b/node.gyp
@@ -27,6 +27,8 @@
     'node_lib_target_name%': 'libnode',
     'node_intermediate_lib_type%': 'static_library',
     'node_builtin_modules_path%': '',
+    'linked_module_files': [
+    ],
     # We list the deps/ files out instead of globbing them in js2c.cc since we
     # only include a subset of all the files under these directories.
     # The lengths of their file names combined should not exceed the
@@ -34,6 +36,7 @@
     # See https://docs.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation
     'library_files': [
       '<@(node_library_files)',
+      '<@(linked_module_files)',
     ],
     'deps_files': [
       'deps/v8/tools/splaytree.mjs',
@@ -954,6 +957,7 @@
             'lib',
             'config.gypi',
             '<@(deps_files)',
+            '<@(linked_module_files)',
           ],
         },
       ],


### PR DESCRIPTION
Add the list of linked modules to the arguments for `js2c.py`. These were unintentionally omitted when the build was previously refactored to avoid command line length limits on Windows.

Fixes: https://github.com/nodejs/node/issues/42302
Refs: https://github.com/nodejs/node/pull/39069

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
