### PR TITLE
stream: allow infinite concurrency

### DIFF
--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -80,7 +80,7 @@ function map(fn, options) {
     concurrency = MathFloor(options.concurrency);
   }
 
-  if(concurrency !== Infinity) {
+  if (concurrency !== Infinity) {
     validateInteger(concurrency, 'concurrency', 1);
   }
 

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -80,7 +80,9 @@ function map(fn, options) {
     concurrency = MathFloor(options.concurrency);
   }
 
-  validateInteger(concurrency, 'concurrency', 1);
+  if(concurrency !== Infinity) {
+    validateInteger(concurrency, 'concurrency', 1);
+  }
 
   return async function* map() {
     const ac = new AbortController();

--- a/test/parallel/test-stream-map.js
+++ b/test/parallel/test-stream-map.js
@@ -159,6 +159,21 @@ const { setTimeout } = require('timers/promises');
 }
 
 {
+  // Allow Infinite concurrency
+  const stream = Readable.from([1, 2]).map(async (item, { signal }) => {
+    await setTimeout(10 - item, { signal });
+    return item;
+  }, { concurrency: Infinity });
+
+  (async () => {
+    const expected = [1, 2];
+    for await (const item of stream) {
+      assert.strictEqual(item, expected.shift());
+    }
+  })().then(common.mustCall());
+}
+
+{
   // Concurrency result order
   const stream = Readable.from([1, 2]).map(async (item, { signal }) => {
     await setTimeout(10 - item, { signal });

--- a/test/parallel/test-stream-map.js
+++ b/test/parallel/test-stream-map.js
@@ -160,13 +160,23 @@ const { setTimeout } = require('timers/promises');
 
 {
   // Allow Infinite concurrency
-  const stream = Readable.from([1, 2]).map(async (item, { signal }) => {
+  let resolve;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  const stream = Readable.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).map(async (item, { signal }) => {
     await setTimeout(10 - item, { signal });
+    if (item === 10) {
+      resolve();
+    } else {
+      await promise;
+    }
+
     return item;
   }, { concurrency: Infinity });
 
   (async () => {
-    const expected = [1, 2];
+    const expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     for await (const item of stream) {
       assert.strictEqual(item, expected.shift());
     }


### PR DESCRIPTION
adding this so we can use it in:
- https://github.com/nodejs/node/pull/48584#discussion_r1245565037

which is needed as we don't want to wait for the prev tests to finish before starting a new one (same issue as in #46132)

This has a pitfall in using `concurrency: Infinity` on infinite stream