### PR TITLE
Permission path delimiter

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -554,7 +554,7 @@ Enable the Permission Model for current process. When enabled, the
 following permissions are restricted:
 
 * File System - manageable through
-  [`--allow-fs-read`][], [`--allow-fs-write`][] flags
+  [`--allow-fs-read`][], [`--allow-fs-write`][] and [`--permission-fs-path-delimiter`][] flags
 * Child Process - manageable through [`--allow-child-process`][] flag
 * Worker Threads - manageable through [`--allow-worker`][] flag
 
@@ -1115,6 +1115,27 @@ unless either the `--pending-deprecation` command-line flag, or the
 `NODE_PENDING_DEPRECATION=1` environment variable, is set. Pending deprecations
 are used to provide a kind of selective "early warning" mechanism that
 developers may leverage to detect deprecated API usage.
+
+### `--permission-fs-path-delimiter`
+
+<!-- YAML
+added: v20.0.0
+-->
+
+> Stability: 1 - Experimental
+
+This flag configures file system path delimiter for permissions using
+the [Permission Model][].
+
+Examples can be found in the [File System Permissions][] documentation.
+
+Especial characters in bash as `;` must be escaped or quoted:
+
+```bash
+node --experimental-permission --permission-fs-path-delimiter=\; \
+--allow-fs-read=/path/to/index.js index.js
+```
+
 
 ### `--policy-integrity=sri`
 
@@ -2183,6 +2204,7 @@ Node.js options that are allowed are:
 * `--openssl-legacy-provider`
 * `--openssl-shared-config`
 * `--pending-deprecation`
+* `--permission-fs-path-delimiter`
 * `--policy-integrity`
 * `--preserve-symlinks-main`
 * `--preserve-symlinks`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1119,17 +1119,17 @@ developers may leverage to detect deprecated API usage.
 ### `--permission-fs-path-delimiter`
 
 <!-- YAML
-added: v20.0.0
+added: REPLACEME
 -->
 
 > Stability: 1 - Experimental
 
-This flag configures file system path delimiter for permissions using
+This flag configures the file system path delimiter for permissions using
 the [Permission Model][].
 
 Examples can be found in the [File System Permissions][] documentation.
 
-Especial characters in bash as `;` must be escaped or quoted:
+Special shell characters such as `;` must be escaped or quoted:
 
 ```bash
 node --experimental-permission --permission-fs-path-delimiter=\; \

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1129,11 +1129,9 @@ the [Permission Model][].
 
 Examples can be found in the [File System Permissions][] documentation.
 
-Special shell characters such as `;` must be escaped or quoted:
-
 ```bash
-node --experimental-permission --permission-fs-path-delimiter=\; \
---allow-fs-read=/path/to/index.js index.js
+node --experimental-permission --permission-fs-path-delimiter=";" \
+--allow-fs-read="/path/to/index.js;/path/with,comma" index.js
 ```
 
 ### `--policy-integrity=sri`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -554,7 +554,7 @@ Enable the Permission Model for current process. When enabled, the
 following permissions are restricted:
 
 * File System - manageable through
-  [`--allow-fs-read`][], [`--allow-fs-write`][] and [`--permission-fs-path-delimiter`][] flags
+  [`--allow-fs-read`][], [`--allow-fs-write`][] flags
 * Child Process - manageable through [`--allow-child-process`][] flag
 * Worker Threads - manageable through [`--allow-worker`][] flag
 
@@ -1135,7 +1135,6 @@ Especial characters in bash as `;` must be escaped or quoted:
 node --experimental-permission --permission-fs-path-delimiter=\; \
 --allow-fs-read=/path/to/index.js index.js
 ```
-
 
 ### `--policy-integrity=sri`
 

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -542,8 +542,8 @@ Wildcards are supported too:
 
 ##### Accessing files with comma in path
 
-To access files with comma in path you can change the path delimiter using the
-`--permission-fs-path-delimiter` flag to set a value not used in any of the
+To access files with a comma in the path you can change the path delimiter using
+the `--permission-fs-path-delimiter` flag to set a value not used in any of the
 paths you want to access.
 
 ```console

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -540,6 +540,24 @@ Wildcards are supported too:
 * `--allow-fs-read=/home/test*` will allow read access to everything
   that matches the wildcard. e.g: `/home/test/file1` or `/home/test2`
 
+##### Accessing files with comma in path
+
+To access files with comma in path you can change the path delimiter using the
+`--permission-fs-path-delimiter` flag to set a value not used in any of the
+paths you want to access.
+
+```console
+$ node --experimental-permission --allow-fs-read="/with,commas_/home" \
+--permission-fs-path-delimiter=_ index.js
+```
+
+Note when using bash special characters like `;` escape or quoting is required.
+
+```console
+$ node --experimental-permission --allow-fs-read="/home/with,commas;/home" \
+--permission-fs-path-delimiter=";" index.js
+```
+
 #### Limitations and known issues
 
 There are constraints you need to know before using this system:

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -551,7 +551,8 @@ $ node --experimental-permission --allow-fs-read="/with,commas_/home" \
 --permission-fs-path-delimiter=_ index.js
 ```
 
-Note when using bash special characters like `;` escape or quoting is required.
+Note when using special shell characters such as `;` escaping or quoting is
+required.
 
 ```console
 $ node --experimental-permission --allow-fs-read="/home/with,commas;/home" \

--- a/doc/node.1
+++ b/doc/node.1
@@ -335,6 +335,9 @@ Among other uses, this can be used to enable FIPS-compliant crypto if Node.js is
 .It Fl -pending-deprecation
 Emit pending deprecation warnings.
 .
+.It Fl -permission-fs-path-delimiter
+File system path delimiter used when providing multiple read or write allowed files using the permission model.
+.
 .It Fl -policy-integrity Ns = Ns Ar sri
 Instructs Node.js to error prior to running any code if the policy does not have the specified integrity. It expects a Subresource Integrity string as a parameter.
 .

--- a/src/env.cc
+++ b/src/env.cc
@@ -856,17 +856,17 @@ Environment::Environment(IsolateData* isolate_data,
     if (!options_->allow_worker_threads) {
       permission()->Apply("*", permission::PermissionScope::kWorkerThreads);
     }
-
+    const std::string delimiter = options_->permission_fs_path_delimiter;
     if (!options_->allow_fs_read.empty()) {
       permission()->Apply(options_->allow_fs_read,
                           permission::PermissionScope::kFileSystemRead,
-                          {{"delimiter", options_->permission_fs_path_delimiter}});
+                          {{"delimiter", delimiter}});
     }
 
     if (!options_->allow_fs_write.empty()) {
       permission()->Apply(options_->allow_fs_write,
                           permission::PermissionScope::kFileSystemWrite,
-                          {{"delimiter", options_->permission_fs_path_delimiter}});
+                          {{"delimiter", delimiter}});
     }
   }
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -859,12 +859,14 @@ Environment::Environment(IsolateData* isolate_data,
 
     if (!options_->allow_fs_read.empty()) {
       permission()->Apply(options_->allow_fs_read,
-                          permission::PermissionScope::kFileSystemRead);
+                          permission::PermissionScope::kFileSystemRead,
+                          {{"delimiter", options_->permission_fs_path_delimiter}});
     }
 
     if (!options_->allow_fs_write.empty()) {
       permission()->Apply(options_->allow_fs_write,
-                          permission::PermissionScope::kFileSystemWrite);
+                          permission::PermissionScope::kFileSystemWrite,
+                          {{"delimiter", options_->permission_fs_path_delimiter}});
     }
   }
 }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -422,6 +422,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "allow permissions to read the filesystem",
             &EnvironmentOptions::allow_fs_read,
             kAllowedInEnvvar);
+  AddOption("--permission-fs-path-delimiter",
+            "set the delimiter for the permissions path",
+            &EnvironmentOptions::permission_fs_path_delimiter,
+            kAllowedInEnvvar);
   AddOption("--allow-fs-write",
             "allow permissions to write in the filesystem",
             &EnvironmentOptions::allow_fs_write,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -423,7 +423,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::allow_fs_read,
             kAllowedInEnvvar);
   AddOption("--permission-fs-path-delimiter",
-            "set the delimiter for the permissions path",
+            "set the delimiter char for the file system permission model",
             &EnvironmentOptions::permission_fs_path_delimiter,
             kAllowedInEnvvar);
   AddOption("--allow-fs-write",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -123,6 +123,7 @@ class EnvironmentOptions : public Options {
   bool experimental_permission = false;
   std::string allow_fs_read;
   std::string allow_fs_write;
+  std::string permission_fs_path_delimiter = ",";
   bool allow_child_process = false;
   bool allow_worker_threads = false;
   bool experimental_repl_await = true;

--- a/src/permission/child_process_permission.cc
+++ b/src/permission/child_process_permission.cc
@@ -9,9 +9,10 @@ namespace permission {
 
 // Currently, ChildProcess manage a single state
 // Once denied, it's always denied
-void ChildProcessPermission::Apply(const std::string& allow,
-                                   PermissionScope scope,
-                                   const std::unordered_map<std::string, std::string>& options) {
+void ChildProcessPermission::Apply(
+    const std::string& allow,
+    PermissionScope scope,
+    const std::unordered_map<std::string, std::string>& options) {
   deny_all_ = true;
 }
 

--- a/src/permission/child_process_permission.cc
+++ b/src/permission/child_process_permission.cc
@@ -10,7 +10,8 @@ namespace permission {
 // Currently, ChildProcess manage a single state
 // Once denied, it's always denied
 void ChildProcessPermission::Apply(const std::string& allow,
-                                   PermissionScope scope) {
+                                   PermissionScope scope,
+                                   const std::unordered_map<std::string, std::string>& options) {
   deny_all_ = true;
 }
 

--- a/src/permission/child_process_permission.cc
+++ b/src/permission/child_process_permission.cc
@@ -1,6 +1,7 @@
 #include "child_process_permission.h"
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace node {

--- a/src/permission/child_process_permission.h
+++ b/src/permission/child_process_permission.h
@@ -3,6 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include <unordered_map>
 #include <vector>
 #include "permission/permission_base.h"
 

--- a/src/permission/child_process_permission.h
+++ b/src/permission/child_process_permission.h
@@ -12,7 +12,9 @@ namespace permission {
 
 class ChildProcessPermission final : public PermissionBase {
  public:
-  void Apply(const std::string& allow, PermissionScope scope) override;
+  void Apply(const std::string& allow,
+             PermissionScope scope,
+             const std::unordered_map<std::string, std::string>& options = {}) override;
   bool is_granted(PermissionScope perm,
                   const std::string_view& param = "") override;
 

--- a/src/permission/child_process_permission.h
+++ b/src/permission/child_process_permission.h
@@ -14,7 +14,8 @@ class ChildProcessPermission final : public PermissionBase {
  public:
   void Apply(const std::string& allow,
              PermissionScope scope,
-             const std::unordered_map<std::string, std::string>& options = {}) override;
+             const std::unordered_map<std::string, std::string>& options = {})
+      override;
   bool is_granted(PermissionScope perm,
                   const std::string_view& param = "") override;
 

--- a/src/permission/fs_permission.cc
+++ b/src/permission/fs_permission.cc
@@ -116,9 +116,10 @@ namespace permission {
 
 // allow = '*'
 // allow = '/tmp/,/home/example.js'
-void FSPermission::Apply(const std::string& allow, PermissionScope scope) {
+void FSPermission::Apply(const std::string& allow, PermissionScope scope, const std::unordered_map<std::string, std::string>& options) {
   using std::string_view_literals::operator""sv;
-  for (const std::string_view res : SplitString(allow, ","sv)) {
+  std::string delimiter = options.find("delimiter") != options.end() ? options.at("delimiter") : ",";
+  for (const std::string_view res : SplitString(allow, delimiter)) {
     if (res == "*"sv) {
       if (scope == PermissionScope::kFileSystemRead) {
         deny_all_in_ = false;

--- a/src/permission/fs_permission.cc
+++ b/src/permission/fs_permission.cc
@@ -122,9 +122,7 @@ void FSPermission::Apply(
     PermissionScope scope,
     const std::unordered_map<std::string, std::string>& options) {
   using std::string_view_literals::operator""sv;
-  std::string delimiter = options.find("delimiter") != options.end()
-                              ? options.at("delimiter")
-                              : ",";
+  std::string delimiter = options.at("delimiter");
   for (const std::string_view res : SplitString(allow, delimiter)) {
     if (res == "*"sv) {
       if (scope == PermissionScope::kFileSystemRead) {

--- a/src/permission/fs_permission.cc
+++ b/src/permission/fs_permission.cc
@@ -122,7 +122,7 @@ void FSPermission::Apply(
     PermissionScope scope,
     const std::unordered_map<std::string, std::string>& options) {
   using std::string_view_literals::operator""sv;
-  std::string delimiter = options.at("delimiter");
+  const std::string delimiter = options.at("delimiter");
   for (const std::string_view res : SplitString(allow, delimiter)) {
     if (res == "*"sv) {
       if (scope == PermissionScope::kFileSystemRead) {

--- a/src/permission/fs_permission.cc
+++ b/src/permission/fs_permission.cc
@@ -116,9 +116,14 @@ namespace permission {
 
 // allow = '*'
 // allow = '/tmp/,/home/example.js'
-void FSPermission::Apply(const std::string& allow, PermissionScope scope, const std::unordered_map<std::string, std::string>& options) {
+void FSPermission::Apply(
+    const std::string& allow,
+    PermissionScope scope,
+    const std::unordered_map<std::string, std::string>& options) {
   using std::string_view_literals::operator""sv;
-  std::string delimiter = options.find("delimiter") != options.end() ? options.at("delimiter") : ",";
+  std::string delimiter = options.find("delimiter") != options.end()
+                              ? options.at("delimiter")
+                              : ",";
   for (const std::string_view res : SplitString(allow, delimiter)) {
     if (res == "*"sv) {
       if (scope == PermissionScope::kFileSystemRead) {

--- a/src/permission/fs_permission.cc
+++ b/src/permission/fs_permission.cc
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace {

--- a/src/permission/fs_permission.h
+++ b/src/permission/fs_permission.h
@@ -15,7 +15,10 @@ namespace permission {
 
 class FSPermission final : public PermissionBase {
  public:
-  void Apply(const std::string& allow, PermissionScope scope, const std::unordered_map<std::string, std::string>& options = {}) override;
+  void Apply(const std::string& allow,
+             PermissionScope scope,
+             const std::unordered_map<std::string, std::string>& options = {})
+      override;
   bool is_granted(PermissionScope perm, const std::string_view& param) override;
 
   struct RadixTree {

--- a/src/permission/fs_permission.h
+++ b/src/permission/fs_permission.h
@@ -15,7 +15,7 @@ namespace permission {
 
 class FSPermission final : public PermissionBase {
  public:
-  void Apply(const std::string& allow, PermissionScope scope) override;
+  void Apply(const std::string& allow, PermissionScope scope, const std::unordered_map<std::string, std::string>& options = {}) override;
   bool is_granted(PermissionScope perm, const std::string_view& param) override;
 
   struct RadixTree {

--- a/src/permission/inspector_permission.cc
+++ b/src/permission/inspector_permission.cc
@@ -8,9 +8,10 @@ namespace permission {
 
 // Currently, Inspector manage a single state
 // Once denied, it's always denied
-void InspectorPermission::Apply(const std::string& allow,
-                                PermissionScope scope,
-                                const std::unordered_map<std::string, std::string>& options) {
+void InspectorPermission::Apply(
+    const std::string& allow,
+    PermissionScope scope,
+    const std::unordered_map<std::string, std::string>& options) {
   deny_all_ = true;
 }
 

--- a/src/permission/inspector_permission.cc
+++ b/src/permission/inspector_permission.cc
@@ -9,7 +9,8 @@ namespace permission {
 // Currently, Inspector manage a single state
 // Once denied, it's always denied
 void InspectorPermission::Apply(const std::string& allow,
-                                PermissionScope scope) {
+                                PermissionScope scope,
+                                const std::unordered_map<std::string, std::string>& options) {
   deny_all_ = true;
 }
 

--- a/src/permission/inspector_permission.cc
+++ b/src/permission/inspector_permission.cc
@@ -1,6 +1,7 @@
 #include "inspector_permission.h"
 
 #include <string>
+#include <unordered_map>
 
 namespace node {
 

--- a/src/permission/inspector_permission.h
+++ b/src/permission/inspector_permission.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include <string>
+#include <unordered_map>
 #include "permission/permission_base.h"
 
 namespace node {

--- a/src/permission/inspector_permission.h
+++ b/src/permission/inspector_permission.h
@@ -14,7 +14,8 @@ class InspectorPermission final : public PermissionBase {
  public:
   void Apply(const std::string& allow,
              PermissionScope scope,
-             const std::unordered_map<std::string, std::string>& options = {}) override;
+             const std::unordered_map<std::string, std::string>& options = {})
+      override;
   bool is_granted(PermissionScope perm,
                   const std::string_view& param = "") override;
 

--- a/src/permission/inspector_permission.h
+++ b/src/permission/inspector_permission.h
@@ -12,7 +12,9 @@ namespace permission {
 
 class InspectorPermission final : public PermissionBase {
  public:
-  void Apply(const std::string& allow, PermissionScope scope) override;
+  void Apply(const std::string& allow,
+             PermissionScope scope,
+             const std::unordered_map<std::string, std::string>& options = {}) override;
   bool is_granted(PermissionScope perm,
                   const std::string_view& param = "") override;
 

--- a/src/permission/permission.cc
+++ b/src/permission/permission.cc
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace node {

--- a/src/permission/permission.cc
+++ b/src/permission/permission.cc
@@ -130,10 +130,12 @@ void Permission::EnablePermissions() {
   }
 }
 
-void Permission::Apply(const std::string& allow, PermissionScope scope) {
+void Permission::Apply(const std::string& allow,
+                       PermissionScope scope,
+                       const std::unordered_map<std::string, std::string>& options) {
   auto permission = nodes_.find(scope);
   if (permission != nodes_.end()) {
-    permission->second->Apply(allow, scope);
+    permission->second->Apply(allow, scope, options);
   }
 }
 

--- a/src/permission/permission.cc
+++ b/src/permission/permission.cc
@@ -130,9 +130,10 @@ void Permission::EnablePermissions() {
   }
 }
 
-void Permission::Apply(const std::string& allow,
-                       PermissionScope scope,
-                       const std::unordered_map<std::string, std::string>& options) {
+void Permission::Apply(
+    const std::string& allow,
+    PermissionScope scope,
+    const std::unordered_map<std::string, std::string>& options) {
   auto permission = nodes_.find(scope);
   if (permission != nodes_.end()) {
     permission->second->Apply(allow, scope, options);

--- a/src/permission/permission.h
+++ b/src/permission/permission.h
@@ -49,7 +49,7 @@ class Permission {
                                 const std::string_view& res);
 
   // CLI Call
-  void Apply(const std::string& allow, PermissionScope scope);
+  void Apply(const std::string& allow, PermissionScope scope, const std::unordered_map<std::string, std::string>& options = {});
   void EnablePermissions();
 
  private:

--- a/src/permission/permission.h
+++ b/src/permission/permission.h
@@ -49,7 +49,9 @@ class Permission {
                                 const std::string_view& res);
 
   // CLI Call
-  void Apply(const std::string& allow, PermissionScope scope, const std::unordered_map<std::string, std::string>& options = {});
+  void Apply(const std::string& allow,
+             PermissionScope scope,
+             const std::unordered_map<std::string, std::string>& options = {});
   void EnablePermissions();
 
  private:

--- a/src/permission/permission_base.h
+++ b/src/permission/permission_base.h
@@ -39,7 +39,7 @@ enum class PermissionScope {
 
 class PermissionBase {
  public:
-  virtual void Apply(const std::string& allow, PermissionScope scope) = 0;
+  virtual void Apply(const std::string& allow, PermissionScope scope, const std::unordered_map<std::string, std::string>& options = {}) = 0;
   virtual bool is_granted(PermissionScope perm,
                           const std::string_view& param = "") = 0;
 };

--- a/src/permission/permission_base.h
+++ b/src/permission/permission_base.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include "v8.h"
 
 namespace node {

--- a/src/permission/permission_base.h
+++ b/src/permission/permission_base.h
@@ -39,7 +39,10 @@ enum class PermissionScope {
 
 class PermissionBase {
  public:
-  virtual void Apply(const std::string& allow, PermissionScope scope, const std::unordered_map<std::string, std::string>& options = {}) = 0;
+  virtual void Apply(
+      const std::string& allow,
+      PermissionScope scope,
+      const std::unordered_map<std::string, std::string>& options = {}) = 0;
   virtual bool is_granted(PermissionScope perm,
                           const std::string_view& param = "") = 0;
 };

--- a/src/permission/worker_permission.cc
+++ b/src/permission/worker_permission.cc
@@ -1,6 +1,7 @@
 #include "permission/worker_permission.h"
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace node {

--- a/src/permission/worker_permission.cc
+++ b/src/permission/worker_permission.cc
@@ -9,9 +9,10 @@ namespace permission {
 
 // Currently, PolicyDenyWorker manage a single state
 // Once denied, it's always denied
-void WorkerPermission::Apply(const std::string& allow,
-                             PermissionScope scope,
-                             const std::unordered_map<std::string, std::string>& options) {
+void WorkerPermission::Apply(
+    const std::string& allow,
+    PermissionScope scope,
+    const std::unordered_map<std::string, std::string>& options) {
   deny_all_ = true;
 }
 

--- a/src/permission/worker_permission.cc
+++ b/src/permission/worker_permission.cc
@@ -9,7 +9,9 @@ namespace permission {
 
 // Currently, PolicyDenyWorker manage a single state
 // Once denied, it's always denied
-void WorkerPermission::Apply(const std::string& allow, PermissionScope scope) {
+void WorkerPermission::Apply(const std::string& allow,
+                             PermissionScope scope,
+                             const std::unordered_map<std::string, std::string>& options) {
   deny_all_ = true;
 }
 

--- a/src/permission/worker_permission.h
+++ b/src/permission/worker_permission.h
@@ -3,6 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include <unordered_map>
 #include <vector>
 #include "permission/permission_base.h"
 

--- a/src/permission/worker_permission.h
+++ b/src/permission/worker_permission.h
@@ -12,7 +12,9 @@ namespace permission {
 
 class WorkerPermission final : public PermissionBase {
  public:
-  void Apply(const std::string& allow, PermissionScope scope) override;
+  void Apply(const std::string& allow,
+             PermissionScope scope,
+             const std::unordered_map<std::string, std::string>& options = {}) override;
   bool is_granted(PermissionScope perm,
                   const std::string_view& param = "") override;
 

--- a/src/permission/worker_permission.h
+++ b/src/permission/worker_permission.h
@@ -14,7 +14,8 @@ class WorkerPermission final : public PermissionBase {
  public:
   void Apply(const std::string& allow,
              PermissionScope scope,
-             const std::unordered_map<std::string, std::string>& options = {}) override;
+             const std::unordered_map<std::string, std::string>& options = {})
+      override;
   bool is_granted(PermissionScope perm,
                   const std::string_view& param = "") override;
 

--- a/test/parallel/test-cli-permission-deny-fs.js
+++ b/test/parallel/test-cli-permission-deny-fs.js
@@ -48,30 +48,6 @@ const path = require('path');
 }
 
 {
-  const tmpPath = path.resolve('/tmp/');
-  const otherPath = path.resolve('/other-path/');
-  const { status, stdout } = spawnSync(
-    process.execPath,
-    [
-      '--experimental-permission',
-      '--allow-fs-write', `${tmpPath},${otherPath}`, '-e',
-      `console.log(process.permission.has("fs"));
-      console.log(process.permission.has("fs.read"));
-      console.log(process.permission.has("fs.write"));
-      console.log(process.permission.has("fs.write", "/tmp/"));
-      console.log(process.permission.has("fs.write", "/other-path/"));`,
-    ]
-  );
-  const [fs, fsIn, fsOut, fsOutAllowed1, fsOutAllowed2] = stdout.toString().split('\n');
-  assert.strictEqual(fs, 'false');
-  assert.strictEqual(fsIn, 'false');
-  assert.strictEqual(fsOut, 'false');
-  assert.strictEqual(fsOutAllowed1, 'true');
-  assert.strictEqual(fsOutAllowed2, 'true');
-  assert.strictEqual(status, 0);
-}
-
-{
   const { status, stdout } = spawnSync(
     process.execPath,
     [

--- a/test/parallel/test-cli-permission-deny-fs.js
+++ b/test/parallel/test-cli-permission-deny-fs.js
@@ -48,6 +48,54 @@ const path = require('path');
 }
 
 {
+  const tmpPath = path.resolve('/tmp/');
+  const otherPath = path.resolve('/other-path/');
+  const { status, stdout } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-permission',
+      '--allow-fs-write', `${tmpPath},${otherPath}`, '-e',
+      `console.log(process.permission.has("fs"));
+      console.log(process.permission.has("fs.read"));
+      console.log(process.permission.has("fs.write"));
+      console.log(process.permission.has("fs.write", "/tmp/"));
+      console.log(process.permission.has("fs.write", "/other-path/"));`,
+    ]
+  );
+  const [fs, fsIn, fsOut, fsOutAllowed1, fsOutAllowed2] = stdout.toString().split('\n');
+  assert.strictEqual(fs, 'false');
+  assert.strictEqual(fsIn, 'false');
+  assert.strictEqual(fsOut, 'false');
+  assert.strictEqual(fsOutAllowed1, 'true');
+  assert.strictEqual(fsOutAllowed2, 'true');
+  assert.strictEqual(status, 0);
+}
+
+{
+  const tmpPath = path.resolve('/tmp/');
+  const pathWithComma = path.resolve('/other,path/');
+  const { status, stdout } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-permission',
+      '--allow-fs-write', `${tmpPath};${pathWithComma}`, '--permission-fs-path-delimiter=;', '-e',
+      `console.log(process.permission.has("fs"));
+      console.log(process.permission.has("fs.read"));
+      console.log(process.permission.has("fs.write"));
+      console.log(process.permission.has("fs.write", "/tmp/"));
+      console.log(process.permission.has("fs.write", "/other,path/"));`,
+    ]
+  );
+  const [fs, fsIn, fsOut, fsOutAllowed1, fsOutAllowed2] = stdout.toString().split('\n');
+  assert.strictEqual(fs, 'false');
+  assert.strictEqual(fsIn, 'false');
+  assert.strictEqual(fsOut, 'false');
+  assert.strictEqual(fsOutAllowed1, 'true');
+  assert.strictEqual(fsOutAllowed2, 'true');
+  assert.strictEqual(status, 0);
+}
+
+{
   const { status, stdout } = spawnSync(
     process.execPath,
     [

--- a/test/parallel/test-cli-permission-deny-fs.js
+++ b/test/parallel/test-cli-permission-deny-fs.js
@@ -72,30 +72,6 @@ const path = require('path');
 }
 
 {
-  const tmpPath = path.resolve('/tmp/');
-  const pathWithComma = path.resolve('/other,path/');
-  const { status, stdout } = spawnSync(
-    process.execPath,
-    [
-      '--experimental-permission',
-      '--allow-fs-write', `${tmpPath};${pathWithComma}`, '--permission-fs-path-delimiter=;', '-e',
-      `console.log(process.permission.has("fs"));
-      console.log(process.permission.has("fs.read"));
-      console.log(process.permission.has("fs.write"));
-      console.log(process.permission.has("fs.write", "/tmp/"));
-      console.log(process.permission.has("fs.write", "/other,path/"));`,
-    ]
-  );
-  const [fs, fsIn, fsOut, fsOutAllowed1, fsOutAllowed2] = stdout.toString().split('\n');
-  assert.strictEqual(fs, 'false');
-  assert.strictEqual(fsIn, 'false');
-  assert.strictEqual(fsOut, 'false');
-  assert.strictEqual(fsOutAllowed1, 'true');
-  assert.strictEqual(fsOutAllowed2, 'true');
-  assert.strictEqual(status, 0);
-}
-
-{
   const { status, stdout } = spawnSync(
     process.execPath,
     [

--- a/test/parallel/test-cli-permission-fs-path-delimiter.js
+++ b/test/parallel/test-cli-permission-fs-path-delimiter.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('../common');
+
 const { spawnSync } = require('child_process');
 const assert = require('assert');
 const path = require('path');

--- a/test/parallel/test-cli-permission-fs-path-delimiter.js
+++ b/test/parallel/test-cli-permission-fs-path-delimiter.js
@@ -6,6 +6,30 @@ const path = require('path');
 
 {
   const tmpPath = path.resolve('/tmp/');
+  const otherPath = path.resolve('/other-path/');
+  const { status, stdout } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-permission',
+      '--allow-fs-write', `${tmpPath},${otherPath}`, '-e',
+      `console.log(process.permission.has("fs"));
+      console.log(process.permission.has("fs.read"));
+      console.log(process.permission.has("fs.write"));
+      console.log(process.permission.has("fs.write", "/tmp/"));
+      console.log(process.permission.has("fs.write", "/other-path/"));`,
+    ]
+  );
+  const [fs, fsIn, fsOut, fsOutAllowed1, fsOutAllowed2] = stdout.toString().split('\n');
+  assert.strictEqual(fs, 'false');
+  assert.strictEqual(fsIn, 'false');
+  assert.strictEqual(fsOut, 'false');
+  assert.strictEqual(fsOutAllowed1, 'true');
+  assert.strictEqual(fsOutAllowed2, 'true');
+  assert.strictEqual(status, 0);
+}
+
+{
+  const tmpPath = path.resolve('/tmp/');
   const pathWithComma = path.resolve('/other,path/');
   const { status, stdout } = spawnSync(
     process.execPath,

--- a/test/parallel/test-cli-permission-fs-path-delimiter.js
+++ b/test/parallel/test-cli-permission-fs-path-delimiter.js
@@ -58,7 +58,7 @@ const path = require('path');
 }
 
 {
-  const filePath = path.resolve('/tmp/file,with,comma.txt')
+  const filePath = path.resolve('/tmp/file,with,comma.txt');
   const { status, stdout } = spawnSync(
     process.execPath,
     [

--- a/test/parallel/test-cli-permission-fs-path-delimiter.js
+++ b/test/parallel/test-cli-permission-fs-path-delimiter.js
@@ -58,12 +58,13 @@ const path = require('path');
 }
 
 {
+  const filePath = path.resolve('/tmp/file,with,comma.txt')
   const { status, stdout } = spawnSync(
     process.execPath,
     [
       '--experimental-permission',
       '--allow-fs-read=*',
-      '--allow-fs-write=/tmp/file,with,comma.txt',
+      `--allow-fs-write=${filePath}`,
       '--permission-fs-path-delimiter=;',
       '-e',
       `console.log(process.permission.has("fs"));

--- a/test/parallel/test-cli-permission-fs-path-delimiter.js
+++ b/test/parallel/test-cli-permission-fs-path-delimiter.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { spawnSync } = require('child_process');
+const assert = require('assert');
+const path = require('path');
+
+{
+  const tmpPath = path.resolve('/tmp/');
+  const pathWithComma = path.resolve('/other,path/');
+  const { status, stdout } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-permission',
+      '--allow-fs-write',
+      `${tmpPath};${pathWithComma}`,
+      '--permission-fs-path-delimiter=;',
+      '-e',
+      `console.log(process.permission.has("fs"));
+      console.log(process.permission.has("fs.read"));
+      console.log(process.permission.has("fs.write"));
+      console.log(process.permission.has("fs.write", "/tmp/"));
+      console.log(process.permission.has("fs.write", "/other,path/"));`,
+    ]
+  );
+  const [fs, fsIn, fsOut, fsOutAllowed1, fsOutAllowed2] = stdout.toString().split('\n');
+  assert.strictEqual(fs, 'false');
+  assert.strictEqual(fsIn, 'false');
+  assert.strictEqual(fsOut, 'false');
+  assert.strictEqual(fsOutAllowed1, 'true');
+  assert.strictEqual(fsOutAllowed2, 'true');
+  assert.strictEqual(status, 0);
+}
+
+{
+  const { status, stdout } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-permission',
+      '--allow-fs-read=*',
+      '--allow-fs-write=/tmp/file,with,comma.txt',
+      '--permission-fs-path-delimiter=;',
+      '-e',
+      `console.log(process.permission.has("fs"));
+      console.log(process.permission.has("fs.read"));
+      console.log(process.permission.has("fs.write"));
+      console.log(process.permission.has("fs.write", "/tmp/file,with,comma.txt"));`,
+    ]
+  );
+  const [fs, fsIn, fsOut, fsOutAllowed] = stdout.toString().split('\n');
+  assert.strictEqual(fs, 'false');
+  assert.strictEqual(fsIn, 'true');
+  assert.strictEqual(fsOut, 'false');
+  assert.strictEqual(fsOutAllowed, 'true');
+  assert.strictEqual(status, 0);
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes nodejs/security-wg#1039

This PR adds a new flag `--permission-fs-path-delimiter` which allows to change the path delimiter when providing a list of files to either `--allow-fs-read` or `allow-fs-write`.