### PR TITLE
doc: drop github actions check in sec release process

### DIFF
--- a/doc/contributing/security-release-process.md
+++ b/doc/contributing/security-release-process.md
@@ -70,8 +70,6 @@ The current security stewards are documented in the main Node.js
 
 ## Announcement (one week in advance of the planned release)
 
-* [ ] Verify that GitHub Actions are working as normal: <https://www.githubstatus.com/>.
-
 * [ ] Check that all vulnerabilities are ready for release integration:
   * PRs against all affected release lines or cherry-pick clean
   * Approved


### PR DESCRIPTION
We perform that check one week in advance, but a lot of things could happen between the announcement and the release itself, so there's no point in checking it beforehand.