### PR TITLE
permission: fix data types in PrintTree

### DIFF
--- a/src/permission/fs_permission.cc
+++ b/src/permission/fs_permission.cc
@@ -73,7 +73,7 @@ namespace node {
 
 namespace permission {
 
-void PrintTree(FSPermission::RadixTree::Node* node, int spaces = 0) {
+void PrintTree(const FSPermission::RadixTree::Node* node, size_t spaces = 0) {
   std::string whitespace(spaces, ' ');
 
   if (node == nullptr) {
@@ -90,8 +90,8 @@ void PrintTree(FSPermission::RadixTree::Node* node, int spaces = 0) {
                        whitespace,
                        node->prefix);
     if (node->children.size()) {
-      int child = 0;
-      for (const auto pair : node->children) {
+      size_t child = 0;
+      for (const auto& pair : node->children) {
         ++child;
         per_process::Debug(DebugCategory::PERMISSION_MODEL,
                            "%s Child(%s): %s\n",


### PR DESCRIPTION
* The first argument `node` should be a const pointer.
* The second argument `spaces` should not be a signed integer type.
* The local variable `child` should be size_t.
* The local variable `pair` in the range declaration should be a reference type to avoid copying the object.

Refs: https://github.com/nodejs/node/pull/48677

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
