### PR TITLE
docs: add default to help description for --enable-source-maps

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -361,7 +361,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddAlias("--enable-network-family-autoselection",
            "--network-family-autoselection");
   AddOption("--enable-source-maps",
-            "Source Map V3 support for stack traces",
+            "Source Map V3 support for stack traces (default: false)",
             &EnvironmentOptions::enable_source_maps,
             kAllowedInEnvvar);
   AddOption("--experimental-abortcontroller", "", NoOp{}, kAllowedInEnvvar);


### PR DESCRIPTION
Without this documentation, you have to dig into the source code to determine the default option.
