### PR TITLE
doc: node inspect port 0 description when help is printed

### DIFF
--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -338,7 +338,7 @@ function startInspect(argv = ArrayPrototypeSlice(process.argv, 2),
 
     process.stderr.write(`Usage: ${invokedAs} script.js\n` +
                          `       ${invokedAs} <host>:<port>\n` +
-                         `       ${invokedAs} --port=<port>\n` +
+                         `       ${invokedAs} --port=<port> Use 0 for random port assignment\n` +
                          `       ${invokedAs} -p <pid>\n`);
     process.exit(kInvalidCommandLineArgument);
   }


### PR DESCRIPTION
this is not clearly documented anywhere and is an incredibly helpful tool for CLI debugging.
