### PR TITLE
src,permission: restrict by default when pm enabled

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -850,19 +850,17 @@ Environment::Environment(IsolateData* isolate_data,
 
   if (options_->experimental_permission) {
     permission()->EnablePermissions();
-    // If any permission is set the process shouldn't be able to neither
+    // The process shouldn't be able to neither
     // spawn/worker nor use addons or enable inspector
     // unless explicitly allowed by the user
-    if (!options_->allow_fs_read.empty() || !options_->allow_fs_write.empty()) {
-      options_->allow_native_addons = false;
-      flags_ = flags_ | EnvironmentFlags::kNoCreateInspector;
-      permission()->Apply("*", permission::PermissionScope::kInspector);
-      if (!options_->allow_child_process) {
-        permission()->Apply("*", permission::PermissionScope::kChildProcess);
-      }
-      if (!options_->allow_worker_threads) {
-        permission()->Apply("*", permission::PermissionScope::kWorkerThreads);
-      }
+    options_->allow_native_addons = false;
+    flags_ = flags_ | EnvironmentFlags::kNoCreateInspector;
+    permission()->Apply("*", permission::PermissionScope::kInspector);
+    if (!options_->allow_child_process) {
+      permission()->Apply("*", permission::PermissionScope::kChildProcess);
+    }
+    if (!options_->allow_worker_threads) {
+      permission()->Apply("*", permission::PermissionScope::kWorkerThreads);
     }
 
     if (!options_->allow_fs_read.empty()) {

--- a/test/parallel/test-permission-inspector.js
+++ b/test/parallel/test-permission-inspector.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-permission --allow-fs-read=*
+// Flags: --experimental-permission --allow-fs-read=* --allow-child-process
 'use strict';
 
 const common = require('../common');
@@ -7,6 +7,7 @@ common.skipIfInspectorDisabled();
 
 const { Session } = require('inspector');
 const assert = require('assert');
+const { spawnSync } = require('child_process');
 
 if (!common.hasCrypto)
   common.skip('no crypto');
@@ -19,4 +20,17 @@ if (!common.hasCrypto)
     code: 'ERR_ACCESS_DENIED',
     permission: 'Inspector',
   }));
+}
+
+{
+  const { status, stderr } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-permission',
+      '-e',
+      '(new (require("inspector")).Session()).connect()',
+    ],
+  );
+  assert.strictEqual(status, 1);
+  assert.match(stderr.toString(), /Error: Access to this API has been restricted/);
 }


### PR DESCRIPTION
It goes according to the documentation:

> When starting Node.js with --experimental-permission, the ability to access the file system through the fs module, spawn processes, use node:worker_threads and enable the runtime inspector will be restricted.

