### PR TITLE
[v18.x backport] src: replace idna functions with ada::idna

### DIFF
--- a/lib/internal/idna.js
+++ b/lib/internal/idna.js
@@ -1,4 +1,4 @@
 'use strict';
 
-const { domainToASCII, domainToUnicode } = require('internal/url');
-module.exports = { toASCII: domainToASCII, toUnicode: domainToUnicode };
+const { toASCII, toUnicode } = internalBinding('url');
+module.exports = { toASCII, toUnicode };

--- a/lib/url.js
+++ b/lib/url.js
@@ -427,10 +427,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
         // It only converts parts of the domain name that
         // have non-ASCII characters, i.e. it doesn't matter if
         // you call it with a domain that already is ASCII-only.
-
-        // Use lenient mode (`true`) to try to support even non-compliant
-        // URLs.
-        this.hostname = toASCII(this.hostname, true);
+        this.hostname = toASCII(this.hostname);
 
         // Prevent two potential routes of hostname spoofing.
         // 1. If this.hostname is empty, it must have become empty due to toASCII

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -294,6 +294,28 @@ void BindingData::Update(const FunctionCallbackInfo<Value>& args) {
           .ToLocalChecked());
 }
 
+void BindingData::ToASCII(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK_GE(args.Length(), 1);
+  CHECK(args[0]->IsString());
+
+  Utf8Value input(env->isolate(), args[0]);
+  auto out = ada::idna::to_ascii(input.ToStringView());
+  args.GetReturnValue().Set(
+      String::NewFromUtf8(env->isolate(), out.c_str()).ToLocalChecked());
+}
+
+void BindingData::ToUnicode(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK_GE(args.Length(), 1);
+  CHECK(args[0]->IsString());
+
+  Utf8Value input(env->isolate(), args[0]);
+  auto out = ada::idna::to_unicode(input.ToStringView());
+  args.GetReturnValue().Set(
+      String::NewFromUtf8(env->isolate(), out.c_str()).ToLocalChecked());
+}
+
 void BindingData::UpdateComponents(const ada::url_components& components,
                                    const ada::scheme::type type) {
   url_components_buffer_[0] = components.protocol_end;
@@ -318,6 +340,8 @@ void BindingData::Initialize(Local<Object> target,
       realm->AddBindingData<BindingData>(context, target);
   if (binding_data == nullptr) return;
 
+  SetMethodNoSideEffect(context, target, "toASCII", ToASCII);
+  SetMethodNoSideEffect(context, target, "toUnicode", ToUnicode);
   SetMethodNoSideEffect(context, target, "domainToASCII", DomainToASCII);
   SetMethodNoSideEffect(context, target, "domainToUnicode", DomainToUnicode);
   SetMethodNoSideEffect(context, target, "canParse", CanParse);
@@ -328,6 +352,8 @@ void BindingData::Initialize(Local<Object> target,
 
 void BindingData::RegisterExternalReferences(
     ExternalReferenceRegistry* registry) {
+  registry->Register(ToASCII);
+  registry->Register(ToUnicode);
   registry->Register(DomainToASCII);
   registry->Register(DomainToUnicode);
   registry->Register(CanParse);

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -45,6 +45,9 @@ class BindingData : public SnapshotableObject {
   SET_SELF_SIZE(BindingData)
   SET_MEMORY_INFO_NAME(BindingData)
 
+  static void ToASCII(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void ToUnicode(const v8::FunctionCallbackInfo<v8::Value>& args);
+
   static void DomainToASCII(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void DomainToUnicode(const v8::FunctionCallbackInfo<v8::Value>& args);
 

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -1007,6 +1007,22 @@ const parseTests = {
     path: '/',
     href: 'https://evil.com$.example.com/'
   },
+
+  // Validate the output of hostname with commas.
+  'x://0.0,1.1/': {
+    protocol: 'x:',
+    slashes: true,
+    auth: null,
+    host: '0.0,1.1',
+    port: null,
+    hostname: '0.0,1.1',
+    hash: null,
+    search: null,
+    query: null,
+    pathname: '/',
+    path: '/',
+    href: 'x://0.0,1.1/'
+  }
 };
 
 for (const u in parseTests) {


### PR DESCRIPTION
This PR includes a slightly modified backport which moves the function declarations to `node_url.cc` instead of `encoding_binding.cc` where Node.js v18 does not have. I've also added a new test to validate the correctness of this backport.

Backport https://github.com/nodejs/node/pull/47735
Backport https://github.com/nodejs/node/pull/48878

Fixes https://github.com/nodejs/node/issues/48855
Fixes https://github.com/nodejs/node/issues/48850
