### PR TITLE
test: fix `es-module/test-esm-initialization`

### DIFF
--- a/test/es-module/test-esm-initialization.mjs
+++ b/test/es-module/test-esm-initialization.mjs
@@ -8,22 +8,23 @@ import { describe, it } from 'node:test';
 describe('ESM: ensure initialization happens only once', { concurrency: true }, () => {
   it(async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
+      '--experimental-import-meta-resolve',
       '--loader',
       fixtures.fileURL('es-module-loaders', 'loader-resolve-passthru.mjs'),
       '--no-warnings',
       fixtures.path('es-modules', 'runmain.mjs'),
     ]);
 
-    // Length minus 1 because the first match is the needle.
-    const resolveHookRunCount = (stdout.match(/resolve passthru/g)?.length ?? 0) - 1;
-
     assert.strictEqual(stderr, '');
     /**
      * resolveHookRunCount = 2:
      * 1. fixtures/…/runmain.mjs
      * 2. node:module (imported by fixtures/…/runmain.mjs)
+     * 3. doesnt-matter.mjs (first import.meta.resolve call)
+     * 4. fixtures/…/runmain.mjs (entry point)
+     * 5. doesnt-matter.mjs (second import.meta.resolve call)
      */
-    assert.strictEqual(resolveHookRunCount, 2);
+    assert.strictEqual(stdout.match(/resolve passthru/g)?.length, 5);
     assert.strictEqual(code, 0);
   });
 });


### PR DESCRIPTION
The `--experimental-import-meta-resolve` flag was not supplied, when the target file does use `import.meta.resolve`. I also cleaned up the comments.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
