### PR TITLE
doc: rename `backport-requested-*` labels to `backport-pr-requested-*`

### DIFF
--- a/doc/contributing/backporting-to-release-lines.md
+++ b/doc/contributing/backporting-to-release-lines.md
@@ -12,7 +12,7 @@ For the active staging branches see the [Release Schedule][].
 
 If a cherry-pick from `main` does not land cleanly on a staging branch, the
 releaser will mark the pull request with a particular label for that release
-line (e.g. `backport-requested-vN.x`), specifying to our tooling that this
+line (e.g. `backport-pr-requested-vN.x`), specifying to our tooling that this
 pull request should not be included. The releaser will then add a comment
 requesting that a backport pull request be made.
 
@@ -28,15 +28,15 @@ commits be cherry-picked or backported.
 
 For the following labels, the `N` in `vN.x` refers to the major release number.
 
-| Label                   | Description                                                                                       |
-| ----------------------- | ------------------------------------------------------------------------------------------------- |
-| backport-blocked-vN.x   | PRs that should land on the vN.x-staging branch but are blocked by another PR's pending backport. |
-| backport-open-vN.x      | Indicate that the PR has an open backport.                                                        |
-| backport-requested-vN.x | PRs awaiting manual backport to the vN.x-staging branch.                                          |
-| backported-to-vN.x      | PRs backported to the vN.x-staging branch.                                                        |
-| baking-for-lts          | PRs that need to wait before landing in a LTS release.                                            |
-| lts-watch-vN.x          | PRs that may need to be released in vN.x.                                                         |
-| vN.x                    | Issues that can be reproduced on vN.x or PRs targeting the vN.x-staging branch.                   |
+| Label                      | Description                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------------- |
+| backport-blocked-vN.x      | PRs that should land on the vN.x-staging branch but are blocked by another PR's pending backport. |
+| backport-pr-open-vN.x      | Indicate that the PR has an open backport.                                                        |
+| backport-pr-requested-vN.x | PRs awaiting manual backport to the vN.x-staging branch.                                          |
+| backported-to-vN.x         | PRs backported to the vN.x-staging branch.                                                        |
+| baking-for-lts             | PRs that need to wait before landing in a LTS release.                                            |
+| lts-watch-vN.x             | PRs that may need to be released in vN.x.                                                         |
+| vN.x                       | Issues that can be reproduced on vN.x or PRs targeting the vN.x-staging branch.                   |
 
 ## How to submit a backport pull request
 
@@ -105,13 +105,13 @@ replace that with the staging branch for the targeted release line.
    6. Run a [`node-test-pull-request`][] CI job (with `REBASE_ONTO` set to the
       default `<pr base branch>`)
 
-10. Replace the `backport-requested-v10.x` label on the original pull request
-    with `backport-open-v10.x`.
+10. Replace the `backport-pr-requested-v10.x` label on the original pull request
+    with `backport-pr-open-v10.x`.
 
 11. If during the review process conflicts arise, use the following to rebase:
     `git pull --rebase upstream v10.x-staging`
 
-After the pull request lands, replace the `backport-open-v10.x` label on the
+After the pull request lands, replace the `backport-pr-open-v10.x` label on the
 original pull request with `backported-to-v10.x`.
 
 [Release Plan]: https://github.com/nodejs/Release#release-plan

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -919,7 +919,7 @@ We use labels to keep track of which branches a commit should land on:
     LTS release
   * Applied to the original pull request for clean cherry-picks, to the backport
     pull request otherwise
-* `backport-requested-v?.x`
+* `backport-pr-requested-v?.x`
   * Used to indicate that a pull request needs a manual backport to a branch in
     order to land the changes on that branch
   * Typically applied by a releaser when the pull request does not apply cleanly

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -165,7 +165,7 @@ For each PR:
 
 When landing the PR add the `Backport-PR-URL:` line to each commit. Close the
 backport PR with `Landed in ...`. Update the label on the original PR from
-`backport-requested-vN.x` to `backported-to-vN.x`.
+`backport-pr-requested-vN.x` to `backported-to-vN.x`.
 
 You can add the `Backport-PR-URL` metadata by using `--backport` with
 `git node land`
@@ -185,7 +185,7 @@ duplicate or not.
 For a list of commits that could be landed in a patch release on v1.x:
 
 ```bash
-branch-diff v1.x-staging main --exclude-label=semver-major,semver-minor,dont-land-on-v1.x,backport-requested-v1.x,backport-blocked-v1.x,backport-open-v1.x,backported-to-v1.x --filter-release --format=simple
+branch-diff v1.x-staging main --exclude-label=semver-major,semver-minor,dont-land-on-v1.x,backport-pr-requested-v1.x,backport-blocked-v1.x,backport-pr-open-v1.x,backported-to-v1.x --filter-release --format=simple
 ```
 
 Previously released commits and version bumps do not need to be
@@ -205,11 +205,11 @@ command. (For semver-minor releases, make sure to remove the `semver-minor` tag
 from `exclude-label`.)
 
 ```bash
-branch-diff v1.x-staging main --exclude-label=semver-major,semver-minor,dont-land-on-v1.x,backport-requested-v1.x,backport-blocked-v1.x,backport-open-v1.x,backported-to-v1.x --filter-release --format=sha --reverse | xargs git cherry-pick
+branch-diff v1.x-staging main --exclude-label=semver-major,semver-minor,dont-land-on-v1.x,backport-pr-requested-v1.x,backport-blocked-v1.x,backport-pr-open-v1.x,backported-to-v1.x --filter-release --format=sha --reverse | xargs git cherry-pick
 ```
 
 When cherry-picking commits, if there are simple conflicts you can resolve
-them. Otherwise, add the `backport-requested-vN.x` label to the original PR
+them. Otherwise, add the `backport-pr-requested-vN.x` label to the original PR
 and post a comment stating that it does not land cleanly and will require a
 backport PR. You can refer the owner of the PR to the "[Backporting to Release
 Lines](https://github.com/nodejs/node/blob/HEAD/doc/contributing/backporting-to-release-lines.md)" guide.
@@ -1114,7 +1114,7 @@ The `lts-watch-vN.x` issue label must be created, with the same color as other
 existing labels for that release line, such as `vN.x`.
 
 If the release is transitioning from Active LTS to Maintenance, the
-`backport-requested-vN.x` label must be deleted.
+`backport-pr-requested-vN.x` label must be deleted.
 
 ### Add new codename to nodejs-latest-linker
 
@@ -1179,8 +1179,8 @@ The following issue labels must be created:
 
 * `vN.x`
 * `backport-blocked-vN.x`
-* `backport-open-vN.x`
-* `backport-requested-vN.x`
+* `backport-pr-open-vN.x`
+* `backport-pr-requested-vN.x`
 * `backported-to-vN.x`
 * `dont-land-on-vN.x`
 


### PR DESCRIPTION
And similarly for `backport-open-*` -> `backport-pr-open-*`.

I think the current `backport-requested` is confusing for folks who not familiar with our process, and maybe `backport-pr-requested` would do a better job at self-explaining. I expect that will mostly affect folks at @nodejs/backporters @nodejs/lts @nodejs/releasers so I'd like to hear your thoughts.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
