### PR TITLE
node-api: update headers for better wasm support

### DIFF
--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -29,15 +29,9 @@
 #ifdef _WIN32
 #define NAPI_EXTERN __declspec(dllexport)
 #elif defined(__wasm__)
-#ifdef __EMSCRIPTEN__
-#define NAPI_EXTERN                                                            \
-  __attribute__((visibility("default")))                                       \
-  __attribute__((__import_module__("env")))
-#else
 #define NAPI_EXTERN                                                            \
   __attribute__((visibility("default")))                                       \
   __attribute__((__import_module__("napi")))
-#endif
 #else
 #define NAPI_EXTERN __attribute__((visibility("default")))
 #endif

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -28,10 +28,16 @@
 #ifndef NAPI_EXTERN
 #ifdef _WIN32
 #define NAPI_EXTERN __declspec(dllexport)
-#elif defined(__wasm32__)
+#elif defined(__wasm__)
+#ifdef __EMSCRIPTEN__
+#define NAPI_EXTERN                                                            \
+  __attribute__((visibility("default")))                                       \
+  __attribute__((__import_module__("env")))
+#else
 #define NAPI_EXTERN                                                            \
   __attribute__((visibility("default")))                                       \
   __attribute__((__import_module__("napi")))
+#endif
 #else
 #define NAPI_EXTERN __attribute__((visibility("default")))
 #endif

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -22,7 +22,8 @@ struct uv_loop_s;  // Forward declaration.
 #define NAPI_MODULE_EXPORT __declspec(dllexport)
 #else
 #ifdef __EMSCRIPTEN__
-#define NAPI_MODULE_EXPORT __attribute__((visibility("default"))) __attribute__((used))
+#define NAPI_MODULE_EXPORT                                                     \
+  __attribute__((visibility("default"))) __attribute__((used))
 #else
 #define NAPI_MODULE_EXPORT __attribute__((visibility("default")))
 #endif

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -5,19 +5,37 @@
 #ifdef _WIN32
 // Building native addon against node
 #define NAPI_EXTERN __declspec(dllimport)
-#elif defined(__wasm32__)
+#elif defined(__wasm__)
+#ifdef __EMSCRIPTEN__
+#define NAPI_EXTERN __attribute__((__import_module__("env")))
+#else
 #define NAPI_EXTERN __attribute__((__import_module__("napi")))
+#endif
 #endif
 #endif
 #include "js_native_api.h"
 #include "node_api_types.h"
+
+// See https://github.com/nodejs/node-addon-api/pull/1283
+#ifndef NAPI_HAS_THREADS
+#if !defined(__wasm__) || (defined(__EMSCRIPTEN_PTHREADS__) ||                 \
+                           (defined(__wasi__) && defined(_REENTRANT)))
+#define NAPI_HAS_THREADS 1
+#else
+#define NAPI_HAS_THREADS 0
+#endif
+#endif
 
 struct uv_loop_s;  // Forward declaration.
 
 #ifdef _WIN32
 #define NAPI_MODULE_EXPORT __declspec(dllexport)
 #else
+#ifdef __EMSCRIPTEN__
+#define NAPI_MODULE_EXPORT __attribute__((visibility("default"))) __attribute__((used))
+#else
 #define NAPI_MODULE_EXPORT __attribute__((visibility("default")))
+#endif
 #endif
 
 #if defined(__GNUC__)
@@ -49,7 +67,7 @@ typedef struct napi_module {
   NAPI_MODULE_INITIALIZER_X_HELPER(base, version)
 #define NAPI_MODULE_INITIALIZER_X_HELPER(base, version) base##version
 
-#ifdef __wasm32__
+#ifdef __wasm__
 #define NAPI_MODULE_INITIALIZER_BASE napi_register_wasm_v
 #else
 #define NAPI_MODULE_INITIALIZER_BASE napi_register_module_v
@@ -143,7 +161,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_get_buffer_info(napi_env env,
                                                         void** data,
                                                         size_t* length);
 
-#ifndef __wasm32__
+#if NAPI_HAS_THREADS
 // Methods to manage simple async operations
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_async_work(napi_env env,
@@ -159,7 +177,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_queue_async_work(napi_env env,
                                                          napi_async_work work);
 NAPI_EXTERN napi_status NAPI_CDECL napi_cancel_async_work(napi_env env,
                                                           napi_async_work work);
-#endif  // __wasm32__
+#endif  // NAPI_HAS_THREADS
 
 // version management
 NAPI_EXTERN napi_status NAPI_CDECL
@@ -197,7 +215,7 @@ napi_close_callback_scope(napi_env env, napi_callback_scope scope);
 
 #if NAPI_VERSION >= 4
 
-#ifndef __wasm32__
+#if NAPI_HAS_THREADS
 // Calling into JS from other threads
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_threadsafe_function(napi_env env,
@@ -231,7 +249,7 @@ napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
-#endif  // __wasm32__
+#endif  // NAPI_HAS_THREADS
 
 #endif  // NAPI_VERSION >= 4
 

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -1,7 +1,7 @@
 #ifndef SRC_NODE_API_H_
 #define SRC_NODE_API_H_
 
-#ifdef BUILDING_NODE_EXTENSION
+#if defined(BUILDING_NODE_EXTENSION) && !defined(NAPI_EXTERN)
 #ifdef _WIN32
 // Building native addon against node
 #define NAPI_EXTERN __declspec(dllimport)

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -6,11 +6,7 @@
 // Building native addon against node
 #define NAPI_EXTERN __declspec(dllimport)
 #elif defined(__wasm__)
-#ifdef __EMSCRIPTEN__
-#define NAPI_EXTERN __attribute__((__import_module__("env")))
-#else
 #define NAPI_EXTERN __attribute__((__import_module__("napi")))
-#endif
 #endif
 #endif
 #include "js_native_api.h"

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -16,16 +16,6 @@
 #include "js_native_api.h"
 #include "node_api_types.h"
 
-// See https://github.com/nodejs/node-addon-api/pull/1283
-#ifndef NAPI_HAS_THREADS
-#if !defined(__wasm__) || (defined(__EMSCRIPTEN_PTHREADS__) ||                 \
-                           (defined(__wasi__) && defined(_REENTRANT)))
-#define NAPI_HAS_THREADS 1
-#else
-#define NAPI_HAS_THREADS 0
-#endif
-#endif
-
 struct uv_loop_s;  // Forward declaration.
 
 #ifdef _WIN32
@@ -161,7 +151,6 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_get_buffer_info(napi_env env,
                                                         void** data,
                                                         size_t* length);
 
-#if NAPI_HAS_THREADS
 // Methods to manage simple async operations
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_async_work(napi_env env,
@@ -177,7 +166,6 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_queue_async_work(napi_env env,
                                                          napi_async_work work);
 NAPI_EXTERN napi_status NAPI_CDECL napi_cancel_async_work(napi_env env,
                                                           napi_async_work work);
-#endif  // NAPI_HAS_THREADS
 
 // version management
 NAPI_EXTERN napi_status NAPI_CDECL
@@ -215,7 +203,6 @@ napi_close_callback_scope(napi_env env, napi_callback_scope scope);
 
 #if NAPI_VERSION >= 4
 
-#if NAPI_HAS_THREADS
 // Calling into JS from other threads
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_threadsafe_function(napi_env env,
@@ -249,7 +236,6 @@ napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
-#endif  // NAPI_HAS_THREADS
 
 #endif  // NAPI_VERSION >= 4
 


### PR DESCRIPTION
Hi, Node-API team @nodejs/node-api 

I'm wondering if [emnapi](https://github.com/toyobayashi/emnapi) could use [node-api-headers](https://github.com/nodejs/node-api-headers) package instead of maintaining [a modified version of headers](https://github.com/toyobayashi/emnapi/tree/be127f0cc5c6b8d4e186b20f4620ed00078cd57d/packages/emnapi/include).

Just a little modification:

- change `__wasm32__` to `__wasm__` for building `wasm64-unknown-emscripten`
- expand `NAPI_MODULE_EXPORT` to `__attribute__((used))` (`EMSCRIPTEN_KEEPALIVE`) to export `napi_register_wasm_v1` and `node_api_module_get_api_version_v1` if build with Emscripten
- ~~expand `NAPI_EXTERN` to `__attribute__((__import_module__("env")))` if build with Emscripten. Not sure if this should.~~ Currently [there is no way to specify a custom module name in wasm import object](https://github.com/emscripten-core/emscripten/blob/0538c9dba690359baa7c09e99a7ff597796c4939/src/preamble.js#L932-L946) for imported function which is implemented in JavaScript, all functions imported from JavaScript are under `env` module by default. If don't do this change, emnapi must require user to provide a `instantiateWasm` hook to emscripten and add `napi` module during this hook call, which isn't what `instantiateWasm` are supposed to be used for, that force users to write loading logic themselves.

    ```js
    import init from './node-api-wasm-module-compiled-by-emcc.js'
    
    await init({
      instantiateWasm (imports, successCallback) {
        imports.napi = imports.env
        WebAssembly.instantiate(..., imports).then(({ instance, module }) => {
          successCallback(instance, module)
        })
        return {}
      }
    })
    ```

- remove `__wasm32__` guards on async work and TSFN, because they have been implemented and are available in wasm, even in `wasm32-unknown-unknown` and `wasm32-wasi`. It is worth mentioning that I created a PR https://github.com/nodejs/node-addon-api/pull/1283 that added `NAPI_HAS_THREADS` to `Napi::AsyncWorker` and `Napi::ThreadSafeFunction`, now maybe just add it to `Napi::AsyncProgressWorker` is enough because it's using `std::mutex`, which requires `__EMSCRIPTEN_PTHREADS__` or `__wasi__ && _REENTRANT`