### PR TITLE
src: Initialize fields accessed by AsyncHooks before AsyncHooks

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -170,15 +170,13 @@ bool AsyncHooks::pop_async_context(double async_id) {
 }
 
 void AsyncHooks::clear_async_id_stack() {
-  if (env()->can_call_into_js()) {
+  if (!js_execution_async_resources_.IsEmpty() && env()->can_call_into_js()) {
     Isolate* isolate = env()->isolate();
     HandleScope handle_scope(isolate);
-    if (!js_execution_async_resources_.IsEmpty()) {
-      USE(PersistentToLocal::Strong(js_execution_async_resources_)
-              ->Set(env()->context(),
-                    env()->length_string(),
-                    Integer::NewFromUnsigned(isolate, 0)));
-    }
+    USE(PersistentToLocal::Strong(js_execution_async_resources_)
+            ->Set(env()->context(),
+                  env()->length_string(),
+                  Integer::NewFromUnsigned(isolate, 0)));
   }
 
   native_execution_async_resources_.clear();

--- a/src/env.h
+++ b/src/env.h
@@ -1015,6 +1015,10 @@ class Environment : public MemoryRetainer {
   uv_async_t task_queues_async_;
   int64_t task_queues_async_refs_ = 0;
 
+  // These may be read by ctors and should be listed before complex fields.
+  std::atomic_bool is_stopping_{false};
+  std::atomic_bool can_call_into_js_{true};
+
   AsyncHooks async_hooks_;
   ImmediateInfo immediate_info_;
   AliasedInt32Array timeout_info_;
@@ -1092,7 +1096,6 @@ class Environment : public MemoryRetainer {
 
   bool has_serialized_options_ = false;
 
-  std::atomic_bool can_call_into_js_ { true };
   uint64_t flags_;
   uint64_t thread_id_;
   std::unordered_set<worker::Worker*> sub_worker_contexts_;
@@ -1149,8 +1152,6 @@ class Environment : public MemoryRetainer {
 
   CleanupQueue cleanup_queue_;
   bool started_cleanup_ = false;
-
-  std::atomic_bool is_stopping_ { false };
 
   std::unordered_set<int> unmanaged_fds_;
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This fixes an issue that was surfaced by an address sanitizer (asan) run:

```
.../cxx_atomic_impl.h:387:12: runtime error: load of value 171, which is not a valid value for type 'bool'
    #0 0x56532ea65fab in can_call_into_js src/env-inl.h:614
    #1 0x56532ea65fab in node::AsyncHooks::clear_async_id_stack() src/env.cc:171:14
    #2 0x56532eab1aed in node::AsyncHooks::AsyncHooks(v8::Isolate*, node::AsyncHooks::SerializeInfo const*) src/env.cc:1393:5
    #3 0x56532eaa8ea0 in node::Environment::Environment(node::IsolateData*, v8::Isolate*, std::__u::vector<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>, std::__u::allocator<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>>> const&, std::__u::vector<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>, std::__u::allocator<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>>> const&, node::EnvSerializeInfo const*, node::EnvironmentFlags::Flags, node::ThreadId) src/env.cc:650:7
    #4 0x56532eaaa6bb in node::Environment::Environment(node::IsolateData*, v8::Local<v8::Context>, std::__u::vector<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>, std::__u::allocator<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>>> const&, std::__u::vector<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>, std::__u::allocator<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>>> const&, node::EnvSerializeInfo const*, node::EnvironmentFlags::Flags, node::ThreadId) src/env.cc:741:7
    #5 0x56532e9646db in node::CreateEnvironment(node::IsolateData*, v8::Local<v8::Context>, std::__u::vector<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>, std::__u::allocator<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>>> const&, std::__u::vector<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>, std::__u::allocator<std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>>> const&, node::EnvironmentFlags::Flags, node::ThreadId, std::__u::unique_ptr<node::InspectorParentHandle, std::__u::default_delete<node::InspectorParentHandle>>) src/api/environment.cc:401:26
    #6 0x56532ec2bed1 in node::NodeMainInstance::CreateMainEnvironment(int*) src/node_main_instance.cc:184:9
    #7 0x56532ec2ba05 in node::NodeMainInstance::Run() src/node_main_instance.cc:118:7
    #8 0x56532eb3637d in node::LoadSnapshotDataAndRun(node::SnapshotData const**, node::InitializationResult const*) src/node.cc:1231:29
```

Afaict https://github.com/nodejs/node/pull/44669 added reads to `is_stopping_` and `can_call_into_js_` but they were triggered from inside of the `AsyncHooks` constructor. Because of the field order in `Environment`, the `AsyncHooks` constructor ran before these fields had been initialized, leading to reads of uninitialized memory.

Moving the fields up seemed like the simplest fix.