### PR TITLE
src: pre-emptively fix tests broken by patch

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.10',
+    'v8_embedder_string': '-node.11',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/codegen/compiler.cc
+++ b/deps/v8/src/codegen/compiler.cc
@@ -3686,7 +3686,7 @@ MaybeHandle<JSFunction> Compiler::GetWrappedFunction(
     // functions fully non-lazy instead thus preventing source positions from
     // being omitted.
     flags.set_collect_source_positions(true);
-    // flags.set_eager(compile_options == ScriptCompiler::kEagerCompile);
+    flags.set_is_eager(compile_options == ScriptCompiler::kEagerCompile);
 
     UnoptimizedCompileState compile_state;
     ReusableUnoptimizedCompileState reusable_state(isolate);

--- a/deps/v8/test/cctest/test-serialize.cc
+++ b/deps/v8/test/cctest/test-serialize.cc
@@ -4979,6 +4979,37 @@ TEST(CachedCompileFunction) {
   }
 }
 
+TEST(CachedCompileFunctionRespectsEager) {
+  DisableAlwaysOpt();
+  LocalContext env;
+  Isolate* isolate = CcTest::i_isolate();
+  isolate->compilation_cache()
+      ->DisableScriptAndEval();  // Disable same-isolate code cache.
+
+  v8::HandleScope scope(CcTest::isolate());
+
+  v8::Local<v8::String> source = v8_str("return function() { return 42; }");
+  v8::ScriptCompiler::Source script_source(source);
+
+  for (bool eager_compile : {false, true}) {
+    v8::ScriptCompiler::CompileOptions options =
+        eager_compile ? v8::ScriptCompiler::kEagerCompile
+                      : v8::ScriptCompiler::kNoCompileOptions;
+    v8::Local<v8::Value> fun =
+        v8::ScriptCompiler::CompileFunction(env.local(), &script_source, 0,
+                                            nullptr, 0, nullptr, options)
+            .ToLocalChecked()
+            .As<v8::Function>()
+            ->Call(env.local(), v8::Undefined(CcTest::isolate()), 0, nullptr)
+            .ToLocalChecked();
+
+    auto i_fun = i::Handle<i::JSFunction>::cast(Utils::OpenHandle(*fun));
+
+    // Function should be compiled iff kEagerCompile was used.
+    CHECK_EQ(i_fun->shared().is_compiled(), eager_compile);
+  }
+}
+
 UNINITIALIZED_TEST(SnapshotCreatorAnonClassWithKeep) {
   DisableAlwaysOpt();
   v8::SnapshotCreator creator;

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -285,7 +285,7 @@ MaybeLocal<Function> BuiltinLoader::LookupAndCompileInternal(
   const bool has_cache = cached_data.data != nullptr;
   ScriptCompiler::CompileOptions options =
       has_cache ? ScriptCompiler::kConsumeCodeCache
-                : ScriptCompiler::kEagerCompile;
+                : ScriptCompiler::kNoCompileOptions;
   ScriptCompiler::Source script_source(
       source,
       origin,

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1270,7 +1270,7 @@ void CompileSerializeMain(const FunctionCallbackInfo<Value>& args) {
                                       parameters.data(),
                                       0,
                                       nullptr,
-                                      ScriptCompiler::kEagerCompile)
+                                      ScriptCompiler::kNoCompileOptions)
           .ToLocal(&fn)) {
     args.GetReturnValue().Set(fn);
   }


### PR DESCRIPTION
I put up a CL to V8 to fix the fact that kEagerCompile was being
completely ignored when used as an input to CompileFunction. Turns
out actually enabling kEagerCompile breaks a bunch of tests. Oops.

To stop us from getting the broken tests when we update V8, (1)
stop using kEagerCompile and (2) cherry-pick the patch. The latter
is not strictly necessary but will hopefully stop us from introducing
new use-cases of kEagerCompile which would break once it's actually
fixed.

Manually tested this by compiling before & after this PR and
inspecting `out/Release/gen/node_snapshot.cc` for differences. There
were no differences in the code cache but some minor differences
in the snapshot (which makes sense since snapshotting is not
deterministic).

#### src: remove kEagerCompile for CompileFunction

It wasn't doing anything, and actually enabling it would cause some
tests to fail.

Refs: https://github.com/nodejs/node/pull/48576

#### deps: V8: cherry-pick cb00db4dba6c

Original commit message:

    [compiler] fix CompileFunction ignoring kEagerCompile

    v8::ScriptCompiler::CompileFunction was ignoring kEagerCompile. Unlike
    the other functions in v8::ScriptCompiler, it was not actually
    propagating kEagerCompile to the parser. The newly updated test fails
    without this change.

    I did some archeology and found that this was commented out since the
    original CL in https://crrev.com/c/980944.

    As far as I know Node.js is the main consumer of this particular API.
    This CL speeds up Node.js's overall startup time by ~13%.

    Change-Id: Ifc3cd6653555194d46ca48db14f7ba7a4afe0053
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4571822
    Commit-Queue: Marja Hölttä <marja@chromium.org>
    Reviewed-by: Marja Hölttä <marja@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#87944}

Refs: https://github.com/v8/v8/commit/cb00db4dba6c4a1900700d134e2293c59155db28