### PR TITLE
diagnostics_channel: handle last subscriber removal

### DIFF
--- a/lib/diagnostics_channel.js
+++ b/lib/diagnostics_channel.js
@@ -136,7 +136,7 @@ class ActiveChannel {
   }
 
   publish(data) {
-    for (let i = 0; i < this._subscribers.length; i++) {
+    for (let i = 0; i < (this._subscribers?.length || 0); i++) {
       try {
         const onMessage = this._subscribers[i];
         onMessage(data, this.name);

--- a/test/parallel/test-diagnostics-channel-sync-unsubscribe.js
+++ b/test/parallel/test-diagnostics-channel-sync-unsubscribe.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const common = require('../common');
+const dc = require('node:diagnostics_channel');
+
+const channel_name = 'test:channel';
+const published_data = 'some message';
+
+const onMessageHandler = common.mustCall(() => dc.unsubscribe(channel_name, onMessageHandler));
+
+dc.subscribe(channel_name, onMessageHandler);
+
+// This must not throw.
+dc.channel(channel_name).publish(published_data);


### PR DESCRIPTION
When iterating over diagnostics channel subscribers, assume their count is zero if the list of subscribers becomes undefined, because there may be only one subscriber which may unsubscribe itself as part of its onMessage handler.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
