### PR TITLE
src: save the performance milestone time origin in the AliasedArray

### DIFF
--- a/lib/internal/perf/utils.js
+++ b/lib/internal/perf/utils.js
@@ -1,33 +1,33 @@
 'use strict';
 
-const binding = internalBinding('performance');
 const {
+  constants: {
+    NODE_PERFORMANCE_MILESTONE_TIME_ORIGIN,
+  },
   milestones,
-  getTimeOrigin,
-} = binding;
+} = internalBinding('performance');
 
-// TODO(joyeecheung): we may want to warn about access to
-// this during snapshot building.
-let timeOrigin = getTimeOrigin();
-
-function now() {
-  const hr = process.hrtime();
-  return (hr[0] * 1000 + hr[1] / 1e6) - timeOrigin;
+function getTimeOrigin() {
+  // Do not cache this to prevent it from being serialized into the
+  // snapshot.
+  return milestones[NODE_PERFORMANCE_MILESTONE_TIME_ORIGIN] / 1e6;
 }
 
+// Returns the time relative to the process start time in milliseconds.
+function now() {
+  const hr = process.hrtime();
+  return (hr[0] * 1000 + hr[1] / 1e6) - getTimeOrigin();
+}
+
+// Returns the milestone relative to the process start time in milliseconds.
 function getMilestoneTimestamp(milestoneIdx) {
   const ns = milestones[milestoneIdx];
   if (ns === -1)
     return ns;
-  return ns / 1e6 - timeOrigin;
-}
-
-function refreshTimeOrigin() {
-  timeOrigin = getTimeOrigin();
+  return ns / 1e6 - getTimeOrigin();
 }
 
 module.exports = {
   now,
   getMilestoneTimestamp,
-  refreshTimeOrigin,
 };

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -67,7 +67,6 @@ function prepareExecution(options) {
   // Patch the process object with legacy properties and normalizations
   patchProcessObject(expandArgv1);
   setupTraceCategoryState();
-  setupPerfHooks();
   setupInspectorHooks();
   setupWarningHandler();
   setupFetch();
@@ -404,10 +403,6 @@ function setupTraceCategoryState() {
   const { isTraceCategoryEnabled } = internalBinding('trace_events');
   const { toggleTraceCategoryState } = require('internal/process/per_thread');
   toggleTraceCategoryState(isTraceCategoryEnabled('node.async_hooks'));
-}
-
-function setupPerfHooks() {
-  require('internal/perf/utils').refreshTimeOrigin();
 }
 
 function setupInspectorHooks() {

--- a/src/env.cc
+++ b/src/env.cc
@@ -783,7 +783,7 @@ Environment::Environment(IsolateData* isolate_data,
   destroy_async_id_list_.reserve(512);
 
   performance_state_ = std::make_unique<performance::PerformanceState>(
-      isolate, MAYBE_FIELD_PTR(env_info, performance_state));
+      isolate, time_origin_, MAYBE_FIELD_PTR(env_info, performance_state));
 
   if (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
           TRACING_CATEGORY_NODE1(environment)) != 0) {
@@ -1732,7 +1732,7 @@ void Environment::DeserializeProperties(const EnvSerializeInfo* info) {
   immediate_info_.Deserialize(ctx);
   timeout_info_.Deserialize(ctx);
   tick_info_.Deserialize(ctx);
-  performance_state_->Deserialize(ctx);
+  performance_state_->Deserialize(ctx, time_origin_);
   exit_info_.Deserialize(ctx);
   stream_base_state_.Deserialize(ctx);
   should_abort_on_uncaught_toggle_.Deserialize(ctx);

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -20,7 +20,6 @@ using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::GCCallbackFlags;
 using v8::GCType;
-using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
@@ -43,6 +42,7 @@ const double performance_process_start_timestamp =
 uint64_t performance_v8_start;
 
 PerformanceState::PerformanceState(Isolate* isolate,
+                                   uint64_t time_origin,
                                    const PerformanceState::SerializeInfo* info)
     : root(isolate,
            sizeof(performance_state_internal),
@@ -58,24 +58,43 @@ PerformanceState::PerformanceState(Isolate* isolate,
                 root,
                 MAYBE_FIELD_PTR(info, observers)) {
   if (info == nullptr) {
-    for (size_t i = 0; i < milestones.Length(); i++) milestones[i] = -1.;
+    // For deserialized performance states, we'll re-initialize in
+    // the deserialize callback.
+    Initialize(time_origin);
   }
 }
 
 PerformanceState::SerializeInfo PerformanceState::Serialize(
     v8::Local<v8::Context> context, v8::SnapshotCreator* creator) {
+  // Reset all the milestones. We'll re-initialize them after deserialization.
+  size_t milestones_length = milestones.Length();
+  for (size_t i = 0; i < milestones_length; ++i) {
+    milestones[i] = -1;
+  }
+
   SerializeInfo info{root.Serialize(context, creator),
                      milestones.Serialize(context, creator),
                      observers.Serialize(context, creator)};
   return info;
 }
 
-void PerformanceState::Deserialize(v8::Local<v8::Context> context) {
+void PerformanceState::Initialize(uint64_t time_origin) {
+  // We are only reusing the milestone array to store the time origin, so do
+  // not use the Mark() method. The time origin milestone is not exposed
+  // to user land.
+  this->milestones[NODE_PERFORMANCE_MILESTONE_TIME_ORIGIN] =
+      static_cast<double>(time_origin);
+}
+
+void PerformanceState::Deserialize(v8::Local<v8::Context> context,
+                                   uint64_t time_origin) {
+  // Resets the pointers.
   root.Deserialize(context);
-  // This is just done to set up the pointers, we will actually reset
-  // all the milestones after deserialization.
   milestones.Deserialize(context);
   observers.Deserialize(context);
+
+  // Re-initialize the time origin i.e. the process start time.
+  Initialize(time_origin);
 }
 
 std::ostream& operator<<(std::ostream& o,
@@ -94,18 +113,6 @@ void PerformanceState::Mark(PerformanceMilestone milestone, uint64_t ts) {
       TRACING_CATEGORY_NODE1(bootstrap),
       GetPerformanceMilestoneName(milestone),
       TRACE_EVENT_SCOPE_THREAD, ts / 1000);
-}
-
-// Allows specific Node.js lifecycle milestones to be set from JavaScript
-void MarkMilestone(const FunctionCallbackInfo<Value>& args) {
-  Realm* realm = Realm::GetCurrent(args);
-  // TODO(legendecas): Remove this check once the sub-realms are supported.
-  CHECK_EQ(realm->kind(), Realm::Kind::kPrincipal);
-  Environment* env = realm->env();
-  PerformanceMilestone milestone =
-      static_cast<PerformanceMilestone>(args[0].As<Int32>()->Value());
-  if (milestone != NODE_PERFORMANCE_MILESTONE_INVALID)
-    env->performance_state()->Mark(milestone);
 }
 
 void SetupPerformanceObservers(const FunctionCallbackInfo<Value>& args) {
@@ -275,12 +282,6 @@ void CreateELDHistogram(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(histogram->object());
 }
 
-void GetTimeOrigin(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  args.GetReturnValue().Set(
-      Number::New(args.GetIsolate(), env->time_origin() / NANOS_PER_MILLIS));
-}
-
 void GetTimeOriginTimeStamp(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   args.GetReturnValue().Set(Number::New(
@@ -300,7 +301,6 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
 
   HistogramBase::Initialize(isolate_data, target);
 
-  SetMethod(isolate, target, "markMilestone", MarkMilestone);
   SetMethod(isolate, target, "setupObservers", SetupPerformanceObservers);
   SetMethod(isolate,
             target,
@@ -312,7 +312,6 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
             RemoveGarbageCollectionTracking);
   SetMethod(isolate, target, "notify", Notify);
   SetMethod(isolate, target, "loopIdleTime", LoopIdleTime);
-  SetMethod(isolate, target, "getTimeOrigin", GetTimeOrigin);
   SetMethod(isolate, target, "getTimeOriginTimestamp", GetTimeOriginTimeStamp);
   SetMethod(isolate, target, "createELDHistogram", CreateELDHistogram);
   SetMethod(isolate, target, "markBootstrapComplete", MarkBootstrapComplete);
@@ -373,13 +372,11 @@ void CreatePerContextProperties(Local<Object> target,
 }
 
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
-  registry->Register(MarkMilestone);
   registry->Register(SetupPerformanceObservers);
   registry->Register(InstallGarbageCollectionTracking);
   registry->Register(RemoveGarbageCollectionTracking);
   registry->Register(Notify);
   registry->Register(LoopIdleTime);
-  registry->Register(GetTimeOrigin);
   registry->Register(GetTimeOriginTimeStamp);
   registry->Register(CreateELDHistogram);
   registry->Register(MarkBootstrapComplete);

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -82,6 +82,7 @@ class PerformanceState {
 
  private:
   void Initialize(uint64_t time_origin);
+  void ResetMilestones();
   struct performance_state_internal {
     // doubles first so that they are always sizeof(double)-aligned
     double milestones[NODE_PERFORMANCE_MILESTONE_INVALID];

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -24,14 +24,14 @@ extern const uint64_t performance_process_start;
 extern const double performance_process_start_timestamp;
 extern uint64_t performance_v8_start;
 
-#define NODE_PERFORMANCE_MILESTONES(V)                                        \
-  V(ENVIRONMENT, "environment")                                               \
-  V(NODE_START, "nodeStart")                                                  \
-  V(V8_START, "v8Start")                                                      \
-  V(LOOP_START, "loopStart")                                                  \
-  V(LOOP_EXIT, "loopExit")                                                    \
+#define NODE_PERFORMANCE_MILESTONES(V)                                         \
+  V(TIME_ORIGIN, "timeOrigin")                                                 \
+  V(ENVIRONMENT, "environment")                                                \
+  V(NODE_START, "nodeStart")                                                   \
+  V(V8_START, "v8Start")                                                       \
+  V(LOOP_START, "loopStart")                                                   \
+  V(LOOP_EXIT, "loopExit")                                                     \
   V(BOOTSTRAP_COMPLETE, "bootstrapComplete")
-
 
 #define NODE_PERFORMANCE_ENTRY_TYPES(V)                                       \
   V(GC, "gc")                                                                 \
@@ -62,10 +62,12 @@ class PerformanceState {
     AliasedBufferIndex observers;
   };
 
-  explicit PerformanceState(v8::Isolate* isolate, const SerializeInfo* info);
+  explicit PerformanceState(v8::Isolate* isolate,
+                            uint64_t time_origin,
+                            const SerializeInfo* info);
   SerializeInfo Serialize(v8::Local<v8::Context> context,
                           v8::SnapshotCreator* creator);
-  void Deserialize(v8::Local<v8::Context> context);
+  void Deserialize(v8::Local<v8::Context> context, uint64_t time_origin);
   friend std::ostream& operator<<(std::ostream& o, const SerializeInfo& i);
 
   AliasedUint8Array root;
@@ -79,6 +81,7 @@ class PerformanceState {
             uint64_t ts = PERFORMANCE_NOW());
 
  private:
+  void Initialize(uint64_t time_origin);
   struct performance_state_internal {
     // doubles first so that they are always sizeof(double)-aligned
     double milestones[NODE_PERFORMANCE_MILESTONE_INVALID];


### PR DESCRIPTION
Previously we cache the time origin for the milestones in the user land, and refresh it at pre-execution. As result the time origin gets serialized into the snapshot and is therefore not deterministic. Now we store it in the milestone array as an internal value and reset the milestones at serialization time instead of deserialization time. This improves the determinism of the snapshot.

Drive-by: remove the unused MarkMilestone() binding.

Refs: https://github.com/nodejs/build/issues/3043

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
