### PR TITLE
vm: store MicrotaskQueue in ContextifyContext directly

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -30,7 +30,6 @@ const {
 
 const {
   ContextifyScript,
-  MicrotaskQueue,
   makeContext,
   constants,
   measureMemory: _measureMemory,
@@ -238,9 +237,7 @@ function createContext(contextObject = {}, options = kEmptyObject) {
   validateOneOf(microtaskMode,
                 'options.microtaskMode',
                 ['afterEvaluate', undefined]);
-  const microtaskQueue = microtaskMode === 'afterEvaluate' ?
-    new MicrotaskQueue() :
-    null;
+  const microtaskQueue = (microtaskMode === 'afterEvaluate');
 
   makeContext(contextObject, name, origin, strings, wasm, microtaskQueue);
   return contextObject;

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -361,7 +361,7 @@ void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {
   Local<Module> module = obj->module_.Get(isolate);
 
   ContextifyContext* contextify_context = obj->contextify_context_;
-  std::shared_ptr<MicrotaskQueue> microtask_queue;
+  MicrotaskQueue* microtask_queue = nullptr;
   if (contextify_context != nullptr)
       microtask_queue = contextify_context->microtask_queue();
 

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -12,34 +12,12 @@ class ExternalReferenceRegistry;
 
 namespace contextify {
 
-class MicrotaskQueueWrap : public BaseObject {
- public:
-  MicrotaskQueueWrap(Environment* env, v8::Local<v8::Object> obj);
-
-  const std::shared_ptr<v8::MicrotaskQueue>& microtask_queue() const;
-
-  static void CreatePerIsolateProperties(IsolateData* isolate_data,
-                                         v8::Local<v8::ObjectTemplate> target);
-  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
-  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
-
-  // This could have methods for running the microtask queue, if we ever decide
-  // to make that fully customizable from userland.
-
-  SET_NO_MEMORY_INFO()
-  SET_MEMORY_INFO_NAME(MicrotaskQueueWrap)
-  SET_SELF_SIZE(MicrotaskQueueWrap)
-
- private:
-  std::shared_ptr<v8::MicrotaskQueue> microtask_queue_;
-};
-
 struct ContextOptions {
   v8::Local<v8::String> name;
   v8::Local<v8::String> origin;
   v8::Local<v8::Boolean> allow_code_gen_strings;
   v8::Local<v8::Boolean> allow_code_gen_wasm;
-  BaseObjectPtr<MicrotaskQueueWrap> microtask_queue_wrap;
+  std::unique_ptr<v8::MicrotaskQueue> own_microtask_queue;
 };
 
 class ContextifyContext : public BaseObject {
@@ -47,7 +25,7 @@ class ContextifyContext : public BaseObject {
   ContextifyContext(Environment* env,
                     v8::Local<v8::Object> wrapper,
                     v8::Local<v8::Context> v8_context,
-                    const ContextOptions& options);
+                    ContextOptions* options);
   ~ContextifyContext();
 
   void MemoryInfo(MemoryTracker* tracker) const override;
@@ -80,9 +58,8 @@ class ContextifyContext : public BaseObject {
         .As<v8::Object>();
   }
 
-  inline std::shared_ptr<v8::MicrotaskQueue> microtask_queue() const {
-    if (!microtask_queue_wrap_) return {};
-    return microtask_queue_wrap_->microtask_queue();
+  inline v8::MicrotaskQueue* microtask_queue() const {
+    return microtask_queue_.get();
   }
 
   template <typename T>
@@ -94,12 +71,12 @@ class ContextifyContext : public BaseObject {
  private:
   static BaseObjectPtr<ContextifyContext> New(Environment* env,
                                               v8::Local<v8::Object> sandbox_obj,
-                                              const ContextOptions& options);
+                                              ContextOptions* options);
   // Initialize a context created from CreateV8Context()
   static BaseObjectPtr<ContextifyContext> New(v8::Local<v8::Context> ctx,
                                               Environment* env,
                                               v8::Local<v8::Object> sandbox_obj,
-                                              const ContextOptions& options);
+                                              ContextOptions* options);
 
   static bool IsStillInitializing(const ContextifyContext* ctx);
   static void MakeContext(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -146,7 +123,7 @@ class ContextifyContext : public BaseObject {
       const v8::PropertyCallbackInfo<v8::Boolean>& args);
 
   v8::Global<v8::Context> context_;
-  BaseObjectPtr<MicrotaskQueueWrap> microtask_queue_wrap_;
+  std::unique_ptr<v8::MicrotaskQueue> microtask_queue_;
 };
 
 class ContextifyScript : public BaseObject {
@@ -171,7 +148,7 @@ class ContextifyScript : public BaseObject {
                           const bool display_errors,
                           const bool break_on_sigint,
                           const bool break_on_first_line,
-                          std::shared_ptr<v8::MicrotaskQueue> microtask_queue,
+                          v8::MicrotaskQueue* microtask_queue,
                           const v8::FunctionCallbackInfo<v8::Value>& args);
 
   inline uint32_t id() { return id_; }


### PR DESCRIPTION
Previously the ContextifyContext holds a MicrotaskQueueWrap which in turns holds a MicrotaskQueue in a shared pointer. The indirection is actually unnecessary, we can directly hold the MicrotaskQueue via a unique pointer in ContextifyContext, the lifetime would still remain the same but the graph would be simpler, and this removes the additional JS -> C++ to create the wrapper object.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
