### PR TITLE
net: fix readable event not emitted (fixes #25969)

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1582,8 +1582,10 @@ function afterConnect(status, handle, req, readable, writable) {
 
     // Start the first read, or get an immediate EOF.
     // this doesn't actually consume any bytes, because len=0.
-    if (readable && !self.isPaused())
+    if (readable) {
       self.read(0);
+    }
+
     if (self[kPerfHooksNetConnectContext] && hasObserver('net')) {
       stopPerf(self, kPerfHooksNetConnectContext);
     }

--- a/lib/net.js
+++ b/lib/net.js
@@ -1033,6 +1033,8 @@ function internalConnect(
   self, address, port, addressType, localAddress, localPort, flags) {
   // TODO return promise from Socket.prototype.connect which
   // wraps _connectReq.
+  debug('resume')
+  self.resume();
 
   assert(self.connecting);
 
@@ -1582,10 +1584,8 @@ function afterConnect(status, handle, req, readable, writable) {
 
     // Start the first read, or get an immediate EOF.
     // this doesn't actually consume any bytes, because len=0.
-    if (readable) {
+    if (readable && !self.isPaused())
       self.read(0);
-    }
-
     if (self[kPerfHooksNetConnectContext] && hasObserver('net')) {
       stopPerf(self, kPerfHooksNetConnectContext);
     }

--- a/lib/net.js
+++ b/lib/net.js
@@ -1033,7 +1033,7 @@ function internalConnect(
   self, address, port, addressType, localAddress, localPort, flags) {
   // TODO return promise from Socket.prototype.connect which
   // wraps _connectReq.
-  debug('resume')
+  debug('resume');
   self.resume();
 
   assert(self.connecting);


### PR DESCRIPTION
fix readable event not emitted  after reconnect

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


Closes: #25969
