### PR TITLE
stream: add `writable.writeAhead()`

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -997,6 +997,44 @@ write('hello', () => {
 
 A `Writable` stream in object mode will always ignore the `encoding` argument.
 
+##### `writable.writeAhead(chunk[, encoding][, callback])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `chunk` {string|Buffer|Uint8Array|any} Optional data to write. For streams
+  not operating in object mode, `chunk` must be a string, `Buffer` or
+  `Uint8Array`. For object mode streams, `chunk` may be any JavaScript value
+  other than `null`.
+* `encoding` {string|null} The encoding, if `chunk` is a string. **Default:** `'utf8'`
+* `callback` {Function} Callback for when this chunk of data is flushed.
+* Returns: {boolean} `false` if the stream wishes for the calling code to
+  wait for the `'drain'` event to be emitted before continuing to write
+  additional data; otherwise `true`.
+
+When using `writable.writeAhead()`, it's recommended to buffer
+the stream using [`writable.cork()`][] first since the stream might
+consume the chunk before writing ahead.
+
+For example:
+
+```js
+const fs = require('node:fs');
+const file = fs.createWriteStream('sentence.txt');
+// file.cork();
+file.write('World!');
+setTimeout(() => {
+  file.writeAhead('hello');
+  file.end();
+}, 1_000);
+```
+
+Running the above code would write `World!hello` to the file,
+by uncommenting the `file.cork()`, the code would write `helloWorld!` instead.
+
 ### Readable streams
 
 Readable streams are an abstraction for a _source_ from which data is

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -290,20 +290,17 @@ Writable.prototype.pipe = function() {
   errorOrDestroy(this, new ERR_STREAM_CANNOT_PIPE());
 };
 
-function _write(stream, chunk, encoding, cb) {
+function _write(stream, chunk, encoding, ahead, cb) {
   const state = stream._writableState;
 
-  if (typeof encoding === 'function') {
-    cb = encoding;
+  cb = [encoding, ahead, cb]
+    .find((item) => typeof item === 'function') ?? nop;
+  ahead = [encoding, ahead]
+    .find((item) => typeof item === 'boolean') ?? false;
+  if (!encoding || typeof encoding !== 'string')
     encoding = state.defaultEncoding;
-  } else {
-    if (!encoding)
-      encoding = state.defaultEncoding;
-    else if (encoding !== 'buffer' && !Buffer.isEncoding(encoding))
-      throw new ERR_UNKNOWN_ENCODING(encoding);
-    if (typeof cb !== 'function')
-      cb = nop;
-  }
+  if (encoding !== 'buffer' && !Buffer.isEncoding(encoding))
+    throw new ERR_UNKNOWN_ENCODING(encoding);
 
   if (chunk === null) {
     throw new ERR_STREAM_NULL_VALUES();
@@ -337,11 +334,15 @@ function _write(stream, chunk, encoding, cb) {
     return err;
   }
   state.pendingcb++;
-  return writeOrBuffer(stream, state, chunk, encoding, cb);
+  return writeOrBuffer(stream, state, chunk, encoding, ahead, cb);
 }
 
 Writable.prototype.write = function(chunk, encoding, cb) {
   return _write(this, chunk, encoding, cb) === true;
+};
+
+Writable.prototype.writeAhead = function(chunk, encoding, cb) {
+  return _write(this, chunk, encoding, true, cb) === true;
 };
 
 Writable.prototype.cork = function() {
@@ -372,7 +373,7 @@ Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
 // If we're already writing something, then just put this
 // in the queue, and wait our turn.  Otherwise, call _write
 // If we return false, then we need a drain event, so set that flag.
-function writeOrBuffer(stream, state, chunk, encoding, callback) {
+function writeOrBuffer(stream, state, chunk, encoding, ahead, callback) {
   const len = state.objectMode ? 1 : chunk.length;
 
   state.length += len;
@@ -384,7 +385,7 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
     state.needDrain = true;
 
   if (state.writing || state.corked || state.errored || !state.constructed) {
-    state.buffered.push({ chunk, encoding, callback });
+    state.buffered[ahead ? 'unshift' : 'push']({ chunk, encoding, callback });
     if (state.allBuffers && encoding !== 'buffer') {
       state.allBuffers = false;
     }

--- a/test/parallel/test-stream-writable-write-ahead.js
+++ b/test/parallel/test-stream-writable-write-ahead.js
@@ -1,0 +1,53 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const { Writable } = require('stream');
+
+{
+  const w = new Writable({
+    writev: common.mustCall((chunks, cb) => {
+      assert.deepStrictEqual(
+        Buffer('4213'),
+        Buffer.concat(chunks.map(({ chunk }) => chunk)),
+      );
+      cb();
+    })
+  });
+  w.cork();
+  w.write('1');
+  w.writeAhead('2');
+  w.write('3');
+  w.writeAhead('4');
+  w.end();
+}
+
+{
+  const items = [
+    { a: 1 },
+    { b: 2 },
+    { c: 3 },
+    { d: 4 },
+  ];
+  const w = new Writable({
+    objectMode: true,
+    writev: common.mustCall((chunks, cb) => {
+      assert.deepStrictEqual(
+        [
+          items[2],
+          items[0],
+          items[1],
+          items[3],
+        ],
+        chunks.map(({ chunk }) => chunk),
+      );
+      cb();
+    }),
+  });
+  w.cork();
+  w.writeAhead(items[0]);
+  w.write(items[1]);
+  w.writeAhead(items[2]);
+  w.write(items[3]);
+  w.end();
+}


### PR DESCRIPTION
This PR add a new function called `writeAhead` to `writable`

The main reason I feel like it should belong to nodejs is because its hard to do first in last out using stream which my code needs to do

Example use case:
```js
queue = new stream.Writable({
  objectMode: true,
  writev(chunks, cb){
    // Assuming that it could only process 2 chunk at a time
    console.log([chunks.shift(), chunks.shift()]);
    // Any write before returning would be cleared soo .nextTick is needed
    process.nextTick(() => {
      this.cork();
      for(let index = chunks.length; index--; ){
        const { chunk, encoding, callback } = chunks[index];
        // Callback needs to be cleared due to that `cb()` would call them automatically
        chunks[index].callback = () => {};
        this.writeAhead(chunk, encoding, callback); // Quite hard to achieve
      }
      process.nextTick(() => this.uncork());
    });
    cb();
  },
});
queue.cork();
queue.write({ a: 1 });
queue.write({ b: 2 });
queue.write({ c: 3 });
queue.write({ d: 4 });
queue.write({ e: 5 });
queue.uncork(); // Assuming the stream never .end()
```

Any suggestion/improvement is welcomed

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
