### PR TITLE
lib: remove double validation on loadBuiltinModule

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -912,7 +912,7 @@ Module._load = function(request, parent, isMain) {
     }
   }
 
-  if (BuiltinModule.canBeRequiredWithoutScheme(filename)) {
+  if (BuiltinModule.canBeRequiredWithoutScheme(filename) && BuiltinModule.canBeRequiredByUsers(filename)) {
     const mod = loadBuiltinModule(filename, request);
     return mod.exports;
   }

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -31,6 +31,7 @@ const {
   loadBuiltinModule,
   stripBOM,
 } = require('internal/modules/helpers');
+const { BuiltinModule } = require('internal/bootstrap/realm');
 const {
   Module: CJSModule,
   cjsParseCache,
@@ -250,11 +251,11 @@ translators.set('builtin', async function builtinStrategy(url) {
   debug(`Translating BuiltinModule ${url}`);
   // Slice 'node:' scheme
   const id = StringPrototypeSlice(url, 5);
-  const module = loadBuiltinModule(id, url);
-  if (!StringPrototypeStartsWith(url, 'node:') || !module) {
+  if (!StringPrototypeStartsWith(url, 'node:') || !BuiltinModule.canBeRequiredByUsers(id)) {
     throw new ERR_UNKNOWN_BUILTIN_MODULE(url);
   }
   debug(`Loading BuiltinModule ${url}`);
+  const module = loadBuiltinModule(id, url);
   return module.getESMFacade();
 });
 

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -57,10 +57,10 @@ function getCjsConditions() {
   return cjsConditions;
 }
 
+/**
+ * This function assumes that the module can be required by users.
+ */
 function loadBuiltinModule(filename, request) {
-  if (!BuiltinModule.canBeRequiredByUsers(filename)) {
-    return;
-  }
   const mod = BuiltinModule.map.get(filename);
   debug('load built-in module %s', request);
   // compileForPublicLoader() throws if canBeRequiredByUsers is false:


### PR DESCRIPTION
We already call `BuiltinModule.canBeRequiredByUsers` in most places where we call `loadBuiltinModule`, except in one place where this PR adds that check. So, no need to check it twice.