### PR TITLE
fs: remove unneeded return statement

### DIFF
--- a/lib/internal/fs/sync_write_stream.js
+++ b/lib/internal/fs/sync_write_stream.js
@@ -25,7 +25,6 @@ ObjectSetPrototypeOf(SyncWriteStream, Writable);
 SyncWriteStream.prototype._write = function(chunk, encoding, cb) {
   writeSync(this.fd, chunk, 0, chunk.length);
   cb();
-  return true;
 };
 
 SyncWriteStream.prototype._destroy = function(err, cb) {

--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -36,7 +36,12 @@ const filename = path.join(tmpdir.path, 'sync-write-stream.txt');
   const stream = new SyncWriteStream(fd);
   const chunk = Buffer.from('foo');
 
-  assert.strictEqual(stream._write(chunk, null, common.mustCall(1)), true);
+  let calledSynchronously = false;
+  stream._write(chunk, null, common.mustCall(() => {
+    calledSynchronously = true;
+  }, 1));
+
+  assert.ok(calledSynchronously);
   assert.strictEqual(fs.readFileSync(filename).equals(chunk), true);
 
   fs.closeSync(fd);


### PR DESCRIPTION
The `writable._write()` implementation does not need to return anything, only call the callback.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
