### PR TITLE
test_runner: do not spawn run in child processes to prevent infinite loops

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -69,6 +69,7 @@ const {
   convertStringToRegExp,
   countCompletedTest,
   kDefaultPattern,
+  parseCommandLine,
 } = require('internal/test_runner/utils');
 const { Glob } = require('internal/fs/glob');
 const { once } = require('events');
@@ -470,13 +471,22 @@ function run(options) {
   }
 
   const root = createTestTree({ concurrency, timeout, signal });
+  let postRun = () => root.postRun();
+
+  // Don't spawn `run` in child processes to prevent infinite loops
+  const { isChildProcess, isChildProcessV8 } = parseCommandLine();
+  if (isChildProcess || isChildProcessV8) {
+    PromisePrototypeThen(PromisePrototypeThen(PromiseResolve(setup?.(root)), []), postRun);
+
+    return root.reporter;
+  }
+
   let testFiles = files ?? createTestFileList();
 
   if (shard) {
     testFiles = ArrayPrototypeFilter(testFiles, (_, index) => index % shard.total === shard.index - 1);
   }
 
-  let postRun = () => root.postRun();
   let filesWatcher;
   if (watch) {
     filesWatcher = watchFiles(testFiles, root, inspectPort, signal, testNamePatterns);

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -235,6 +235,8 @@ function parseCommandLine() {
     testNamePatterns,
     reporters,
     destinations,
+    isChildProcess,
+    isChildProcessV8,
   };
 
   return globalTestOptions;

--- a/test/fixtures/test-runner/run_null_files/run.mjs
+++ b/test/fixtures/test-runner/run_null_files/run.mjs
@@ -1,0 +1,16 @@
+import { run } from 'node:test';
+import assert from 'node:assert';
+import { tap } from 'node:test/reporters';
+
+const stream = run({
+  timeout: 1000
+})
+  .compose(tap)
+  .pipe(process.stdout)
+
+stream.on('test:fail', (f) => {
+  assert.ok(false)
+});
+stream.on('test:pass', (p) => {
+  assert.ok(false)
+});

--- a/test/fixtures/test-runner/run_self_path.mjs
+++ b/test/fixtures/test-runner/run_self_path.mjs
@@ -1,0 +1,22 @@
+import { run, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import assert from 'node:assert';
+import { tap } from 'node:test/reporters';
+
+const stream = run({
+  files: [fileURLToPath(import.meta.url)],
+  timeout: 1000
+})
+  .compose(tap)
+  .pipe(process.stdout)
+
+stream.on('test:fail', (f) => {
+  assert.ok(false)
+});
+stream.on('test:pass', (p) => {
+  assert.ok(false)
+});
+
+test('1 + 1 = 2', async () => {
+  assert.strictEqual(1 + 1, 2, '1 + 1 = 2')
+})

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -3,6 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { join } from 'node:path';
 import { describe, it, run } from 'node:test';
 import { dot, spec, tap } from 'node:test/reporters';
+import { execFileSync } from 'child_process';
 import assert from 'node:assert';
 
 const testFixtures = fixtures.path('test-runner');
@@ -15,6 +16,23 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
     stream.on('test:pass', common.mustNotCall());
     // eslint-disable-next-line no-unused-vars
     for await (const _ of stream);
+  });
+
+  it('should run without infinite loops (self path)', { timeout: 10000 }, async () => {
+    execFileSync(
+      process.execPath,
+      ['--test', join(testFixtures, 'run_self_path.mjs')],
+      { timeout: 10000, cwd: testFixtures }
+    );
+  });
+
+  it('should run without infinite loops (Default: files)', { timeout: 10000 }, async () => {
+    const cwd = join(testFixtures, 'run_null_files');
+    execFileSync(
+      process.execPath,
+      ['--test', join(cwd, 'run.mjs')],
+      { timeout: 10000, cwd }
+    );
   });
 
   it('should fail with non existing file', async () => {


### PR DESCRIPTION
Infinite loop occurs when the file in `options.files` has `run`.
I send this PR to avoid the risk of occuring infinite loop.

Ref: https://github.com/nodejs/node/issues/48823

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
