### PR TITLE
test_runner: todo, only, skip are expected to return a Promise

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -216,9 +216,7 @@ function runInParentContext(Factory) {
 
   const test = (name, options, fn) => run(name, options, fn);
   ArrayPrototypeForEach(['skip', 'todo', 'only'], (keyword) => {
-    test[keyword] = (name, options, fn) => {
-      run(name, options, fn, { [keyword]: true });
-    };
+    test[keyword] = (name, options, fn) => run(name, options, fn, { [keyword]: true });
   });
   return test;
 }

--- a/test/parallel/test-runner-typechecking.js
+++ b/test/parallel/test-runner-typechecking.js
@@ -1,34 +1,36 @@
 'use strict';
-const common = require('../common');
+require('../common');
 
 // Return type of shorthands should be consistent
 // with the return type of test
 
 const assert = require('assert');
-const test = require('node:test');
+const { test, describe, it } = require('node:test');
 const { isPromise } = require('util/types');
 
-const testOnly = test({ only: true });
-const testTodo = test({ todo: true });
-const testSkip = test({ skip: true });
-const testOnlyShorthand = test.only();
-const testTodoShorthand = test.todo();
-const testSkipShorthand = test.skip();
+const testOnly = test('only test', { only: true });
+const testTodo = test('todo test', { todo: true });
+const testSkip = test('skip test', { skip: true });
+const testOnlyShorthand = test.only('only test shorthand');
+const testTodoShorthand = test.todo('todo test shorthand');
+const testSkipShorthand = test.skip('skip test shorthand');
 
-// return Promise
-assert(isPromise(testOnly));
-assert(isPromise(testTodo));
-assert(isPromise(testSkip));
-assert(isPromise(testOnlyShorthand));
-assert(isPromise(testTodoShorthand));
-assert(isPromise(testSkipShorthand));
+describe('\'node:test\' and its shorthands should return the same', () => {
+  it('should return a Promise', () => {
+    assert(isPromise(testOnly));
+    assert(isPromise(testTodo));
+    assert(isPromise(testSkip));
+    assert(isPromise(testOnlyShorthand));
+    assert(isPromise(testTodoShorthand));
+    assert(isPromise(testSkipShorthand));
+  });
 
-// resolve to undefined
-(async () => {
-  assert.strictEqual(await testOnly, undefined);
-  assert.strictEqual(await testTodo, undefined);
-  assert.strictEqual(await testSkip, undefined);
-  assert.strictEqual(await testOnlyShorthand, undefined);
-  assert.strictEqual(await testTodoShorthand, undefined);
-  assert.strictEqual(await testSkipShorthand, undefined);
-})().then(common.mustCall());
+  it('should resolve undefined', async () => {
+    assert.strictEqual(await testOnly, undefined);
+    assert.strictEqual(await testTodo, undefined);
+    assert.strictEqual(await testSkip, undefined);
+    assert.strictEqual(await testOnlyShorthand, undefined);
+    assert.strictEqual(await testTodoShorthand, undefined);
+    assert.strictEqual(await testSkipShorthand, undefined);
+  });
+});

--- a/test/parallel/test-runner-typechecking.js
+++ b/test/parallel/test-runner-typechecking.js
@@ -1,0 +1,34 @@
+'use strict';
+const common = require('../common');
+
+// Return type of shorthands should be consistent
+// with the return type of test
+
+const assert = require('assert');
+const test = require('node:test');
+const { isPromise } = require('util/types');
+
+const testOnly = test({ only: true });
+const testTodo = test({ todo: true });
+const testSkip = test({ skip: true });
+const testOnlyShorthand = test.only();
+const testTodoShorthand = test.todo();
+const testSkipShorthand = test.skip();
+
+// return Promise
+assert(isPromise(testOnly));
+assert(isPromise(testTodo));
+assert(isPromise(testSkip));
+assert(isPromise(testOnlyShorthand));
+assert(isPromise(testTodoShorthand));
+assert(isPromise(testSkipShorthand));
+
+// resolve to undefined
+(async () => {
+  assert.strictEqual(await testOnly, undefined);
+  assert.strictEqual(await testTodo, undefined);
+  assert.strictEqual(await testSkip, undefined);
+  assert.strictEqual(await testOnlyShorthand, undefined);
+  assert.strictEqual(await testTodoShorthand, undefined);
+  assert.strictEqual(await testSkipShorthand, undefined);
+})().then(common.mustCall());


### PR DESCRIPTION
`todo`, `only` and `skip` are shorthands for `test`, so all of them should return the same type.

Currently `todo()` returns `undefined` while `test({ todo: true })` returns a `Promise` that resolves to `undefined`.