### PR TITLE
tools: limit the number of auto start CIs

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -34,7 +34,7 @@ jobs:
                   --label 'request-ci' \
                   --json 'number' \
                   -t '{{ range . }}{{ .number }} {{ end }}' \
-                  --limit 100)
+                  --limit 5)
           echo "numbers=$numbers" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Every time the CI is locked, there is a backup of PRs to test with Jenkins, we usually disable the auto-start-ci workflow until the CI is unlocked. It sometimes causes problems when dozens of CI jobs are spawned at the same time. But actually there's no reason to send up to 100 requests at the same time, we could limit that to a more reasonable value.
5 is an arbitrary value, my hope is that is will be low enough to not cause the CI to be overwhelmed when we re-enable the workflow (5 PRs every 5 minutes), and high enough to not slow down the regular day-to-day operations.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
