### PR TITLE
src: remove OnScopeLeaveImpl's move assignment overload

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -579,8 +579,8 @@ struct OnScopeLeaveImpl {
   }
   OnScopeLeaveImpl& operator=(OnScopeLeaveImpl&& other) {
     if (this == &other) return *this;
-    if (active_) fn_();  // Invoke the function for the current instance
-    fn_ = std::move(other.fn_);  // Move assign the function from the other instance
+    if (active_) fn_();
+    fn_ = std::move(other.fn_);
     active_ = other.active_;
     other.active_ = false;
     return *this;

--- a/src/util.h
+++ b/src/util.h
@@ -579,8 +579,10 @@ struct OnScopeLeaveImpl {
   }
   OnScopeLeaveImpl& operator=(OnScopeLeaveImpl&& other) {
     if (this == &other) return *this;
-    this->~OnScopeLeave();
-    new (this)OnScopeLeaveImpl(std::move(other));
+    if (active_) fn_();  // Invoke the function for the current instance
+    fn_ = std::move(other.fn_);  // Move assign the function from the other instance
+    active_ = other.active_;
+    other.active_ = false;
     return *this;
   }
 };

--- a/src/util.h
+++ b/src/util.h
@@ -577,14 +577,6 @@ struct OnScopeLeaveImpl {
     : fn_(std::move(other.fn_)), active_(other.active_) {
     other.active_ = false;
   }
-  OnScopeLeaveImpl& operator=(OnScopeLeaveImpl&& other) {
-    if (this == &other) return *this;
-    if (active_) fn_();
-    fn_ = std::move(other.fn_);
-    active_ = other.active_;
-    other.active_ = false;
-    return *this;
-  }
 };
 
 // Run a function when exiting the current scope. Used like this:


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR removes OnScopeLeaveImpl's move assignment overload as it's not valid implementation and also has not been used 