### PR TITLE
esm: protect `ERR_UNSUPPORTED_DIR_IMPORT` against prototype pollution

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1693,8 +1693,11 @@ E('ERR_UNKNOWN_FILE_EXTENSION', (ext, path, suggestion) => {
 E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s for URL %s',
   RangeError);
 E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s', TypeError);
-E('ERR_UNSUPPORTED_DIR_IMPORT', "Directory import '%s' is not supported " +
-'resolving ES modules imported from %s', Error);
+E('ERR_UNSUPPORTED_DIR_IMPORT', function(path, base, exactUrl) {
+  lazyInternalUtil().setOwnProperty(this, 'url', exactUrl);
+  return `Directory import '${path}' is not supported ` +
+    `resolving ES modules imported from ${base}`;
+}, Error);
 E('ERR_UNSUPPORTED_ESM_URL_SCHEME', (url, supported) => {
   let msg = `Only URLs with a scheme in: ${formatList(supported)} are supported by the default ESM loader`;
   if (isWindows && url.protocol.length === 2) {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -215,9 +215,7 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
 
   // Check for stats.isDirectory()
   if (stats === 1) {
-    const err = new ERR_UNSUPPORTED_DIR_IMPORT(path, fileURLToPath(base));
-    err.url = String(resolved);
-    throw err;
+    throw new ERR_UNSUPPORTED_DIR_IMPORT(path, fileURLToPath(base), String(resolved));
   } else if (stats !== 0) {
     // Check for !stats.isFile()
     if (process.env.WATCH_REPORT_DEPENDENCIES && process.send) {

--- a/test/es-module/test-esm-main-lookup.mjs
+++ b/test/es-module/test-esm-main-lookup.mjs
@@ -1,24 +1,22 @@
-import '../common/index.mjs';
+import { mustNotCall } from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'assert';
 
-async function main() {
-  let mod;
-  try {
-    mod = await import('../fixtures/es-modules/pjson-main');
-  } catch (e) {
-    assert.strictEqual(e.code, 'ERR_UNSUPPORTED_DIR_IMPORT');
-  }
+Object.defineProperty(Error.prototype, 'url', {
+  get: mustNotCall('get %Error.prototype%.url'),
+  set: mustNotCall('set %Error.prototype%.url'),
+});
+Object.defineProperty(Object.prototype, 'url', {
+  get: mustNotCall('get %Object.prototype%.url'),
+  set: mustNotCall('set %Object.prototype%.url'),
+});
 
-  assert.strictEqual(mod, undefined);
+await assert.rejects(import('../fixtures/es-modules/pjson-main'), {
+  code: 'ERR_UNSUPPORTED_DIR_IMPORT',
+  url: fixtures.fileURL('es-modules/pjson-main').href,
+});
 
-  try {
-    mod = await import('../fixtures/es-modules/pjson-main/main.mjs');
-  } catch (e) {
-    console.log(e);
-    assert.fail();
-  }
-
-  assert.strictEqual(mod.main, 'main');
-}
-
-main();
+assert.deepStrictEqual(
+  { ...await import('../fixtures/es-modules/pjson-main/main.mjs') },
+  { main: 'main' },
+);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
