### PR TITLE
test: add `tmpdir.resolve()`

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -1056,6 +1056,13 @@ Avoid calling it more than once in an asynchronous context as one call
 might refresh the temporary directory of a different context, causing
 the test to fail somewhat mysteriously.
 
+### `resolve([...paths])`
+
+* `...paths` [\<string>][<string>]
+* return [\<string>][<string>]
+
+Resolves a sequence of paths into absolute path in the temporary directory.
+
 ### `hasEnoughSpace(size)`
 
 * `size` [\<number>][<number>] Required size, in bytes.

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -70,6 +70,10 @@ function onexit(useSpawn) {
   }
 }
 
+function resolve(...paths) {
+  return path.resolve(tmpPath, ...paths);
+}
+
 function hasEnoughSpace(size) {
   const { bavail, bsize } = fs.statfsSync(tmpPath);
   return bavail >= Math.ceil(size / bsize);
@@ -87,4 +91,5 @@ module.exports = {
   hasEnoughSpace,
   path: tmpPath,
   refresh,
+  resolve,
 };


### PR DESCRIPTION
Adds a simple method to make the usual routine of `path.join(tmpdir.path, ...)` more concise and avoid unnecessary import from `node:path` almost every time `tmpdir` is used.