### PR TITLE
esm: fix `globalPreload` warning

### DIFF
--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -86,7 +86,6 @@ let importMetaInitializer;
 
 // [2] `validate...()`s throw the wrong error
 
-let globalPreloadWarned = false;
 class Hooks {
   #chains = {
     /**
@@ -162,12 +161,9 @@ class Hooks {
     } = pluckHooks(exports);
 
     if (globalPreload && !initialize) {
-      if (globalPreloadWarned === false) {
-        globalPreloadWarned = true;
-        emitExperimentalWarning(
-          '`globalPreload` will be removed in a future version. Please use `initialize` instead.',
-        );
-      }
+      emitExperimentalWarning(
+        'It is recommended to use `initialize` instead of `globalPreload`, which',
+      );
       ArrayPrototypePush(this.#chains.globalPreload, { __proto__: null, fn: globalPreload, url });
     }
     if (resolve) {

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -162,7 +162,7 @@ class Hooks {
 
     if (globalPreload && !initialize) {
       emitExperimentalWarning(
-        'It is recommended to use `initialize` instead of `globalPreload`, which',
+        '`globalPreload` is planned for removal in favor of `initialize`. `globalPreload`',
       );
       ArrayPrototypePush(this.#chains.globalPreload, { __proto__: null, fn: globalPreload, url });
     }

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -436,6 +436,16 @@ describe('Loader hooks', { concurrency: true }, () => {
       assert.strictEqual(stderr.match(/use `initialize` instead of `globalPreload`/g).length, 1);
     });
 
+    it('should not emit deprecation warning when initialize is supplied', async () => {
+      const { stderr } = await spawnPromisified(execPath, [
+        '--experimental-loader',
+        'data:text/javascript,export function globalPreload(){}export function initialize(){}',
+        fixtures.path('empty.js'),
+      ]);
+
+      assert.doesNotMatch(stderr, /use `initialize` instead of `globalPreload`/);
+    });
+
     it('should handle globalPreload returning undefined', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
         '--no-warnings',

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -433,7 +433,7 @@ describe('Loader hooks', { concurrency: true }, () => {
         fixtures.path('empty.js'),
       ]);
 
-      assert.strictEqual(stderr.match(/use `initialize` instead of `globalPreload`/g).length, 1);
+      assert.strictEqual(stderr.match(/`globalPreload` is an experimental feature/g).length, 1);
     });
 
     it('should not emit deprecation warning when initialize is supplied', async () => {
@@ -443,7 +443,7 @@ describe('Loader hooks', { concurrency: true }, () => {
         fixtures.path('empty.js'),
       ]);
 
-      assert.doesNotMatch(stderr, /use `initialize` instead of `globalPreload`/);
+      assert.doesNotMatch(stderr, /`globalPreload` is an experimental feature/);
     });
 
     it('should handle globalPreload returning undefined', async () => {

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -428,10 +428,12 @@ describe('Loader hooks', { concurrency: true }, () => {
       const { stderr } = await spawnPromisified(execPath, [
         '--experimental-loader',
         'data:text/javascript,export function globalPreload(){}',
+        '--experimental-loader',
+        'data:text/javascript,export function globalPreload(){return""}',
         fixtures.path('empty.js'),
       ]);
 
-      assert.match(stderr, /`globalPreload` will be removed/);
+      assert.strictEqual(stderr.match(/use `initialize` instead of `globalPreload`/g).length, 1);
     });
 
     it('should handle globalPreload returning undefined', async () => {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/49026

Before:

```
(node:9201) ExperimentalWarning: `globalPreload` will be removed in a future version. Please use `initialize` instead. is an experimental feature and might change at any time
```

After:

```
(node:34642) ExperimentalWarning: It is recommended to use `initialize` instead of `globalPreload`, which is an experimental feature and might change at any time
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
