### PR TITLE
stream: fix deadlock when pipeing to full sink 

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -822,9 +822,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   // Start the flow if it hasn't been started already.
 
   if (dest.writableNeedDrain === true) {
-    if (state.flowing) {
-      pause();
-    }
+    pause();
   } else if (!state.flowing) {
     debug('pipe resume');
     src.resume();

--- a/test/parallel/test-stream-pipe-deadlock.js
+++ b/test/parallel/test-stream-pipe-deadlock.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+const { Readable, Writable } = require('stream');
+
+// https://github.com/nodejs/node/issues/48666
+(async () => {
+  // Prepare src that is internally ended, with buffered data pending
+  const src = new Readable({ read() {} });
+  src.push(Buffer.alloc(100));
+  src.push(null);
+  src.pause();
+
+  // Give it time to settle
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const dst = new Writable({
+    highWaterMark: 1000,
+    write(buf, enc, cb) {
+      process.nextTick(cb);
+    }
+  });
+
+  dst.write(Buffer.alloc(1000)); // Fill write buffer
+  dst.on('finish', common.mustCall());
+  src.pipe(dst);
+})().then(common.mustCall());


### PR DESCRIPTION
When piping a paused Readable to a full Writable we didn't  register a drain listener which cause the src to never resume.
    
Refs: https://github.com/nodejs/node/issues/48666