### PR TITLE
deps: update llhttp to 9.1.2

### DIFF
--- a/deps/llhttp/.gitignore
+++ b/deps/llhttp/.gitignore
@@ -1,0 +1,1 @@
+libllhttp.pc

--- a/deps/llhttp/CMakeLists.txt
+++ b/deps/llhttp/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5.1)
 cmake_policy(SET CMP0069 NEW)
 
-project(llhttp VERSION 8.1.1)
+project(llhttp VERSION 9.1.2)
 include(GNUInstallDirs)
 
 set(CMAKE_C_STANDARD 99)
@@ -47,8 +47,9 @@ configure_file(
 function(config_library target)
   target_sources(${target} PRIVATE ${LLHTTP_SOURCES} ${LLHTTP_HEADERS})
 
-  target_include_directories(${target} PRIVATE
-      ${CMAKE_CURRENT_SOURCE_DIR}/include
+  target_include_directories(${target} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
   )
 
   set_target_properties(${target} PROPERTIES
@@ -72,9 +73,10 @@ function(config_library target)
 
   # This is required to work with FetchContent
   install(EXPORT llhttp
-        FILE llhttp-config.cmake
-        NAMESPACE llhttp::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/llhttp)
+    FILE llhttp-config.cmake
+    NAMESPACE llhttp::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/llhttp
+  )
 endfunction(config_library target)
 
 if(BUILD_SHARED_LIBS)

--- a/deps/llhttp/README.md
+++ b/deps/llhttp/README.md
@@ -61,33 +61,41 @@ checks could be performed to get even stricter verification of the llhttp.
 ## Usage
 
 ```C
+#include "stdio.h"
 #include "llhttp.h"
+#include "string.h"
 
-llhttp_t parser;
-llhttp_settings_t settings;
+int handle_on_message_complete(llhttp_t* parser) {
+	fprintf(stdout, "Message completed!\n");
+	return 0;
+}
 
-/* Initialize user callbacks and settings */
-llhttp_settings_init(&settings);
+int main() {
+	llhttp_t parser;
+	llhttp_settings_t settings;
 
-/* Set user callback */
-settings.on_message_complete = handle_on_message_complete;
+	/*Initialize user callbacks and settings */
+	llhttp_settings_init(&settings);
 
-/* Initialize the parser in HTTP_BOTH mode, meaning that it will select between
- * HTTP_REQUEST and HTTP_RESPONSE parsing automatically while reading the first
- * input.
- */
-llhttp_init(&parser, HTTP_BOTH, &settings);
+	/*Set user callback */
+	settings.on_message_complete = handle_on_message_complete;
 
-/* Parse request! */
-const char* request = "GET / HTTP/1.1\r\n\r\n";
-int request_len = strlen(request);
+	/*Initialize the parser in HTTP_BOTH mode, meaning that it will select between
+	*HTTP_REQUEST and HTTP_RESPONSE parsing automatically while reading the first
+	*input.
+	*/
+	llhttp_init(&parser, HTTP_BOTH, &settings);
 
-enum llhttp_errno err = llhttp_execute(&parser, request, request_len);
-if (err == HPE_OK) {
-  /* Successfully parsed! */
-} else {
-  fprintf(stderr, "Parse error: %s %s\n", llhttp_errno_name(err),
-          parser.reason);
+	/*Parse request! */
+	const char* request = "GET / HTTP/1.1\r\n\r\n";
+	int request_len = strlen(request);
+
+	enum llhttp_errno err = llhttp_execute(&parser, request, request_len);
+	if (err == HPE_OK) {
+		fprintf(stdout, "Successfully parsed!\n");
+	} else {
+		fprintf(stderr, "Parse error: %s %s\n", llhttp_errno_name(err), parser.reason);
+	}
 }
 ```
 For more information on API usage, please refer to [src/native/api.h](https://github.com/nodejs/llhttp/blob/main/src/native/api.h).
@@ -279,7 +287,7 @@ protocol support to highly non-compliant clients/server.
 No `HPE_INVALID_HEADER_TOKEN` will be raised for incorrect header values when
 lenient parsing is "on".
 
-**USE AT YOUR OWN RISK!**
+**Enabling this flag can pose a security issue since you will be exposed to request smuggling attacks. USE WITH CAUTION!**
 
 ### `void llhttp_set_lenient_chunked_length(llhttp_t* parser, int enabled)`
 
@@ -292,23 +300,22 @@ conjunction with `Content-Length`.
 This error is important to prevent HTTP request smuggling, but may be less desirable
 for small number of cases involving legacy servers.
 
-**USE AT YOUR OWN RISK!**
+**Enabling this flag can pose a security issue since you will be exposed to request smuggling attacks. USE WITH CAUTION!**
 
 ### `void llhttp_set_lenient_keep_alive(llhttp_t* parser, int enabled)`
 
 Enables/disables lenient handling of `Connection: close` and HTTP/1.0
 requests responses.
 
-Normally `llhttp` would error on (in strict mode) or discard (in loose mode)
-the HTTP request/response after the request/response with `Connection: close`
-and `Content-Length`. 
+Normally `llhttp` would error the HTTP request/response 
+after the request/response with `Connection: close` and `Content-Length`. 
 
 This is important to prevent cache poisoning attacks,
 but might interact badly with outdated and insecure clients. 
 
 With this flag the extra request/response will be parsed normally.
 
-**USE AT YOUR OWN RISK!**
+**Enabling this flag can pose a security issue since you will be exposed to poisoning attacks. USE WITH CAUTION!**
 
 ### `void llhttp_set_lenient_transfer_encoding(llhttp_t* parser, int enabled)`
 
@@ -323,7 +330,67 @@ avoid request smuggling.
 
 With this flag the extra value will be parsed normally.
 
-**USE AT YOUR OWN RISK!**
+**Enabling this flag can pose a security issue since you will be exposed to request smuggling attacks. USE WITH CAUTION!**
+
+### `void llhttp_set_lenient_version(llhttp_t* parser, int enabled)`
+
+Enables/disables lenient handling of HTTP version.
+
+Normally `llhttp` would error when the HTTP version in the request or status line
+is not `0.9`, `1.0`, `1.1` or `2.0`.
+With this flag the extra value will be parsed normally.
+
+**Enabling this flag can pose a security issue since you will allow unsupported HTTP versions. USE WITH CAUTION!**
+
+### `void llhttp_set_lenient_data_after_close(llhttp_t* parser, int enabled)`
+
+Enables/disables lenient handling of additional data received after a message ends
+and keep-alive is disabled.
+
+Normally `llhttp` would error when additional unexpected data is received if the message
+contains the `Connection` header with `close` value.
+With this flag the extra data will discarded without throwing an error.
+
+**Enabling this flag can pose a security issue since you will be exposed to poisoning attacks. USE WITH CAUTION!**
+
+### `void llhttp_set_lenient_optional_lf_after_cr(llhttp_t* parser, int enabled)`
+
+Enables/disables lenient handling of incomplete CRLF sequences.
+
+Normally `llhttp` would error when a CR is not followed by LF when terminating the
+request line, the status line, the headers or a chunk header.
+With this flag only a CR is required to terminate such sections.
+
+**Enabling this flag can pose a security issue since you will be exposed to request smuggling attacks. USE WITH CAUTION!**
+
+### `void llhttp_set_lenient_optional_cr_before_lf(llhttp_t* parser, int enabled)`
+
+Enables/disables lenient handling of line separators.
+
+Normally `llhttp` would error when a LF is not preceded by CR when terminating the
+request line, the status line, the headers, a chunk header or a chunk data.
+With this flag only a LF is required to terminate such sections.
+
+**Enabling this flag can pose a security issue since you will be exposed to request smuggling attacks. USE WITH CAUTION!**
+
+### `void llhttp_set_lenient_optional_crlf_after_chunk(llhttp_t* parser, int enabled)`
+
+Enables/disables lenient handling of chunks not separated via CRLF.
+
+Normally `llhttp` would error when after a chunk data a CRLF is missing before
+starting a new chunk.
+With this flag the new chunk can start immediately after the previous one.
+
+**Enabling this flag can pose a security issue since you will be exposed to request smuggling attacks. USE WITH CAUTION!**
+
+### `void llhttp_set_lenient_spaces_after_chunk_size(llhttp_t* parser, int enabled)`
+
+Enables/disables lenient handling of spaces after chunk size.
+
+Normally `llhttp` would error when after a chunk size is followed by one or more spaces are present instead of a CRLF or `;`.
+With this flag this check is disabled.
+
+**Enabling this flag can pose a security issue since you will be exposed to request smuggling attacks. USE WITH CAUTION!**
 
 ## Build Instructions
 
@@ -345,16 +412,33 @@ make
 
 ### Using with CMake
 
-If you want to use this library in a CMake project you can use the snippet below.
+If you want to use this library in a CMake project as a shared library, you can use the snippet below.
 
 ```
 FetchContent_Declare(llhttp
-  URL "https://github.com/nodejs/llhttp/archive/refs/tags/v6.0.5.tar.gz")  # Using version 6.0.5
+  URL "https://github.com/nodejs/llhttp/archive/refs/tags/release/v8.1.0.tar.gz")
 
 FetchContent_MakeAvailable(llhttp)
 
-target_link_libraries(${EXAMPLE_PROJECT_NAME} ${PROJECT_LIBRARIES} llhttp ${PROJECT_NAME})
+# Link with the llhttp_shared target
+target_link_libraries(${EXAMPLE_PROJECT_NAME} ${PROJECT_LIBRARIES} llhttp_shared ${PROJECT_NAME})
 ```
+
+If you want to use this library in a CMake project as a static library, you can set some cache variables first.
+
+```
+FetchContent_Declare(llhttp
+  URL "https://github.com/nodejs/llhttp/archive/refs/tags/release/v8.1.0.tar.gz")
+
+set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
+set(BUILD_STATIC_LIBS ON CACHE INTERNAL "")
+FetchContent_MakeAvailable(llhttp)
+
+# Link with the llhttp_static target
+target_link_libraries(${EXAMPLE_PROJECT_NAME} ${PROJECT_LIBRARIES} llhttp_static ${PROJECT_NAME})
+```
+
+_Note that using the git repo directly (e.g., via a git repo url and tag) will not work with FetchContent_Declare because [CMakeLists.txt](./CMakeLists.txt) requires string replacements (e.g., `_RELEASE_`) before it will build._
 
 ## Building on Windows
 

--- a/deps/llhttp/include/llhttp.h
+++ b/deps/llhttp/include/llhttp.h
@@ -1,13 +1,10 @@
+
 #ifndef INCLUDE_LLHTTP_H_
 #define INCLUDE_LLHTTP_H_
 
-#define LLHTTP_VERSION_MAJOR 8
+#define LLHTTP_VERSION_MAJOR 9
 #define LLHTTP_VERSION_MINOR 1
-#define LLHTTP_VERSION_PATCH 1
-
-#ifndef LLHTTP_STRICT_MODE
-# define LLHTTP_STRICT_MODE 0
-#endif
+#define LLHTTP_VERSION_PATCH 2
 
 #ifndef INCLUDE_LLHTTP_ITSELF_H_
 #define INCLUDE_LLHTTP_ITSELF_H_
@@ -33,7 +30,7 @@ struct llhttp__internal_s {
   uint8_t http_major;
   uint8_t http_minor;
   uint8_t header_state;
-  uint8_t lenient_flags;
+  uint16_t lenient_flags;
   uint8_t upgrade;
   uint8_t finish;
   uint16_t flags;
@@ -49,6 +46,7 @@ int llhttp__internal_execute(llhttp__internal_t* s, const char* p, const char* e
 }  /* extern "C" */
 #endif
 #endif  /* INCLUDE_LLHTTP_ITSELF_H_ */
+
 
 #ifndef LLLLHTTP_C_HEADERS_
 #define LLLLHTTP_C_HEADERS_
@@ -114,7 +112,12 @@ enum llhttp_lenient_flags {
   LENIENT_CHUNKED_LENGTH = 0x2,
   LENIENT_KEEP_ALIVE = 0x4,
   LENIENT_TRANSFER_ENCODING = 0x8,
-  LENIENT_VERSION = 0x10
+  LENIENT_VERSION = 0x10,
+  LENIENT_DATA_AFTER_CLOSE = 0x20,
+  LENIENT_OPTIONAL_LF_AFTER_CR = 0x40,
+  LENIENT_OPTIONAL_CRLF_AFTER_CHUNK = 0x80,
+  LENIENT_OPTIONAL_CR_BEFORE_LF = 0x100,
+  LENIENT_SPACES_AFTER_CHUNK_SIZE = 0x200
 };
 typedef enum llhttp_lenient_flags llhttp_lenient_flags_t;
 
@@ -534,6 +537,7 @@ typedef enum llhttp_status llhttp_status_t;
 #endif
 #endif  /* LLLLHTTP_C_HEADERS_ */
 
+
 #ifndef INCLUDE_LLHTTP_API_H_
 #define INCLUDE_LLHTTP_API_H_
 #ifdef __cplusplus
@@ -759,7 +763,8 @@ const char* llhttp_status_name(llhttp_status_t status);
  * `HPE_INVALID_HEADER_TOKEN` will be raised for incorrect header values when
  * lenient parsing is "on".
  *
- * **(USE AT YOUR OWN RISK)**
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * request smuggling attacks. USE WITH CAUTION!**
  */
 LLHTTP_EXPORT
 void llhttp_set_lenient_headers(llhttp_t* parser, int enabled);
@@ -773,7 +778,8 @@ void llhttp_set_lenient_headers(llhttp_t* parser, int enabled);
  * request smuggling, but may be less desirable for small number of cases
  * involving legacy servers.
  *
- * **(USE AT YOUR OWN RISK)**
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * request smuggling attacks. USE WITH CAUTION!**
  */
 LLHTTP_EXPORT
 void llhttp_set_lenient_chunked_length(llhttp_t* parser, int enabled);
@@ -788,7 +794,8 @@ void llhttp_set_lenient_chunked_length(llhttp_t* parser, int enabled);
  * but might interact badly with outdated and insecure clients. With this flag
  * the extra request/response will be parsed normally.
  *
- * **(USE AT YOUR OWN RISK)**
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * poisoning attacks. USE WITH CAUTION!**
  */
 LLHTTP_EXPORT
 void llhttp_set_lenient_keep_alive(llhttp_t* parser, int enabled);
@@ -802,14 +809,90 @@ void llhttp_set_lenient_keep_alive(llhttp_t* parser, int enabled);
  * avoid request smuggling.
  * With this flag the extra value will be parsed normally.
  *
- * **(USE AT YOUR OWN RISK)**
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * request smuggling attacks. USE WITH CAUTION!**
  */
 LLHTTP_EXPORT
 void llhttp_set_lenient_transfer_encoding(llhttp_t* parser, int enabled);
+
+/* Enables/disables lenient handling of HTTP version.
+ *
+ * Normally `llhttp` would error when the HTTP version in the request or status line
+ * is not `0.9`, `1.0`, `1.1` or `2.0`.
+ * With this flag the invalid value will be parsed normally.
+ *
+ * **Enabling this flag can pose a security issue since you will allow unsupported
+ * HTTP versions. USE WITH CAUTION!**
+ */
+LLHTTP_EXPORT
+void llhttp_set_lenient_version(llhttp_t* parser, int enabled);
+
+/* Enables/disables lenient handling of additional data received after a message ends
+ * and keep-alive is disabled.
+ *
+ * Normally `llhttp` would error when additional unexpected data is received if the message
+ * contains the `Connection` header with `close` value.
+ * With this flag the extra data will discarded without throwing an error.
+ *
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * poisoning attacks. USE WITH CAUTION!**
+ */
+LLHTTP_EXPORT
+void llhttp_set_lenient_data_after_close(llhttp_t* parser, int enabled);
+
+/* Enables/disables lenient handling of incomplete CRLF sequences.
+ *
+ * Normally `llhttp` would error when a CR is not followed by LF when terminating the
+ * request line, the status line, the headers or a chunk header.
+ * With this flag only a CR is required to terminate such sections.
+ *
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * request smuggling attacks. USE WITH CAUTION!**
+ */
+LLHTTP_EXPORT
+void llhttp_set_lenient_optional_lf_after_cr(llhttp_t* parser, int enabled);
+
+/*
+ * Enables/disables lenient handling of line separators.
+ *
+ * Normally `llhttp` would error when a LF is not preceded by CR when terminating the
+ * request line, the status line, the headers, a chunk header or a chunk data.
+ * With this flag only a LF is required to terminate such sections.
+ *
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * request smuggling attacks. USE WITH CAUTION!**
+ */
+LLHTTP_EXPORT
+void llhttp_set_lenient_optional_cr_before_lf(llhttp_t* parser, int enabled);
+
+/* Enables/disables lenient handling of chunks not separated via CRLF.
+ *
+ * Normally `llhttp` would error when after a chunk data a CRLF is missing before
+ * starting a new chunk.
+ * With this flag the new chunk can start immediately after the previous one.
+ *
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * request smuggling attacks. USE WITH CAUTION!**
+ */
+LLHTTP_EXPORT
+void llhttp_set_lenient_optional_crlf_after_chunk(llhttp_t* parser, int enabled);
+
+/* Enables/disables lenient handling of spaces after chunk size.
+ *
+ * Normally `llhttp` would error when after a chunk size is followed by one or more
+ * spaces are present instead of a CRLF or `;`.
+ * With this flag this check is disabled.
+ *
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * request smuggling attacks. USE WITH CAUTION!**
+ */
+LLHTTP_EXPORT
+void llhttp_set_lenient_spaces_after_chunk_size(llhttp_t* parser, int enabled);
 
 #ifdef __cplusplus
 }  /* extern "C" */
 #endif
 #endif  /* INCLUDE_LLHTTP_API_H_ */
+
 
 #endif  /* INCLUDE_LLHTTP_H_ */

--- a/deps/llhttp/src/api.c
+++ b/deps/llhttp/src/api.c
@@ -283,6 +283,54 @@ void llhttp_set_lenient_transfer_encoding(llhttp_t* parser, int enabled) {
   }
 }
 
+void llhttp_set_lenient_version(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_VERSION;
+  } else {
+    parser->lenient_flags &= ~LENIENT_VERSION;
+  }
+}
+
+void llhttp_set_lenient_data_after_close(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_DATA_AFTER_CLOSE;
+  } else {
+    parser->lenient_flags &= ~LENIENT_DATA_AFTER_CLOSE;
+  }
+}
+
+void llhttp_set_lenient_optional_lf_after_cr(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_OPTIONAL_LF_AFTER_CR;
+  } else {
+    parser->lenient_flags &= ~LENIENT_OPTIONAL_LF_AFTER_CR;
+  }
+}
+
+void llhttp_set_lenient_optional_crlf_after_chunk(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_OPTIONAL_CRLF_AFTER_CHUNK;
+  } else {
+    parser->lenient_flags &= ~LENIENT_OPTIONAL_CRLF_AFTER_CHUNK;
+  }
+}
+
+void llhttp_set_lenient_optional_cr_before_lf(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_OPTIONAL_CR_BEFORE_LF;
+  } else {
+    parser->lenient_flags &= ~LENIENT_OPTIONAL_CR_BEFORE_LF;
+  }
+}
+
+void llhttp_set_lenient_spaces_after_chunk_size(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_SPACES_AFTER_CHUNK_SIZE;
+  } else {
+    parser->lenient_flags &= ~LENIENT_SPACES_AFTER_CHUNK_SIZE;
+  }
+}
+
 /* Callbacks */
 
 

--- a/deps/llhttp/src/llhttp.c
+++ b/deps/llhttp/src/llhttp.c
@@ -1,5 +1,3 @@
-#if LLHTTP_STRICT_MODE
-
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
@@ -24,197 +22,194 @@ typedef int (*llhttp__internal__span_cb)(
              llhttp__internal_t*, const char*, const char*);
 
 static const unsigned char llparse_blob0[] = {
-  0xd, 0xa
-};
-static const unsigned char llparse_blob1[] = {
   'o', 'n'
 };
-static const unsigned char llparse_blob2[] = {
+static const unsigned char llparse_blob1[] = {
   'e', 'c', 't', 'i', 'o', 'n'
 };
-static const unsigned char llparse_blob3[] = {
+static const unsigned char llparse_blob2[] = {
   'l', 'o', 's', 'e'
 };
-static const unsigned char llparse_blob4[] = {
+static const unsigned char llparse_blob3[] = {
   'e', 'e', 'p', '-', 'a', 'l', 'i', 'v', 'e'
 };
-static const unsigned char llparse_blob5[] = {
+static const unsigned char llparse_blob4[] = {
   'p', 'g', 'r', 'a', 'd', 'e'
 };
-static const unsigned char llparse_blob6[] = {
+static const unsigned char llparse_blob5[] = {
   'c', 'h', 'u', 'n', 'k', 'e', 'd'
 };
 #ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob7[] = {
+static const unsigned char ALIGN(16) llparse_blob6[] = {
   0x9, 0x9, ' ', '~', 0x80, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0,
   0x0, 0x0, 0x0, 0x0, 0x0
 };
 #endif  /* __SSE4_2__ */
 #ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob8[] = {
+static const unsigned char ALIGN(16) llparse_blob7[] = {
   '!', '!', '#', '\'', '*', '+', '-', '.', '0', '9', 'A',
   'Z', '^', 'z', '|', '|'
 };
 #endif  /* __SSE4_2__ */
 #ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob9[] = {
+static const unsigned char ALIGN(16) llparse_blob8[] = {
   '~', '~', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
   0x0, 0x0, 0x0, 0x0, 0x0
 };
 #endif  /* __SSE4_2__ */
-static const unsigned char llparse_blob10[] = {
+static const unsigned char llparse_blob9[] = {
   'e', 'n', 't', '-', 'l', 'e', 'n', 'g', 't', 'h'
 };
-static const unsigned char llparse_blob11[] = {
+static const unsigned char llparse_blob10[] = {
   'r', 'o', 'x', 'y', '-', 'c', 'o', 'n', 'n', 'e', 'c',
   't', 'i', 'o', 'n'
 };
-static const unsigned char llparse_blob12[] = {
+static const unsigned char llparse_blob11[] = {
   'r', 'a', 'n', 's', 'f', 'e', 'r', '-', 'e', 'n', 'c',
   'o', 'd', 'i', 'n', 'g'
 };
-static const unsigned char llparse_blob13[] = {
+static const unsigned char llparse_blob12[] = {
   'p', 'g', 'r', 'a', 'd', 'e'
 };
-static const unsigned char llparse_blob14[] = {
+static const unsigned char llparse_blob13[] = {
   'T', 'T', 'P', '/'
 };
-static const unsigned char llparse_blob15[] = {
+static const unsigned char llparse_blob14[] = {
   0xd, 0xa, 0xd, 0xa, 'S', 'M', 0xd, 0xa, 0xd, 0xa
 };
-static const unsigned char llparse_blob16[] = {
+static const unsigned char llparse_blob15[] = {
   'C', 'E', '/'
 };
-static const unsigned char llparse_blob17[] = {
+static const unsigned char llparse_blob16[] = {
   'T', 'S', 'P', '/'
 };
-static const unsigned char llparse_blob18[] = {
+static const unsigned char llparse_blob17[] = {
   'N', 'O', 'U', 'N', 'C', 'E'
 };
-static const unsigned char llparse_blob19[] = {
+static const unsigned char llparse_blob18[] = {
   'I', 'N', 'D'
 };
-static const unsigned char llparse_blob20[] = {
+static const unsigned char llparse_blob19[] = {
   'E', 'C', 'K', 'O', 'U', 'T'
 };
-static const unsigned char llparse_blob21[] = {
+static const unsigned char llparse_blob20[] = {
   'N', 'E', 'C', 'T'
 };
-static const unsigned char llparse_blob22[] = {
+static const unsigned char llparse_blob21[] = {
   'E', 'T', 'E'
 };
-static const unsigned char llparse_blob23[] = {
+static const unsigned char llparse_blob22[] = {
   'C', 'R', 'I', 'B', 'E'
 };
-static const unsigned char llparse_blob24[] = {
+static const unsigned char llparse_blob23[] = {
   'L', 'U', 'S', 'H'
 };
-static const unsigned char llparse_blob25[] = {
+static const unsigned char llparse_blob24[] = {
   'E', 'T'
 };
-static const unsigned char llparse_blob26[] = {
+static const unsigned char llparse_blob25[] = {
   'P', 'A', 'R', 'A', 'M', 'E', 'T', 'E', 'R'
 };
-static const unsigned char llparse_blob27[] = {
+static const unsigned char llparse_blob26[] = {
   'E', 'A', 'D'
 };
-static const unsigned char llparse_blob28[] = {
+static const unsigned char llparse_blob27[] = {
   'N', 'K'
+};
+static const unsigned char llparse_blob28[] = {
+  'C', 'K'
 };
 static const unsigned char llparse_blob29[] = {
-  'C', 'K'
-};
-static const unsigned char llparse_blob30[] = {
   'S', 'E', 'A', 'R', 'C', 'H'
 };
-static const unsigned char llparse_blob31[] = {
+static const unsigned char llparse_blob30[] = {
   'R', 'G', 'E'
 };
-static const unsigned char llparse_blob32[] = {
+static const unsigned char llparse_blob31[] = {
   'C', 'T', 'I', 'V', 'I', 'T', 'Y'
 };
-static const unsigned char llparse_blob33[] = {
+static const unsigned char llparse_blob32[] = {
   'L', 'E', 'N', 'D', 'A', 'R'
 };
-static const unsigned char llparse_blob34[] = {
+static const unsigned char llparse_blob33[] = {
   'V', 'E'
 };
-static const unsigned char llparse_blob35[] = {
+static const unsigned char llparse_blob34[] = {
   'O', 'T', 'I', 'F', 'Y'
 };
-static const unsigned char llparse_blob36[] = {
+static const unsigned char llparse_blob35[] = {
   'P', 'T', 'I', 'O', 'N', 'S'
 };
-static const unsigned char llparse_blob37[] = {
+static const unsigned char llparse_blob36[] = {
   'C', 'H'
 };
-static const unsigned char llparse_blob38[] = {
+static const unsigned char llparse_blob37[] = {
   'S', 'E'
 };
-static const unsigned char llparse_blob39[] = {
+static const unsigned char llparse_blob38[] = {
   'A', 'Y'
 };
-static const unsigned char llparse_blob40[] = {
+static const unsigned char llparse_blob39[] = {
   'S', 'T'
 };
-static const unsigned char llparse_blob41[] = {
+static const unsigned char llparse_blob40[] = {
   'I', 'N', 'D'
 };
-static const unsigned char llparse_blob42[] = {
+static const unsigned char llparse_blob41[] = {
   'A', 'T', 'C', 'H'
 };
-static const unsigned char llparse_blob43[] = {
+static const unsigned char llparse_blob42[] = {
   'G', 'E'
 };
-static const unsigned char llparse_blob44[] = {
+static const unsigned char llparse_blob43[] = {
   'I', 'N', 'D'
 };
-static const unsigned char llparse_blob45[] = {
+static const unsigned char llparse_blob44[] = {
   'O', 'R', 'D'
 };
-static const unsigned char llparse_blob46[] = {
+static const unsigned char llparse_blob45[] = {
   'I', 'R', 'E', 'C', 'T'
 };
-static const unsigned char llparse_blob47[] = {
+static const unsigned char llparse_blob46[] = {
   'O', 'R', 'T'
 };
-static const unsigned char llparse_blob48[] = {
+static const unsigned char llparse_blob47[] = {
   'R', 'C', 'H'
 };
-static const unsigned char llparse_blob49[] = {
+static const unsigned char llparse_blob48[] = {
   'P', 'A', 'R', 'A', 'M', 'E', 'T', 'E', 'R'
 };
-static const unsigned char llparse_blob50[] = {
+static const unsigned char llparse_blob49[] = {
   'U', 'R', 'C', 'E'
 };
-static const unsigned char llparse_blob51[] = {
+static const unsigned char llparse_blob50[] = {
   'B', 'S', 'C', 'R', 'I', 'B', 'E'
 };
-static const unsigned char llparse_blob52[] = {
+static const unsigned char llparse_blob51[] = {
   'A', 'R', 'D', 'O', 'W', 'N'
 };
-static const unsigned char llparse_blob53[] = {
+static const unsigned char llparse_blob52[] = {
   'A', 'C', 'E'
 };
-static const unsigned char llparse_blob54[] = {
+static const unsigned char llparse_blob53[] = {
   'I', 'N', 'D'
 };
-static const unsigned char llparse_blob55[] = {
+static const unsigned char llparse_blob54[] = {
   'N', 'K'
 };
-static const unsigned char llparse_blob56[] = {
+static const unsigned char llparse_blob55[] = {
   'C', 'K'
 };
-static const unsigned char llparse_blob57[] = {
+static const unsigned char llparse_blob56[] = {
   'U', 'B', 'S', 'C', 'R', 'I', 'B', 'E'
 };
-static const unsigned char llparse_blob58[] = {
+static const unsigned char llparse_blob57[] = {
   'H', 'T', 'T', 'P', '/'
 };
-static const unsigned char llparse_blob59[] = {
+static const unsigned char llparse_blob58[] = {
   'A', 'D'
 };
-static const unsigned char llparse_blob60[] = {
+static const unsigned char llparse_blob59[] = {
   'T', 'P', '/'
 };
 
@@ -230,38 +225,6 @@ struct llparse_match_s {
   const unsigned char* current;
 };
 typedef struct llparse_match_s llparse_match_t;
-
-static llparse_match_t llparse__match_sequence_id(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp,
-    const unsigned char* seq, uint32_t seq_len) {
-  uint32_t index;
-  llparse_match_t res;
-
-  index = s->_index;
-  for (; p != endp; p++) {
-    unsigned char current;
-
-    current = *p;
-    if (current == seq[index]) {
-      if (++index == seq_len) {
-        res.status = kMatchComplete;
-        goto reset;
-      }
-    } else {
-      res.status = kMatchMismatch;
-      goto reset;
-    }
-  }
-  s->_index = index;
-  res.status = kMatchPause;
-  res.current = p;
-  return res;
-reset:
-  s->_index = 0;
-  res.current = p;
-  return res;
-}
 
 static llparse_match_t llparse__match_sequence_to_lower(
     llhttp__internal_t* s, const unsigned char* p,
@@ -327,6 +290,38 @@ reset:
   return res;
 }
 
+static llparse_match_t llparse__match_sequence_id(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp,
+    const unsigned char* seq, uint32_t seq_len) {
+  uint32_t index;
+  llparse_match_t res;
+
+  index = s->_index;
+  for (; p != endp; p++) {
+    unsigned char current;
+
+    current = *p;
+    if (current == seq[index]) {
+      if (++index == seq_len) {
+        res.status = kMatchComplete;
+        goto reset;
+      }
+    } else {
+      res.status = kMatchMismatch;
+      goto reset;
+    }
+  }
+  s->_index = index;
+  res.status = kMatchPause;
+  res.current = p;
+  return res;
+reset:
+  s->_index = 0;
+  res.current = p;
+  return res;
+}
+
 enum llparse_state_e {
   s_error,
   s_n_llhttp__internal__n_closed,
@@ -334,23 +329,28 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_pause_1,
   s_n_llhttp__internal__n_invoke_is_equal_upgrade,
   s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2,
+  s_n_llhttp__internal__n_chunk_data_almost_done_1,
   s_n_llhttp__internal__n_chunk_data_almost_done,
   s_n_llhttp__internal__n_consume_content_length,
   s_n_llhttp__internal__n_span_start_llhttp__on_body,
   s_n_llhttp__internal__n_invoke_is_equal_content_length,
   s_n_llhttp__internal__n_chunk_size_almost_done,
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_9,
   s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete,
   s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1,
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_2,
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_10,
   s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete,
-  s_n_llhttp__internal__n_chunk_extension_quoted_value_done,
   s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1,
-  s_n_llhttp__internal__n_error_21,
-  s_n_llhttp__internal__n_chunk_extension_quoted_value,
+  s_n_llhttp__internal__n_chunk_extension_quoted_value_done,
   s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2,
-  s_n_llhttp__internal__n_error_23,
+  s_n_llhttp__internal__n_error_30,
+  s_n_llhttp__internal__n_chunk_extension_quoted_value,
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_3,
+  s_n_llhttp__internal__n_error_32,
   s_n_llhttp__internal__n_chunk_extension_value,
   s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value,
-  s_n_llhttp__internal__n_error_24,
+  s_n_llhttp__internal__n_error_33,
   s_n_llhttp__internal__n_chunk_extension_name,
   s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name,
   s_n_llhttp__internal__n_chunk_extensions,
@@ -363,17 +363,18 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_eof,
   s_n_llhttp__internal__n_span_start_llhttp__on_body_2,
   s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete,
+  s_n_llhttp__internal__n_error_5,
   s_n_llhttp__internal__n_headers_almost_done,
   s_n_llhttp__internal__n_header_field_colon_discard_ws,
-  s_n_llhttp__internal__n_error_33,
   s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete,
   s_n_llhttp__internal__n_span_start_llhttp__on_header_value,
   s_n_llhttp__internal__n_header_value_discard_lws,
   s_n_llhttp__internal__n_header_value_discard_ws_almost_done,
   s_n_llhttp__internal__n_header_value_lws,
   s_n_llhttp__internal__n_header_value_almost_done,
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_17,
   s_n_llhttp__internal__n_header_value_lenient,
-  s_n_llhttp__internal__n_error_41,
+  s_n_llhttp__internal__n_error_51,
   s_n_llhttp__internal__n_header_value_otherwise,
   s_n_llhttp__internal__n_header_value_connection_token,
   s_n_llhttp__internal__n_header_value_connection_ws,
@@ -381,12 +382,12 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_header_value_connection_2,
   s_n_llhttp__internal__n_header_value_connection_3,
   s_n_llhttp__internal__n_header_value_connection,
-  s_n_llhttp__internal__n_error_43,
-  s_n_llhttp__internal__n_error_44,
+  s_n_llhttp__internal__n_error_53,
+  s_n_llhttp__internal__n_error_54,
   s_n_llhttp__internal__n_header_value_content_length_ws,
   s_n_llhttp__internal__n_header_value_content_length,
-  s_n_llhttp__internal__n_error_46,
-  s_n_llhttp__internal__n_error_45,
+  s_n_llhttp__internal__n_error_56,
+  s_n_llhttp__internal__n_error_55,
   s_n_llhttp__internal__n_header_value_te_token_ows,
   s_n_llhttp__internal__n_header_value,
   s_n_llhttp__internal__n_header_value_te_token,
@@ -394,6 +395,7 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_header_value_te_chunked,
   s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1,
   s_n_llhttp__internal__n_header_value_discard_ws,
+  s_n_llhttp__internal__n_invoke_load_header_state,
   s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete,
   s_n_llhttp__internal__n_header_field_general_otherwise,
   s_n_llhttp__internal__n_header_field_general,
@@ -414,16 +416,16 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_url_skip_lf_to_http09_1,
   s_n_llhttp__internal__n_url_skip_lf_to_http09,
   s_n_llhttp__internal__n_req_pri_upgrade,
-  s_n_llhttp__internal__n_req_http_complete_1,
+  s_n_llhttp__internal__n_req_http_complete_crlf,
   s_n_llhttp__internal__n_req_http_complete,
   s_n_llhttp__internal__n_invoke_load_method_1,
   s_n_llhttp__internal__n_invoke_llhttp__on_version_complete,
-  s_n_llhttp__internal__n_error_51,
-  s_n_llhttp__internal__n_error_56,
+  s_n_llhttp__internal__n_error_63,
+  s_n_llhttp__internal__n_error_70,
   s_n_llhttp__internal__n_req_http_minor,
-  s_n_llhttp__internal__n_error_57,
+  s_n_llhttp__internal__n_error_71,
   s_n_llhttp__internal__n_req_http_dot,
-  s_n_llhttp__internal__n_error_58,
+  s_n_llhttp__internal__n_error_72,
   s_n_llhttp__internal__n_req_http_major,
   s_n_llhttp__internal__n_span_start_llhttp__on_version,
   s_n_llhttp__internal__n_req_http_start_1,
@@ -525,21 +527,22 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_after_start_req_63,
   s_n_llhttp__internal__n_after_start_req,
   s_n_llhttp__internal__n_span_start_llhttp__on_method_1,
-  s_n_llhttp__internal__n_invoke_llhttp__on_status_complete,
   s_n_llhttp__internal__n_res_line_almost_done,
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_29,
   s_n_llhttp__internal__n_res_status,
   s_n_llhttp__internal__n_span_start_llhttp__on_status,
-  s_n_llhttp__internal__n_res_status_start,
   s_n_llhttp__internal__n_res_status_code_otherwise,
-  s_n_llhttp__internal__n_res_status_code,
+  s_n_llhttp__internal__n_res_status_code_digit_3,
+  s_n_llhttp__internal__n_res_status_code_digit_2,
+  s_n_llhttp__internal__n_res_status_code_digit_1,
   s_n_llhttp__internal__n_res_after_version,
   s_n_llhttp__internal__n_invoke_llhttp__on_version_complete_1,
-  s_n_llhttp__internal__n_error_73,
-  s_n_llhttp__internal__n_error_80,
+  s_n_llhttp__internal__n_error_86,
+  s_n_llhttp__internal__n_error_100,
   s_n_llhttp__internal__n_res_http_minor,
-  s_n_llhttp__internal__n_error_81,
+  s_n_llhttp__internal__n_error_101,
   s_n_llhttp__internal__n_res_http_dot,
-  s_n_llhttp__internal__n_error_82,
+  s_n_llhttp__internal__n_error_102,
   s_n_llhttp__internal__n_res_http_major,
   s_n_llhttp__internal__n_span_start_llhttp__on_version_1,
   s_n_llhttp__internal__n_start_res,
@@ -670,6 +673,13 @@ int llhttp__internal__c_test_lenient_flags(
   return (state->lenient_flags & 1) == 1;
 }
 
+int llhttp__internal__c_test_lenient_flags_1(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 256) == 256;
+}
+
 int llhttp__internal__c_test_flags(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -720,25 +730,18 @@ int llhttp__internal__c_update_finish_1(
   return 0;
 }
 
-int llhttp__internal__c_test_lenient_flags_1(
+int llhttp__internal__c_test_lenient_flags_2(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
   return (state->lenient_flags & 4) == 4;
 }
 
-int llhttp__internal__c_test_flags_1(
+int llhttp__internal__c_test_lenient_flags_3(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
-  return (state->flags & 544) == 544;
-}
-
-int llhttp__internal__c_test_lenient_flags_2(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 2) == 2;
+  return (state->lenient_flags & 32) == 32;
 }
 
 int llhttp__before_headers_complete(
@@ -779,6 +782,13 @@ int llhttp__internal__c_mul_add_content_length(
   return 0;
 }
 
+int llhttp__internal__c_test_lenient_flags_4(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 512) == 512;
+}
+
 int llhttp__on_chunk_header(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
@@ -790,12 +800,26 @@ int llhttp__internal__c_is_equal_content_length(
   return state->content_length == 0;
 }
 
+int llhttp__internal__c_test_lenient_flags_7(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 128) == 128;
+}
+
 int llhttp__internal__c_or_flags(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
   state->flags |= 128;
   return 0;
+}
+
+int llhttp__internal__c_test_lenient_flags_8(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 64) == 64;
 }
 
 int llhttp__on_chunk_extension_name_complete(
@@ -850,7 +874,21 @@ int llhttp__internal__c_load_header_state(
   return state->header_state;
 }
 
-int llhttp__internal__c_or_flags_3(
+int llhttp__internal__c_test_flags_4(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->flags & 512) == 512;
+}
+
+int llhttp__internal__c_test_lenient_flags_21(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 2) == 2;
+}
+
+int llhttp__internal__c_or_flags_5(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -870,7 +908,7 @@ int llhttp__on_header_value_complete(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
 
-int llhttp__internal__c_or_flags_4(
+int llhttp__internal__c_or_flags_6(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -878,7 +916,7 @@ int llhttp__internal__c_or_flags_4(
   return 0;
 }
 
-int llhttp__internal__c_or_flags_5(
+int llhttp__internal__c_or_flags_7(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -886,7 +924,7 @@ int llhttp__internal__c_or_flags_5(
   return 0;
 }
 
-int llhttp__internal__c_or_flags_6(
+int llhttp__internal__c_or_flags_8(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -959,7 +997,7 @@ int llhttp__internal__c_mul_add_content_length_1(
   return 0;
 }
 
-int llhttp__internal__c_or_flags_15(
+int llhttp__internal__c_or_flags_17(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -974,14 +1012,14 @@ int llhttp__internal__c_test_flags_3(
   return (state->flags & 8) == 8;
 }
 
-int llhttp__internal__c_test_lenient_flags_8(
+int llhttp__internal__c_test_lenient_flags_19(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
   return (state->lenient_flags & 8) == 8;
 }
 
-int llhttp__internal__c_or_flags_16(
+int llhttp__internal__c_or_flags_18(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -1005,7 +1043,7 @@ int llhttp__internal__c_update_header_state_8(
   return 0;
 }
 
-int llhttp__internal__c_or_flags_18(
+int llhttp__internal__c_or_flags_20(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -1038,7 +1076,7 @@ int llhttp__internal__c_store_http_minor(
   return 0;
 }
 
-int llhttp__internal__c_test_lenient_flags_10(
+int llhttp__internal__c_test_lenient_flags_23(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -1094,11 +1132,6 @@ int llhttp__internal__c_mul_add_status_code(
     }
   }
   state->status_code += match;
-  
-  /* Enforce maximum */
-  if (state->status_code > 999) {
-    return 1;
-  }
   return 0;
 }
 
@@ -1150,7 +1183,7 @@ static llparse_state_t llhttp__internal__run(
         }
         default: {
           p++;
-          goto s_n_llhttp__internal__n_error_7;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_3;
         }
       }
       /* UNREACHABLE */;
@@ -1194,32 +1227,46 @@ static llparse_state_t llhttp__internal__run(
         case 0:
           goto s_n_llhttp__internal__n_invoke_is_equal_upgrade;
         case 21:
-          goto s_n_llhttp__internal__n_pause_11;
+          goto s_n_llhttp__internal__n_pause_13;
         default:
-          goto s_n_llhttp__internal__n_error_28;
+          goto s_n_llhttp__internal__n_error_37;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_data_almost_done_1:
+    s_n_llhttp__internal__n_chunk_data_almost_done_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_data_almost_done_1;
+      }
+      switch (*p) {
+        case 10: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_7;
+        }
       }
       /* UNREACHABLE */;
       abort();
     }
     case s_n_llhttp__internal__n_chunk_data_almost_done:
     s_n_llhttp__internal__n_chunk_data_almost_done: {
-      llparse_match_t match_seq;
-      
       if (p == endp) {
         return s_n_llhttp__internal__n_chunk_data_almost_done;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob0, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
+      switch (*p) {
+        case 10: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_6;
         }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_chunk_data_almost_done;
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_data_almost_done_1;
         }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_11;
+        default: {
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_7;
         }
       }
       /* UNREACHABLE */;
@@ -1276,8 +1323,19 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_header;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_12;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_8;
         }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_test_lenient_flags_9:
+    s_n_llhttp__internal__n_invoke_test_lenient_flags_9: {
+      switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+        case 1:
+          goto s_n_llhttp__internal__n_chunk_size_almost_done;
+        default:
+          goto s_n_llhttp__internal__n_error_20;
       }
       /* UNREACHABLE */;
       abort();
@@ -1286,11 +1344,11 @@ static llparse_state_t llhttp__internal__run(
     s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete: {
       switch (llhttp__on_chunk_extension_name_complete(state, p, endp)) {
         case 0:
-          goto s_n_llhttp__internal__n_chunk_size_almost_done;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_9;
         case 21:
           goto s_n_llhttp__internal__n_pause_5;
         default:
-          goto s_n_llhttp__internal__n_error_15;
+          goto s_n_llhttp__internal__n_error_19;
       }
       /* UNREACHABLE */;
       abort();
@@ -1299,11 +1357,35 @@ static llparse_state_t llhttp__internal__run(
     s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1: {
       switch (llhttp__on_chunk_extension_name_complete(state, p, endp)) {
         case 0:
-          goto s_n_llhttp__internal__n_chunk_extensions;
+          goto s_n_llhttp__internal__n_chunk_size_almost_done;
         case 21:
           goto s_n_llhttp__internal__n_pause_6;
         default:
-          goto s_n_llhttp__internal__n_error_16;
+          goto s_n_llhttp__internal__n_error_21;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_2:
+    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_2: {
+      switch (llhttp__on_chunk_extension_name_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_chunk_extensions;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_7;
+        default:
+          goto s_n_llhttp__internal__n_error_22;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_test_lenient_flags_10:
+    s_n_llhttp__internal__n_invoke_test_lenient_flags_10: {
+      switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+        case 1:
+          goto s_n_llhttp__internal__n_chunk_size_almost_done;
+        default:
+          goto s_n_llhttp__internal__n_error_25;
       }
       /* UNREACHABLE */;
       abort();
@@ -1312,11 +1394,24 @@ static llparse_state_t llhttp__internal__run(
     s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete: {
       switch (llhttp__on_chunk_extension_value_complete(state, p, endp)) {
         case 0:
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_10;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_8;
+        default:
+          goto s_n_llhttp__internal__n_error_24;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1:
+    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1: {
+      switch (llhttp__on_chunk_extension_value_complete(state, p, endp)) {
+        case 0:
           goto s_n_llhttp__internal__n_chunk_size_almost_done;
         case 21:
-          goto s_n_llhttp__internal__n_pause_7;
+          goto s_n_llhttp__internal__n_pause_9;
         default:
-          goto s_n_llhttp__internal__n_error_18;
+          goto s_n_llhttp__internal__n_error_26;
       }
       /* UNREACHABLE */;
       abort();
@@ -1327,6 +1422,9 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_chunk_extension_quoted_value_done;
       }
       switch (*p) {
+        case 10: {
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_11;
+        }
         case 13: {
           p++;
           goto s_n_llhttp__internal__n_chunk_size_almost_done;
@@ -1336,27 +1434,27 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_chunk_extensions;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_20;
+          goto s_n_llhttp__internal__n_error_29;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1:
-    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1: {
+    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2:
+    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2: {
       switch (llhttp__on_chunk_extension_value_complete(state, p, endp)) {
         case 0:
           goto s_n_llhttp__internal__n_chunk_extension_quoted_value_done;
         case 21:
-          goto s_n_llhttp__internal__n_pause_8;
+          goto s_n_llhttp__internal__n_pause_10;
         default:
-          goto s_n_llhttp__internal__n_error_19;
+          goto s_n_llhttp__internal__n_error_27;
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_21:
-    s_n_llhttp__internal__n_error_21: {
+    case s_n_llhttp__internal__n_error_30:
+    s_n_llhttp__internal__n_error_30: {
       state->error = 0x2;
       state->reason = "Invalid character in chunk extensions quoted value";
       state->error_pos = (const char*) p;
@@ -1395,30 +1493,30 @@ static llparse_state_t llhttp__internal__run(
         }
         case 2: {
           p++;
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_1;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_2;
         }
         default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_2;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_3;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2:
-    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2: {
+    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_3:
+    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_3: {
       switch (llhttp__on_chunk_extension_value_complete(state, p, endp)) {
         case 0:
           goto s_n_llhttp__internal__n_chunk_size_otherwise;
         case 21:
-          goto s_n_llhttp__internal__n_pause_9;
+          goto s_n_llhttp__internal__n_pause_11;
         default:
-          goto s_n_llhttp__internal__n_error_22;
+          goto s_n_llhttp__internal__n_error_31;
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_23:
-    s_n_llhttp__internal__n_error_23: {
+    case s_n_llhttp__internal__n_error_32:
+    s_n_llhttp__internal__n_error_32: {
       state->error = 0x2;
       state->reason = "Invalid character in chunk extensions value";
       state->error_pos = (const char*) p;
@@ -1430,14 +1528,14 @@ static llparse_state_t llhttp__internal__run(
     case s_n_llhttp__internal__n_chunk_extension_value:
     s_n_llhttp__internal__n_chunk_extension_value: {
       static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 2, 3, 2, 2, 2, 2, 2, 0, 0, 2, 2, 0, 2, 2, 0,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 4, 0, 0, 0, 0,
-        0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 0, 2, 0,
+        0, 3, 4, 3, 3, 3, 3, 3, 0, 0, 3, 3, 0, 3, 3, 0,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 5, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 3, 0, 3, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1455,18 +1553,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value;
         }
         case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_extension_value;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_1;
         }
         case 3: {
           p++;
-          goto s_n_llhttp__internal__n_chunk_extension_quoted_value;
+          goto s_n_llhttp__internal__n_chunk_extension_value;
         }
         case 4: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_3;
+          p++;
+          goto s_n_llhttp__internal__n_chunk_extension_quoted_value;
+        }
+        case 5: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_4;
         }
         default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_4;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_5;
         }
       }
       /* UNREACHABLE */;
@@ -1479,12 +1580,12 @@ static llparse_state_t llhttp__internal__run(
       }
       state->_span_pos0 = (void*) p;
       state->_span_cb0 = llhttp__on_chunk_extension_value;
-      goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_2;
+      goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_3;
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_24:
-    s_n_llhttp__internal__n_error_24: {
+    case s_n_llhttp__internal__n_error_33:
+    s_n_llhttp__internal__n_error_33: {
       state->error = 0x2;
       state->reason = "Invalid character in chunk extensions name";
       state->error_pos = (const char*) p;
@@ -1496,14 +1597,14 @@ static llparse_state_t llhttp__internal__run(
     case s_n_llhttp__internal__n_chunk_extension_name:
     s_n_llhttp__internal__n_chunk_extension_name: {
       static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 2, 0, 2, 2, 2, 2, 2, 0, 0, 2, 2, 0, 2, 2, 0,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 3, 0, 4, 0, 0,
-        0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 0, 2, 0,
+        0, 3, 0, 3, 3, 3, 3, 3, 0, 0, 3, 3, 0, 3, 3, 0,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 4, 0, 5, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 3, 0, 3, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1521,17 +1622,20 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name;
         }
         case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_extension_name;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_1;
         }
         case 3: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_1;
+          p++;
+          goto s_n_llhttp__internal__n_chunk_extension_name;
         }
         case 4: {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_2;
         }
-        default: {
+        case 5: {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_3;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_4;
         }
       }
       /* UNREACHABLE */;
@@ -1556,11 +1660,11 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 13: {
           p++;
-          goto s_n_llhttp__internal__n_error_13;
+          goto s_n_llhttp__internal__n_error_17;
         }
         case ' ': {
           p++;
-          goto s_n_llhttp__internal__n_error_14;
+          goto s_n_llhttp__internal__n_error_18;
         }
         default: {
           goto s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name;
@@ -1575,16 +1679,28 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_chunk_size_otherwise;
       }
       switch (*p) {
+        case 9: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_4;
+        }
+        case 10: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_5;
+        }
         case 13: {
           p++;
           goto s_n_llhttp__internal__n_chunk_size_almost_done;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_4;
         }
         case ';': {
           p++;
           goto s_n_llhttp__internal__n_chunk_extensions;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_25;
+          goto s_n_llhttp__internal__n_error_34;
         }
       }
       /* UNREACHABLE */;
@@ -1830,7 +1946,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_27;
+          goto s_n_llhttp__internal__n_error_36;
         }
       }
       /* UNREACHABLE */;
@@ -1907,10 +2023,20 @@ static llparse_state_t llhttp__internal__run(
         case 4:
           goto s_n_llhttp__internal__n_invoke_update_finish_3;
         case 5:
-          goto s_n_llhttp__internal__n_error_29;
+          goto s_n_llhttp__internal__n_error_38;
         default:
           goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete;
       }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_5:
+    s_n_llhttp__internal__n_error_5: {
+      state->error = 0xa;
+      state->reason = "Invalid header field char";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
       /* UNREACHABLE */;
       abort();
     }
@@ -1922,10 +2048,10 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_test_flags;
+          goto s_n_llhttp__internal__n_invoke_test_flags_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_32;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_12;
         }
       }
       /* UNREACHABLE */;
@@ -1948,25 +2074,15 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_33:
-    s_n_llhttp__internal__n_error_33: {
-      state->error = 0xa;
-      state->reason = "Invalid header field char";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
     case s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete:
     s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete: {
       switch (llhttp__on_header_value_complete(state, p, endp)) {
         case 0:
           goto s_n_llhttp__internal__n_header_field_start;
         case 21:
-          goto s_n_llhttp__internal__n_pause_14;
+          goto s_n_llhttp__internal__n_pause_18;
         default:
-          goto s_n_llhttp__internal__n_error_37;
+          goto s_n_llhttp__internal__n_error_46;
       }
       /* UNREACHABLE */;
       abort();
@@ -1990,14 +2106,14 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_5;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_15;
         }
         case ' ': {
           p++;
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_5;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_15;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_load_header_state;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_1;
         }
       }
       /* UNREACHABLE */;
@@ -2014,7 +2130,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_value_discard_lws;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_6;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_16;
         }
       }
       /* UNREACHABLE */;
@@ -2027,13 +2143,13 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case 9: {
-          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
         }
         case ' ': {
-          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_5;
         }
       }
       /* UNREACHABLE */;
@@ -2050,8 +2166,19 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_value_lws;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_40;
+          goto s_n_llhttp__internal__n_error_50;
         }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_test_lenient_flags_17:
+    s_n_llhttp__internal__n_invoke_test_lenient_flags_17: {
+      switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+        case 1:
+          goto s_n_llhttp__internal__n_header_value_almost_done;
+        default:
+          goto s_n_llhttp__internal__n_error_49;
       }
       /* UNREACHABLE */;
       abort();
@@ -2063,10 +2190,10 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case 10: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
         }
         case 13: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
         }
         default: {
           p++;
@@ -2076,8 +2203,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_41:
-    s_n_llhttp__internal__n_error_41: {
+    case s_n_llhttp__internal__n_error_51:
+    s_n_llhttp__internal__n_error_51: {
       state->error = 0xa;
       state->reason = "Invalid header value char";
       state->error_pos = (const char*) p;
@@ -2092,11 +2219,14 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_header_value_otherwise;
       }
       switch (*p) {
-        case 13: {
+        case 10: {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
         }
+        case 13: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
+        }
         default: {
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_7;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_18;
         }
       }
       /* UNREACHABLE */;
@@ -2159,7 +2289,7 @@ static llparse_state_t llhttp__internal__run(
         }
         case ',': {
           p++;
-          goto s_n_llhttp__internal__n_invoke_load_header_state_5;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_6;
         }
         default: {
           goto s_n_llhttp__internal__n_invoke_update_header_state_5;
@@ -2175,7 +2305,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_1;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob3, 4);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob2, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2199,7 +2329,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_2;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob4, 9);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob3, 9);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2223,7 +2353,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_3;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob5, 6);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob4, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2273,8 +2403,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_43:
-    s_n_llhttp__internal__n_error_43: {
+    case s_n_llhttp__internal__n_error_53:
+    s_n_llhttp__internal__n_error_53: {
       state->error = 0xb;
       state->reason = "Content-Length overflow";
       state->error_pos = (const char*) p;
@@ -2283,8 +2413,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_44:
-    s_n_llhttp__internal__n_error_44: {
+    case s_n_llhttp__internal__n_error_54:
+    s_n_llhttp__internal__n_error_54: {
       state->error = 0xb;
       state->reason = "Invalid character in Content-Length";
       state->error_pos = (const char*) p;
@@ -2300,17 +2430,17 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case 10: {
-          goto s_n_llhttp__internal__n_invoke_or_flags_15;
+          goto s_n_llhttp__internal__n_invoke_or_flags_17;
         }
         case 13: {
-          goto s_n_llhttp__internal__n_invoke_or_flags_15;
+          goto s_n_llhttp__internal__n_invoke_or_flags_17;
         }
         case ' ': {
           p++;
           goto s_n_llhttp__internal__n_header_value_content_length_ws;
         }
         default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7;
         }
       }
       /* UNREACHABLE */;
@@ -2379,8 +2509,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_46:
-    s_n_llhttp__internal__n_error_46: {
+    case s_n_llhttp__internal__n_error_56:
+    s_n_llhttp__internal__n_error_56: {
       state->error = 0xf;
       state->reason = "Invalid `Transfer-Encoding` header value";
       state->error_pos = (const char*) p;
@@ -2389,8 +2519,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_45:
-    s_n_llhttp__internal__n_error_45: {
+    case s_n_llhttp__internal__n_error_55:
+    s_n_llhttp__internal__n_error_55: {
       state->error = 0xf;
       state->reason = "Invalid `Transfer-Encoding` header value";
       state->error_pos = (const char*) p;
@@ -2452,7 +2582,7 @@ static llparse_state_t llhttp__internal__run(
       
         /* Load input */
         input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob7);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob6);
       
         /* Find first character that does not match `ranges` */
         match_len = _mm_cmpestri(ranges, 6,
@@ -2551,7 +2681,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_te_chunked;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob6, 7);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob5, 7);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2575,7 +2705,7 @@ static llparse_state_t llhttp__internal__run(
       }
       state->_span_pos0 = (void*) p;
       state->_span_cb0 = llhttp__on_header_value;
-      goto s_n_llhttp__internal__n_invoke_load_header_state_2;
+      goto s_n_llhttp__internal__n_invoke_load_header_state_3;
       /* UNREACHABLE */;
       abort();
     }
@@ -2591,7 +2721,7 @@ static llparse_state_t llhttp__internal__run(
         }
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_4;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_14;
         }
         case 13: {
           p++;
@@ -2608,15 +2738,28 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
+    case s_n_llhttp__internal__n_invoke_load_header_state:
+    s_n_llhttp__internal__n_invoke_load_header_state: {
+      switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+        case 2:
+          goto s_n_llhttp__internal__n_invoke_test_flags_4;
+        case 3:
+          goto s_n_llhttp__internal__n_invoke_test_flags_5;
+        default:
+          goto s_n_llhttp__internal__n_header_value_discard_ws;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
     case s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete:
     s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete: {
       switch (llhttp__on_header_field_complete(state, p, endp)) {
         case 0:
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
+          goto s_n_llhttp__internal__n_invoke_load_header_state;
         case 21:
-          goto s_n_llhttp__internal__n_pause_15;
+          goto s_n_llhttp__internal__n_pause_19;
         default:
-          goto s_n_llhttp__internal__n_error_34;
+          goto s_n_llhttp__internal__n_error_43;
       }
       /* UNREACHABLE */;
       abort();
@@ -2631,7 +2774,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_2;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_47;
+          goto s_n_llhttp__internal__n_error_59;
         }
       }
       /* UNREACHABLE */;
@@ -2669,7 +2812,7 @@ static llparse_state_t llhttp__internal__run(
       
         /* Load input */
         input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob8);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob7);
       
         /* Find first character that does not match `ranges` */
         match_len = _mm_cmpestri(ranges, 16,
@@ -2681,7 +2824,7 @@ static llparse_state_t llhttp__internal__run(
           p += match_len;
           goto s_n_llhttp__internal__n_header_field_general;
         }
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob9);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob8);
       
         /* Find first character that does not match `ranges` */
         match_len = _mm_cmpestri(ranges, 2,
@@ -2715,7 +2858,7 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case ' ': {
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_3;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_13;
         }
         case ':': {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
@@ -2734,7 +2877,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_3;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob2, 6);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob1, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2759,7 +2902,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_4;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob10, 10);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob9, 10);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2805,7 +2948,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_1;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob1, 2);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob0, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2829,7 +2972,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_5;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob11, 15);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob10, 15);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2854,7 +2997,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_6;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob12, 16);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob11, 16);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2879,7 +3022,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_7;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob13, 6);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob12, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2944,7 +3087,8 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case 10: {
-          goto s_n_llhttp__internal__n_headers_almost_done;
+          p++;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_1;
         }
         case 13: {
           p++;
@@ -3028,7 +3172,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_to_http_09;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_48;
+          goto s_n_llhttp__internal__n_error_60;
         }
       }
       /* UNREACHABLE */;
@@ -3053,7 +3197,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_skip_lf_to_http09_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_48;
+          goto s_n_llhttp__internal__n_error_60;
         }
       }
       /* UNREACHABLE */;
@@ -3066,27 +3210,27 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_pri_upgrade;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob15, 10);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob14, 10);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_error_54;
+          goto s_n_llhttp__internal__n_error_68;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_req_pri_upgrade;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_55;
+          goto s_n_llhttp__internal__n_error_69;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_req_http_complete_1:
-    s_n_llhttp__internal__n_req_http_complete_1: {
+    case s_n_llhttp__internal__n_req_http_complete_crlf:
+    s_n_llhttp__internal__n_req_http_complete_crlf: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_complete_1;
+        return s_n_llhttp__internal__n_req_http_complete_crlf;
       }
       switch (*p) {
         case 10: {
@@ -3094,7 +3238,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_headers_start;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_53;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_25;
         }
       }
       /* UNREACHABLE */;
@@ -3108,14 +3252,14 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_headers_start;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_24;
         }
         case 13: {
           p++;
-          goto s_n_llhttp__internal__n_req_http_complete_1;
+          goto s_n_llhttp__internal__n_req_http_complete_crlf;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_53;
+          goto s_n_llhttp__internal__n_error_67;
         }
       }
       /* UNREACHABLE */;
@@ -3138,15 +3282,15 @@ static llparse_state_t llhttp__internal__run(
         case 0:
           goto s_n_llhttp__internal__n_invoke_load_method_1;
         case 21:
-          goto s_n_llhttp__internal__n_pause_17;
+          goto s_n_llhttp__internal__n_pause_21;
         default:
-          goto s_n_llhttp__internal__n_error_52;
+          goto s_n_llhttp__internal__n_error_64;
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_51:
-    s_n_llhttp__internal__n_error_51: {
+    case s_n_llhttp__internal__n_error_63:
+    s_n_llhttp__internal__n_error_63: {
       state->error = 0x9;
       state->reason = "Invalid HTTP version";
       state->error_pos = (const char*) p;
@@ -3155,8 +3299,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_56:
-    s_n_llhttp__internal__n_error_56: {
+    case s_n_llhttp__internal__n_error_70:
+    s_n_llhttp__internal__n_error_70: {
       state->error = 0x9;
       state->reason = "Invalid minor version";
       state->error_pos = (const char*) p;
@@ -3228,8 +3372,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_57:
-    s_n_llhttp__internal__n_error_57: {
+    case s_n_llhttp__internal__n_error_71:
+    s_n_llhttp__internal__n_error_71: {
       state->error = 0x9;
       state->reason = "Expected dot";
       state->error_pos = (const char*) p;
@@ -3255,8 +3399,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_58:
-    s_n_llhttp__internal__n_error_58: {
+    case s_n_llhttp__internal__n_error_72:
+    s_n_llhttp__internal__n_error_72: {
       state->error = 0x9;
       state->reason = "Invalid major version";
       state->error_pos = (const char*) p;
@@ -3346,7 +3490,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_http_start_1;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob14, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob13, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3357,7 +3501,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_http_start_1;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_61;
+          goto s_n_llhttp__internal__n_error_75;
         }
       }
       /* UNREACHABLE */;
@@ -3370,7 +3514,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_http_start_2;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob16, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob15, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3381,7 +3525,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_http_start_2;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_61;
+          goto s_n_llhttp__internal__n_error_75;
         }
       }
       /* UNREACHABLE */;
@@ -3394,7 +3538,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_http_start_3;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob17, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob16, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3405,7 +3549,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_http_start_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_61;
+          goto s_n_llhttp__internal__n_error_75;
         }
       }
       /* UNREACHABLE */;
@@ -3434,7 +3578,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_http_start_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_61;
+          goto s_n_llhttp__internal__n_error_75;
         }
       }
       /* UNREACHABLE */;
@@ -3525,7 +3669,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_fragment;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_62;
+          goto s_n_llhttp__internal__n_error_76;
         }
       }
       /* UNREACHABLE */;
@@ -3586,7 +3730,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_stub_query_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_63;
+          goto s_n_llhttp__internal__n_error_77;
         }
       }
       /* UNREACHABLE */;
@@ -3624,7 +3768,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_query;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_64;
+          goto s_n_llhttp__internal__n_error_78;
         }
       }
       /* UNREACHABLE */;
@@ -3749,10 +3893,10 @@ static llparse_state_t llhttp__internal__run(
         }
         case 8: {
           p++;
-          goto s_n_llhttp__internal__n_error_65;
+          goto s_n_llhttp__internal__n_error_79;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_66;
+          goto s_n_llhttp__internal__n_error_80;
         }
       }
       /* UNREACHABLE */;
@@ -3811,7 +3955,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_server_with_at;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_67;
+          goto s_n_llhttp__internal__n_error_81;
         }
       }
       /* UNREACHABLE */;
@@ -3828,7 +3972,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_server;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_82;
         }
       }
       /* UNREACHABLE */;
@@ -3846,7 +3990,7 @@ static llparse_state_t llhttp__internal__run(
         }
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_error_68;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 12: {
           p++;
@@ -3854,18 +3998,18 @@ static llparse_state_t llhttp__internal__run(
         }
         case 13: {
           p++;
-          goto s_n_llhttp__internal__n_error_68;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case ' ': {
           p++;
-          goto s_n_llhttp__internal__n_error_68;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case '/': {
           p++;
           goto s_n_llhttp__internal__n_url_schema_delim_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_82;
         }
       }
       /* UNREACHABLE */;
@@ -3884,14 +4028,14 @@ static llparse_state_t llhttp__internal__run(
     case s_n_llhttp__internal__n_url_schema:
     s_n_llhttp__internal__n_url_schema: {
       static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 2, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0,
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3910,18 +4054,14 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_error_2;
         }
         case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_error_68;
-        }
-        case 3: {
           goto s_n_llhttp__internal__n_span_end_stub_schema;
         }
-        case 4: {
+        case 3: {
           p++;
           goto s_n_llhttp__internal__n_url_schema;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_70;
+          goto s_n_llhttp__internal__n_error_83;
         }
       }
       /* UNREACHABLE */;
@@ -3930,14 +4070,14 @@ static llparse_state_t llhttp__internal__run(
     case s_n_llhttp__internal__n_url_start:
     s_n_llhttp__internal__n_url_start: {
       static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 2, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 3,
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3956,17 +4096,13 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_error_2;
         }
         case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_error_68;
-        }
-        case 3: {
           goto s_n_llhttp__internal__n_span_start_stub_path_2;
         }
-        case 4: {
+        case 3: {
           goto s_n_llhttp__internal__n_url_schema;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_71;
+          goto s_n_llhttp__internal__n_error_84;
         }
       }
       /* UNREACHABLE */;
@@ -4064,7 +4200,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_spaces_before_url;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_72;
+          goto s_n_llhttp__internal__n_error_85;
         }
       }
       /* UNREACHABLE */;
@@ -4076,9 +4212,9 @@ static llparse_state_t llhttp__internal__run(
         case 0:
           goto s_n_llhttp__internal__n_req_first_space_before_url;
         case 21:
-          goto s_n_llhttp__internal__n_pause_22;
+          goto s_n_llhttp__internal__n_pause_26;
         default:
-          goto s_n_llhttp__internal__n_error_84;
+          goto s_n_llhttp__internal__n_error_104;
       }
       /* UNREACHABLE */;
       abort();
@@ -4095,7 +4231,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4108,7 +4244,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_3;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob17, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4120,7 +4256,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4141,7 +4277,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4154,7 +4290,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_4;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4166,7 +4302,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_4;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4179,7 +4315,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_6;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4191,7 +4327,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_6;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4204,7 +4340,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_8;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4216,7 +4352,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_8;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4234,7 +4370,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4255,7 +4391,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_9;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4276,7 +4412,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_7;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4289,7 +4425,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_12;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4301,7 +4437,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_12;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4314,7 +4450,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_13;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 5);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4326,7 +4462,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_13;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4347,7 +4483,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_13;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4364,7 +4500,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_11;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4377,7 +4513,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_14;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4389,7 +4525,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_14;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4402,7 +4538,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_17;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 9);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 9);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4414,7 +4550,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_17;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4445,7 +4581,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_15;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4456,7 +4592,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_15;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4469,7 +4605,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_18;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4481,7 +4617,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_18;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4494,7 +4630,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_20;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4506,7 +4642,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_20;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4519,7 +4655,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_21;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4531,7 +4667,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_21;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4552,7 +4688,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_21;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4565,7 +4701,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_23;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4577,7 +4713,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_23;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4590,7 +4726,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_24;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4602,7 +4738,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_24;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4615,7 +4751,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_26;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 7);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 7);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4627,7 +4763,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_26;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4640,7 +4776,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_28;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4652,7 +4788,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_28;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4670,7 +4806,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4691,7 +4827,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_29;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4712,7 +4848,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_27;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4725,7 +4861,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_30;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4737,7 +4873,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_30;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4766,7 +4902,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_30;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4779,7 +4915,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_31;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 5);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4791,7 +4927,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_31;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4804,7 +4940,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_32;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4816,7 +4952,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_32;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4829,7 +4965,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_35;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4841,7 +4977,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_35;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4854,7 +4990,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_36;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4866,7 +5002,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_36;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4887,7 +5023,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_36;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4900,7 +5036,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_37;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4912,7 +5048,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_37;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4925,7 +5061,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_38;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4937,7 +5073,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_38;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4950,7 +5086,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_42;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4962,7 +5098,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_42;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -4975,7 +5111,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_43;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob42, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4987,7 +5123,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_43;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5008,7 +5144,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_43;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5025,7 +5161,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_41;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5047,7 +5183,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_40;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5060,7 +5196,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_45;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob43, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob42, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5072,7 +5208,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_45;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5094,7 +5230,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5127,7 +5263,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_44;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5140,7 +5276,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_48;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob43, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5152,7 +5288,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_48;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5165,7 +5301,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_49;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5177,7 +5313,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_49;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5190,7 +5326,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_50;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 5);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5202,7 +5338,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_50;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5215,7 +5351,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_51;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5227,7 +5363,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_51;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5256,7 +5392,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_51;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5273,7 +5409,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_47;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5286,7 +5422,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_54;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob48, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5298,7 +5434,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_54;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5316,7 +5452,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5329,7 +5465,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_57;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob49, 9);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob48, 9);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5341,7 +5477,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_57;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5362,7 +5498,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_57;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5383,7 +5519,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_55;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5396,7 +5532,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_58;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob50, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob49, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5408,7 +5544,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_58;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5421,7 +5557,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_59;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob51, 7);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob50, 7);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5433,7 +5569,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_59;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5458,7 +5594,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_59;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5471,7 +5607,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_61;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob52, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob51, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5483,7 +5619,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_61;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5496,7 +5632,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_62;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob53, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob52, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5508,7 +5644,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_62;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5529,7 +5665,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_62;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5542,7 +5678,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_65;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob54, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob53, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5554,7 +5690,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_65;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5567,7 +5703,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_67;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob55, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob54, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5579,7 +5715,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_67;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5592,7 +5728,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_68;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob56, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob55, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5604,7 +5740,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_68;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5625,7 +5761,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_68;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5638,7 +5774,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_after_start_req_69;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob57, 8);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob56, 8);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5650,7 +5786,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_after_start_req_69;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5675,7 +5811,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_69;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5692,7 +5828,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_64;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5769,7 +5905,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_after_start_req_63;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_85;
+          goto s_n_llhttp__internal__n_error_105;
         }
       }
       /* UNREACHABLE */;
@@ -5786,19 +5922,6 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_status_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_status_complete: {
-      switch (llhttp__on_status_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_headers_start;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_20;
-        default:
-          goto s_n_llhttp__internal__n_error_76;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
     case s_n_llhttp__internal__n_res_line_almost_done:
     s_n_llhttp__internal__n_res_line_almost_done: {
       if (p == endp) {
@@ -5809,9 +5932,24 @@ static llparse_state_t llhttp__internal__run(
           p++;
           goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
         }
-        default: {
-          goto s_n_llhttp__internal__n_error_77;
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
         }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_28;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_test_lenient_flags_29:
+    s_n_llhttp__internal__n_invoke_test_lenient_flags_29: {
+      switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+        case 1:
+          goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
+        default:
+          goto s_n_llhttp__internal__n_error_91;
       }
       /* UNREACHABLE */;
       abort();
@@ -5847,27 +5985,6 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_res_status_start:
-    s_n_llhttp__internal__n_res_status_start: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_status_start;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_res_line_almost_done;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_status;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
     case s_n_llhttp__internal__n_res_status_code_otherwise:
     s_n_llhttp__internal__n_res_status_code_otherwise: {
       if (p == endp) {
@@ -5875,26 +5992,154 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case 10: {
-          goto s_n_llhttp__internal__n_res_status_start;
+          p++;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_27;
         }
         case 13: {
-          goto s_n_llhttp__internal__n_res_status_start;
+          p++;
+          goto s_n_llhttp__internal__n_res_line_almost_done;
         }
         case ' ': {
           p++;
-          goto s_n_llhttp__internal__n_res_status_start;
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_status;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_78;
+          goto s_n_llhttp__internal__n_error_92;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_res_status_code:
-    s_n_llhttp__internal__n_res_status_code: {
+    case s_n_llhttp__internal__n_res_status_code_digit_3:
+    s_n_llhttp__internal__n_res_status_code_digit_3: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_res_status_code;
+        return s_n_llhttp__internal__n_res_status_code_digit_3;
+      }
+      switch (*p) {
+        case '0': {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '1': {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '2': {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '3': {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '4': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '5': {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '6': {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '7': {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '8': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '9': {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_94;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_status_code_digit_2:
+    s_n_llhttp__internal__n_res_status_code_digit_2: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_status_code_digit_2;
+      }
+      switch (*p) {
+        case '0': {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '1': {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '2': {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '3': {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '4': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '5': {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '6': {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '7': {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '8': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '9': {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_96;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_status_code_digit_1:
+    s_n_llhttp__internal__n_res_status_code_digit_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_status_code_digit_1;
       }
       switch (*p) {
         case '0': {
@@ -5948,7 +6193,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
         }
         default: {
-          goto s_n_llhttp__internal__n_res_status_code_otherwise;
+          goto s_n_llhttp__internal__n_error_98;
         }
       }
       /* UNREACHABLE */;
@@ -5965,7 +6210,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_update_status_code;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_79;
+          goto s_n_llhttp__internal__n_error_99;
         }
       }
       /* UNREACHABLE */;
@@ -5977,15 +6222,15 @@ static llparse_state_t llhttp__internal__run(
         case 0:
           goto s_n_llhttp__internal__n_res_after_version;
         case 21:
-          goto s_n_llhttp__internal__n_pause_21;
+          goto s_n_llhttp__internal__n_pause_25;
         default:
-          goto s_n_llhttp__internal__n_error_74;
+          goto s_n_llhttp__internal__n_error_87;
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_73:
-    s_n_llhttp__internal__n_error_73: {
+    case s_n_llhttp__internal__n_error_86:
+    s_n_llhttp__internal__n_error_86: {
       state->error = 0x9;
       state->reason = "Invalid HTTP version";
       state->error_pos = (const char*) p;
@@ -5994,8 +6239,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_80:
-    s_n_llhttp__internal__n_error_80: {
+    case s_n_llhttp__internal__n_error_100:
+    s_n_llhttp__internal__n_error_100: {
       state->error = 0x9;
       state->reason = "Invalid minor version";
       state->error_pos = (const char*) p;
@@ -6067,8 +6312,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_81:
-    s_n_llhttp__internal__n_error_81: {
+    case s_n_llhttp__internal__n_error_101:
+    s_n_llhttp__internal__n_error_101: {
       state->error = 0x9;
       state->reason = "Expected dot";
       state->error_pos = (const char*) p;
@@ -6094,8 +6339,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_82:
-    s_n_llhttp__internal__n_error_82: {
+    case s_n_llhttp__internal__n_error_102:
+    s_n_llhttp__internal__n_error_102: {
       state->error = 0x9;
       state->reason = "Invalid major version";
       state->error_pos = (const char*) p;
@@ -6185,7 +6430,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_res;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob58, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob57, 5);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -6196,7 +6441,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_res;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_86;
+          goto s_n_llhttp__internal__n_error_106;
         }
       }
       /* UNREACHABLE */;
@@ -6208,7 +6453,7 @@ static llparse_state_t llhttp__internal__run(
         case 0:
           goto s_n_llhttp__internal__n_req_first_space_before_url;
         case 21:
-          goto s_n_llhttp__internal__n_pause_19;
+          goto s_n_llhttp__internal__n_pause_23;
         default:
           goto s_n_llhttp__internal__n_error_1;
       }
@@ -6222,7 +6467,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_or_res_method_2;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob59, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob58, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -6234,7 +6479,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_or_res_method_2;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_83;
+          goto s_n_llhttp__internal__n_error_103;
         }
       }
       /* UNREACHABLE */;
@@ -6256,7 +6501,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_or_res_method_3;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob60, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob59, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -6267,7 +6512,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_or_res_method_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_83;
+          goto s_n_llhttp__internal__n_error_103;
         }
       }
       /* UNREACHABLE */;
@@ -6288,7 +6533,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_or_res_method_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_83;
+          goto s_n_llhttp__internal__n_error_103;
         }
       }
       /* UNREACHABLE */;
@@ -6305,7 +6550,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_or_res_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_83;
+          goto s_n_llhttp__internal__n_error_103;
         }
       }
       /* UNREACHABLE */;
@@ -6387,15 +6632,6 @@ static llparse_state_t llhttp__internal__run(
   }
   s_n_llhttp__internal__n_error_2: {
     state->error = 0x7;
-    state->reason = "Invalid characters in url (strict mode)";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_68: {
-    state->error = 0x7;
     state->reason = "Invalid characters in url";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
@@ -6427,7 +6663,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_7: {
+  s_n_llhttp__internal__n_error_8: {
     state->error = 0x5;
     state->reason = "Data after `Connection: close`";
     state->error_pos = (const char*) p;
@@ -6436,8 +6672,18 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_1: {
-    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_3: {
+    switch (llhttp__internal__c_test_lenient_flags_3(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_closed;
+      default:
+        goto s_n_llhttp__internal__n_error_8;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_2: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_invoke_update_initial_message_completed;
       default:
@@ -6449,12 +6695,12 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_update_finish_1: {
     switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_1;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_2;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_11: {
+  s_n_llhttp__internal__n_pause_13: {
     state->error = 0x15;
     state->reason = "on_message_complete pause";
     state->error_pos = (const char*) p;
@@ -6463,7 +6709,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_28: {
+  s_n_llhttp__internal__n_error_37: {
     state->error = 0x12;
     state->reason = "`on_message_complete` callback error";
     state->error_pos = (const char*) p;
@@ -6472,7 +6718,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_13: {
+  s_n_llhttp__internal__n_pause_15: {
     state->error = 0x15;
     state->reason = "on_chunk_complete pause";
     state->error_pos = (const char*) p;
@@ -6481,7 +6727,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_31: {
+  s_n_llhttp__internal__n_error_39: {
     state->error = 0x14;
     state->reason = "`on_chunk_complete` callback error";
     state->error_pos = (const char*) p;
@@ -6495,19 +6741,10 @@ static llparse_state_t llhttp__internal__run(
       case 0:
         goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
       case 21:
-        goto s_n_llhttp__internal__n_pause_13;
+        goto s_n_llhttp__internal__n_pause_15;
       default:
-        goto s_n_llhttp__internal__n_error_31;
+        goto s_n_llhttp__internal__n_error_39;
     }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_30: {
-    state->error = 0x4;
-    state->reason = "Content-Length can't be present with Transfer-Encoding";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
     /* UNREACHABLE */;
     abort();
   }
@@ -6520,7 +6757,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_8: {
+  s_n_llhttp__internal__n_error_9: {
     state->error = 0x12;
     state->reason = "`on_message_complete` callback error";
     state->error_pos = (const char*) p;
@@ -6536,17 +6773,36 @@ static llparse_state_t llhttp__internal__run(
       case 21:
         goto s_n_llhttp__internal__n_pause_2;
       default:
-        goto s_n_llhttp__internal__n_error_8;
+        goto s_n_llhttp__internal__n_error_9;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_26: {
+  s_n_llhttp__internal__n_error_35: {
     state->error = 0xc;
     state->reason = "Chunk size overflow";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_10: {
+    state->error = 0xc;
+    state->reason = "Invalid character in chunk size";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_4: {
+    switch (llhttp__internal__c_test_lenient_flags_4(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_chunk_size_otherwise;
+      default:
+        goto s_n_llhttp__internal__n_error_10;
+    }
     /* UNREACHABLE */;
     abort();
   }
@@ -6559,7 +6815,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_10: {
+  s_n_llhttp__internal__n_error_14: {
     state->error = 0x14;
     state->reason = "`on_chunk_complete` callback error";
     state->error_pos = (const char*) p;
@@ -6575,17 +6831,46 @@ static llparse_state_t llhttp__internal__run(
       case 21:
         goto s_n_llhttp__internal__n_pause_3;
       default:
-        goto s_n_llhttp__internal__n_error_10;
+        goto s_n_llhttp__internal__n_error_14;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_11: {
-    state->error = 0x2;
-    state->reason = "Expected CRLF after chunk";
+  s_n_llhttp__internal__n_error_13: {
+    state->error = 0x19;
+    state->reason = "Missing expected CR after chunk data";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_6: {
+    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete;
+      default:
+        goto s_n_llhttp__internal__n_error_13;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_15: {
+    state->error = 0x2;
+    state->reason = "Expected LF after chunk data";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_7: {
+    switch (llhttp__internal__c_test_lenient_flags_7(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete;
+      default:
+        goto s_n_llhttp__internal__n_error_15;
+    }
     /* UNREACHABLE */;
     abort();
   }
@@ -6623,7 +6908,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_9: {
+  s_n_llhttp__internal__n_error_12: {
     state->error = 0x13;
     state->reason = "`on_chunk_header` callback error";
     state->error_pos = (const char*) p;
@@ -6639,12 +6924,12 @@ static llparse_state_t llhttp__internal__run(
       case 21:
         goto s_n_llhttp__internal__n_pause_4;
       default:
-        goto s_n_llhttp__internal__n_error_9;
+        goto s_n_llhttp__internal__n_error_12;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_12: {
+  s_n_llhttp__internal__n_error_16: {
     state->error = 0x2;
     state->reason = "Expected LF after chunk size";
     state->error_pos = (const char*) p;
@@ -6653,7 +6938,36 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_13: {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_8: {
+    switch (llhttp__internal__c_test_lenient_flags_8(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_header;
+      default:
+        goto s_n_llhttp__internal__n_error_16;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_11: {
+    state->error = 0x19;
+    state->reason = "Missing expected CR after chunk size";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_5: {
+    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_chunk_size_almost_done;
+      default:
+        goto s_n_llhttp__internal__n_error_11;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_17: {
     state->error = 0x2;
     state->reason = "Invalid character in chunk extensions";
     state->error_pos = (const char*) p;
@@ -6662,9 +6976,18 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_14: {
+  s_n_llhttp__internal__n_error_18: {
     state->error = 0x2;
     state->reason = "Invalid character in chunk extensions";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_20: {
+    state->error = 0x19;
+    state->reason = "Missing expected CR after chunk extension name";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
@@ -6675,12 +6998,12 @@ static llparse_state_t llhttp__internal__run(
     state->error = 0x15;
     state->reason = "on_chunk_extension_name pause";
     state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_almost_done;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_test_lenient_flags_9;
     return s_error;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_15: {
+  s_n_llhttp__internal__n_error_19: {
     state->error = 0x22;
     state->reason = "`on_chunk_extension_name` callback error";
     state->error_pos = (const char*) p;
@@ -6698,11 +7021,10 @@ static llparse_state_t llhttp__internal__run(
     err = llhttp__on_chunk_extension_name(state, start, p);
     if (err != 0) {
       state->error = err;
-      state->error_pos = (const char*) (p + 1);
+      state->error_pos = (const char*) p;
       state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete;
       return s_error;
     }
-    p++;
     goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete;
     /* UNREACHABLE */;
     abort();
@@ -6711,12 +7033,12 @@ static llparse_state_t llhttp__internal__run(
     state->error = 0x15;
     state->reason = "on_chunk_extension_name pause";
     state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_extensions;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_almost_done;
     return s_error;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_16: {
+  s_n_llhttp__internal__n_error_21: {
     state->error = 0x22;
     state->reason = "`on_chunk_extension_name` callback error";
     state->error_pos = (const char*) p;
@@ -6745,14 +7067,59 @@ static llparse_state_t llhttp__internal__run(
   }
   s_n_llhttp__internal__n_pause_7: {
     state->error = 0x15;
-    state->reason = "on_chunk_extension_value pause";
+    state->reason = "on_chunk_extension_name pause";
     state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_almost_done;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_extensions;
     return s_error;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_18: {
+  s_n_llhttp__internal__n_error_22: {
+    state->error = 0x22;
+    state->reason = "`on_chunk_extension_name` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_2: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_extension_name(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_2;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_2;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_25: {
+    state->error = 0x19;
+    state->reason = "Missing expected CR after chunk extension value";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_8: {
+    state->error = 0x15;
+    state->reason = "on_chunk_extension_value pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_test_lenient_flags_10;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_24: {
     state->error = 0x23;
     state->reason = "`on_chunk_extension_value` callback error";
     state->error_pos = (const char*) p;
@@ -6770,34 +7137,24 @@ static llparse_state_t llhttp__internal__run(
     err = llhttp__on_chunk_extension_value(state, start, p);
     if (err != 0) {
       state->error = err;
-      state->error_pos = (const char*) (p + 1);
+      state->error_pos = (const char*) p;
       state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete;
       return s_error;
     }
-    p++;
     goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_20: {
-    state->error = 0x2;
-    state->reason = "Invalid character in chunk extensions quote value";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_8: {
+  s_n_llhttp__internal__n_pause_9: {
     state->error = 0x15;
     state->reason = "on_chunk_extension_value pause";
     state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_extension_quoted_value_done;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_almost_done;
     return s_error;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_19: {
+  s_n_llhttp__internal__n_error_26: {
     state->error = 0x23;
     state->reason = "`on_chunk_extension_value` callback error";
     state->error_pos = (const char*) p;
@@ -6815,11 +7172,58 @@ static llparse_state_t llhttp__internal__run(
     err = llhttp__on_chunk_extension_value(state, start, p);
     if (err != 0) {
       state->error = err;
-      state->error_pos = (const char*) p;
+      state->error_pos = (const char*) (p + 1);
       state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1;
       return s_error;
     }
+    p++;
     goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_28: {
+    state->error = 0x19;
+    state->reason = "Missing expected CR after chunk extension value";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_11: {
+    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_chunk_size_almost_done;
+      default:
+        goto s_n_llhttp__internal__n_error_28;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_29: {
+    state->error = 0x2;
+    state->reason = "Invalid character in chunk extensions quote value";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_10: {
+    state->error = 0x15;
+    state->reason = "on_chunk_extension_value pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_extension_quoted_value_done;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_27: {
+    state->error = 0x23;
+    state->reason = "`on_chunk_extension_value` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
     /* UNREACHABLE */;
     abort();
   }
@@ -6832,30 +7236,11 @@ static llparse_state_t llhttp__internal__run(
     err = llhttp__on_chunk_extension_value(state, start, p);
     if (err != 0) {
       state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_21;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2;
       return s_error;
     }
-    p++;
-    goto s_n_llhttp__internal__n_error_21;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_9: {
-    state->error = 0x15;
-    state->reason = "on_chunk_extension_value pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_otherwise;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_22: {
-    state->error = 0x23;
-    state->reason = "`on_chunk_extension_value` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2;
     /* UNREACHABLE */;
     abort();
   }
@@ -6869,11 +7254,29 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_30;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2;
+    goto s_n_llhttp__internal__n_error_30;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_11: {
+    state->error = 0x15;
+    state->reason = "on_chunk_extension_value pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_otherwise;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_31: {
+    state->error = 0x23;
+    state->reason = "`on_chunk_extension_value` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
     /* UNREACHABLE */;
     abort();
   }
@@ -6887,15 +7290,33 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_23;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_3;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_error_23;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_3;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_10: {
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_5: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_extension_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_32;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_error_32;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_12: {
     state->error = 0x15;
     state->reason = "on_chunk_extension_name pause";
     state->error_pos = (const char*) p;
@@ -6904,7 +7325,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_17: {
+  s_n_llhttp__internal__n_error_23: {
     state->error = 0x22;
     state->reason = "`on_chunk_extension_name` callback error";
     state->error_pos = (const char*) p;
@@ -6913,19 +7334,19 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_2: {
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_3: {
     switch (llhttp__on_chunk_extension_name_complete(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_chunk_extension_value;
       case 21:
-        goto s_n_llhttp__internal__n_pause_10;
+        goto s_n_llhttp__internal__n_pause_12;
       default:
-        goto s_n_llhttp__internal__n_error_17;
+        goto s_n_llhttp__internal__n_error_23;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_2: {
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_3: {
     const unsigned char* start;
     int err;
     
@@ -6943,7 +7364,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_3: {
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_4: {
     const unsigned char* start;
     int err;
     
@@ -6953,15 +7374,15 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_24;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_33;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_error_24;
+    goto s_n_llhttp__internal__n_error_33;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_25: {
+  s_n_llhttp__internal__n_error_34: {
     state->error = 0xc;
     state->reason = "Invalid character in chunk size";
     state->error_pos = (const char*) p;
@@ -6973,14 +7394,14 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_mul_add_content_length: {
     switch (llhttp__internal__c_mul_add_content_length(state, p, endp, match)) {
       case 1:
-        goto s_n_llhttp__internal__n_error_26;
+        goto s_n_llhttp__internal__n_error_35;
       default:
         goto s_n_llhttp__internal__n_chunk_size;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_27: {
+  s_n_llhttp__internal__n_error_36: {
     state->error = 0xc;
     state->reason = "Invalid character in chunk size";
     state->error_pos = (const char*) p;
@@ -7014,7 +7435,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_29: {
+  s_n_llhttp__internal__n_error_38: {
     state->error = 0xf;
     state->reason = "Request has invalid `Transfer-Encoding`";
     state->error_pos = (const char*) p;
@@ -7032,7 +7453,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_6: {
+  s_n_llhttp__internal__n_error_7: {
     state->error = 0x12;
     state->reason = "`on_message_complete` callback error";
     state->error_pos = (const char*) p;
@@ -7048,7 +7469,7 @@ static llparse_state_t llhttp__internal__run(
       case 21:
         goto s_n_llhttp__internal__n_pause;
       default:
-        goto s_n_llhttp__internal__n_error_6;
+        goto s_n_llhttp__internal__n_error_7;
     }
     /* UNREACHABLE */;
     abort();
@@ -7077,7 +7498,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_12: {
+  s_n_llhttp__internal__n_pause_14: {
     state->error = 0x15;
     state->reason = "Paused by on_headers_complete";
     state->error_pos = (const char*) p;
@@ -7086,7 +7507,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_5: {
+  s_n_llhttp__internal__n_error_6: {
     state->error = 0x11;
     state->reason = "User callback error";
     state->error_pos = (const char*) p;
@@ -7104,9 +7525,9 @@ static llparse_state_t llhttp__internal__run(
       case 2:
         goto s_n_llhttp__internal__n_invoke_update_upgrade;
       case 21:
-        goto s_n_llhttp__internal__n_pause_12;
+        goto s_n_llhttp__internal__n_pause_14;
       default:
-        goto s_n_llhttp__internal__n_error_5;
+        goto s_n_llhttp__internal__n_error_6;
     }
     /* UNREACHABLE */;
     abort();
@@ -7119,42 +7540,148 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_2: {
-    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_error_30;
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags_1: {
-    switch (llhttp__internal__c_test_flags_1(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_2;
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
   s_n_llhttp__internal__n_invoke_test_flags: {
     switch (llhttp__internal__c_test_flags(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete_1;
       default:
-        goto s_n_llhttp__internal__n_invoke_test_flags_1;
+        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_32: {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_1: {
+    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_test_flags;
+      default:
+        goto s_n_llhttp__internal__n_error_5;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_17: {
+    state->error = 0x15;
+    state->reason = "on_chunk_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_41: {
+    state->error = 0x14;
+    state->reason = "`on_chunk_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete_2: {
+    switch (llhttp__on_chunk_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
+      case 21:
+        goto s_n_llhttp__internal__n_pause_17;
+      default:
+        goto s_n_llhttp__internal__n_error_41;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_3: {
+    switch (llhttp__internal__c_or_flags_1(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_4: {
+    switch (llhttp__internal__c_or_flags_1(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_upgrade_1: {
+    switch (llhttp__internal__c_update_upgrade(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_or_flags_4;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_16: {
+    state->error = 0x15;
+    state->reason = "Paused by on_headers_complete";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_40: {
+    state->error = 0x11;
+    state->reason = "User callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_headers_complete_1: {
+    switch (llhttp__on_headers_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_or_flags_3;
+      case 2:
+        goto s_n_llhttp__internal__n_invoke_update_upgrade_1;
+      case 21:
+        goto s_n_llhttp__internal__n_pause_16;
+      default:
+        goto s_n_llhttp__internal__n_error_40;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete_1: {
+    switch (llhttp__before_headers_complete(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_headers_complete_1;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_flags_1: {
+    switch (llhttp__internal__c_test_flags(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete_2;
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete_1;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_42: {
     state->error = 0x2;
     state->reason = "Expected LF after headers";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_12: {
+    switch (llhttp__internal__c_test_lenient_flags_8(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_test_flags_1;
+      default:
+        goto s_n_llhttp__internal__n_error_42;
+    }
     /* UNREACHABLE */;
     abort();
   }
@@ -7168,15 +7695,15 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_33;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_5;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_error_33;
+    goto s_n_llhttp__internal__n_error_5;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_3: {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_13: {
     switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_field_colon_discard_ws;
@@ -7186,7 +7713,16 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_36: {
+  s_n_llhttp__internal__n_error_57: {
+    state->error = 0xb;
+    state->reason = "Content-Length can't be present with Transfer-Encoding";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_45: {
     state->error = 0xa;
     state->reason = "Invalid header value char";
     state->error_pos = (const char*) p;
@@ -7195,17 +7731,17 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_5: {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_15: {
     switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_value_discard_ws;
       default:
-        goto s_n_llhttp__internal__n_error_36;
+        goto s_n_llhttp__internal__n_error_45;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_38: {
+  s_n_llhttp__internal__n_error_47: {
     state->error = 0xb;
     state->reason = "Empty Content-Length";
     state->error_pos = (const char*) p;
@@ -7214,7 +7750,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_14: {
+  s_n_llhttp__internal__n_pause_18: {
     state->error = 0x15;
     state->reason = "on_header_value_complete pause";
     state->error_pos = (const char*) p;
@@ -7223,7 +7759,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_37: {
+  s_n_llhttp__internal__n_error_46: {
     state->error = 0x1d;
     state->reason = "`on_header_value_complete` callback error";
     state->error_pos = (const char*) p;
@@ -7257,22 +7793,6 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_or_flags_3: {
-    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_4: {
-    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
   s_n_llhttp__internal__n_invoke_or_flags_5: {
     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
       default:
@@ -7284,6 +7804,38 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_6: {
     switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
       default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_7: {
+    switch (llhttp__internal__c_or_flags_7(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_8: {
+    switch (llhttp__internal__c_or_flags_8(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_header_state_2: {
+    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+      case 5:
+        goto s_n_llhttp__internal__n_invoke_or_flags_5;
+      case 6:
+        goto s_n_llhttp__internal__n_invoke_or_flags_6;
+      case 7:
+        goto s_n_llhttp__internal__n_invoke_or_flags_7;
+      case 8:
+        goto s_n_llhttp__internal__n_invoke_or_flags_8;
+      default:
         goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
     }
     /* UNREACHABLE */;
@@ -7291,31 +7843,15 @@ static llparse_state_t llhttp__internal__run(
   }
   s_n_llhttp__internal__n_invoke_load_header_state_1: {
     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 5:
-        goto s_n_llhttp__internal__n_invoke_or_flags_3;
-      case 6:
-        goto s_n_llhttp__internal__n_invoke_or_flags_4;
-      case 7:
-        goto s_n_llhttp__internal__n_invoke_or_flags_5;
-      case 8:
-        goto s_n_llhttp__internal__n_invoke_or_flags_6;
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
       case 2:
-        goto s_n_llhttp__internal__n_error_38;
+        goto s_n_llhttp__internal__n_error_47;
       default:
-        goto s_n_llhttp__internal__n_invoke_load_header_state_1;
+        goto s_n_llhttp__internal__n_invoke_load_header_state_2;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_35: {
+  s_n_llhttp__internal__n_error_44: {
     state->error = 0xa;
     state->reason = "Invalid header value char";
     state->error_pos = (const char*) p;
@@ -7324,17 +7860,17 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_4: {
-    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_14: {
+    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_value_discard_lws;
       default:
-        goto s_n_llhttp__internal__n_error_35;
+        goto s_n_llhttp__internal__n_error_44;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_39: {
+  s_n_llhttp__internal__n_error_48: {
     state->error = 0x2;
     state->reason = "Expected LF after CR";
     state->error_pos = (const char*) p;
@@ -7343,12 +7879,12 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_6: {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_16: {
     switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_value_discard_lws;
       default:
-        goto s_n_llhttp__internal__n_error_39;
+        goto s_n_llhttp__internal__n_error_48;
     }
     /* UNREACHABLE */;
     abort();
@@ -7361,7 +7897,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+  s_n_llhttp__internal__n_invoke_load_header_state_4: {
     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
       case 8:
         goto s_n_llhttp__internal__n_invoke_update_header_state_1;
@@ -7379,22 +7915,6 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_or_flags_7: {
-    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_8: {
-    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
   s_n_llhttp__internal__n_invoke_or_flags_9: {
     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
       default:
@@ -7406,28 +7926,44 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_10: {
     switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
+        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_load_header_state_4: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 5:
-        goto s_n_llhttp__internal__n_invoke_or_flags_7;
-      case 6:
-        goto s_n_llhttp__internal__n_invoke_or_flags_8;
-      case 7:
-        goto s_n_llhttp__internal__n_invoke_or_flags_9;
-      case 8:
-        goto s_n_llhttp__internal__n_invoke_or_flags_10;
+  s_n_llhttp__internal__n_invoke_or_flags_11: {
+    switch (llhttp__internal__c_or_flags_7(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_12: {
+    switch (llhttp__internal__c_or_flags_8(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_40: {
+  s_n_llhttp__internal__n_invoke_load_header_state_5: {
+    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+      case 5:
+        goto s_n_llhttp__internal__n_invoke_or_flags_9;
+      case 6:
+        goto s_n_llhttp__internal__n_invoke_or_flags_10;
+      case 7:
+        goto s_n_llhttp__internal__n_invoke_or_flags_11;
+      case 8:
+        goto s_n_llhttp__internal__n_invoke_or_flags_12;
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_50: {
     state->error = 0x3;
     state->reason = "Missing expected LF after header value";
     state->error_pos = (const char*) p;
@@ -7436,7 +7972,68 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_error_49: {
+    state->error = 0x19;
+    state->reason = "Missing expected CR after header value";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_test_lenient_flags_17;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_invoke_test_lenient_flags_17;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_header_value_almost_done;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_header_value_almost_done;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
     const unsigned char* start;
     int err;
     
@@ -7464,54 +8061,19 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_51;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_header_value_almost_done;
+    goto s_n_llhttp__internal__n_error_51;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_header_value_almost_done;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_41;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_41;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_7: {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_18: {
     switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_value_lenient;
       default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
     }
     /* UNREACHABLE */;
     abort();
@@ -7520,22 +8082,6 @@ static llparse_state_t llhttp__internal__run(
     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_header_value_connection;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_11: {
-    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_12: {
-    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
     }
     /* UNREACHABLE */;
     abort();
@@ -7551,21 +8097,37 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_14: {
     switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
       default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_15: {
+    switch (llhttp__internal__c_or_flags_7(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_16: {
+    switch (llhttp__internal__c_or_flags_8(state, p, endp)) {
+      default:
         goto s_n_llhttp__internal__n_header_value_connection;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_load_header_state_5: {
+  s_n_llhttp__internal__n_invoke_load_header_state_6: {
     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
       case 5:
-        goto s_n_llhttp__internal__n_invoke_or_flags_11;
-      case 6:
-        goto s_n_llhttp__internal__n_invoke_or_flags_12;
-      case 7:
         goto s_n_llhttp__internal__n_invoke_or_flags_13;
-      case 8:
+      case 6:
         goto s_n_llhttp__internal__n_invoke_or_flags_14;
+      case 7:
+        goto s_n_llhttp__internal__n_invoke_or_flags_15;
+      case 8:
+        goto s_n_llhttp__internal__n_invoke_or_flags_16;
       default:
         goto s_n_llhttp__internal__n_header_value_connection;
     }
@@ -7604,41 +8166,6 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_43;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_43;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_mul_add_content_length_1: {
-    switch (llhttp__internal__c_mul_add_content_length_1(state, p, endp, match)) {
-      case 1:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
-      default:
-        goto s_n_llhttp__internal__n_header_value_content_length;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_15: {
-    switch (llhttp__internal__c_or_flags_15(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_otherwise;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
   s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6: {
     const unsigned char* start;
     int err;
@@ -7649,52 +8176,25 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_44;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_53;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_44;
+    goto s_n_llhttp__internal__n_error_53;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_42: {
-    state->error = 0x4;
-    state->reason = "Duplicate Content-Length";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags_2: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_header_value_content_length;
+  s_n_llhttp__internal__n_invoke_mul_add_content_length_1: {
+    switch (llhttp__internal__c_mul_add_content_length_1(state, p, endp, match)) {
+      case 1:
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6;
       default:
-        goto s_n_llhttp__internal__n_error_42;
+        goto s_n_llhttp__internal__n_header_value_content_length;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_46;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_error_46;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_8: {
-    switch (llhttp__internal__c_update_header_state_8(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_or_flags_17: {
+    switch (llhttp__internal__c_or_flags_17(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_header_value_otherwise;
     }
@@ -7710,19 +8210,81 @@ static llparse_state_t llhttp__internal__run(
     err = llhttp__on_header_value(state, start, p);
     if (err != 0) {
       state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_45;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_54;
       return s_error;
     }
-    p++;
-    goto s_n_llhttp__internal__n_error_45;
+    goto s_n_llhttp__internal__n_error_54;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_8: {
-    switch (llhttp__internal__c_test_lenient_flags_8(state, p, endp)) {
+  s_n_llhttp__internal__n_error_52: {
+    state->error = 0x4;
+    state->reason = "Duplicate Content-Length";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_flags_2: {
+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
       case 0:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7;
+        goto s_n_llhttp__internal__n_header_value_content_length;
+      default:
+        goto s_n_llhttp__internal__n_error_52;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_9: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_56;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_error_56;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_8: {
+    switch (llhttp__internal__c_update_header_state_8(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_value_otherwise;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_55;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_error_55;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_19: {
+    switch (llhttp__internal__c_test_lenient_flags_19(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8;
       default:
         goto s_n_llhttp__internal__n_header_value_te_chunked;
     }
@@ -7732,7 +8294,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_type_1: {
     switch (llhttp__internal__c_load_type(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_8;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_19;
       default:
         goto s_n_llhttp__internal__n_header_value_te_chunked;
     }
@@ -7755,20 +8317,20 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_or_flags_17: {
-    switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_or_flags_19: {
+    switch (llhttp__internal__c_or_flags_18(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_invoke_and_flags;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_9: {
-    switch (llhttp__internal__c_test_lenient_flags_8(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_20: {
+    switch (llhttp__internal__c_test_lenient_flags_19(state, p, endp)) {
       case 0:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_9;
       default:
-        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+        goto s_n_llhttp__internal__n_invoke_or_flags_19;
     }
     /* UNREACHABLE */;
     abort();
@@ -7776,15 +8338,15 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_type_2: {
     switch (llhttp__internal__c_load_type(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_9;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_20;
       default:
-        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+        goto s_n_llhttp__internal__n_invoke_or_flags_19;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_or_flags_16: {
-    switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_or_flags_18: {
+    switch (llhttp__internal__c_or_flags_18(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_invoke_and_flags;
     }
@@ -7796,20 +8358,20 @@ static llparse_state_t llhttp__internal__run(
       case 1:
         goto s_n_llhttp__internal__n_invoke_load_type_2;
       default:
-        goto s_n_llhttp__internal__n_invoke_or_flags_16;
+        goto s_n_llhttp__internal__n_invoke_or_flags_18;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_or_flags_18: {
-    switch (llhttp__internal__c_or_flags_18(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_or_flags_20: {
+    switch (llhttp__internal__c_or_flags_20(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_invoke_update_header_state_9;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_load_header_state_2: {
+  s_n_llhttp__internal__n_invoke_load_header_state_3: {
     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_value_connection;
@@ -7818,23 +8380,72 @@ static llparse_state_t llhttp__internal__run(
       case 3:
         goto s_n_llhttp__internal__n_invoke_test_flags_3;
       case 4:
-        goto s_n_llhttp__internal__n_invoke_or_flags_18;
+        goto s_n_llhttp__internal__n_invoke_or_flags_20;
       default:
         goto s_n_llhttp__internal__n_header_value;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_15: {
-    state->error = 0x15;
-    state->reason = "on_header_field_complete pause";
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_21: {
+    switch (llhttp__internal__c_test_lenient_flags_21(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_error_57;
+      default:
+        goto s_n_llhttp__internal__n_header_value_discard_ws;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_flags_4: {
+    switch (llhttp__internal__c_test_flags_4(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_21;
+      default:
+        goto s_n_llhttp__internal__n_header_value_discard_ws;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_58: {
+    state->error = 0xf;
+    state->reason = "Transfer-Encoding can't be present with Content-Length";
     state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_discard_ws;
+    state->_current = (void*) (intptr_t) s_error;
     return s_error;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_34: {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_22: {
+    switch (llhttp__internal__c_test_lenient_flags_21(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_error_58;
+      default:
+        goto s_n_llhttp__internal__n_header_value_discard_ws;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_flags_5: {
+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_22;
+      default:
+        goto s_n_llhttp__internal__n_header_value_discard_ws;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_19: {
+    state->error = 0x15;
+    state->reason = "on_header_field_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_load_header_state;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_43: {
     state->error = 0x1c;
     state->reason = "`on_header_field_complete` callback error";
     state->error_pos = (const char*) p;
@@ -7879,7 +8490,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_47: {
+  s_n_llhttp__internal__n_error_59: {
     state->error = 0xa;
     state->reason = "Invalid header token";
     state->error_pos = (const char*) p;
@@ -7931,7 +8542,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_16: {
+  s_n_llhttp__internal__n_pause_20: {
     state->error = 0x15;
     state->reason = "on_url_complete pause";
     state->error_pos = (const char*) p;
@@ -7954,7 +8565,7 @@ static llparse_state_t llhttp__internal__run(
       case 0:
         goto s_n_llhttp__internal__n_headers_start;
       case 21:
-        goto s_n_llhttp__internal__n_pause_16;
+        goto s_n_llhttp__internal__n_pause_20;
       default:
         goto s_n_llhttp__internal__n_error_3;
     }
@@ -7994,7 +8605,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_48: {
+  s_n_llhttp__internal__n_error_60: {
     state->error = 0x7;
     state->reason = "Expected CRLF";
     state->error_pos = (const char*) p;
@@ -8020,7 +8631,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_54: {
+  s_n_llhttp__internal__n_error_68: {
     state->error = 0x17;
     state->reason = "Pause on PRI/Upgrade";
     state->error_pos = (const char*) p;
@@ -8029,7 +8640,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_55: {
+  s_n_llhttp__internal__n_error_69: {
     state->error = 0x9;
     state->reason = "Expected HTTP/2 Connection Preface";
     state->error_pos = (const char*) p;
@@ -8038,7 +8649,26 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_53: {
+  s_n_llhttp__internal__n_error_66: {
+    state->error = 0x2;
+    state->reason = "Expected CRLF after version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_25: {
+    switch (llhttp__internal__c_test_lenient_flags_8(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_headers_start;
+      default:
+        goto s_n_llhttp__internal__n_error_66;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_65: {
     state->error = 0x9;
     state->reason = "Expected CRLF after version";
     state->error_pos = (const char*) p;
@@ -8047,7 +8677,26 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_17: {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_24: {
+    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_req_http_complete_crlf;
+      default:
+        goto s_n_llhttp__internal__n_error_65;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_67: {
+    state->error = 0x9;
+    state->reason = "Expected CRLF after version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_21: {
     state->error = 0x15;
     state->reason = "on_version_complete pause";
     state->error_pos = (const char*) p;
@@ -8056,7 +8705,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_52: {
+  s_n_llhttp__internal__n_error_64: {
     state->error = 0x21;
     state->reason = "`on_version_complete` callback error";
     state->error_pos = (const char*) p;
@@ -8092,10 +8741,10 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_51;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_63;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_51;
+    goto s_n_llhttp__internal__n_error_63;
     /* UNREACHABLE */;
     abort();
   }
@@ -8145,8 +8794,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_10: {
-    switch (llhttp__internal__c_test_lenient_flags_10(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_23: {
+    switch (llhttp__internal__c_test_lenient_flags_23(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_span_end_llhttp__on_version_1;
       default:
@@ -8158,7 +8807,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_store_http_minor: {
     switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_10;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_23;
     }
     /* UNREACHABLE */;
     abort();
@@ -8173,10 +8822,10 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_56;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_70;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_56;
+    goto s_n_llhttp__internal__n_error_70;
     /* UNREACHABLE */;
     abort();
   }
@@ -8190,10 +8839,10 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_57;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_71;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_57;
+    goto s_n_llhttp__internal__n_error_71;
     /* UNREACHABLE */;
     abort();
   }
@@ -8215,14 +8864,14 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_58;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_72;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_58;
+    goto s_n_llhttp__internal__n_error_72;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_50: {
+  s_n_llhttp__internal__n_error_62: {
     state->error = 0x8;
     state->reason = "Invalid method for HTTP/x.x request";
     state->error_pos = (const char*) p;
@@ -8304,12 +8953,12 @@ static llparse_state_t llhttp__internal__run(
       case 34:
         goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       default:
-        goto s_n_llhttp__internal__n_error_50;
+        goto s_n_llhttp__internal__n_error_62;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_61: {
+  s_n_llhttp__internal__n_error_75: {
     state->error = 0x8;
     state->reason = "Expected HTTP/";
     state->error_pos = (const char*) p;
@@ -8318,7 +8967,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_59: {
+  s_n_llhttp__internal__n_error_73: {
     state->error = 0x8;
     state->reason = "Expected SOURCE method for ICE/x.x request";
     state->error_pos = (const char*) p;
@@ -8332,12 +8981,12 @@ static llparse_state_t llhttp__internal__run(
       case 33:
         goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       default:
-        goto s_n_llhttp__internal__n_error_59;
+        goto s_n_llhttp__internal__n_error_73;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_60: {
+  s_n_llhttp__internal__n_error_74: {
     state->error = 0x8;
     state->reason = "Invalid method for RTSP/x.x request";
     state->error_pos = (const char*) p;
@@ -8377,12 +9026,12 @@ static llparse_state_t llhttp__internal__run(
       case 45:
         goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       default:
-        goto s_n_llhttp__internal__n_error_60;
+        goto s_n_llhttp__internal__n_error_74;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_18: {
+  s_n_llhttp__internal__n_pause_22: {
     state->error = 0x15;
     state->reason = "on_url_complete pause";
     state->error_pos = (const char*) p;
@@ -8391,7 +9040,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_49: {
+  s_n_llhttp__internal__n_error_61: {
     state->error = 0x1a;
     state->reason = "`on_url_complete` callback error";
     state->error_pos = (const char*) p;
@@ -8405,9 +9054,9 @@ static llparse_state_t llhttp__internal__run(
       case 0:
         goto s_n_llhttp__internal__n_req_http_start;
       case 21:
-        goto s_n_llhttp__internal__n_pause_18;
+        goto s_n_llhttp__internal__n_pause_22;
       default:
-        goto s_n_llhttp__internal__n_error_49;
+        goto s_n_llhttp__internal__n_error_61;
     }
     /* UNREACHABLE */;
     abort();
@@ -8480,7 +9129,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_62: {
+  s_n_llhttp__internal__n_error_76: {
     state->error = 0x7;
     state->reason = "Invalid char in url fragment start";
     state->error_pos = (const char*) p;
@@ -8540,7 +9189,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_63: {
+  s_n_llhttp__internal__n_error_77: {
     state->error = 0x7;
     state->reason = "Invalid char in url query";
     state->error_pos = (const char*) p;
@@ -8549,7 +9198,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_64: {
+  s_n_llhttp__internal__n_error_78: {
     state->error = 0x7;
     state->reason = "Invalid char in url path";
     state->error_pos = (const char*) p;
@@ -8660,7 +9309,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_65: {
+  s_n_llhttp__internal__n_error_79: {
     state->error = 0x7;
     state->reason = "Double @ in url";
     state->error_pos = (const char*) p;
@@ -8669,7 +9318,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_66: {
+  s_n_llhttp__internal__n_error_80: {
     state->error = 0x7;
     state->reason = "Unexpected char in url server";
     state->error_pos = (const char*) p;
@@ -8678,7 +9327,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_67: {
+  s_n_llhttp__internal__n_error_81: {
     state->error = 0x7;
     state->reason = "Unexpected char in url server";
     state->error_pos = (const char*) p;
@@ -8687,7 +9336,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_69: {
+  s_n_llhttp__internal__n_error_82: {
     state->error = 0x7;
     state->reason = "Unexpected char in url schema";
     state->error_pos = (const char*) p;
@@ -8696,7 +9345,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_70: {
+  s_n_llhttp__internal__n_error_83: {
     state->error = 0x7;
     state->reason = "Unexpected char in url schema";
     state->error_pos = (const char*) p;
@@ -8705,7 +9354,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_71: {
+  s_n_llhttp__internal__n_error_84: {
     state->error = 0x7;
     state->reason = "Unexpected start char in url";
     state->error_pos = (const char*) p;
@@ -8724,7 +9373,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_72: {
+  s_n_llhttp__internal__n_error_85: {
     state->error = 0x6;
     state->reason = "Expected space after method";
     state->error_pos = (const char*) p;
@@ -8733,7 +9382,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_22: {
+  s_n_llhttp__internal__n_pause_26: {
     state->error = 0x15;
     state->reason = "on_method_complete pause";
     state->error_pos = (const char*) p;
@@ -8742,7 +9391,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_84: {
+  s_n_llhttp__internal__n_error_104: {
     state->error = 0x20;
     state->reason = "`on_method_complete` callback error";
     state->error_pos = (const char*) p;
@@ -8776,7 +9425,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_85: {
+  s_n_llhttp__internal__n_error_105: {
     state->error = 0x6;
     state->reason = "Invalid method encountered";
     state->error_pos = (const char*) p;
@@ -8785,26 +9434,34 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_75: {
+  s_n_llhttp__internal__n_error_97: {
     state->error = 0xd;
-    state->reason = "Response overflow";
+    state->reason = "Invalid status code";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_mul_add_status_code: {
-    switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
-      case 1:
-        goto s_n_llhttp__internal__n_error_75;
-      default:
-        goto s_n_llhttp__internal__n_res_status_code;
-    }
+  s_n_llhttp__internal__n_error_95: {
+    state->error = 0xd;
+    state->reason = "Invalid status code";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_20: {
+  s_n_llhttp__internal__n_error_93: {
+    state->error = 0xd;
+    state->reason = "Invalid status code";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_24: {
     state->error = 0x15;
     state->reason = "on_status_complete pause";
     state->error_pos = (const char*) p;
@@ -8813,7 +9470,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_76: {
+  s_n_llhttp__internal__n_error_89: {
     state->error = 0x1b;
     state->reason = "`on_status_complete` callback error";
     state->error_pos = (const char*) p;
@@ -8822,9 +9479,59 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_77: {
+  s_n_llhttp__internal__n_invoke_llhttp__on_status_complete: {
+    switch (llhttp__on_status_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_headers_start;
+      case 21:
+        goto s_n_llhttp__internal__n_pause_24;
+      default:
+        goto s_n_llhttp__internal__n_error_89;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_88: {
+    state->error = 0xd;
+    state->reason = "Invalid response status";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_27: {
+    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
+      default:
+        goto s_n_llhttp__internal__n_error_88;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_90: {
     state->error = 0x2;
     state->reason = "Expected LF after CR";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_28: {
+    switch (llhttp__internal__c_test_lenient_flags_8(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
+      default:
+        goto s_n_llhttp__internal__n_error_90;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_91: {
+    state->error = 0x19;
+    state->reason = "Missing expected CR after response line";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
@@ -8841,11 +9548,11 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_test_lenient_flags_29;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
+    goto s_n_llhttp__internal__n_invoke_test_lenient_flags_29;
     /* UNREACHABLE */;
     abort();
   }
@@ -8867,9 +9574,66 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_78: {
+  s_n_llhttp__internal__n_error_92: {
     state->error = 0xd;
     state->reason = "Invalid response status";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_mul_add_status_code_2: {
+    switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
+      case 1:
+        goto s_n_llhttp__internal__n_error_93;
+      default:
+        goto s_n_llhttp__internal__n_res_status_code_otherwise;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_94: {
+    state->error = 0xd;
+    state->reason = "Invalid status code";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_mul_add_status_code_1: {
+    switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
+      case 1:
+        goto s_n_llhttp__internal__n_error_95;
+      default:
+        goto s_n_llhttp__internal__n_res_status_code_digit_3;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_96: {
+    state->error = 0xd;
+    state->reason = "Invalid status code";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_mul_add_status_code: {
+    switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
+      case 1:
+        goto s_n_llhttp__internal__n_error_97;
+      default:
+        goto s_n_llhttp__internal__n_res_status_code_digit_2;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_98: {
+    state->error = 0xd;
+    state->reason = "Invalid status code";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
@@ -8879,12 +9643,12 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_update_status_code: {
     switch (llhttp__internal__c_update_status_code(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_res_status_code;
+        goto s_n_llhttp__internal__n_res_status_code_digit_1;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_79: {
+  s_n_llhttp__internal__n_error_99: {
     state->error = 0x9;
     state->reason = "Expected space after version";
     state->error_pos = (const char*) p;
@@ -8893,9051 +9657,16 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_21: {
+  s_n_llhttp__internal__n_pause_25: {
     state->error = 0x15;
     state->reason = "on_version_complete pause";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_res_after_version;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_74: {
-    state->error = 0x21;
-    state->reason = "`on_version_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_version_6: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_version(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_version_complete_1;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_version_complete_1;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_version_5: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_version(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_73;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_73;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor_3: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 9:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_6;
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_5;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor_4: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_6;
-      case 1:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_6;
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_5;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor_5: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_6;
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_5;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_major_1: {
-    switch (llhttp__internal__c_load_http_major(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor_3;
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor_4;
-      case 2:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor_5;
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_5;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_11: {
-    switch (llhttp__internal__c_test_lenient_flags_10(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_6;
-      default:
-        goto s_n_llhttp__internal__n_invoke_load_http_major_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_http_minor_1: {
-    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_11;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_version_7: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_version(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_80;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_80;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_version_8: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_version(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_81;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_81;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_http_major_1: {
-    switch (llhttp__internal__c_store_http_major(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_res_http_dot;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_version_9: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_version(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_82;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_82;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_86: {
-    state->error = 0x8;
-    state->reason = "Expected HTTP/";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_19: {
-    state->error = 0x15;
-    state->reason = "on_method_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_req_first_space_before_url;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_1: {
-    state->error = 0x20;
-    state->reason = "`on_method_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_method: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_method(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_method_complete;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_method_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_type: {
-    switch (llhttp__internal__c_update_type(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_method;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_method: {
-    switch (llhttp__internal__c_store_method(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_type;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_83: {
-    state->error = 0x8;
-    state->reason = "Invalid word encountered";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_method_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_method(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_update_type_1;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_invoke_update_type_1;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_type_2: {
-    switch (llhttp__internal__c_update_type(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_method_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_23: {
-    state->error = 0x15;
-    state->reason = "on_message_begin pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_load_type;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error: {
-    state->error = 0x10;
-    state->reason = "`on_message_begin` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_message_begin: {
-    switch (llhttp__on_message_begin(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_load_type;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_23;
-      default:
-        goto s_n_llhttp__internal__n_error;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_24: {
-    state->error = 0x15;
-    state->reason = "on_reset pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_update_finish;
     return s_error;
     /* UNREACHABLE */;
     abort();
   }
   s_n_llhttp__internal__n_error_87: {
-    state->error = 0x1f;
-    state->reason = "`on_reset` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_reset: {
-    switch (llhttp__on_reset(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_update_finish;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_24;
-      default:
-        goto s_n_llhttp__internal__n_error_87;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_initial_message_completed: {
-    switch (llhttp__internal__c_load_initial_message_completed(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_reset;
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_finish;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-}
-
-int llhttp__internal_execute(llhttp__internal_t* state, const char* p, const char* endp) {
-  llparse_state_t next;
-
-  /* check lingering errors */
-  if (state->error != 0) {
-    return state->error;
-  }
-
-  /* restart spans */
-  if (state->_span_pos0 != NULL) {
-    state->_span_pos0 = (void*) p;
-  }
-  
-  next = llhttp__internal__run(state, (const unsigned char*) p, (const unsigned char*) endp);
-  if (next == s_error) {
-    return state->error;
-  }
-  state->_current = (void*) (intptr_t) next;
-
-  /* execute spans */
-  if (state->_span_pos0 != NULL) {
-    int error;
-  
-    error = ((llhttp__internal__span_cb) state->_span_cb0)(state, state->_span_pos0, (const char*) endp);
-    if (error != 0) {
-      state->error = error;
-      state->error_pos = endp;
-      return error;
-    }
-  }
-  
-  return 0;
-}
-
-#else  /* !LLHTTP_STRICT_MODE */
-
-#include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
-
-#ifdef __SSE4_2__
- #ifdef _MSC_VER
-  #include <nmmintrin.h>
- #else  /* !_MSC_VER */
-  #include <x86intrin.h>
- #endif  /* _MSC_VER */
-#endif  /* __SSE4_2__ */
-
-#ifdef _MSC_VER
- #define ALIGN(n) _declspec(align(n))
-#else  /* !_MSC_VER */
- #define ALIGN(n) __attribute__((aligned(n)))
-#endif  /* _MSC_VER */
-
-#include "llhttp.h"
-
-typedef int (*llhttp__internal__span_cb)(
-             llhttp__internal_t*, const char*, const char*);
-
-#ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob0[] = {
-  0x9, 0x9, 0xc, 0xc, '!', '"', '$', '>', '@', '~', 0x80,
-  0xff, 0x0, 0x0, 0x0, 0x0
-};
-#endif  /* __SSE4_2__ */
-static const unsigned char llparse_blob1[] = {
-  'o', 'n'
-};
-static const unsigned char llparse_blob2[] = {
-  'e', 'c', 't', 'i', 'o', 'n'
-};
-static const unsigned char llparse_blob3[] = {
-  'l', 'o', 's', 'e'
-};
-static const unsigned char llparse_blob4[] = {
-  'e', 'e', 'p', '-', 'a', 'l', 'i', 'v', 'e'
-};
-static const unsigned char llparse_blob5[] = {
-  'p', 'g', 'r', 'a', 'd', 'e'
-};
-static const unsigned char llparse_blob6[] = {
-  'c', 'h', 'u', 'n', 'k', 'e', 'd'
-};
-#ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob7[] = {
-  0x9, 0x9, ' ', '~', 0x80, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0,
-  0x0, 0x0, 0x0, 0x0, 0x0
-};
-#endif  /* __SSE4_2__ */
-#ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob8[] = {
-  ' ', '!', '#', '\'', '*', '+', '-', '.', '0', '9', 'A',
-  'Z', '^', 'z', '|', '|'
-};
-#endif  /* __SSE4_2__ */
-#ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob9[] = {
-  '~', '~', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-  0x0, 0x0, 0x0, 0x0, 0x0
-};
-#endif  /* __SSE4_2__ */
-static const unsigned char llparse_blob10[] = {
-  'e', 'n', 't', '-', 'l', 'e', 'n', 'g', 't', 'h'
-};
-static const unsigned char llparse_blob11[] = {
-  'r', 'o', 'x', 'y', '-', 'c', 'o', 'n', 'n', 'e', 'c',
-  't', 'i', 'o', 'n'
-};
-static const unsigned char llparse_blob12[] = {
-  'r', 'a', 'n', 's', 'f', 'e', 'r', '-', 'e', 'n', 'c',
-  'o', 'd', 'i', 'n', 'g'
-};
-static const unsigned char llparse_blob13[] = {
-  'p', 'g', 'r', 'a', 'd', 'e'
-};
-static const unsigned char llparse_blob14[] = {
-  0xd, 0xa
-};
-static const unsigned char llparse_blob15[] = {
-  'T', 'T', 'P', '/'
-};
-static const unsigned char llparse_blob16[] = {
-  0xd, 0xa, 0xd, 0xa, 'S', 'M', 0xd, 0xa, 0xd, 0xa
-};
-static const unsigned char llparse_blob17[] = {
-  'C', 'E', '/'
-};
-static const unsigned char llparse_blob18[] = {
-  'T', 'S', 'P', '/'
-};
-static const unsigned char llparse_blob19[] = {
-  'N', 'O', 'U', 'N', 'C', 'E'
-};
-static const unsigned char llparse_blob20[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob21[] = {
-  'E', 'C', 'K', 'O', 'U', 'T'
-};
-static const unsigned char llparse_blob22[] = {
-  'N', 'E', 'C', 'T'
-};
-static const unsigned char llparse_blob23[] = {
-  'E', 'T', 'E'
-};
-static const unsigned char llparse_blob24[] = {
-  'C', 'R', 'I', 'B', 'E'
-};
-static const unsigned char llparse_blob25[] = {
-  'L', 'U', 'S', 'H'
-};
-static const unsigned char llparse_blob26[] = {
-  'E', 'T'
-};
-static const unsigned char llparse_blob27[] = {
-  'P', 'A', 'R', 'A', 'M', 'E', 'T', 'E', 'R'
-};
-static const unsigned char llparse_blob28[] = {
-  'E', 'A', 'D'
-};
-static const unsigned char llparse_blob29[] = {
-  'N', 'K'
-};
-static const unsigned char llparse_blob30[] = {
-  'C', 'K'
-};
-static const unsigned char llparse_blob31[] = {
-  'S', 'E', 'A', 'R', 'C', 'H'
-};
-static const unsigned char llparse_blob32[] = {
-  'R', 'G', 'E'
-};
-static const unsigned char llparse_blob33[] = {
-  'C', 'T', 'I', 'V', 'I', 'T', 'Y'
-};
-static const unsigned char llparse_blob34[] = {
-  'L', 'E', 'N', 'D', 'A', 'R'
-};
-static const unsigned char llparse_blob35[] = {
-  'V', 'E'
-};
-static const unsigned char llparse_blob36[] = {
-  'O', 'T', 'I', 'F', 'Y'
-};
-static const unsigned char llparse_blob37[] = {
-  'P', 'T', 'I', 'O', 'N', 'S'
-};
-static const unsigned char llparse_blob38[] = {
-  'C', 'H'
-};
-static const unsigned char llparse_blob39[] = {
-  'S', 'E'
-};
-static const unsigned char llparse_blob40[] = {
-  'A', 'Y'
-};
-static const unsigned char llparse_blob41[] = {
-  'S', 'T'
-};
-static const unsigned char llparse_blob42[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob43[] = {
-  'A', 'T', 'C', 'H'
-};
-static const unsigned char llparse_blob44[] = {
-  'G', 'E'
-};
-static const unsigned char llparse_blob45[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob46[] = {
-  'O', 'R', 'D'
-};
-static const unsigned char llparse_blob47[] = {
-  'I', 'R', 'E', 'C', 'T'
-};
-static const unsigned char llparse_blob48[] = {
-  'O', 'R', 'T'
-};
-static const unsigned char llparse_blob49[] = {
-  'R', 'C', 'H'
-};
-static const unsigned char llparse_blob50[] = {
-  'P', 'A', 'R', 'A', 'M', 'E', 'T', 'E', 'R'
-};
-static const unsigned char llparse_blob51[] = {
-  'U', 'R', 'C', 'E'
-};
-static const unsigned char llparse_blob52[] = {
-  'B', 'S', 'C', 'R', 'I', 'B', 'E'
-};
-static const unsigned char llparse_blob53[] = {
-  'A', 'R', 'D', 'O', 'W', 'N'
-};
-static const unsigned char llparse_blob54[] = {
-  'A', 'C', 'E'
-};
-static const unsigned char llparse_blob55[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob56[] = {
-  'N', 'K'
-};
-static const unsigned char llparse_blob57[] = {
-  'C', 'K'
-};
-static const unsigned char llparse_blob58[] = {
-  'U', 'B', 'S', 'C', 'R', 'I', 'B', 'E'
-};
-static const unsigned char llparse_blob59[] = {
-  'H', 'T', 'T', 'P', '/'
-};
-static const unsigned char llparse_blob60[] = {
-  'A', 'D'
-};
-static const unsigned char llparse_blob61[] = {
-  'T', 'P', '/'
-};
-
-enum llparse_match_status_e {
-  kMatchComplete,
-  kMatchPause,
-  kMatchMismatch
-};
-typedef enum llparse_match_status_e llparse_match_status_t;
-
-struct llparse_match_s {
-  llparse_match_status_t status;
-  const unsigned char* current;
-};
-typedef struct llparse_match_s llparse_match_t;
-
-static llparse_match_t llparse__match_sequence_to_lower(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp,
-    const unsigned char* seq, uint32_t seq_len) {
-  uint32_t index;
-  llparse_match_t res;
-
-  index = s->_index;
-  for (; p != endp; p++) {
-    unsigned char current;
-
-    current = ((*p) >= 'A' && (*p) <= 'Z' ? (*p | 0x20) : (*p));
-    if (current == seq[index]) {
-      if (++index == seq_len) {
-        res.status = kMatchComplete;
-        goto reset;
-      }
-    } else {
-      res.status = kMatchMismatch;
-      goto reset;
-    }
-  }
-  s->_index = index;
-  res.status = kMatchPause;
-  res.current = p;
-  return res;
-reset:
-  s->_index = 0;
-  res.current = p;
-  return res;
-}
-
-static llparse_match_t llparse__match_sequence_to_lower_unsafe(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp,
-    const unsigned char* seq, uint32_t seq_len) {
-  uint32_t index;
-  llparse_match_t res;
-
-  index = s->_index;
-  for (; p != endp; p++) {
-    unsigned char current;
-
-    current = ((*p) | 0x20);
-    if (current == seq[index]) {
-      if (++index == seq_len) {
-        res.status = kMatchComplete;
-        goto reset;
-      }
-    } else {
-      res.status = kMatchMismatch;
-      goto reset;
-    }
-  }
-  s->_index = index;
-  res.status = kMatchPause;
-  res.current = p;
-  return res;
-reset:
-  s->_index = 0;
-  res.current = p;
-  return res;
-}
-
-static llparse_match_t llparse__match_sequence_id(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp,
-    const unsigned char* seq, uint32_t seq_len) {
-  uint32_t index;
-  llparse_match_t res;
-
-  index = s->_index;
-  for (; p != endp; p++) {
-    unsigned char current;
-
-    current = *p;
-    if (current == seq[index]) {
-      if (++index == seq_len) {
-        res.status = kMatchComplete;
-        goto reset;
-      }
-    } else {
-      res.status = kMatchMismatch;
-      goto reset;
-    }
-  }
-  s->_index = index;
-  res.status = kMatchPause;
-  res.current = p;
-  return res;
-reset:
-  s->_index = 0;
-  res.current = p;
-  return res;
-}
-
-enum llparse_state_e {
-  s_error,
-  s_n_llhttp__internal__n_closed,
-  s_n_llhttp__internal__n_invoke_llhttp__after_message_complete,
-  s_n_llhttp__internal__n_pause_1,
-  s_n_llhttp__internal__n_invoke_is_equal_upgrade,
-  s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2,
-  s_n_llhttp__internal__n_chunk_data_almost_done_skip,
-  s_n_llhttp__internal__n_chunk_data_almost_done,
-  s_n_llhttp__internal__n_consume_content_length,
-  s_n_llhttp__internal__n_span_start_llhttp__on_body,
-  s_n_llhttp__internal__n_invoke_is_equal_content_length,
-  s_n_llhttp__internal__n_chunk_size_almost_done,
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete,
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1,
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete,
-  s_n_llhttp__internal__n_chunk_extension_quoted_value_done,
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1,
-  s_n_llhttp__internal__n_error_17,
-  s_n_llhttp__internal__n_chunk_extension_quoted_value,
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2,
-  s_n_llhttp__internal__n_error_19,
-  s_n_llhttp__internal__n_chunk_extension_value,
-  s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value,
-  s_n_llhttp__internal__n_error_20,
-  s_n_llhttp__internal__n_chunk_extension_name,
-  s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name,
-  s_n_llhttp__internal__n_chunk_extensions,
-  s_n_llhttp__internal__n_chunk_size_otherwise,
-  s_n_llhttp__internal__n_chunk_size,
-  s_n_llhttp__internal__n_chunk_size_digit,
-  s_n_llhttp__internal__n_invoke_update_content_length_1,
-  s_n_llhttp__internal__n_consume_content_length_1,
-  s_n_llhttp__internal__n_span_start_llhttp__on_body_1,
-  s_n_llhttp__internal__n_eof,
-  s_n_llhttp__internal__n_span_start_llhttp__on_body_2,
-  s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete,
-  s_n_llhttp__internal__n_headers_almost_done,
-  s_n_llhttp__internal__n_header_field_colon_discard_ws,
-  s_n_llhttp__internal__n_error_28,
-  s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete,
-  s_n_llhttp__internal__n_span_start_llhttp__on_header_value,
-  s_n_llhttp__internal__n_header_value_discard_lws,
-  s_n_llhttp__internal__n_header_value_discard_ws_almost_done,
-  s_n_llhttp__internal__n_header_value_lws,
-  s_n_llhttp__internal__n_header_value_almost_done,
-  s_n_llhttp__internal__n_header_value_lenient,
-  s_n_llhttp__internal__n_error_36,
-  s_n_llhttp__internal__n_header_value_otherwise,
-  s_n_llhttp__internal__n_header_value_connection_token,
-  s_n_llhttp__internal__n_header_value_connection_ws,
-  s_n_llhttp__internal__n_header_value_connection_1,
-  s_n_llhttp__internal__n_header_value_connection_2,
-  s_n_llhttp__internal__n_header_value_connection_3,
-  s_n_llhttp__internal__n_header_value_connection,
-  s_n_llhttp__internal__n_error_38,
-  s_n_llhttp__internal__n_error_39,
-  s_n_llhttp__internal__n_header_value_content_length_ws,
-  s_n_llhttp__internal__n_header_value_content_length,
-  s_n_llhttp__internal__n_error_41,
-  s_n_llhttp__internal__n_error_40,
-  s_n_llhttp__internal__n_header_value_te_token_ows,
-  s_n_llhttp__internal__n_header_value,
-  s_n_llhttp__internal__n_header_value_te_token,
-  s_n_llhttp__internal__n_header_value_te_chunked_last,
-  s_n_llhttp__internal__n_header_value_te_chunked,
-  s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1,
-  s_n_llhttp__internal__n_header_value_discard_ws,
-  s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete,
-  s_n_llhttp__internal__n_header_field_general_otherwise,
-  s_n_llhttp__internal__n_header_field_general,
-  s_n_llhttp__internal__n_header_field_colon,
-  s_n_llhttp__internal__n_header_field_3,
-  s_n_llhttp__internal__n_header_field_4,
-  s_n_llhttp__internal__n_header_field_2,
-  s_n_llhttp__internal__n_header_field_1,
-  s_n_llhttp__internal__n_header_field_5,
-  s_n_llhttp__internal__n_header_field_6,
-  s_n_llhttp__internal__n_header_field_7,
-  s_n_llhttp__internal__n_header_field,
-  s_n_llhttp__internal__n_span_start_llhttp__on_header_field,
-  s_n_llhttp__internal__n_header_field_start,
-  s_n_llhttp__internal__n_headers_start,
-  s_n_llhttp__internal__n_url_skip_to_http09,
-  s_n_llhttp__internal__n_url_skip_lf_to_http09,
-  s_n_llhttp__internal__n_req_pri_upgrade,
-  s_n_llhttp__internal__n_req_http_complete_1,
-  s_n_llhttp__internal__n_req_http_complete,
-  s_n_llhttp__internal__n_invoke_load_method_1,
-  s_n_llhttp__internal__n_invoke_llhttp__on_version_complete,
-  s_n_llhttp__internal__n_error_46,
-  s_n_llhttp__internal__n_error_51,
-  s_n_llhttp__internal__n_req_http_minor,
-  s_n_llhttp__internal__n_error_52,
-  s_n_llhttp__internal__n_req_http_dot,
-  s_n_llhttp__internal__n_error_53,
-  s_n_llhttp__internal__n_req_http_major,
-  s_n_llhttp__internal__n_span_start_llhttp__on_version,
-  s_n_llhttp__internal__n_req_http_start_1,
-  s_n_llhttp__internal__n_req_http_start_2,
-  s_n_llhttp__internal__n_req_http_start_3,
-  s_n_llhttp__internal__n_req_http_start,
-  s_n_llhttp__internal__n_url_skip_to_http,
-  s_n_llhttp__internal__n_url_fragment,
-  s_n_llhttp__internal__n_span_end_stub_query_3,
-  s_n_llhttp__internal__n_url_query,
-  s_n_llhttp__internal__n_url_query_or_fragment,
-  s_n_llhttp__internal__n_url_path,
-  s_n_llhttp__internal__n_span_start_stub_path_2,
-  s_n_llhttp__internal__n_span_start_stub_path,
-  s_n_llhttp__internal__n_span_start_stub_path_1,
-  s_n_llhttp__internal__n_url_server_with_at,
-  s_n_llhttp__internal__n_url_server,
-  s_n_llhttp__internal__n_url_schema_delim_1,
-  s_n_llhttp__internal__n_url_schema_delim,
-  s_n_llhttp__internal__n_span_end_stub_schema,
-  s_n_llhttp__internal__n_url_schema,
-  s_n_llhttp__internal__n_url_start,
-  s_n_llhttp__internal__n_span_start_llhttp__on_url_1,
-  s_n_llhttp__internal__n_span_start_llhttp__on_url,
-  s_n_llhttp__internal__n_req_spaces_before_url,
-  s_n_llhttp__internal__n_req_first_space_before_url,
-  s_n_llhttp__internal__n_invoke_llhttp__on_method_complete_1,
-  s_n_llhttp__internal__n_after_start_req_2,
-  s_n_llhttp__internal__n_after_start_req_3,
-  s_n_llhttp__internal__n_after_start_req_1,
-  s_n_llhttp__internal__n_after_start_req_4,
-  s_n_llhttp__internal__n_after_start_req_6,
-  s_n_llhttp__internal__n_after_start_req_8,
-  s_n_llhttp__internal__n_after_start_req_9,
-  s_n_llhttp__internal__n_after_start_req_7,
-  s_n_llhttp__internal__n_after_start_req_5,
-  s_n_llhttp__internal__n_after_start_req_12,
-  s_n_llhttp__internal__n_after_start_req_13,
-  s_n_llhttp__internal__n_after_start_req_11,
-  s_n_llhttp__internal__n_after_start_req_10,
-  s_n_llhttp__internal__n_after_start_req_14,
-  s_n_llhttp__internal__n_after_start_req_17,
-  s_n_llhttp__internal__n_after_start_req_16,
-  s_n_llhttp__internal__n_after_start_req_15,
-  s_n_llhttp__internal__n_after_start_req_18,
-  s_n_llhttp__internal__n_after_start_req_20,
-  s_n_llhttp__internal__n_after_start_req_21,
-  s_n_llhttp__internal__n_after_start_req_19,
-  s_n_llhttp__internal__n_after_start_req_23,
-  s_n_llhttp__internal__n_after_start_req_24,
-  s_n_llhttp__internal__n_after_start_req_26,
-  s_n_llhttp__internal__n_after_start_req_28,
-  s_n_llhttp__internal__n_after_start_req_29,
-  s_n_llhttp__internal__n_after_start_req_27,
-  s_n_llhttp__internal__n_after_start_req_25,
-  s_n_llhttp__internal__n_after_start_req_30,
-  s_n_llhttp__internal__n_after_start_req_22,
-  s_n_llhttp__internal__n_after_start_req_31,
-  s_n_llhttp__internal__n_after_start_req_32,
-  s_n_llhttp__internal__n_after_start_req_35,
-  s_n_llhttp__internal__n_after_start_req_36,
-  s_n_llhttp__internal__n_after_start_req_34,
-  s_n_llhttp__internal__n_after_start_req_37,
-  s_n_llhttp__internal__n_after_start_req_38,
-  s_n_llhttp__internal__n_after_start_req_42,
-  s_n_llhttp__internal__n_after_start_req_43,
-  s_n_llhttp__internal__n_after_start_req_41,
-  s_n_llhttp__internal__n_after_start_req_40,
-  s_n_llhttp__internal__n_after_start_req_39,
-  s_n_llhttp__internal__n_after_start_req_45,
-  s_n_llhttp__internal__n_after_start_req_44,
-  s_n_llhttp__internal__n_after_start_req_33,
-  s_n_llhttp__internal__n_after_start_req_48,
-  s_n_llhttp__internal__n_after_start_req_49,
-  s_n_llhttp__internal__n_after_start_req_50,
-  s_n_llhttp__internal__n_after_start_req_51,
-  s_n_llhttp__internal__n_after_start_req_47,
-  s_n_llhttp__internal__n_after_start_req_46,
-  s_n_llhttp__internal__n_after_start_req_54,
-  s_n_llhttp__internal__n_after_start_req_56,
-  s_n_llhttp__internal__n_after_start_req_57,
-  s_n_llhttp__internal__n_after_start_req_55,
-  s_n_llhttp__internal__n_after_start_req_53,
-  s_n_llhttp__internal__n_after_start_req_58,
-  s_n_llhttp__internal__n_after_start_req_59,
-  s_n_llhttp__internal__n_after_start_req_52,
-  s_n_llhttp__internal__n_after_start_req_61,
-  s_n_llhttp__internal__n_after_start_req_62,
-  s_n_llhttp__internal__n_after_start_req_60,
-  s_n_llhttp__internal__n_after_start_req_65,
-  s_n_llhttp__internal__n_after_start_req_67,
-  s_n_llhttp__internal__n_after_start_req_68,
-  s_n_llhttp__internal__n_after_start_req_66,
-  s_n_llhttp__internal__n_after_start_req_69,
-  s_n_llhttp__internal__n_after_start_req_64,
-  s_n_llhttp__internal__n_after_start_req_63,
-  s_n_llhttp__internal__n_after_start_req,
-  s_n_llhttp__internal__n_span_start_llhttp__on_method_1,
-  s_n_llhttp__internal__n_invoke_llhttp__on_status_complete,
-  s_n_llhttp__internal__n_res_line_almost_done,
-  s_n_llhttp__internal__n_res_status,
-  s_n_llhttp__internal__n_span_start_llhttp__on_status,
-  s_n_llhttp__internal__n_res_status_start,
-  s_n_llhttp__internal__n_res_status_code_otherwise,
-  s_n_llhttp__internal__n_res_status_code,
-  s_n_llhttp__internal__n_res_after_version,
-  s_n_llhttp__internal__n_invoke_llhttp__on_version_complete_1,
-  s_n_llhttp__internal__n_error_68,
-  s_n_llhttp__internal__n_error_74,
-  s_n_llhttp__internal__n_res_http_minor,
-  s_n_llhttp__internal__n_error_75,
-  s_n_llhttp__internal__n_res_http_dot,
-  s_n_llhttp__internal__n_error_76,
-  s_n_llhttp__internal__n_res_http_major,
-  s_n_llhttp__internal__n_span_start_llhttp__on_version_1,
-  s_n_llhttp__internal__n_start_res,
-  s_n_llhttp__internal__n_invoke_llhttp__on_method_complete,
-  s_n_llhttp__internal__n_req_or_res_method_2,
-  s_n_llhttp__internal__n_invoke_update_type_1,
-  s_n_llhttp__internal__n_req_or_res_method_3,
-  s_n_llhttp__internal__n_req_or_res_method_1,
-  s_n_llhttp__internal__n_req_or_res_method,
-  s_n_llhttp__internal__n_span_start_llhttp__on_method,
-  s_n_llhttp__internal__n_start_req_or_res,
-  s_n_llhttp__internal__n_invoke_load_type,
-  s_n_llhttp__internal__n_invoke_update_finish,
-  s_n_llhttp__internal__n_start,
-};
-typedef enum llparse_state_e llparse_state_t;
-
-int llhttp__on_method(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_url(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_version(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_header_field(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_header_value(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_body(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_chunk_extension_name(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_chunk_extension_value(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_status(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_load_initial_message_completed(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->initial_message_completed;
-}
-
-int llhttp__on_reset(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_update_finish(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->finish = 2;
-  return 0;
-}
-
-int llhttp__on_message_begin(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_load_type(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->type;
-}
-
-int llhttp__internal__c_store_method(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  state->method = match;
-  return 0;
-}
-
-int llhttp__on_method_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_is_equal_method(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->method == 5;
-}
-
-int llhttp__internal__c_update_http_major(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->http_major = 0;
-  return 0;
-}
-
-int llhttp__internal__c_update_http_minor(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->http_minor = 9;
-  return 0;
-}
-
-int llhttp__on_url_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_test_lenient_flags(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 1) == 1;
-}
-
-int llhttp__internal__c_test_flags(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->flags & 128) == 128;
-}
-
-int llhttp__on_chunk_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_message_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_is_equal_upgrade(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->upgrade == 1;
-}
-
-int llhttp__after_message_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_update_content_length(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->content_length = 0;
-  return 0;
-}
-
-int llhttp__internal__c_update_initial_message_completed(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->initial_message_completed = 1;
-  return 0;
-}
-
-int llhttp__internal__c_update_finish_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->finish = 0;
-  return 0;
-}
-
-int llhttp__internal__c_test_lenient_flags_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 4) == 4;
-}
-
-int llhttp__internal__c_test_flags_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->flags & 544) == 544;
-}
-
-int llhttp__internal__c_test_lenient_flags_2(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 2) == 2;
-}
-
-int llhttp__before_headers_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_headers_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__after_headers_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_mul_add_content_length(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  /* Multiplication overflow */
-  if (state->content_length > 0xffffffffffffffffULL / 16) {
-    return 1;
-  }
-  
-  state->content_length *= 16;
-  
-  /* Addition overflow */
-  if (match >= 0) {
-    if (state->content_length > 0xffffffffffffffffULL - match) {
-      return 1;
-    }
-  } else {
-    if (state->content_length < 0ULL - match) {
-      return 1;
-    }
-  }
-  state->content_length += match;
-  return 0;
-}
-
-int llhttp__on_chunk_header(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_is_equal_content_length(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->content_length == 0;
-}
-
-int llhttp__internal__c_or_flags(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 128;
-  return 0;
-}
-
-int llhttp__on_chunk_extension_name_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_chunk_extension_value_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_update_finish_3(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->finish = 1;
-  return 0;
-}
-
-int llhttp__internal__c_or_flags_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 64;
-  return 0;
-}
-
-int llhttp__internal__c_update_upgrade(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->upgrade = 1;
-  return 0;
-}
-
-int llhttp__internal__c_store_header_state(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  state->header_state = match;
-  return 0;
-}
-
-int llhttp__on_header_field_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_load_header_state(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->header_state;
-}
-
-int llhttp__internal__c_or_flags_3(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 1;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 1;
-  return 0;
-}
-
-int llhttp__on_header_value_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_or_flags_4(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 2;
-  return 0;
-}
-
-int llhttp__internal__c_or_flags_5(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 4;
-  return 0;
-}
-
-int llhttp__internal__c_or_flags_6(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 8;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state_3(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 6;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 0;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state_6(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 5;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state_7(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 7;
-  return 0;
-}
-
-int llhttp__internal__c_test_flags_2(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->flags & 32) == 32;
-}
-
-int llhttp__internal__c_mul_add_content_length_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  /* Multiplication overflow */
-  if (state->content_length > 0xffffffffffffffffULL / 10) {
-    return 1;
-  }
-  
-  state->content_length *= 10;
-  
-  /* Addition overflow */
-  if (match >= 0) {
-    if (state->content_length > 0xffffffffffffffffULL - match) {
-      return 1;
-    }
-  } else {
-    if (state->content_length < 0ULL - match) {
-      return 1;
-    }
-  }
-  state->content_length += match;
-  return 0;
-}
-
-int llhttp__internal__c_or_flags_15(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 32;
-  return 0;
-}
-
-int llhttp__internal__c_test_flags_3(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->flags & 8) == 8;
-}
-
-int llhttp__internal__c_test_lenient_flags_8(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 8) == 8;
-}
-
-int llhttp__internal__c_or_flags_16(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 512;
-  return 0;
-}
-
-int llhttp__internal__c_and_flags(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags &= -9;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state_8(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 8;
-  return 0;
-}
-
-int llhttp__internal__c_or_flags_18(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 16;
-  return 0;
-}
-
-int llhttp__internal__c_load_method(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->method;
-}
-
-int llhttp__internal__c_store_http_major(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  state->http_major = match;
-  return 0;
-}
-
-int llhttp__internal__c_store_http_minor(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  state->http_minor = match;
-  return 0;
-}
-
-int llhttp__internal__c_test_lenient_flags_10(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 16) == 16;
-}
-
-int llhttp__on_version_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_load_http_major(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->http_major;
-}
-
-int llhttp__internal__c_load_http_minor(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->http_minor;
-}
-
-int llhttp__internal__c_update_status_code(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->status_code = 0;
-  return 0;
-}
-
-int llhttp__internal__c_mul_add_status_code(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  /* Multiplication overflow */
-  if (state->status_code > 0xffff / 10) {
-    return 1;
-  }
-  
-  state->status_code *= 10;
-  
-  /* Addition overflow */
-  if (match >= 0) {
-    if (state->status_code > 0xffff - match) {
-      return 1;
-    }
-  } else {
-    if (state->status_code < 0 - match) {
-      return 1;
-    }
-  }
-  state->status_code += match;
-  
-  /* Enforce maximum */
-  if (state->status_code > 999) {
-    return 1;
-  }
-  return 0;
-}
-
-int llhttp__on_status_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_update_type(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->type = 1;
-  return 0;
-}
-
-int llhttp__internal__c_update_type_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->type = 2;
-  return 0;
-}
-
-int llhttp__internal_init(llhttp__internal_t* state) {
-  memset(state, 0, sizeof(*state));
-  state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_start;
-  return 0;
-}
-
-static llparse_state_t llhttp__internal__run(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  int match;
-  switch ((llparse_state_t) (intptr_t) state->_current) {
-    case s_n_llhttp__internal__n_closed:
-    s_n_llhttp__internal__n_closed: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_closed;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_closed;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__after_message_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__after_message_complete: {
-      switch (llhttp__after_message_complete(state, p, endp)) {
-        case 1:
-          goto s_n_llhttp__internal__n_invoke_update_content_length;
-        default:
-          goto s_n_llhttp__internal__n_invoke_update_finish_1;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_pause_1:
-    s_n_llhttp__internal__n_pause_1: {
-      state->error = 0x16;
-      state->reason = "Pause on CONNECT/Upgrade";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_is_equal_upgrade:
-    s_n_llhttp__internal__n_invoke_is_equal_upgrade: {
-      switch (llhttp__internal__c_is_equal_upgrade(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
-        default:
-          goto s_n_llhttp__internal__n_pause_1;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2:
-    s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2: {
-      switch (llhttp__on_message_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_invoke_is_equal_upgrade;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_11;
-        default:
-          goto s_n_llhttp__internal__n_error_24;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_data_almost_done_skip:
-    s_n_llhttp__internal__n_chunk_data_almost_done_skip: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_data_almost_done_skip;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_data_almost_done:
-    s_n_llhttp__internal__n_chunk_data_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_data_almost_done;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_chunk_data_almost_done_skip;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_consume_content_length:
-    s_n_llhttp__internal__n_consume_content_length: {
-      size_t avail;
-      uint64_t need;
-      
-      avail = endp - p;
-      need = state->content_length;
-      if (avail >= need) {
-        p += need;
-        state->content_length = 0;
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_body;
-      }
-      
-      state->content_length -= avail;
-      return s_n_llhttp__internal__n_consume_content_length;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_body:
-    s_n_llhttp__internal__n_span_start_llhttp__on_body: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_body;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_body;
-      goto s_n_llhttp__internal__n_consume_content_length;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_is_equal_content_length:
-    s_n_llhttp__internal__n_invoke_is_equal_content_length: {
-      switch (llhttp__internal__c_is_equal_content_length(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_body;
-        default:
-          goto s_n_llhttp__internal__n_invoke_or_flags;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_size_almost_done:
-    s_n_llhttp__internal__n_chunk_size_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_size_almost_done;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_header;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete: {
-      switch (llhttp__on_chunk_extension_name_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_chunk_size_almost_done;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_5;
-        default:
-          goto s_n_llhttp__internal__n_error_11;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1:
-    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1: {
-      switch (llhttp__on_chunk_extension_name_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_chunk_extensions;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_6;
-        default:
-          goto s_n_llhttp__internal__n_error_12;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete: {
-      switch (llhttp__on_chunk_extension_value_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_chunk_size_almost_done;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_7;
-        default:
-          goto s_n_llhttp__internal__n_error_14;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_extension_quoted_value_done:
-    s_n_llhttp__internal__n_chunk_extension_quoted_value_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_extension_quoted_value_done;
-      }
-      switch (*p) {
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_size_almost_done;
-        }
-        case ';': {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_extensions;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_16;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1:
-    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1: {
-      switch (llhttp__on_chunk_extension_value_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_chunk_extension_quoted_value_done;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_8;
-        default:
-          goto s_n_llhttp__internal__n_error_15;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_17:
-    s_n_llhttp__internal__n_error_17: {
-      state->error = 0x2;
-      state->reason = "Invalid character in chunk extensions quoted value";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_extension_quoted_value:
-    s_n_llhttp__internal__n_chunk_extension_quoted_value: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_extension_quoted_value;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_extension_quoted_value;
-        }
-        case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_2;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2:
-    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2: {
-      switch (llhttp__on_chunk_extension_value_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_chunk_size_otherwise;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_9;
-        default:
-          goto s_n_llhttp__internal__n_error_18;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_19:
-    s_n_llhttp__internal__n_error_19: {
-      state->error = 0x2;
-      state->reason = "Invalid character in chunk extensions value";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_extension_value:
-    s_n_llhttp__internal__n_chunk_extension_value: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 2, 3, 2, 2, 2, 2, 2, 0, 0, 2, 2, 0, 2, 2, 0,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 4, 0, 0, 0, 0,
-        0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 0, 2, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_extension_value;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value;
-        }
-        case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_extension_value;
-        }
-        case 3: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_extension_quoted_value;
-        }
-        case 4: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_4;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value:
-    s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_chunk_extension_value;
-      goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_2;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_20:
-    s_n_llhttp__internal__n_error_20: {
-      state->error = 0x2;
-      state->reason = "Invalid character in chunk extensions name";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_extension_name:
-    s_n_llhttp__internal__n_chunk_extension_name: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 2, 0, 2, 2, 2, 2, 2, 0, 0, 2, 2, 0, 2, 2, 0,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 3, 0, 4, 0, 0,
-        0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 0, 2, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_extension_name;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name;
-        }
-        case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_extension_name;
-        }
-        case 3: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_1;
-        }
-        case 4: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_2;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_3;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name:
-    s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_chunk_extension_name;
-      goto s_n_llhttp__internal__n_chunk_extension_name;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_extensions:
-    s_n_llhttp__internal__n_chunk_extensions: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_extensions;
-      }
-      switch (*p) {
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_error_9;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_error_10;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_size_otherwise:
-    s_n_llhttp__internal__n_chunk_size_otherwise: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_size_otherwise;
-      }
-      switch (*p) {
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_size_almost_done;
-        }
-        case ';': {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_extensions;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_21;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_size:
-    s_n_llhttp__internal__n_chunk_size: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_size;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'A': {
-          p++;
-          match = 10;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'B': {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'C': {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'D': {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'E': {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'F': {
-          p++;
-          match = 15;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'a': {
-          p++;
-          match = 10;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'b': {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'c': {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'd': {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'e': {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'f': {
-          p++;
-          match = 15;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_chunk_size_otherwise;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_size_digit:
-    s_n_llhttp__internal__n_chunk_size_digit: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_size_digit;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'A': {
-          p++;
-          match = 10;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'B': {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'C': {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'D': {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'E': {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'F': {
-          p++;
-          match = 15;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'a': {
-          p++;
-          match = 10;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'b': {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'c': {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'd': {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'e': {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'f': {
-          p++;
-          match = 15;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_23;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_update_content_length_1:
-    s_n_llhttp__internal__n_invoke_update_content_length_1: {
-      switch (llhttp__internal__c_update_content_length(state, p, endp)) {
-        default:
-          goto s_n_llhttp__internal__n_chunk_size_digit;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_consume_content_length_1:
-    s_n_llhttp__internal__n_consume_content_length_1: {
-      size_t avail;
-      uint64_t need;
-      
-      avail = endp - p;
-      need = state->content_length;
-      if (avail >= need) {
-        p += need;
-        state->content_length = 0;
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_body_1;
-      }
-      
-      state->content_length -= avail;
-      return s_n_llhttp__internal__n_consume_content_length_1;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_body_1:
-    s_n_llhttp__internal__n_span_start_llhttp__on_body_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_body_1;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_body;
-      goto s_n_llhttp__internal__n_consume_content_length_1;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_eof:
-    s_n_llhttp__internal__n_eof: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_eof;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_eof;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_body_2:
-    s_n_llhttp__internal__n_span_start_llhttp__on_body_2: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_body_2;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_body;
-      goto s_n_llhttp__internal__n_eof;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete: {
-      switch (llhttp__after_headers_complete(state, p, endp)) {
-        case 1:
-          goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_1;
-        case 2:
-          goto s_n_llhttp__internal__n_invoke_update_content_length_1;
-        case 3:
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_body_1;
-        case 4:
-          goto s_n_llhttp__internal__n_invoke_update_finish_3;
-        case 5:
-          goto s_n_llhttp__internal__n_error_25;
-        default:
-          goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_headers_almost_done:
-    s_n_llhttp__internal__n_headers_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_headers_almost_done;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_test_flags;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_colon_discard_ws:
-    s_n_llhttp__internal__n_header_field_colon_discard_ws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_colon_discard_ws;
-      }
-      switch (*p) {
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_colon_discard_ws;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_field_colon;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_28:
-    s_n_llhttp__internal__n_error_28: {
-      state->error = 0xa;
-      state->reason = "Invalid header field char";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete: {
-      switch (llhttp__on_header_value_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_header_field_start;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_14;
-        default:
-          goto s_n_llhttp__internal__n_error_32;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_header_value:
-    s_n_llhttp__internal__n_span_start_llhttp__on_header_value: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_header_value;
-      goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_discard_lws:
-    s_n_llhttp__internal__n_header_value_discard_lws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_discard_lws;
-      }
-      switch (*p) {
-        case 9: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_5;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_5;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_load_header_state;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_discard_ws_almost_done:
-    s_n_llhttp__internal__n_header_value_discard_ws_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_discard_ws_almost_done;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_discard_lws;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_6;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_lws:
-    s_n_llhttp__internal__n_header_value_lws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_lws;
-      }
-      switch (*p) {
-        case 9: {
-          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
-        }
-        case ' ': {
-          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_almost_done:
-    s_n_llhttp__internal__n_header_value_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_almost_done;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_lws;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_35;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_lenient:
-    s_n_llhttp__internal__n_header_value_lenient: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_lenient;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
-        }
-        default: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_lenient;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_36:
-    s_n_llhttp__internal__n_error_36: {
-      state->error = 0xa;
-      state->reason = "Invalid header value char";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_otherwise:
-    s_n_llhttp__internal__n_header_value_otherwise: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_otherwise;
-      }
-      switch (*p) {
-        case 13: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_7;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection_token:
-    s_n_llhttp__internal__n_header_value_connection_token: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection_token;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection_token;
-        }
-        case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_otherwise;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection_ws:
-    s_n_llhttp__internal__n_header_value_connection_ws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection_ws;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_header_value_otherwise;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_header_value_otherwise;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection_ws;
-        }
-        case ',': {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_load_header_state_5;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection_1:
-    s_n_llhttp__internal__n_header_value_connection_1: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection_1;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob3, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_update_header_state_3;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_value_connection_1;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_header_value_connection_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection_2:
-    s_n_llhttp__internal__n_header_value_connection_2: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection_2;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob4, 9);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_value_connection_2;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_header_value_connection_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection_3:
-    s_n_llhttp__internal__n_header_value_connection_3: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection_3;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob5, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_value_connection_3;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_header_value_connection_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection:
-    s_n_llhttp__internal__n_header_value_connection: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection;
-      }
-      switch (((*p) >= 'A' && (*p) <= 'Z' ? (*p | 0x20) : (*p))) {
-        case 9: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection;
-        }
-        case 'c': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection_1;
-        }
-        case 'k': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection_2;
-        }
-        case 'u': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_connection_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_38:
-    s_n_llhttp__internal__n_error_38: {
-      state->error = 0xb;
-      state->reason = "Content-Length overflow";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_39:
-    s_n_llhttp__internal__n_error_39: {
-      state->error = 0xb;
-      state->reason = "Invalid character in Content-Length";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_content_length_ws:
-    s_n_llhttp__internal__n_header_value_content_length_ws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_content_length_ws;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_invoke_or_flags_15;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_invoke_or_flags_15;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_content_length_ws;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_content_length:
-    s_n_llhttp__internal__n_header_value_content_length: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_content_length;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_content_length_ws;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_41:
-    s_n_llhttp__internal__n_error_41: {
-      state->error = 0xf;
-      state->reason = "Invalid `Transfer-Encoding` header value";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_40:
-    s_n_llhttp__internal__n_error_40: {
-      state->error = 0xf;
-      state->reason = "Invalid `Transfer-Encoding` header value";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_te_token_ows:
-    s_n_llhttp__internal__n_header_value_te_token_ows: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_te_token_ows;
-      }
-      switch (*p) {
-        case 9: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_token_ows;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_token_ows;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_te_chunked;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value:
-    s_n_llhttp__internal__n_header_value: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value;
-      }
-      #ifdef __SSE4_2__
-      if (endp - p >= 16) {
-        __m128i ranges;
-        __m128i input;
-        int avail;
-        int match_len;
-      
-        /* Load input */
-        input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob7);
-      
-        /* Find first character that does not match `ranges` */
-        match_len = _mm_cmpestri(ranges, 6,
-            input, 16,
-            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
-              _SIDD_NEGATIVE_POLARITY);
-      
-        if (match_len != 0) {
-          p += match_len;
-          goto s_n_llhttp__internal__n_header_value;
-        }
-        goto s_n_llhttp__internal__n_header_value_otherwise;
-      }
-      #endif  /* __SSE4_2__ */
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_otherwise;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_te_token:
-    s_n_llhttp__internal__n_header_value_te_token: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_te_token;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_token;
-        }
-        case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_token_ows;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_te_chunked_last:
-    s_n_llhttp__internal__n_header_value_te_chunked_last: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_te_chunked_last;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
-        }
-        case ',': {
-          goto s_n_llhttp__internal__n_invoke_load_type_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_te_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_te_chunked:
-    s_n_llhttp__internal__n_header_value_te_chunked: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_te_chunked;
-      }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob6, 7);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_value_te_chunked;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_header_value_te_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1:
-    s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_header_value;
-      goto s_n_llhttp__internal__n_invoke_load_header_state_2;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_discard_ws:
-    s_n_llhttp__internal__n_header_value_discard_ws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_discard_ws;
-      }
-      switch (*p) {
-        case 9: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
-        }
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_4;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws_almost_done;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete: {
-      switch (llhttp__on_header_field_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_15;
-        default:
-          goto s_n_llhttp__internal__n_error_29;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_general_otherwise:
-    s_n_llhttp__internal__n_header_field_general_otherwise: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_general_otherwise;
-      }
-      switch (*p) {
-        case ':': {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_2;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_42;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_general:
-    s_n_llhttp__internal__n_header_field_general: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0,
-        0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_general;
-      }
-      #ifdef __SSE4_2__
-      if (endp - p >= 16) {
-        __m128i ranges;
-        __m128i input;
-        int avail;
-        int match_len;
-      
-        /* Load input */
-        input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob8);
-      
-        /* Find first character that does not match `ranges` */
-        match_len = _mm_cmpestri(ranges, 16,
-            input, 16,
-            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
-              _SIDD_NEGATIVE_POLARITY);
-      
-        if (match_len != 0) {
-          p += match_len;
-          goto s_n_llhttp__internal__n_header_field_general;
-        }
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob9);
-      
-        /* Find first character that does not match `ranges` */
-        match_len = _mm_cmpestri(ranges, 2,
-            input, 16,
-            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
-              _SIDD_NEGATIVE_POLARITY);
-      
-        if (match_len != 0) {
-          p += match_len;
-          goto s_n_llhttp__internal__n_header_field_general;
-        }
-        goto s_n_llhttp__internal__n_header_field_general_otherwise;
-      }
-      #endif  /* __SSE4_2__ */
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_general;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_field_general_otherwise;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_colon:
-    s_n_llhttp__internal__n_header_field_colon: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_colon;
-      }
-      switch (*p) {
-        case ' ': {
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_3;
-        }
-        case ':': {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_3:
-    s_n_llhttp__internal__n_header_field_3: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_3;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob2, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_header_state;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_3;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_4:
-    s_n_llhttp__internal__n_header_field_4: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_4;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob10, 10);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_header_state;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_4;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_2:
-    s_n_llhttp__internal__n_header_field_2: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_2;
-      }
-      switch (((*p) >= 'A' && (*p) <= 'Z' ? (*p | 0x20) : (*p))) {
-        case 'n': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_3;
-        }
-        case 't': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_4;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_1:
-    s_n_llhttp__internal__n_header_field_1: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_1;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob1, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_2;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_1;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_5:
-    s_n_llhttp__internal__n_header_field_5: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_5;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob11, 15);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_header_state;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_5;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_6:
-    s_n_llhttp__internal__n_header_field_6: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_6;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob12, 16);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_header_state;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_6;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_7:
-    s_n_llhttp__internal__n_header_field_7: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_7;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob13, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_header_state;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_7;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field:
-    s_n_llhttp__internal__n_header_field: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field;
-      }
-      switch (((*p) >= 'A' && (*p) <= 'Z' ? (*p | 0x20) : (*p))) {
-        case 'c': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_1;
-        }
-        case 'p': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_5;
-        }
-        case 't': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_6;
-        }
-        case 'u': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_7;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_header_field:
-    s_n_llhttp__internal__n_span_start_llhttp__on_header_field: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_header_field;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_header_field;
-      goto s_n_llhttp__internal__n_header_field;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_start:
-    s_n_llhttp__internal__n_header_field_start: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_start;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_headers_almost_done;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_headers_almost_done;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_field;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_headers_start:
-    s_n_llhttp__internal__n_headers_start: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_headers_start;
-      }
-      switch (*p) {
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_field_start;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_skip_to_http09:
-    s_n_llhttp__internal__n_url_skip_to_http09: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_skip_to_http09;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_update_http_major;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_skip_lf_to_http09:
-    s_n_llhttp__internal__n_url_skip_lf_to_http09: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob14, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_update_http_major;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_url_skip_lf_to_http09;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_pri_upgrade:
-    s_n_llhttp__internal__n_req_pri_upgrade: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_pri_upgrade;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob16, 10);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_error_49;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_pri_upgrade;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_50;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_complete_1:
-    s_n_llhttp__internal__n_req_http_complete_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_complete_1;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_headers_start;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_48;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_complete:
-    s_n_llhttp__internal__n_req_http_complete: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_complete;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_headers_start;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_complete_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_48;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_load_method_1:
-    s_n_llhttp__internal__n_invoke_load_method_1: {
-      switch (llhttp__internal__c_load_method(state, p, endp)) {
-        case 34:
-          goto s_n_llhttp__internal__n_req_pri_upgrade;
-        default:
-          goto s_n_llhttp__internal__n_req_http_complete;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_version_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_version_complete: {
-      switch (llhttp__on_version_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_invoke_load_method_1;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_17;
-        default:
-          goto s_n_llhttp__internal__n_error_47;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_46:
-    s_n_llhttp__internal__n_error_46: {
-      state->error = 0x9;
-      state->reason = "Invalid HTTP version";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_51:
-    s_n_llhttp__internal__n_error_51: {
-      state->error = 0x9;
-      state->reason = "Invalid minor version";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_minor:
-    s_n_llhttp__internal__n_req_http_minor: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_minor;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_2;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_52:
-    s_n_llhttp__internal__n_error_52: {
-      state->error = 0x9;
-      state->reason = "Expected dot";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_dot:
-    s_n_llhttp__internal__n_req_http_dot: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_dot;
-      }
-      switch (*p) {
-        case '.': {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_minor;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_3;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_53:
-    s_n_llhttp__internal__n_error_53: {
-      state->error = 0x9;
-      state->reason = "Invalid major version";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_major:
-    s_n_llhttp__internal__n_req_http_major: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_major;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_4;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_version:
-    s_n_llhttp__internal__n_span_start_llhttp__on_version: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_version;
-      goto s_n_llhttp__internal__n_req_http_major;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_start_1:
-    s_n_llhttp__internal__n_req_http_start_1: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_start_1;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob15, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_load_method;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_http_start_1;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_56;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_start_2:
-    s_n_llhttp__internal__n_req_http_start_2: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_start_2;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob17, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_load_method_2;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_http_start_2;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_56;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_start_3:
-    s_n_llhttp__internal__n_req_http_start_3: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_start_3;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_load_method_3;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_http_start_3;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_56;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_start:
-    s_n_llhttp__internal__n_req_http_start: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_start;
-      }
-      switch (*p) {
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_start;
-        }
-        case 'H': {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_start_1;
-        }
-        case 'I': {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_start_2;
-        }
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_start_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_56;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_skip_to_http:
-    s_n_llhttp__internal__n_url_skip_to_http: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_skip_to_http;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_llhttp__on_url_complete_1;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_fragment:
-    s_n_llhttp__internal__n_url_fragment: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 3, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_fragment;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_url_fragment;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_6;
-        }
-        case 3: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_7;
-        }
-        case 4: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_8;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_57;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_end_stub_query_3:
-    s_n_llhttp__internal__n_span_end_stub_query_3: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_end_stub_query_3;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_url_fragment;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_query:
-    s_n_llhttp__internal__n_url_query: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 3, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        4, 1, 1, 5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_query;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_url_query;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_9;
-        }
-        case 3: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_10;
-        }
-        case 4: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_11;
-        }
-        case 5: {
-          goto s_n_llhttp__internal__n_span_end_stub_query_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_query_or_fragment:
-    s_n_llhttp__internal__n_url_query_or_fragment: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_query_or_fragment;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_3;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_4;
-        }
-        case ' ': {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_5;
-        }
-        case '#': {
-          p++;
-          goto s_n_llhttp__internal__n_url_fragment;
-        }
-        case '?': {
-          p++;
-          goto s_n_llhttp__internal__n_url_query;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_59;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_path:
-    s_n_llhttp__internal__n_url_path: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_path;
-      }
-      #ifdef __SSE4_2__
-      if (endp - p >= 16) {
-        __m128i ranges;
-        __m128i input;
-        int avail;
-        int match_len;
-      
-        /* Load input */
-        input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob0);
-      
-        /* Find first character that does not match `ranges` */
-        match_len = _mm_cmpestri(ranges, 12,
-            input, 16,
-            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
-              _SIDD_NEGATIVE_POLARITY);
-      
-        if (match_len != 0) {
-          p += match_len;
-          goto s_n_llhttp__internal__n_url_path;
-        }
-        goto s_n_llhttp__internal__n_url_query_or_fragment;
-      }
-      #endif  /* __SSE4_2__ */
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_url_path;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_url_query_or_fragment;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_stub_path_2:
-    s_n_llhttp__internal__n_span_start_stub_path_2: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_stub_path_2;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_url_path;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_stub_path:
-    s_n_llhttp__internal__n_span_start_stub_path: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_stub_path;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_url_path;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_stub_path_1:
-    s_n_llhttp__internal__n_span_start_stub_path_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_stub_path_1;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_url_path;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_server_with_at:
-    s_n_llhttp__internal__n_url_server_with_at: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        3, 4, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 6,
-        7, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 4,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 4, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_server_with_at;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_12;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_13;
-        }
-        case 3: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_14;
-        }
-        case 4: {
-          p++;
-          goto s_n_llhttp__internal__n_url_server;
-        }
-        case 5: {
-          goto s_n_llhttp__internal__n_span_start_stub_path_1;
-        }
-        case 6: {
-          p++;
-          goto s_n_llhttp__internal__n_url_query;
-        }
-        case 7: {
-          p++;
-          goto s_n_llhttp__internal__n_error_60;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_61;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_server:
-    s_n_llhttp__internal__n_url_server: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        3, 4, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 6,
-        7, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 4,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 4, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_server;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_1;
-        }
-        case 3: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_2;
-        }
-        case 4: {
-          p++;
-          goto s_n_llhttp__internal__n_url_server;
-        }
-        case 5: {
-          goto s_n_llhttp__internal__n_span_start_stub_path;
-        }
-        case 6: {
-          p++;
-          goto s_n_llhttp__internal__n_url_query;
-        }
-        case 7: {
-          p++;
-          goto s_n_llhttp__internal__n_url_server_with_at;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_schema_delim_1:
-    s_n_llhttp__internal__n_url_schema_delim_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_schema_delim_1;
-      }
-      switch (*p) {
-        case '/': {
-          p++;
-          goto s_n_llhttp__internal__n_url_server;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_64;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_schema_delim:
-    s_n_llhttp__internal__n_url_schema_delim: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_schema_delim;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_error_63;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_error_63;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_error_63;
-        }
-        case '/': {
-          p++;
-          goto s_n_llhttp__internal__n_url_schema_delim_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_64;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_end_stub_schema:
-    s_n_llhttp__internal__n_span_end_stub_schema: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_end_stub_schema;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_url_schema_delim;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_schema:
-    s_n_llhttp__internal__n_url_schema: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
-        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
-        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_schema;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_error_63;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_end_stub_schema;
-        }
-        case 3: {
-          p++;
-          goto s_n_llhttp__internal__n_url_schema;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_65;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_start:
-    s_n_llhttp__internal__n_url_start: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
-        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_start;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_error_63;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_start_stub_path_2;
-        }
-        case 3: {
-          goto s_n_llhttp__internal__n_url_schema;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_66;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_url_1:
-    s_n_llhttp__internal__n_span_start_llhttp__on_url_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_url_1;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_url;
-      goto s_n_llhttp__internal__n_url_start;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_url:
-    s_n_llhttp__internal__n_span_start_llhttp__on_url: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_url;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_url;
-      goto s_n_llhttp__internal__n_url_server;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_spaces_before_url:
-    s_n_llhttp__internal__n_req_spaces_before_url: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_spaces_before_url;
-      }
-      switch (*p) {
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_req_spaces_before_url;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_is_equal_method;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_first_space_before_url:
-    s_n_llhttp__internal__n_req_first_space_before_url: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_first_space_before_url;
-      }
-      switch (*p) {
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_req_spaces_before_url;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_67;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_method_complete_1:
-    s_n_llhttp__internal__n_invoke_llhttp__on_method_complete_1: {
-      switch (llhttp__on_method_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_req_first_space_before_url;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_22;
-        default:
-          goto s_n_llhttp__internal__n_error_78;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_2:
-    s_n_llhttp__internal__n_after_start_req_2: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_2;
-      }
-      switch (*p) {
-        case 'L': {
-          p++;
-          match = 19;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_3:
-    s_n_llhttp__internal__n_after_start_req_3: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_3;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 36;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_3;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_1:
-    s_n_llhttp__internal__n_after_start_req_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_1;
-      }
-      switch (*p) {
-        case 'C': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_2;
-        }
-        case 'N': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_4:
-    s_n_llhttp__internal__n_after_start_req_4: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_4;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 16;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_4;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_6:
-    s_n_llhttp__internal__n_after_start_req_6: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_6;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 22;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_6;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_8:
-    s_n_llhttp__internal__n_after_start_req_8: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_8;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_8;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_9:
-    s_n_llhttp__internal__n_after_start_req_9: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_9;
-      }
-      switch (*p) {
-        case 'Y': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_7:
-    s_n_llhttp__internal__n_after_start_req_7: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_7;
-      }
-      switch (*p) {
-        case 'N': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_8;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_9;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_5:
-    s_n_llhttp__internal__n_after_start_req_5: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_5;
-      }
-      switch (*p) {
-        case 'H': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_6;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_7;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_12:
-    s_n_llhttp__internal__n_after_start_req_12: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_12;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_12;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_13:
-    s_n_llhttp__internal__n_after_start_req_13: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_13;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 5);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 35;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_13;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_11:
-    s_n_llhttp__internal__n_after_start_req_11: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_11;
-      }
-      switch (*p) {
-        case 'L': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_12;
-        }
-        case 'S': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_13;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_10:
-    s_n_llhttp__internal__n_after_start_req_10: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_10;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_11;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_14:
-    s_n_llhttp__internal__n_after_start_req_14: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_14;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 45;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_14;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_17:
-    s_n_llhttp__internal__n_after_start_req_17: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_17;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 9);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 41;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_17;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_16:
-    s_n_llhttp__internal__n_after_start_req_16: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_16;
-      }
-      switch (*p) {
-        case '_': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_17;
-        }
-        default: {
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_15:
-    s_n_llhttp__internal__n_after_start_req_15: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_15;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_16;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_15;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_18:
-    s_n_llhttp__internal__n_after_start_req_18: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_18;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_18;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_20:
-    s_n_llhttp__internal__n_after_start_req_20: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_20;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 31;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_20;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_21:
-    s_n_llhttp__internal__n_after_start_req_21: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_21;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_21;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_19:
-    s_n_llhttp__internal__n_after_start_req_19: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_19;
-      }
-      switch (*p) {
-        case 'I': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_20;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_21;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_23:
-    s_n_llhttp__internal__n_after_start_req_23: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_23;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 24;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_23;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_24:
-    s_n_llhttp__internal__n_after_start_req_24: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_24;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 23;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_24;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_26:
-    s_n_llhttp__internal__n_after_start_req_26: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_26;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 7);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 21;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_26;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_28:
-    s_n_llhttp__internal__n_after_start_req_28: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_28;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 30;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_28;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_29:
-    s_n_llhttp__internal__n_after_start_req_29: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_29;
-      }
-      switch (*p) {
-        case 'L': {
-          p++;
-          match = 10;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_27:
-    s_n_llhttp__internal__n_after_start_req_27: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_27;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_28;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_29;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_25:
-    s_n_llhttp__internal__n_after_start_req_25: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_25;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_26;
-        }
-        case 'C': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_27;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_30:
-    s_n_llhttp__internal__n_after_start_req_30: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_30;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_30;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_22:
-    s_n_llhttp__internal__n_after_start_req_22: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_22;
-      }
-      switch (*p) {
-        case '-': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_23;
-        }
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_24;
-        }
-        case 'K': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_25;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_30;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_31:
-    s_n_llhttp__internal__n_after_start_req_31: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_31;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 5);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 25;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_31;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_32:
-    s_n_llhttp__internal__n_after_start_req_32: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_32;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_32;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_35:
-    s_n_llhttp__internal__n_after_start_req_35: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_35;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 28;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_35;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_36:
-    s_n_llhttp__internal__n_after_start_req_36: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_36;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 39;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_36;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_34:
-    s_n_llhttp__internal__n_after_start_req_34: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_34;
-      }
-      switch (*p) {
-        case 'T': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_35;
-        }
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_36;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_37:
-    s_n_llhttp__internal__n_after_start_req_37: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_37;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 38;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_37;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_38:
-    s_n_llhttp__internal__n_after_start_req_38: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_38;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_38;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_42:
-    s_n_llhttp__internal__n_after_start_req_42: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_42;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob42, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_42;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_43:
-    s_n_llhttp__internal__n_after_start_req_43: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_43;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob43, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_43;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_41:
-    s_n_llhttp__internal__n_after_start_req_41: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_41;
-      }
-      switch (*p) {
-        case 'F': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_42;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_43;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_40:
-    s_n_llhttp__internal__n_after_start_req_40: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_40;
-      }
-      switch (*p) {
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_41;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_39:
-    s_n_llhttp__internal__n_after_start_req_39: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_39;
-      }
-      switch (*p) {
-        case 'I': {
-          p++;
-          match = 34;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_40;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_45:
-    s_n_llhttp__internal__n_after_start_req_45: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_45;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 29;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_45;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_44:
-    s_n_llhttp__internal__n_after_start_req_44: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_44;
-      }
-      switch (*p) {
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_45;
-        }
-        case 'T': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_33:
-    s_n_llhttp__internal__n_after_start_req_33: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_33;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_34;
-        }
-        case 'L': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_37;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_38;
-        }
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_39;
-        }
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_44;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_48:
-    s_n_llhttp__internal__n_after_start_req_48: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_48;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 17;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_48;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_49:
-    s_n_llhttp__internal__n_after_start_req_49: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_49;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 44;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_49;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_50:
-    s_n_llhttp__internal__n_after_start_req_50: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_50;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 5);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 43;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_50;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_51:
-    s_n_llhttp__internal__n_after_start_req_51: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_51;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob48, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 20;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_51;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_47:
-    s_n_llhttp__internal__n_after_start_req_47: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_47;
-      }
-      switch (*p) {
-        case 'B': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_48;
-        }
-        case 'C': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_49;
-        }
-        case 'D': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_50;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_51;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_46:
-    s_n_llhttp__internal__n_after_start_req_46: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_46;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_47;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_54:
-    s_n_llhttp__internal__n_after_start_req_54: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_54;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob49, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_54;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_56:
-    s_n_llhttp__internal__n_after_start_req_56: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_56;
-      }
-      switch (*p) {
-        case 'P': {
-          p++;
-          match = 37;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_57:
-    s_n_llhttp__internal__n_after_start_req_57: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_57;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob50, 9);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 42;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_57;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_55:
-    s_n_llhttp__internal__n_after_start_req_55: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_55;
-      }
-      switch (*p) {
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_56;
-        }
-        case '_': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_57;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_53:
-    s_n_llhttp__internal__n_after_start_req_53: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_53;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_54;
-        }
-        case 'T': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_55;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_58:
-    s_n_llhttp__internal__n_after_start_req_58: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_58;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob51, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 33;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_58;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_59:
-    s_n_llhttp__internal__n_after_start_req_59: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_59;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob52, 7);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 26;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_59;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_52:
-    s_n_llhttp__internal__n_after_start_req_52: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_52;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_53;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_58;
-        }
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_59;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_61:
-    s_n_llhttp__internal__n_after_start_req_61: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_61;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob53, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 40;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_61;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_62:
-    s_n_llhttp__internal__n_after_start_req_62: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_62;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob54, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_62;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_60:
-    s_n_llhttp__internal__n_after_start_req_60: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_60;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_61;
-        }
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_62;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_65:
-    s_n_llhttp__internal__n_after_start_req_65: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_65;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob55, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 18;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_65;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_67:
-    s_n_llhttp__internal__n_after_start_req_67: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_67;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob56, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 32;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_67;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_68:
-    s_n_llhttp__internal__n_after_start_req_68: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_68;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob57, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 15;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_68;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_66:
-    s_n_llhttp__internal__n_after_start_req_66: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_66;
-      }
-      switch (*p) {
-        case 'I': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_67;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_68;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_69:
-    s_n_llhttp__internal__n_after_start_req_69: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_69;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob58, 8);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 27;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_after_start_req_69;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_64:
-    s_n_llhttp__internal__n_after_start_req_64: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_64;
-      }
-      switch (*p) {
-        case 'B': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_65;
-        }
-        case 'L': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_66;
-        }
-        case 'S': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_69;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req_63:
-    s_n_llhttp__internal__n_after_start_req_63: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req_63;
-      }
-      switch (*p) {
-        case 'N': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_64;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_after_start_req:
-    s_n_llhttp__internal__n_after_start_req: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_after_start_req;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_1;
-        }
-        case 'B': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_4;
-        }
-        case 'C': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_5;
-        }
-        case 'D': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_10;
-        }
-        case 'F': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_14;
-        }
-        case 'G': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_15;
-        }
-        case 'H': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_18;
-        }
-        case 'L': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_19;
-        }
-        case 'M': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_22;
-        }
-        case 'N': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_31;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_32;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_33;
-        }
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_46;
-        }
-        case 'S': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_52;
-        }
-        case 'T': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_60;
-        }
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_after_start_req_63;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_79;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_method_1:
-    s_n_llhttp__internal__n_span_start_llhttp__on_method_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_method_1;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_method;
-      goto s_n_llhttp__internal__n_after_start_req;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_status_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_status_complete: {
-      switch (llhttp__on_status_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_headers_start;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_20;
-        default:
-          goto s_n_llhttp__internal__n_error_71;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_line_almost_done:
-    s_n_llhttp__internal__n_res_line_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_line_almost_done;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_status:
-    s_n_llhttp__internal__n_res_status: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_status;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_status;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_status_1;
-        }
-        default: {
-          p++;
-          goto s_n_llhttp__internal__n_res_status;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_status:
-    s_n_llhttp__internal__n_span_start_llhttp__on_status: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_status;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_status;
-      goto s_n_llhttp__internal__n_res_status;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_status_start:
-    s_n_llhttp__internal__n_res_status_start: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_status_start;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_res_line_almost_done;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_status;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_status_code_otherwise:
-    s_n_llhttp__internal__n_res_status_code_otherwise: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_status_code_otherwise;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_res_status_start;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_res_status_start;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_res_status_start;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_72;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_status_code:
-    s_n_llhttp__internal__n_res_status_code: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_status_code;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_res_status_code_otherwise;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_after_version:
-    s_n_llhttp__internal__n_res_after_version: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_after_version;
-      }
-      switch (*p) {
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_update_status_code;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_73;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_version_complete_1:
-    s_n_llhttp__internal__n_invoke_llhttp__on_version_complete_1: {
-      switch (llhttp__on_version_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_res_after_version;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_21;
-        default:
-          goto s_n_llhttp__internal__n_error_69;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_68:
-    s_n_llhttp__internal__n_error_68: {
-      state->error = 0x9;
-      state->reason = "Invalid HTTP version";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_74:
-    s_n_llhttp__internal__n_error_74: {
-      state->error = 0x9;
-      state->reason = "Invalid minor version";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_http_minor:
-    s_n_llhttp__internal__n_res_http_minor: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_http_minor;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_7;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_75:
-    s_n_llhttp__internal__n_error_75: {
-      state->error = 0x9;
-      state->reason = "Expected dot";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_http_dot:
-    s_n_llhttp__internal__n_res_http_dot: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_http_dot;
-      }
-      switch (*p) {
-        case '.': {
-          p++;
-          goto s_n_llhttp__internal__n_res_http_minor;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_8;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_76:
-    s_n_llhttp__internal__n_error_76: {
-      state->error = 0x9;
-      state->reason = "Invalid major version";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_http_major:
-    s_n_llhttp__internal__n_res_http_major: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_http_major;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_9;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_version_1:
-    s_n_llhttp__internal__n_span_start_llhttp__on_version_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_version_1;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_version;
-      goto s_n_llhttp__internal__n_res_http_major;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_res:
-    s_n_llhttp__internal__n_start_res: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_res;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob59, 5);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_version_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_res;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_80;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_method_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_method_complete: {
-      switch (llhttp__on_method_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_req_first_space_before_url;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_19;
-        default:
-          goto s_n_llhttp__internal__n_error_1;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_or_res_method_2:
-    s_n_llhttp__internal__n_req_or_res_method_2: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_or_res_method_2;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob60, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_method;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_or_res_method_2;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_77;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_update_type_1:
-    s_n_llhttp__internal__n_invoke_update_type_1: {
-      switch (llhttp__internal__c_update_type_1(state, p, endp)) {
-        default:
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_version_1;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_or_res_method_3:
-    s_n_llhttp__internal__n_req_or_res_method_3: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_or_res_method_3;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob61, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_or_res_method_3;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_77;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_or_res_method_1:
-    s_n_llhttp__internal__n_req_or_res_method_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_or_res_method_1;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_req_or_res_method_2;
-        }
-        case 'T': {
-          p++;
-          goto s_n_llhttp__internal__n_req_or_res_method_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_77;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_or_res_method:
-    s_n_llhttp__internal__n_req_or_res_method: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_or_res_method;
-      }
-      switch (*p) {
-        case 'H': {
-          p++;
-          goto s_n_llhttp__internal__n_req_or_res_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_77;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_method:
-    s_n_llhttp__internal__n_span_start_llhttp__on_method: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_method;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_method;
-      goto s_n_llhttp__internal__n_req_or_res_method;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_or_res:
-    s_n_llhttp__internal__n_start_req_or_res: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_or_res;
-      }
-      switch (*p) {
-        case 'H': {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_method;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_type_2;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_load_type:
-    s_n_llhttp__internal__n_invoke_load_type: {
-      switch (llhttp__internal__c_load_type(state, p, endp)) {
-        case 1:
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_method_1;
-        case 2:
-          goto s_n_llhttp__internal__n_start_res;
-        default:
-          goto s_n_llhttp__internal__n_start_req_or_res;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_update_finish:
-    s_n_llhttp__internal__n_invoke_update_finish: {
-      switch (llhttp__internal__c_update_finish(state, p, endp)) {
-        default:
-          goto s_n_llhttp__internal__n_invoke_llhttp__on_message_begin;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start:
-    s_n_llhttp__internal__n_start: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_start;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_start;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_load_initial_message_completed;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    default:
-      /* UNREACHABLE */
-      abort();
-  }
-  s_n_llhttp__internal__n_error_63: {
-    state->error = 0x7;
-    state->reason = "Invalid characters in url";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_finish_2: {
-    switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_start;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_initial_message_completed: {
-    switch (llhttp__internal__c_update_initial_message_completed(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_finish_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_content_length: {
-    switch (llhttp__internal__c_update_content_length(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_initial_message_completed;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_1: {
-    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_update_initial_message_completed;
-      default:
-        goto s_n_llhttp__internal__n_closed;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_finish_1: {
-    switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_11: {
-    state->error = 0x15;
-    state->reason = "on_message_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_is_equal_upgrade;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_24: {
-    state->error = 0x12;
-    state->reason = "`on_message_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_13: {
-    state->error = 0x15;
-    state->reason = "on_chunk_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_27: {
-    state->error = 0x14;
-    state->reason = "`on_chunk_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete_1: {
-    switch (llhttp__on_chunk_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_13;
-      default:
-        goto s_n_llhttp__internal__n_error_27;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_26: {
-    state->error = 0x4;
-    state->reason = "Content-Length can't be present with Transfer-Encoding";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_2: {
-    state->error = 0x15;
-    state->reason = "on_message_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_pause_1;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_6: {
-    state->error = 0x12;
-    state->reason = "`on_message_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_1: {
-    switch (llhttp__on_message_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_pause_1;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_2;
-      default:
-        goto s_n_llhttp__internal__n_error_6;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_22: {
-    state->error = 0xc;
-    state->reason = "Chunk size overflow";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_3: {
-    state->error = 0x15;
-    state->reason = "on_chunk_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_update_content_length_1;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_8: {
-    state->error = 0x14;
-    state->reason = "`on_chunk_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete: {
-    switch (llhttp__on_chunk_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_update_content_length_1;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_3;
-      default:
-        goto s_n_llhttp__internal__n_error_8;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_body: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_body(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_data_almost_done;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_chunk_data_almost_done;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags: {
-    switch (llhttp__internal__c_or_flags(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_field_start;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_4: {
-    state->error = 0x15;
-    state->reason = "on_chunk_header pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_is_equal_content_length;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_7: {
-    state->error = 0x13;
-    state->reason = "`on_chunk_header` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_header: {
-    switch (llhttp__on_chunk_header(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_is_equal_content_length;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_4;
-      default:
-        goto s_n_llhttp__internal__n_error_7;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_9: {
-    state->error = 0x2;
-    state->reason = "Invalid character in chunk extensions";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_10: {
-    state->error = 0x2;
-    state->reason = "Invalid character in chunk extensions";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_5: {
-    state->error = 0x15;
-    state->reason = "on_chunk_extension_name pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_almost_done;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_11: {
-    state->error = 0x22;
-    state->reason = "`on_chunk_extension_name` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_chunk_extension_name(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_6: {
-    state->error = 0x15;
-    state->reason = "on_chunk_extension_name pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_extensions;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_12: {
-    state->error = 0x22;
-    state->reason = "`on_chunk_extension_name` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_chunk_extension_name(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_7: {
-    state->error = 0x15;
-    state->reason = "on_chunk_extension_value pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_almost_done;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_14: {
-    state->error = 0x23;
-    state->reason = "`on_chunk_extension_value` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_chunk_extension_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_16: {
-    state->error = 0x2;
-    state->reason = "Invalid character in chunk extensions quote value";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_8: {
-    state->error = 0x15;
-    state->reason = "on_chunk_extension_value pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_extension_quoted_value_done;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_15: {
-    state->error = 0x23;
-    state->reason = "`on_chunk_extension_value` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_chunk_extension_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_2: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_chunk_extension_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_17;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_error_17;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_9: {
-    state->error = 0x15;
-    state->reason = "on_chunk_extension_value pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_otherwise;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_18: {
-    state->error = 0x23;
-    state->reason = "`on_chunk_extension_value` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_3: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_chunk_extension_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_4: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_chunk_extension_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_19;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_error_19;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_10: {
-    state->error = 0x15;
-    state->reason = "on_chunk_extension_name pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_extension_value;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_13: {
-    state->error = 0x22;
-    state->reason = "`on_chunk_extension_name` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_2: {
-    switch (llhttp__on_chunk_extension_name_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_chunk_extension_value;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_10;
-      default:
-        goto s_n_llhttp__internal__n_error_13;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_2: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_chunk_extension_name(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_3: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_chunk_extension_name(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_20;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_error_20;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_21: {
-    state->error = 0xc;
-    state->reason = "Invalid character in chunk size";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_mul_add_content_length: {
-    switch (llhttp__internal__c_mul_add_content_length(state, p, endp, match)) {
-      case 1:
-        goto s_n_llhttp__internal__n_error_22;
-      default:
-        goto s_n_llhttp__internal__n_chunk_size;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_23: {
-    state->error = 0xc;
-    state->reason = "Invalid character in chunk size";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_body_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_body(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_finish_3: {
-    switch (llhttp__internal__c_update_finish_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_body_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_25: {
-    state->error = 0xf;
-    state->reason = "Request has invalid `Transfer-Encoding`";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause: {
-    state->error = 0x15;
-    state->reason = "on_message_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_5: {
-    state->error = 0x12;
-    state->reason = "`on_message_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_message_complete: {
-    switch (llhttp__on_message_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
-      case 21:
-        goto s_n_llhttp__internal__n_pause;
-      default:
-        goto s_n_llhttp__internal__n_error_5;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_1: {
-    switch (llhttp__internal__c_or_flags_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_2: {
-    switch (llhttp__internal__c_or_flags_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_upgrade: {
-    switch (llhttp__internal__c_update_upgrade(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_or_flags_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_12: {
-    state->error = 0x15;
-    state->reason = "Paused by on_headers_complete";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_4: {
-    state->error = 0x11;
-    state->reason = "User callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_headers_complete: {
-    switch (llhttp__on_headers_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_or_flags_1;
-      case 2:
-        goto s_n_llhttp__internal__n_invoke_update_upgrade;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_12;
-      default:
-        goto s_n_llhttp__internal__n_error_4;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete: {
-    switch (llhttp__before_headers_complete(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_2: {
-    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_error_26;
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags_1: {
-    switch (llhttp__internal__c_test_flags_1(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_2;
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags: {
-    switch (llhttp__internal__c_test_flags(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete_1;
-      default:
-        goto s_n_llhttp__internal__n_invoke_test_flags_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_field: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_field(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_28;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_error_28;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_3: {
-    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_header_field_colon_discard_ws;
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_31: {
-    state->error = 0xa;
-    state->reason = "Invalid header value char";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_5: {
-    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_header_value_discard_ws;
-      default:
-        goto s_n_llhttp__internal__n_error_31;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_33: {
-    state->error = 0xb;
-    state->reason = "Empty Content-Length";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_14: {
-    state->error = 0x15;
-    state->reason = "on_header_value_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_field_start;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_32: {
-    state->error = 0x1d;
-    state->reason = "`on_header_value_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state: {
-    switch (llhttp__internal__c_update_header_state(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_3: {
-    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_4: {
-    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_5: {
-    switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_6: {
-    switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state_1: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 5:
-        goto s_n_llhttp__internal__n_invoke_or_flags_3;
-      case 6:
-        goto s_n_llhttp__internal__n_invoke_or_flags_4;
-      case 7:
-        goto s_n_llhttp__internal__n_invoke_or_flags_5;
-      case 8:
-        goto s_n_llhttp__internal__n_invoke_or_flags_6;
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 2:
-        goto s_n_llhttp__internal__n_error_33;
-      default:
-        goto s_n_llhttp__internal__n_invoke_load_header_state_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_30: {
-    state->error = 0xa;
-    state->reason = "Invalid header value char";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_4: {
-    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_header_value_discard_lws;
-      default:
-        goto s_n_llhttp__internal__n_error_30;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_34: {
-    state->error = 0x2;
-    state->reason = "Expected LF after CR";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_6: {
-    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_header_value_discard_lws;
-      default:
-        goto s_n_llhttp__internal__n_error_34;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_1: {
-    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state_3: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 8:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_2: {
-    switch (llhttp__internal__c_update_header_state(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_7: {
-    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_8: {
-    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_9: {
-    switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_10: {
-    switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state_4: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 5:
-        goto s_n_llhttp__internal__n_invoke_or_flags_7;
-      case 6:
-        goto s_n_llhttp__internal__n_invoke_or_flags_8;
-      case 7:
-        goto s_n_llhttp__internal__n_invoke_or_flags_9;
-      case 8:
-        goto s_n_llhttp__internal__n_invoke_or_flags_10;
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_35: {
-    state->error = 0x3;
-    state->reason = "Missing expected LF after header value";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_header_value_almost_done;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_header_value_almost_done;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_header_value_almost_done;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_36;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_36;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_7: {
-    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_header_value_lenient;
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_4: {
-    switch (llhttp__internal__c_update_header_state(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_11: {
-    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_12: {
-    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_13: {
-    switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_14: {
-    switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state_5: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 5:
-        goto s_n_llhttp__internal__n_invoke_or_flags_11;
-      case 6:
-        goto s_n_llhttp__internal__n_invoke_or_flags_12;
-      case 7:
-        goto s_n_llhttp__internal__n_invoke_or_flags_13;
-      case 8:
-        goto s_n_llhttp__internal__n_invoke_or_flags_14;
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_5: {
-    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection_token;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_3: {
-    switch (llhttp__internal__c_update_header_state_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection_ws;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_6: {
-    switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection_ws;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_7: {
-    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection_ws;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_38;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_38;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_mul_add_content_length_1: {
-    switch (llhttp__internal__c_mul_add_content_length_1(state, p, endp, match)) {
-      case 1:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
-      default:
-        goto s_n_llhttp__internal__n_header_value_content_length;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_15: {
-    switch (llhttp__internal__c_or_flags_15(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_otherwise;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_39;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_39;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_37: {
-    state->error = 0x4;
-    state->reason = "Duplicate Content-Length";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags_2: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_header_value_content_length;
-      default:
-        goto s_n_llhttp__internal__n_error_37;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_41;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_error_41;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_8: {
-    switch (llhttp__internal__c_update_header_state_8(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_otherwise;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_40;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_error_40;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_8: {
-    switch (llhttp__internal__c_test_lenient_flags_8(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7;
-      default:
-        goto s_n_llhttp__internal__n_header_value_te_chunked;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_type_1: {
-    switch (llhttp__internal__c_load_type(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_8;
-      default:
-        goto s_n_llhttp__internal__n_header_value_te_chunked;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_9: {
-    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_and_flags: {
-    switch (llhttp__internal__c_and_flags(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_te_chunked;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_17: {
-    switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_and_flags;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_9: {
-    switch (llhttp__internal__c_test_lenient_flags_8(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8;
-      default:
-        goto s_n_llhttp__internal__n_invoke_or_flags_17;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_type_2: {
-    switch (llhttp__internal__c_load_type(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_9;
-      default:
-        goto s_n_llhttp__internal__n_invoke_or_flags_17;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_16: {
-    switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_and_flags;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags_3: {
-    switch (llhttp__internal__c_test_flags_3(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_load_type_2;
-      default:
-        goto s_n_llhttp__internal__n_invoke_or_flags_16;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_18: {
-    switch (llhttp__internal__c_or_flags_18(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_9;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state_2: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_header_value_connection;
-      case 2:
-        goto s_n_llhttp__internal__n_invoke_test_flags_2;
-      case 3:
-        goto s_n_llhttp__internal__n_invoke_test_flags_3;
-      case 4:
-        goto s_n_llhttp__internal__n_invoke_or_flags_18;
-      default:
-        goto s_n_llhttp__internal__n_header_value;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_15: {
-    state->error = 0x15;
-    state->reason = "on_header_field_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_discard_ws;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_29: {
-    state->error = 0x1c;
-    state->reason = "`on_header_field_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_field(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_field_2: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_field(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_42: {
-    state->error = 0xa;
-    state->reason = "Invalid header token";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_10: {
-    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_field_general;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_header_state: {
-    switch (llhttp__internal__c_store_header_state(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_header_field_colon;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_11: {
-    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_field_general;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_3: {
-    state->error = 0x1e;
-    state->reason = "Unexpected space after start line";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags: {
-    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_header_field_start;
-      default:
-        goto s_n_llhttp__internal__n_error_3;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_16: {
-    state->error = 0x15;
-    state->reason = "on_url_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_headers_start;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_2: {
-    state->error = 0x1a;
-    state->reason = "`on_url_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_url_complete: {
-    switch (llhttp__on_url_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_headers_start;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_16;
-      default:
-        goto s_n_llhttp__internal__n_error_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_http_minor: {
-    switch (llhttp__internal__c_update_http_minor(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_url_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_http_major: {
-    switch (llhttp__internal__c_update_http_major(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_http_minor;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_3: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_43: {
-    state->error = 0x7;
-    state->reason = "Expected CRLF";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_4: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_49: {
-    state->error = 0x17;
-    state->reason = "Pause on PRI/Upgrade";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_50: {
-    state->error = 0x9;
-    state->reason = "Expected HTTP/2 Connection Preface";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_48: {
-    state->error = 0x9;
-    state->reason = "Expected CRLF after version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_17: {
-    state->error = 0x15;
-    state->reason = "on_version_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_load_method_1;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_47: {
-    state->error = 0x21;
-    state->reason = "`on_version_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_version_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_version(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_version_complete;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_version_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_version: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_version(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_46;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_46;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 9:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_1;
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor_1: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_1;
-      case 1:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_1;
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor_2: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_1;
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_major: {
-    switch (llhttp__internal__c_load_http_major(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor;
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor_1;
-      case 2:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor_2;
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_10: {
-    switch (llhttp__internal__c_test_lenient_flags_10(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_1;
-      default:
-        goto s_n_llhttp__internal__n_invoke_load_http_major;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_http_minor: {
-    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_10;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_version_2: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_version(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_51;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_51;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_version_3: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_version(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_52;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_52;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_http_major: {
-    switch (llhttp__internal__c_store_http_major(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_req_http_dot;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_version_4: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_version(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_53;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_53;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_45: {
-    state->error = 0x8;
-    state->reason = "Invalid method for HTTP/x.x request";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_method: {
-    switch (llhttp__internal__c_load_method(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 1:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 2:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 3:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 4:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 5:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 6:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 7:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 8:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 9:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 10:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 11:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 12:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 13:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 14:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 15:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 16:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 17:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 18:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 19:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 20:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 21:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 22:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 23:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 24:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 25:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 26:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 27:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 28:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 29:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 30:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 31:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 32:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 33:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 34:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      default:
-        goto s_n_llhttp__internal__n_error_45;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_56: {
-    state->error = 0x8;
-    state->reason = "Expected HTTP/";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_54: {
-    state->error = 0x8;
-    state->reason = "Expected SOURCE method for ICE/x.x request";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_method_2: {
-    switch (llhttp__internal__c_load_method(state, p, endp)) {
-      case 33:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      default:
-        goto s_n_llhttp__internal__n_error_54;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_55: {
-    state->error = 0x8;
-    state->reason = "Invalid method for RTSP/x.x request";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_method_3: {
-    switch (llhttp__internal__c_load_method(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 3:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 6:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 35:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 36:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 37:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 38:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 39:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 40:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 41:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 42:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 43:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 44:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      case 45:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
-      default:
-        goto s_n_llhttp__internal__n_error_55;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_18: {
-    state->error = 0x15;
-    state->reason = "on_url_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_req_http_start;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_44: {
-    state->error = 0x1a;
-    state->reason = "`on_url_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_url_complete_1: {
-    switch (llhttp__on_url_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_req_http_start;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_18;
-      default:
-        goto s_n_llhttp__internal__n_error_44;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_5: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_6: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_7: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_8: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_57: {
-    state->error = 0x7;
-    state->reason = "Invalid char in url fragment start";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_9: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_10: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_11: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_58: {
-    state->error = 0x7;
-    state->reason = "Invalid char in url query";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_59: {
-    state->error = 0x7;
-    state->reason = "Invalid char in url path";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_2: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_12: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_13: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_14: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_60: {
-    state->error = 0x7;
-    state->reason = "Double @ in url";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_61: {
-    state->error = 0x7;
-    state->reason = "Unexpected char in url server";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_62: {
-    state->error = 0x7;
-    state->reason = "Unexpected char in url server";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_64: {
-    state->error = 0x7;
-    state->reason = "Unexpected char in url schema";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_65: {
-    state->error = 0x7;
-    state->reason = "Unexpected char in url schema";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_66: {
-    state->error = 0x7;
-    state->reason = "Unexpected start char in url";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_is_equal_method: {
-    switch (llhttp__internal__c_is_equal_method(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_url_1;
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_url;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_67: {
-    state->error = 0x6;
-    state->reason = "Expected space after method";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_22: {
-    state->error = 0x15;
-    state->reason = "on_method_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_req_first_space_before_url;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_78: {
-    state->error = 0x20;
-    state->reason = "`on_method_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_method_2: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_method(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_method_complete_1;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_method_complete_1;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_method_1: {
-    switch (llhttp__internal__c_store_method(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_method_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_79: {
-    state->error = 0x6;
-    state->reason = "Invalid method encountered";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_70: {
-    state->error = 0xd;
-    state->reason = "Response overflow";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_mul_add_status_code: {
-    switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
-      case 1:
-        goto s_n_llhttp__internal__n_error_70;
-      default:
-        goto s_n_llhttp__internal__n_res_status_code;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_20: {
-    state->error = 0x15;
-    state->reason = "on_status_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_headers_start;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_71: {
-    state->error = 0x1b;
-    state->reason = "`on_status_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_status: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_status(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_status_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_status(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_res_line_almost_done;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_res_line_almost_done;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_72: {
-    state->error = 0xd;
-    state->reason = "Invalid response status";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_status_code: {
-    switch (llhttp__internal__c_update_status_code(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_res_status_code;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_73: {
-    state->error = 0x9;
-    state->reason = "Expected space after version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_21: {
-    state->error = 0x15;
-    state->reason = "on_version_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_res_after_version;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_69: {
     state->error = 0x21;
     state->reason = "`on_version_complete` callback error";
     state->error_pos = (const char*) p;
@@ -17973,10 +9702,10 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_68;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_86;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_68;
+    goto s_n_llhttp__internal__n_error_86;
     /* UNREACHABLE */;
     abort();
   }
@@ -18026,8 +9755,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_11: {
-    switch (llhttp__internal__c_test_lenient_flags_10(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_26: {
+    switch (llhttp__internal__c_test_lenient_flags_23(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_span_end_llhttp__on_version_6;
       default:
@@ -18039,7 +9768,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_store_http_minor_1: {
     switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_11;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_26;
     }
     /* UNREACHABLE */;
     abort();
@@ -18054,10 +9783,10 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_74;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_100;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_74;
+    goto s_n_llhttp__internal__n_error_100;
     /* UNREACHABLE */;
     abort();
   }
@@ -18071,10 +9800,10 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_75;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_101;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_75;
+    goto s_n_llhttp__internal__n_error_101;
     /* UNREACHABLE */;
     abort();
   }
@@ -18096,14 +9825,14 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_76;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_102;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_76;
+    goto s_n_llhttp__internal__n_error_102;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_80: {
+  s_n_llhttp__internal__n_error_106: {
     state->error = 0x8;
     state->reason = "Expected HTTP/";
     state->error_pos = (const char*) p;
@@ -18112,7 +9841,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_19: {
+  s_n_llhttp__internal__n_pause_23: {
     state->error = 0x15;
     state->reason = "on_method_complete pause";
     state->error_pos = (const char*) p;
@@ -18163,7 +9892,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_77: {
+  s_n_llhttp__internal__n_error_103: {
     state->error = 0x8;
     state->reason = "Invalid word encountered";
     state->error_pos = (const char*) p;
@@ -18197,7 +9926,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_23: {
+  s_n_llhttp__internal__n_pause_27: {
     state->error = 0x15;
     state->reason = "on_message_begin pause";
     state->error_pos = (const char*) p;
@@ -18220,14 +9949,14 @@ static llparse_state_t llhttp__internal__run(
       case 0:
         goto s_n_llhttp__internal__n_invoke_load_type;
       case 21:
-        goto s_n_llhttp__internal__n_pause_23;
+        goto s_n_llhttp__internal__n_pause_27;
       default:
         goto s_n_llhttp__internal__n_error;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_24: {
+  s_n_llhttp__internal__n_pause_28: {
     state->error = 0x15;
     state->reason = "on_reset pause";
     state->error_pos = (const char*) p;
@@ -18236,7 +9965,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_81: {
+  s_n_llhttp__internal__n_error_107: {
     state->error = 0x1f;
     state->reason = "`on_reset` callback error";
     state->error_pos = (const char*) p;
@@ -18250,9 +9979,9 @@ static llparse_state_t llhttp__internal__run(
       case 0:
         goto s_n_llhttp__internal__n_invoke_update_finish;
       case 21:
-        goto s_n_llhttp__internal__n_pause_24;
+        goto s_n_llhttp__internal__n_pause_28;
       default:
-        goto s_n_llhttp__internal__n_error_81;
+        goto s_n_llhttp__internal__n_error_107;
     }
     /* UNREACHABLE */;
     abort();
@@ -18302,5 +10031,3 @@ int llhttp__internal_execute(llhttp__internal_t* state, const char* p, const cha
   
   return 0;
 }
-
-#endif  /* LLHTTP_STRICT_MODE */

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -984,10 +984,23 @@ added:
  - v10.19.0
 -->
 
-Use an insecure HTTP parser that accepts invalid HTTP headers. This may allow
-interoperability with non-conformant HTTP implementations. It may also allow
-request smuggling and other HTTP attacks that rely on invalid headers being
-accepted. Avoid using this option.
+Enable leniency flags on the HTTP parser. This may allow
+interoperability with non-conformant HTTP implementations.
+
+When enabled, the parser will accept the following:
+
+* Invalid HTTP headers values.
+* Invalid HTTP versions.
+* Allow message containing both `Transfer-Encoding`
+  and `Content-Length` headers.
+* Allow extra data after message when `Connection: close` is present.
+* Allow extra trasfer encodings after `chunked` has been provided.
+* Allow `\n` to be used as token separator instead of `\r\n`.
+* Allow `\r\n` not to be provided after a chunk.
+* Allow spaces to be present after a chunk size and before `\r\n`.
+
+All the above will expose your application to request smuggling
+or poisoning attack. Avoid using this option.
 
 ### `--jitless`
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3449,9 +3449,9 @@ changes:
     `readableHighWaterMark` and `writableHighWaterMark`. This affects
     `highWaterMark` property of both `IncomingMessage` and `ServerResponse`.
     **Default:** See [`stream.getDefaultHighWaterMark()`][].
-  * `insecureHTTPParser` {boolean} Use an insecure HTTP parser that accepts
-    invalid HTTP headers when `true`. Using the insecure parser should be
-    avoided. See [`--insecure-http-parser`][] for more information.
+  * `insecureHTTPParser` {boolean} If set to `true`, it will use a HTTP parser
+    with leniency flags enabled. Using the insecure parser should be avoided.
+    See [`--insecure-http-parser`][] for more information.
     **Default:** `false`.
   * `IncomingMessage` {http.IncomingMessage} Specifies the `IncomingMessage`
     class to be used. Useful for extending the original `IncomingMessage`.
@@ -3742,9 +3742,9 @@ changes:
     request to. **Default:** `'localhost'`.
   * `hostname` {string} Alias for `host`. To support [`url.parse()`][],
     `hostname` will be used if both `host` and `hostname` are specified.
-  * `insecureHTTPParser` {boolean} Use an insecure HTTP parser that accepts
-    invalid HTTP headers when `true`. Using the insecure parser should be
-    avoided. See [`--insecure-http-parser`][] for more information.
+  * `insecureHTTPParser` {boolean} If set to `true`, it will use a HTTP parser
+    with leniency flags enabled. Using the insecure parser should be avoided.
+    See [`--insecure-http-parser`][] for more information.
     **Default:** `false`
   * `joinDuplicateHeaders` {boolean} It joins the field line values of
     multiple headers in a request with `, ` instead of discarding

--- a/doc/contributing/maintaining/maintaining-dependencies.md
+++ b/doc/contributing/maintaining/maintaining-dependencies.md
@@ -19,7 +19,7 @@ This a list of all the dependencies:
 * [histogram 0.11.8][]
 * [icu-small 73.2][]
 * [libuv 1.46.0][]
-* [llhttp 8.1.0][]
+* [llhttp 9.1.2][]
 * [minimatch 9.0.3][]
 * [nghttp2 1.55.1][]
 * [nghttp3 0.7.0][]
@@ -212,7 +212,7 @@ The [libuv](https://github.com/libuv/libuv) dependency is a
 multi-platform support library with a focus on asynchronous I/O.
 It was primarily developed for use by Node.js.
 
-### llhttp 8.1.0
+### llhttp 9.1.2
 
 The [llhttp](https://github.com/nodejs/llhttp) dependency is
 the http parser used by Node.js.
@@ -330,7 +330,7 @@ performance improvements not currently available in standard zlib.
 [histogram 0.11.8]: #histogram-0118
 [icu-small 73.2]: #icu-small-732
 [libuv 1.46.0]: #libuv-1460
-[llhttp 8.1.0]: #llhttp-810
+[llhttp 9.1.2]: #llhttp-912
 [maintaining-V8]: ./maintaining-V8.md
 [maintaining-cjs-module-lexer]: ./maintaining-cjs-module-lexer.md
 [maintaining-http]: ./maintaining-http.md

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -91,11 +91,11 @@ const uint32_t kLenientOptionalLFAfterCR = 1 << 6;
 const uint32_t kLenientOptionalCRLFAfterChunk = 1 << 7;
 const uint32_t kLenientOptionalCRBeforeLF = 1 << 8;
 const uint32_t kLenientSpacesAfterChunkSize = 1 << 9;
-const uint32_t kLenientAll = kLenientHeaders | kLenientChunkedLength |
-  kLenientKeepAlive | kLenientTransferEncoding | kLenientVersion |
-  kLenientDataAfterClose | kLenientOptionalLFAfterCR |
-  kLenientOptionalCRLFAfterChunk | kLenientOptionalCRBeforeLF |
-  kLenientSpacesAfterChunkSize;
+const uint32_t kLenientAll =
+    kLenientHeaders | kLenientChunkedLength | kLenientKeepAlive |
+    kLenientTransferEncoding | kLenientVersion | kLenientDataAfterClose |
+    kLenientOptionalLFAfterCR | kLenientOptionalCRLFAfterChunk |
+    kLenientOptionalCRBeforeLF | kLenientSpacesAfterChunkSize;
 
 inline bool IsOWS(char c) {
   return c == ' ' || c == '\t';
@@ -1274,20 +1274,15 @@ void InitializeHttpParser(Local<Object> target,
   t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientDataAfterClose"),
          Integer::NewFromUnsigned(env->isolate(), kLenientDataAfterClose));
   t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientOptionalLFAfterCR"),
-         Integer::NewFromUnsigned(env->isolate(),
-                kLenientOptionalLFAfterCR));
-  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(),
-         "kLenientOptionalCRLFAfterChunk"),
-         Integer::NewFromUnsigned(env->isolate(),
-                kLenientOptionalCRLFAfterChunk));
-  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(),
-         "kLenientOptionalCRBeforeLF"),
-         Integer::NewFromUnsigned(env->isolate(),
-                kLenientOptionalCRBeforeLF));
-  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(),
-         "kLenientSpacesAfterChunkSize"),
-         Integer::NewFromUnsigned(env->isolate(),
-                kLenientSpacesAfterChunkSize));
+         Integer::NewFromUnsigned(env->isolate(), kLenientOptionalLFAfterCR));
+  t->Set(
+      FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientOptionalCRLFAfterChunk"),
+      Integer::NewFromUnsigned(env->isolate(), kLenientOptionalCRLFAfterChunk));
+  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientOptionalCRBeforeLF"),
+         Integer::NewFromUnsigned(env->isolate(), kLenientOptionalCRBeforeLF));
+  t->Set(
+      FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientSpacesAfterChunkSize"),
+      Integer::NewFromUnsigned(env->isolate(), kLenientSpacesAfterChunkSize));
 
   t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientAll"),
          Integer::NewFromUnsigned(env->isolate(), kLenientAll));

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -84,8 +84,18 @@ const uint32_t kLenientNone = 0;
 const uint32_t kLenientHeaders = 1 << 0;
 const uint32_t kLenientChunkedLength = 1 << 1;
 const uint32_t kLenientKeepAlive = 1 << 2;
+const uint32_t kLenientTransferEncoding = 1 << 3;
+const uint32_t kLenientVersion = 1 << 4;
+const uint32_t kLenientDataAfterClose = 1 << 5;
+const uint32_t kLenientOptionalLFAfterCR = 1 << 6;
+const uint32_t kLenientOptionalCRLFAfterChunk = 1 << 7;
+const uint32_t kLenientOptionalCRBeforeLF = 1 << 8;
+const uint32_t kLenientSpacesAfterChunkSize = 1 << 9;
 const uint32_t kLenientAll = kLenientHeaders | kLenientChunkedLength |
-  kLenientKeepAlive;
+  kLenientKeepAlive | kLenientTransferEncoding | kLenientVersion |
+  kLenientDataAfterClose | kLenientOptionalLFAfterCR |
+  kLenientOptionalCRLFAfterChunk | kLenientOptionalCRBeforeLF |
+  kLenientSpacesAfterChunkSize;
 
 inline bool IsOWS(char c) {
   return c == ' ' || c == '\t';
@@ -930,6 +940,27 @@ class Parser : public AsyncWrap, public StreamListener {
     if (lenient_flags & kLenientKeepAlive) {
       llhttp_set_lenient_keep_alive(&parser_, 1);
     }
+    if (lenient_flags & kLenientTransferEncoding) {
+      llhttp_set_lenient_transfer_encoding(&parser_, 1);
+    }
+    if (lenient_flags & kLenientVersion) {
+      llhttp_set_lenient_version(&parser_, 1);
+    }
+    if (lenient_flags & kLenientDataAfterClose) {
+      llhttp_set_lenient_data_after_close(&parser_, 1);
+    }
+    if (lenient_flags & kLenientOptionalLFAfterCR) {
+      llhttp_set_lenient_optional_lf_after_cr(&parser_, 1);
+    }
+    if (lenient_flags & kLenientOptionalCRLFAfterChunk) {
+      llhttp_set_lenient_optional_crlf_after_chunk(&parser_, 1);
+    }
+    if (lenient_flags & kLenientOptionalCRBeforeLF) {
+      llhttp_set_lenient_optional_cr_before_lf(&parser_, 1);
+    }
+    if (lenient_flags & kLenientSpacesAfterChunkSize) {
+      llhttp_set_lenient_spaces_after_chunk_size(&parser_, 1);
+    }
 
     header_nread_ = 0;
     url_.Reset();
@@ -1236,6 +1267,28 @@ void InitializeHttpParser(Local<Object> target,
          Integer::NewFromUnsigned(env->isolate(), kLenientChunkedLength));
   t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientKeepAlive"),
          Integer::NewFromUnsigned(env->isolate(), kLenientKeepAlive));
+  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientTransferEncoding"),
+         Integer::NewFromUnsigned(env->isolate(), kLenientTransferEncoding));
+  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientVersion"),
+         Integer::NewFromUnsigned(env->isolate(), kLenientVersion));
+  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientDataAfterClose"),
+         Integer::NewFromUnsigned(env->isolate(), kLenientDataAfterClose));
+  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientOptionalLFAfterCR"),
+         Integer::NewFromUnsigned(env->isolate(),
+                kLenientOptionalLFAfterCR));
+  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(),
+         "kLenientOptionalCRLFAfterChunk"),
+         Integer::NewFromUnsigned(env->isolate(),
+                kLenientOptionalCRLFAfterChunk));
+  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(),
+         "kLenientOptionalCRBeforeLF"),
+         Integer::NewFromUnsigned(env->isolate(),
+                kLenientOptionalCRBeforeLF));
+  t->Set(FIXED_ONE_BYTE_STRING(env->isolate(),
+         "kLenientSpacesAfterChunkSize"),
+         Integer::NewFromUnsigned(env->isolate(),
+                kLenientSpacesAfterChunkSize));
+
   t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kLenientAll"),
          Integer::NewFromUnsigned(env->isolate(), kLenientAll));
 

--- a/test/parallel/test-http-client-error-rawbytes.js
+++ b/test/parallel/test-http-client-error-rawbytes.js
@@ -19,11 +19,11 @@ server.listen(0, common.mustCall(() => {
   const req = http.get(`http://localhost:${server.address().port}/`);
   req.end();
   req.on('error', common.mustCall((err) => {
-    const reason = 'Content-Length can\'t be present with Transfer-Encoding';
+    const reason = "Transfer-Encoding can't be present with Content-Length";
     assert.strictEqual(err.message, `Parse Error: ${reason}`);
     assert(err.bytesParsed < response.length);
     assert(err.bytesParsed >= response.indexOf('Transfer-Encoding'));
-    assert.strictEqual(err.code, 'HPE_UNEXPECTED_CONTENT_LENGTH');
+    assert.strictEqual(err.code, 'HPE_INVALID_TRANSFER_ENCODING');
     assert.strictEqual(err.reason, reason);
     assert.deepStrictEqual(err.rawPacket, response);
 

--- a/test/parallel/test-http-client-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-client-reject-chunked-with-content-length.js
@@ -20,7 +20,7 @@ server.listen(0, () => {
   const req = http.get({ port: server.address().port }, common.mustNotCall());
   req.on('error', common.mustCall((err) => {
     assert.match(err.message, /^Parse Error/);
-    assert.strictEqual(err.code, 'HPE_UNEXPECTED_CONTENT_LENGTH');
+    assert.strictEqual(err.code, 'HPE_INVALID_TRANSFER_ENCODING');
     server.close();
   }));
 });

--- a/test/parallel/test-http-dummy-characters-smuggling.js
+++ b/test/parallel/test-http-dummy-characters-smuggling.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const net = require('net');
+const assert = require('assert');
+
+// Verify that arbitrary characters after a \r cannot be used to perform HTTP request smuggling attacks.
+
+{
+  const server = http.createServer(common.mustNotCall());
+
+  server.listen(0, common.mustCall(() => {
+    const client = net.connect(server.address().port);
+    let response = '';
+
+    client.on('data', common.mustCall((chunk) => {
+      response += chunk;
+    }));
+
+    client.setEncoding('utf8');
+    client.on('error', common.mustNotCall());
+    client.on('end', common.mustCall(() => {
+      assert.strictEqual(
+        response,
+        'HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'
+      );
+      server.close();
+    }));
+
+    client.write('' +
+      'GET / HTTP/1.1\r\n' +
+      'Connection: close\r\n' +
+      'Host: a\r\n\rZ\r\n' + // Note the Z at the end of the line instead of a \n
+      'GET /evil: HTTP/1.1\r\n' +
+      'Host: a\r\n\r\n'
+    );
+
+    client.resume();
+  }));
+}
+
+{
+  const server = http.createServer((request, response) => {
+    // Since chunk parsing failed, none of this should be called
+
+    request.on('data', common.mustNotCall());
+    request.on('end', common.mustNotCall());
+  });
+
+  server.listen(0, common.mustCall(() => {
+    const client = net.connect(server.address().port);
+    let response = '';
+
+    client.on('data', common.mustCall((chunk) => {
+      response += chunk;
+    }));
+
+    client.setEncoding('utf8');
+    client.on('error', common.mustNotCall());
+    client.on('end', common.mustCall(() => {
+      assert.strictEqual(
+        response,
+        'HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'
+      );
+      server.close();
+    }));
+
+    client.write('' +
+      'GET / HTTP/1.1\r\n' +
+      'Host: a\r\n' +
+      'Connection: close \r\n' +
+      'Transfer-Encoding: chunked \r\n' +
+      '\r\n' +
+      '5\r\r;ABCD\r\n' + // Note the second \r instead of \n after the chunk length
+      '34\r\n' +
+      'E\r\n' +
+      '0\r\n' +
+      '\r\n' +
+      'GET / HTTP/1.1 \r\n' +
+      'Host: a\r\n' +
+      'Content-Length: 5\r\n' +
+      '\r\n' +
+      '0\r\n' +
+      '\r\n'
+    );
+
+    client.resume();
+  }));
+}

--- a/test/parallel/test-http-invalid-te.js
+++ b/test/parallel/test-http-invalid-te.js
@@ -27,7 +27,7 @@ I AM A SMUGGLED REQUEST!!!
 const server = http.createServer(common.mustNotCall());
 
 server.on('clientError', common.mustCall((err) => {
-  assert.strictEqual(err.code, 'HPE_UNEXPECTED_CONTENT_LENGTH');
+  assert.strictEqual(err.code, 'HPE_INVALID_TRANSFER_ENCODING');
   server.close();
 }));
 

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -8,10 +8,10 @@ const assert = require('assert');
 const Countdown = require('../common/countdown');
 
 // Response splitting example, credit: Amit Klein, Safebreach
-const str = '/welcome?lang=bar%c4%8d%c4%8aContent­Length:%200%c4%8d%c4%8a%c' +
-            '4%8d%c4%8aHTTP/1.1%20200%20OK%c4%8d%c4%8aContent­Length:%202' +
-            '0%c4%8d%c4%8aLast­Modified:%20Mon,%2027%20Oct%202003%2014:50:18' +
-            '%20GMT%c4%8d%c4%8aContent­Type:%20text/html%c4%8d%c4%8a%c4%8' +
+const str = '/welcome?lang=bar%c4%8d%c4%8aContent-Length:%200%c4%8d%c4%8a%c' +
+            '4%8d%c4%8aHTTP/1.1%20200%20OK%c4%8d%c4%8aContent-Length:%202' +
+            '0%c4%8d%c4%8aLast-Modified:%20Mon,%2027%20Oct%202003%2014:50:18' +
+            '%20GMT%c4%8d%c4%8aContent-Type:%20text/html%c4%8d%c4%8a%c4%8' +
             'd%c4%8a%3chtml%3eGotcha!%3c/html%3e';
 
 // Response splitting example, credit: Сковорода Никита Андреевич (@ChALkeR)

--- a/test/parallel/test-http-server-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-server-reject-chunked-with-content-length.js
@@ -12,7 +12,7 @@ const reqstr = 'POST / HTTP/1.1\r\n' +
 const server = http.createServer(common.mustNotCall());
 server.on('clientError', common.mustCall((err) => {
   assert.match(err.message, /^Parse Error/);
-  assert.strictEqual(err.code, 'HPE_UNEXPECTED_CONTENT_LENGTH');
+  assert.strictEqual(err.code, 'HPE_INVALID_TRANSFER_ENCODING');
   server.close();
 }));
 server.listen(0, () => {

--- a/test/parallel/test-https-foafssl.js
+++ b/test/parallel/test-https-foafssl.js
@@ -81,7 +81,7 @@ server.listen(0, function() {
     console.log('server.close() called');
   });
 
-  client.stdin.write('GET /\n\n');
+  client.stdin.write('GET /\r\n\r\n');
 
   client.on('error', function(error) {
     throw error;

--- a/test/parallel/test-stream-destroy.js
+++ b/test/parallel/test-stream-destroy.js
@@ -62,11 +62,11 @@ const http = require('http');
 
   server.listen(0, () => {
     const req = http.request({
+      method: 'POST',
       port: server.address().port,
       agent: new http.Agent()
     });
 
-    req.write('asd');
     req.on('response', (res) => {
       const buf = [];
       res.on('data', (data) => buf.push(data));
@@ -78,6 +78,8 @@ const http = require('http');
         server.close();
       }));
     });
+
+    req.end('asd');
   });
 }
 
@@ -97,11 +99,10 @@ const http = require('http');
 
   server.listen(0, () => {
     const req = http.request({
+      method: 'POST',
       port: server.address().port,
       agent: new http.Agent()
     });
-
-    req.write('asd');
     req.on('response', (res) => {
       const buf = [];
       res.on('data', (data) => buf.push(data));
@@ -113,5 +114,7 @@ const http = require('http');
         server.close();
       }));
     });
+
+    req.end('asd');
   });
 }


### PR DESCRIPTION
This PR updates llhttp to version 9.1.2, which drops strict mode in favor of specific leniency flags.