### PR TITLE
esm: fix emit deprecation on legacy main resolve

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -30,7 +30,7 @@ const { getOptionValue } = require('internal/options');
 const policy = getOptionValue('--experimental-policy') ?
   require('internal/process/policy') :
   null;
-const { sep, relative, toNamespacedPath } = require('path');
+const { sep, relative, toNamespacedPath, resolve } = require('path');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const experimentalNetworkImports =
@@ -111,9 +111,9 @@ function emitLegacyIndexDeprecation(url, packageJSONUrl, base, main) {
   const path = fileURLToPath(url);
   const pkgPath = fileURLToPath(new URL('.', packageJSONUrl));
   const basePath = fileURLToPath(base);
-  if (main)
+  if (main && resolve(pkgPath, main) !== path)
     process.emitWarning(
-      `Package ${pkgPath} has a "main" field set to ${JSONStringify(main)}, ` +
+      `Package ${pkgPath} has a "main" field set to "${main}", ` +
       `excluding the full filename and extension to the resolved file at "${
         StringPrototypeSlice(path, pkgPath.length)}", imported from ${
         basePath}.\n Automatic extension resolution of the "main" field is ` +
@@ -121,7 +121,7 @@ function emitLegacyIndexDeprecation(url, packageJSONUrl, base, main) {
       'DeprecationWarning',
       'DEP0151',
     );
-  else
+  else if (!main)
     process.emitWarning(
       `No "main" or "exports" field defined in the package.json for ${pkgPath
       } resolving the main entry point "${


### PR DESCRIPTION
https://github.com/nodejs/node/pull/48325 introduced a bug where the deprecation is thrown for every resolve. This PR fixes that.

Refs: https://github.com/nodejs/node/pull/48325

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
