### PR TITLE
test: remove `--no-warnings` flag in `test_runner` fixtures

### DIFF
--- a/test/fixtures/test-runner/output/abort.js
+++ b/test/fixtures/test-runner/output/abort.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 require('../../../common');
 const test = require('node:test');

--- a/test/fixtures/test-runner/output/abort_hooks.js
+++ b/test/fixtures/test-runner/output/abort_hooks.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 const { before, beforeEach, describe, it, after, afterEach } = require('node:test');
 

--- a/test/fixtures/test-runner/output/abort_suite.js
+++ b/test/fixtures/test-runner/output/abort_suite.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 require('../../../common');
 const { describe, it } = require('node:test');

--- a/test/fixtures/test-runner/output/describe_it.js
+++ b/test/fixtures/test-runner/output/describe_it.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 require('../../../common');
 const assert = require('node:assert');

--- a/test/fixtures/test-runner/output/describe_nested.js
+++ b/test/fixtures/test-runner/output/describe_nested.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 require('../../../common');
 const { describe, it } = require('node:test');

--- a/test/fixtures/test-runner/output/dot_reporter.js
+++ b/test/fixtures/test-runner/output/dot_reporter.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 require('../../../common');
 const fixtures = require('../../../common/fixtures');

--- a/test/fixtures/test-runner/output/hooks.js
+++ b/test/fixtures/test-runner/output/hooks.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 const common = require('../../../common');
 const assert = require('assert');

--- a/test/fixtures/test-runner/output/name_pattern.js
+++ b/test/fixtures/test-runner/output/name_pattern.js
@@ -1,4 +1,4 @@
-// Flags: --no-warnings --test-name-pattern=enabled --test-name-pattern=yes --test-name-pattern=/pattern/i
+// Flags: --test-name-pattern=enabled --test-name-pattern=yes --test-name-pattern=/pattern/i
 'use strict';
 const common = require('../../../common');
 const {

--- a/test/fixtures/test-runner/output/name_pattern_with_only.js
+++ b/test/fixtures/test-runner/output/name_pattern_with_only.js
@@ -1,4 +1,4 @@
-// Flags: --no-warnings --test-only --test-name-pattern=enabled
+// Flags: --test-only --test-name-pattern=enabled
 'use strict';
 const common = require('../../../common');
 const { test } = require('node:test');

--- a/test/fixtures/test-runner/output/no_refs.js
+++ b/test/fixtures/test-runner/output/no_refs.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 require('../../../common');
 const test = require('node:test');

--- a/test/fixtures/test-runner/output/no_tests.js
+++ b/test/fixtures/test-runner/output/no_tests.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 require('../../../common');
 const test = require('node:test');

--- a/test/fixtures/test-runner/output/only_tests.js
+++ b/test/fixtures/test-runner/output/only_tests.js
@@ -1,4 +1,4 @@
-// Flags: --no-warnings --test-only
+// Flags: --test-only
 'use strict';
 require('../../../common');
 const { test, describe, it } = require('node:test');

--- a/test/fixtures/test-runner/output/output_cli.js
+++ b/test/fixtures/test-runner/output/output_cli.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 require('../../../common');
 const fixtures = require('../../../common/fixtures');

--- a/test/fixtures/test-runner/output/single.js
+++ b/test/fixtures/test-runner/output/single.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 const test = require('node:test');
 test('last test', () => {});

--- a/test/fixtures/test-runner/output/spec_reporter.js
+++ b/test/fixtures/test-runner/output/spec_reporter.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 require('../../../common');
 const fixtures = require('../../../common/fixtures');

--- a/test/fixtures/test-runner/output/spec_reporter_cli.js
+++ b/test/fixtures/test-runner/output/spec_reporter_cli.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 require('../../../common');
 const fixtures = require('../../../common/fixtures');

--- a/test/fixtures/test-runner/output/spec_reporter_successful.js
+++ b/test/fixtures/test-runner/output/spec_reporter_successful.js
@@ -1,4 +1,4 @@
-// Flags: --no-warnings --test-reporter=spec
+// Flags: --test-reporter=spec
 'use strict';
 require('../../../common');
 const { it } = require('node:test');

--- a/test/fixtures/test-runner/output/unresolved_promise.js
+++ b/test/fixtures/test-runner/output/unresolved_promise.js
@@ -1,4 +1,3 @@
-// Flags: --no-warnings
 'use strict';
 require('../../../common');
 const test = require('node:test');


### PR DESCRIPTION
no longer needed after #48915 fix
