### PR TITLE
doc: clarify use of Uint8Array for n-api

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3887,7 +3887,9 @@ napi_status napi_is_buffer(napi_env env, napi_value value, bool* result)
 
 Returns `napi_ok` if the API succeeded.
 
-This API checks if the `Object` passed in is a buffer.
+This API checks if the `Object` passed in is a buffer or Uint8Array.
+[`napi_is_typedarray`][] should be preferred if the caller needs to check if the
+value is a Uint8Array.
 
 ### `napi_is_date`
 
@@ -6562,6 +6564,7 @@ the add-on's file name during loading.
 [`napi_instanceof`]: #napi_instanceof
 [`napi_is_error`]: #napi_is_error
 [`napi_is_exception_pending`]: #napi_is_exception_pending
+[`napi_is_typedarray`]: #napi_is_typedarray
 [`napi_make_callback`]: #napi_make_callback
 [`napi_open_callback_scope`]: #napi_open_callback_scope
 [`napi_open_escapable_handle_scope`]: #napi_open_escapable_handle_scope

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3130,7 +3130,9 @@ napi_status napi_get_buffer_info(napi_env env,
 
 Returns `napi_ok` if the API succeeded.
 
-This method returns the identical `data` and `byte_length` as \[`napi_get_typedarray_info`]\[]. And `napi_get_typedarray_info` accepts a `node::Buffer` (a Uint8Array) as the value too.
+This method returns the identical `data` and `byte_length` as
+[`napi_get_typedarray_info`][]. And `napi_get_typedarray_info` accepts a
+`node::Buffer` (a Uint8Array) as the value too.
 
 This API is used to retrieve the underlying data buffer of a `node::Buffer`
 and its length.
@@ -6559,6 +6561,7 @@ the add-on's file name during loading.
 [`napi_get_last_error_info`]: #napi_get_last_error_info
 [`napi_get_property`]: #napi_get_property
 [`napi_get_reference_value`]: #napi_get_reference_value
+[`napi_get_typedarray_info`]: #napi_get_typedarray_info
 [`napi_get_value_external`]: #napi_get_value_external
 [`napi_has_property`]: #napi_has_property
 [`napi_instanceof`]: #napi_instanceof

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3130,6 +3130,8 @@ napi_status napi_get_buffer_info(napi_env env,
 
 Returns `napi_ok` if the API succeeded.
 
+This method returns the identical `data` and `byte_length` as [`napi_get_typedarray_info`][]. And `napi_get_typedarray_info` accepts a `node::Buffer` (a Uint8Array) as the value too.
+
 This API is used to retrieve the underlying data buffer of a `node::Buffer`
 and its length.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3122,9 +3122,10 @@ napi_status napi_get_buffer_info(napi_env env,
 ```
 
 * `[in] env`: The environment that the API is invoked under.
-* `[in] value`: `napi_value` representing the `node::Buffer` being queried.
-* `[out] data`: The underlying data buffer of the `node::Buffer`.
-  If length is `0`, this may be `NULL` or any other pointer value.
+* `[in] value`: `napi_value` representing the `node::Buffer` or `Uint8Array`
+  being queried.
+* `[out] data`: The underlying data buffer of the `node::Buffer` or
+  `Uint8Array`. If length is `0`, this may be `NULL` or any other pointer value.
 * `[out] length`: Length in bytes of the underlying data buffer.
 
 Returns `napi_ok` if the API succeeded.
@@ -3879,8 +3880,8 @@ napi_status napi_is_buffer(napi_env env, napi_value value, bool* result)
 
 * `[in] env`: The environment that the API is invoked under.
 * `[in] value`: The JavaScript value to check.
-* `[out] result`: Whether the given `napi_value` represents a `node::Buffer`
-  object.
+* `[out] result`: Whether the given `napi_value` represents a `node::Buffer` or
+  `Uint8Array` object.
 
 Returns `napi_ok` if the API succeeded.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3130,7 +3130,7 @@ napi_status napi_get_buffer_info(napi_env env,
 
 Returns `napi_ok` if the API succeeded.
 
-This method returns the identical `data` and `byte_length` as [`napi_get_typedarray_info`][]. And `napi_get_typedarray_info` accepts a `node::Buffer` (a Uint8Array) as the value too.
+This method returns the identical `data` and `byte_length` as \[`napi_get_typedarray_info`]\[]. And `napi_get_typedarray_info` accepts a `node::Buffer` (a Uint8Array) as the value too.
 
 This API is used to retrieve the underlying data buffer of a `node::Buffer`
 and its length.


### PR DESCRIPTION
`napi_get_buffer_info` always supported receiving `Uint8Array` as a `value` argument because `node::Buffer` is a subclass of `Uint8Array` and the underlying V8 APIs don't distinguish between two. With this change we mark both types as supported by the API so that the user code doesn't have to unknowingly use oficially unsupported type of the `value` argument.

---

Hello!

I think it'd be great to officially mark `Uint8Array`s as supported since it is very likely that there is existing code in the wild that relies on this. The N-API never distinguished between `node::Buffer` and `Uint8Array` so it'd be a breaking change if we started to bail on `Uint8Array` anyway. Let's mark it as supported now to signify existing code as compliant to official APIs!