### PR TITLE
permission: move PrintTree into unnamed namespace

### DIFF
--- a/src/permission/fs_permission.cc
+++ b/src/permission/fs_permission.cc
@@ -67,51 +67,52 @@ bool is_tree_granted(node::permission::FSPermission::RadixTree* granted_tree,
   return granted_tree->Lookup(param, true);
 }
 
-}  // namespace
-
-namespace node {
-
-namespace permission {
-
-void PrintTree(const FSPermission::RadixTree::Node* node, size_t spaces = 0) {
+void PrintTree(const node::permission::FSPermission::RadixTree::Node* node,
+               size_t spaces = 0) {
   std::string whitespace(spaces, ' ');
 
   if (node == nullptr) {
     return;
   }
   if (node->wildcard_child != nullptr) {
-    per_process::Debug(DebugCategory::PERMISSION_MODEL,
-                       "%s Wildcard: %s\n",
-                       whitespace,
-                       node->prefix);
+    node::per_process::Debug(node::DebugCategory::PERMISSION_MODEL,
+                             "%s Wildcard: %s\n",
+                             whitespace,
+                             node->prefix);
   } else {
-    per_process::Debug(DebugCategory::PERMISSION_MODEL,
-                       "%s Prefix: %s\n",
-                       whitespace,
-                       node->prefix);
+    node::per_process::Debug(node::DebugCategory::PERMISSION_MODEL,
+                             "%s Prefix: %s\n",
+                             whitespace,
+                             node->prefix);
     if (node->children.size()) {
       size_t child = 0;
       for (const auto& pair : node->children) {
         ++child;
-        per_process::Debug(DebugCategory::PERMISSION_MODEL,
-                           "%s Child(%s): %s\n",
-                           whitespace,
-                           child,
-                           std::string(1, pair.first));
+        node::per_process::Debug(node::DebugCategory::PERMISSION_MODEL,
+                                 "%s Child(%s): %s\n",
+                                 whitespace,
+                                 child,
+                                 std::string(1, pair.first));
         PrintTree(pair.second, spaces + 2);
       }
-      per_process::Debug(DebugCategory::PERMISSION_MODEL,
-                         "%s End of tree - child(%s)\n",
-                         whitespace,
-                         child);
+      node::per_process::Debug(node::DebugCategory::PERMISSION_MODEL,
+                               "%s End of tree - child(%s)\n",
+                               whitespace,
+                               child);
     } else {
-      per_process::Debug(DebugCategory::PERMISSION_MODEL,
-                         "%s End of tree: %s\n",
-                         whitespace,
-                         node->prefix);
+      node::per_process::Debug(node::DebugCategory::PERMISSION_MODEL,
+                               "%s End of tree: %s\n",
+                               whitespace,
+                               node->prefix);
     }
   }
 }
+
+}  // namespace
+
+namespace node {
+
+namespace permission {
 
 // allow = '*'
 // allow = '/tmp/,/home/example.js'


### PR DESCRIPTION
This function is not declared outside of `fs_permission.cc` and thus should not be visible outside the file during the linking stage.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
