### PR TITLE
esm: introduce `node:interop` to expose the path of the current module

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -30,7 +30,7 @@ const { getOptionValue } = require('internal/options');
 const policy = getOptionValue('--experimental-policy') ?
   require('internal/process/policy') :
   null;
-const { sep, relative, toNamespacedPath, resolve } = require('path');
+const { sep, relative, toNamespacedPath, resolve, dirname } = require('path');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const experimentalNetworkImports =
@@ -976,6 +976,15 @@ function defaultResolve(specifier, context = {}) {
     } catch {
       // Ignore exception
     }
+  }
+
+  if (specifier === 'node:interop') {
+    const path = fileURLToPath(parsedParentURL);
+    const dir = dirname(path);
+    return {
+      url: `data:text/javascript,export const __filename=${JSONStringify(path)};export const __dirname=${JSONStringify(dir)}`,
+      format: 'module',
+    };
   }
 
   let parsed;

--- a/test/es-module/test-esm-interop.mjs
+++ b/test/es-module/test-esm-interop.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 const filename = fileURLToPath(import.meta.url);
 
 assert.strictEqual(__dirname, dirname(filename));
-assert.strictEqual(__filename, (filename));
+assert.strictEqual(__filename, filename);
 
 await assert.rejects(
   import('data:text/javascript,import"node:interop"'),

--- a/test/es-module/test-esm-interop.mjs
+++ b/test/es-module/test-esm-interop.mjs
@@ -1,0 +1,15 @@
+import '../common/index.mjs';
+import assert from 'node:assert';
+import { __filename, __dirname } from 'node:interop';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const filename = fileURLToPath(import.meta.url);
+
+assert.strictEqual(__dirname, dirname(filename));
+assert.strictEqual(__filename, (filename));
+
+await assert.rejects(
+  import('data:text/javascript,import"node:interop"'),
+  { code: 'ERR_INVALID_URL_SCHEME' },
+);


### PR DESCRIPTION
This is an alternative to https://github.com/nodejs/node/pull/48740. This exposes a new "magic" module `node:interop` that exports the path of the importing module. This aims to simplify uses of paths from within ESM modules, obviously it only works for modules loaded from the `file:` protocol (i.e. the modules corresponding to files on the FS). I think this would be a better approach than #48740 because it doesn't pollute `import.meta`, and it provides an early error when it is used from an unsupported protocol, and doesn't go in the way of folks who do not want any path within their ESM code.

Before it can land, this would need:

- [ ] agreement on the principle
- [ ] bikesheding on the module specifier (currently `node:interop`)
- [ ] bikeshedding on the export names (currently `__filename` and `__dirname`)
- [ ] bikeshedding on the error that it should throw when imported from a non-`file:` protocol (currently `ERR_INVALID_URL_SCHEME`)
- [ ] Docs

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
