### PR TITLE
fs: fix readdir recursive sync & callback

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1437,14 +1437,21 @@ function readdirSyncRecursive(basePath, options) {
     );
     handleErrorFromBinding(ctx);
 
-    for (let i = 0; i < readdirResult.length; i++) {
-      if (withFileTypes) {
+    if (withFileTypes) {
+      // Calling `readdir` with `withFileTypes=true`, the result is an array of arrays.
+      // The first array is the names, and the second array is the types.
+      // They are guaranteed to be the same length; hence, setting `length` to the length
+      // of the first array within the result.
+      const length = readdirResult[0].length;
+      for (let i = 0; i < length; i++) {
         const dirent = getDirent(path, readdirResult[0][i], readdirResult[1][i]);
         ArrayPrototypePush(readdirResults, dirent);
         if (dirent.isDirectory()) {
           ArrayPrototypePush(pathsQueue, pathModule.join(dirent.path, dirent.name));
         }
-      } else {
+      }
+    } else {
+      for (let i = 0; i < readdirResult.length; i++) {
         const resultPath = pathModule.join(path, readdirResult[i]);
         const relativeResultPath = pathModule.relative(basePath, resultPath);
         const stat = binding.internalModuleStat(resultPath);

--- a/test/sequential/test-fs-readdir-recursive.js
+++ b/test/sequential/test-fs-readdir-recursive.js
@@ -131,9 +131,11 @@ function getDirentPath(dirent) {
 }
 
 function assertDirents(dirents) {
+  assert.strictEqual(dirents.length, expected.length);
   dirents.sort((a, b) => (getDirentPath(a) < getDirentPath(b) ? -1 : 1));
   for (const [i, dirent] of dirents.entries()) {
     assert(dirent instanceof fs.Dirent);
+    assert.notStrictEqual(dirent.name, undefined);
     assert.strictEqual(getDirentPath(dirent), expected[i]);
   }
 }


### PR DESCRIPTION
This PR fixes the broken behavior for readdir recursive sync and callback. It updates the test assertions to catch the issue in the old code, and then adds the necessary fix in the implementation.

Refs: https://github.com/nodejs/node/issues/48640
Fixes: https://github.com/nodejs/node/issues/48858