### PR TITLE
worker: support case-insensitive process.env usage on Windows in worker threads

### DIFF
--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -62,7 +62,26 @@ class MapKVStore final : public KVStore {
 
  private:
   mutable Mutex mutex_;
+#ifdef _WIN32
+  struct Hash {
+    inline size_t operator()(const std::string& str) const {
+      return std::hash<std::string>()(ToLower(str));
+    }
+  };
+
+  struct Equal {
+    inline bool operator()(const std::string& a, const std::string& b) const {
+      return a.size() == b.size() &&
+             std::equal(a.begin(), a.end(), b.begin(), [](char a, char b) {
+               return ToLower(a) == ToLower(b);
+             });
+    }
+  };
+
+  std::unordered_map<std::string, std::string, Hash, Equal> map_;
+#else
   std::unordered_map<std::string, std::string> map_;
+#endif
 };
 
 namespace per_process {

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -71,7 +71,8 @@ class MapKVStore final : public KVStore {
 
   struct Equal {
     inline bool operator()(const std::string& a, const std::string& b) const {
-      return a.size() == b.size() && StringEqualNoCase(a.c_str(), b.c_str());
+      return a.size() == b.size() &&
+             StringEqualNoCaseN(a.data(), b.data(), b.size());
     }
   };
 

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -71,10 +71,7 @@ class MapKVStore final : public KVStore {
 
   struct Equal {
     inline bool operator()(const std::string& a, const std::string& b) const {
-      return a.size() == b.size() &&
-             std::equal(a.begin(), a.end(), b.begin(), [](char a, char b) {
-               return ToLower(a) == ToLower(b);
-             });
+      return a.size() == b.size() && StringEqualNoCase(a.c_str(), b.c_str());
     }
   };
 

--- a/test/parallel/test-worker-process-env-windows.js
+++ b/test/parallel/test-worker-process-env-windows.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const { Worker, isMainThread, parentPort } = require('node:worker_threads');
+const { strictEqual } = require('node:assert');
+
+// Test for https://github.com/nodejs/node/issues/48955.
+
+if (!common.isWindows) {
+  common.skip('this test is Windows-specific.');
+}
+
+if (isMainThread) {
+  process.env.barkey = 'foovalue';
+  strictEqual(process.env.barkey, process.env.BARKEY);
+
+  const worker = new Worker(__filename);
+  worker.once('message', (data) => {
+    strictEqual(data.barkey, data.BARKEY);
+  });
+} else {
+  parentPort.postMessage({
+    barkey: process.env.barkey,
+    BARKEY: process.env.BARKEY,
+  });
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/48955

By default, a Worker thread uses a copy of parent thread's `process.env`, which is currently case-sensitive. It can be a problem on Windows using case-insensitive env keys, as reported issue.

This fixes the issue by using a case-insensitive `unordered_map` for the copied `process.env` on Windows.

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
