### PR TITLE
lib: fix emit deprecation on legacy main resolve

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -185,11 +185,13 @@ function legacyMainResolve(packageJSONUrl, packageConfig, base) {
   const baseStringified = isURL(base) ? base.href : base;
 
   const resolvedOption = FSLegacyMainResolve(packageJsonUrlString, packageConfig.main, baseStringified);
-
-  const baseUrl = resolvedOption <= legacyMainResolveExtensionsIndexes.kResolvedByMainIndexNode ? `./${packageConfig.main}` : '';
+  const isValid = resolvedOption <= legacyMainResolveExtensionsIndexes.kResolvedByMainIndexNode;
+  const baseUrl = isValid ? `./${packageConfig.main}` : '';
   const resolvedUrl = new URL(baseUrl + legacyMainResolveExtensions[resolvedOption], packageJSONUrl);
 
-  emitLegacyIndexDeprecation(resolvedUrl, packageJSONUrl, base, packageConfig.main);
+  if (!isValid) {
+    emitLegacyIndexDeprecation(resolvedUrl, packageJSONUrl, base, packageConfig.main);
+  }
 
   return resolvedUrl;
 }


### PR DESCRIPTION
https://github.com/nodejs/node/pull/48325 introduced a bug where the deprecation is thrown for every resolve. This PR fixes that.

cc @H4ad 