### PR TITLE
lib: runtime deprecate process.binding()

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2203,6 +2203,9 @@ The `produceCachedData` option is deprecated. Use
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/48568
+    description: Runtime deprecation.
   - version: v11.12.0
     pr-url: https://github.com/nodejs/node/pull/26500
     description: Added support for `--pending-deprecation`.
@@ -2211,7 +2214,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only (supports [`--pending-deprecation`][])
+Type: Runtime
 
 `process.binding()` is for use by Node.js internal code only.
 

--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -116,15 +116,6 @@ const processBindingAllowList = new SafeSet([
   'zlib',
 ]);
 
-const runtimeDeprecatedList = new SafeSet([
-  'async_wrap',
-  'crypto',
-  'http_parser',
-  'signal_wrap',
-  'url',
-  'v8',
-]);
-
 const legacyWrapperList = new SafeSet([
   'natives',
   'util',
@@ -146,16 +137,7 @@ const experimentalModuleList = new SafeSet();
 
   process.binding = function binding(module) {
     module = String(module);
-    // Deprecated specific process.binding() modules, but not all, allow
-    // selective fallback to internalBinding for the deprecated ones.
     if (processBindingAllowList.has(module)) {
-      if (runtimeDeprecatedList.has(module)) {
-        runtimeDeprecatedList.delete(module);
-        process.emitWarning(
-          `Access to process.binding('${module}') is deprecated.`,
-          'DeprecationWarning',
-          'DEP0111');
-      }
       if (legacyWrapperList.has(module)) {
         return requireBuiltin('internal/legacy/processbinding')[module]();
       }

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -477,11 +477,10 @@ function initializeDeprecations() {
     });
   }
 
+  process.binding = deprecate(process.binding,
+                              'process.binding() is deprecated. ' +
+                              'Please use public APIs instead.', 'DEP0111');
   if (pendingDeprecation) {
-    process.binding = deprecate(process.binding,
-                                'process.binding() is deprecated. ' +
-                                'Please use public APIs instead.', 'DEP0111');
-
     process._tickCallback = deprecate(process._tickCallback,
                                       'process._tickCallback() is deprecated',
                                       'DEP0134');

--- a/test/parallel/test-process-binding-allowedlist-deprecation.js
+++ b/test/parallel/test-process-binding-allowedlist-deprecation.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+// Assert that all allowed process.binding modules are
+// runtime deprecated.
+const processBindingAllowList = [
+  'async_wrap',
+  'buffer',
+  'cares_wrap',
+  'config',
+  'constants',
+  'contextify',
+  'crypto',
+  'fs',
+  'fs_event_wrap',
+  'http_parser',
+  'icu',
+  'inspector',
+  'js_stream',
+  'natives',
+  'os',
+  'pipe_wrap',
+  'process_wrap',
+  'signal_wrap',
+  'spawn_sync',
+  'stream_wrap',
+  'tcp_wrap',
+  'tls_wrap',
+  'tty_wrap',
+  'udp_wrap',
+  'url',
+  'util',
+  'uv',
+  'v8',
+  'zlib',
+];
+
+const requireCryptoModules = ['crypto', 'tls_wrap'];
+const requireIntlModules = ['icu'];
+
+for (const module of processBindingAllowList) {
+  if (requireCryptoModules.includes(module) && !common.hasCrypto) {
+    continue;
+  }
+
+  if (requireIntlModules.includes(module) && !common.hasIntl) {
+    continue;
+  }
+
+  const { stderr } = spawnSync(
+    process.execPath,
+    [
+      '-p', `process.binding('${module}');`,
+    ]
+  );
+  assert.match(stderr.toString(), /process\.binding\(\) is deprecated/);
+}


### PR DESCRIPTION
Following up @jasnell work on runtime deprecation of some modules. This pr deprecates the process.binding entirely, targetting Node.js 21 (non-LTS version).

I'm opening this PR just to see how feasible/impactful is this approach. I wonder if https://github.com/nodejs/node/pull/37485#pullrequestreview-600060802 is still an issue.

cc: @nodejs/tsc 