### PR TITLE
build: drop support for Visual Studio 2019

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        windows: [windows-2019, windows-2022]
+        windows: [windows-2022]
       fail-fast: false
     runs-on: ${{ matrix.windows }}
     steps:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -153,7 +153,7 @@ Depending on the host platform, the selection of toolchains may vary.
 | Operating System | Compiler Versions                                              |
 | ---------------- | -------------------------------------------------------------- |
 | Linux            | GCC >= 10.1                                                    |
-| Windows          | Visual Studio >= 2019 with the Windows 10 SDK on a 64-bit host |
+| Windows          | Visual Studio >= 2022 with the Windows 10 SDK on a 64-bit host |
 | macOS            | Xcode >= 13 (Apple LLVM >= 12)                                 |
 
 ### Official binary platforms and toolchains
@@ -170,7 +170,7 @@ Binaries at <https://nodejs.org/download/release/> are produced on:
 | linux-ppc64le           | RHEL 8 with gcc-toolset-10[^6]                                                                              |
 | linux-s390x             | RHEL 8 with gcc-toolset-10[^6]                                                                              |
 | linux-x64               | RHEL 8 with gcc-toolset-10[^6]                                                                              |
-| win-x64 and win-x86     | Windows 2012 R2 (x64) with Visual Studio 2019                                                               |
+| win-x64 and win-x86     | Windows Server 2022 (x64) with Visual Studio 2022                                                           |
 
 [^6]: Binaries produced on these systems are compatible with glibc >= 2.28
     and libstdc++ >= 6.0.25 (`GLIBCXX_3.4.25`). These are available on

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -83,7 +83,6 @@ if /i "%1"=="ia32"          set target_arch=x86&goto arg-ok
 if /i "%1"=="x86"           set target_arch=x86&goto arg-ok
 if /i "%1"=="x64"           set target_arch=x64&goto arg-ok
 if /i "%1"=="arm64"         set target_arch=arm64&goto arg-ok
-if /i "%1"=="vs2019"        set target_env=vs2019&goto arg-ok
 if /i "%1"=="vs2022"        set target_env=vs2022&goto arg-ok
 if /i "%1"=="noprojgen"     set noprojgen=1&goto arg-ok
 if /i "%1"=="projgen"       set projgen=1&goto arg-ok
@@ -176,7 +175,6 @@ if defined package set stage_package=1
 set "node_exe=%config%\node.exe"
 set "node_gyp_exe="%node_exe%" deps\npm\node_modules\node-gyp\bin\node-gyp"
 set "npm_exe="%~dp0%node_exe%" %~dp0deps\npm\bin\npm-cli.js"
-if "%target_env%"=="vs2019" set "node_gyp_exe=%node_gyp_exe% --msvs_version=2019"
 if "%target_env%"=="vs2022" set "node_gyp_exe=%node_gyp_exe% --msvs_version=2022"
 
 :: skip building if the only argument received was lint
@@ -246,14 +244,14 @@ if %target_arch%==%msvs_host_arch% set vcvarsall_arg=%target_arch%
 
 @rem Look for Visual Studio 2022
 :vs-set-2022
-if defined target_env if "%target_env%" NEQ "vs2022" goto vs-set-2019
+if defined target_env if "%target_env%" NEQ "vs2022" goto msbuild-not-found
 echo Looking for Visual Studio 2022
 @rem VCINSTALLDIR may be set if run from a VS Command Prompt and needs to be
 @rem cleared first as vswhere_usability_wrapper.cmd doesn't when it fails to
 @rem detect the version searched for
 if not defined target_env set "VCINSTALLDIR="
-call tools\msvs\vswhere_usability_wrapper.cmd "[17.0,18.0)" %target_arch% "prerelease"
-if "_%VCINSTALLDIR%_" == "__" goto vs-set-2019
+call tools\msvs\vswhere_usability_wrapper.cmd "[17.6,18.0)" %target_arch% "prerelease"
+if "_%VCINSTALLDIR%_" == "__" goto msbuild-not-found
 @rem check if VS2022 is already setup, and for the requested arch
 if "_%VisualStudioVersion%_" == "_17.0_" if "_%VSCMD_ARG_TGT_ARCH%_"=="_%target_arch%_" goto found_vs2022
 @rem need to clear VSINSTALLDIR for vcvarsall to work as expected
@@ -263,39 +261,12 @@ set "VSCMD_START_DIR=%CD%"
 set vcvars_call="%VCINSTALLDIR%\Auxiliary\Build\vcvarsall.bat" %vcvarsall_arg%
 echo calling: %vcvars_call%
 call %vcvars_call%
-if errorlevel 1 goto vs-set-2019
+if errorlevel 1 goto msbuild-not-found
 if defined DEBUG_HELPER @ECHO ON
 :found_vs2022
 echo Found MSVS version %VisualStudioVersion%
 set GYP_MSVS_VERSION=2022
 set PLATFORM_TOOLSET=v143
-goto msbuild-found
-
-@rem Look for Visual Studio 2019
-:vs-set-2019
-if defined target_env if "%target_env%" NEQ "vs2019" goto msbuild-not-found
-echo Looking for Visual Studio 2019
-@rem VCINSTALLDIR may be set if run from a VS Command Prompt and needs to be
-@rem cleared first as vswhere_usability_wrapper.cmd doesn't when it fails to
-@rem detect the version searched for
-if not defined target_env set "VCINSTALLDIR="
-call tools\msvs\vswhere_usability_wrapper.cmd "[16.0,17.0)" %target_arch% "prerelease"
-if "_%VCINSTALLDIR%_" == "__" goto msbuild-not-found
-@rem check if VS2019 is already setup, and for the requested arch
-if "_%VisualStudioVersion%_" == "_16.0_" if "_%VSCMD_ARG_TGT_ARCH%_"=="_%target_arch%_" goto found_vs2019
-@rem need to clear VSINSTALLDIR for vcvarsall to work as expected
-set "VSINSTALLDIR="
-@rem prevent VsDevCmd.bat from changing the current working directory
-set "VSCMD_START_DIR=%CD%"
-set vcvars_call="%VCINSTALLDIR%\Auxiliary\Build\vcvarsall.bat" %vcvarsall_arg%
-echo calling: %vcvars_call%
-call %vcvars_call%
-if errorlevel 1 goto msbuild-not-found
-if defined DEBUG_HELPER @ECHO ON
-:found_vs2019
-echo Found MSVS version %VisualStudioVersion%
-set GYP_MSVS_VERSION=2019
-set PLATFORM_TOOLSET=v142
 goto msbuild-found
 
 :msbuild-not-found
@@ -740,7 +711,7 @@ set exit_code=1
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [doc] [test/test-all/test-addons/test-doc/test-js-native-api/test-node-api/test-internet/test-tick-processor/test-known-issues/test-node-inspect/test-check-deopts/test-npm/test-v8/test-v8-intl/test-v8-benchmarks/test-v8-all] [ignore-flaky] [static/dll] [noprojgen] [projgen] [small-icu/full-icu/without-intl] [nobuild] [nosnapshot] [nonpm] [nocorepack] [ltcg] [licensetf] [sign] [ia32/x86/x64/arm64] [vs2019/vs2022] [download-all] [enable-vtune] [lint/lint-ci/lint-js/lint-md] [lint-md-build] [package] [build-release] [upload] [no-NODE-OPTIONS] [link-module path-to-module] [debug-http2] [debug-nghttp2] [clean] [cctest] [no-cctest] [openssl-no-asm]
+echo vcbuild.bat [debug/release] [msi] [doc] [test/test-all/test-addons/test-doc/test-js-native-api/test-node-api/test-internet/test-tick-processor/test-known-issues/test-node-inspect/test-check-deopts/test-npm/test-v8/test-v8-intl/test-v8-benchmarks/test-v8-all] [ignore-flaky] [static/dll] [noprojgen] [projgen] [small-icu/full-icu/without-intl] [nobuild] [nosnapshot] [nonpm] [nocorepack] [ltcg] [licensetf] [sign] [ia32/x86/x64/arm64] [vs2022] [download-all] [enable-vtune] [lint/lint-ci/lint-js/lint-md] [lint-md-build] [package] [build-release] [upload] [no-NODE-OPTIONS] [link-module path-to-module] [debug-http2] [debug-nghttp2] [clean] [cctest] [no-cctest] [openssl-no-asm]
 echo Examples:
 echo   vcbuild.bat                          : builds release build
 echo   vcbuild.bat debug                    : builds debug build


### PR DESCRIPTION
V8 and Chromium are starting to use C++20 features. Only Visual Studio 2022 17.6 includes a version of MSVC with sufficient C++20 support to compile V8.

Refs: https://bugs.chromium.org/p/chromium/issues/detail?id=1284275
Refs: https://github.com/nodejs/node/pull/45427

/cc @nodejs/build @nodejs/platform-windows 