### PR TITLE
test: use --max-opt=0 instead of --no-opt test-linux-perf.js

### DIFF
--- a/test/v8-updates/test-linux-perf.js
+++ b/test/v8-updates/test-linux-perf.js
@@ -50,7 +50,7 @@ const perfInterpretedFramesArgs = [
   '--',
   process.execPath,
   ...nodeCommonFlags,
-  '--no-opt',
+  '--max-opt=0',  // Interpreter only.
   fixtures.path('linux-perf.js'),
   `${sleepTime}`,
   `${repeat}`,


### PR DESCRIPTION
--no-opt only disables turbofan but other compilers may still be enabled, in that case we may not be able to find the interpreted frames if the function is compiled soon enough. Instead use --max-opt=0 which turns off all compilers.

Refs: https://github.com/nodejs/node/issues/48861

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
