### PR TITLE
url: reduce `pathToFileURL` cpp calls

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1414,6 +1414,8 @@ const backslashRegEx = /\\/g;
 const newlineRegEx = /\n/g;
 const carriageReturnRegEx = /\r/g;
 const tabRegEx = /\t/g;
+const questionRegex = /\?/;
+const hashRegex = /#/;
 
 function encodePathChars(filepath) {
   if (StringPrototypeIncludes(filepath, '%'))
@@ -1431,8 +1433,8 @@ function encodePathChars(filepath) {
 }
 
 function pathToFileURL(filepath) {
-  const outURL = new URL('file://');
   if (isWindows && StringPrototypeStartsWith(filepath, '\\\\')) {
+    const outURL = new URL('file://');
     // UNC path format: \\server\share\resource
     const hostnameEndIndex = StringPrototypeIndexOf(filepath, '\\', 2);
     if (hostnameEndIndex === -1) {
@@ -1453,18 +1455,29 @@ function pathToFileURL(filepath) {
     outURL.hostname = domainToASCII(hostname);
     outURL.pathname = encodePathChars(
       RegExpPrototypeSymbolReplace(backslashRegEx, StringPrototypeSlice(filepath, hostnameEndIndex), '/'));
-  } else {
-    let resolved = path.resolve(filepath);
-    // path.resolve strips trailing slashes so we must add them back
-    const filePathLast = StringPrototypeCharCodeAt(filepath,
-                                                   filepath.length - 1);
-    if ((filePathLast === CHAR_FORWARD_SLASH ||
-         (isWindows && filePathLast === CHAR_BACKWARD_SLASH)) &&
-        resolved[resolved.length - 1] !== path.sep)
-      resolved += '/';
-    outURL.pathname = encodePathChars(resolved);
+    return outURL;
   }
-  return outURL;
+  let resolved = path.resolve(filepath);
+  // path.resolve strips trailing slashes so we must add them back
+  const filePathLast = StringPrototypeCharCodeAt(filepath,
+                                                 filepath.length - 1);
+  if ((filePathLast === CHAR_FORWARD_SLASH ||
+       (isWindows && filePathLast === CHAR_BACKWARD_SLASH)) &&
+      resolved[resolved.length - 1] !== path.sep)
+    resolved += '/';
+
+  // Call encodePathChars first to avoid encoding % again for ? and #.
+  resolved = encodePathChars(resolved);
+
+  // Question and hash character should be included in pathname.
+  // Therefore, encoding is required to eliminate parsing them in different states.
+  // This is done as an optimization to not creating a URL instance and
+  // later triggering pathname setter, which impacts performance
+  if (StringPrototypeIncludes(resolved, '?'))
+    resolved = RegExpPrototypeSymbolReplace(questionRegex, resolved, '%3F');
+  if (StringPrototypeIncludes(resolved, '#'))
+    resolved = RegExpPrototypeSymbolReplace(hashRegex, resolved, '%23');
+  return new URL(`file://${resolved}`);
 }
 
 function toPathIfFileURL(fileURLOrPath) {

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1414,20 +1414,20 @@ const backslashRegEx = /\\/g;
 const newlineRegEx = /\n/g;
 const carriageReturnRegEx = /\r/g;
 const tabRegEx = /\t/g;
-const questionRegex = /\?/;
-const hashRegex = /#/;
+const questionRegex = /\?/g;
+const hashRegex = /#/g;
 
 function encodePathChars(filepath) {
-  if (StringPrototypeIncludes(filepath, '%'))
+  if (StringPrototypeIndexOf(filepath, '%') !== -1)
     filepath = RegExpPrototypeSymbolReplace(percentRegEx, filepath, '%25');
   // In posix, backslash is a valid character in paths:
-  if (!isWindows && StringPrototypeIncludes(filepath, '\\'))
+  if (!isWindows && StringPrototypeIndexOf(filepath, '\\') !== -1)
     filepath = RegExpPrototypeSymbolReplace(backslashRegEx, filepath, '%5C');
-  if (StringPrototypeIncludes(filepath, '\n'))
+  if (StringPrototypeIndexOf(filepath, '\n') !== -1)
     filepath = RegExpPrototypeSymbolReplace(newlineRegEx, filepath, '%0A');
-  if (StringPrototypeIncludes(filepath, '\r'))
+  if (StringPrototypeIndexOf(filepath, '\r') !== -1)
     filepath = RegExpPrototypeSymbolReplace(carriageReturnRegEx, filepath, '%0D');
-  if (StringPrototypeIncludes(filepath, '\t'))
+  if (StringPrototypeIndexOf(filepath, '\t') !== -1)
     filepath = RegExpPrototypeSymbolReplace(tabRegEx, filepath, '%09');
   return filepath;
 }
@@ -1473,9 +1473,9 @@ function pathToFileURL(filepath) {
   // Therefore, encoding is required to eliminate parsing them in different states.
   // This is done as an optimization to not creating a URL instance and
   // later triggering pathname setter, which impacts performance
-  if (StringPrototypeIncludes(resolved, '?'))
+  if (StringPrototypeIndexOf(resolved, '?') !== -1)
     resolved = RegExpPrototypeSymbolReplace(questionRegex, resolved, '%3F');
-  if (StringPrototypeIncludes(resolved, '#'))
+  if (StringPrototypeIndexOf(resolved, '#') !== -1)
     resolved = RegExpPrototypeSymbolReplace(hashRegex, resolved, '%23');
   return new URL(`file://${resolved}`);
 }


### PR DESCRIPTION
My local benchmarks show the following changes:

```
                                                                                                                 confidence improvement accuracy (*)   (**)  (***)
url/whatwg-url-to-and-from-path.js n=1000000 method='fileURLToPath' input='file:///dev/null?key=param&bool'             ***     12.59 %       ±1.21% ±1.62% ±2.12%
url/whatwg-url-to-and-from-path.js n=1000000 method='fileURLToPath' input='file:///dev/null?key=param&bool#hash'        ***      9.72 %       ±0.70% ±0.94% ±1.22%
url/whatwg-url-to-and-from-path.js n=1000000 method='fileURLToPath' input='file:///dev/null'                            ***     18.85 %       ±1.02% ±1.36% ±1.78%
url/whatwg-url-to-and-from-path.js n=1000000 method='pathToFileURL' input='file:///dev/null?key=param&bool'             ***     11.93 %       ±0.78% ±1.04% ±1.35%
url/whatwg-url-to-and-from-path.js n=1000000 method='pathToFileURL' input='file:///dev/null?key=param&bool#hash'        ***     10.31 %       ±0.67% ±0.89% ±1.16%
url/whatwg-url-to-and-from-path.js n=1000000 method='pathToFileURL' input='file:///dev/null'                            ***     18.86 %       ±1.25% ±1.67% ±2.18%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 6 comparisons, you can thus expect the following amount of false-positive results:
  0.30 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.06 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```