### PR TITLE
Document `require("stream/promises").pipeline` `end` option

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -65,6 +65,15 @@ or `require('node:stream').promises`.
 
 <!-- YAML
 added: v15.0.0
+changes:
+  - version:
+      - v18.0.0
+      - v17.2.0
+      - v16.14.0
+    pr-url: https://github.com/nodejs/node/pull/40886
+    description: Add the `end` option, which can be set to `false` to prevent
+                 automatically closing the destination stream when the source
+                 ends.
 -->
 
 * `streams` {Stream\[]|Iterable\[]|AsyncIterable\[]|Function\[]}
@@ -76,9 +85,11 @@ added: v15.0.0
 * `destination` {Stream|Function}
   * `source` {AsyncIterable}
   * Returns: {Promise|AsyncIterable}
-* `options` {Object}
+* `options` {Object} Pipeline options
   * `signal` {AbortSignal}
-  * `end` {boolean}
+  * `end` {boolean} End the destination stream when the source stream ends.
+    Transform streams are always ended, even if this value is `false`.
+    **Default:** `true`.
 * Returns: {Promise} Fulfills when the pipeline is complete.
 
 ```cjs

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1476,10 +1476,14 @@ const tsp = require('timers/promises');
     });
 
     const duplex = new PassThrough();
+    const transform = new PassThrough();
 
     read.push(null);
 
-    await pipelinePromise(read, duplex, { end: false });
+    await pipelinePromise(read, transform, duplex, { end: false });
+
+    assert.strictEqual(transform.destroyed, true);
+    assert.strictEqual(transform.writableEnded, true);
 
     assert.strictEqual(duplex.destroyed, false);
     assert.strictEqual(duplex.writableEnded, false);


### PR DESCRIPTION
Add documentation for the `require("stream/promises").pipeline(...streams, {end: false})` option, that was added in https://github.com/nodejs/node/pull/40886.

The lacking documentation has been mentioned before (see https://github.com/nodejs/node/issues/34805#issuecomment-1345655205, and https://github.com/nodejs/node/issues/45821), but although https://github.com/nodejs/node/pull/45832 did document that the `end` option existed, it didn't document what the `end` option did.

I've also added a test to sanity check that setting `end: false` doesn't stop ending `transform` streams when calling `pipeline()`, since this behavior seems a bit unintuitive to me.
