### PR TITLE
esm: add `initialize` hook, integrate with `register`

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -774,7 +774,7 @@ Loader code:
 // In the below example this file is referenced as
 // '/path-to-my-loader.js'
 
-export function initialize({ number, port }) {
+export async function initialize({ number, port }) {
   port.postMessage(`increment: ${number + 1}`);
   return 'ok';
 }

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -755,11 +755,18 @@ added: REPLACEME
 * Returns: {any} The data to be returned to the caller of `register`.
 
 The `initialize` hook provides a way to define a custom function that runs
-in the loader's thread when the loader is initialized. This hook can send
-and receive data from a [`register`][] invocation, including ports and other
-transferrable objects. The return value of `initialize` must be something
-that can be posted as a message between threads, like the input to
-[`port.postMessage`][].
+in the loader's thread when the loader is initialized. Initialization happens
+when the loader is registered via [`register`][] or registered via the
+`--loader` command line option.
+
+This hook can send and receive data from a [`register`][] invocation, including
+ports and other transferrable objects. The return value of `initialize` must be
+either:
+
+* `undefined`,
+* something that can be posted as a message between threads (e.g. the input to
+  [`port.postMessage`][]),
+* a `Promise` resolving to one of the aforementioned values.
 
 Loader code:
 
@@ -1009,7 +1016,7 @@ changes:
 -->
 
 > This hook will be removed in a future version. Use [`initialize`][] instead.
-> When a loader has an `initilize` export, `globalPreload` will be ignored.
+> When a loader has an `initialize` export, `globalPreload` will be ignored.
 
 > In a previous version of this API, this hook was named
 > `getGlobalPreloadCode`.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -685,6 +685,9 @@ of Node.js applications.
 <!-- YAML
 added: v8.8.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/48842
+    description: Added `initialize` hook to replace `globalPreload`.
   - version:
     - v18.6.0
     - v16.17.0
@@ -738,6 +741,62 @@ Hooks are run in a separate thread, isolated from the main. That means it is a
 different [realm](https://tc39.es/ecma262/#realm). The hooks thread may be
 terminated by the main thread at any time, so do not depend on asynchronous
 operations (like `console.log`) to complete.
+
+#### `initialize()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> The loaders API is being redesigned. This hook may disappear or its
+> signature may change. Do not rely on the API described below.
+
+* `data` {any} The data from `register(loader, import.meta.url, { data })`.
+* Returns: {any} The data to be returned to the caller of `register`.
+
+The `initialize` hook provides a way to define a custom function that runs
+in the loader's thread when the loader is initialized. This hook can send
+and receive data from a [`register`][] invocation, including ports and other
+transferrable objects. The return value of `initialize` must be something
+that can be posted as a message between threads, like the input to
+[`port.postMessage`][].
+
+Loader code:
+
+```js
+// In the below example this file is referenced as
+// '/path-to-my-loader.js'
+
+export function initialize({ number, port }) {
+  port.postMessage(`increment: ${number + 1}`);
+  return 'ok';
+}
+```
+
+Caller code:
+
+```js
+import assert from 'node:assert';
+import { register } from 'node:module';
+import { MessageChannel } from 'node:worker_threads';
+
+// This example showcases how a message channel can be used to
+// communicate between the main (application) thread and the loader
+// running on the loaders thread, by sending `port2` to the loader.
+const { port1, port2 } = new MessageChannel();
+
+port1.on('message', (msg) => {
+  assert.strictEqual(msg, 'increment: 2');
+});
+
+const result = register('/path-to-my-loader.js', {
+  parentURL: import.meta.url,
+  data: { number: 1, port: port2 },
+  transferList: [port2],
+});
+
+assert.strictEqual(result, 'ok');
+```
 
 #### `resolve(specifier, context, nextResolve)`
 
@@ -949,8 +1008,8 @@ changes:
     description: Add support for chaining globalPreload hooks.
 -->
 
-> The loaders API is being redesigned. This hook may disappear or its
-> signature may change. Do not rely on the API described below.
+> This hook will be removed in a future version. Use [`initialize`][] instead.
+> When a loader has an `initilize` export, `globalPreload` will be ignored.
 
 > In a previous version of this API, this hook was named
 > `getGlobalPreloadCode`.
@@ -1609,13 +1668,16 @@ for ESM specifiers is [commonjs-extension-resolution-loader][].
 [`import.meta.resolve`]: #importmetaresolvespecifier-parent
 [`import.meta.url`]: #importmetaurl
 [`import`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
+[`initialize`]: #initialize
 [`module.createRequire()`]: module.md#modulecreaterequirefilename
 [`module.register()`]: module.md#moduleregister
 [`module.syncBuiltinESMExports()`]: module.md#modulesyncbuiltinesmexports
 [`package.json`]: packages.md#nodejs-packagejson-field-definitions
+[`port.postMessage`]: worker_threads.md#portpostmessagevalue-transferlist
 [`port.ref()`]: https://nodejs.org/dist/latest-v17.x/docs/api/worker_threads.html#portref
 [`port.unref()`]: https://nodejs.org/dist/latest-v17.x/docs/api/worker_threads.html#portunref
 [`process.dlopen`]: process.md#processdlopenmodule-filename-flags
+[`register`]: module.md#moduleregister
 [`string`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
 [`util.TextDecoder`]: util.md#class-utiltextdecoder
 [cjs-module-lexer]: https://github.com/nodejs/cjs-module-lexer/tree/1.2.2

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -176,7 +176,7 @@ globalPreload: unpkg
 ```
 
 This function can also be used to pass data to the loader's [`initialize`][]
-hook include transferrable objects like ports.
+hook; the data passed to the hook may include transferrable objects like ports.
 
 ```mjs
 import { register } from 'node:module';

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -175,6 +175,28 @@ globalPreload: http-to-https
 globalPreload: unpkg
 ```
 
+This function can also be used to pass data to the loader's [`initialize`][]
+hook include transferrable objects like ports.
+
+```mjs
+import { register } from 'node:module';
+import { MessageChannel } from 'node:worker_threads';
+
+// This example showcases how a message channel can be used to
+// communicate to the loader, by sending `port2` to the loader.
+const { port1, port2 } = new MessageChannel();
+
+port1.on('message', (msg) => {
+  console.log(msg);
+});
+
+register('./my-programmatic-loader.mjs', {
+  parentURL: import.meta.url,
+  data: { number: 1, port: port2 },
+  transferList: [port2],
+});
+```
+
 ### `module.syncBuiltinESMExports()`
 
 <!-- YAML
@@ -364,6 +386,7 @@ returned object contains the following keys:
 [`--enable-source-maps`]: cli.md#--enable-source-maps
 [`NODE_V8_COVERAGE=dir`]: cli.md#node_v8_coveragedir
 [`SourceMap`]: #class-modulesourcemap
+[`initialize`]: esm.md#initialize
 [`module`]: modules.md#the-module-object
 [module wrapper]: modules.md#the-module-wrapper
 [source map include directives]: https://sourcemaps.info/spec.html#h.lmz475t4mvbx

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayPrototypePush,
+  ArrayPrototypePushApply,
   FunctionPrototypeCall,
   Int32Array,
   ObjectAssign,
@@ -47,8 +48,10 @@ const {
   validateObject,
   validateString,
 } = require('internal/validators');
-
-const { kEmptyObject } = require('internal/util');
+const {
+  emitExperimentalWarning,
+  kEmptyObject,
+} = require('internal/util');
 
 const {
   defaultResolve,
@@ -83,6 +86,7 @@ let importMetaInitializer;
 
 // [2] `validate...()`s throw the wrong error
 
+let globalPreloadWarned = false;
 class Hooks {
   #chains = {
     /**
@@ -127,15 +131,17 @@ class Hooks {
    * Import and register custom/user-defined module loader hook(s).
    * @param {string} urlOrSpecifier
    * @param {string} parentURL
+   * @param {any} [data] Arbitrary data to be passed from the custom
+   * loader (user-land) to the worker.
    */
-  async register(urlOrSpecifier, parentURL) {
+  async register(urlOrSpecifier, parentURL, data) {
     const moduleLoader = require('internal/process/esm_loader').esmLoader;
     const keyedExports = await moduleLoader.import(
       urlOrSpecifier,
       parentURL,
       kEmptyObject,
     );
-    this.addCustomLoader(urlOrSpecifier, keyedExports);
+    return this.addCustomLoader(urlOrSpecifier, keyedExports, data);
   }
 
   /**
@@ -143,15 +149,25 @@ class Hooks {
    * After all hooks have been collected, the global preload hook(s) must be initialized.
    * @param {string} url Custom loader specifier
    * @param {Record<string, unknown>} exports
+   * @param {any} [data] Arbitrary data to be passed from the custom loader (user-land)
+   * to the worker.
+   * @returns {any} The result of the loader's `initialize` hook, if provided.
    */
-  addCustomLoader(url, exports) {
+  addCustomLoader(url, exports, data) {
     const {
       globalPreload,
+      initialize,
       resolve,
       load,
     } = pluckHooks(exports);
 
-    if (globalPreload) {
+    if (globalPreload && !initialize) {
+      if (globalPreloadWarned === false) {
+        globalPreloadWarned = true;
+        emitExperimentalWarning(
+          '`globalPreload` will be removed in a future version. Please use `initialize` instead.',
+        );
+      }
       ArrayPrototypePush(this.#chains.globalPreload, { __proto__: null, fn: globalPreload, url });
     }
     if (resolve) {
@@ -162,6 +178,7 @@ class Hooks {
       const next = this.#chains.load[this.#chains.load.length - 1];
       ArrayPrototypePush(this.#chains.load, { __proto__: null, fn: load, url, next });
     }
+    return initialize?.(data);
   }
 
   /**
@@ -553,15 +570,30 @@ class HooksProxy {
     }
   }
 
-  async makeAsyncRequest(method, ...args) {
+  /**
+   * Invoke a remote method asynchronously.
+   * @param {string} method Method to invoke
+   * @param {any[]} [transferList] Objects in `args` to be transferred
+   * @param  {any[]} args Arguments to pass to `method`
+   * @returns {Promise<any>}
+   */
+  async makeAsyncRequest(method, transferList, ...args) {
     this.waitForWorker();
 
     MessageChannel ??= require('internal/worker/io').MessageChannel;
     const asyncCommChannel = new MessageChannel();
 
     // Pass work to the worker.
-    debug('post async message to worker', { method, args });
-    this.#worker.postMessage({ method, args, port: asyncCommChannel.port2 }, [asyncCommChannel.port2]);
+    debug('post async message to worker', { method, args, transferList });
+    const finalTransferList = [asyncCommChannel.port2];
+    if (transferList) {
+      ArrayPrototypePushApply(finalTransferList, transferList);
+    }
+    this.#worker.postMessage({
+      __proto__: null,
+      method, args,
+      port: asyncCommChannel.port2,
+    }, finalTransferList);
 
     if (this.#numberOfPendingAsyncResponses++ === 0) {
       // On the next lines, the main thread will await a response from the worker thread that might
@@ -593,12 +625,19 @@ class HooksProxy {
     return body;
   }
 
-  makeSyncRequest(method, ...args) {
+  /**
+   * Invoke a remote method synchronously.
+   * @param {string} method Method to invoke
+   * @param {any[]} [transferList] Objects in `args` to be transferred
+   * @param  {any[]} args Arguments to pass to `method`
+   * @returns {any}
+   */
+  makeSyncRequest(method, transferList, ...args) {
     this.waitForWorker();
 
     // Pass work to the worker.
-    debug('post sync message to worker', { method, args });
-    this.#worker.postMessage({ method, args });
+    debug('post sync message to worker', { method, args, transferList });
+    this.#worker.postMessage({ __proto__: null, method, args }, transferList);
 
     let response;
     do {
@@ -708,6 +747,7 @@ ObjectSetPrototypeOf(HooksProxy.prototype, null);
  */
 function pluckHooks({
   globalPreload,
+  initialize,
   resolve,
   load,
 }) {
@@ -721,6 +761,10 @@ function pluckHooks({
   }
   if (load) {
     acceptedHooks.load = load;
+  }
+
+  if (initialize) {
+    acceptedHooks.initialize = initialize;
   }
 
   return acceptedHooks;

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -307,7 +307,10 @@ class ModuleLoader {
     return module.getNamespace();
   }
 
-  register(specifier, parentURL) {
+  /**
+   * @see {@link CustomizedModuleLoader.register}
+   */
+  register(specifier, parentURL, data, transferList) {
     if (!this.#customizations) {
       // `CustomizedModuleLoader` is defined at the bottom of this file and
       // available well before this line is ever invoked. This is here in
@@ -315,7 +318,7 @@ class ModuleLoader {
       // eslint-disable-next-line no-use-before-define
       this.setCustomizations(new CustomizedModuleLoader());
     }
-    return this.#customizations.register(specifier, parentURL);
+    return this.#customizations.register(specifier, parentURL, data, transferList);
   }
 
   /**
@@ -426,10 +429,13 @@ class CustomizedModuleLoader {
    *                                   be registered.
    * @param {string} parentURL The parent URL from where the loader will be
    *                           registered if using it package name as specifier
+   * @param {any} [data] Arbitrary data to be passed from the custom loader
+   * (user-land) to the worker.
+   * @param {any[]} [transferList] Objects in `data` that are changing ownership
    * @returns {{ format: string, url: URL['href'] }}
    */
-  register(originalSpecifier, parentURL) {
-    return hooksProxy.makeSyncRequest('register', originalSpecifier, parentURL);
+  register(originalSpecifier, parentURL, data, transferList) {
+    return hooksProxy.makeSyncRequest('register', transferList, originalSpecifier, parentURL, data);
   }
 
   /**
@@ -442,12 +448,12 @@ class CustomizedModuleLoader {
    * @returns {{ format: string, url: URL['href'] }}
    */
   resolve(originalSpecifier, parentURL, importAssertions) {
-    return hooksProxy.makeAsyncRequest('resolve', originalSpecifier, parentURL, importAssertions);
+    return hooksProxy.makeAsyncRequest('resolve', undefined, originalSpecifier, parentURL, importAssertions);
   }
 
   resolveSync(originalSpecifier, parentURL, importAssertions) {
     // This happens only as a result of `import.meta.resolve` calls, which must be sync per spec.
-    return hooksProxy.makeSyncRequest('resolve', originalSpecifier, parentURL, importAssertions);
+    return hooksProxy.makeSyncRequest('resolve', undefined, originalSpecifier, parentURL, importAssertions);
   }
 
   /**
@@ -457,7 +463,7 @@ class CustomizedModuleLoader {
    * @returns {Promise<{ format: ModuleFormat, source: ModuleSource }>}
    */
   load(url, context) {
-    return hooksProxy.makeAsyncRequest('load', url, context);
+    return hooksProxy.makeAsyncRequest('load', undefined, url, context);
   }
 
   importMetaInitialize(meta, context, loader) {
@@ -513,19 +519,44 @@ function getHooksProxy() {
 /**
  * Register a single loader programmatically.
  * @param {string} specifier
- * @param {string} [parentURL]
- * @returns {void}
+ * @param {string} [parentURL] Base to use when resolving `specifier`; optional if
+ * `specifier` is absolute. Same as `options.parentUrl`, just inline
+ * @param {object} [options] Additional options to apply, described below.
+ * @param {string} [options.parentURL] Base to use when resolving `specifier`
+ * @param {any} [options.data] Arbitrary data passed to the loader's `initialize` hook
+ * @param {any[]} [options.transferList] Objects in `data` that are changing ownership
+ * @returns {any} The result of the loader's initialize hook, if any
  * @example
  * ```js
  * register('./myLoader.js');
+ * register('ts-node/esm', { parentURL: import.meta.url });
+ * register('./myLoader.js', { parentURL: import.meta.url });
  * register('ts-node/esm', import.meta.url);
  * register('./myLoader.js', import.meta.url);
  * register(new URL('./myLoader.js', import.meta.url));
+ * register('./myLoader.js', {
+ *   parentURL: import.meta.url,
+ *   data: { banana: 'tasty' },
+ * });
+ * register('./myLoader.js', {
+ *   parentURL: import.meta.url,
+ *   data: someArrayBuffer,
+ *   transferList: [someArrayBuffer],
+ * });
  * ```
  */
-function register(specifier, parentURL = 'data:') {
+function register(specifier, parentURL = undefined, options) {
   const moduleLoader = require('internal/process/esm_loader').esmLoader;
-  moduleLoader.register(`${specifier}`, parentURL);
+  if (parentURL != null && typeof parentURL === 'object') {
+    options = parentURL;
+    parentURL = options.parentURL;
+  }
+  return moduleLoader.register(
+    `${specifier}`,
+    parentURL ?? 'data:',
+    options?.data,
+    options?.transferList,
+  );
 }
 
 module.exports = {

--- a/lib/internal/modules/esm/utils.js
+++ b/lib/internal/modules/esm/utils.js
@@ -12,6 +12,10 @@ const {
   ERR_INVALID_ARG_VALUE,
 } = require('internal/errors').codes;
 const { getOptionValue } = require('internal/options');
+const {
+  loadPreloadModules,
+  initializeFrozenIntrinsics,
+} = require('internal/process/pre_execution');
 const { pathToFileURL } = require('internal/url');
 const {
   setImportModuleDynamicallyCallback,
@@ -122,6 +126,16 @@ async function initializeHooks() {
 
   const hooks = new Hooks();
   esmLoader.setCustomizations(hooks);
+
+  // We need the loader customizations to be set _before_ we start invoking
+  // `--require`, otherwise loops can happen because a `--require` script
+  // might call `register(...)` before we've installed ourselves. These
+  // global values are magically set in `setupUserModules` just for us and
+  // we call them in the correct order.
+  // N.B.  This block appears here specifically in order to ensure that
+  // `--require` calls occur before `--loader` ones do.
+  loadPreloadModules();
+  initializeFrozenIntrinsics();
 
   const parentURL = pathToFileURL(cwd).href;
   for (let i = 0; i < customLoaderURLs.length; i++) {

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -154,6 +154,10 @@ function setupUserModules(isLoaderWorker = false) {
   initializeESMLoader(isLoaderWorker);
   const CJSLoader = require('internal/modules/cjs/loader');
   assert(!CJSLoader.hasLoadedAnyUserCJSModule);
+  // Loader workers are responsible for doing this themselves.
+  if (isLoaderWorker) {
+    return;
+  }
   loadPreloadModules();
   // Need to be done after --require setup.
   initializeFrozenIntrinsics();
@@ -680,4 +684,6 @@ module.exports = {
   prepareMainThreadExecution,
   prepareWorkerThreadExecution,
   markBootstrapComplete,
+  loadPreloadModules,
+  initializeFrozenIntrinsics,
 };

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -424,6 +424,16 @@ describe('Loader hooks', { concurrency: true }, () => {
   });
 
   describe('globalPreload', () => {
+    it('should emit deprecation warning', async () => {
+      const { stderr } = await spawnPromisified(execPath, [
+        '--experimental-loader',
+        'data:text/javascript,export function globalPreload(){}',
+        fixtures.path('empty.js'),
+      ]);
+
+      assert.match(stderr, /`globalPreload` will be removed/);
+    });
+
     it('should handle globalPreload returning undefined', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
         '--no-warnings',
@@ -550,6 +560,166 @@ describe('Loader hooks', { concurrency: true }, () => {
 
     assert.strictEqual(stderr, '');
     assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should invoke `initialize` correctly', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      fixtures.fileURL('/es-module-loaders/hooks-initialize.mjs'),
+      '--input-type=module',
+      '--eval',
+      'import os from "node:os";',
+    ]);
+
+    const lines = stdout.trim().split('\n');
+
+    assert.strictEqual(lines.length, 1);
+    assert.strictEqual(lines[0], 'hooks initialize 1');
+
+    assert.strictEqual(stderr, '');
+
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should allow communicating with loader via `register` ports', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--input-type=module',
+      '--eval',
+      `
+        import {MessageChannel} from 'node:worker_threads';
+        import {register} from 'node:module';
+        const {port1, port2} = new MessageChannel();
+        port1.on('message', (msg) => {
+          console.log('message', msg);
+        });
+        const result = register(
+          ${JSON.stringify(fixtures.fileURL('/es-module-loaders/hooks-initialize-port.mjs'))},
+          {data: port2, transferList: [port2]},
+        );
+        console.log('register', result);
+
+        await import('node:os');
+        port1.close();
+      `,
+    ]);
+
+    const lines = stdout.split('\n');
+
+    assert.strictEqual(lines[0], 'register ok');
+    assert.strictEqual(lines[1], 'message initialize');
+    assert.strictEqual(lines[2], 'message resolve node:os');
+
+    assert.strictEqual(stderr, '');
+
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should have `register` work with cjs', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--input-type=commonjs',
+      '--eval',
+      `
+        const {register} = require('node:module');
+        register(
+          ${JSON.stringify(fixtures.fileURL('/es-module-loaders/hooks-initialize.mjs'))},
+        );
+        register(
+          ${JSON.stringify(fixtures.fileURL('/es-module-loaders/loader-load-foo-or-42.mjs'))},
+        );
+
+        import('node:os').then((result) => {
+          console.log(result.default);
+        });
+      `,
+    ]);
+
+    const lines = stdout.split('\n');
+
+    assert.strictEqual(lines[0], 'hooks initialize 1');
+    assert.strictEqual(lines[1], 'foo');
+
+    assert.strictEqual(stderr, '');
+
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('`register` should work with `require`', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--require',
+      fixtures.path('/es-module-loaders/register-loader.cjs'),
+      '--input-type=module',
+      '--eval',
+      'import "node:os";',
+    ]);
+
+    const lines = stdout.split('\n');
+
+    assert.strictEqual(lines[0], 'resolve passthru');
+
+    assert.strictEqual(stderr, '');
+
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('`register` should work with `import`', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--import',
+      fixtures.fileURL('/es-module-loaders/register-loader.mjs'),
+      '--input-type=module',
+      '--eval',
+      `
+        import 'node:os';
+      `,
+    ]);
+
+    const lines = stdout.split('\n');
+
+    assert.strictEqual(lines[0], 'resolve passthru');
+
+    assert.strictEqual(stderr, '');
+
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should execute `initialize` in sequence', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--input-type=module',
+      '--eval',
+      `
+        import {register} from 'node:module';
+        console.log('result', register(
+          ${JSON.stringify(fixtures.fileURL('/es-module-loaders/hooks-initialize.mjs'))}
+        ));
+        console.log('result', register(
+          ${JSON.stringify(fixtures.fileURL('/es-module-loaders/hooks-initialize.mjs'))}
+        ));
+
+        await import('node:os');
+      `,
+    ]);
+
+    const lines = stdout.split('\n');
+
+    assert.strictEqual(lines[0], 'result 1');
+    assert.strictEqual(lines[1], 'result 2');
+    assert.strictEqual(lines[2], 'hooks initialize 1');
+    assert.strictEqual(lines[3], 'hooks initialize 2');
+
+    assert.strictEqual(stderr, '');
+
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
   });

--- a/test/es-module/test-esm-loader-programmatically.mjs
+++ b/test/es-module/test-esm-loader-programmatically.mjs
@@ -22,12 +22,15 @@ const commonEvals = {
 
 describe('ESM: programmatically register loaders', { concurrency: true }, () => {
   it('works with only a dummy CLI argument', async () => {
+    const parentURL = fixtures.fileURL('es-module-loaders', 'loader-resolve-passthru.mjs');
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
       ...commonArgs,
       '--eval',
       "import { register } from 'node:module';" +
       commonEvals.register(fixtures.fileURL('es-module-loaders', 'loader-resolve-passthru.mjs')) +
       commonEvals.register(fixtures.fileURL('es-module-loaders', 'loader-load-passthru.mjs')) +
+      `register(${JSON.stringify('./loader-resolve-passthru.mjs')}, ${JSON.stringify({ parentURL })});` +
+      `register(${JSON.stringify('./loader-load-passthru.mjs')}, ${JSON.stringify({ parentURL })});` +
       commonEvals.dynamicImport('console.log("Hello from dynamic import");'),
     ]);
 
@@ -38,10 +41,12 @@ describe('ESM: programmatically register loaders', { concurrency: true }, () => 
     const lines = stdout.split('\n');
 
     assert.match(lines[0], /resolve passthru/);
-    assert.match(lines[1], /load passthru/);
-    assert.match(lines[2], /Hello from dynamic import/);
+    assert.match(lines[1], /resolve passthru/);
+    assert.match(lines[2], /load passthru/);
+    assert.match(lines[3], /load passthru/);
+    assert.match(lines[4], /Hello from dynamic import/);
 
-    assert.strictEqual(lines[3], '');
+    assert.strictEqual(lines[5], '');
   });
 
   describe('registering via --import', { concurrency: true }, () => {

--- a/test/fixtures/es-module-loaders/hooks-initialize-port.mjs
+++ b/test/fixtures/es-module-loaders/hooks-initialize-port.mjs
@@ -1,0 +1,17 @@
+let thePort = null;
+
+export async function initialize(port) {
+  port.postMessage('initialize');
+  thePort = port;
+  return 'ok';
+}
+
+export async function resolve(specifier, context, next) {
+  if (specifier === 'node:fs' || specifier.includes('loader')) {
+    return next(specifier);
+  }
+
+  thePort.postMessage(`resolve ${specifier}`);
+
+  return next(specifier);
+}

--- a/test/fixtures/es-module-loaders/hooks-initialize.mjs
+++ b/test/fixtures/es-module-loaders/hooks-initialize.mjs
@@ -1,0 +1,7 @@
+let counter = 0;
+
+export async function initialize() {
+  counter += 1;
+  console.log('hooks initialize', counter);
+  return counter;
+}


### PR DESCRIPTION
Follows @giltayar's proposed API:

> `register` can pass any data it wants to the loader, which will be passed to the exported `initialize` function of the loader. Additionally, if the user of `register` wants to communicate with the loader, it can just create a `MessageChannel` and pass the port to the loader as data.

The `register` API is now:

```ts
interface Options {
  parentUrl?: string;
  data?: any;
  transferList?: any[];
}

function register(loader: string, parentUrl?: string): any;
function register(loader: string, options?: Options): any;
```

This API is backwards compatible with the old one (new arguments are optional and at the end) and allows for passing data into the new `initialize` hook. If this hook returns data it is passed back to `register`:

```ts
function initialize(data: any): Promise<any>;
```

**NOTE**: Currently there is no mechanism for a loader to exchange ownership of something back to the caller.

Refs: https://github.com/nodejs/loaders/issues/147

----

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
