### PR TITLE
events: fix bug listenerCount don't compare wrapped listener

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -845,7 +845,7 @@ function listenerCount(type, listener) {
 
     if (typeof evlistener === 'function') {
       if (listener != null) {
-        return listener === evlistener ? 1 : 0;
+        return listener === evlistener || listener === evlistener.listener ? 1 : 0;
       }
 
       return 1;

--- a/test/parallel/test-events-listener-count-with-listener.js
+++ b/test/parallel/test-events-listener-count-with-listener.js
@@ -12,6 +12,18 @@ assert.strictEqual(EE.listenerCount('event'), 0);
 assert.strictEqual(EE.listenerCount('event', handler), 0);
 assert.strictEqual(EE.listenerCount('event', anotherHandler), 0);
 
+EE.once('event', handler);
+
+assert.strictEqual(EE.listenerCount('event'), 1);
+assert.strictEqual(EE.listenerCount('event', handler), 1);
+assert.strictEqual(EE.listenerCount('event', anotherHandler), 0);
+
+EE.removeAllListeners('event')
+
+assert.strictEqual(EE.listenerCount('event'), 0);
+assert.strictEqual(EE.listenerCount('event', handler), 0);
+assert.strictEqual(EE.listenerCount('event', anotherHandler), 0);
+
 EE.on('event', handler);
 
 assert.strictEqual(EE.listenerCount('event'), 1);

--- a/test/parallel/test-events-listener-count-with-listener.js
+++ b/test/parallel/test-events-listener-count-with-listener.js
@@ -18,7 +18,7 @@ assert.strictEqual(EE.listenerCount('event'), 1);
 assert.strictEqual(EE.listenerCount('event', handler), 1);
 assert.strictEqual(EE.listenerCount('event', anotherHandler), 0);
 
-EE.removeAllListeners('event')
+EE.removeAllListeners('event');
 
 assert.strictEqual(EE.listenerCount('event'), 0);
 assert.strictEqual(EE.listenerCount('event', handler), 0);


### PR DESCRIPTION
### description
When add listener by once, it will be wrapped into another function. And when pass listener and there is just one event listener added by once, it will return 0 even if passed listener equal wrapped event listener.

This bug is included in https://github.com/nodejs/node/pull/46523

Refs: https://github.com/nodejs/node/pull/46523

### how to trigger this

```javascript
const ee = new EventEmitter()
const listener = () => undefined
ee.once('event', listener)
console.log('ee.listenerCount("event",listener)', ee.listenerCount('event', listener))
```

And it will output like this:

![image](https://github.com/nodejs/node/assets/55919198/81a7e020-1a9d-42ec-94a8-849cb1a90a26)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
