### PR TITLE
doc: remove v14 mention

### DIFF
--- a/doc/contributing/maintaining/maintaining-openssl.md
+++ b/doc/contributing/maintaining/maintaining-openssl.md
@@ -13,8 +13,6 @@ currently need to generate four PRs as follows:
   of this guide.
 * a PR for 16.x following the instructions in the v16.x-staging version
   of this guide.
-* a PR for 14.x following the instructions in the [v14.x-staging version][]
-  of this guide.
 
 ## Use of the quictls/openssl fork
 
@@ -158,4 +156,3 @@ regenerated and committed by:
 Finally, build Node.js and run the tests.
 
 [update-openssl-action]: ../../../.github/workflows/update-openssl.yml
-[v14.x-staging version]: https://github.com/nodejs/node/blob/v14.x-staging/doc/guides/maintaining-openssl.md


### PR DESCRIPTION
Node.js 14.x is EOL. We don't perform OpenSSL patches anymore.