### PR TITLE
Feat/exec stdio

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -168,6 +168,9 @@ changes:
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.
     **Default:** `process.cwd()`.
+  * `input` {string|Buffer|TypedArray|DataView} The value which will be passed
+    as stdin to the spawned process. Supplying this value will override
+    `stdio[0]`.
   * `stdio` {string|Array} Child's stdio configuration. `stderr` by default will
     be output to the parent process' stderr unless `stdio` is specified.
     **Default:** `'pipe'`.
@@ -305,6 +308,9 @@ changes:
 * `args` {string\[]} List of string arguments.
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.
+  * `input` {string|Buffer|TypedArray|DataView} The value which will be passed
+    as stdin to the spawned process. Supplying this value will override
+    `stdio[0]`.
   * `stdio` {string|Array} Child's stdio configuration. `stderr` by default will
     be output to the parent process' stderr unless `stdio` is specified.
     **Default:** `'pipe'`.
@@ -569,6 +575,9 @@ changes:
 * `args` {string\[]} List of string arguments.
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.
+  * `input` {string|Buffer|TypedArray|DataView} The value which will be passed
+    as stdin to the spawned process. Supplying this value will override
+    `stdio[0]`.
   * `env` {Object} Environment key-value pairs. **Default:** `process.env`.
   * `argv0` {string} Explicitly set the value of `argv[0]` sent to the child
     process. This will be set to `command` if not specified.

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -168,6 +168,9 @@ changes:
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.
     **Default:** `process.cwd()`.
+  * `stdio` {string|Array} Child's stdio configuration. `stderr` by default will
+    be output to the parent process' stderr unless `stdio` is specified.
+    **Default:** `'pipe'`.
   * `env` {Object} Environment key-value pairs. **Default:** `process.env`.
   * `encoding` {string} **Default:** `'utf8'`
   * `shell` {string} Shell to execute the command with. See
@@ -302,6 +305,9 @@ changes:
 * `args` {string\[]} List of string arguments.
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.
+  * `stdio` {string|Array} Child's stdio configuration. `stderr` by default will
+    be output to the parent process' stderr unless `stdio` is specified.
+    **Default:** `'pipe'`.
   * `env` {Object} Environment key-value pairs. **Default:** `process.env`.
   * `encoding` {string} **Default:** `'utf8'`
   * `timeout` {number} **Default:** `0`

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -209,6 +209,7 @@ function normalizeExecArgs(command, options, callback) {
  * @param {string} command
  * @param {{
  *   cmd?: string;
+ *   input?: string | Buffer | TypedArray | DataView;
  *   stdio?: Array | string;
  *   env?: Record<string, string>;
  *   encoding?: string;
@@ -303,6 +304,7 @@ function normalizeExecFileArgs(file, args, options, callback) {
  * @param {string[]} [args]
  * @param {{
  *   cwd?: string;
+ *   input?: string | Buffer | TypedArray | DataView;
  *   stdio?: Array | string;
  *   env?: Record<string, string>;
  *   encoding?: string;
@@ -347,6 +349,7 @@ function execFile(file, args, options, callback) {
 
   const child = spawn(file, args, {
     cwd: options.cwd,
+    input: options.input,
     stdio: options.stdio,
     env: options.env,
     gid: options.gid,
@@ -731,6 +734,7 @@ function abortChildProcess(child, killSignal, reason) {
  * @param {string[]} [args]
  * @param {{
  *   cwd?: string;
+ *   input?: string | Buffer | TypedArray | DataView;
  *   env?: Record<string, string>;
  *   argv0?: string;
  *   stdio?: Array | string;
@@ -755,6 +759,22 @@ function spawn(file, args, options) {
   const child = new ChildProcess();
 
   debug('spawn', options);
+  let input = options.input;
+  if (options.input) {
+    if (isArrayBufferView(input)) {
+      input = Buffer.from(input.buffer, input.byteOffset, input.byteLength);
+    } else if (typeof input === 'string') {
+      input = Buffer.from(input, options.encoding);
+    } else {
+      throw new ERR_INVALID_ARG_TYPE('options.input',
+                                     ['Buffer',
+                                      'TypedArray',
+                                      'DataView',
+                                      'string'],
+                                     input);
+    }
+  }
+
   child.spawn(options);
 
   if (options.timeout > 0) {
@@ -790,6 +810,10 @@ function spawn(file, args, options) {
     function onAbortListener() {
       abortChildProcess(child, killSignal, options.signal.reason);
     }
+  }
+
+  if (options.input) {
+    child.stdin.end(input);
   }
 
   return child;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -209,6 +209,7 @@ function normalizeExecArgs(command, options, callback) {
  * @param {string} command
  * @param {{
  *   cmd?: string;
+ *   stdio?: Array | string;
  *   env?: Record<string, string>;
  *   encoding?: string;
  *   shell?: string;
@@ -229,9 +230,7 @@ function normalizeExecArgs(command, options, callback) {
  */
 function exec(command, options, callback) {
   const opts = normalizeExecArgs(command, options, callback);
-  return module.exports.execFile(opts.file,
-                                 opts.options,
-                                 opts.callback);
+  return execFile(opts.file, opts.options, opts.callback);
 }
 
 const customPromiseExecFunction = (orig) => {
@@ -304,6 +303,7 @@ function normalizeExecFileArgs(file, args, options, callback) {
  * @param {string[]} [args]
  * @param {{
  *   cwd?: string;
+ *   stdio?: Array | string;
  *   env?: Record<string, string>;
  *   encoding?: string;
  *   timeout?: number;
@@ -347,6 +347,7 @@ function execFile(file, args, options, callback) {
 
   const child = spawn(file, args, {
     cwd: options.cwd,
+    stdio: options.stdio,
     env: options.env,
     gid: options.gid,
     shell: options.shell,

--- a/test/parallel/test-child-process-exec-stdio-ignore.js
+++ b/test/parallel/test-child-process-exec-stdio-ignore.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+if (process.argv[2] === 'child') {
+  process.stdout.write('this should be ignored');
+  process.stderr.write('this should not be ignored');
+
+} else {
+  const cmd = `"${process.execPath}" "${__filename}" child`;
+  cp.exec(cmd,
+          { stdio: ['pipe', 'ignore', 'pipe'] },
+          common.mustCall((err, stdout, stderr) => {
+            assert.strictEqual(stderr, 'this should not be ignored');
+            assert.strictEqual(stdout, '');
+          }));
+}

--- a/test/parallel/test-child-process-exec-stdio-inherit.js
+++ b/test/parallel/test-child-process-exec-stdio-inherit.js
@@ -1,24 +1,3 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 'use strict';
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-child-process-exec-stdio-inherit.js
+++ b/test/parallel/test-child-process-exec-stdio-inherit.js
@@ -1,0 +1,46 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+require('../common');
+const assert = require('assert');
+const exec = require('child_process').exec;
+
+if (process.argv[2] === 'parent')
+  parent();
+else
+  grandparent();
+
+function grandparent() {
+  const cmd = `"${process.execPath}" "${__filename}" parent`;
+  const input = 'asdfasdf';
+  const child = exec(cmd, (err, stdout, stderr) => {
+    assert.strictEqual(stdout.trim(), input.trim());
+  });
+  child.stderr.pipe(process.stderr);
+
+  child.stdin.end(input);
+}
+
+function parent() {
+  // Should not immediately exit.
+  exec('cat', { stdio: 'inherit' });
+}

--- a/test/parallel/test-child-process-execfile-stdio-ignore.js
+++ b/test/parallel/test-child-process-execfile-stdio-ignore.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+if (process.argv[2] === 'child') {
+  process.stdout.write('this should be ignored');
+  process.stderr.write('this should not be ignored');
+
+} else {
+  cp.execFile(process.execPath,
+              [__filename, 'child'],
+              { stdio: ['pipe', 'ignore', 'pipe'] },
+              common.mustCall((err, stdout, stderr) => {
+                assert.strictEqual(stderr, 'this should not be ignored');
+                assert.strictEqual(stdout, '');
+              }));
+}

--- a/test/parallel/test-child-process-execfile-stdio-inherit.js
+++ b/test/parallel/test-child-process-execfile-stdio-inherit.js
@@ -1,24 +1,3 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 'use strict';
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-child-process-execfile-stdio-inherit.js
+++ b/test/parallel/test-child-process-execfile-stdio-inherit.js
@@ -1,0 +1,45 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+require('../common');
+const assert = require('assert');
+const execFile = require('child_process').execFile;
+
+if (process.argv[2] === 'parent')
+  parent();
+else
+  grandparent();
+
+function grandparent() {
+  const input = 'asdfasdf';
+  const child = execFile(process.execPath, [__filename, 'parent'], (err, stdout, stderr) => {
+    assert.strictEqual(stdout.trim(), input.trim());
+  });
+  child.stderr.pipe(process.stderr);
+
+  child.stdin.end(input);
+}
+
+function parent() {
+  // Should not immediately exit.
+  execFile('cat', [], { stdio: 'inherit' });
+}

--- a/test/parallel/test-child-process-spawn-input.js
+++ b/test/parallel/test-child-process-spawn-input.js
@@ -1,24 +1,3 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 'use strict';
 const common = require('../common');
 

--- a/test/parallel/test-child-process-spawn-input.js
+++ b/test/parallel/test-child-process-spawn-input.js
@@ -1,0 +1,85 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+
+const assert = require('assert');
+
+const spawn = require('child_process').spawn;
+
+const badOptions = {
+  input: 1234
+};
+
+assert.throws(
+  () => spawn('cat', [], badOptions),
+  { code: 'ERR_INVALID_ARG_TYPE', name: 'TypeError' });
+
+const stringOptions = {
+  input: 'hello world'
+};
+
+const catString = spawn('cat', [], stringOptions);
+
+catString.stdout.on('data', common.mustCall((data) => {
+  assert.strictEqual(data.toString('utf8'), stringOptions.input);
+}));
+
+catString.on('close', common.mustCall((code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+}));
+
+const bufferOptions = {
+  input: Buffer.from('hello world')
+};
+
+const catBuffer = spawn('cat', [], bufferOptions);
+
+catBuffer.stdout.on('data', common.mustCall((data) => {
+  assert.deepStrictEqual(data, bufferOptions.input);
+}));
+
+catBuffer.on('close', common.mustCall((code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+}));
+
+// common.getArrayBufferViews expects a buffer
+// with length an multiple of 8
+const msgBuf = Buffer.from('hello world'.repeat(8));
+for (const arrayBufferView of common.getArrayBufferViews(msgBuf)) {
+  const options = {
+    input: arrayBufferView
+  };
+
+  const catArrayBufferView = spawn('cat', [], options);
+
+  catArrayBufferView.stdout.on('data', common.mustCall((data) => {
+    assert.deepStrictEqual(data, msgBuf);
+  }));
+
+  catArrayBufferView.on('close', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR attempts to add input and stdio options to child process async method who hadn't while its sync counterparts did. `spawn` only input and `exec` and `execFile` both.

Fixes https://github.com/nodejs/node/issues/45306
Fixes https://github.com/nodejs/node/issues/25231