### PR TITLE
test_runner: implement first iteration of date.now

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1925,7 +1925,7 @@ clocks or actual timers outside of the mocking environment.
 
 ### `timers.setTime(milliseconds)`
 
-Sets the current UNIX timestamp that will be used as reference for `Date.now`.
+Sets the current Unix timestamp that will be used as reference for `Date.now`.
 
 ```mjs
 import assert from 'node:assert';
@@ -1944,7 +1944,7 @@ test('runAll functions following the given order', (context) => {
 });
 ```
 
-```mjs
+```js
 const assert = require('node:assert');
 const { test } = require('node:test');
 
@@ -1960,7 +1960,6 @@ test('setTime replaces current time', (context) => {
   assert.strictEqual(Date.now(), setTime);
 });
 ```
-
 
 ## Class: `TestsStream`
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1524,12 +1524,16 @@ added:
 Enables timer mocking for the specified timers.
 
 * `timers` {Array} An optional array containing the timers to mock.
-  The currently supported timer values are `'setInterval'` and `'setTimeout'`.
-  If no array is provided, all timers (`'setInterval'`, `'clearInterval'`, `'setTimeout'`,
-  and `'clearTimeout'`) will be mocked by default.
+  The currently supported timer values are `'setInterval'`, `'setTimeout'`,
+  and `'Date.now'`.
+  If no array is provided, all timers (`'setInterval'`, `'clearInterval'`,
+  `'setTimeout'`, `'clearTimeout'`, and `'Date.now'`) will be mocked by default.
 
 **Note:** When you enable mocking for a specific timer, its associated
 clear function will also be implicitly mocked.
+
+**Note:** Mocking `Date.now` will affect the behavior of the mocked timers
+as they use this value internally.
 
 Example usage:
 
@@ -1918,6 +1922,45 @@ test('runAll functions following the given order', (context) => {
 triggering timers in the context of timer mocking.
 It does not have any effect on real-time system
 clocks or actual timers outside of the mocking environment.
+
+### `timers.setTime(milliseconds)`
+
+Sets the current UNIX timestamp that will be used as reference for `Date.now`.
+
+```mjs
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+test('runAll functions following the given order', (context) => {
+  const now = Date.now();
+  const setTime = 1000;
+  // Date.now is not mocked
+  assert.deepStrictEqual(Date.now(), now);
+
+  context.mock.timers.enable(['Date.now']);
+  context.mock.timers.setTime(setTime);
+  // Date.now is now 1000
+  assert.strictEqual(Date.now(), setTime);
+});
+```
+
+```mjs
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+test('setTime replaces current time', (context) => {
+  const now = Date.now();
+  const setTime = 1000;
+  // Date.now is not mocked
+  assert.deepStrictEqual(Date.now(), now);
+
+  context.mock.timers.enable(['Date.now']);
+  context.mock.timers.setTime(setTime);
+  // Date.now is now 1000
+  assert.strictEqual(Date.now(), setTime);
+});
+```
+
 
 ## Class: `TestsStream`
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1925,6 +1925,11 @@ clocks or actual timers outside of the mocking environment.
 
 ### `timers.setTime(milliseconds)`
 
+<!-- YAML
+added:
+  - REPLACEME
+-->
+
 Sets the current Unix timestamp that will be used as reference for `Date.now`.
 
 ```mjs

--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -48,7 +48,7 @@ function abortIt(signal) {
   return new AbortError(undefined, { cause: signal.reason });
 }
 
-const SUPPORTED_TIMERS = ['setTimeout', 'setInterval'];
+const SUPPORTED_TIMERS = ['setTimeout', 'setInterval', 'Date.now'];
 
 class MockTimers {
   #realSetTimeout;
@@ -64,6 +64,8 @@ class MockTimers {
   #realTimersSetInterval;
   #realTimersClearInterval;
 
+  #realDateNow;
+
   #timersInContext = [];
   #isEnabled = false;
   #currentTimer = 1;
@@ -75,6 +77,7 @@ class MockTimers {
   #clearTimeout = FunctionPrototypeBind(this.#clearTimer, this);
   #setInterval = FunctionPrototypeBind(this.#createTimer, this, true);
   #clearInterval = FunctionPrototypeBind(this.#clearTimer, this);
+  #dateNow = FunctionPrototypeBind(this.#fakeDateNow, this);
 
   constructor() {
     emitExperimentalWarning('The MockTimers API');
@@ -98,7 +101,11 @@ class MockTimers {
     this.#executionQueue.removeAt(position);
   }
 
-  async * #setIntervalPromisified(interval, startTime, options) {
+  #fakeDateNow() {
+    return this.#now;
+  }
+
+  async *#setIntervalPromisified(interval, startTime, options) {
     const context = this;
     const emitter = new EventEmitter();
     if (options?.signal) {
@@ -112,7 +119,8 @@ class MockTimers {
         emitter.emit('data', { __proto__: null, aborted: true, reason });
       };
 
-      kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
+      kResistStopPropagation ??=
+        require('internal/event_target').kResistStopPropagation;
       options.signal.addEventListener('abort', onAbort, {
         __proto__: null,
         once: true,
@@ -182,7 +190,8 @@ class MockTimers {
       }, ms);
 
       if (options?.signal) {
-        kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
+        kResistStopPropagation ??=
+          require('internal/event_target').kResistStopPropagation;
         options.signal.addEventListener('abort', onabort, {
           __proto__: null,
           once: true,
@@ -190,6 +199,20 @@ class MockTimers {
         });
       }
     });
+  }
+
+  #assertTimersAreEnabled() {
+    if (!this.#isEnabled) {
+      throw new ERR_INVALID_STATE(
+        'You should enable MockTimers first by calling the .enable function'
+      );
+    }
+  }
+
+  #assertTimeArg(time) {
+    if (time < 0) {
+      throw new ERR_INVALID_ARG_VALUE('time', 'positive integer', time);
+    }
   }
 
   #toggleEnableTimers(activate) {
@@ -210,7 +233,7 @@ class MockTimers {
 
           nodeTimersPromises.setTimeout = FunctionPrototypeBind(
             this.#setTimeoutPromisified,
-            this,
+            this
           );
         },
         setInterval: () => {
@@ -228,8 +251,12 @@ class MockTimers {
 
           nodeTimersPromises.setInterval = FunctionPrototypeBind(
             this.#setIntervalPromisified,
-            this,
+            this
           );
+        },
+        'Date.now': () => {
+          this.#realDateNow = globalThis.Date.now;
+          globalThis.Date.now = this.#dateNow;
         },
       },
       toReal: {
@@ -251,6 +278,9 @@ class MockTimers {
 
           nodeTimersPromises.setInterval = this.#realPromisifiedSetInterval;
         },
+        'Date.now': () => {
+          globalThis.Date.now = this.#realDateNow;
+        },
       },
     };
 
@@ -260,19 +290,8 @@ class MockTimers {
   }
 
   tick(time = 1) {
-    if (!this.#isEnabled) {
-      throw new ERR_INVALID_STATE(
-        'You should enable MockTimers first by calling the .enable function',
-      );
-    }
-
-    if (time < 0) {
-      throw new ERR_INVALID_ARG_VALUE(
-        'time',
-        'positive integer',
-        time,
-      );
-    }
+    this.#assertTimersAreEnabled();
+    this.#assertTimeArg(time);
 
     this.#now += time;
     let timer = this.#executionQueue.peek();
@@ -292,11 +311,9 @@ class MockTimers {
     }
   }
 
-  enable(timers = SUPPORTED_TIMERS) {
+  enable(timers = SUPPORTED_TIMERS, currentTime = DateNow()) {
     if (this.#isEnabled) {
-      throw new ERR_INVALID_STATE(
-        'MockTimers is already enabled!',
-      );
+      throw new ERR_INVALID_STATE('MockTimers is already enabled!');
     }
 
     validateArray(timers, 'timers');
@@ -307,14 +324,20 @@ class MockTimers {
         throw new ERR_INVALID_ARG_VALUE(
           'timers',
           timer,
-          `option ${timer} is not supported`,
+          `option ${timer} is not supported`
         );
       }
     });
 
     this.#timersInContext = timers;
-    this.#now = DateNow();
+    this.#now = currentTime;
     this.#toggleEnableTimers(true);
+  }
+
+  setTime(time = DateNow()) {
+    this.#assertTimeArg(time);
+    this.#assertTimersAreEnabled();
+    this.#now = time;
   }
 
   [SymbolDispose]() {
@@ -327,6 +350,7 @@ class MockTimers {
 
     this.#toggleEnableTimers(false);
     this.#timersInContext = [];
+    this.#now = DateNow();
 
     let timer = this.#executionQueue.peek();
     while (timer) {
@@ -338,7 +362,7 @@ class MockTimers {
   runAll() {
     if (!this.#isEnabled) {
       throw new ERR_INVALID_STATE(
-        'You should enable MockTimers first by calling the .enable function',
+        'You should enable MockTimers first by calling the .enable function'
       );
     }
 

--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -360,12 +360,7 @@ class MockTimers {
   }
 
   runAll() {
-    if (!this.#isEnabled) {
-      throw new ERR_INVALID_STATE(
-        'You should enable MockTimers first by calling the .enable function'
-      );
-    }
-
+    this.#assertTimersAreEnabled();
     this.tick(Infinity);
   }
 }

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -10,20 +10,26 @@ const nodeTimersPromises = require('node:timers/promises');
 describe('Mock Timers Test Suite', () => {
   describe('MockTimers API', () => {
     it('should throw an error if trying to enable a timer that is not supported', (t) => {
-      assert.throws(() => {
-        t.mock.timers.enable(['DOES_NOT_EXIST']);
-      }, {
-        code: 'ERR_INVALID_ARG_VALUE',
-      });
+      assert.throws(
+        () => {
+          t.mock.timers.enable(['DOES_NOT_EXIST']);
+        },
+        {
+          code: 'ERR_INVALID_ARG_VALUE',
+        }
+      );
     });
 
     it('should throw an error if trying to enable a timer twice', (t) => {
       t.mock.timers.enable();
-      assert.throws(() => {
-        t.mock.timers.enable();
-      }, {
-        code: 'ERR_INVALID_STATE',
-      });
+      assert.throws(
+        () => {
+          t.mock.timers.enable();
+        },
+        {
+          code: 'ERR_INVALID_STATE',
+        }
+      );
     });
 
     it('should not throw if calling reset without enabling timers', (t) => {
@@ -31,20 +37,26 @@ describe('Mock Timers Test Suite', () => {
     });
 
     it('should throw an error if calling tick without enabling timers', (t) => {
-      assert.throws(() => {
-        t.mock.timers.tick();
-      }, {
-        code: 'ERR_INVALID_STATE',
-      });
+      assert.throws(
+        () => {
+          t.mock.timers.tick();
+        },
+        {
+          code: 'ERR_INVALID_STATE',
+        }
+      );
     });
 
     it('should throw an error if calling tick with a negative number', (t) => {
       t.mock.timers.enable();
-      assert.throws(() => {
-        t.mock.timers.tick(-1);
-      }, {
-        code: 'ERR_INVALID_ARG_VALUE',
-      });
+      assert.throws(
+        () => {
+          t.mock.timers.tick(-1);
+        },
+        {
+          code: 'ERR_INVALID_ARG_VALUE',
+        }
+      );
     });
 
     it('should reset all timers when calling .reset function', (t) => {
@@ -52,11 +64,15 @@ describe('Mock Timers Test Suite', () => {
       const fn = t.mock.fn();
       global.setTimeout(fn, 1000);
       t.mock.timers.reset();
-      assert.throws(() => {
-        t.mock.timers.tick(1000);
-      }, {
-        code: 'ERR_INVALID_STATE',
-      });
+      assert.deepStrictEqual(Date.now, globalThis.Date.now);
+      assert.throws(
+        () => {
+          t.mock.timers.tick(1000);
+        },
+        {
+          code: 'ERR_INVALID_STATE',
+        }
+      );
 
       assert.strictEqual(fn.mock.callCount(), 0);
     });
@@ -67,11 +83,14 @@ describe('Mock Timers Test Suite', () => {
       global.setTimeout(fn, 1000);
       // TODO(benjamingr) refactor to `using`
       t.mock.timers[Symbol.dispose]();
-      assert.throws(() => {
-        t.mock.timers.tick(1000);
-      }, {
-        code: 'ERR_INVALID_STATE',
-      });
+      assert.throws(
+        () => {
+          t.mock.timers.tick(1000);
+        },
+        {
+          code: 'ERR_INVALID_STATE',
+        }
+      );
 
       assert.strictEqual(fn.mock.callCount(), 0);
     });
@@ -91,11 +110,14 @@ describe('Mock Timers Test Suite', () => {
 
     describe('runAll Suite', () => {
       it('should throw an error if calling runAll without enabling timers', (t) => {
-        assert.throws(() => {
-          t.mock.timers.runAll();
-        }, {
-          code: 'ERR_INVALID_STATE',
-        });
+        assert.throws(
+          () => {
+            t.mock.timers.runAll();
+          },
+          {
+            code: 'ERR_INVALID_STATE',
+          }
+        );
       });
 
       it('should trigger all timers when calling .runAll function', async (t) => {
@@ -112,7 +134,6 @@ describe('Mock Timers Test Suite', () => {
         assert.strictEqual(intervalFn.mock.callCount(), 1);
       });
     });
-
   });
 
   describe('globals/timers', () => {
@@ -161,12 +182,14 @@ describe('Mock Timers Test Suite', () => {
         const now = Date.now();
         const timeout = 2;
         const expected = () => now - timeout;
-        global.setTimeout(common.mustCall(() => {
-          assert.strictEqual(now - timeout, expected());
-          done();
-        }), timeout);
+        global.setTimeout(
+          common.mustCall(() => {
+            assert.strictEqual(now - timeout, expected());
+            done();
+          }),
+          timeout
+        );
       });
-
     });
 
     describe('clearTimeout Suite', () => {
@@ -215,7 +238,6 @@ describe('Mock Timers Test Suite', () => {
         assert.deepStrictEqual(fn.mock.calls[0].arguments, args);
         assert.deepStrictEqual(fn.mock.calls[1].arguments, args);
         assert.deepStrictEqual(fn.mock.calls[2].arguments, args);
-
       });
     });
 
@@ -231,7 +253,6 @@ describe('Mock Timers Test Suite', () => {
         assert.strictEqual(fn.mock.callCount(), 0);
       });
     });
-
   });
 
   describe('timers Suite', () => {
@@ -314,7 +335,6 @@ describe('Mock Timers Test Suite', () => {
         assert.deepStrictEqual(fn.mock.calls[1].arguments, args);
         assert.deepStrictEqual(fn.mock.calls[2].arguments, args);
         assert.deepStrictEqual(fn.mock.calls[3].arguments, args);
-
       });
     });
 
@@ -329,6 +349,49 @@ describe('Mock Timers Test Suite', () => {
         t.mock.timers.tick(200);
 
         assert.strictEqual(fn.mock.callCount(), 0);
+      });
+    });
+
+    describe.only('Date.now Suite', () => {
+      it('should return roughly the same value as the original Date.now if not set for a specific time', (t) => {
+        const originalNow = Date.now();
+        t.mock.timers.enable(['Date.now']);
+        const now = Date.now();
+        assert(now <= originalNow);
+      });
+
+      it('should throw an error when setting a negative time', (t) => {
+        t.mock.timers.enable(['Date.now']);
+        assert.throws(
+          () => {
+            t.mock.timers.setTime(-1);
+          },
+          { code: 'ERR_INVALID_ARG_VALUE' }
+        );
+      });
+
+      it('should throw an error if setTime is called without enabling timers', (t) => {
+        assert.throws(
+          () => {
+            t.mock.timers.setTime(100);
+          },
+          { code: 'ERR_INVALID_STATE' }
+        );
+      });
+
+      it('should replace the original Date.now with the mocked one', (t) => {
+        t.mock.timers.enable(['Date.now']);
+        t.mock.timers.setTime(100);
+        const now = Date.now();
+        assert.deepStrictEqual(now, 100);
+      });
+
+      it('should return the ticked time when calling Date.now after tick', (t) => {
+        t.mock.timers.enable(['Date.now']);
+        t.mock.timers.setTime(100);
+        t.mock.timers.tick(100);
+        const now = Date.now();
+        assert.deepStrictEqual(now, 200);
       });
     });
   });


### PR DESCRIPTION
This builds on top of @ErickWendel's #47775, I saw the next steps would be to implement the mock timers for Date.now and performance.now.

This PR implements the Date.now mock, I'm also working on the performance.now. This one includes the Docs already updated and the added tests.

## Open Questions

- Should `Date.now` also mock the `new Date` API to return the date based on the timestamp set by the user? (basically mocking the `new Date()` constructor by replacing it with a static call to `new Date(setTime)`)
- Should `mock.timers.reset()` return the `now()` implementation to the originally set time from `timers.setTime` or `DateNow()`?

## New `MockTimers` API

```js
// All that was before, with no changes
MockTimers.reset()  // clean up to the original state
MockTimers.tick(100) // advance in time by 100ms
MockTimers.runAll() // release all timers

// Implementation changes
MockTimers.enable(['setInterval', 'setTimeout', 'Date.now' ]) // enable fake timers

// New methods
MockTimers.setTime(100) // sets Date.now to the desired value
```

### Example usage

```js
import assert from 'node:assert';
import { test } from 'node:test';

test('mocks Date.now to whatever value the user sets', (context) => {
  const now = Date.now()
  console.log(now) // not mocked, will print correct timestamp

  context.mock.timers.enable(['Date.now']);

  // This will be roughly true. Just to take it as example
  assert.strictEqual(now, Date.now()) // if not set, will take the value of Date.now() as initial value
  context.mock.timers.setTime(1000)
  assert.strictEqual(Date.now(), 1000) // Date.now is 1000
});
```

All the remaining APIs are the same