### PR TITLE
[v18.x]: fix py-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1518,8 +1518,8 @@ cpplint: lint-cpp
 # Try with '--system' if it fails without; the system may have set '--user'
 lint-py-build:
 	$(info Pip installing ruff on $(shell $(PYTHON) --version)...)
-	$(PYTHON) -m pip install --upgrade --target tools/pip/site-packages ruff || \
-		$(PYTHON) -m pip install --upgrade --system --target tools/pip/site-packages ruff
+	$(PYTHON) -m pip install --upgrade --target tools/pip/site-packages ruff==0.0.272 || \
+		$(PYTHON) -m pip install --upgrade --system --target tools/pip/site-packages ruff==0.0.272
 
 .PHONY: lint-py
 ifneq ("","$(wildcard tools/pip/site-packages/ruff)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ ignore = [
   "PLC1901",
   "RUF005",
   "RUF100",
-  "RUF012",
 ]
 line-length = 172
 target-version = "py37"


### PR DESCRIPTION
this backports the changes from https://github.com/nodejs/node/pull/48505
adjusting changes done in https://github.com/nodejs/node/commit/fcf3781d22259cb7b30f285bcd09cb984407bf20 to work after it