### PR TITLE
test: validate host with commas on url.parse

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -401,10 +401,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
         // It only converts parts of the domain name that
         // have non-ASCII characters, i.e. it doesn't matter if
         // you call it with a domain that already is ASCII-only.
-
-        // Use lenient mode (`true`) to try to support even non-compliant
-        // URLs.
-        this.hostname = toASCII(this.hostname, true);
+        this.hostname = toASCII(this.hostname);
 
         // Prevent two potential routes of hostname spoofing.
         // 1. If this.hostname is empty, it must have become empty due to toASCII

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -1007,6 +1007,22 @@ const parseTests = {
     path: '/',
     href: 'https://evil.com$.example.com/'
   },
+
+  // Validate the output of hostname with commas.
+  'x://0.0,1.1/': {
+    protocol: 'x:',
+    slashes: true,
+    auth: null,
+    host: '0.0,1.1',
+    port: null,
+    hostname: '0.0,1.1',
+    hash: null,
+    search: null,
+    query: null,
+    pathname: '/',
+    path: '/',
+    href: 'x://0.0,1.1/'
+  }
 };
 
 for (const u in parseTests) {


### PR DESCRIPTION
Add missing test for url's with commas for `url.parse` and removes unnecessary parameter to `toASCII`

Ref: https://github.com/nodejs/node/pull/48873
Ref: https://github.com/nodejs/node/issues/48855
Ref: https://github.com/nodejs/node/issues/48850

cc @nodejs/url @aduh95 