### PR TITLE
src: use per-realm GetBindingData() wherever applicable

### DIFF
--- a/src/dataqueue/queue.cc
+++ b/src/dataqueue/queue.cc
@@ -876,12 +876,12 @@ class FdEntry final : public EntryImpl {
       }
       Realm* realm = entry->env()->principal_realm();
       return std::make_shared<ReaderImpl>(
-          BaseObjectPtr<fs::FileHandle>(fs::FileHandle::New(
-              realm->GetBindingData<fs::BindingData>(realm->context()),
-              file,
-              Local<Object>(),
-              entry->start_,
-              entry->end_ - entry->start_)),
+          BaseObjectPtr<fs::FileHandle>(
+              fs::FileHandle::New(realm->GetBindingData<fs::BindingData>(),
+                                  file,
+                                  Local<Object>(),
+                                  entry->start_,
+                                  entry->end_ - entry->start_)),
           entry);
     }
 

--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -83,12 +83,13 @@ void BindingData::Deserialize(Local<Context> context,
 }
 
 void BindingData::EncodeInto(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
   CHECK_GE(args.Length(), 2);
   CHECK(args[0]->IsString());
   CHECK(args[1]->IsUint8Array());
-  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
+
+  Realm* realm = Realm::GetCurrent(args);
+  Isolate* isolate = realm->isolate();
+  BindingData* binding_data = realm->GetBindingData<BindingData>();
 
   Local<String> source = args[0].As<String>();
 

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -400,20 +400,22 @@ std::unique_ptr<worker::TransferData> Blob::CloneForMessaging() const {
 }
 
 void Blob::StoreDataObject(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  BlobBindingData* binding_data = Realm::GetBindingData<BlobBindingData>(args);
+  Realm* realm = Realm::GetCurrent(args);
 
   CHECK(args[0]->IsString());  // ID key
-  CHECK(Blob::HasInstance(env, args[1]));  // Blob
+  CHECK(Blob::HasInstance(realm->env(), args[1]));  // Blob
   CHECK(args[2]->IsUint32());  // Length
   CHECK(args[3]->IsString());  // Type
 
-  Utf8Value key(env->isolate(), args[0]);
+  BlobBindingData* binding_data = realm->GetBindingData<BlobBindingData>();
+  Isolate* isolate = realm->isolate();
+
+  Utf8Value key(isolate, args[0]);
   Blob* blob;
   ASSIGN_OR_RETURN_UNWRAP(&blob, args[1]);
 
   size_t length = args[2].As<Uint32>()->Value();
-  Utf8Value type(env->isolate(), args[3]);
+  Utf8Value type(isolate, args[3]);
 
   binding_data->store_data_object(
       std::string(*key, key.length()),
@@ -427,9 +429,11 @@ void Blob::StoreDataObject(const v8::FunctionCallbackInfo<v8::Value>& args) {
 void Blob::RevokeObjectURL(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(args.Length(), 1);
   CHECK(args[0]->IsString());
-  BlobBindingData* binding_data = Realm::GetBindingData<BlobBindingData>(args);
-  Environment* env = Environment::GetCurrent(args);
-  Utf8Value input(env->isolate(), args[0].As<String>());
+  Realm* realm = Realm::GetCurrent(args);
+  BlobBindingData* binding_data = realm->GetBindingData<BlobBindingData>();
+  Isolate* isolate = realm->isolate();
+
+  Utf8Value input(isolate, args[0].As<String>());
   auto out = ada::parse<ada::url_aggregator>(input.ToStringView());
 
   if (!out) {
@@ -449,36 +453,30 @@ void Blob::RevokeObjectURL(const FunctionCallbackInfo<Value>& args) {
 }
 
 void Blob::GetDataObject(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  BlobBindingData* binding_data = Realm::GetBindingData<BlobBindingData>(args);
-
-  Environment* env = Environment::GetCurrent(args);
   CHECK(args[0]->IsString());
+  Realm* realm = Realm::GetCurrent(args);
+  BlobBindingData* binding_data = realm->GetBindingData<BlobBindingData>();
+  Isolate* isolate = realm->isolate();
 
-  Utf8Value key(env->isolate(), args[0]);
+  Utf8Value key(isolate, args[0]);
 
   BlobBindingData::StoredDataObject stored =
       binding_data->get_data_object(std::string(*key, key.length()));
   if (stored.blob) {
     Local<Value> type;
-    if (!String::NewFromUtf8(
-            env->isolate(),
-            stored.type.c_str(),
-            v8::NewStringType::kNormal,
-            static_cast<int>(stored.type.length())).ToLocal(&type)) {
+    if (!String::NewFromUtf8(isolate,
+                             stored.type.c_str(),
+                             v8::NewStringType::kNormal,
+                             static_cast<int>(stored.type.length()))
+             .ToLocal(&type)) {
       return;
     }
 
-    Local<Value> values[] = {
-      stored.blob->object(),
-      Uint32::NewFromUnsigned(env->isolate(), stored.length),
-      type
-    };
+    Local<Value> values[] = {stored.blob->object(),
+                             Uint32::NewFromUnsigned(isolate, stored.length),
+                             type};
 
-    args.GetReturnValue().Set(
-        Array::New(
-            env->isolate(),
-            values,
-            arraysize(values)));
+    args.GetReturnValue().Set(Array::New(isolate, values, arraysize(values)));
   }
 }
 

--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -277,9 +277,10 @@ FSReqBase* GetReqWrap(const v8::FunctionCallbackInfo<v8::Value>& args,
     return Unwrap<FSReqBase>(value.As<v8::Object>());
   }
 
-  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
-  Environment* env = binding_data->env();
-  if (value->StrictEquals(env->fs_use_promises_symbol())) {
+  Realm* realm = Realm::GetCurrent(args);
+  BindingData* binding_data = realm->GetBindingData<BindingData>();
+
+  if (value->StrictEquals(realm->isolate_data()->fs_use_promises_symbol())) {
     if (use_bigint) {
       return FSReqPromise<AliasedBigInt64Array>::New(binding_data, use_bigint);
     } else {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2068,14 +2068,14 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
-  Environment* env = binding_data->env();
-  Isolate* isolate = env->isolate();
+  Realm* realm = Realm::GetCurrent(args);
+  BindingData* binding_data = realm->GetBindingData<BindingData>();
+  Environment* env = realm->env();
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
 
-  BufferValue path(isolate, args[0]);
+  BufferValue path(realm->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
 
   CHECK(args[1]->IsInt32());

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -264,17 +264,17 @@ FileHandle* FileHandle::New(BindingData* binding_data,
 }
 
 void FileHandle::New(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
-  Environment* env = binding_data->env();
   CHECK(args.IsConstructCall());
   CHECK(args[0]->IsInt32());
+  Realm* realm = Realm::GetCurrent(args);
+  BindingData* binding_data = realm->GetBindingData<BindingData>();
 
   std::optional<int64_t> maybeOffset = std::nullopt;
   std::optional<int64_t> maybeLength = std::nullopt;
   if (args[1]->IsNumber())
-    maybeOffset = args[1]->IntegerValue(env->context()).FromJust();
+    maybeOffset = args[1]->IntegerValue(realm->context()).FromJust();
   if (args[2]->IsNumber())
-    maybeLength = args[2]->IntegerValue(env->context()).FromJust();
+    maybeLength = args[2]->IntegerValue(realm->context()).FromJust();
 
   FileHandle::New(binding_data,
                   args[0].As<Int32>()->Value(),
@@ -1108,13 +1108,14 @@ static void InternalModuleStat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Stat(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
-  Environment* env = binding_data->env();
+  Realm* realm = Realm::GetCurrent(args);
+  BindingData* binding_data = realm->GetBindingData<BindingData>();
+  Environment* env = realm->env();
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
 
-  BufferValue path(env->isolate(), args[0]);
+  BufferValue path(realm->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
@@ -1143,13 +1144,14 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void LStat(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
-  Environment* env = binding_data->env();
+  Realm* realm = Realm::GetCurrent(args);
+  BindingData* binding_data = realm->GetBindingData<BindingData>();
+  Environment* env = realm->env();
 
   const int argc = args.Length();
   CHECK_GE(argc, 3);
 
-  BufferValue path(env->isolate(), args[0]);
+  BufferValue path(realm->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
 
   bool use_bigint = args[1]->IsTrue();
@@ -1177,8 +1179,9 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void FStat(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
-  Environment* env = binding_data->env();
+  Realm* realm = Realm::GetCurrent(args);
+  BindingData* binding_data = realm->GetBindingData<BindingData>();
+  Environment* env = realm->env();
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
@@ -1209,13 +1212,14 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void StatFs(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
-  Environment* env = binding_data->env();
+  Realm* realm = Realm::GetCurrent(args);
+  BindingData* binding_data = realm->GetBindingData<BindingData>();
+  Environment* env = realm->env();
 
   const int argc = args.Length();
   CHECK_GE(argc, 2);
 
-  BufferValue path(env->isolate(), args[0]);
+  BufferValue path(realm->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
 
   bool use_bigint = args[1]->IsTrue();

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2650,12 +2650,12 @@ void Http2Session::RefreshState(const FunctionCallbackInfo<Value>& args) {
 
 // Constructor for new Http2Session instances.
 void Http2Session::New(const FunctionCallbackInfo<Value>& args) {
-  Http2State* state = Realm::GetBindingData<Http2State>(args);
-  Environment* env = state->env();
+  Realm* realm = Realm::GetCurrent(args);
+  Http2State* state = realm->GetBindingData<Http2State>();
+
   CHECK(args.IsConstructCall());
-  SessionType type =
-      static_cast<SessionType>(
-          args[0]->Int32Value(env->context()).ToChecked());
+  SessionType type = static_cast<SessionType>(
+      args[0]->Int32Value(realm->context()).ToChecked());
   Http2Session* session = new Http2Session(state, args.This(), type);
   Debug(session, "session created");
 }

--- a/src/node_realm-inl.h
+++ b/src/node_realm-inl.h
@@ -67,16 +67,17 @@ inline T* Realm::GetBindingData(
 template <typename T>
 inline T* Realm::GetBindingData(v8::Local<v8::Context> context) {
   Realm* realm = GetCurrent(context);
-  DCHECK_NOT_NULL(realm);
-  BindingDataStore* map = realm->binding_data_store();
-  DCHECK_NOT_NULL(map);
+  return realm->GetBindingData<T>();
+}
+
+template <typename T>
+inline T* Realm::GetBindingData() {
   constexpr size_t binding_index = static_cast<size_t>(T::binding_type_int);
   static_assert(binding_index < std::tuple_size_v<BindingDataStore>);
-  auto ptr = (*map)[binding_index];
+  auto ptr = binding_data_store_[binding_index];
   if (UNLIKELY(!ptr)) return nullptr;
   T* result = static_cast<T*>(ptr.get());
   DCHECK_NOT_NULL(result);
-  DCHECK_EQ(result->realm(), GetCurrent(context));
   return result;
 }
 

--- a/src/node_realm.h
+++ b/src/node_realm.h
@@ -101,6 +101,8 @@ class Realm : public MemoryRetainer {
       const v8::FunctionCallbackInfo<v8::Value>& info);
   template <typename T>
   static inline T* GetBindingData(v8::Local<v8::Context> context);
+  template <typename T>
+  inline T* GetBindingData();
   inline BindingDataStore* binding_data_store();
 
   // The BaseObject count is a debugging helper that makes sure that there are

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -231,17 +231,16 @@ void BindingData::Parse(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());  // input
   // args[1] // base url
 
-  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
-  Environment* env = Environment::GetCurrent(args);
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
+  Realm* realm = Realm::GetCurrent(args);
+  BindingData* binding_data = realm->GetBindingData<BindingData>();
+  Isolate* isolate = realm->isolate();
 
-  Utf8Value input(env->isolate(), args[0]);
+  Utf8Value input(isolate, args[0]);
   ada::result<ada::url_aggregator> base;
   ada::url_aggregator* base_pointer = nullptr;
   if (args[1]->IsString()) {
-    base = ada::parse<ada::url_aggregator>(
-        Utf8Value(env->isolate(), args[1]).ToString());
+    base =
+        ada::parse<ada::url_aggregator>(Utf8Value(isolate, args[1]).ToString());
     if (!base) {
       return args.GetReturnValue().Set(false);
     }
@@ -257,8 +256,7 @@ void BindingData::Parse(const FunctionCallbackInfo<Value>& args) {
   binding_data->UpdateComponents(out->get_components(), out->type);
 
   args.GetReturnValue().Set(
-      ToV8Value(env->context(), out->get_href(), env->isolate())
-          .ToLocalChecked());
+      ToV8Value(realm->context(), out->get_href(), isolate).ToLocalChecked());
 }
 
 void BindingData::Update(const FunctionCallbackInfo<Value>& args) {
@@ -266,12 +264,12 @@ void BindingData::Update(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsNumber());    // action type
   CHECK(args[2]->IsString());    // new value
 
-  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
+  Realm* realm = Realm::GetCurrent(args);
+  BindingData* binding_data = realm->GetBindingData<BindingData>();
+  Isolate* isolate = realm->isolate();
 
   enum url_update_action action = static_cast<enum url_update_action>(
-      args[1]->Uint32Value(env->context()).FromJust());
+      args[1]->Uint32Value(realm->context()).FromJust());
   Utf8Value input(isolate, args[0].As<String>());
   Utf8Value new_value(isolate, args[2].As<String>());
 
@@ -332,8 +330,7 @@ void BindingData::Update(const FunctionCallbackInfo<Value>& args) {
 
   binding_data->UpdateComponents(out->get_components(), out->type);
   args.GetReturnValue().Set(
-      ToV8Value(env->context(), out->get_href(), env->isolate())
-          .ToLocalChecked());
+      ToV8Value(realm->context(), out->get_href(), isolate).ToLocalChecked());
 }
 
 void BindingData::UpdateComponents(const ada::url_components& components,

--- a/src/quic/bindingdata.cc
+++ b/src/quic/bindingdata.cc
@@ -25,7 +25,7 @@ using v8::Value;
 namespace quic {
 
 BindingData& BindingData::Get(Environment* env) {
-  return *Realm::GetBindingData<BindingData>(env->context());
+  return *(env->principal_realm()->GetBindingData<BindingData>());
 }
 
 BindingData::operator ngtcp2_mem() {


### PR DESCRIPTION
### src: add per-realm GetBindingData() method

This version avoids the additional access to the embedder slot
when we already have a reference to the realm.

### src: use per-realm GetBindingData() wherever applicable

This reduce the number of embedder slot accesses and also removes
the assumption in a few binding methods that the current realm is
the principal realm of the current environment (which is not true
for shadow realms).

Refs: https://github.com/nodejs/node/pull/48836

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
