### PR TITLE
child_process: allow `URL` instances as paths to executables

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -282,6 +282,10 @@ controller.abort();
 <!-- YAML
 added: v0.1.91
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/49031
+    description: The `file` parameter can be a WHATWG `URL` object using
+                 `file:` protocol.
   - version:
       - v16.4.0
       - v14.18.0
@@ -298,7 +302,7 @@ changes:
     description: The `windowsHide` option is supported now.
 -->
 
-* `file` {string} The name or path of the executable file to run.
+* `file` {string|URL} The name or path of the executable file to run.
 * `args` {string\[]} List of string arguments.
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.
@@ -394,6 +398,10 @@ controller.abort();
 <!-- YAML
 added: v0.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/49031
+    description: The `execPath` option can be a WHATWG `URL` object using
+                 `file:` protocol.
   - version:
       - v17.4.0
       - v16.14.0
@@ -442,7 +450,7 @@ changes:
     process. Specific behavior depends on the platform, see
     [`options.detached`][]).
   * `env` {Object} Environment key-value pairs. **Default:** `process.env`.
-  * `execPath` {string} Executable used to create the child process.
+  * `execPath` {string|URL} Executable used to create the child process.
   * `execArgv` {string\[]} List of string arguments passed to the executable.
     **Default:** `process.execArgv`.
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
@@ -522,6 +530,10 @@ if (process.argv[2] === 'child') {
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/49031
+    description: The `command` parameter can be a WHATWG `URL` object using
+                 `file:` protocol.
   - version:
       - v16.4.0
       - v14.18.0
@@ -559,7 +571,7 @@ changes:
     description: The `shell` option is supported now.
 -->
 
-* `command` {string} The command to run.
+* `command` {string|URL} The command to run.
 * `args` {string\[]} List of string arguments.
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.
@@ -897,6 +909,10 @@ configuration at startup.
 <!-- YAML
 added: v0.11.12
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/49031
+    description: The `file` parameter can be a WHATWG `URL` object using
+                 `file:` protocol.
   - version:
       - v16.4.0
       - v14.18.0
@@ -920,7 +936,7 @@ changes:
     description: The `encoding` option can now explicitly be set to `buffer`.
 -->
 
-* `file` {string} The name or path of the executable file to run.
+* `file` {string|URL} The name or path of the executable file to run.
 * `args` {string\[]} List of string arguments.
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.
@@ -1040,6 +1056,10 @@ metacharacters may be used to trigger arbitrary command execution.**
 <!-- YAML
 added: v0.11.12
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/49031
+    description: The `command` parameter can be a WHATWG `URL` object using
+                 `file:` protocol.
   - version:
       - v16.4.0
       - v14.18.0
@@ -1066,7 +1086,7 @@ changes:
     description: The `shell` option is supported now.
 -->
 
-* `command` {string} The command to run.
+* `command` {string|URL} The command to run.
 * `args` {string\[]} List of string arguments.
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -546,6 +546,7 @@ function copyProcessEnvToEnv(env, name, optionEnv) {
 
 function normalizeSpawnArguments(file, args, options) {
   file = getValidatedPath(file, 'file');
+  validateString(file, 'file');
 
   if (file.length === 0)
     throw new ERR_INVALID_ARG_VALUE('file', file, 'cannot be empty');

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -106,7 +106,7 @@ let addAbortListener;
  *   cwd?: string | URL;
  *   detached?: boolean;
  *   env?: Record<string, string>;
- *   execPath?: string;
+ *   execPath?: string | URL;
  *   execArgv?: string[];
  *   gid?: number;
  *   serialization?: string;
@@ -302,7 +302,7 @@ function normalizeExecFileArgs(file, args, options, callback) {
 
 /**
  * Spawns the specified file as a shell.
- * @param {string} file
+ * @param {string | URL} file
  * @param {string[]} [args]
  * @param {{
  *   cwd?: string | URL;
@@ -545,8 +545,7 @@ function copyProcessEnvToEnv(env, name, optionEnv) {
 }
 
 function normalizeSpawnArguments(file, args, options) {
-  validateString(file, 'file');
-  validateArgumentNullCheck(file, 'file');
+  file = getValidatedPath(file, 'file');
 
   if (file.length === 0)
     throw new ERR_INVALID_ARG_VALUE('file', file, 'cannot be empty');
@@ -730,7 +729,7 @@ function abortChildProcess(child, killSignal, reason) {
 
 /**
  * Spawns a new process using the given `file`.
- * @param {string} file
+ * @param {string | URL} file
  * @param {string[]} [args]
  * @param {{
  *   cwd?: string | URL;
@@ -800,7 +799,7 @@ function spawn(file, args, options) {
 
 /**
  * Spawns a new process synchronously using the given `file`.
- * @param {string} file
+ * @param {string | URL} file
  * @param {string[]} [args]
  * @param {{
  *   cwd?: string | URL;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -263,8 +263,8 @@ function createZeroFilledFile(filename) {
 
 
 const pwdCommand = isWindows ?
-  ['cmd.exe', ['/d', '/c', 'cd']] :
-  ['pwd', []];
+  [new URL('file:///C:/Windows/system32/cmd.exe'), ['/d', '/c', 'cd']] :
+  [new URL('file:///bin/pwd'), []];
 
 
 function platformTimeout(ms) {

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -263,8 +263,8 @@ function createZeroFilledFile(filename) {
 
 
 const pwdCommand = isWindows ?
-  [new URL('file:///C:/Windows/system32/cmd.exe'), ['/d', '/c', 'cd']] :
-  [new URL('file:///bin/pwd'), []];
+  ['cmd.exe', ['/d', '/c', 'cd']] :
+  ['pwd', []];
 
 
 function platformTimeout(ms) {

--- a/test/parallel/test-child-process-urlfile.mjs
+++ b/test/parallel/test-child-process-urlfile.mjs
@@ -1,0 +1,42 @@
+import { isWindows, mustCall, mustSucceed, mustNotCall } from '../common/index.mjs';
+import { strictEqual } from 'node:assert';
+import { pathToFileURL } from 'node:url';
+import cp from 'node:child_process';
+import tmpdir from '../common/tmpdir.js';
+
+tmpdir.refresh();
+
+const cwd = tmpdir.path;
+const whichCommand = isWindows ? 'where.exe cmd.exe' : 'which pwd';
+const pwdFullPath = `${cp.execSync(whichCommand)}`.trim();
+const pwdUrl = pathToFileURL(pwdFullPath);
+const pwdCommandAndOptions = isWindows ?
+  [pwdUrl, ['/d', '/c', 'cd'], { cwd: pathToFileURL(cwd) }] :
+  [pwdUrl, [], { cwd: pathToFileURL(cwd) }];
+
+{
+  cp.execFile(...pwdCommandAndOptions, mustSucceed((stdout) => {
+    strictEqual(`${stdout}`.trim(), cwd);
+  }));
+}
+
+{
+  const stdout = cp.execFileSync(...pwdCommandAndOptions);
+  strictEqual(`${stdout}`.trim(), cwd);
+}
+
+{
+  const pwd = cp.spawn(...pwdCommandAndOptions);
+  pwd.stdout.on('data', mustCall((stdout) => {
+    strictEqual(`${stdout}`.trim(), cwd);
+  }));
+  pwd.stderr.on('data', mustNotCall());
+  pwd.on('close', mustCall((code) => {
+    strictEqual(code, 0);
+  }));
+}
+
+{
+  const stdout = cp.spawnSync(...pwdCommandAndOptions).stdout;
+  strictEqual(`${stdout}`.trim(), cwd);
+}

--- a/test/parallel/test-child-process-urlfile.mjs
+++ b/test/parallel/test-child-process-urlfile.mjs
@@ -147,50 +147,51 @@ for (const badFile of [
 }
 
 // Test for malformed file URL objects
-for (const badFile of [
-  new URL('file://nodejs.org/file:///'),
-  new url.URL('file://nodejs.org/file:///'),
-  {
-    href: 'file://nodejs.org/file:///',
-    origin: 'null',
-    protocol: 'file:',
-    username: '',
-    password: '',
-    host: 'nodejs.org',
-    hostname: 'nodejs.org',
-    port: '',
-    pathname: '/file:///',
-    search: '',
-    searchParams: new URLSearchParams(),
-    hash: ''
-  },
-]) {
-  const pwdCommandAndOptions = isWindows ?
-    [badFile, ['/d', '/c', 'cd'], { cwd: cwdUrl }] :
-    [badFile, [], { cwd: cwdUrl }];
+// On Windows, non-empty host is allowed
+if (!isWindows) {
+  for (const badFile of [
+    new URL('file://nodejs.org/file:///'),
+    new url.URL('file://nodejs.org/file:///'),
+    {
+      href: 'file://nodejs.org/file:///',
+      origin: 'null',
+      protocol: 'file:',
+      username: '',
+      password: '',
+      host: 'nodejs.org',
+      hostname: 'nodejs.org',
+      port: '',
+      pathname: '/file:///',
+      search: '',
+      searchParams: new URLSearchParams(),
+      hash: ''
+    },
+  ]) {
+    const pwdCommandAndOptions = [badFile, [], { cwd: cwdUrl }];
 
-  // Passing an URL object with non-empty host
-  // results in TypeError
+    // Passing an URL object with non-empty host
+    // results in TypeError
 
-  throws(
-    () => cp.execFile(...pwdCommandAndOptions, mustNotCall()),
-    { code: 'ERR_INVALID_FILE_URL_HOST' },
-  );
+    throws(
+      () => cp.execFile(...pwdCommandAndOptions, mustNotCall()),
+      { code: 'ERR_INVALID_FILE_URL_HOST' },
+    );
 
-  throws(
-    () => cp.execFileSync(...pwdCommandAndOptions),
-    { code: 'ERR_INVALID_FILE_URL_HOST' },
-  );
+    throws(
+      () => cp.execFileSync(...pwdCommandAndOptions),
+      { code: 'ERR_INVALID_FILE_URL_HOST' },
+    );
 
-  throws(
-    () => cp.spawn(...pwdCommandAndOptions),
-    { code: 'ERR_INVALID_FILE_URL_HOST' },
-  );
+    throws(
+      () => cp.spawn(...pwdCommandAndOptions),
+      { code: 'ERR_INVALID_FILE_URL_HOST' },
+    );
 
-  throws(
-    () => cp.spawnSync(...pwdCommandAndOptions),
-    { code: 'ERR_INVALID_FILE_URL_HOST' },
-  );
+    throws(
+      () => cp.spawnSync(...pwdCommandAndOptions),
+      { code: 'ERR_INVALID_FILE_URL_HOST' },
+    );
+  }
 }
 
 // Test for file URL objects with %2F in path

--- a/test/parallel/test-child-process-urlfile.mjs
+++ b/test/parallel/test-child-process-urlfile.mjs
@@ -75,6 +75,9 @@ for (const badFile of [
     [badFile, ['/d', '/c', 'cd'], { cwd: cwdUrl }] :
     [badFile, [], { cwd: cwdUrl }];
 
+  // Passing an object that doesn't have shape of WHATWG URL object
+  // results in TypeError
+
   throws(
     () => cp.execFile(...pwdCommandAndOptions, mustNotCall()),
     { code: 'ERR_INVALID_ARG_TYPE' },
@@ -93,5 +96,197 @@ for (const badFile of [
   throws(
     () => cp.spawnSync(...pwdCommandAndOptions),
     { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+}
+
+// Test for non-file: URL objects
+for (const badFile of [
+  new URL('https://nodejs.org/file:///'),
+  new url.URL('https://nodejs.org/file:///'),
+  {
+    href: 'https://nodejs.org/file:///',
+    origin: 'https://nodejs.org',
+    protocol: 'https:',
+    username: '',
+    password: '',
+    host: 'nodejs.org',
+    hostname: 'nodejs.org',
+    port: '',
+    pathname: '/file:///',
+    search: '',
+    searchParams: new URLSearchParams(),
+    hash: ''
+  },
+]) {
+  const pwdCommandAndOptions = isWindows ?
+    [badFile, ['/d', '/c', 'cd'], { cwd: cwdUrl }] :
+    [badFile, [], { cwd: cwdUrl }];
+
+  // Passing an URL object with protocol other than `file:`
+  // results in TypeError
+
+  throws(
+    () => cp.execFile(...pwdCommandAndOptions, mustNotCall()),
+    { code: 'ERR_INVALID_URL_SCHEME' },
+  );
+
+  throws(
+    () => cp.execFileSync(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_URL_SCHEME' },
+  );
+
+  throws(
+    () => cp.spawn(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_URL_SCHEME' },
+  );
+
+  throws(
+    () => cp.spawnSync(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_URL_SCHEME' },
+  );
+}
+
+// Test for malformed file URL objects
+for (const badFile of [
+  new URL('file://nodejs.org/file:///'),
+  new url.URL('file://nodejs.org/file:///'),
+  {
+    href: 'file://nodejs.org/file:///',
+    origin: 'null',
+    protocol: 'file:',
+    username: '',
+    password: '',
+    host: 'nodejs.org',
+    hostname: 'nodejs.org',
+    port: '',
+    pathname: '/file:///',
+    search: '',
+    searchParams: new URLSearchParams(),
+    hash: ''
+  },
+]) {
+  const pwdCommandAndOptions = isWindows ?
+    [badFile, ['/d', '/c', 'cd'], { cwd: cwdUrl }] :
+    [badFile, [], { cwd: cwdUrl }];
+
+  // Passing an URL object with non-empty host
+  // results in TypeError
+
+  throws(
+    () => cp.execFile(...pwdCommandAndOptions, mustNotCall()),
+    { code: 'ERR_INVALID_FILE_URL_HOST' },
+  );
+
+  throws(
+    () => cp.execFileSync(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_FILE_URL_HOST' },
+  );
+
+  throws(
+    () => cp.spawn(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_FILE_URL_HOST' },
+  );
+
+  throws(
+    () => cp.spawnSync(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_FILE_URL_HOST' },
+  );
+}
+
+// Test for file URL objects with %2F in path
+const urlWithSlash = new URL(pwdWHATWGUrl);
+urlWithSlash.pathname += '%2F';
+for (const badFile of [
+  urlWithSlash,
+  new url.URL(urlWithSlash),
+  {
+    href: urlWithSlash.href,
+    origin: urlWithSlash.origin,
+    protocol: urlWithSlash.protocol,
+    username: urlWithSlash.username,
+    password: urlWithSlash.password,
+    host: urlWithSlash.host,
+    hostname: urlWithSlash.hostname,
+    port: urlWithSlash.port,
+    pathname: urlWithSlash.pathname,
+    search: urlWithSlash.search,
+    searchParams: new URLSearchParams(urlWithSlash.searchParams),
+    hash: urlWithSlash.hash,
+  },
+]) {
+  const pwdCommandAndOptions = isWindows ?
+    [badFile, ['/d', '/c', 'cd'], { cwd: cwdUrl }] :
+    [badFile, [], { cwd: cwdUrl }];
+
+  // Passing an URL object with percent-encoded '/'
+  // results in TypeError
+
+  throws(
+    () => cp.execFile(...pwdCommandAndOptions, mustNotCall()),
+    { code: 'ERR_INVALID_FILE_URL_PATH' },
+  );
+
+  throws(
+    () => cp.execFileSync(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_FILE_URL_PATH' },
+  );
+
+  throws(
+    () => cp.spawn(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_FILE_URL_PATH' },
+  );
+
+  throws(
+    () => cp.spawnSync(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_FILE_URL_PATH' },
+  );
+}
+
+// Test for file URL objects with %00 in path
+const urlWithNul = new URL(pwdWHATWGUrl);
+urlWithNul.pathname += '%00';
+for (const badFile of [
+  urlWithNul,
+  new url.URL(urlWithNul),
+  {
+    href: urlWithNul.href,
+    origin: urlWithNul.origin,
+    protocol: urlWithNul.protocol,
+    username: urlWithNul.username,
+    password: urlWithNul.password,
+    host: urlWithNul.host,
+    hostname: urlWithNul.hostname,
+    port: urlWithNul.port,
+    pathname: urlWithNul.pathname,
+    search: urlWithNul.search,
+    searchParams: new URLSearchParams(urlWithNul.searchParams),
+    hash: urlWithNul.hash,
+  },
+]) {
+  const pwdCommandAndOptions = isWindows ?
+    [badFile, ['/d', '/c', 'cd'], { cwd: cwdUrl }] :
+    [badFile, [], { cwd: cwdUrl }];
+
+  // Passing an URL object with percent-encoded '\0'
+  // results in TypeError
+
+  throws(
+    () => cp.execFile(...pwdCommandAndOptions, mustNotCall()),
+    { code: 'ERR_INVALID_ARG_VALUE' },
+  );
+
+  throws(
+    () => cp.execFileSync(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_ARG_VALUE' },
+  );
+
+  throws(
+    () => cp.spawn(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_ARG_VALUE' },
+  );
+
+  throws(
+    () => cp.spawnSync(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_ARG_VALUE' },
   );
 }

--- a/test/parallel/test-child-process-urlfile.mjs
+++ b/test/parallel/test-child-process-urlfile.mjs
@@ -1,42 +1,97 @@
 import { isWindows, mustCall, mustSucceed, mustNotCall } from '../common/index.mjs';
-import { strictEqual } from 'node:assert';
-import { pathToFileURL } from 'node:url';
+import { strictEqual, throws } from 'node:assert';
 import cp from 'node:child_process';
+import url from 'node:url';
 import tmpdir from '../common/tmpdir.js';
 
 tmpdir.refresh();
 
 const cwd = tmpdir.path;
+const cwdUrl = url.pathToFileURL(cwd);
 const whichCommand = isWindows ? 'where.exe cmd.exe' : 'which pwd';
 const pwdFullPath = `${cp.execSync(whichCommand)}`.trim();
-const pwdUrl = pathToFileURL(pwdFullPath);
-const pwdCommandAndOptions = isWindows ?
-  [pwdUrl, ['/d', '/c', 'cd'], { cwd: pathToFileURL(cwd) }] :
-  [pwdUrl, [], { cwd: pathToFileURL(cwd) }];
+const pwdWHATWGUrl = url.pathToFileURL(pwdFullPath);
 
-{
-  cp.execFile(...pwdCommandAndOptions, mustSucceed((stdout) => {
+// Test for WHATWG URL instance, legacy URL, and URL-like object
+for (const pwdUrl of [
+  pwdWHATWGUrl,
+  new url.URL(pwdWHATWGUrl),
+  {
+    href: pwdWHATWGUrl.href,
+    origin: pwdWHATWGUrl.origin,
+    protocol: pwdWHATWGUrl.protocol,
+    username: pwdWHATWGUrl.username,
+    password: pwdWHATWGUrl.password,
+    host: pwdWHATWGUrl.host,
+    hostname: pwdWHATWGUrl.hostname,
+    port: pwdWHATWGUrl.port,
+    pathname: pwdWHATWGUrl.pathname,
+    search: pwdWHATWGUrl.search,
+    searchParams: new URLSearchParams(pwdWHATWGUrl.searchParams),
+    hash: pwdWHATWGUrl.hash,
+  },
+]) {
+  const pwdCommandAndOptions = isWindows ?
+    [pwdUrl, ['/d', '/c', 'cd'], { cwd: cwdUrl }] :
+    [pwdUrl, [], { cwd: cwdUrl }];
+
+  {
+    cp.execFile(...pwdCommandAndOptions, mustSucceed((stdout) => {
+      strictEqual(`${stdout}`.trim(), cwd);
+    }));
+  }
+
+  {
+    const stdout = cp.execFileSync(...pwdCommandAndOptions);
     strictEqual(`${stdout}`.trim(), cwd);
-  }));
-}
+  }
 
-{
-  const stdout = cp.execFileSync(...pwdCommandAndOptions);
-  strictEqual(`${stdout}`.trim(), cwd);
-}
+  {
+    const pwd = cp.spawn(...pwdCommandAndOptions);
+    pwd.stdout.on('data', mustCall((stdout) => {
+      strictEqual(`${stdout}`.trim(), cwd);
+    }));
+    pwd.stderr.on('data', mustNotCall());
+    pwd.on('close', mustCall((code) => {
+      strictEqual(code, 0);
+    }));
+  }
 
-{
-  const pwd = cp.spawn(...pwdCommandAndOptions);
-  pwd.stdout.on('data', mustCall((stdout) => {
+  {
+    const stdout = cp.spawnSync(...pwdCommandAndOptions).stdout;
     strictEqual(`${stdout}`.trim(), cwd);
-  }));
-  pwd.stderr.on('data', mustNotCall());
-  pwd.on('close', mustCall((code) => {
-    strictEqual(code, 0);
-  }));
+  }
+
 }
 
-{
-  const stdout = cp.spawnSync(...pwdCommandAndOptions).stdout;
-  strictEqual(`${stdout}`.trim(), cwd);
+// Test for non-URL objects
+for (const badFile of [
+  Buffer.from(pwdFullPath),
+  {},
+  { href: pwdWHATWGUrl.href },
+  { pathname: pwdWHATWGUrl.pathname },
+]) {
+  const pwdCommandAndOptions = isWindows ?
+    [badFile, ['/d', '/c', 'cd'], { cwd: cwdUrl }] :
+    [badFile, [], { cwd: cwdUrl }];
+
+  throws(
+    () => cp.execFile(...pwdCommandAndOptions, mustNotCall()),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+
+  throws(
+    () => cp.execFileSync(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+
+  throws(
+    () => cp.spawn(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+
+  throws(
+    () => cp.spawnSync(...pwdCommandAndOptions),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
 }


### PR DESCRIPTION
Allow `URL` instances to be passed as `file` parameters and `execPath` options. For example:
```mjs
import { execFile } from 'node:child_process';

execFile(
  new URL('../../bin/executable', import.meta.url),
  ['argv1'],
  { cwd: new URL('../dir/subdir', import.meta.url) },
  () => { ... }
);
```