### PR TITLE
src: avoid string copy in BuiltinLoader::GetBuiltinIds

### DIFF
--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -126,7 +126,7 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
   void LoadJavaScriptSource();  // Loads data into source_
   UnionBytes GetConfig();       // Return data for config.gypi
 
-  std::vector<std::string> GetBuiltinIds() const;
+  std::vector<std::string_view> GetBuiltinIds() const;
 
   struct BuiltinCategories {
     std::set<std::string> can_be_required;


### PR DESCRIPTION
Replaces `std::vector<std::string>` with `std::vector<std::string_view>`