### PR TITLE
test_runner: unwrap error message in TAP reporter

### DIFF
--- a/lib/internal/test_runner/reporter/tap.js
+++ b/lib/internal/test_runner/reporter/tap.js
@@ -171,7 +171,7 @@ function jsToYaml(indent, name, value, seen) {
   }
 
   if (isErrorObj) {
-    const { kTestCodeFailure, kUnwrapErrors } = lazyLoadTest();
+    const { kUnwrapErrors } = lazyLoadTest();
     const {
       cause,
       code,

--- a/lib/internal/test_runner/reporter/tap.js
+++ b/lib/internal/test_runner/reporter/tap.js
@@ -198,14 +198,13 @@ function jsToYaml(indent, name, value, seen) {
       errStack = cause?.stack ?? errStack;
       errCode = cause?.code ?? errCode;
       errName = cause?.name ?? errName;
+      errMsg = cause?.message ?? errMsg;
+
       if (isAssertionLike(cause)) {
         errExpected = cause.expected;
         errActual = cause.actual;
         errOperator = cause.operator ?? errOperator;
         errIsAssertion = true;
-      }
-      if (failureType === kTestCodeFailure) {
-        errMsg = cause?.message ?? errMsg;
       }
     }
 

--- a/test/fixtures/test-runner/output/hooks.snapshot
+++ b/test/fixtures/test-runner/output/hooks.snapshot
@@ -56,7 +56,7 @@ not ok 2 - before throws
   duration_ms: *
   type: 'suite'
   failureType: 'hookFailed'
-  error: 'failed running before hook'
+  error: 'before'
   code: 'ERR_TEST_FAILURE'
   stack: |-
     *
@@ -86,7 +86,7 @@ not ok 3 - after throws
   duration_ms: *
   type: 'suite'
   failureType: 'hookFailed'
-  error: 'failed running after hook'
+  error: 'after'
   code: 'ERR_TEST_FAILURE'
   stack: |-
     *
@@ -105,7 +105,7 @@ not ok 3 - after throws
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running beforeEach hook'
+      error: 'beforeEach'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -124,7 +124,7 @@ not ok 3 - after throws
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running beforeEach hook'
+      error: 'beforeEach'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -153,7 +153,7 @@ not ok 4 - beforeEach throws
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running afterEach hook'
+      error: 'afterEach'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -172,7 +172,7 @@ not ok 4 - beforeEach throws
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running afterEach hook'
+      error: 'afterEach'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -254,7 +254,7 @@ not ok 6 - afterEach when test fails
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running afterEach hook'
+      error: 'afterEach'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -315,7 +315,7 @@ ok 8 - test hooks
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running before hook'
+      error: 'before'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -334,7 +334,7 @@ ok 8 - test hooks
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running before hook'
+      error: 'before'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -362,7 +362,7 @@ not ok 9 - t.before throws
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running beforeEach hook'
+      error: 'beforeEach'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -381,7 +381,7 @@ not ok 9 - t.before throws
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running beforeEach hook'
+      error: 'beforeEach'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -409,7 +409,7 @@ not ok 10 - t.beforeEach throws
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running afterEach hook'
+      error: 'afterEach'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -428,7 +428,7 @@ not ok 10 - t.beforeEach throws
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running afterEach hook'
+      error: 'afterEach'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *
@@ -506,7 +506,7 @@ not ok 12 - afterEach when test fails
       ---
       duration_ms: *
       failureType: 'hookFailed'
-      error: 'failed running afterEach hook'
+      error: 'afterEach'
       code: 'ERR_TEST_FAILURE'
       stack: |-
         *


### PR DESCRIPTION
The TAP reporter unwraps errors that come from user code. It was not properly unwrapping the error message when the failure originated from a test hook. This lead to difficult to debug errors when TAP output was used. This commit updates the TAP reporter to properly unwrap the error message.

Fixes: https://github.com/nodejs/node/issues/48941

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
