### PR TITLE
esm: add import.meta.dirname and import.meta.filename

### DIFF
--- a/benchmark/fixtures/esm-dir-file.mjs
+++ b/benchmark/fixtures/esm-dir-file.mjs
@@ -1,0 +1,3 @@
+import assert from 'assert';
+assert.ok(import.meta.dirname);
+assert.ok(import.meta.filename);

--- a/benchmark/fixtures/load-esm-dir-file.js
+++ b/benchmark/fixtures/load-esm-dir-file.js
@@ -1,0 +1,5 @@
+(async function () {
+  for (let i = 0; i < 1000; i += 1) {
+    await import(`./esm-dir-file.mjs?i=${i}`);
+  }
+}());

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -9,6 +9,7 @@ const bench = common.createBenchmark(main, {
   script: [
     'benchmark/fixtures/require-builtins',
     'test/fixtures/semicolon',
+    'benchmark/fixtures/load-esm-dir-file',
   ],
   mode: ['process', 'worker'],
   count: [30],

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -330,6 +330,7 @@ added: REPLACEME
 -->
 
 > Stability: 1.2 - Release candidate
+
 * {string} The full absolute path and filename of the current module, with
 * symlinks resolved.
 * This is the same as the [`url.fileURLToPath()`][] of the

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -315,6 +315,7 @@ properties.
 added: REPLACEME
 -->
 
+> Stability: 1.2 - Release candidate
 * {string} The directory name of the current module. This is the same as the
   [`path.dirname()`][] of the [`import.meta.filename`][].
 
@@ -327,6 +328,7 @@ added: REPLACEME
 added: REPLACEME
 -->
 
+> Stability: 1.2 - Release candidate
 * {string} The full absolute path and filename of the current module, with
 * symlinks resolved.
 * This is the same as the [`url.fileURLToPath()`][] of the

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -320,7 +320,7 @@ added: REPLACEME
 * {string} The directory name of the current module. This is the same as the
   [`path.dirname()`][] of the [`import.meta.filename`][].
 
-> **Caveat** only file-based modules support this property.
+> **Caveat**: only present on `file:` modules.
 
 ### `import.meta.filename`
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -309,6 +309,32 @@ modules it can be used to load ES modules.
 The `import.meta` meta property is an `Object` that contains the following
 properties.
 
+### `import.meta.dirname`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string} The directory name of the current module. This is the same as the
+  [`path.dirname()`][] of the [`import.meta.filename`][].
+
+> **Caveat** only local modules support this property. Modules not using the
+> `file:` protocol will not provide it.
+
+### `import.meta.filename`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string} The full absolute path and filename of the current module, with
+* symlinks resolved.
+* This is the same as the [`url.fileURLToPath()`][] of the
+* [`import.meta.url`][].
+
+> **Caveat** only local modules support this property. Modules not using the
+> `file:` protocol will not provide it.
+
 ### `import.meta.url`
 
 * {string} The absolute `file:` URL of the module.
@@ -497,13 +523,6 @@ In most cases, the ES module `import` can be used to load CommonJS modules.
 
 If needed, a `require` function can be constructed within an ES module using
 [`module.createRequire()`][].
-
-#### No `__filename` or `__dirname`
-
-These CommonJS variables are not available in ES modules.
-
-`__filename` and `__dirname` use cases can be replicated via
-[`import.meta.url`][].
 
 #### No Addon Loading
 
@@ -1065,13 +1084,16 @@ resolution for ESM specifiers is [commonjs-extension-resolution-loader][].
 [`data:` URLs]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
 [`export`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export
 [`import()`]: #import-expressions
+[`import.meta.filename`]: #importmetafilename
 [`import.meta.resolve`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve
 [`import.meta.url`]: #importmetaurl
 [`import`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 [`module.createRequire()`]: module.md#modulecreaterequirefilename
 [`module.syncBuiltinESMExports()`]: module.md#modulesyncbuiltinesmexports
 [`package.json`]: packages.md#nodejs-packagejson-field-definitions
+[`path.dirname()`]: path.md#pathdirnamepath
 [`process.dlopen`]: process.md#processdlopenmodule-filename-flags
+[`url.fileURLToPath()`]: url.md#urlfileurltopathurl
 [cjs-module-lexer]: https://github.com/nodejs/cjs-module-lexer/tree/1.2.2
 [commonjs-extension-resolution-loader]: https://github.com/nodejs/loaders-test/tree/main/commonjs-extension-resolution-loader
 [custom https loader]: module.md#import-from-https

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -528,6 +528,13 @@ In most cases, the ES module `import` can be used to load CommonJS modules.
 If needed, a `require` function can be constructed within an ES module using
 [`module.createRequire()`][].
 
+#### No `__filename` or `__dirname`
+
+These CommonJS variables are not available in ES modules.
+
+`__filename` and `__dirname` use cases can be replicated via
+[`import.meta.filename`][] and [`import.meta.dirname`][].
+
 #### No Addon Loading
 
 [Addons][] are not currently supported with ES module imports.
@@ -1088,6 +1095,7 @@ resolution for ESM specifiers is [commonjs-extension-resolution-loader][].
 [`data:` URLs]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
 [`export`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export
 [`import()`]: #import-expressions
+[`import.meta.dirname`]: #importmetadirname
 [`import.meta.filename`]: #importmetafilename
 [`import.meta.resolve`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve
 [`import.meta.url`]: #importmetaurl

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -320,8 +320,7 @@ added: REPLACEME
 * {string} The directory name of the current module. This is the same as the
   [`path.dirname()`][] of the [`import.meta.filename`][].
 
-> **Caveat** only local modules support this property. Modules not using the
-> `file:` protocol will not provide it.
+> **Caveat** only file-based modules support this property.
 
 ### `import.meta.filename`
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -316,6 +316,7 @@ added: REPLACEME
 -->
 
 > Stability: 1.2 - Release candidate
+
 * {string} The directory name of the current module. This is the same as the
   [`path.dirname()`][] of the [`import.meta.filename`][].
 

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -2,7 +2,7 @@
 
 const { StringPrototypeStartsWith } = primordials;
 const { getOptionValue } = require('internal/options');
-const { fileURLToPath } = require('url');
+const { fileURLToPath } = require('internal/url');
 const { dirname } = require('path');
 const experimentalImportMetaResolve = getOptionValue('--experimental-import-meta-resolve');
 

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -1,6 +1,9 @@
 'use strict';
 
+const { StringPrototypeStartsWith } = primordials;
 const { getOptionValue } = require('internal/options');
+const { fileURLToPath } = require('url');
+const { dirname } = require('path');
 const experimentalImportMetaResolve = getOptionValue('--experimental-import-meta-resolve');
 
 /**
@@ -45,12 +48,16 @@ function createImportMetaResolve(defaultParentURL, loader, allowParentURL) {
  * @param {object} meta
  * @param {{url: string}} context
  * @param {typeof import('./loader.js').ModuleLoader} loader Reference to the current module loader
- * @returns {{url: string, resolve?: Function}}
+ * @returns {{dirname?: string, filename?: string, url: string, resolve?: Function}}
  */
 function initializeImportMeta(meta, context, loader) {
   const { url } = context;
 
   // Alphabetical
+  const moduleMeta = getModuleMetaPathProperties(url);
+  meta.dirname = moduleMeta.dirname;
+  meta.filename = moduleMeta.filename;
+
   if (!loader || loader.allowImportMetaResolve) {
     meta.resolve = createImportMetaResolve(url, loader, experimentalImportMetaResolve);
   }
@@ -58,6 +65,25 @@ function initializeImportMeta(meta, context, loader) {
   meta.url = url;
 
   return meta;
+}
+
+/**
+ * Produce path-based `dirname` and `filename` properties for modules loaded from the filesystem.
+ * @param {string} url
+ * @returns {{dirname?: string, filename?: string}}
+ */
+function getModuleMetaPathProperties(url) {
+  if (StringPrototypeStartsWith(url, 'file://') === false) {
+    // These only make sense for locally loaded modules,
+    // i.e. network modules are not supported.
+    return { dirname: undefined, filename: undefined };
+  }
+
+  const filePath = fileURLToPath(url);
+  return {
+    dirname: dirname(filePath),
+    filename: filePath,
+  };
 }
 
 module.exports = {

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -54,9 +54,13 @@ function initializeImportMeta(meta, context, loader) {
   const { url } = context;
 
   // Alphabetical
-  const moduleMeta = getModuleMetaPathProperties(url);
-  meta.dirname = moduleMeta.dirname;
-  meta.filename = moduleMeta.filename;
+  if (StringPrototypeStartsWith(url, 'file:') === true) {
+    // These only make sense for locally loaded modules,
+    // i.e. network modules are not supported.
+    const filePath = fileURLToPath(url);
+    meta.dirname = dirname(filePath);
+    meta.filename = filePath;
+  }
 
   if (!loader || loader.allowImportMetaResolve) {
     meta.resolve = createImportMetaResolve(url, loader, experimentalImportMetaResolve);
@@ -65,25 +69,6 @@ function initializeImportMeta(meta, context, loader) {
   meta.url = url;
 
   return meta;
-}
-
-/**
- * Produce path-based `dirname` and `filename` properties for modules loaded from the filesystem.
- * @param {string} url
- * @returns {{dirname?: string, filename?: string}}
- */
-function getModuleMetaPathProperties(url) {
-  if (StringPrototypeStartsWith(url, 'file://') === false) {
-    // These only make sense for locally loaded modules,
-    // i.e. network modules are not supported.
-    return { dirname: undefined, filename: undefined };
-  }
-
-  const filePath = fileURLToPath(url);
-  return {
-    dirname: dirname(filePath),
-    filename: filePath,
-  };
 }
 
 module.exports = {

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -26,5 +26,5 @@ const fileReg = /^\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
 assert.match(import.meta.filename, fileReg);
 
 // Verify that `data:` imports do not behave like `file:` imports.
-import dataDirname from 'data:text/javascript,export default import.meta.dirname';
-assert.strictEqual(dataDirname, undefined);
+import dataDirname from 'data:text/javascript,export default "dirname" in import.meta';
+assert.strictEqual(dataDirname, false);

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -19,10 +19,14 @@ for (const descriptor of Object.values(descriptors)) {
 const urlReg = /^file:\/\/\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
 assert(import.meta.url.match(urlReg));
 
-const dirReg = /^\/.*\/test\/es-module$/;
+// Match *nix paths: `/some/path/test/es-module`
+// Match Windows paths: `d:\\some\\path\\test\\es-module`
+const dirReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\{2})es-module$/;
 assert.match(import.meta.dirname, dirReg);
 
-const fileReg = /^\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
+// Match *nix paths: `/some/path/test/es-module/test-esm-import-meta.mjs`
+// Match Windows paths: `d:\\some\\path\\test\\es-module\\test-esm-import-meta.js`
+const fileReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\{2})es-module(\/|\\{2})test-esm-import-meta\.mjs$/;
 assert.match(import.meta.filename, fileReg);
 
 // Verify that `data:` imports do not behave like `file:` imports.

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -3,7 +3,7 @@ import assert from 'assert';
 
 assert.strictEqual(Object.getPrototypeOf(import.meta), null);
 
-const keys = ['resolve', 'url'];
+const keys = ['dirname', 'filename', 'resolve', 'url'];
 assert.deepStrictEqual(Reflect.ownKeys(import.meta), keys);
 
 const descriptors = Object.getOwnPropertyDescriptors(import.meta);
@@ -18,3 +18,13 @@ for (const descriptor of Object.values(descriptors)) {
 
 const urlReg = /^file:\/\/\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
 assert(import.meta.url.match(urlReg));
+
+const dirReg = /^\/.*\/test\/es-module$/;
+assert.match(import.meta.dirname, dirReg);
+
+const fileReg = /^\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
+assert.match(import.meta.filename, fileReg);
+
+// Verify that `data:` imports do not behave like `file:` imports.
+import dataDirname from 'data:text/javascript,export default import.meta.dirname';
+assert.strictEqual(dataDirname, undefined);

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -21,12 +21,12 @@ assert(import.meta.url.match(urlReg));
 
 // Match *nix paths: `/some/path/test/es-module`
 // Match Windows paths: `d:\\some\\path\\test\\es-module`
-const dirReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\{2})es-module$/;
+const dirReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\)es-module$/;
 assert.match(import.meta.dirname, dirReg);
 
 // Match *nix paths: `/some/path/test/es-module/test-esm-import-meta.mjs`
 // Match Windows paths: `d:\\some\\path\\test\\es-module\\test-esm-import-meta.js`
-const fileReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\{2})es-module(\/|\\{2})test-esm-import-meta\.mjs$/;
+const fileReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\)es-module(\/|\\)test-esm-import-meta\.mjs$/;
 assert.match(import.meta.filename, fileReg);
 
 // Verify that `data:` imports do not behave like `file:` imports.

--- a/test/js-native-api/test_cannot_run_js/entry_point.c
+++ b/test/js-native-api/test_cannot_run_js/entry_point.c
@@ -1,0 +1,7 @@
+#include <node_api.h>
+
+EXTERN_C_START
+napi_value Init(napi_env env, napi_value exports);
+EXTERN_C_END
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR adds `import.meta.dirname` and `import.meta.filename` for ECMAScript Modules that are loaded from the local filesystem. In my view, these properties don’t make any sense for modules loaded from the network, but they are very desired for local modules. At least one recent issue (https://github.com/nodejs/node/issues/47756) wanted them, and there exists at least two ecosystem modules to solve for them:

* https://www.npmjs.com/package/umeta
* https://www.npmjs.com/package/desm

## The Problem

As it stands, to determine the containing directory of a script we must write code like:

```js
import url from 'url'
import path from 'path'
const dirname = path.dirname(url.fileURLToPath(import.meta.url))
```

Of course, this needs to be repeated in every script that needs the information. With this PR, the code is reduced to:

```js
const dirname = import.meta.__dirname
```

The developer doesn’t need to remember how to convert the file URL to a path and then resolve the directory from that.

## External Discussion

The impetus for this PR is a recent Twitter discussion – https://twitter.com/jasnell/status/1677335322978295809

## Notable change

In `file:`-based ES modules, new properties `import.meta.filename` and `import.meta.dirname` provide equivalents to CommonJS `__filename` and `__dirname`. In particular, `import.meta.filename` provides the full absolute path (as a file path, not URL) to the module; and `import.meta.dirname` provides the full absolute path to the module’s containing folder. These properties are missing for non-`file:`-based ES modules, such as those loaded from `data:` or `https:` URLs.