### PR TITLE
url: do not append slashes when unicode is enabled if empty hostname

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -205,7 +205,7 @@ void BindingData::Format(const FunctionCallbackInfo<Value>& args) {
     out->hash = std::nullopt;
   }
 
-  if (unicode) {
+  if (unicode && out->has_hostname()) {
     out->host = ada::idna::to_unicode(out->get_hostname());
   }
 

--- a/test/parallel/test-url-format-whatwg.js
+++ b/test/parallel/test-url-format-whatwg.js
@@ -140,3 +140,8 @@ assert.strictEqual(
   url.format(new URL('http://user:pass@xn--0zwm56d.com:8080/path'), { unicode: true }),
   'http://user:pass@测试.com:8080/path'
 );
+
+assert.strictEqual(
+  url.format(new URL('tel:123')),
+  url.format(new URL('tel:123'), { unicode: true })
+)


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/48759
