### PR TITLE
test_runner: add new MockTracker.spyOn function

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1512,6 +1512,31 @@ test('spies on an object method', (t) => {
 });
 ```
 
+### `mock.spyOn(object, methodName)`
+
+This function is a syntax sugar for [`MockTracker.method`][] that returns only a
+spy of certain method.
+
+* `object` {Object} The object whose method is being spied.
+* `methodName` {string|symbol} The identifier of the method on `object` to spy.
+* Returns: {MockFunctionContext} The spy method. The spy method is an instance
+  of [`MockFunctionContext`][], and can be used for inspecting the spyed method.
+
+```js
+test('spies on an object method', (t) => {
+  let count = 0;
+  const calc = {
+    addOne: () => {
+      count++;
+    },
+  };
+  const spy = t.mock.spyOn(calc, 'addOne');
+  calc.addOne();
+  assert.strictEqual(count, 1);
+  assert.strictEqual(spy.callCount(), 1);
+});
+```
+
 ### `mock.reset()`
 
 <!-- YAML

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -272,6 +272,13 @@ class MockTracker {
     });
   }
 
+  spyOn(object, methodName) {
+    const spy = this.fn();
+    spy.mock.mockImplementation(object[methodName]);
+    this.method(object, methodName, spy);
+    return spy.mock;
+  }
+
   reset() {
     this.restoreAll();
     this.#timers?.reset();


### PR DESCRIPTION
This PR introduces a new spyOn function to the MockTracker class for the native Node.js test runner.

This function is a syntax sugar of the MockTracker.method, but it's present on other major testing libraries, such as Jest and Vite.

Although it's simple, I believe it's a common way of creating a spy of a method.

In this implementation, I choose to still make the call to the original function, as it would be possible to mockImplementation if needed.

Usage example:
```javascript
import assert from 'node:assert';
import { describe, test } from 'node:test';


it('spies method inside object', (t) => {
  let value = 0;
  const calculator = {
    addOne: () => {
      value++;
    }
  }
  const spy = t.mock.spyOn(calculator, 'addOne');
  calculator.addOne();
  assert.strictEqual(value, 1);
  assert.strictEqual(spy.callCount(), 1);
});

it('spies and mockImplementation', (t) => {
  let value = 0;
  const calculator = {
    addOne: () => {
      value++;
    }
  }
  const spy = t.mock.spyOn(calculator, 'addOne');
  spy.mockImplementation(t.mock.fn())
  calculator.addOne();
  assert.strictEqual(value, 0);
  assert.strictEqual(spy.callCount(), 1);
})
```