### PR TITLE
test: fix flaky test-string-decode.js on x86

### DIFF
--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -203,7 +203,7 @@ assert.throws(
 
 if (common.enoughTestMem) {
   assert.throws(
-    () => new StringDecoder().write(Buffer.alloc(0x1fffffe8 + 1).fill('a')),
+    () => new StringDecoder().write(Buffer.alloc((process.arch === 'ia32' ? 0x18ffffe8 : 0x1fffffe8) + 1).fill('a')),
     {
       code: 'ERR_STRING_TOO_LONG',
     }


### PR DESCRIPTION
I first noticed `test-string-decoder` failing in CI [here](https://ci.nodejs.org/job/node-test-binary-windows-js-suites/21850/). Although it failed with VS2022-produced Node.js binaries, when I tested locally I noticed it was coming up with the same failure on VS2019 too. The only constant is that it happens sometimes and only on x86.

After investigating, this is what I found: in some cases, [this error](https://github.com/nodejs/node/blob/c3468322cfc179da2ea593fe25628e8db4c18d08/deps/v8/src/builtins/builtins-arraybuffer.cc#L104) was thrown instead of the expected one. Further down the call stack, [this line](https://github.com/nodejs/node/blob/c3468322cfc179da2ea593fe25628e8db4c18d08/deps/v8/src/objects/backing-store.cc#L327) is the root of the issue. It uses `std::numeric_limits<size_t>::max()` which differs on x64 and x86, so it's much easier for this condition to be fulfilled on x86 than on x64.

The change is simple. It just decreases the buffer size on x86. @targos since you worked on this part of the code before (even fixing the same issue in https://github.com/nodejs/node/pull/36795), I'd be glad to hear your opinion on this. To me, it seemed I just changed one magic number with another, but if there is more context to it please share.

This flaky test is the only thing preventing us to enable the JS test suites for `VS2022-x86`, so it would be very good to land this ASAP.