### PR TITLE
test_runner: add support for chainable `mockImplementationOnce`

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1328,8 +1328,9 @@ changes:
   mock's implementation for the invocation number specified by `onCall`.
 * `onCall` {integer} The invocation number that will use `implementation`. If
   the specified invocation has already occurred then an exception is thrown.
-  **Default:** The number of the next invocation than is not mocked by `mockImplementationOnce`.
-* Returns: {MockFunctionContext} the context to allow chaining.
+  **Default:** The number of the next invocation that is not mocked by `mockImplementationOnce`.
+* Returns: {MockFunctionContext} A reference to the `MockFunctionContext`,
+  so that calls can be chained.
 
 This function is used to change the behavior of an existing mock for a single
 invocation. Once invocation `onCall` has occurred, the mock will revert to

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1318,13 +1318,18 @@ test('changes a mock behavior', (t) => {
 added:
   - v19.1.0
   - v18.13.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/49088
+    description: this now return the context as well as appending when not providing the onCall argument.
 -->
 
 * `implementation` {Function|AsyncFunction} The function to be used as the
   mock's implementation for the invocation number specified by `onCall`.
 * `onCall` {integer} The invocation number that will use `implementation`. If
   the specified invocation has already occurred then an exception is thrown.
-  **Default:** The number of the next invocation.
+  **Default:** The number of the next invocation than is not mocked by `mockImplementationOnce`.
+* Returns: {MockFunctionContext} the context to allow chaining.
 
 This function is used to change the behavior of an existing mock for a single
 invocation. Once invocation `onCall` has occurred, the mock will revert to

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1352,8 +1352,15 @@ test('changes a mock behavior once', (t) => {
   const fn = t.mock.fn(addOne);
 
   assert.strictEqual(fn(), 1);
-  fn.mock.mockImplementationOnce(addTwo);
+  assert.strictEqual(fn(), 2);
+  fn.mock
+    .mockImplementationOnce(() => 17)
+    .mockImplementationOnce(() => 77, 5)
+    .mockImplementationOnce(() => 42);
+  assert.strictEqual(fn(), 17);
+  assert.strictEqual(fn(), 42);
   assert.strictEqual(fn(), 3);
+  assert.strictEqual(fn(), 77);
   assert.strictEqual(fn(), 4);
 });
 ```

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1329,7 +1329,7 @@ changes:
 * `onCall` {integer} The invocation number that will use `implementation`. If
   the specified invocation has already occurred then an exception is thrown.
   **Default:** The number of the next invocation that is not mocked by `mockImplementationOnce`.
-* Returns: {MockFunctionContext} A reference to the `MockFunctionContext`,
+* Returns: {MockFunctionContext} A reference to the [`MockFunctionContext`][],
   so that calls can be chained.
 
 This function is used to change the behavior of an existing mock for a single

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -75,7 +75,7 @@ class MockFunctionContext {
         return this;
       }
     }
-    this.#mocks.set(this.#mocks.size + nextCall, implementation);
+    this.#mocks.set(mocksSize + nextCall, implementation);
 
     return this;
   }

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -61,11 +61,11 @@ class MockFunctionContext {
   mockImplementationOnce(implementation, onCall) {
     validateFunction(implementation, 'implementation');
     const nextCall = this.#calls.length;
-    if(onCall) {
-        validateInteger(onCall, 'onCall', nextCall);
-        this.#mocks.set(onCall, implementation);
+    if (onCall) {
+      validateInteger(onCall, 'onCall', nextCall);
+      this.#mocks.set(onCall, implementation);
     } else {
-        this.#mocks.set(this.#mocks.size + nextCall, implementation);
+      this.#mocks.set(this.#mocks.size + nextCall, implementation);
     }
 
     return this;

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -68,15 +68,8 @@ class MockFunctionContext {
       return this;
     }
 
-    // #calls:
-    // - 0: X
-    // - 1: Y
-
-    // #mock:
-    // - 2: Z
-
     const mocksSize = this.#mocks.size;
-    for(let i = 0; i < mocksSize; i++) {
+    for (let i = 0; i < mocksSize; i++) {
       if (!this.#mocks.has(i + nextCall)) {
         this.#mocks.set(i + nextCall, implementation);
         return this;

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -2,8 +2,6 @@
 const {
   ArrayPrototypePush,
   ArrayPrototypeSlice,
-  ArrayPrototypeShift,
-  ArrayPrototypeAt,
   Error,
   FunctionPrototypeCall,
   ObjectDefineProperty,
@@ -13,7 +11,7 @@ const {
   ReflectApply,
   ReflectConstruct,
   ReflectGet,
-  SafeSet,
+  SafeMap,
 } = primordials;
 const {
   codes: {
@@ -34,19 +32,17 @@ function kDefaultFunction() {}
 
 class MockFunctionContext {
   #calls;
+  #mocks;
   #implementation;
   #restore;
   #times;
-  #queue;
-  #emptyImpl;
 
   constructor(implementation, restore, times) {
     this.#calls = [];
+    this.#mocks = new SafeMap();
     this.#implementation = implementation;
     this.#restore = restore;
     this.#times = times;
-    this.#queue = [];
-    this.#emptyImpl = new SafeSet();
   }
 
   get calls() {
@@ -65,64 +61,30 @@ class MockFunctionContext {
   mockImplementationOnce(implementation, onCall) {
     validateFunction(implementation, 'implementation');
     const nextCall = this.#calls.length;
-    const call = onCall ?? nextCall;
-    // eslint-disable-next-line eqeqeq
-    if (onCall != undefined) {
-      validateInteger(call, 'onCall', nextCall);
-    }
+    if (onCall) {
+      validateInteger(onCall, 'onCall', nextCall);
+      this.#mocks.set(onCall, implementation);
 
-    // eslint-disable-next-line eqeqeq
-    if (onCall == undefined) {
-      this.#addMockToFirstEmptyImpl(implementation);
       return this;
     }
 
-    const lastCall = ArrayPrototypeAt(this.#queue, -1)?.index;
-    if (lastCall >= onCall) {
-      this.#replaceCallImplementation(onCall, implementation);
-    } else {
-      this.#addImplementationsPadding(lastCall, onCall);
-      ArrayPrototypePush(this.#queue, { __proto__: null, index: onCall, impl: implementation });
-    }
+    // #calls:
+    // - 0: X
+    // - 1: Y
 
-    return this;
-  }
+    // #mock:
+    // - 2: Z
 
-  #addMockToFirstEmptyImpl(implementation) {
-    if (this.#emptyImpl.size) {
-      const emptyImpl = this.#emptyImpl.values().next().value;
-      this.#emptyImpl.delete(emptyImpl);
-      emptyImpl.impl = implementation;
-
-      return;
-    }
-
-    const lastCall = ArrayPrototypeAt(this.#queue, -1)?.index;
-    ArrayPrototypePush(this.#queue, {
-      __proto__: null,
-      index: lastCall === undefined ? this.#calls.length : lastCall + 1,
-      impl: implementation,
-    });
-  }
-
-  #replaceCallImplementation(call, implementation) {
-    for (let i = 0; i < this.#queue.length; i++) {
-      if (this.#queue[i]?.index === call) {
-        this.#emptyImpl.delete(this.#queue[i]);
-        this.#queue[i].impl = implementation;
-        return;
+    const mocksSize = this.#mocks.size;
+    for(let i = 0; i < mocksSize; i++) {
+      if (!this.#mocks.has(i + nextCall)) {
+        this.#mocks.set(i + nextCall, implementation);
+        return this;
       }
     }
-  }
+    this.#mocks.set(this.#mocks.size + nextCall, implementation);
 
-  #addImplementationsPadding(fromIndex, toIndex) {
-    const from = fromIndex === undefined ? this.#calls.length : fromIndex + 1;
-
-    for (let i = from; i < toIndex; i++) {
-      const emptyImpl = { __proto__: null, index: i };
-      ArrayPrototypePush(this.#queue, emptyImpl);
-      this.#emptyImpl.add(emptyImpl);
-    }
+    return this;
   }
 
   restore() {
@@ -136,8 +98,6 @@ class MockFunctionContext {
       // the mock call the original function.
       this.#implementation = original;
     }
-    this.#queue = [];
-    this.#emptyImpl.clear();
   }
 
   resetCalls() {
@@ -150,15 +110,14 @@ class MockFunctionContext {
 
   nextImpl() {
     const nextCall = this.#calls.length;
-    const mock = ArrayPrototypeShift(this.#queue);
-    const impl = mock?.impl ?? this.#implementation;
+    const mock = this.#mocks.get(nextCall);
+    const impl = mock ?? this.#implementation;
 
-    this.#emptyImpl.delete(mock);
-
-    if (this.#queue.length === 0 && nextCall + 1 === this.#times) {
+    if (nextCall + 1 === this.#times) {
       this.restore();
     }
 
+    this.#mocks.delete(nextCall);
     return impl;
   }
 }

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -2,6 +2,9 @@
 const {
   ArrayPrototypePush,
   ArrayPrototypeSlice,
+  ArrayPrototypeShift,
+  ArrayPrototypeAt,
+  SetPrototypeDelete,
   Error,
   FunctionPrototypeCall,
   ObjectDefineProperty,
@@ -75,12 +78,12 @@ class MockFunctionContext {
       return this;
     }
 
-    const lastCall = this.#queue[this.#queue.length - 1]?.index;
+    const lastCall = ArrayPrototypeAt(this.#queue, -1)?.index;
     if (lastCall >= onCall) {
       this.#replaceCallImplementation(onCall, implementation);
     } else {
       this.#addImplementationsPadding(lastCall, onCall);
-      this.#queue.push({ __proto__: null, index: onCall, impl: implementation });
+      ArrayPrototypePush(this.#queue, { __proto__: null, index: onCall, impl: implementation });
     }
 
     return this;
@@ -88,15 +91,15 @@ class MockFunctionContext {
 
   #addMockToFirstEmptyImpl(implementation) {
     if (this.#emptyImpl.size) {
-      const emptyImpl = this.#emptyImpl.values().next().value;
-      this.#emptyImpl.delete(emptyImpl);
+      const { 0: emptyImpl } = this.#emptyImpl;
+      SetPrototypeDelete(this.#emptyImpl, emptyImpl);
       emptyImpl.impl = implementation;
 
       return;
     }
 
-    const lastCall = this.#queue[this.#queue.length - 1]?.index;
-    this.#queue.push({
+    const lastCall = ArrayPrototypeAt(this.#queue, -1)?.index;
+    ArrayPrototypePush(this.#queue, {
       __proto__: null,
       index: lastCall === undefined ? this.#calls.length : lastCall + 1,
       impl: implementation,
@@ -106,7 +109,7 @@ class MockFunctionContext {
   #replaceCallImplementation(call, implementation) {
     for (let i = 0; i < this.#queue.length; i++) {
       if (this.#queue[i]?.index === call) {
-        this.#emptyImpl.delete(this.#queue[i]);
+        SetPrototypeDelete(this.#emptyImpl, this.#queue[i]);
         this.#queue[i].impl = implementation;
         return;
       }
@@ -118,8 +121,8 @@ class MockFunctionContext {
 
     for (let i = from; i < toIndex; i++) {
       const emptyImpl = { __proto__: null, index: i };
-      this.#queue.push(emptyImpl);
-      this.#emptyImpl.add(emptyImpl);
+      ArrayPrototypePush(this.#queue, emptyImpl);
+      SetPrototypeAdd(this.#emptyImpl, emptyImpl);
     }
   }
 
@@ -135,7 +138,7 @@ class MockFunctionContext {
       this.#implementation = original;
     }
     this.#queue = [];
-    this.#emptyImpl.clear();
+    SetPrototypeClear(this.#emptyImpl);
   }
 
   resetCalls() {
@@ -148,10 +151,10 @@ class MockFunctionContext {
 
   nextImpl() {
     const nextCall = this.#calls.length;
-    const mock = this.#queue.shift();
+    const mock = ArrayPrototypeShift(this.#queue);
     const impl = mock?.impl ?? this.#implementation;
 
-    this.#emptyImpl.delete(mock);
+    SetPrototypeDelete(this.#emptyImpl, mock);
 
     if (this.#queue.length === 0 && nextCall + 1 === this.#times) {
       this.restore();

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -4,9 +4,6 @@ const {
   ArrayPrototypeSlice,
   ArrayPrototypeShift,
   ArrayPrototypeAt,
-  SetPrototypeAdd,
-  SetPrototypeClear,
-  SetPrototypeDelete,
   Error,
   FunctionPrototypeCall,
   ObjectDefineProperty,
@@ -94,7 +91,7 @@ class MockFunctionContext {
   #addMockToFirstEmptyImpl(implementation) {
     if (this.#emptyImpl.size) {
       const emptyImpl = this.#emptyImpl.values().next().value;
-      SetPrototypeDelete(this.#emptyImpl, emptyImpl);
+      this.#emptyImpl.delete(emptyImpl);
       emptyImpl.impl = implementation;
 
       return;
@@ -111,7 +108,7 @@ class MockFunctionContext {
   #replaceCallImplementation(call, implementation) {
     for (let i = 0; i < this.#queue.length; i++) {
       if (this.#queue[i]?.index === call) {
-        SetPrototypeDelete(this.#emptyImpl, this.#queue[i]);
+        this.#emptyImpl.delete(this.#queue[i]);
         this.#queue[i].impl = implementation;
         return;
       }
@@ -124,7 +121,7 @@ class MockFunctionContext {
     for (let i = from; i < toIndex; i++) {
       const emptyImpl = { __proto__: null, index: i };
       ArrayPrototypePush(this.#queue, emptyImpl);
-      SetPrototypeAdd(this.#emptyImpl, emptyImpl);
+      this.#emptyImpl.add(emptyImpl);
     }
   }
 
@@ -140,7 +137,7 @@ class MockFunctionContext {
       this.#implementation = original;
     }
     this.#queue = [];
-    SetPrototypeClear(this.#emptyImpl);
+    this.#emptyImpl.clear();
   }
 
   resetCalls() {
@@ -156,7 +153,7 @@ class MockFunctionContext {
     const mock = ArrayPrototypeShift(this.#queue);
     const impl = mock?.impl ?? this.#implementation;
 
-    SetPrototypeDelete(this.#emptyImpl, mock);
+    this.#emptyImpl.delete(mock);
 
     if (this.#queue.length === 0 && nextCall + 1 === this.#times) {
       this.restore();

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -71,38 +71,22 @@ class MockFunctionContext {
 
     // eslint-disable-next-line eqeqeq
     if (onCall == undefined) {
-      this.addMockToFirstEmptyImpl(implementation);
+      this.#addMockToFirstEmptyImpl(implementation);
       return this;
     }
 
-    // If want a specific call - if the call is already in the queue, replace the implementation.
     const lastCall = this.#queue[this.#queue.length - 1]?.index;
     if (lastCall >= onCall) {
-      for (let i = 0; i < this.#queue.length; i++) {
-        if (this.#queue[i]?.index === onCall) {
-          this.#emptyImpl.delete(this.#queue[i]);
-          this.#queue[i].impl = implementation;
-          break;
-        }
-      }
-
+      this.#replaceCallImplementation(onCall, implementation);
       return this;
     }
 
-    // If want a specific call - if the call is not in the queue, push empty implementations to the queue
-    // until the call index is reached.
-    const from = lastCall === undefined ? this.#calls.length : lastCall + 1;
-    for (let i = from; i < onCall; i++) {
-      const emptyImpl = { __proto__: null, index: i };
-      this.#queue.push(emptyImpl);
-      this.#emptyImpl.add(emptyImpl);
-    }
-
+    this.#addImplementationsPadding(lastCall, onCall);
     this.#queue.push({ __proto__: null, index: onCall, impl: implementation });
     return this;
   }
 
-  addMockToFirstEmptyImpl(implementation) {
+  #addMockToFirstEmptyImpl(implementation) {
     if (this.#emptyImpl.size) {
       const emptyImpl = this.#emptyImpl.values().next().value;
       this.#emptyImpl.delete(emptyImpl);
@@ -117,6 +101,26 @@ class MockFunctionContext {
       impl: implementation,
     });
     return this;
+  }
+
+  #replaceCallImplementation(call, implementation) {
+    for (let i = 0; i < this.#queue.length; i++) {
+      if (this.#queue[i]?.index === call) {
+        this.#emptyImpl.delete(this.#queue[i]);
+        this.#queue[i].impl = implementation;
+        return;
+      }
+    }
+  }
+
+  #addImplementationsPadding(lastCall, onCall) {
+    const from = lastCall === undefined ? this.#calls.length : lastCall + 1;
+
+    for (let i = from; i < onCall; i++) {
+      const emptyImpl = { __proto__: null, index: i };
+      this.#queue.push(emptyImpl);
+      this.#emptyImpl.add(emptyImpl);
+    }
   }
 
   restore() {

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -61,9 +61,14 @@ class MockFunctionContext {
   mockImplementationOnce(implementation, onCall) {
     validateFunction(implementation, 'implementation');
     const nextCall = this.#calls.length;
-    const call = onCall ?? nextCall;
-    validateInteger(call, 'onCall', nextCall);
-    this.#mocks.set(call, implementation);
+    if(onCall) {
+        validateInteger(onCall, 'onCall', nextCall);
+        this.#mocks.set(onCall, implementation);
+    } else {
+        this.#mocks.set(this.#mocks.size + nextCall, implementation);
+    }
+
+    return this;
   }
 
   restore() {

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -78,11 +78,11 @@ class MockFunctionContext {
     const lastCall = this.#queue[this.#queue.length - 1]?.index;
     if (lastCall >= onCall) {
       this.#replaceCallImplementation(onCall, implementation);
-      return this;
+    } else {
+      this.#addImplementationsPadding(lastCall, onCall);
+      this.#queue.push({ __proto__: null, index: onCall, impl: implementation });
     }
 
-    this.#addImplementationsPadding(lastCall, onCall);
-    this.#queue.push({ __proto__: null, index: onCall, impl: implementation });
     return this;
   }
 
@@ -91,6 +91,7 @@ class MockFunctionContext {
       const emptyImpl = this.#emptyImpl.values().next().value;
       this.#emptyImpl.delete(emptyImpl);
       emptyImpl.impl = implementation;
+
       return;
     }
 
@@ -100,7 +101,6 @@ class MockFunctionContext {
       index: lastCall === undefined ? this.#calls.length : lastCall + 1,
       impl: implementation,
     });
-    return this;
   }
 
   #replaceCallImplementation(call, implementation) {
@@ -113,10 +113,10 @@ class MockFunctionContext {
     }
   }
 
-  #addImplementationsPadding(lastCall, onCall) {
-    const from = lastCall === undefined ? this.#calls.length : lastCall + 1;
+  #addImplementationsPadding(fromIndex, toIndex) {
+    const from = fromIndex === undefined ? this.#calls.length : fromIndex + 1;
 
-    for (let i = from; i < onCall; i++) {
+    for (let i = from; i < toIndex; i++) {
       const emptyImpl = { __proto__: null, index: i };
       this.#queue.push(emptyImpl);
       this.#emptyImpl.add(emptyImpl);

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -61,7 +61,8 @@ class MockFunctionContext {
   mockImplementationOnce(implementation, onCall) {
     validateFunction(implementation, 'implementation');
     const nextCall = this.#calls.length;
-    if (onCall) {
+    // eslint-disable-next-line eqeqeq
+    if (onCall != undefined) {
       validateInteger(onCall, 'onCall', nextCall);
       this.#mocks.set(onCall, implementation);
 

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -4,6 +4,8 @@ const {
   ArrayPrototypeSlice,
   ArrayPrototypeShift,
   ArrayPrototypeAt,
+  SetPrototypeAdd,
+  SetPrototypeClear,
   SetPrototypeDelete,
   Error,
   FunctionPrototypeCall,
@@ -91,7 +93,7 @@ class MockFunctionContext {
 
   #addMockToFirstEmptyImpl(implementation) {
     if (this.#emptyImpl.size) {
-      const { 0: emptyImpl } = this.#emptyImpl;
+      const emptyImpl = this.#emptyImpl.values().next().value;
       SetPrototypeDelete(this.#emptyImpl, emptyImpl);
       emptyImpl.impl = implementation;
 

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -11,7 +11,6 @@ const {
   ReflectApply,
   ReflectConstruct,
   ReflectGet,
-  SafeMap,
 } = primordials;
 const {
   codes: {
@@ -32,17 +31,17 @@ function kDefaultFunction() {}
 
 class MockFunctionContext {
   #calls;
-  #mocks;
   #implementation;
   #restore;
   #times;
+  #queue;
 
   constructor(implementation, restore, times) {
     this.#calls = [];
-    this.#mocks = new SafeMap();
     this.#implementation = implementation;
     this.#restore = restore;
     this.#times = times;
+    this.#queue = [];
   }
 
   get calls() {
@@ -61,13 +60,46 @@ class MockFunctionContext {
   mockImplementationOnce(implementation, onCall) {
     validateFunction(implementation, 'implementation');
     const nextCall = this.#calls.length;
-    if (onCall) {
-      validateInteger(onCall, 'onCall', nextCall);
-      this.#mocks.set(onCall, implementation);
-    } else {
-      this.#mocks.set(this.#mocks.size + nextCall, implementation);
+    const call = onCall ?? nextCall;
+    // eslint-disable-next-line eqeqeq
+    if (onCall != undefined) {
+      validateInteger(call, 'onCall', nextCall);
     }
 
+    // eslint-disable-next-line eqeqeq
+    if (onCall == undefined) {
+      for (let i = 0; i < this.#queue.length; i++) {
+        if (this.#queue[i]?.impl === undefined) {
+          this.#queue[i].impl = implementation;
+          return this;
+        }
+      }
+
+      const lastCall = this.#queue[this.#queue.length - 1]?.index;
+      this.#queue.push({
+        __proto__: null,
+        index: lastCall === undefined ? this.#calls.length : lastCall + 1,
+        impl: implementation,
+      });
+      return this;
+    }
+
+    const lastCall = this.#queue[this.#queue.length - 1]?.index;
+    if (lastCall !== undefined && lastCall >= onCall) {
+      for (let i = 0; i < this.#queue.length; i++) {
+        if (this.#queue[i]?.index === onCall) {
+          this.#queue[i].impl = implementation;
+          break;
+        }
+      }
+      return this;
+    }
+
+    const from = lastCall === undefined ? this.#calls.length : lastCall + 1;
+    for (let i = from; i < onCall; i++) {
+      this.#queue.push({ __proto__: null, index: i });
+    }
+    this.#queue.push({ __proto__: null, index: onCall, impl: implementation });
     return this;
   }
 
@@ -82,6 +114,7 @@ class MockFunctionContext {
       // the mock call the original function.
       this.#implementation = original;
     }
+    this.#queue = [];
   }
 
   resetCalls() {
@@ -94,14 +127,13 @@ class MockFunctionContext {
 
   nextImpl() {
     const nextCall = this.#calls.length;
-    const mock = this.#mocks.get(nextCall);
-    const impl = mock ?? this.#implementation;
+    const mock = this.#queue.shift();
+    const impl = mock?.impl ?? this.#implementation;
 
-    if (nextCall + 1 === this.#times) {
+    if (this.#queue.length === 0 && nextCall + 1 === this.#times) {
       this.restore();
     }
 
-    this.#mocks.delete(nextCall);
     return impl;
   }
 }

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -11,6 +11,7 @@ const {
   ReflectApply,
   ReflectConstruct,
   ReflectGet,
+  SafeSet,
 } = primordials;
 const {
   codes: {
@@ -35,6 +36,7 @@ class MockFunctionContext {
   #restore;
   #times;
   #queue;
+  #emptyImpl;
 
   constructor(implementation, restore, times) {
     this.#calls = [];
@@ -42,6 +44,7 @@ class MockFunctionContext {
     this.#restore = restore;
     this.#times = times;
     this.#queue = [];
+    this.#emptyImpl = new SafeSet();
   }
 
   get calls() {
@@ -68,38 +71,51 @@ class MockFunctionContext {
 
     // eslint-disable-next-line eqeqeq
     if (onCall == undefined) {
-      for (let i = 0; i < this.#queue.length; i++) {
-        if (this.#queue[i]?.impl === undefined) {
-          this.#queue[i].impl = implementation;
-          return this;
-        }
-      }
-
-      const lastCall = this.#queue[this.#queue.length - 1]?.index;
-      this.#queue.push({
-        __proto__: null,
-        index: lastCall === undefined ? this.#calls.length : lastCall + 1,
-        impl: implementation,
-      });
+      this.addMockToFirstEmptyImpl(implementation);
       return this;
     }
 
+    // If want a specific call - if the call is already in the queue, replace the implementation.
     const lastCall = this.#queue[this.#queue.length - 1]?.index;
-    if (lastCall !== undefined && lastCall >= onCall) {
+    if (lastCall >= onCall) {
       for (let i = 0; i < this.#queue.length; i++) {
         if (this.#queue[i]?.index === onCall) {
+          this.#emptyImpl.delete(this.#queue[i]);
           this.#queue[i].impl = implementation;
           break;
         }
       }
+
       return this;
     }
 
+    // If want a specific call - if the call is not in the queue, push empty implementations to the queue
+    // until the call index is reached.
     const from = lastCall === undefined ? this.#calls.length : lastCall + 1;
     for (let i = from; i < onCall; i++) {
-      this.#queue.push({ __proto__: null, index: i });
+      const emptyImpl = { __proto__: null, index: i };
+      this.#queue.push(emptyImpl);
+      this.#emptyImpl.add(emptyImpl);
     }
+
     this.#queue.push({ __proto__: null, index: onCall, impl: implementation });
+    return this;
+  }
+
+  addMockToFirstEmptyImpl(implementation) {
+    if (this.#emptyImpl.size) {
+      const emptyImpl = this.#emptyImpl.values().next().value;
+      this.#emptyImpl.delete(emptyImpl);
+      emptyImpl.impl = implementation;
+      return;
+    }
+
+    const lastCall = this.#queue[this.#queue.length - 1]?.index;
+    this.#queue.push({
+      __proto__: null,
+      index: lastCall === undefined ? this.#calls.length : lastCall + 1,
+      impl: implementation,
+    });
     return this;
   }
 
@@ -115,6 +131,7 @@ class MockFunctionContext {
       this.#implementation = original;
     }
     this.#queue = [];
+    this.#emptyImpl.clear();
   }
 
   resetCalls() {
@@ -129,6 +146,8 @@ class MockFunctionContext {
     const nextCall = this.#calls.length;
     const mock = this.#queue.shift();
     const impl = mock?.impl ?? this.#implementation;
+
+    this.#emptyImpl.delete(mock);
 
     if (this.#queue.length === 0 && nextCall + 1 === this.#times) {
       this.restore();

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -902,9 +902,9 @@ test('mockImplementationOnce chaining', (t) => {
   assert.strictEqual(fn(), 1);
   assert.strictEqual(fn(), 2);
   fn.mock
+    .mockImplementationOnce(() => 77, 5)
     .mockImplementationOnce(() => 17)
     .mockImplementationOnce(() => 42)
-    .mockImplementationOnce(() => 77, 5);
   assert.strictEqual(fn(), 17);
   assert.strictEqual(fn(), 42);
   assert.strictEqual(fn(), 3);

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -891,6 +891,55 @@ test('mock implementation can be changed dynamically', (t) => {
   assert.strictEqual(fn.mock.callCount(), 12);
 });
 
+test('mockImplementationOnce chaining', (t) => {
+  let cnt = 0;
+  function addOne() {
+    cnt++;
+    return cnt;
+  }
+
+  const fn = t.mock.fn(addOne);
+  assert.strictEqual(fn(), 1);
+  assert.strictEqual(fn(), 2);
+  fn.mock
+    .mockImplementationOnce(() => 17)
+    .mockImplementationOnce(() => 42)
+    .mockImplementationOnce(() => 77, 5)
+  assert.strictEqual(fn(), 17);
+  assert.strictEqual(fn(), 42);
+  assert.strictEqual(fn(), 3);
+  assert.strictEqual(fn(), 77);
+  assert.strictEqual(fn(), 4);
+  assert.strictEqual(fn(), 5);
+
+  fn.mock.mockImplementationOnce(() => 52)
+  assert.strictEqual(fn(), 52);
+  assert.strictEqual(fn(), 6);
+});
+
+test('mockImplementationOnce chaining with default value', (t) => {
+  let cnt = 0;
+  function addOne() {
+    cnt++;
+    return cnt;
+  }
+
+  const fn = t.mock.fn(addOne);
+  assert.strictEqual(fn(), 1);
+  fn.mock
+    .mockImplementationOnce(() => 17)
+    .mockImplementationOnce(() => 42)
+    .mockImplementation(() => 99)
+  assert.strictEqual(fn(), 17);
+  assert.strictEqual(fn(), 42);
+  assert.strictEqual(fn(), 99);
+  assert.strictEqual(fn(), 99);
+
+  fn.mock.mockImplementationOnce(() => 52)
+  assert.strictEqual(fn(), 52);
+  assert.strictEqual(fn(), 99);
+});
+
 test('local mocks are auto restored after the test finishes', async (t) => {
   const obj = {
     foo() {},

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -904,7 +904,7 @@ test('mockImplementationOnce chaining', (t) => {
   fn.mock
     .mockImplementationOnce(() => 17)
     .mockImplementationOnce(() => 42)
-    .mockImplementationOnce(() => 77, 5)
+    .mockImplementationOnce(() => 77, 5);
   assert.strictEqual(fn(), 17);
   assert.strictEqual(fn(), 42);
   assert.strictEqual(fn(), 3);
@@ -912,7 +912,7 @@ test('mockImplementationOnce chaining', (t) => {
   assert.strictEqual(fn(), 4);
   assert.strictEqual(fn(), 5);
 
-  fn.mock.mockImplementationOnce(() => 52)
+  fn.mock.mockImplementationOnce(() => 52);
   assert.strictEqual(fn(), 52);
   assert.strictEqual(fn(), 6);
 });
@@ -929,13 +929,13 @@ test('mockImplementationOnce chaining with default value', (t) => {
   fn.mock
     .mockImplementationOnce(() => 17)
     .mockImplementationOnce(() => 42)
-    .mockImplementation(() => 99)
+    .mockImplementation(() => 99);
   assert.strictEqual(fn(), 17);
   assert.strictEqual(fn(), 42);
   assert.strictEqual(fn(), 99);
   assert.strictEqual(fn(), 99);
 
-  fn.mock.mockImplementationOnce(() => 52)
+  fn.mock.mockImplementationOnce(() => 52);
   assert.strictEqual(fn(), 52);
   assert.strictEqual(fn(), 99);
 });

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -904,7 +904,7 @@ test('mockImplementationOnce chaining', (t) => {
   fn.mock
     .mockImplementationOnce(() => 77, 5)
     .mockImplementationOnce(() => 17)
-    .mockImplementationOnce(() => 42)
+    .mockImplementationOnce(() => 42);
   assert.strictEqual(fn(), 17);
   assert.strictEqual(fn(), 42);
   assert.strictEqual(fn(), 3);

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -212,6 +212,7 @@ const customTypesMap = {
   'Timer': 'timers.html#timers',
 
   'TestsStream': 'test.html#class-testsstream',
+  'MockFunctionContext': 'test.html#class-mockfunctioncontext',
 
   'tls.SecureContext': 'tls.html#tlscreatesecurecontextoptions',
   'tls.Server': 'tls.html#class-tlsserver',

--- a/typings/primordials.d.ts
+++ b/typings/primordials.d.ts
@@ -120,6 +120,7 @@ declare namespace primordials {
   export const ArrayPrototypeLastIndexOf: UncurryThis<typeof Array.prototype.lastIndexOf>
   export const ArrayPrototypePop: UncurryThis<typeof Array.prototype.pop>
   export const ArrayPrototypePush: UncurryThis<typeof Array.prototype.push>
+  export const ArrayPrototypeAt: UncurryThis<typeof Array.prototype.at>
   export const ArrayPrototypePushApply: UncurryThisStaticApply<typeof Array.prototype.push>
   export const ArrayPrototypeReverse: UncurryThis<typeof Array.prototype.reverse>
   export const ArrayPrototypeShift: UncurryThis<typeof Array.prototype.shift>


### PR DESCRIPTION
This also includes appending implementation rather than replacing when using `mockImplementationOnce`

Fixes: https://github.com/nodejs/node/issues/47718


this is a breaking change I believe