### PR TITLE
deps: V8: cherry-pick c1a54d5ffcd1

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/test/mjsunit/regress/regress-1320641.js
+++ b/deps/v8/test/mjsunit/regress/regress-1320641.js
@@ -8,9 +8,21 @@ function foo(){
   const xs = new Uint16Array(3775336418);
   return xs[-981886074];
 }
-%PrepareFunctionForOptimization(foo);
-foo();
 
-assertEquals(undefined, foo());
-%OptimizeFunctionOnNextCall(foo);
-assertEquals(undefined, foo());
+var skip = false;
+try {
+  new Uint16Array(3775336418);
+} catch (e) {
+  if (e.message.test(/Array buffer allocation failed/)) {
+    skip = true;  // We don't have enough memory, just skip the test.
+  }
+}
+
+if (!skip) {
+  %PrepareFunctionForOptimization(foo);
+  foo();
+
+  assertEquals(undefined, foo());
+  %OptimizeFunctionOnNextCall(foo);
+  assertEquals(undefined, foo());
+}

--- a/deps/v8/test/mjsunit/regress/regress-1320641.js
+++ b/deps/v8/test/mjsunit/regress/regress-1320641.js
@@ -13,7 +13,7 @@ var skip = false;
 try {
   new Uint16Array(3775336418);
 } catch (e) {
-  if (e.message.test(/Array buffer allocation failed/)) {
+  if (/Array buffer allocation failed/.test(e.message)) {
     skip = true;  // We don't have enough memory, just skip the test.
   }
 }


### PR DESCRIPTION
Original commit message:

    Skip regress-1320641 when the system does not have enough memory

    Change-Id: I23a5232f6437c4bc77390796ee2986f1600cb1bf
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4689686
    Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
    Commit-Queue: Joyee Cheung <joyee@igalia.com>
    Cr-Commit-Position: refs/heads/main@{#88973}

Refs: https://github.com/v8/v8/commit/c1a54d5ffcd1a3b769376be3b46b57b860b5aa9e

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
