### PR TITLE
quic: prevent copying ngtcp2_cid

### DIFF
--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -643,7 +643,7 @@ void Session::Destroy() {
   endpoint_->DisassociateCID(config_.dcid);
   endpoint_->DisassociateCID(config_.preferred_address_cid);
 
-  for (auto cid : cids) endpoint_->DisassociateCID(CID(&cid));
+  for (const auto& cid : cids) endpoint_->DisassociateCID(CID(&cid));
 
   for (const auto& token : tokens) {
     if (token.token_present)


### PR DESCRIPTION
The existing code explicitly uses the `CID(const ngtcp2_cid*)` constructor that does not copy the given `ngtcp2_cid`, but the range-based for loop still unnecessarily copies the `ngtcp2_cid`. Use `auto&` to avoid copying.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
