### PR TITLE
permission: handle end nodes with children cases

### DIFF
--- a/src/permission/fs_permission.cc
+++ b/src/permission/fs_permission.cc
@@ -130,7 +130,6 @@ bool FSPermission::RadixTree::Lookup(const std::string_view& s,
   if (current_node->children.size() == 0) {
     return when_empty_return;
   }
-
   unsigned int parent_node_prefix_len = current_node->prefix.length();
   const std::string path(s);
   auto path_len = path.length();

--- a/src/permission/fs_permission.h
+++ b/src/permission/fs_permission.h
@@ -25,13 +25,18 @@ class FSPermission final : public PermissionBase {
       std::string prefix;
       std::unordered_map<char, Node*> children;
       Node* wildcard_child;
+      bool is_leaf;
 
       explicit Node(const std::string& pre)
-          : prefix(pre), wildcard_child(nullptr) {}
+          : prefix(pre), wildcard_child(nullptr), is_leaf(false) {}
 
-      Node() : wildcard_child(nullptr) {}
+      Node() : wildcard_child(nullptr), is_leaf(false) {}
 
       Node* CreateChild(std::string prefix) {
+        if (prefix.empty() && !is_leaf) {
+          is_leaf = true;
+          return this;
+        }
         char label = prefix[0];
 
         Node* child = children[label];
@@ -56,6 +61,7 @@ class FSPermission final : public PermissionBase {
             return split_child->CreateChild(prefix.substr(i));
           }
         }
+        child->is_leaf = true;
         return child->CreateChild(prefix.substr(i));
       }
 
@@ -114,7 +120,7 @@ class FSPermission final : public PermissionBase {
         if (children.size() == 0) {
           return true;
         }
-        return children['\0'] != nullptr;
+        return is_leaf;
       }
     };
 

--- a/test/parallel/test-permission-fs-wildcard.js
+++ b/test/parallel/test-permission-fs-wildcard.js
@@ -59,6 +59,9 @@ if (common.isWindows) {
     '/slower',
     '/slown',
     '/home/foo/*',
+    '/files/index.js',
+    '/files/index.json',
+    '/files/i',
   ];
   const { status, stderr } = spawnSync(
     process.execPath,
@@ -74,6 +77,10 @@ if (common.isWindows) {
         assert.ok(process.permission.has('fs.read', '/home/foo'));
         assert.ok(process.permission.has('fs.read', '/home/foo/'));
         assert.ok(!process.permission.has('fs.read', '/home/fo'));
+        assert.ok(process.permission.has('fs.read', '/files/index.js'));
+        assert.ok(process.permission.has('fs.read', '/files/index.json'));
+        assert.ok(!process.permission.has('fs.read', '/files/index.j'));
+        assert.ok(process.permission.has('fs.read', '/files/i'));
       `,
     ]
   );


### PR DESCRIPTION
When two paths overlaps, the permission model returns a false negative cause the Node* doesn't contain an empty child ("") to consider it as an end node. For instance, if you call `--allow-fs-read=/home/index.js,/home/index.json` and call process.permission.has for both paths, it will return false for the `index.js` since it will create the following radix tree:

```
Child /
  Prefix: /home/index.js
  Child o
    Prefix: on
    End of tree: on
  End of tree(c): /home/index.js
End of tree(c):
```

and if you invert the parameters order: `--allow-fs-read=/home/index.json,/home/index.js` it will create an empty child for "/home/index.js" indicating "end node".

To handle it I've included a new parameter to `Node*`: `is_leaf`.