### PR TITLE
test: add `tmpdir.fileURL()`

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -1027,6 +1027,16 @@ The `tmpdir` module supports the use of a temporary directory for testing.
 
 The realpath of the testing temporary directory.
 
+### `fileURL([...paths])`
+
+* `...paths` [\<string>][<string>]
+* return [\<URL>][<URL>]
+
+Resolves a sequence of paths into absolute url in the temporary directory.
+
+When called without arguments, returns absolute url of the testing
+temporary directory with explicit trailing `/`.
+
 ### `refresh(useSpawn)`
 
 * `useSpawn` [\<boolean>][<boolean>] default = false
@@ -1092,6 +1102,7 @@ See [the WPT tests README][] for details.
 [<Function>]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function
 [<Object>]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
 [<RegExp>]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
+[<URL>]: https://developer.mozilla.org/en-US/docs/Web/API/URL
 [<any>]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Data_types
 [<bigint>]: https://github.com/tc39/proposal-bigint
 [<boolean>]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -3,6 +3,7 @@
 const { spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { pathToFileURL } = require('url');
 const { isMainThread } = require('worker_threads');
 
 function rmSync(pathname, useSpawn) {
@@ -74,8 +75,16 @@ function hasEnoughSpace(size) {
   return bavail >= Math.ceil(size / bsize);
 }
 
+function fileURL(...paths) {
+  // When called without arguments, add explicit trailing slash
+  const fullPath = path.resolve(tmpPath + path.sep, ...paths);
+
+  return pathToFileURL(fullPath);
+}
+
 module.exports = {
+  fileURL,
+  hasEnoughSpace,
   path: tmpPath,
   refresh,
-  hasEnoughSpace,
 };

--- a/test/es-module/test-esm-extension-lookup-deprecation.mjs
+++ b/test/es-module/test-esm-extension-lookup-deprecation.mjs
@@ -1,5 +1,5 @@
 import { spawnPromisified } from '../common/index.mjs';
-import * as tmpdir from '../common/tmpdir.js';
+import tmpdir from '../common/tmpdir.js';
 
 import assert from 'node:assert';
 import { mkdir, writeFile } from 'node:fs/promises';

--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -27,7 +27,6 @@ tmpdir.refresh();
 
 const assert = require('assert');
 const { spawn } = require('child_process');
-const { pathToFileURL, URL } = require('url');
 
 // Spawns 'pwd' with given options, then test
 // - whether the child pid is undefined or number,
@@ -88,7 +87,7 @@ function testCwd(options, expectPidType, expectCode = 0, expectData) {
 testCwd({ cwd: tmpdir.path }, 'number', 0, tmpdir.path);
 const shouldExistDir = common.isWindows ? process.env.windir : '/dev';
 testCwd({ cwd: shouldExistDir }, 'number', 0, shouldExistDir);
-testCwd({ cwd: pathToFileURL(tmpdir.path) }, 'number', 0, tmpdir.path);
+testCwd({ cwd: tmpdir.fileURL() }, 'number', 0, tmpdir.path);
 
 // Spawn() shouldn't try to chdir() to invalid arg, so this should just work
 testCwd({ cwd: '' }, 'number');

--- a/test/parallel/test-fs-mkdtemp.js
+++ b/test/parallel/test-fs-mkdtemp.js
@@ -4,7 +4,6 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const { pathToFileURL } = require('url');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
@@ -41,27 +40,24 @@ function handler(err, folder) {
 
 // Test with URL object
 {
-  tmpdir.url = pathToFileURL(tmpdir.path);
-  const urljoin = (base, path) => new URL(path, base);
-
-  const tmpFolder = fs.mkdtempSync(urljoin(tmpdir.url, 'foo.'));
+  const tmpFolder = fs.mkdtempSync(tmpdir.fileURL('foo.'));
 
   assert.strictEqual(path.basename(tmpFolder).length, 'foo.XXXXXX'.length);
   assert(fs.existsSync(tmpFolder));
 
-  const utf8 = fs.mkdtempSync(urljoin(tmpdir.url, '\u0222abc.'));
+  const utf8 = fs.mkdtempSync(tmpdir.fileURL('\u0222abc.'));
   assert.strictEqual(Buffer.byteLength(path.basename(utf8)),
                      Buffer.byteLength('\u0222abc.XXXXXX'));
   assert(fs.existsSync(utf8));
 
-  fs.mkdtemp(urljoin(tmpdir.url, 'bar.'), common.mustCall(handler));
+  fs.mkdtemp(tmpdir.fileURL('bar.'), common.mustCall(handler));
 
   // Same test as above, but making sure that passing an options object doesn't
   // affect the way the callback function is handled.
-  fs.mkdtemp(urljoin(tmpdir.url, 'bar.'), {}, common.mustCall(handler));
+  fs.mkdtemp(tmpdir.fileURL('bar.'), {}, common.mustCall(handler));
 
   // Warning fires only once
-  fs.mkdtemp(urljoin(tmpdir.url, 'bar.X'), common.mustCall(handler));
+  fs.mkdtemp(tmpdir.fileURL('bar.X'), common.mustCall(handler));
 }
 
 // Test with Buffer

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -270,7 +270,7 @@ if (isGitPresent) {
   }
 
   // Should accept URL
-  const fileURL = pathToFileURL(path.join(tmpdir.path, 'rm-file.txt'));
+  const fileURL = tmpdir.fileURL('rm-file.txt');
   fs.writeFileSync(fileURL, '');
 
   try {
@@ -376,7 +376,7 @@ if (isGitPresent) {
   }
 
   // Should accept URL
-  const fileURL = pathToFileURL(path.join(tmpdir.path, 'rm-promises-file.txt'));
+  const fileURL = tmpdir.fileURL('rm-promises-file.txt');
   fs.writeFileSync(fileURL, '');
 
   try {

--- a/test/parallel/test-runner-inspect.mjs
+++ b/test/parallel/test-runner-inspect.mjs
@@ -1,6 +1,6 @@
 import * as common from '../common/index.mjs';
-import * as tmpdir from '../common/tmpdir.js';
 import * as fixtures from '../common/fixtures.mjs';
+import tmpdir from '../common/tmpdir.js';
 import assert from 'node:assert';
 import path from 'node:path';
 import fs from 'node:fs/promises';


### PR DESCRIPTION
Almost every time `tmpdir.path` is used in tests, we have to import `path` to use it.
Whenever we need `URL` of something in tmpdir, we also have to import `url.pathToFileURL`.
Adding `tmpdir.url` would reduce
```mjs
import { join } from 'node:path';
import { pathToFileURL } from 'node:url';
const testFile = pathToFileURL(join(tmpdir.path, 'subdir', 'tst-file-123'));
```
to
```mjs
const testFile = tmpdir.resolve('subdir', 'tst-file-123');
```
or to native resolving
```mjs
const tmpBase = tmpdir.fileURL();
const testFile = new URL('subdir/tst-file-123', tmpBase);
```

Additionally, maybe we could add path-oriented `tmpdir.resolve(...paths)` to replace `path.join(tmpdir.path, ...paths)` in tests?