### PR TITLE
esm: import.meta.resolve exact module not found errors should return

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -195,6 +195,11 @@ function lazyUtilColors() {
   utilColors ??= require('internal/util/colors');
   return utilColors;
 }
+let url;
+function lazyUrl() {
+  url ??= require('internal/url');
+  return url;
+}
 
 let buffer;
 function lazyBuffer() {
@@ -1450,7 +1455,11 @@ E('ERR_MISSING_ARGS',
     return `${msg} must be specified`;
   }, TypeError);
 E('ERR_MISSING_OPTION', '%s is required', TypeError);
-E('ERR_MODULE_NOT_FOUND', (path, base, type = 'package') => {
+E('ERR_MODULE_NOT_FOUND', function(path, base, type = 'package') {
+  if (type === 'module') {
+    const { pathToFileURL } = lazyUrl();
+    this.url = pathToFileURL(path).href;
+  }
   return `Cannot find ${type} '${path}' imported from ${base}`;
 }, Error);
 E('ERR_MULTIPLE_CALLBACK', 'Callback called multiple times', Error);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -195,11 +195,6 @@ function lazyUtilColors() {
   utilColors ??= require('internal/util/colors');
   return utilColors;
 }
-let url;
-function lazyUrl() {
-  url ??= require('internal/url');
-  return url;
-}
 
 let buffer;
 function lazyBuffer() {
@@ -1455,12 +1450,12 @@ E('ERR_MISSING_ARGS',
     return `${msg} must be specified`;
   }, TypeError);
 E('ERR_MISSING_OPTION', '%s is required', TypeError);
-E('ERR_MODULE_NOT_FOUND', function(path, base, type = 'package') {
-  if (type === 'module') {
-    const { pathToFileURL } = lazyUrl();
-    this.url = pathToFileURL(path).href;
+E('ERR_MODULE_NOT_FOUND', function(path, base, exactUrl) {
+  if (exactUrl) {
+    this.url = exactUrl;
   }
-  return `Cannot find ${type} '${path}' imported from ${base}`;
+  return `Cannot find ${
+    exactUrl ? 'module' : 'package'} '${path}' imported from ${base}`;
 }, Error);
 E('ERR_MULTIPLE_CALLBACK', 'Callback called multiple times', Error);
 E('ERR_NAPI_CONS_FUNCTION', 'Constructor must be a function', TypeError);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1452,7 +1452,7 @@ E('ERR_MISSING_ARGS',
 E('ERR_MISSING_OPTION', '%s is required', TypeError);
 E('ERR_MODULE_NOT_FOUND', function(path, base, exactUrl) {
   if (exactUrl) {
-    this.url = exactUrl;
+    lazyInternalUtil().setOwnProperty(this, 'url', exactUrl);
   }
   return `Cannot find ${
     exactUrl ? 'module' : 'package'} '${path}' imported from ${base}`;

--- a/lib/internal/modules/esm/fetch_module.js
+++ b/lib/internal/modules/esm/fetch_module.js
@@ -144,7 +144,7 @@ function fetchWithRedirects(parsed) {
         return entry;
       }
       if (res.statusCode === 404) {
-        const err = new ERR_MODULE_NOT_FOUND(parsed.href, null);
+        const err = new ERR_MODULE_NOT_FOUND(parsed.href, null, parsed);
         err.message = `Cannot find module '${parsed.href}', HTTP 404`;
         throw err;
       }

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -12,18 +12,20 @@ const experimentalImportMetaResolve = getOptionValue('--experimental-import-meta
 function createImportMetaResolve(defaultParentURL, loader) {
   return function resolve(specifier, parentURL = defaultParentURL) {
     let url;
-
     try {
       ({ url } = loader.resolveSync(specifier, parentURL));
+      return url;
     } catch (error) {
-      if (error?.code === 'ERR_UNSUPPORTED_DIR_IMPORT') {
-        ({ url } = error);
-      } else {
-        throw error;
+      switch (error?.code) {
+        case 'ERR_UNSUPPORTED_DIR_IMPORT':
+        case 'ERR_MODULE_NOT_FOUND':
+          ({ url } = error);
+          if (url) {
+            return url;
+          }
       }
+      throw error;
     }
-
-    return url;
   };
 }
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -224,7 +224,7 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
       process.send({ 'watch:require': [path || resolved.pathname] });
     }
     throw new ERR_MODULE_NOT_FOUND(
-      path || resolved.pathname, base && fileURLToPath(base), 'module');
+      path || resolved.pathname, base && fileURLToPath(base), resolved);
   }
 
   if (!preserveSymlinks) {
@@ -779,7 +779,7 @@ function packageResolve(specifier, base, conditions) {
 
   // eslint can't handle the above code.
   // eslint-disable-next-line no-unreachable
-  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base));
+  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
 }
 
 /**

--- a/test/es-module/test-esm-import-meta-resolve.mjs
+++ b/test/es-module/test-esm-import-meta-resolve.mjs
@@ -9,8 +9,12 @@ const fixtures = dirname.slice(0, dirname.lastIndexOf('/', dirname.length - 2) +
 
 assert.strictEqual(import.meta.resolve('./test-esm-import-meta.mjs'),
                    dirname + 'test-esm-import-meta.mjs');
+const notFound = import.meta.resolve('./notfound.mjs');
+assert.strictEqual(new URL(notFound).href, new URL('./notfound.mjs', import.meta.url).href);
+const noExtension = import.meta.resolve('./asset');
+assert.strictEqual(new URL(noExtension).href, new URL('./asset', import.meta.url).href);
 try {
-  import.meta.resolve('./notfound.mjs');
+  import.meta.resolve('does-not-exist');
   assert.fail();
 } catch (e) {
   assert.strictEqual(e.code, 'ERR_MODULE_NOT_FOUND');


### PR DESCRIPTION
This resolves https://github.com/nodejs/node/issues/49010, ensuring that not found errors to exact modules in `import.meta.resolve`  still return the resolved string. Package not found errors remain module not found errors.

@nodejs/modules 