### PR TITLE
Fix event handler function signature of http upgrade event

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -633,7 +633,7 @@ See also: [`request.setTimeout()`][].
 added: v0.1.94
 -->
 
-* `response` {http.IncomingMessage}
+* `request` {http.IncomingMessage}
 * `socket` {stream.Duplex}
 * `head` {Buffer}
 


### PR DESCRIPTION
Fix documentation to replace `response` parameter with `request` in http upgrade event handler signature.