### PR TITLE
test: skip experimental test with pointer compression

### DIFF
--- a/test/parallel/test-experimental-shared-value-conveyor.js
+++ b/test/parallel/test-experimental-shared-value-conveyor.js
@@ -1,25 +1,38 @@
 'use strict';
-
-// Flags: --harmony-struct
-
 const common = require('../common');
 const assert = require('assert');
+const { spawnSync } = require('child_process');
 const { Worker, parentPort } = require('worker_threads');
 
-// Do not use isMainThread so that this test itself can be run inside a Worker.
-if (!process.env.HAS_STARTED_WORKER) {
-  process.env.HAS_STARTED_WORKER = 1;
-  const m = new globalThis.SharedArray(16);
+if (process.env.TEST_CHILD_PROCESS === '1') {
+  // Do not use isMainThread so that this test itself can be run inside a Worker.
+  if (!process.env.HAS_STARTED_WORKER) {
+    process.env.HAS_STARTED_WORKER = 1;
+    const m = new globalThis.SharedArray(16);
 
-  const worker = new Worker(__filename);
-  worker.once('message', common.mustCall((message) => {
-    assert.strictEqual(message, m);
-  }));
+    const worker = new Worker(__filename);
+    worker.once('message', common.mustCall((message) => {
+      assert.strictEqual(message, m);
+    }));
 
-  worker.postMessage(m);
+    worker.postMessage(m);
+  } else {
+    parentPort.once('message', common.mustCall((message) => {
+      // Simple echo.
+      parentPort.postMessage(message);
+    }));
+  }
 } else {
-  parentPort.once('message', common.mustCall((message) => {
-    // Simple echo.
-    parentPort.postMessage(message);
-  }));
+  if (process.config.variables.v8_enable_pointer_compression === 1) {
+    common.skip('--harmony-struct cannot be used with pointer compression');
+  }
+
+  const args = ['--harmony-struct', __filename];
+  const options = { env: { TEST_CHILD_PROCESS: '1' } };
+  const child = spawnSync(process.execPath, args, options);
+
+  assert.strictEqual(child.stderr.toString().trim(), '');
+  assert.strictEqual(child.stdout.toString().trim(), '');
+  assert.strictEqual(child.status, 0);
+  assert.strictEqual(child.signal, null);
 }

--- a/test/parallel/test-experimental-shared-value-conveyor.js
+++ b/test/parallel/test-experimental-shared-value-conveyor.js
@@ -28,7 +28,7 @@ if (process.env.TEST_CHILD_PROCESS === '1') {
   }
 
   const args = ['--harmony-struct', __filename];
-  const options = { env: { TEST_CHILD_PROCESS: '1' } };
+  const options = { env: { TEST_CHILD_PROCESS: '1', ...process.env } };
   const child = spawnSync(process.execPath, args, options);
 
   assert.strictEqual(child.stderr.toString().trim(), '');


### PR DESCRIPTION
The test test/parallel/test-experimental-shared-value-conveyor.js was added to test the --harmony-struct feature of V8. However, when used with pointer compression, the process crashes. This commit skips the test for pointer compression builds. This change uses a child process because starting a Node pointer compression build with --harmony-struct immediately crashes the process. Once this crash is addressed, this commit can be reverted.

Refs: https://github.com/nodejs/build/issues/3204#issuecomment-1550411656

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
