### PR TITLE
https: make https.globalAgent overridable also under ECMAScript Modules

### DIFF
--- a/lib/https.js
+++ b/lib/https.js
@@ -30,6 +30,7 @@ const {
   FunctionPrototypeCall,
   JSONStringify,
   ObjectAssign,
+  ObjectDefineProperty,
   ObjectSetPrototypeOf,
   ReflectApply,
   ReflectConstruct,
@@ -350,7 +351,7 @@ Agent.prototype._evictSession = function _evictSession(key) {
   delete this._sessionCache.map[key];
 };
 
-const globalAgent = new Agent({ keepAlive: true, scheduling: 'lifo', timeout: 5000 });
+let globalAgent = new Agent({ keepAlive: true, scheduling: 'lifo', timeout: 5000 });
 
 /**
  * Makes a request to a secure web server.
@@ -415,9 +416,21 @@ function get(input, options, cb) {
 
 module.exports = {
   Agent,
-  globalAgent,
   Server,
   createServer,
   get,
   request,
 };
+
+// Make https.globalAgent overridable also under ECMAScript Modules
+ObjectDefineProperty(module.exports, 'globalAgent', {
+  __proto__: null,
+  configurable: true,
+  enumerable: true,
+  get() {
+    return globalAgent;
+  },
+  set(value) {
+    globalAgent = value;
+  },
+});

--- a/test/parallel/test-https-client-override-global-agent.mjs
+++ b/test/parallel/test-https-client-override-global-agent.mjs
@@ -1,0 +1,43 @@
+import { hasCrypto, skip, mustCall } from '../common/index.mjs';
+if (!hasCrypto) skip('missing crypto');
+import { readKey } from '../common/fixtures.mjs';
+import assert from 'assert';
+// To override https.globalAgent we need to use namespace import
+import * as https from 'https';
+
+// Disable strict server certificate validation by the client
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+const options = {
+  key: readKey('agent1-key.pem'),
+  cert: readKey('agent1-cert.pem'),
+};
+
+const server = https.Server(
+  options,
+  mustCall((req, res) => {
+    res.writeHead(200);
+    res.end('Hello, World!');
+  })
+);
+
+server.listen(
+  0,
+  mustCall(() => {
+    const agent = new https.Agent();
+    const name = agent.getName({ port: server.address().port });
+    // That is exactly what we want here:)
+    /* eslint-disable no-import-assign */
+    https.globalAgent = agent;
+
+    makeRequest();
+    assert(name in agent.sockets); // Agent has indeed been used
+  })
+);
+
+function makeRequest() {
+  const req = https.get({
+    port: server.address().port,
+  });
+  req.on('close', () => server.close());
+}


### PR DESCRIPTION
Under ECMAScript modules when you do "import * as https from 'https'" you get a new object with properties copied from https module exports. So if this is a regular data property, you will just override a copy, but if this would be a accessor property, we can still access the actual https.globalAgent.

Refs: https://github.com/nodejs/node/pull/25170, https://github.com/nodejs/node/pull/9386

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
