### PR TITLE
[v18.x] test: mark test-child-process-stdio-reuse-readable-stdio flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -15,6 +15,7 @@ test-crypto-keygen: PASS,FLAKY
 test-fs-rmdir-recursive: PASS, FLAKY
 # https://github.com/nodejs/node/issues/48300
 test-child-process-pipe-dataflow: PASS, FLAKY
+test-child-process-stdio-reuse-readable-stdio: PASS, FLAKY
 
 [$system==linux]
 # https://github.com/nodejs/node/issues/39368

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -13,6 +13,8 @@ test-timers-immediate-queue: PASS,FLAKY
 test-crypto-keygen: PASS,FLAKY
 # https://github.com/nodejs/node/issues/41201
 test-fs-rmdir-recursive: PASS, FLAKY
+# https://github.com/nodejs/node/issues/48300
+test-child-process-pipe-dataflow: PASS, FLAKY
 
 [$system==linux]
 # https://github.com/nodejs/node/issues/39368


### PR DESCRIPTION
As mentioned https://github.com/nodejs/node/pull/48345#issuecomment-1612803566, this PR includes the current v18.x release line blockers to get any PR landed there. I hope this fixes the problems :)