### PR TITLE
Perf: Implement RAII for Mutex in RandomCIDFactory

### DIFF
--- a/src/quic/cid.cc
+++ b/src/quic/cid.cc
@@ -107,7 +107,7 @@ class RandomCIDFactory : public CID::Factory {
   CID Generate(size_t length_hint) const override {
     DCHECK_GE(length_hint, CID::kMinLength);
     DCHECK_LE(length_hint, CID::kMaxLength);
-    Mutex::ScopedLock lock(mutex_);
+    std::lock_guard<Mutex> lock(mutex_);
     maybe_refresh_pool(length_hint);
     auto start = pool_ + pos_;
     pos_ += length_hint;
@@ -118,7 +118,7 @@ class RandomCIDFactory : public CID::Factory {
                     size_t length_hint = CID::kMaxLength) const override {
     DCHECK_GE(length_hint, CID::kMinLength);
     DCHECK_LE(length_hint, CID::kMaxLength);
-    Mutex::ScopedLock lock(mutex_);
+    std::lock_guard<Mutex> lock(mutex_);
     maybe_refresh_pool(length_hint);
     auto start = pool_ + pos_;
     pos_ += length_hint;


### PR DESCRIPTION
Used RAII to manage the mutex in the RandomCIDFactory class. Replaced manual locking and unlocking with std::lock_guard for automatic locking and unlocking of the mutex within the critical sections of code
