### PR TITLE
http: null the joinDuplicateHeaders property on cleanup

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -236,6 +236,7 @@ function cleanParser(parser) {
   parser[kOnTimeout] = null;
   parser._consumed = false;
   parser.onIncoming = null;
+  parser.joinDuplicateHeaders = null;
 }
 
 function prepareError(err, parser, rawPacket) {

--- a/test/parallel/test-http-parser-memory-retention.js
+++ b/test/parallel/test-http-parser-memory-retention.js
@@ -25,18 +25,24 @@ server.on('request', common.mustCall((request, response) => {
 }));
 
 server.listen(common.mustCall(() => {
-  const request = http.get({ port: server.address().port });
+  const request = http.get({
+    headers: { Connection: 'close' },
+    port: server.address().port,
+    joinDuplicateHeaders: true
+  });
   let parser;
 
   request.on('socket', common.mustCall(() => {
     parser = request.parser;
     assert.strictEqual(typeof parser.onIncoming, 'function');
+    assert.strictEqual(parser.joinDuplicateHeaders, true);
   }));
 
   request.on('response', common.mustCall((response) => {
     response.resume();
     response.on('end', common.mustCall(() => {
       assert.strictEqual(parser.onIncoming, null);
+      assert.strictEqual(parser.joinDuplicateHeaders, null);
     }));
   }));
 }));


### PR DESCRIPTION
Null the `joinDuplicateHeaders` property when the parser is freed.

Refs: https://github.com/nodejs/node/pull/45982

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
