### PR TITLE
test: do not use test patterns in sharding tests

### DIFF
--- a/test/parallel/test-runner-cli.js
+++ b/test/parallel/test-runner-cli.js
@@ -272,7 +272,7 @@ const testFixtures = fixtures.path('test-runner');
   const args = [
     '--test',
     '--test-shard=1/2',
-    join(testFixtures, 'shards/*.cjs'),
+    fixtures.path(testFixtures, 'shards'),
   ];
   const child = spawnSync(process.execPath, args);
 
@@ -306,7 +306,7 @@ const testFixtures = fixtures.path('test-runner');
   const args = [
     '--test',
     '--test-shard=2/2',
-    join(testFixtures, 'shards/*.cjs'),
+    fixtures.path(testFixtures, 'shards')
   ];
   const child = spawnSync(process.execPath, args);
 

--- a/test/parallel/test-runner-cli.js
+++ b/test/parallel/test-runner-cli.js
@@ -306,7 +306,7 @@ const testFixtures = fixtures.path('test-runner');
   const args = [
     '--test',
     '--test-shard=2/2',
-    fixtures.path(testFixtures, 'shards')
+    fixtures.path(testFixtures, 'shards'),
   ];
   const child = spawnSync(process.execPath, args);
 

--- a/test/parallel/test-runner-cli.js
+++ b/test/parallel/test-runner-cli.js
@@ -4,6 +4,7 @@ require('../common');
 const assert = require('assert');
 const { spawnSync } = require('child_process');
 const { join } = require('path');
+const { readdirSync } = require('fs');
 const fixtures = require('../common/fixtures');
 const testFixtures = fixtures.path('test-runner');
 
@@ -269,18 +270,8 @@ const testFixtures = fixtures.path('test-runner');
 
 {
   // --test-shard option, first shard
-  const allShardsTestsFiles = [
-    'a.cjs',
-    'b.cjs',
-    'c.cjs',
-    'd.cjs',
-    'e.cjs',
-    'f.cjs',
-    'g.cjs',
-    'h.cjs',
-    'i.cjs',
-    'j.cjs',
-  ].map((file) => join(testFixtures, 'shards', file));
+  const shardsTestPath = join(testFixtures, 'shards');
+  const allShardsTestsFiles = readdirSync(shardsTestPath).map((file) => join(shardsTestPath, file));
   const args = [
     '--test',
     '--test-shard=1/2',
@@ -315,18 +306,8 @@ const testFixtures = fixtures.path('test-runner');
 
 {
   // --test-shard option, last shard
-  const allShardsTestsFiles = [
-    'a.cjs',
-    'b.cjs',
-    'c.cjs',
-    'd.cjs',
-    'e.cjs',
-    'f.cjs',
-    'g.cjs',
-    'h.cjs',
-    'i.cjs',
-    'j.cjs',
-  ].map((file) => join(testFixtures, 'shards', file));
+  const shardsTestPath = join(testFixtures, 'shards');
+  const allShardsTestsFiles = readdirSync(shardsTestPath).map((file) => join(shardsTestPath, file));
   const args = [
     '--test',
     '--test-shard=2/2',

--- a/test/parallel/test-runner-cli.js
+++ b/test/parallel/test-runner-cli.js
@@ -269,10 +269,22 @@ const testFixtures = fixtures.path('test-runner');
 
 {
   // --test-shard option, first shard
+  const allShardsTestsFiles = [
+    'a.cjs',
+    'b.cjs',
+    'c.cjs',
+    'd.cjs',
+    'e.cjs',
+    'f.cjs',
+    'g.cjs',
+    'h.cjs',
+    'i.cjs',
+    'j.cjs',
+  ].map((file) => join(testFixtures, 'shards', file));
   const args = [
     '--test',
     '--test-shard=1/2',
-    fixtures.path(testFixtures, 'shards'),
+    ...allShardsTestsFiles,
   ];
   const child = spawnSync(process.execPath, args);
 
@@ -303,10 +315,22 @@ const testFixtures = fixtures.path('test-runner');
 
 {
   // --test-shard option, last shard
+  const allShardsTestsFiles = [
+    'a.cjs',
+    'b.cjs',
+    'c.cjs',
+    'd.cjs',
+    'e.cjs',
+    'f.cjs',
+    'g.cjs',
+    'h.cjs',
+    'i.cjs',
+    'j.cjs',
+  ].map((file) => join(testFixtures, 'shards', file));
   const args = [
     '--test',
     '--test-shard=2/2',
-    fixtures.path(testFixtures, 'shards'),
+    ...allShardsTestsFiles,
   ];
   const child = spawnSync(process.execPath, args);
 


### PR DESCRIPTION
Do not use test files glob patterns in test runner sharding tests so the sharding can be backported to version 20:
- #48639

Cc @juanarbol, @MoLow 

