### PR TITLE
crypto: add `randomULID` function

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5121,6 +5121,17 @@ added:
 Generates a random [RFC 4122][] version 4 UUID. The UUID is generated using a
 cryptographic pseudorandom number generator.
 
+### `crypto.randomULID([seed])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `seed` {integer} Seed for the random number generator. **Default:** `Date.now()`.
+
+Generates a random [ULID][]. The ULID is generated using a cryptographic
+pseudorandom number generator.
+
 ### `crypto.scrypt(password, salt, keylen[, options], callback)`
 
 <!-- YAML
@@ -6106,6 +6117,7 @@ See the [list of SSL OP Flags][] for details.
 [RFC 4122]: https://www.rfc-editor.org/rfc/rfc4122.txt
 [RFC 5208]: https://www.rfc-editor.org/rfc/rfc5208.txt
 [RFC 5280]: https://www.rfc-editor.org/rfc/rfc5280.txt
+[ULID]: https://github.com/ulid/spec
 [Web Crypto API documentation]: webcrypto.md
 [`BN_is_prime_ex`]: https://www.openssl.org/docs/man1.1.1/man3/BN_is_prime_ex.html
 [`Buffer`]: buffer.md

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -56,6 +56,7 @@ const {
   randomFillSync,
   randomInt,
   randomUUID,
+  randomULID,
 } = require('internal/crypto/random');
 const {
   pbkdf2,
@@ -219,6 +220,7 @@ module.exports = {
   randomFillSync,
   randomInt,
   randomUUID,
+  randomULID,
   scrypt,
   scryptSync,
   sign: signOneShot,

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -11,9 +11,13 @@ const {
   BigIntPrototypeToString,
   DataView,
   DataViewPrototypeGetUint8,
+  DateNow,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
+  MathFloor,
   MathMin,
+  MathPow,
+  NumberIsInteger,
   NumberIsNaN,
   NumberIsSafeInteger,
   NumberPrototypeToString,
@@ -411,6 +415,73 @@ function randomUUID(options) {
   return disableEntropyCache ? getUnbufferedUUID() : getBufferedUUID();
 }
 
+const kCrockford = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+const kCrockfordBase = 32;
+const kUlidMaxTime = MathPow(2, 48) - 1;
+const kUlidTimeSize = 10;
+const kUlidRandomSize = 16;
+
+function numberToCrockfordBase(num) {
+  let result = '';
+  while (num > 0) {
+    result = kCrockford[num % kCrockfordBase] + result;
+    num = MathFloor(num / kCrockfordBase);
+  }
+  return result;
+}
+
+function ulidTimePart(seed) {
+  if (NumberIsNaN(seed)) throw new ERR_INVALID_ARG_TYPE('seed', 'number', seed);
+  if (seed < 0 || kUlidMaxTime < seed) throw new ERR_OUT_OF_RANGE('seed', `>= 0 && < ${kUlidMaxTime}`, seed);
+  if (!NumberIsInteger(seed)) throw new ERR_INVALID_ARG_TYPE('seed', 'integer', seed);
+  return StringPrototypePadStart(numberToCrockfordBase(seed), kUlidTimeSize, '0');
+}
+
+function ulidRandomPart() {
+  let result = '';
+  for (let i = 0; i < kUlidRandomSize; i++) {
+    result += kCrockford[randomInt(0, kCrockfordBase)];
+  }
+  return result;
+}
+
+function incrementCrockfordBase32(ulid) {
+  for (let i = ulid.length - 1; i >= 0; i--) {
+    const index = kCrockford.indexOf(ulid[i]);
+    if (index === -1) throw new ERR_INVALID_ARG_TYPE('ulid', 'invalid' +
+      ' crockford base32 char', ulid[i]);
+
+    if (index === kCrockfordBase - 1) {
+      ulid = ulid.slice(0, i) + kCrockford[0] + ulid.slice(i + 1);
+      continue;
+    }
+
+    return ulid.slice(0, i) + kCrockford[index + 1] + ulid.slice(i + 1);
+  }
+
+  throw new ERR_OUT_OF_RANGE('ulid', 'cannot increment string', ulid);
+}
+
+const randomULID = (() => {
+  let lastTime = -1;
+  let lastRandom;
+
+  return (seed) => {
+    if (seed === undefined) {
+      seed = DateNow();
+    }
+
+    if (seed <= lastTime) {
+      lastRandom = incrementCrockfordBase32(lastRandom);
+    } else {
+      lastTime = seed;
+      lastRandom = ulidRandomPart();
+    }
+    return ulidTimePart(seed) + lastRandom;
+  };
+})();
+
+
 function createRandomPrimeJob(type, size, options) {
   validateObject(options, 'options');
 
@@ -608,6 +679,7 @@ module.exports = {
   randomInt,
   getRandomValues,
   randomUUID,
+  randomULID,
   generatePrime,
   generatePrimeSync,
 };

--- a/test/parallel/test-crypto-randomulid.js
+++ b/test/parallel/test-crypto-randomulid.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('node:assert');
+const {
+  randomULID,
+} = require('node:crypto');
+
+function testMatch(ulid) {
+  assert.match(
+    ulid,
+    /^[0-9A-HJKMNP-TV-Z]{26}$/
+  );
+}
+
+const crockfordBase32 = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+function incrementULID(ulid) {
+  for (let i = ulid.length - 1; i >= 0; i--) {
+    const index = crockfordBase32.indexOf(ulid[i]);
+    if (index === -1) {
+      throw new Error('Invalid ULID character');
+    }
+    if (index === crockfordBase32.length - 1) {
+      ulid = ulid.substring(0, i) + '0' + ulid.substring(i + 1);
+      continue;
+    }
+
+    ulid = ulid.substring(0, i) + crockfordBase32[index + 1] + ulid.substring(i + 1);
+    return ulid;
+  }
+}
+
+// Generate some ULIDs
+for (let n = 0; n < 130; n++) {
+  const ulid = randomULID();
+  assert.strictEqual(typeof ulid, 'string');
+  assert.strictEqual(ulid.length, 26);
+  testMatch(ulid);
+}
+
+// Generate some ULIDs with a fixed seed
+let last = randomULID(42);
+for (let n = 0; n < 130; n++) {
+  const ulid = randomULID(42);
+  assert.strictEqual(ulid, incrementULID(last));
+  last = ulid;
+}
+
+assert.throws(() => randomULID('foo'), {
+  code: 'ERR_INVALID_ARG_TYPE'
+});
+
+assert.throws(() => randomULID(Math.PI), {
+  code: 'ERR_INVALID_ARG_TYPE'
+});
+
+assert.throws(() => randomULID(-1), {
+  code: 'ERR_OUT_OF_RANGE'
+});
+
+assert.throws(() => randomULID(NaN), {
+  code: 'ERR_INVALID_ARG_TYPE'
+});


### PR DESCRIPTION
I propose to land `randomULID` in the `crypto` subsystem.

ULID are lexicographically sortable identifiers contaning both the time it was generated and a random part. Spec can be found here: https://github.com/ulid/spec

ULID implementation exists in userland, currently getting around 768'000 downloads per week: https://www.npmjs.com/package/ulid
Since its release, popularity constantly grew: https://npmtrends.com/ulid

I will be happy to get feedbacks on the implementation and I'm obviously open to discuss if you have reluctance to land it in Node.js.