### PR TITLE
test: add Symbol.dispose support to mocktimers

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1582,7 +1582,7 @@ mock.timers.reset();
 
 ### `timers[Symbol.dispose]()`
 
-An alias for `timers.reset()`.
+Calls `timers.reset()`.
 
 ### `timers.tick(milliseconds)`
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1580,6 +1580,10 @@ const { mock } = require('node:test');
 mock.timers.reset();
 ```
 
+### `timers[Symbol.dispose]()`
+
+An alias for `timers.reset()`.
+
 ### `timers.tick(milliseconds)`
 
 <!-- YAML

--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -13,6 +13,7 @@ const {
   FunctionPrototypeBind,
   Promise,
   SymbolAsyncIterator,
+  SymbolDispose,
   globalThis,
 } = primordials;
 const {
@@ -314,6 +315,10 @@ class MockTimers {
     this.#timersInContext = timers;
     this.#now = DateNow();
     this.#toggleEnableTimers(true);
+  }
+
+  [SymbolDispose]() {
+    this.reset();
   }
 
   reset() {

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -61,6 +61,21 @@ describe('Mock Timers Test Suite', () => {
       assert.strictEqual(fn.mock.callCount(), 0);
     });
 
+    it('should reset all timers when calling Symbol.dispose', (t) => {
+      t.mock.timers.enable();
+      const fn = t.mock.fn();
+      global.setTimeout(fn, 1000);
+      // TODO(benjamingr) refactor to `using`
+      t.mock.timers[Symbol.dispose]();
+      assert.throws(() => {
+        t.mock.timers.tick(1000);
+      }, {
+        code: 'ERR_INVALID_STATE',
+      });
+
+      assert.strictEqual(fn.mock.callCount(), 0);
+    });
+
     it('should execute in order if timeout is the same', (t) => {
       t.mock.timers.enable();
       const order = [];


### PR DESCRIPTION
Support Symbol.dispose in mock timers. Letting users of TS/Babel (and everyone else as soon as v8 ships) use `using` with the mock timers.

cc @ErickWendel @nodejs/test_runner 

