### PR TITLE
bootstrap: hide experimental web globals with flag kNoBrowserGlobals

### DIFF
--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -14,6 +14,7 @@ const {
 const {
   getOptionValue,
   refreshOptions,
+  getEmbedderOptions,
 } = require('internal/options');
 const { reconnectZeroFillToggle } = require('internal/buffer');
 const {
@@ -220,7 +221,7 @@ function setupWarningHandler() {
 
 // https://fetch.spec.whatwg.org/
 function setupFetch() {
-  if (process.config.variables.node_no_browser_globals ||
+  if (getEmbedderOptions().noBrowserGlobals ||
       getOptionValue('--no-experimental-fetch')) {
     return;
   }
@@ -270,7 +271,7 @@ function setupFetch() {
 // TODO(aduh95): move this to internal/bootstrap/web/* when the CLI flag is
 //               removed.
 function setupWebCrypto() {
-  if (process.config.variables.node_no_browser_globals ||
+  if (getEmbedderOptions().noBrowserGlobals ||
       getOptionValue('--no-experimental-global-webcrypto')) {
     return;
   }
@@ -318,7 +319,7 @@ function setupCodeCoverage() {
 // TODO(daeyeon): move this to internal/bootstrap/web/* when the CLI flag is
 //                removed.
 function setupCustomEvent() {
-  if (process.config.variables.node_no_browser_globals ||
+  if (getEmbedderOptions().noBrowserGlobals ||
       getOptionValue('--no-experimental-global-customevent')) {
     return;
   }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1239,6 +1239,12 @@ void GetEmbedderOptions(const FunctionCallbackInfo<Value>& args) {
            Boolean::New(isolate, env->no_global_search_paths()))
       .IsNothing()) return;
 
+  if (ret->Set(context,
+               FIXED_ONE_BYTE_STRING(env->isolate(), "noBrowserGlobals"),
+               Boolean::New(isolate, env->no_browser_globals()))
+          .IsNothing())
+    return;
+
   args.GetReturnValue().Set(ret);
 }
 

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -38,6 +38,39 @@ class EnvironmentTest : public EnvironmentTestFixture {
   }
 };
 
+TEST_F(EnvironmentTest, EnvironmentWithoutBrowserGlobals) {
+  const v8::HandleScope handle_scope(isolate_);
+  Argv argv;
+  Env env{handle_scope, argv, node::EnvironmentFlags::kNoBrowserGlobals};
+
+  SetProcessExitHandler(*env, [&](node::Environment* env_, int exit_code) {
+    EXPECT_EQ(*env, env_);
+    EXPECT_EQ(exit_code, 0);
+    node::Stop(*env);
+  });
+
+  node::LoadEnvironment(
+      *env,
+      "const assert = require('assert');"
+      "const path = require('path');"
+      "const relativeRequire = "
+      "  require('module').createRequire(path.join(process.cwd(), 'stub.js'));"
+      "const { intrinsics, nodeGlobals } = "
+      "  relativeRequire('./test/common/globals');"
+      "const items = Object.getOwnPropertyNames(globalThis);"
+      "const leaks = [];"
+      "for (const item of items) {"
+      "  if (intrinsics.has(item)) {"
+      "    continue;"
+      "  }"
+      "  if (nodeGlobals.has(item)) {"
+      "    continue;"
+      "  }"
+      "  leaks.push(item);"
+      "}"
+      "assert.deepStrictEqual(leaks, []);");
+}
+
 TEST_F(EnvironmentTest, EnvironmentWithESMLoader) {
   const v8::HandleScope handle_scope(isolate_);
   Argv argv;


### PR DESCRIPTION
Do not install experimental web globals when the environment is
initialized with embedder flag
`node::EnvironmentFlags::kNoBrowserGlobals`.