### PR TITLE
timers: support `Symbol.dispose`

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -63,6 +63,16 @@ loop to remain active. If there is no other activity keeping the event loop
 running, the process may exit before the `Immediate` object's callback is
 invoked. Calling `immediate.unref()` multiple times will have no effect.
 
+### `immediate[Symbol.dispose]()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Cancels the immediate. This is similar to calling `clearImmediate()`.
+
 ## Class: `Timeout`
 
 This object is created internally and is returned from [`setTimeout()`][] and
@@ -156,6 +166,16 @@ same thread where the timeout was created. Therefore, to use it
 across [`worker_threads`][] it must first be passed to the correct
 thread. This allows enhanced compatibility with browser
 `setTimeout()` and `setInterval()` implementations.
+
+### `timeout[Symbol.dispose]()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Cancels the timeout.
 
 ## Scheduling timers
 

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -228,7 +228,7 @@ function copyPrototype(src, dest, prefix) {
   copyPrototype(original.prototype, primordials, `${name}Prototype`);
 });
 
-// Define Symbol.Dispose and Symbol.AsyncDispose
+// Define Symbol.dispose and Symbol.asyncDispose
 // Until these are defined by the environment.
 // TODO(MoLow): Remove this polyfill once Symbol.dispose and Symbol.asyncDispose are available in V8.
 primordials.SymbolDispose ??= primordials.SymbolFor('nodejs.dispose');

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -24,6 +24,7 @@
 const {
   MathTrunc,
   ObjectDefineProperty,
+  SymbolDispose,
   SymbolToPrimitive,
 } = primordials;
 
@@ -253,6 +254,10 @@ Timeout.prototype.close = function() {
   return this;
 };
 
+Timeout.prototype[SymbolDispose] = function() {
+  clearTimeout(this);
+};
+
 /**
  * Coerces a `Timeout` to a primitive.
  * @returns {number}
@@ -337,6 +342,10 @@ function clearImmediate(immediate) {
 
   immediateQueue.remove(immediate);
 }
+
+Immediate.prototype[SymbolDispose] = function() {
+  clearImmediate(this);
+};
 
 module.exports = {
   setTimeout,

--- a/test/parallel/test-timers-dispose.js
+++ b/test/parallel/test-timers-dispose.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const timer = setTimeout(common.mustNotCall(), 10);
+const interval = setInterval(common.mustNotCall(), 10);
+const immediate = setImmediate(common.mustNotCall());
+
+timer[Symbol.dispose]();
+interval[Symbol.dispose]();
+immediate[Symbol.dispose]();
+
+
+process.on('exit', () => {
+  assert.strictEqual(timer._destroyed, true);
+  assert.strictEqual(interval._destroyed, true);
+  assert.strictEqual(immediate._destroyed, true);
+});


### PR DESCRIPTION
this does not change the behavior of `node:timers/promises`.