### PR TITLE
doc: clarify transform._transform() callback argument logic

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -4517,7 +4517,8 @@ The `callback` function must be called only when the current chunk is completely
 consumed. The first argument passed to the `callback` must be an `Error` object
 if an error occurred while processing the input or `null` otherwise. If a second
 argument is passed to the `callback`, it will be forwarded on to the
-`transform.push()` method. In other words, the following are equivalent:
+`transform.push()` method, but only if the first argument is falsy. In other
+words, the following are equivalent:
 
 ```js
 transform.prototype._transform = function(data, encoding, callback) {


### PR DESCRIPTION
Edited / fixed version of https://github.com/nodejs/node/pull/48653

Clarified that `stream.Transform` callback second argument is passed only if the first argument is `null`, i.e. no error occured processing the chunk.

From the way the documentation is written right now, I expected the second argument to be forwarded to `transform.push()`, even if the first argument is an `Error`. I was implementing a truncation stream, and passed both an `Error` ("stream exceeded maximum size"; could be optionally caught and ignored), and the last (truncated) chunk. Only after digging through [the relevant implementaton](https://github.com/nodejs/node/blob/b40f0c30743aaecd57071f7be305df43e1083817/lib/internal/streams/transform.js#L176) I could confirm for sure that the second argument is entirely ignored if the first one is not `null`.

Please tell me if you want to adjust the wording somehow, or whether I should add an alternative example to the one following the line "In other words, the following are equivalent:". Hopefully you'll find this useful.