### PR TITLE
src: refactor vector writing in snapshot builder

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -885,9 +885,6 @@
           'node_target_type=="executable"', {
           'defines': [ 'NODE_ENABLE_LARGE_CODE_PAGES=1' ],
         }],
-        ['OS in "linux mac"', {
-          'defines': [ 'NODE_MKSNAPSHOT_USE_STRING_LITERALS' ],
-        }],
         [ 'use_openssl_def==1', {
           # TODO(bnoordhuis) Make all platforms export the same list of symbols.
           # Teach mkssldef.py to generate linker maps that UNIX linkers understand.
@@ -1256,6 +1253,9 @@
       ],
 
       'conditions': [
+        ['OS in "linux mac"', {
+          'defines': [ 'NODE_MKSNAPSHOT_USE_STRING_LITERALS=1' ],
+        }],
         [ 'node_use_openssl=="true"', {
           'defines': [
             'HAVE_OPENSSL=1',

--- a/src/node_snapshot_builder.h
+++ b/src/node_snapshot_builder.h
@@ -18,10 +18,12 @@ struct SnapshotData;
 
 class NODE_EXTERN_PRIVATE SnapshotBuilder {
  public:
-  static ExitCode Generate(std::ostream& out,
-                           const std::vector<std::string>& args,
-                           const std::vector<std::string>& exec_args,
-                           std::optional<std::string_view> main_script);
+  static ExitCode GenerateAsSource(
+      const char* out_path,
+      const std::vector<std::string>& args,
+      const std::vector<std::string>& exec_args,
+      std::optional<std::string_view> main_script_path = std::nullopt,
+      bool use_string_literals = true);
 
   // Generate the snapshot into out.
   static ExitCode Generate(SnapshotData* out,

--- a/tools/snapshot/node_mksnapshot.cc
+++ b/tools/snapshot/node_mksnapshot.cc
@@ -1,5 +1,4 @@
 #include <cstdio>
-#include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -72,29 +71,26 @@ int BuildSnapshot(int argc, char* argv[]) {
   CHECK_EQ(result->exit_code(), 0);
 
   std::string out_path;
+  std::optional<std::string_view> main_script_path = std::nullopt;
   if (node::per_process::cli_options->per_isolate->build_snapshot) {
+    main_script_path = result->args()[1];
     out_path = result->args()[2];
   } else {
     out_path = result->args()[1];
   }
 
-  std::ofstream out(out_path, std::ios::out | std::ios::binary);
-  if (!out) {
-    std::cerr << "Cannot open " << out_path << "\n";
-    return 1;
-  }
+#ifdef NODE_MKSNAPSHOT_USE_STRING_LITERALS
+  bool use_string_literals = true;
+#else
+  bool use_string_literals = false;
+#endif
 
-  node::ExitCode exit_code = node::ExitCode::kNoFailure;
-  {
-    exit_code = node::SnapshotBuilder::Generate(
-        out, result->args(), result->exec_args(), std::nullopt);
-    if (exit_code == node::ExitCode::kNoFailure) {
-      if (!out) {
-        std::cerr << "Failed to write " << out_path << "\n";
-        exit_code = node::ExitCode::kGenericUserError;
-      }
-    }
-  }
+  node::ExitCode exit_code =
+      node::SnapshotBuilder::GenerateAsSource(out_path.c_str(),
+                                              result->args(),
+                                              result->exec_args(),
+                                              main_script_path,
+                                              use_string_literals);
 
   node::TearDownOncePerProcess();
   return static_cast<int>(exit_code);


### PR DESCRIPTION
- Build a static table of octal strings and use it instead of building octal strings repeatedly during printing.
- Print a newline and an offset for every 64 bytes in the case of printing array literals so it's easier to locate variation in snapshot blobs.
- Rework the printing routines so that the differences are only made in a WriteByteVectorLiteral routine. We can update this for compression support in the future.
- Rename Snapshot::Generate() that write the data as C++ source instead of a blob as Snaphost::GenerateAsSource() for clarity, and move the file stream operations into it to streamline error handling.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
