### PR TITLE
node-api: avoid macro redefinition

### DIFF
--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -268,14 +268,6 @@ inline napi_status napi_set_last_error(napi_env env,
     }                                                                          \
   } while (0)
 
-#define RETURN_STATUS_IF_FALSE_WITH_PREAMBLE(env, condition, status)           \
-  do {                                                                         \
-    if (!(condition)) {                                                        \
-      return napi_set_last_error(                                              \
-          (env), try_catch.HasCaught() ? napi_pending_exception : (status));   \
-    }                                                                          \
-  } while (0)
-
 #define CHECK_MAYBE_EMPTY_WITH_PREAMBLE(env, maybe, status)                    \
   RETURN_STATUS_IF_FALSE_WITH_PREAMBLE((env), !((maybe).IsEmpty()), (status))
 


### PR DESCRIPTION
Even though the redefinition complies with the C standard because the second definition is "effectively the same" as the first definition, it's best to avoid any redefinition.

The first definition is here:

https://github.com/nodejs/node/blob/b68fa599607f69f2ce3b1a3104e0d5984f6bc0d8/src/js_native_api_v8.h#L183-L189

The definition that is being removed is here:

https://github.com/nodejs/node/blob/b68fa599607f69f2ce3b1a3104e0d5984f6bc0d8/src/js_native_api_v8.h#L271-L277

Refs: https://github.com/nodejs/node/pull/28237
Refs: https://github.com/nodejs/node/pull/30006

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
