### PR TITLE
src: add ability to overload fast api functions

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1054,9 +1054,11 @@ class URL {
     url = `${url}`;
 
     if (base !== undefined) {
-      return bindingUrl.canParseWithBase(url, `${base}`);
+      return bindingUrl.canParse(url, `${base}`);
     }
 
+    // It is important to differentiate the canParse call statements
+    // since they resolve into different v8 fast api overloads.
     return bindingUrl.canParse(url);
   }
 }

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -75,8 +75,7 @@ class BindingData : public SnapshotableObject {
   void UpdateComponents(const ada::url_components& components,
                         const ada::scheme::type type);
 
-  static v8::CFunction fast_can_parse_;
-  static v8::CFunction fast_can_parse_with_base_;
+  static v8::CFunction fast_can_parse_methods_[];
 };
 
 std::string FromFilePath(const std::string_view file_path);

--- a/src/util.cc
+++ b/src/util.cc
@@ -482,6 +482,53 @@ void SetFastMethodNoSideEffect(Isolate* isolate,
   that->Set(name_string, t);
 }
 
+void SetFastMethod(Isolate* isolate,
+                   Local<Template> that,
+                   const std::string_view name,
+                   v8::FunctionCallback slow_callback,
+                   const v8::MemorySpan<const v8::CFunction>& methods) {
+  Local<v8::FunctionTemplate> t = FunctionTemplate::NewWithCFunctionOverloads(
+      isolate,
+      slow_callback,
+      Local<Value>(),
+      Local<v8::Signature>(),
+      0,
+      v8::ConstructorBehavior::kThrow,
+      v8::SideEffectType::kHasSideEffect,
+      methods);
+
+  // kInternalized strings are created in the old space.
+  const v8::NewStringType type = v8::NewStringType::kInternalized;
+  Local<v8::String> name_string =
+      v8::String::NewFromUtf8(isolate, name.data(), type, name.size())
+          .ToLocalChecked();
+  that->Set(name_string, t);
+}
+
+void SetFastMethodNoSideEffect(
+    Isolate* isolate,
+    Local<Template> that,
+    const std::string_view name,
+    v8::FunctionCallback slow_callback,
+    const v8::MemorySpan<const v8::CFunction>& methods) {
+  Local<v8::FunctionTemplate> t = FunctionTemplate::NewWithCFunctionOverloads(
+      isolate,
+      slow_callback,
+      Local<Value>(),
+      Local<v8::Signature>(),
+      0,
+      v8::ConstructorBehavior::kThrow,
+      v8::SideEffectType::kHasNoSideEffect,
+      methods);
+
+  // kInternalized strings are created in the old space.
+  const v8::NewStringType type = v8::NewStringType::kInternalized;
+  Local<v8::String> name_string =
+      v8::String::NewFromUtf8(isolate, name.data(), type, name.size())
+          .ToLocalChecked();
+  that->Set(name_string, t);
+}
+
 void SetMethodNoSideEffect(Local<v8::Context> context,
                            Local<v8::Object> that,
                            const std::string_view name,

--- a/src/util.h
+++ b/src/util.h
@@ -890,6 +890,11 @@ void SetFastMethod(v8::Local<v8::Context> context,
                    const std::string_view name,
                    v8::FunctionCallback slow_callback,
                    const v8::CFunction* c_function);
+void SetFastMethod(v8::Isolate* isolate,
+                   v8::Local<v8::Template> that,
+                   const std::string_view name,
+                   v8::FunctionCallback slow_callback,
+                   const v8::MemorySpan<const v8::CFunction>& methods);
 void SetFastMethodNoSideEffect(v8::Isolate* isolate,
                                v8::Local<v8::Template> that,
                                const std::string_view name,
@@ -900,7 +905,12 @@ void SetFastMethodNoSideEffect(v8::Local<v8::Context> context,
                                const std::string_view name,
                                v8::FunctionCallback slow_callback,
                                const v8::CFunction* c_function);
-
+void SetFastMethodNoSideEffect(
+    v8::Isolate* isolate,
+    v8::Local<v8::Template> that,
+    const std::string_view name,
+    v8::FunctionCallback slow_callback,
+    const v8::MemorySpan<const v8::CFunction>& methods);
 void SetProtoMethod(v8::Isolate* isolate,
                     v8::Local<v8::FunctionTemplate> that,
                     const std::string_view name,

--- a/typings/internalBinding/url.d.ts
+++ b/typings/internalBinding/url.d.ts
@@ -6,7 +6,6 @@ declare function InternalBinding(binding: 'url'): {
   domainToASCII(input: string): string;
   domainToUnicode(input: string): string;
   canParse(input: string): boolean;
-  canParseWithBase(input: string, base: string): boolean;
   format(input: string, fragment?: boolean, unicode?: boolean, search?: boolean, auth?: boolean): string;
   parse(input: string, base?: string): string | false;
   update(input: string, actionType: typeof urlUpdateActions, value: string): string | false;


### PR DESCRIPTION
Uses v8 fast api overloads to define `canParse` method, and remove duplicated external symbols.

cc @nodejs/url @nodejs/performance 