### PR TITLE
src: do not pass user input to format string

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3043,11 +3043,10 @@ void BindingData::LegacyMainResolve(const FunctionCallbackInfo<Value>& args) {
   }
 
   env->isolate()->ThrowException(
-      ERR_MODULE_NOT_FOUND(
-        env->isolate(),
-        "Cannot find package '%s' imported from %s",
-        module_path,
-        module_base));
+      ERR_MODULE_NOT_FOUND(env->isolate(),
+                           "Cannot find package '%s' imported from %s",
+                           module_path,
+                           module_base));
 }
 
 void BindingData::MemoryInfo(MemoryTracker* tracker) const {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3042,10 +3042,12 @@ void BindingData::LegacyMainResolve(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  std::string err_module_message =
-      "Cannot find package '%s' imported from %s";
   env->isolate()->ThrowException(
-      ERR_MODULE_NOT_FOUND(env->isolate(), err_module_message.c_str(), module_path, module_base));
+      ERR_MODULE_NOT_FOUND(
+        env->isolate(),
+        "Cannot find package '%s' imported from %s",
+        module_path,
+        module_base));
 }
 
 void BindingData::MemoryInfo(MemoryTracker* tracker) const {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3043,9 +3043,9 @@ void BindingData::LegacyMainResolve(const FunctionCallbackInfo<Value>& args) {
   }
 
   std::string err_module_message =
-      "Cannot find package '" + module_path + "' imported from " + module_base;
+      "Cannot find package '%s' imported from %s";
   env->isolate()->ThrowException(
-      ERR_MODULE_NOT_FOUND(env->isolate(), err_module_message.c_str()));
+      ERR_MODULE_NOT_FOUND(env->isolate(), err_module_message.c_str(), module_path, module_base));
 }
 
 void BindingData::MemoryInfo(MemoryTracker* tracker) const {

--- a/test/es-module/test-cjs-legacyMainResolve.js
+++ b/test/es-module/test-cjs-legacyMainResolve.js
@@ -133,6 +133,14 @@ describe('legacyMainResolve', () => {
     );
   });
 
+  it('should not crash when cannot resolve to a file that contains special chars', () => {
+    const packageJsonUrl = pathToFileURL('/c/file%20with%20percents/package.json');
+    assert.throws(
+      () => legacyMainResolve(packageJsonUrl, { main: null }, packageJsonUrl),
+      { code: 'ERR_MODULE_NOT_FOUND' },
+    );
+  });
+
   it('should throw when cannot resolve to a file (base not defined)', () => {
     const packageJsonUrl = pathToFileURL(
       path.resolve(


### PR DESCRIPTION
When passing a URL that contains a `%`, the following assertion is likely to fail: https://github.com/nodejs/node/blob/1773b2ada4b2b5ce9ad9f526808360fd5faf0282/src/debug_utils-inl.h#L70
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
