### PR TITLE
[v16.x] doc: include git add -f to include folder

### DIFF
--- a/doc/contributing/maintaining-openssl.md
+++ b/doc/contributing/maintaining-openssl.md
@@ -137,9 +137,9 @@ files if they are changed before committing:
 
 ```console
 % git add deps/openssl/config/archs
-% git add deps/openssl/openssl/include/crypto/bn_conf.h
-% git add deps/openssl/openssl/include/crypto/dso_conf.h
-% git add deps/openssl/openssl/include/openssl/opensslconf.h
+% git add -f deps/openssl/openssl/include/crypto/bn_conf.h
+% git add -f deps/openssl/openssl/include/crypto/dso_conf.h
+% git add -f deps/openssl/openssl/include/openssl/opensslconf.h
 % git commit
 ```
 


### PR DESCRIPTION
Ref: 

```console
$ git add deps/openssl/openssl/include/openssl/opensslconf.h
The following paths are ignored by one of your .gitignore files:
deps/openssl/openssl/include/openssl/opensslconf.h
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"
````

The `.gitignore` from quictls/openssl is read by git so we need to force include it