### PR TITLE
fix: pr template CONTRIBUTING.md url

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Before submitting a pull request, please read the CONTRIBUTING guide:
+Before submitting a pull request, please read:
 
 - the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
 - the commit message formatting guidelines at

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 <!--
 Before submitting a pull request, please read the CONTRIBUTING guide:
-https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
 
-Commit message formatting guidelines:
-https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines
+- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
+- the commit message formatting guidelines at
+  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines
 
 For code changes:
 1. Include tests for any bug fixes or new features.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Before submitting a pull request, please read
+Before submitting a pull request, please read the CONTRIBUTING guide:
 https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
 
 Commit message formatting guidelines:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 Before submitting a pull request, please read
-https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.
+https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
 
 Commit message formatting guidelines:
 https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

When someone triple clicks to select the URL, they will result a 404 page because of the inclusion of the dot at the end

![image](https://github.com/nodejs/node/assets/15936231/21e3e7d8-8c80-4a3b-8fa5-9ae8a8556ead)
![image](https://github.com/nodejs/node/assets/15936231/877703d2-732e-4de7-86ef-86e88c44a581)


