### PR TITLE
module: bootstrap module loaders in shadow realm

### DIFF
--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -50,6 +50,8 @@
 
 const {
   ArrayFrom,
+  ArrayPrototypeFilter,
+  ArrayPrototypeIncludes,
   ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypeSlice,
@@ -215,8 +217,8 @@ const internalBuiltinIds = builtinIds
   .filter((id) => StringPrototypeStartsWith(id, 'internal/') && id !== selfId);
 
 // When --expose-internals is on we'll add the internal builtin ids to these.
-const canBeRequiredByUsersList = new SafeSet(publicBuiltinIds);
-const canBeRequiredByUsersWithoutSchemeList =
+let canBeRequiredByUsersList = new SafeSet(publicBuiltinIds);
+let canBeRequiredByUsersWithoutSchemeList =
   new SafeSet(publicBuiltinIds.filter((id) => !schemelessBlockList.has(id)));
 
 /**
@@ -267,6 +269,13 @@ class BuiltinModule {
     if (!schemelessBlockList.has(id)) {
       canBeRequiredByUsersWithoutSchemeList.add(id);
     }
+  }
+
+  static setRealmAllowRequireByUsers(ids) {
+    canBeRequiredByUsersList =
+      new SafeSet(ArrayPrototypeFilter(ids, (id) => ArrayPrototypeIncludes(publicBuiltinIds, id)));
+    canBeRequiredByUsersWithoutSchemeList =
+      new SafeSet(ArrayPrototypeFilter(ids, (id) => !schemelessBlockList.has(id)));
   }
 
   // To be called during pre-execution when --expose-internals is on.

--- a/lib/internal/bootstrap/shadow_realm.js
+++ b/lib/internal/bootstrap/shadow_realm.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// This script sets up the context for shadow realms.
+
+const {
+  prepareShadowRealmExecution,
+} = require('internal/process/pre_execution');
+const {
+  BuiltinModule,
+} = require('internal/bootstrap/realm');
+
+BuiltinModule.setRealmAllowRequireByUsers([
+  /**
+   * The built-in modules exposed in the ShadowRealm must each be providing
+   * platform capabilities with no authority to cause side effects such as
+   * I/O or mutation of values that are shared across different realms within
+   * the same Node.js environment.
+   */
+]);
+
+prepareShadowRealmExecution();

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -136,6 +136,7 @@ port.on('message', (message) => {
     const isLoaderWorker =
       doEval === 'internal' &&
       filename === require('internal/modules/esm/utils').loaderWorkerId;
+    // Disable custom loaders in loader worker.
     setupUserModules(isLoaderWorker);
 
     if (!hasStdin)

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -524,15 +524,13 @@ let emittedLoaderFlagWarning = false;
  * A loader instance is used as the main entry point for loading ES modules. Currently, this is a singleton; there is
  * only one used for loading the main module and everything in its dependency graph, though separate instances of this
  * class might be instantiated as part of bootstrap for other purposes.
- * @param {boolean} useCustomLoadersIfPresent If the user has provided loaders via the --loader flag, use them.
  * @returns {ModuleLoader}
  */
-function createModuleLoader(useCustomLoadersIfPresent = true) {
+function createModuleLoader() {
   let customizations = null;
-  if (useCustomLoadersIfPresent &&
-      // Don't spawn a new worker if we're already in a worker thread created by instantiating CustomizedModuleLoader;
-      // doing so would cause an infinite loop.
-      !require('internal/modules/esm/utils').isLoaderWorker()) {
+  // Don't spawn a new worker if we're already in a worker thread created by instantiating CustomizedModuleLoader;
+  // doing so would cause an infinite loop.
+  if (!require('internal/modules/esm/utils').isLoaderWorker()) {
     const userLoaderPaths = getOptionValue('--experimental-loader');
     if (userLoaderPaths.length > 0) {
       if (!emittedLoaderFlagWarning) {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -528,9 +528,10 @@ let emittedLoaderFlagWarning = false;
  */
 function createModuleLoader() {
   let customizations = null;
-  // Don't spawn a new worker if we're already in a worker thread created by instantiating CustomizedModuleLoader;
-  // doing so would cause an infinite loop.
-  if (!require('internal/modules/esm/utils').isLoaderWorker()) {
+  // Don't spawn a new worker if custom loaders are disabled. For instance, if
+  // we're already in a worker thread created by instantiating
+  // CustomizedModuleLoader; doing so would cause an infinite loop.
+  if (!require('internal/modules/esm/utils').forceDefaultLoader()) {
     const userLoaderPaths = getOptionValue('--experimental-loader');
     if (userLoaderPaths.length > 0) {
       if (!emittedLoaderFlagWarning) {

--- a/lib/internal/modules/esm/utils.js
+++ b/lib/internal/modules/esm/utils.js
@@ -4,6 +4,7 @@ const {
   ArrayIsArray,
   SafeSet,
   SafeWeakMap,
+  Symbol,
   ObjectFreeze,
 } = primordials;
 
@@ -158,6 +159,26 @@ function registerModule(referrer, registry) {
 }
 
 /**
+ * Registers the ModuleRegistry for dynamic import() calls with a realm
+ * as the referrer. Similar to {@link registerModule}, but this function
+ * generates a new id symbol instead of using the one from the referrer
+ * object.
+ * @param {globalThis} globalThis The globalThis object of the realm.
+ * @param {ModuleRegistry} registry
+ */
+function registerRealm(globalThis, registry) {
+  let idSymbol = globalThis[host_defined_option_symbol];
+  // If the per-realm host-defined options is already registered, do nothing.
+  if (idSymbol) {
+    return;
+  }
+  // Otherwise, register the per-realm host-defined options.
+  idSymbol = Symbol('Realm globalThis');
+  globalThis[host_defined_option_symbol] = idSymbol;
+  moduleRegistries.set(idSymbol, registry);
+}
+
+/**
  * Defines the `import.meta` object for a given module.
  * @param {symbol} symbol - Reference to the module.
  * @param {Record<string, string | Function>} meta - The import.meta object to initialize.
@@ -192,28 +213,29 @@ async function importModuleDynamicallyCallback(referrerSymbol, specifier, attrib
   throw new ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING();
 }
 
-let _isLoaderWorker = false;
+let _forceDefaultLoader = false;
 /**
  * Initializes handling of ES modules.
  * This is configured during pre-execution. Specifically it's set to true for
  * the loader worker in internal/main/worker_thread.js.
- * @param {boolean} [isLoaderWorker=false] - A boolean indicating whether the loader is a worker or not.
+ * @param {boolean} [forceDefaultLoader=false] - A boolean indicating disabling custom loaders.
  */
-function initializeESM(isLoaderWorker = false) {
-  _isLoaderWorker = isLoaderWorker;
+function initializeESM(forceDefaultLoader = false) {
+  _forceDefaultLoader = forceDefaultLoader;
   initializeDefaultConditions();
-  // Setup per-isolate callbacks that locate data or callbacks that we keep
+  // Setup per-realm callbacks that locate data or callbacks that we keep
   // track of for different ESM modules.
   setInitializeImportMetaObjectCallback(initializeImportMetaObject);
   setImportModuleDynamicallyCallback(importModuleDynamicallyCallback);
 }
 
 /**
- * Determine whether the current process is a loader worker.
- * @returns {boolean} Whether the current process is a loader worker.
+ * Determine whether custom loaders are disabled and it is forced to use the
+ * default loader.
+ * @returns {boolean}
  */
-function isLoaderWorker() {
-  return _isLoaderWorker;
+function forceDefaultLoader() {
+  return _forceDefaultLoader;
 }
 
 /**
@@ -251,10 +273,11 @@ async function initializeHooks() {
 
 module.exports = {
   registerModule,
+  registerRealm,
   initializeESM,
   initializeHooks,
   getDefaultConditions,
   getConditionsSet,
   loaderWorkerId: 'internal/modules/esm/worker',
-  isLoaderWorker,
+  forceDefaultLoader,
 };

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -11,10 +11,10 @@ let esmLoader;
 
 module.exports = {
   get esmLoader() {
-    return esmLoader ??= createModuleLoader(true);
+    return esmLoader ??= createModuleLoader();
   },
   async loadESM(callback) {
-    esmLoader ??= createModuleLoader(true);
+    esmLoader ??= createModuleLoader();
     try {
       const userImports = getOptionValue('--import');
       if (userImports.length > 0) {

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -28,7 +28,6 @@ const {
   StringPrototypeStartsWith,
   Symbol,
   SymbolIterator,
-  Uint32Array,
 } = primordials;
 
 const {
@@ -65,10 +64,10 @@ function refreshHrtimeBuffer() {
   // The 3 entries filled in by the original process.hrtime contains
   // the upper/lower 32 bits of the second part of the value,
   // and the remaining nanoseconds of the value.
-  hrValues = new Uint32Array(binding.hrtimeBuffer);
+  hrValues = binding.hrtimeBuffer;
   // Use a BigUint64Array in the closure because this is actually a bit
   // faster than simply returning a BigInt from C++ in V8 7.1.
-  hrBigintValues = new BigUint64Array(binding.hrtimeBuffer, 0, 1);
+  hrBigintValues = new BigUint64Array(binding.hrtimeBuffer.buffer, 0, 1);
 }
 
 // Create the buffers.

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -67,6 +67,26 @@ function prepareWorkerThreadExecution() {
   });
 }
 
+function prepareShadowRealmExecution() {
+  const { registerRealm } = require('internal/modules/esm/utils');
+  // Patch the process object with legacy properties and normalizations.
+  // Do not expand argv1 as it is not available in ShadowRealm.
+  patchProcessObject(false);
+  setupDebugEnv();
+
+  // Disable custom loaders in ShadowRealm.
+  setupUserModules(true);
+  registerRealm(globalThis, {
+    __proto__: null,
+    importModuleDynamically: (specifier, _referrer, attributes) => {
+      // The handler for `ShadowRealm.prototype.importValue`.
+      const { esmLoader } = require('internal/process/esm_loader');
+      // `parentURL` is not set in the case of a ShadowRealm top-level import.
+      return esmLoader.import(specifier, undefined, attributes);
+    },
+  });
+}
+
 function prepareExecution(options) {
   const { expandArgv1, initializeModules, isMainThread } = options;
 
@@ -161,16 +181,17 @@ function setupSymbolDisposePolyfill() {
   }
 }
 
-function setupUserModules(isLoaderWorker = false) {
+function setupUserModules(forceDefaultLoader = false) {
   initializeCJSLoader();
-  initializeESMLoader(isLoaderWorker);
+  initializeESMLoader(forceDefaultLoader);
   const CJSLoader = require('internal/modules/cjs/loader');
   assert(!CJSLoader.hasLoadedAnyUserCJSModule);
-  // Loader workers are responsible for doing this themselves.
-  if (isLoaderWorker) {
-    return;
+  // Do not enable preload modules if custom loaders are disabled.
+  // For example, loader workers are responsible for doing this themselves.
+  // And preload modules are not supported in ShadowRealm as well.
+  if (!forceDefaultLoader) {
+    loadPreloadModules();
   }
-  loadPreloadModules();
   // Need to be done after --require setup.
   initializeFrozenIntrinsics();
 }
@@ -701,9 +722,9 @@ function initializeCJSLoader() {
   initializeCJS();
 }
 
-function initializeESMLoader(isLoaderWorker) {
+function initializeESMLoader(forceDefaultLoader) {
   const { initializeESM } = require('internal/modules/esm/utils');
-  initializeESM(isLoaderWorker);
+  initializeESM(forceDefaultLoader);
 
   // Patch the vm module when --experimental-vm-modules is on.
   // Please update the comments in vm.js when this block changes.
@@ -779,6 +800,7 @@ module.exports = {
   setupUserModules,
   prepareMainThreadExecution,
   prepareWorkerThreadExecution,
+  prepareShadowRealmExecution,
   markBootstrapComplete,
   loadPreloadModules,
   initializeFrozenIntrinsics,

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -372,8 +372,9 @@ void AsyncWrap::CreatePerContextProperties(Local<Object> target,
                                            Local<Value> unused,
                                            Local<Context> context,
                                            void* priv) {
-  Environment* env = Environment::GetCurrent(context);
-  Isolate* isolate = env->isolate();
+  Realm* realm = Realm::GetCurrent(context);
+  Environment* env = realm->env();
+  Isolate* isolate = realm->isolate();
   HandleScope scope(isolate);
 
   PropertyAttribute ReadOnlyDontDelete =
@@ -446,13 +447,16 @@ void AsyncWrap::CreatePerContextProperties(Local<Object> target,
 
 #undef FORCE_SET_TARGET_FIELD
 
-  env->set_async_hooks_init_function(Local<Function>());
-  env->set_async_hooks_before_function(Local<Function>());
-  env->set_async_hooks_after_function(Local<Function>());
-  env->set_async_hooks_destroy_function(Local<Function>());
-  env->set_async_hooks_promise_resolve_function(Local<Function>());
-  env->set_async_hooks_callback_trampoline(Local<Function>());
-  env->set_async_hooks_binding(target);
+  // TODO(legendecas): async hook functions are not realm-aware yet.
+  // This simply avoid overriding principal realm's functions when a
+  // ShadowRealm initializes the binding.
+  realm->set_async_hooks_init_function(Local<Function>());
+  realm->set_async_hooks_before_function(Local<Function>());
+  realm->set_async_hooks_after_function(Local<Function>());
+  realm->set_async_hooks_destroy_function(Local<Function>());
+  realm->set_async_hooks_promise_resolve_function(Local<Function>());
+  realm->set_async_hooks_callback_trampoline(Local<Function>());
+  realm->set_async_hooks_binding(target);
 }
 
 void AsyncWrap::RegisterExternalReferences(

--- a/src/env.cc
+++ b/src/env.cc
@@ -501,6 +501,7 @@ void IsolateData::CreateProperties() {
   binding::CreateInternalBindingTemplates(this);
 
   contextify::ContextifyContext::InitializeGlobalTemplates(this);
+  CreateEnvProxyTemplate(this);
 }
 
 constexpr uint16_t kDefaultCppGCEmebdderID = 0x90de;

--- a/src/env.cc
+++ b/src/env.cc
@@ -1651,10 +1651,13 @@ void AsyncHooks::MemoryInfo(MemoryTracker* tracker) const {
 void AsyncHooks::grow_async_ids_stack() {
   async_ids_stack_.reserve(async_ids_stack_.Length() * 3);
 
-  env()->async_hooks_binding()->Set(
-      env()->context(),
-      env()->async_ids_stack_string(),
-      async_ids_stack_.GetJSArray()).Check();
+  env()
+      ->principal_realm()
+      ->async_hooks_binding()
+      ->Set(env()->context(),
+            env()->async_ids_stack_string(),
+            async_ids_stack_.GetJSArray())
+      .Check();
 }
 
 void AsyncHooks::FailWithCorruptedAsyncStack(double expected_async_id) {

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -39,6 +39,7 @@ using v8::MicrotaskQueue;
 using v8::Module;
 using v8::ModuleRequest;
 using v8::Object;
+using v8::ObjectTemplate;
 using v8::PrimitiveArray;
 using v8::Promise;
 using v8::ScriptCompiler;
@@ -49,15 +50,17 @@ using v8::UnboundModuleScript;
 using v8::Undefined;
 using v8::Value;
 
-ModuleWrap::ModuleWrap(Environment* env,
+ModuleWrap::ModuleWrap(Realm* realm,
                        Local<Object> object,
                        Local<Module> module,
                        Local<String> url,
                        Local<Object> context_object,
                        Local<Value> synthetic_evaluation_step)
-    : BaseObject(env, object),
-      module_(env->isolate(), module),
+    : BaseObject(realm, object),
+      module_(realm->isolate(), module),
       module_hash_(module->GetIdentityHash()) {
+  realm->env()->hash_to_module_map.emplace(module_hash_, this);
+
   object->SetInternalField(kModuleSlot, module);
   object->SetInternalField(kURLSlot, url);
   object->SetInternalField(kSyntheticEvaluationStepsSlot,
@@ -72,7 +75,6 @@ ModuleWrap::ModuleWrap(Environment* env,
 }
 
 ModuleWrap::~ModuleWrap() {
-  HandleScope scope(env()->isolate());
   auto range = env()->hash_to_module_map.equal_range(module_hash_);
   for (auto it = range.first; it != range.second; ++it) {
     if (it->second == this) {
@@ -107,8 +109,8 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
   CHECK_GE(args.Length(), 3);
 
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
+  Realm* realm = Realm::GetCurrent(args);
+  Isolate* isolate = realm->isolate();
 
   Local<Object> that = args.This();
 
@@ -122,7 +124,7 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
   } else {
     CHECK(args[1]->IsObject());
     contextify_context = ContextifyContext::ContextFromContextifiedSandbox(
-        env, args[1].As<Object>());
+        realm->env(), args[1].As<Object>());
     CHECK_NOT_NULL(contextify_context);
     context = contextify_context->context();
   }
@@ -148,8 +150,8 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
   Local<Symbol> id_symbol = Symbol::New(isolate, url);
   host_defined_options->Set(isolate, HostDefinedOptions::kID, id_symbol);
 
-  ShouldNotAbortOnUncaughtScope no_abort_scope(env);
-  TryCatchScope try_catch(env);
+  ShouldNotAbortOnUncaughtScope no_abort_scope(realm->env());
+  TryCatchScope try_catch(realm->env());
 
   Local<Module> module;
 
@@ -206,7 +208,9 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
         if (try_catch.HasCaught() && !try_catch.HasTerminated()) {
           CHECK(!try_catch.Message().IsEmpty());
           CHECK(!try_catch.Exception().IsEmpty());
-          AppendExceptionLine(env, try_catch.Exception(), try_catch.Message(),
+          AppendExceptionLine(realm->env(),
+                              try_catch.Exception(),
+                              try_catch.Message(),
                               ErrorHandlingMode::MODULE_ERROR);
           try_catch.ReThrow();
         }
@@ -215,18 +219,21 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
       if (options == ScriptCompiler::kConsumeCodeCache &&
           source.GetCachedData()->rejected) {
         THROW_ERR_VM_MODULE_CACHED_DATA_REJECTED(
-            env, "cachedData buffer was rejected");
+            realm, "cachedData buffer was rejected");
         try_catch.ReThrow();
         return;
       }
     }
   }
 
-  if (!that->Set(context, env->url_string(), url).FromMaybe(false)) {
+  if (!that->Set(context, realm->isolate_data()->url_string(), url)
+           .FromMaybe(false)) {
     return;
   }
 
-  if (that->SetPrivate(context, env->host_defined_option_symbol(), id_symbol)
+  if (that->SetPrivate(context,
+                       realm->isolate_data()->host_defined_option_symbol(),
+                       id_symbol)
           .IsNothing()) {
     return;
   }
@@ -236,28 +243,26 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
   // be stored in an internal field.
   Local<Object> context_object = context->GetExtrasBindingObject();
   Local<Value> synthetic_evaluation_step =
-      synthetic ? args[3] : Undefined(env->isolate()).As<v8::Value>();
+      synthetic ? args[3] : Undefined(realm->isolate()).As<v8::Value>();
 
   ModuleWrap* obj = new ModuleWrap(
-      env, that, module, url, context_object, synthetic_evaluation_step);
+      realm, that, module, url, context_object, synthetic_evaluation_step);
 
   obj->contextify_context_ = contextify_context;
-
-  env->hash_to_module_map.emplace(module->GetIdentityHash(), obj);
 
   that->SetIntegrityLevel(context, IntegrityLevel::kFrozen);
   args.GetReturnValue().Set(that);
 }
 
 static Local<Object> createImportAttributesContainer(
-    Environment* env, Isolate* isolate, Local<FixedArray> raw_attributes) {
+    Realm* realm, Isolate* isolate, Local<FixedArray> raw_attributes) {
   Local<Object> attributes =
-      Object::New(isolate, v8::Null(env->isolate()), nullptr, nullptr, 0);
+      Object::New(isolate, v8::Null(isolate), nullptr, nullptr, 0);
   for (int i = 0; i < raw_attributes->Length(); i += 3) {
     attributes
-        ->Set(env->context(),
-              raw_attributes->Get(env->context(), i).As<String>(),
-              raw_attributes->Get(env->context(), i + 1).As<Value>())
+        ->Set(realm->context(),
+              raw_attributes->Get(realm->context(), i).As<String>(),
+              raw_attributes->Get(realm->context(), i + 1).As<Value>())
         .ToChecked();
   }
 
@@ -265,7 +270,7 @@ static Local<Object> createImportAttributesContainer(
 }
 
 void ModuleWrap::Link(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  Realm* realm = Realm::GetCurrent(args);
   Isolate* isolate = args.GetIsolate();
 
   CHECK_EQ(args.Length(), 1);
@@ -292,14 +297,14 @@ void ModuleWrap::Link(const FunctionCallbackInfo<Value>& args) {
   // call the dependency resolve callbacks
   for (int i = 0; i < module_requests_length; i++) {
     Local<ModuleRequest> module_request =
-      module_requests->Get(env->context(), i).As<ModuleRequest>();
+        module_requests->Get(realm->context(), i).As<ModuleRequest>();
     Local<String> specifier = module_request->GetSpecifier();
-    Utf8Value specifier_utf8(env->isolate(), specifier);
+    Utf8Value specifier_utf8(realm->isolate(), specifier);
     std::string specifier_std(*specifier_utf8, specifier_utf8.length());
 
     Local<FixedArray> raw_attributes = module_request->GetImportAssertions();
     Local<Object> attributes =
-        createImportAttributesContainer(env, isolate, raw_attributes);
+        createImportAttributesContainer(realm, isolate, raw_attributes);
 
     Local<Value> argv[] = {
         specifier,
@@ -315,11 +320,11 @@ void ModuleWrap::Link(const FunctionCallbackInfo<Value>& args) {
         maybe_resolve_return_value.ToLocalChecked();
     if (!resolve_return_value->IsPromise()) {
       THROW_ERR_VM_MODULE_LINK_FAILURE(
-          env, "request for '%s' did not return promise", specifier_std);
+          realm, "request for '%s' did not return promise", specifier_std);
       return;
     }
     Local<Promise> resolve_promise = resolve_return_value.As<Promise>();
-    obj->resolve_cache_[specifier_std].Reset(env->isolate(), resolve_promise);
+    obj->resolve_cache_[specifier_std].Reset(isolate, resolve_promise);
 
     promises[i] = resolve_promise;
   }
@@ -329,13 +334,13 @@ void ModuleWrap::Link(const FunctionCallbackInfo<Value>& args) {
 }
 
 void ModuleWrap::Instantiate(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  Realm* realm = Realm::GetCurrent(args);
   Isolate* isolate = args.GetIsolate();
   ModuleWrap* obj;
   ASSIGN_OR_RETURN_UNWRAP(&obj, args.This());
   Local<Context> context = obj->context();
   Local<Module> module = obj->module_.Get(isolate);
-  TryCatchScope try_catch(env);
+  TryCatchScope try_catch(realm->env());
   USE(module->InstantiateModule(context, ResolveModuleCallback));
 
   // clear resolve cache on instantiate
@@ -344,7 +349,9 @@ void ModuleWrap::Instantiate(const FunctionCallbackInfo<Value>& args) {
   if (try_catch.HasCaught() && !try_catch.HasTerminated()) {
     CHECK(!try_catch.Message().IsEmpty());
     CHECK(!try_catch.Exception().IsEmpty());
-    AppendExceptionLine(env, try_catch.Exception(), try_catch.Message(),
+    AppendExceptionLine(realm->env(),
+                        try_catch.Exception(),
+                        try_catch.Message(),
                         ErrorHandlingMode::MODULE_ERROR);
     try_catch.ReThrow();
     return;
@@ -352,8 +359,8 @@ void ModuleWrap::Instantiate(const FunctionCallbackInfo<Value>& args) {
 }
 
 void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
+  Realm* realm = Realm::GetCurrent(args);
+  Isolate* isolate = realm->isolate();
   ModuleWrap* obj;
   ASSIGN_OR_RETURN_UNWRAP(&obj, args.This());
   Local<Context> context = obj->context();
@@ -368,14 +375,14 @@ void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 2);
 
   CHECK(args[0]->IsNumber());
-  int64_t timeout = args[0]->IntegerValue(env->context()).FromJust();
+  int64_t timeout = args[0]->IntegerValue(realm->context()).FromJust();
 
   CHECK(args[1]->IsBoolean());
   bool break_on_sigint = args[1]->IsTrue();
 
-  ShouldNotAbortOnUncaughtScope no_abort_scope(env);
-  TryCatchScope try_catch(env);
-  Isolate::SafeForTerminationScope safe_for_termination(env->isolate());
+  ShouldNotAbortOnUncaughtScope no_abort_scope(realm->env());
+  TryCatchScope try_catch(realm->env());
+  Isolate::SafeForTerminationScope safe_for_termination(isolate);
 
   bool timed_out = false;
   bool received_signal = false;
@@ -406,16 +413,15 @@ void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {
 
   // Convert the termination exception into a regular exception.
   if (timed_out || received_signal) {
-    if (!env->is_main_thread() && env->is_stopping())
-      return;
-    env->isolate()->CancelTerminateExecution();
+    if (!realm->env()->is_main_thread() && realm->env()->is_stopping()) return;
+    isolate->CancelTerminateExecution();
     // It is possible that execution was terminated by another timeout in
     // which this timeout is nested, so check whether one of the watchdogs
     // from this invocation is responsible for termination.
     if (timed_out) {
-      THROW_ERR_SCRIPT_EXECUTION_TIMEOUT(env, timeout);
+      THROW_ERR_SCRIPT_EXECUTION_TIMEOUT(realm->env(), timeout);
     } else if (received_signal) {
-      THROW_ERR_SCRIPT_EXECUTION_INTERRUPTED(env);
+      THROW_ERR_SCRIPT_EXECUTION_INTERRUPTED(realm->env());
     }
   }
 
@@ -429,7 +435,7 @@ void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {
 }
 
 void ModuleWrap::GetNamespace(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  Realm* realm = Realm::GetCurrent(args);
   Isolate* isolate = args.GetIsolate();
   ModuleWrap* obj;
   ASSIGN_OR_RETURN_UNWRAP(&obj, args.This());
@@ -439,7 +445,7 @@ void ModuleWrap::GetNamespace(const FunctionCallbackInfo<Value>& args) {
   switch (module->GetStatus()) {
     case v8::Module::Status::kUninstantiated:
     case v8::Module::Status::kInstantiating:
-      return env->ThrowError(
+      return realm->env()->ThrowError(
           "cannot get namespace, module has not been instantiated");
     case v8::Module::Status::kInstantiated:
     case v8::Module::Status::kEvaluating:
@@ -466,11 +472,11 @@ void ModuleWrap::GetStatus(const FunctionCallbackInfo<Value>& args) {
 
 void ModuleWrap::GetStaticDependencySpecifiers(
     const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  Realm* realm = Realm::GetCurrent(args);
   ModuleWrap* obj;
   ASSIGN_OR_RETURN_UNWRAP(&obj, args.This());
 
-  Local<Module> module = obj->module_.Get(env->isolate());
+  Local<Module> module = obj->module_.Get(realm->isolate());
 
   Local<FixedArray> module_requests = module->GetModuleRequests();
   int count = module_requests->Length();
@@ -479,12 +485,12 @@ void ModuleWrap::GetStaticDependencySpecifiers(
 
   for (int i = 0; i < count; i++) {
     Local<ModuleRequest> module_request =
-      module_requests->Get(env->context(), i).As<ModuleRequest>();
+        module_requests->Get(realm->context(), i).As<ModuleRequest>();
     specifiers[i] = module_request->GetSpecifier();
   }
 
   args.GetReturnValue().Set(
-      Array::New(env->isolate(), specifiers.out(), count));
+      Array::New(realm->isolate(), specifiers.out(), count));
 }
 
 void ModuleWrap::GetError(const FunctionCallbackInfo<Value>& args) {
@@ -501,14 +507,12 @@ MaybeLocal<Module> ModuleWrap::ResolveModuleCallback(
     Local<String> specifier,
     Local<FixedArray> import_attributes,
     Local<Module> referrer) {
+  Isolate* isolate = context->GetIsolate();
   Environment* env = Environment::GetCurrent(context);
   if (env == nullptr) {
-    Isolate* isolate = context->GetIsolate();
     THROW_ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE(isolate);
     return MaybeLocal<Module>();
   }
-
-  Isolate* isolate = env->isolate();
 
   Utf8Value specifier_utf8(isolate, specifier);
   std::string specifier_std(*specifier_utf8, specifier_utf8.length());
@@ -559,11 +563,16 @@ static MaybeLocal<Promise> ImportModuleDynamically(
     THROW_ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE(isolate);
     return MaybeLocal<Promise>();
   }
+  Realm* realm = Realm::GetCurrent(context);
+  if (realm == nullptr) {
+    // Fallback to the principal realm if it's in a vm context.
+    realm = env->principal_realm();
+  }
 
   EscapableHandleScope handle_scope(isolate);
 
   Local<Function> import_callback =
-    env->host_import_module_dynamically_callback();
+      realm->host_import_module_dynamically_callback();
   Local<Value> id;
 
   Local<FixedArray> options = host_defined_options.As<FixedArray>();
@@ -579,7 +588,7 @@ static MaybeLocal<Promise> ImportModuleDynamically(
   }
 
   Local<Object> attributes =
-      createImportAttributesContainer(env, isolate, import_attributes);
+      createImportAttributesContainer(realm, isolate, import_attributes);
 
   Local<Value> import_args[] = {
       id,
@@ -603,13 +612,13 @@ static MaybeLocal<Promise> ImportModuleDynamically(
 void ModuleWrap::SetImportModuleDynamicallyCallback(
     const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  Environment* env = Environment::GetCurrent(args);
+  Realm* realm = Realm::GetCurrent(args);
   HandleScope handle_scope(isolate);
 
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsFunction());
   Local<Function> import_callback = args[0].As<Function>();
-  env->set_host_import_module_dynamically_callback(import_callback);
+  realm->set_host_import_module_dynamically_callback(import_callback);
 
   isolate->SetHostImportModuleDynamicallyCallback(ImportModuleDynamically);
 }
@@ -624,10 +633,15 @@ void ModuleWrap::HostInitializeImportMetaObjectCallback(
   if (module_wrap == nullptr) {
     return;
   }
+  Realm* realm = Realm::GetCurrent(context);
+  if (realm == nullptr) {
+    // Fallback to the principal realm if it's in a vm context.
+    realm = env->principal_realm();
+  }
 
   Local<Object> wrap = module_wrap->object();
   Local<Function> callback =
-      env->host_initialize_import_meta_object_callback();
+      realm->host_initialize_import_meta_object_callback();
   Local<Value> id;
   if (!wrap->GetPrivate(context, env->host_defined_option_symbol())
            .ToLocal(&id)) {
@@ -637,7 +651,7 @@ void ModuleWrap::HostInitializeImportMetaObjectCallback(
   Local<Value> args[] = {id, meta};
   TryCatchScope try_catch(env);
   USE(callback->Call(
-        context, Undefined(env->isolate()), arraysize(args), args));
+      context, Undefined(realm->isolate()), arraysize(args), args));
   if (try_catch.HasCaught() && !try_catch.HasTerminated()) {
     try_catch.ReThrow();
   }
@@ -645,13 +659,13 @@ void ModuleWrap::HostInitializeImportMetaObjectCallback(
 
 void ModuleWrap::SetInitializeImportMetaObjectCallback(
     const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
+  Realm* realm = Realm::GetCurrent(args);
+  Isolate* isolate = realm->isolate();
 
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsFunction());
   Local<Function> import_meta_callback = args[0].As<Function>();
-  env->set_host_initialize_import_meta_object_callback(import_meta_callback);
+  realm->set_host_initialize_import_meta_object_callback(import_meta_callback);
 
   isolate->SetHostInitializeImportMetaObjectCallback(
       HostInitializeImportMetaObjectCallback);
@@ -742,12 +756,9 @@ void ModuleWrap::CreateCachedData(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-void ModuleWrap::Initialize(Local<Object> target,
-                            Local<Value> unused,
-                            Local<Context> context,
-                            void* priv) {
-  Environment* env = Environment::GetCurrent(context);
-  Isolate* isolate = env->isolate();
+void ModuleWrap::CreatePerIsolateProperties(IsolateData* isolate_data,
+                                            Local<ObjectTemplate> target) {
+  Isolate* isolate = isolate_data->isolate();
 
   Local<FunctionTemplate> tpl = NewFunctionTemplate(isolate, New);
   tpl->InstanceTemplate()->SetInternalFieldCount(
@@ -767,28 +778,36 @@ void ModuleWrap::Initialize(Local<Object> target,
                              "getStaticDependencySpecifiers",
                              GetStaticDependencySpecifiers);
 
-  SetConstructorFunction(context, target, "ModuleWrap", tpl);
+  SetConstructorFunction(isolate, target, "ModuleWrap", tpl);
 
-  SetMethod(context,
+  SetMethod(isolate,
             target,
             "setImportModuleDynamicallyCallback",
             SetImportModuleDynamicallyCallback);
-  SetMethod(context,
+  SetMethod(isolate,
             target,
             "setInitializeImportMetaObjectCallback",
             SetInitializeImportMetaObjectCallback);
+}
 
+void ModuleWrap::CreatePerContextProperties(Local<Object> target,
+                                            Local<Value> unused,
+                                            Local<Context> context,
+                                            void* priv) {
+  Realm* realm = Realm::GetCurrent(context);
+  Isolate* isolate = realm->isolate();
 #define V(name)                                                                \
-    target->Set(context,                                                       \
-      FIXED_ONE_BYTE_STRING(env->isolate(), #name),                            \
-      Integer::New(env->isolate(), Module::Status::name))                      \
-        .FromJust()
-    V(kUninstantiated);
-    V(kInstantiating);
-    V(kInstantiated);
-    V(kEvaluating);
-    V(kEvaluated);
-    V(kErrored);
+  target                                                                       \
+      ->Set(context,                                                           \
+            FIXED_ONE_BYTE_STRING(isolate, #name),                             \
+            Integer::New(isolate, Module::Status::name))                       \
+      .FromJust()
+  V(kUninstantiated);
+  V(kInstantiating);
+  V(kInstantiated);
+  V(kEvaluating);
+  V(kEvaluated);
+  V(kErrored);
 #undef V
 }
 
@@ -812,7 +831,9 @@ void ModuleWrap::RegisterExternalReferences(
 }  // namespace loader
 }  // namespace node
 
-NODE_BINDING_CONTEXT_AWARE_INTERNAL(module_wrap,
-                                    node::loader::ModuleWrap::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(
+    module_wrap, node::loader::ModuleWrap::CreatePerContextProperties)
+NODE_BINDING_PER_ISOLATE_INIT(
+    module_wrap, node::loader::ModuleWrap::CreatePerIsolateProperties)
 NODE_BINDING_EXTERNAL_REFERENCE(
     module_wrap, node::loader::ModuleWrap::RegisterExternalReferences)

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -10,6 +10,7 @@
 
 namespace node {
 
+class IsolateData;
 class Environment;
 class ExternalReferenceRegistry;
 
@@ -40,10 +41,12 @@ class ModuleWrap : public BaseObject {
     kInternalFieldCount
   };
 
-  static void Initialize(v8::Local<v8::Object> target,
-                         v8::Local<v8::Value> unused,
-                         v8::Local<v8::Context> context,
-                         void* priv);
+  static void CreatePerIsolateProperties(IsolateData* isolate_data,
+                                         v8::Local<v8::ObjectTemplate> target);
+  static void CreatePerContextProperties(v8::Local<v8::Object> target,
+                                         v8::Local<v8::Value> unused,
+                                         v8::Local<v8::Context> context,
+                                         void* priv);
   static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
   static void HostInitializeImportMetaObjectCallback(
       v8::Local<v8::Context> context,
@@ -66,7 +69,7 @@ class ModuleWrap : public BaseObject {
   }
 
  private:
-  ModuleWrap(Environment* env,
+  ModuleWrap(Realm* realm,
              v8::Local<v8::Object> object,
              v8::Local<v8::Module> module,
              v8::Local<v8::String> url,

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -37,10 +37,11 @@ static_assert(static_cast<int>(NM_F_LINKED) ==
   V(contextify)                                                                \
   V(encoding_binding)                                                          \
   V(fs)                                                                        \
+  V(messaging)                                                                 \
   V(mksnapshot)                                                                \
-  V(timers)                                                                    \
-  V(process_methods)                                                           \
   V(performance)                                                               \
+  V(process_methods)                                                           \
+  V(timers)                                                                    \
   V(url)                                                                       \
   V(worker)                                                                    \
   NODE_BUILTIN_ICU_BINDINGS(V)

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -40,6 +40,7 @@ static_assert(static_cast<int>(NM_F_LINKED) ==
   V(fs_dir)                                                                    \
   V(messaging)                                                                 \
   V(mksnapshot)                                                                \
+  V(module_wrap)                                                               \
   V(performance)                                                               \
   V(process_methods)                                                           \
   V(timers)                                                                    \

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -37,6 +37,7 @@ static_assert(static_cast<int>(NM_F_LINKED) ==
   V(contextify)                                                                \
   V(encoding_binding)                                                          \
   V(fs)                                                                        \
+  V(fs_dir)                                                                    \
   V(messaging)                                                                 \
   V(mksnapshot)                                                                \
   V(performance)                                                               \

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -456,7 +456,8 @@ static void EnvDefiner(Local<Name> property,
   }
 }
 
-void CreateEnvProxyTemplate(Isolate* isolate, IsolateData* isolate_data) {
+void CreateEnvProxyTemplate(IsolateData* isolate_data) {
+  Isolate* isolate = isolate_data->isolate();
   HandleScope scope(isolate);
   if (!isolate_data->env_proxy_template().IsEmpty()) return;
   Local<FunctionTemplate> env_proxy_ctor_template =

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -123,6 +123,10 @@ void AppendExceptionLine(Environment* env,
   inline void THROW_##code(                                                    \
       Environment* env, const char* format, Args&&... args) {                  \
     THROW_##code(env->isolate(), format, std::forward<Args>(args)...);         \
+  }                                                                            \
+  template <typename... Args>                                                  \
+  inline void THROW_##code(Realm* realm, const char* format, Args&&... args) { \
+    THROW_##code(realm->isolate(), format, std::forward<Args>(args)...);       \
   }
 ERRORS_WITH_CODE(V)
 #undef V

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -30,6 +30,7 @@ using v8::Maybe;
 using v8::MaybeLocal;
 using v8::Nothing;
 using v8::Object;
+using v8::ObjectTemplate;
 using v8::SharedArrayBuffer;
 using v8::SharedValueConveyor;
 using v8::String;
@@ -717,7 +718,8 @@ MessagePort* MessagePort::New(
     std::unique_ptr<MessagePortData> data,
     std::shared_ptr<SiblingGroup> sibling_group) {
   Context::Scope context_scope(context);
-  Local<FunctionTemplate> ctor_templ = GetMessagePortConstructorTemplate(env);
+  Local<FunctionTemplate> ctor_templ =
+      GetMessagePortConstructorTemplate(env->isolate_data());
 
   // Construct a new instance, then assign the listener instance and possibly
   // the MessagePortData to it.
@@ -1116,7 +1118,8 @@ void MessagePort::Stop(const FunctionCallbackInfo<Value>& args) {
 void MessagePort::CheckType(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   args.GetReturnValue().Set(
-      GetMessagePortConstructorTemplate(env)->HasInstance(args[0]));
+      GetMessagePortConstructorTemplate(env->isolate_data())
+          ->HasInstance(args[0]));
 }
 
 void MessagePort::Drain(const FunctionCallbackInfo<Value>& args) {
@@ -1193,28 +1196,30 @@ void MessagePort::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("emit_message_fn", emit_message_fn_);
 }
 
-Local<FunctionTemplate> GetMessagePortConstructorTemplate(Environment* env) {
+Local<FunctionTemplate> GetMessagePortConstructorTemplate(
+    IsolateData* isolate_data) {
   // Factor generating the MessagePort JS constructor into its own piece
   // of code, because it is needed early on in the child environment setup.
-  Local<FunctionTemplate> templ = env->message_port_constructor_template();
+  Local<FunctionTemplate> templ =
+      isolate_data->message_port_constructor_template();
   if (!templ.IsEmpty())
     return templ;
 
   {
-    Isolate* isolate = env->isolate();
+    Isolate* isolate = isolate_data->isolate();
     Local<FunctionTemplate> m = NewFunctionTemplate(isolate, MessagePort::New);
-    m->SetClassName(env->message_port_constructor_string());
+    m->SetClassName(isolate_data->message_port_constructor_string());
     m->InstanceTemplate()->SetInternalFieldCount(
         MessagePort::kInternalFieldCount);
-    m->Inherit(HandleWrap::GetConstructorTemplate(env));
+    m->Inherit(HandleWrap::GetConstructorTemplate(isolate_data));
 
     SetProtoMethod(isolate, m, "postMessage", MessagePort::PostMessage);
     SetProtoMethod(isolate, m, "start", MessagePort::Start);
 
-    env->set_message_port_constructor_template(m);
+    isolate_data->set_message_port_constructor_template(m);
   }
 
-  return GetMessagePortConstructorTemplate(env);
+  return GetMessagePortConstructorTemplate(isolate_data);
 }
 
 // static
@@ -1636,15 +1641,12 @@ static void BroadcastChannel(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-static void InitMessaging(Local<Object> target,
-                          Local<Value> unused,
-                          Local<Context> context,
-                          void* priv) {
-  Environment* env = Environment::GetCurrent(context);
-  Isolate* isolate = env->isolate();
+static void CreatePerIsolateProperties(IsolateData* isolate_data,
+                                       Local<ObjectTemplate> target) {
+  Isolate* isolate = isolate_data->isolate();
 
   {
-    SetConstructorFunction(context,
+    SetConstructorFunction(isolate,
                            target,
                            "MessageChannel",
                            NewFunctionTemplate(isolate, MessageChannel));
@@ -1655,31 +1657,36 @@ static void InitMessaging(Local<Object> target,
     t->InstanceTemplate()->SetInternalFieldCount(
         JSTransferable::kInternalFieldCount);
     t->SetClassName(OneByteString(isolate, "JSTransferable"));
-    env->isolate_data()->set_js_transferable_constructor_template(t);
+    isolate_data->set_js_transferable_constructor_template(t);
   }
 
-  SetConstructorFunction(context,
+  SetConstructorFunction(isolate,
                          target,
-                         env->message_port_constructor_string(),
-                         GetMessagePortConstructorTemplate(env),
-                         SetConstructorFunctionFlag::NONE);
+                         isolate_data->message_port_constructor_string(),
+                         GetMessagePortConstructorTemplate(isolate_data));
 
   // These are not methods on the MessagePort prototype, because
   // the browser equivalents do not provide them.
-  SetMethod(context, target, "stopMessagePort", MessagePort::Stop);
-  SetMethod(context, target, "checkMessagePort", MessagePort::CheckType);
-  SetMethod(context, target, "drainMessagePort", MessagePort::Drain);
+  SetMethod(isolate, target, "stopMessagePort", MessagePort::Stop);
+  SetMethod(isolate, target, "checkMessagePort", MessagePort::CheckType);
+  SetMethod(isolate, target, "drainMessagePort", MessagePort::Drain);
   SetMethod(
-      context, target, "receiveMessageOnPort", MessagePort::ReceiveMessage);
+      isolate, target, "receiveMessageOnPort", MessagePort::ReceiveMessage);
   SetMethod(
-      context, target, "moveMessagePortToContext", MessagePort::MoveToContext);
-  SetMethod(context,
+      isolate, target, "moveMessagePortToContext", MessagePort::MoveToContext);
+  SetMethod(isolate,
             target,
             "setDeserializerCreateObjectFunction",
             SetDeserializerCreateObjectFunction);
-  SetMethod(context, target, "broadcastChannel", BroadcastChannel);
-  SetMethod(context, target, "structuredClone", StructuredClone);
+  SetMethod(isolate, target, "broadcastChannel", BroadcastChannel);
+  SetMethod(isolate, target, "structuredClone", StructuredClone);
+}
 
+static void CreatePerContextProperties(Local<Object> target,
+                                       Local<Value> unused,
+                                       Local<Context> context,
+                                       void* priv) {
+  Environment* env = Environment::GetCurrent(context);
   {
     Local<Function> domexception = GetDOMException(context).ToLocalChecked();
     target
@@ -1710,6 +1717,9 @@ static void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 }  // namespace worker
 }  // namespace node
 
-NODE_BINDING_CONTEXT_AWARE_INTERNAL(messaging, node::worker::InitMessaging)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(messaging,
+                                    node::worker::CreatePerContextProperties)
+NODE_BINDING_PER_ISOLATE_INIT(messaging,
+                              node::worker::CreatePerIsolateProperties)
 NODE_BINDING_EXTERNAL_REFERENCE(messaging,
                                 node::worker::RegisterExternalReferences)

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -379,7 +379,7 @@ class JSTransferable : public BaseObject {
 };
 
 v8::Local<v8::FunctionTemplate> GetMessagePortConstructorTemplate(
-    Environment* env);
+    IsolateData* isolate_data);
 
 }  // namespace worker
 }  // namespace node

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -15,7 +15,7 @@ class MemoryTracker;
 class ExternalReferenceRegistry;
 class Realm;
 
-void CreateEnvProxyTemplate(v8::Isolate* isolate, IsolateData* isolate_data);
+void CreateEnvProxyTemplate(IsolateData* isolate_data);
 
 // Most of the time, it's best to use `console.error` to write
 // to the process.stderr stream.  However, in some cases, such as

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -48,16 +48,20 @@ void PatchProcessObject(const v8::FunctionCallbackInfo<v8::Value>& args);
 namespace process {
 class BindingData : public SnapshotableObject {
  public:
+  struct InternalFieldInfo : public node::InternalFieldInfoBase {
+    AliasedBufferIndex hrtime_buffer;
+  };
+
   static void AddMethods(v8::Isolate* isolate,
                          v8::Local<v8::ObjectTemplate> target);
   static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
 
-  using InternalFieldInfo = InternalFieldInfoBase;
-
   SERIALIZABLE_OBJECT_METHODS()
   SET_BINDING_ID(process_binding_data)
 
-  BindingData(Realm* realm, v8::Local<v8::Object> object);
+  BindingData(Realm* realm,
+              v8::Local<v8::Object> object,
+              InternalFieldInfo* info = nullptr);
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(BindingData)
@@ -81,10 +85,10 @@ class BindingData : public SnapshotableObject {
   static void SlowBigInt(const v8::FunctionCallbackInfo<v8::Value>& args);
 
  private:
-  static constexpr size_t kBufferSize =
-      std::max(sizeof(uint64_t), sizeof(uint32_t) * 3);
-  v8::Global<v8::ArrayBuffer> array_buffer_;
-  std::shared_ptr<v8::BackingStore> backing_store_;
+  // Buffer length in uint32.
+  static constexpr size_t kHrTimeBufferLength = 3;
+  AliasedUint32Array hrtime_buffer_;
+  InternalFieldInfo* internal_field_info_ = nullptr;
 
   // These need to be static so that we have their addresses available to
   // register as external references in the snapshot at environment creation

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -465,15 +465,29 @@ static void ReallyExit(const FunctionCallbackInfo<Value>& args) {
 
 namespace process {
 
-BindingData::BindingData(Realm* realm, v8::Local<v8::Object> object)
-    : SnapshotableObject(realm, object, type_int) {
+BindingData::BindingData(Realm* realm,
+                         v8::Local<v8::Object> object,
+                         InternalFieldInfo* info)
+    : SnapshotableObject(realm, object, type_int),
+      hrtime_buffer_(realm->isolate(),
+                     kHrTimeBufferLength,
+                     MAYBE_FIELD_PTR(info, hrtime_buffer)) {
   Isolate* isolate = realm->isolate();
   Local<Context> context = realm->context();
-  Local<ArrayBuffer> ab = ArrayBuffer::New(isolate, kBufferSize);
-  array_buffer_.Reset(isolate, ab);
-  object->Set(context, FIXED_ONE_BYTE_STRING(isolate, "hrtimeBuffer"), ab)
-      .ToChecked();
-  backing_store_ = ab->GetBackingStore();
+
+  if (info == nullptr) {
+    object
+        ->Set(context,
+              FIXED_ONE_BYTE_STRING(isolate, "hrtimeBuffer"),
+              hrtime_buffer_.GetJSArray())
+        .ToChecked();
+  } else {
+    hrtime_buffer_.Deserialize(realm->context());
+  }
+
+  // The hrtime buffer is referenced from the binding data js object.
+  // Make the native handle weak to avoid keeping the realm alive.
+  hrtime_buffer_.MakeWeak();
 }
 
 v8::CFunction BindingData::fast_number_(v8::CFunction::Make(FastNumber));
@@ -503,7 +517,7 @@ BindingData* BindingData::FromV8Value(Local<Value> value) {
 }
 
 void BindingData::MemoryInfo(MemoryTracker* tracker) const {
-  tracker->TrackField("array_buffer", array_buffer_);
+  tracker->TrackField("hrtime_buffer", hrtime_buffer_);
 }
 
 // This is the legacy version of hrtime before BigInt was introduced in
@@ -516,20 +530,19 @@ void BindingData::MemoryInfo(MemoryTracker* tracker) const {
 // because there is no Uint64Array in JS.
 // The third entry contains the remaining nanosecond part of the value.
 void BindingData::NumberImpl(BindingData* receiver) {
-  // Make sure we don't accidentally access buffers wiped for snapshot.
-  CHECK(!receiver->array_buffer_.IsEmpty());
   uint64_t t = uv_hrtime();
-  uint32_t* fields = static_cast<uint32_t*>(receiver->backing_store_->Data());
-  fields[0] = (t / NANOS_PER_SEC) >> 32;
-  fields[1] = (t / NANOS_PER_SEC) & 0xffffffff;
-  fields[2] = t % NANOS_PER_SEC;
+  receiver->hrtime_buffer_[0] = (t / NANOS_PER_SEC) >> 32;
+  receiver->hrtime_buffer_[1] = (t / NANOS_PER_SEC) & 0xffffffff;
+  receiver->hrtime_buffer_[2] = t % NANOS_PER_SEC;
 }
 
 void BindingData::BigIntImpl(BindingData* receiver) {
-  // Make sure we don't accidentally access buffers wiped for snapshot.
-  CHECK(!receiver->array_buffer_.IsEmpty());
   uint64_t t = uv_hrtime();
-  uint64_t* fields = static_cast<uint64_t*>(receiver->backing_store_->Data());
+  // The buffer is a Uint32Array, so we need to reinterpret it as a
+  // Uint64Array to write the value. The buffer is valid at this scope so we
+  // can safely cast away the constness.
+  uint64_t* fields = reinterpret_cast<uint64_t*>(
+      const_cast<uint32_t*>(receiver->hrtime_buffer_.GetNativeBuffer()));
   fields[0] = t;
 }
 
@@ -543,9 +556,10 @@ void BindingData::SlowNumber(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
 bool BindingData::PrepareForSerialization(Local<Context> context,
                                           v8::SnapshotCreator* creator) {
-  // It's not worth keeping.
-  // Release it, we will recreate it when the instance is dehydrated.
-  array_buffer_.Reset();
+  DCHECK_NULL(internal_field_info_);
+  internal_field_info_ = InternalFieldInfoBase::New<InternalFieldInfo>(type());
+  internal_field_info_->hrtime_buffer =
+      hrtime_buffer_.Serialize(context, creator);
   // Return true because we need to maintain the reference to the binding from
   // JS land.
   return true;
@@ -553,8 +567,8 @@ bool BindingData::PrepareForSerialization(Local<Context> context,
 
 InternalFieldInfoBase* BindingData::Serialize(int index) {
   DCHECK_IS_SNAPSHOT_SLOT(index);
-  InternalFieldInfo* info =
-      InternalFieldInfoBase::New<InternalFieldInfo>(type());
+  InternalFieldInfo* info = internal_field_info_;
+  internal_field_info_ = nullptr;
   return info;
 }
 
@@ -566,7 +580,9 @@ void BindingData::Deserialize(Local<Context> context,
   v8::HandleScope scope(context->GetIsolate());
   Realm* realm = Realm::GetCurrent(context);
   // Recreate the buffer in the constructor.
-  BindingData* binding = realm->AddBindingData<BindingData>(holder);
+  InternalFieldInfo* casted_info = static_cast<InternalFieldInfo*>(info);
+  BindingData* binding =
+      realm->AddBindingData<BindingData>(holder, casted_info);
   CHECK_NOT_NULL(binding);
 }
 

--- a/src/node_realm.cc
+++ b/src/node_realm.cc
@@ -344,10 +344,11 @@ MaybeLocal<Value> PrincipalRealm::BootstrapRealm() {
     return MaybeLocal<Value>();
   }
 
+  // Setup process.env proxy.
   Local<String> env_string = FIXED_ONE_BYTE_STRING(isolate_, "env");
   Local<Object> env_proxy;
-  CreateEnvProxyTemplate(isolate_, env_->isolate_data());
-  if (!env_->env_proxy_template()->NewInstance(context()).ToLocal(&env_proxy) ||
+  if (!isolate_data()->env_proxy_template()->NewInstance(context()).ToLocal(
+          &env_proxy) ||
       process_object()->Set(context(), env_string, env_proxy).IsNothing()) {
     return MaybeLocal<Value>();
   }

--- a/test/fixtures/es-module-shadow-realm/custom-loaders.js
+++ b/test/fixtures/es-module-shadow-realm/custom-loaders.js
@@ -1,0 +1,15 @@
+// This fixture is used to test that custom loaders are not enabled in the ShadowRealm.
+
+'use strict';
+const assert = require('assert');
+
+async function workInChildProcess() {
+  // Assert that the process is running with a custom loader.
+  const moduleNamespace = await import('file:///42.mjs');
+  assert.strictEqual(moduleNamespace.default, 42);
+
+  const realm = new ShadowRealm();
+  await assert.rejects(realm.importValue('file:///42.mjs', 'default'), TypeError);
+}
+
+workInChildProcess();

--- a/test/fixtures/es-module-shadow-realm/preload-main.js
+++ b/test/fixtures/es-module-shadow-realm/preload-main.js
@@ -1,0 +1,9 @@
+// This fixture is used to test that --require preload modules are not enabled in the ShadowRealm.
+
+'use strict';
+const assert = require('assert');
+
+assert.strictEqual(globalThis.preload, 42);
+const realm = new ShadowRealm();
+const value = realm.evaluate(`globalThis.preload`);
+assert.strictEqual(value, undefined);

--- a/test/fixtures/es-module-shadow-realm/preload.js
+++ b/test/fixtures/es-module-shadow-realm/preload.js
@@ -1,0 +1,1 @@
+globalThis.preload = 42;

--- a/test/fixtures/es-module-shadow-realm/re-export-state-counter.mjs
+++ b/test/fixtures/es-module-shadow-realm/re-export-state-counter.mjs
@@ -1,0 +1,3 @@
+// This module verifies that the module specifier is resolved relative to the
+// current module and not the current working directory in the ShadowRealm.
+export { getCounter } from "./state-counter.mjs";

--- a/test/fixtures/es-module-shadow-realm/state-counter.mjs
+++ b/test/fixtures/es-module-shadow-realm/state-counter.mjs
@@ -1,0 +1,4 @@
+let counter = 0;
+export const getCounter = () => {
+  return counter++;
+};

--- a/test/parallel/test-shadow-realm-allowed-builtin-modules.js
+++ b/test/parallel/test-shadow-realm-allowed-builtin-modules.js
@@ -1,0 +1,21 @@
+// Flags: --experimental-shadow-realm
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+async function main() {
+  // Verifies that builtin modules can not be imported in the ShadowRealm.
+  const realm = new ShadowRealm();
+  // The error object created inside the ShadowRealm with the error code
+  // property is not copied on the realm boundary. Only the error message
+  // is copied. Simply check the error message here.
+  await assert.rejects(realm.importValue('fs', 'readFileSync'), {
+    message: /Cannot find package 'fs'/,
+  });
+  // As above, we can only validate the error message, not the error code.
+  await assert.rejects(realm.importValue('node:fs', 'readFileSync'), {
+    message: /No such built-in module: node:fs/,
+  });
+}
+
+main().then(common.mustCall());

--- a/test/parallel/test-shadow-realm-custom-loaders.js
+++ b/test/parallel/test-shadow-realm-custom-loaders.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+
+const commonArgs = [
+  '--experimental-shadow-realm',
+  '--no-warnings',
+];
+
+async function main() {
+  // Verifies that custom loaders are not enabled in the ShadowRealm.
+  const child = await common.spawnPromisified(process.execPath, [
+    ...commonArgs,
+    '--experimental-loader',
+    fixtures.fileURL('es-module-loaders', 'loader-resolve-shortcircuit.mjs'),
+    '--experimental-loader',
+    fixtures.fileURL('es-module-loaders', 'loader-load-foo-or-42.mjs'),
+    fixtures.path('es-module-shadow-realm', 'custom-loaders.js'),
+  ]);
+
+  assert.strictEqual(child.stderr, '');
+  assert.strictEqual(child.code, 0);
+}
+
+main().then(common.mustCall());

--- a/test/parallel/test-shadow-realm-gc-module.js
+++ b/test/parallel/test-shadow-realm-gc-module.js
@@ -1,0 +1,20 @@
+// Flags: --experimental-shadow-realm --max-old-space-size=20
+'use strict';
+
+/**
+ * Verifying modules imported by ShadowRealm instances can be correctly
+ * garbage collected.
+ */
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+async function main() {
+  const mod = fixtures.fileURL('es-module-shadow-realm', 'state-counter.mjs');
+  for (let i = 0; i < 100; i++) {
+    const realm = new ShadowRealm();
+    await realm.importValue(mod, 'getCounter');
+  }
+}
+
+main().then(common.mustCall());

--- a/test/parallel/test-shadow-realm-import-value-resolve.js
+++ b/test/parallel/test-shadow-realm-import-value-resolve.js
@@ -1,0 +1,28 @@
+// Flags: --experimental-shadow-realm
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+
+common.skipIfWorker('process.chdir is not supported in workers.');
+
+async function main() {
+  const realm = new ShadowRealm();
+
+  const dirname = __dirname;
+  // Set process cwd to the parent directory of __dirname.
+  const cwd = path.dirname(dirname);
+  process.chdir(cwd);
+  // Hardcode the relative path to ensure the string is still a valid relative
+  // URL string.
+  const relativePath = './fixtures/es-module-shadow-realm/re-export-state-counter.mjs';
+
+  // Make sure that the module can not be resolved relative to __filename.
+  assert.throws(() => require.resolve(relativePath), { code: 'MODULE_NOT_FOUND' });
+
+  // Resolve relative to the current working directory.
+  const getCounter = await realm.importValue(relativePath, 'getCounter');
+  assert.strictEqual(typeof getCounter, 'function');
+}
+
+main().then(common.mustCall());

--- a/test/parallel/test-shadow-realm-module.js
+++ b/test/parallel/test-shadow-realm-module.js
@@ -1,0 +1,29 @@
+// Flags: --experimental-shadow-realm
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+
+async function main() {
+  const realm = new ShadowRealm();
+  const mod = fixtures.fileURL('es-module-shadow-realm', 'state-counter.mjs');
+  const getCounter = await realm.importValue(mod, 'getCounter');
+  assert.strictEqual(getCounter(), 0);
+  const getCounter1 = await realm.importValue(mod, 'getCounter');
+  // Returned value is a newly wrapped function.
+  assert.notStrictEqual(getCounter, getCounter1);
+  // Verify that the module state is shared between two `importValue` calls.
+  assert.strictEqual(getCounter1(), 1);
+  assert.strictEqual(getCounter(), 2);
+
+  const { getCounter: getCounterThisRealm } = await import(mod);
+  assert.notStrictEqual(getCounterThisRealm, getCounter);
+  // Verify that the module state is not shared between two realms.
+  assert.strictEqual(getCounterThisRealm(), 0);
+  assert.strictEqual(getCounter(), 3);
+
+  // Verify that shadow realm rejects to import a non-existing module.
+  await assert.rejects(realm.importValue('non-exists', 'exports'), TypeError);
+}
+
+main().then(common.mustCall());

--- a/test/parallel/test-shadow-realm-preload-module.js
+++ b/test/parallel/test-shadow-realm-preload-module.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+
+const commonArgs = [
+  '--experimental-shadow-realm',
+];
+
+async function main() {
+  // Verifies that --require preload modules are not enabled in the ShadowRealm.
+  spawnSyncAndExitWithoutError(process.execPath, [
+    ...commonArgs,
+    '--require',
+    fixtures.path('es-module-shadow-realm', 'preload.js'),
+    fixtures.path('es-module-shadow-realm', 'preload-main.js'),
+  ]);
+}
+
+main().then(common.mustCall());


### PR DESCRIPTION
This bootstraps ESM loaders in the ShadowRealm with `ShadowRealm.prototype.importValue` as its entry point and enables loading ESM and CJS modules in the ShadowRealm. The module is imported without a parent URL and resolved with the current process's working directory. 