### PR TITLE
doc: expand on squashing and rebasing to land a PR

### DIFF
--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -540,8 +540,8 @@ For pull requests from first-time contributors, be
 [welcoming](#welcoming-first-time-contributors). Also, verify that their git
 settings are to their liking.
 
-If the pull request contains more than one commits, it can be landed with
-squashing into one commit or rebasing all the commits. Generally, a
+If the pull request contains more than one commit, it can be landed either by
+squashing into one commit or by rebasing all the commits. Generally, a
 collaborator should land the pull request with squashing. If the pull request
 has more than one self-contained subsystem commits, a collaborator may land it
 with rebasing.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -540,6 +540,11 @@ For pull requests from first-time contributors, be
 [welcoming](#welcoming-first-time-contributors). Also, verify that their git
 settings are to their liking.
 
+If the pull request contains several commits, it can be landed with squashing
+into one commit or rebasing all the commits. Generally, a collaborator should
+land the pull request with squashing. If the pull request has more than one
+self-contained subsystem commits, a collaborator may land it with rebasing.
+
 All commits should be self-contained, meaning every commit should pass all
 tests. This makes it much easier when bisecting to find a breaking change.
 

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -540,10 +540,11 @@ For pull requests from first-time contributors, be
 [welcoming](#welcoming-first-time-contributors). Also, verify that their git
 settings are to their liking.
 
-If the pull request contains several commits, it can be landed with squashing
-into one commit or rebasing all the commits. Generally, a collaborator should
-land the pull request with squashing. If the pull request has more than one
-self-contained subsystem commits, a collaborator may land it with rebasing.
+If the pull request contains more than one commits, it can be landed with
+squashing into one commit or rebasing all the commits. Generally, a
+collaborator should land the pull request with squashing. If the pull request
+has more than one self-contained subsystem commits, a collaborator may land it
+with rebasing.
 
 All commits should be self-contained, meaning every commit should pass all
 tests. This makes it much easier when bisecting to find a breaking change.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -540,11 +540,11 @@ For pull requests from first-time contributors, be
 [welcoming](#welcoming-first-time-contributors). Also, verify that their git
 settings are to their liking.
 
-If the pull request contains more than one commit, it can be landed either by
-squashing into one commit or by rebasing all the commits. Generally, a
-collaborator should land the pull request with squashing. If the pull request
-has more than one self-contained subsystem commits, a collaborator may land it
-with rebasing.
+If a pull request contains more than one commit, it can be landed either by
+squashing into one commit or by rebasing all the commits, or a mix of the two.
+Generally, a collaborator should land a pull request by squashing. If a pull
+request has more than one self-contained subsystem commits, a collaborator
+may land it as several commits.
 
 All commits should be self-contained, meaning every commit should pass all
 tests. This makes it much easier when bisecting to find a breaking change.


### PR DESCRIPTION
Document the choice of squashing and rebasing when landing a pull request containing more than one subsystem commits.

Refs: https://github.com/nodejs/node/pull/47956#issuecomment-1631783652