### PR TITLE
bootstrap: polyfill Symbol.dispose/Symbol.asyncDispose with correct descriptor

### DIFF
--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -128,9 +128,26 @@ function prepareExecution(options) {
 function setupSymbolDisposePolyfill() {
   // TODO(MoLow): Remove this polyfill once Symbol.dispose and Symbol.asyncDispose are available in V8.
   // eslint-disable-next-line node-core/prefer-primordials
-  Symbol.dispose ??= SymbolDispose;
+  if (typeof Symbol.dispose !== 'symbol') {
+    ObjectDefineProperty(Symbol, 'dispose', {
+      __proto__: null,
+      configurable: false,
+      enumerable: false,
+      value: SymbolDispose,
+      writable: false,
+    });
+  }
+
   // eslint-disable-next-line node-core/prefer-primordials
-  Symbol.asyncDispose ??= SymbolAsyncDispose;
+  if (typeof Symbol.asyncDispose !== 'symbol') {
+    ObjectDefineProperty(Symbol, 'asyncDispose', {
+      __proto__: null,
+      configurable: false,
+      enumerable: false,
+      value: SymbolAsyncDispose,
+      writable: false,
+    });
+  }
 }
 
 function setupUserModules(isLoaderWorker = false) {


### PR DESCRIPTION
Followup to #48518; fixes #48699

Happy to add a test if needed - but I both wasn't sure where it would go, and I also wasn't sure if this was worth testing since node rarely polyfills JS builtins and v8 will supply it soon enough anyways (backed by test262)