### PR TITLE
stream: improve WebStreams creation performance

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1020,7 +1020,7 @@ class ReadableStreamDefaultController {
   [kType] = 'ReadableStreamDefaultController';
 
   constructor() {
-    if(new.target === ReadableStreamDefaultController) {
+    if (new.target === ReadableStreamDefaultController) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
   }

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1021,7 +1021,7 @@ class ReadableStreamDefaultController {
   [kType] = 'ReadableStreamDefaultController';
 
   constructor(skipThrowSymbol) {
-    if (new.target === ReadableStreamDefaultController || skipThrowSymbol !== kSkipThrow) {
+    if (skipThrowSymbol !== kSkipThrow) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
   }
@@ -1079,12 +1079,13 @@ ObjectDefineProperties(ReadableStreamDefaultController.prototype, {
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(ReadableStreamDefaultController.name),
 });
 
-class ReadableStreamDefaultControllerClazz extends ReadableStreamDefaultController {
-  constructor(skipThrowSymbol) {
-    super(skipThrowSymbol);
-    this[kType] = 'ReadableStreamDefaultController';
-    this[kState] = {};
-  }
+function createReadableStreamDefaultController() {
+  const controller = new ReadableStreamDefaultController(kSkipThrow);
+
+  controller[kType] = 'ReadableStreamDefaultController';
+  controller[kState] = {};
+
+  return controller;
 }
 
 class ReadableByteStreamController {
@@ -2415,7 +2416,7 @@ function setupReadableStreamDefaultControllerFromSource(
   source,
   highWaterMark,
   sizeAlgorithm) {
-  const controller = new ReadableStreamDefaultControllerClazz(kSkipThrow);
+  const controller = createReadableStreamDefaultController();
   const start = source?.start;
   const pull = source?.pull;
   const cancel = source?.cancel;

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1021,7 +1021,7 @@ class ReadableStreamDefaultController {
   [kType] = 'ReadableStreamDefaultController';
   [kState] = {};
 
-  constructor(skipThrowSymbol) {
+  constructor(skipThrowSymbol = undefined) {
     if (skipThrowSymbol !== kSkipThrow) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -676,8 +676,10 @@ TransferredReadableStream.prototype[kDeserialize] = () => {};
 class ReadableStreamBYOBRequest {
   [kType] = 'ReadableStreamBYOBRequest';
 
-  constructor() {
-    throw new ERR_ILLEGAL_CONSTRUCTOR();
+  constructor(skipThrowSymbol = undefined) {
+    if (skipThrowSymbol !== kSkipThrow) {
+      throw new ERR_ILLEGAL_CONSTRUCTOR();
+    }
   }
 
   /**
@@ -759,17 +761,14 @@ ObjectDefineProperties(ReadableStreamBYOBRequest.prototype, {
 });
 
 function createReadableStreamBYOBRequest(controller, view) {
-  return ReflectConstruct(
-    function() {
-      this[kType] = 'ReadableStreamBYOBRequest';
-      this[kState] = {
-        controller,
-        view,
-      };
-    },
-    [],
-    ReadableStreamBYOBRequest,
-  );
+  const stream = new ReadableStreamBYOBRequest(kSkipThrow);
+
+  stream[kState] = {
+    controller,
+    view,
+  };
+
+  return stream;
 }
 
 class DefaultReadRequest {

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -140,6 +140,7 @@ const kChunk = Symbol('kChunk');
 const kError = Symbol('kError');
 const kPull = Symbol('kPull');
 const kRelease = Symbol('kRelease');
+const kSkipThrow = Symbol('kSkipThrow');
 
 let releasedError;
 let releasingError;
@@ -1019,8 +1020,8 @@ ObjectDefineProperties(ReadableStreamBYOBReader.prototype, {
 class ReadableStreamDefaultController {
   [kType] = 'ReadableStreamDefaultController';
 
-  constructor() {
-    if (new.target === ReadableStreamDefaultController) {
+  constructor(skipThrowSymbol) {
+    if (new.target === ReadableStreamDefaultController || skipThrowSymbol !== kSkipThrow) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
   }
@@ -1079,8 +1080,8 @@ ObjectDefineProperties(ReadableStreamDefaultController.prototype, {
 });
 
 class ReadableStreamDefaultControllerClazz extends ReadableStreamDefaultController {
-  constructor() {
-    super();
+  constructor(skipThrowSymbol) {
+    super(skipThrowSymbol);
     this[kType] = 'ReadableStreamDefaultController';
     this[kState] = {};
   }
@@ -2414,7 +2415,7 @@ function setupReadableStreamDefaultControllerFromSource(
   source,
   highWaterMark,
   sizeAlgorithm) {
-  const controller = new ReadableStreamDefaultControllerClazz();
+  const controller = new ReadableStreamDefaultControllerClazz(kSkipThrow);
   const start = source?.start;
   const pull = source?.pull;
   const cancel = source?.cancel;

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1019,6 +1019,7 @@ ObjectDefineProperties(ReadableStreamBYOBReader.prototype, {
 
 class ReadableStreamDefaultController {
   [kType] = 'ReadableStreamDefaultController';
+  [kState] = {};
 
   constructor(skipThrowSymbol) {
     if (skipThrowSymbol !== kSkipThrow) {
@@ -1080,12 +1081,7 @@ ObjectDefineProperties(ReadableStreamDefaultController.prototype, {
 });
 
 function createReadableStreamDefaultController() {
-  const controller = new ReadableStreamDefaultController(kSkipThrow);
-
-  controller[kType] = 'ReadableStreamDefaultController';
-  controller[kState] = {};
-
-  return controller;
+  return new ReadableStreamDefaultController(kSkipThrow);
 }
 
 class ReadableByteStreamController {

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1080,10 +1080,6 @@ ObjectDefineProperties(ReadableStreamDefaultController.prototype, {
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(ReadableStreamDefaultController.name),
 });
 
-function createReadableStreamDefaultController() {
-  return new ReadableStreamDefaultController(kSkipThrow);
-}
-
 class ReadableByteStreamController {
   [kType] = 'ReadableByteStreamController';
   [kState] = {};
@@ -1201,10 +1197,6 @@ ObjectDefineProperties(ReadableByteStreamController.prototype, {
   error: kEnumerableProperty,
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(ReadableByteStreamController.name),
 });
-
-function createReadableByteStreamController() {
-  return new ReadableByteStreamController(kSkipThrow);
-}
 
 function createTeeReadableStream(start, pull, cancel) {
   return ReflectConstruct(
@@ -2408,7 +2400,7 @@ function setupReadableStreamDefaultControllerFromSource(
   source,
   highWaterMark,
   sizeAlgorithm) {
-  const controller = createReadableStreamDefaultController();
+  const controller = new ReadableStreamDefaultController(kSkipThrow);
   const start = source?.start;
   const pull = source?.pull;
   const cancel = source?.cancel;
@@ -3206,7 +3198,7 @@ function setupReadableByteStreamControllerFromSource(
   stream,
   source,
   highWaterMark) {
-  const controller = createReadableByteStreamController();
+  const controller = new ReadableByteStreamController(kSkipThrow);
   const start = source?.start;
   const pull = source?.pull;
   const cancel = source?.cancel;

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1086,9 +1086,12 @@ function createReadableStreamDefaultController() {
 
 class ReadableByteStreamController {
   [kType] = 'ReadableByteStreamController';
+  [kState] = {};
 
-  constructor() {
-    throw new ERR_ILLEGAL_CONSTRUCTOR();
+  constructor(skipThrowSymbol = undefined) {
+    if (skipThrowSymbol !== kSkipThrow) {
+      throw new ERR_ILLEGAL_CONSTRUCTOR();
+    }
   }
 
   /**
@@ -1200,14 +1203,7 @@ ObjectDefineProperties(ReadableByteStreamController.prototype, {
 });
 
 function createReadableByteStreamController() {
-  return ReflectConstruct(
-    function() {
-      this[kType] = 'ReadableByteStreamController';
-      this[kState] = {};
-    },
-    [],
-    ReadableByteStreamController,
-  );
+  return new ReadableByteStreamController(kSkipThrow);
 }
 
 function createTeeReadableStream(start, pull, cancel) {

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1020,7 +1020,9 @@ class ReadableStreamDefaultController {
   [kType] = 'ReadableStreamDefaultController';
 
   constructor() {
-    throw new ERR_ILLEGAL_CONSTRUCTOR();
+    if(new.target === ReadableStreamDefaultController) {
+      throw new ERR_ILLEGAL_CONSTRUCTOR();
+    }
   }
 
   /**
@@ -1076,15 +1078,12 @@ ObjectDefineProperties(ReadableStreamDefaultController.prototype, {
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(ReadableStreamDefaultController.name),
 });
 
-function createReadableStreamDefaultController() {
-  return ReflectConstruct(
-    function() {
-      this[kType] = 'ReadableStreamDefaultController';
-      this[kState] = {};
-    },
-    [],
-    ReadableStreamDefaultController,
-  );
+class ReadableStreamDefaultControllerClazz extends ReadableStreamDefaultController {
+  constructor() {
+    super();
+    this[kType] = 'ReadableStreamDefaultController';
+    this[kState] = {};
+  }
 }
 
 class ReadableByteStreamController {
@@ -2415,7 +2414,7 @@ function setupReadableStreamDefaultControllerFromSource(
   source,
   highWaterMark,
   sizeAlgorithm) {
-  const controller = createReadableStreamDefaultController();
+  const controller = new ReadableStreamDefaultControllerClazz();
   const start = source?.start;
   const pull = source?.pull;
   const cancel = source?.cancel;

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -8,6 +8,7 @@ const {
   PromiseResolve,
   ReflectConstruct,
   SymbolToStringTag,
+  Symbol,
 } = primordials;
 
 const {
@@ -334,11 +335,10 @@ ObjectDefineProperties(TransformStreamDefaultController.prototype, {
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(TransformStreamDefaultController.name),
 });
 
-class TransformStreamDefaultControllerClazz extends TransformStreamDefaultController {
-  constructor(skipThrowSymbol) {
-    super(skipThrowSymbol);
-    this[kType] = 'TransformStreamDefaultController';
-  }
+function createTransformStreamDefaultController() {
+  const controller = new TransformStreamDefaultController(kSkipThrow);
+  controller[kType] = 'TransformStreamDefaultController';
+  return controller;
 }
 
 const isTransformStream =
@@ -455,7 +455,7 @@ function setupTransformStreamDefaultController(
 function setupTransformStreamDefaultControllerFromTransformer(
   stream,
   transformer) {
-  const controller = new TransformStreamDefaultControllerClazz(kSkipThrow);
+  const controller = createTransformStreamDefaultController();
   const transform = transformer?.transform || defaultTransformAlgorithm;
   const flush = transformer?.flush || nonOpFlush;
   const transformAlgorithm =

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -269,7 +269,7 @@ class TransformStreamDefaultController {
   [kType] = 'TransformStreamDefaultController';
 
   constructor() {
-    if(new.target === TransformStreamDefaultController) {
+    if (new.target === TransformStreamDefaultController) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
   }
@@ -333,10 +333,10 @@ ObjectDefineProperties(TransformStreamDefaultController.prototype, {
 });
 
 class TransformStreamDefaultControllerClazz extends TransformStreamDefaultController {
-    constructor() {
-      super();
-      this[kType] = 'TransformStreamDefaultController';
-    }
+  constructor() {
+    super();
+    this[kType] = 'TransformStreamDefaultController';
+  }
 }
 
 const isTransformStream =

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -336,9 +336,7 @@ ObjectDefineProperties(TransformStreamDefaultController.prototype, {
 });
 
 function createTransformStreamDefaultController() {
-  const controller = new TransformStreamDefaultController(kSkipThrow);
-  controller[kType] = 'TransformStreamDefaultController';
-  return controller;
+  return new TransformStreamDefaultController(kSkipThrow);
 }
 
 const isTransformStream =

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -271,7 +271,7 @@ TransferredTransformStream.prototype[kDeserialize] = () => {};
 class TransformStreamDefaultController {
   [kType] = 'TransformStreamDefaultController';
 
-  constructor(skipThrowSymbol) {
+  constructor(skipThrowSymbol = undefined) {
     if (skipThrowSymbol !== kSkipThrow) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -65,6 +65,8 @@ const {
 
 const assert = require('internal/assert');
 
+const kSkipThrow = Symbol('kSkipThrow');
+
 const getNonWritablePropertyDescriptor = (value) => {
   return {
     __proto__: null,
@@ -268,8 +270,8 @@ TransferredTransformStream.prototype[kDeserialize] = () => {};
 class TransformStreamDefaultController {
   [kType] = 'TransformStreamDefaultController';
 
-  constructor() {
-    if (new.target === TransformStreamDefaultController) {
+  constructor(skipThrowSymbol) {
+    if (skipThrowSymbol !== kSkipThrow) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
   }
@@ -333,8 +335,8 @@ ObjectDefineProperties(TransformStreamDefaultController.prototype, {
 });
 
 class TransformStreamDefaultControllerClazz extends TransformStreamDefaultController {
-  constructor() {
-    super();
+  constructor(skipThrowSymbol) {
+    super(skipThrowSymbol);
     this[kType] = 'TransformStreamDefaultController';
   }
 }
@@ -453,7 +455,7 @@ function setupTransformStreamDefaultController(
 function setupTransformStreamDefaultControllerFromTransformer(
   stream,
   transformer) {
-  const controller = new TransformStreamDefaultControllerClazz();
+  const controller = new TransformStreamDefaultControllerClazz(kSkipThrow);
   const transform = transformer?.transform || defaultTransformAlgorithm;
   const flush = transformer?.flush || nonOpFlush;
   const transformAlgorithm =

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -269,7 +269,9 @@ class TransformStreamDefaultController {
   [kType] = 'TransformStreamDefaultController';
 
   constructor() {
-    throw new ERR_ILLEGAL_CONSTRUCTOR();
+    if(new.target === TransformStreamDefaultController) {
+      throw new ERR_ILLEGAL_CONSTRUCTOR();
+    }
   }
 
   /**
@@ -330,13 +332,11 @@ ObjectDefineProperties(TransformStreamDefaultController.prototype, {
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(TransformStreamDefaultController.name),
 });
 
-function createTransformStreamDefaultController() {
-  return ReflectConstruct(
-    function() {
+class TransformStreamDefaultControllerClazz extends TransformStreamDefaultController {
+    constructor() {
+      super();
       this[kType] = 'TransformStreamDefaultController';
-    },
-    [],
-    TransformStreamDefaultController);
+    }
 }
 
 const isTransformStream =
@@ -453,7 +453,7 @@ function setupTransformStreamDefaultController(
 function setupTransformStreamDefaultControllerFromTransformer(
   stream,
   transformer) {
-  const controller = createTransformStreamDefaultController();
+  const controller = new TransformStreamDefaultControllerClazz();
   const transform = transformer?.transform || defaultTransformAlgorithm;
   const flush = transformer?.flush || nonOpFlush;
   const transformAlgorithm =

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -335,10 +335,6 @@ ObjectDefineProperties(TransformStreamDefaultController.prototype, {
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(TransformStreamDefaultController.name),
 });
 
-function createTransformStreamDefaultController() {
-  return new TransformStreamDefaultController(kSkipThrow);
-}
-
 const isTransformStream =
   isBrandCheck('TransformStream');
 const isTransformStreamDefaultController =
@@ -453,7 +449,7 @@ function setupTransformStreamDefaultController(
 function setupTransformStreamDefaultControllerFromTransformer(
   stream,
   transformer) {
-  const controller = createTransformStreamDefaultController();
+  const controller = new TransformStreamDefaultController(kSkipThrow);
   const transform = transformer?.transform || defaultTransformAlgorithm;
   const flush = transformer?.flush || nonOpFlush;
   const transformAlgorithm =

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -524,7 +524,7 @@ class WritableStreamDefaultController {
   [kType] = 'WritableStreamDefaultController';
 
   constructor(skipThrowSymbol) {
-    if (new.target === WritableStreamDefaultController || skipThrowSymbol !== kSkipThrow) {
+    if (skipThrowSymbol !== kSkipThrow) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
   }
@@ -572,11 +572,10 @@ ObjectDefineProperties(WritableStreamDefaultController.prototype, {
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(WritableStreamDefaultController.name),
 });
 
-class WritableStreamDefaultControllerClazz extends WritableStreamDefaultController {
-  constructor(skipThrowSymbol) {
-    super(skipThrowSymbol);
-    this[kType] = 'WritableStreamDefaultController';
-  }
+function createWritableStreamDefaultController() {
+  const controller = new WritableStreamDefaultController(kSkipThrow);
+  controller[kType] = 'WritableStreamDefaultController';
+  return controller;
 }
 
 const isWritableStream =
@@ -1235,7 +1234,7 @@ function setupWritableStreamDefaultControllerFromSink(
   sink,
   highWaterMark,
   sizeAlgorithm) {
-  const controller = new WritableStreamDefaultControllerClazz(kSkipThrow);
+  const controller = createWritableStreamDefaultController();
   const start = sink?.start;
   const write = sink?.write;
   const close = sink?.close;

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -573,9 +573,7 @@ ObjectDefineProperties(WritableStreamDefaultController.prototype, {
 });
 
 function createWritableStreamDefaultController() {
-  const controller = new WritableStreamDefaultController(kSkipThrow);
-  controller[kType] = 'WritableStreamDefaultController';
-  return controller;
+  return new WritableStreamDefaultController(kSkipThrow);
 }
 
 const isWritableStream =

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -523,7 +523,9 @@ class WritableStreamDefaultController {
   [kType] = 'WritableStreamDefaultController';
 
   constructor() {
-    throw new ERR_ILLEGAL_CONSTRUCTOR();
+    if (new.target === WritableStreamDefaultController) {
+      throw new ERR_ILLEGAL_CONSTRUCTOR();
+    }
   }
 
   [kAbort](reason) {
@@ -569,12 +571,12 @@ ObjectDefineProperties(WritableStreamDefaultController.prototype, {
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(WritableStreamDefaultController.name),
 });
 
-function createWritableStreamDefaultController() {
-  return ReflectConstruct(
-    function() {
-      this[kType] = 'WritableStreamDefaultController';
-    },
-    [], WritableStreamDefaultController);
+class WritableStreamDefaultControllerClazz extends WritableStreamDefaultController {
+    constructor() {
+        super();
+        this[kType] = 'WritableStreamDefaultController';
+        // throw new ERR_ILLEGAL_CONSTRUCTOR();
+    }
 }
 
 const isWritableStream =
@@ -1233,7 +1235,7 @@ function setupWritableStreamDefaultControllerFromSink(
   sink,
   highWaterMark,
   sizeAlgorithm) {
-  const controller = createWritableStreamDefaultController();
+  const controller = new WritableStreamDefaultControllerClazz();
   const start = sink?.start;
   const write = sink?.write;
   const close = sink?.close;

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -572,11 +572,10 @@ ObjectDefineProperties(WritableStreamDefaultController.prototype, {
 });
 
 class WritableStreamDefaultControllerClazz extends WritableStreamDefaultController {
-    constructor() {
-        super();
-        this[kType] = 'WritableStreamDefaultController';
-        // throw new ERR_ILLEGAL_CONSTRUCTOR();
-    }
+  constructor() {
+    super();
+    this[kType] = 'WritableStreamDefaultController';
+  }
 }
 
 const isWritableStream =

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -572,10 +572,6 @@ ObjectDefineProperties(WritableStreamDefaultController.prototype, {
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(WritableStreamDefaultController.name),
 });
 
-function createWritableStreamDefaultController() {
-  return new WritableStreamDefaultController(kSkipThrow);
-}
-
 const isWritableStream =
   isBrandCheck('WritableStream');
 const isWritableStreamDefaultWriter =
@@ -1232,7 +1228,7 @@ function setupWritableStreamDefaultControllerFromSink(
   sink,
   highWaterMark,
   sizeAlgorithm) {
-  const controller = createWritableStreamDefaultController();
+  const controller = new WritableStreamDefaultController(kSkipThrow);
   const start = sink?.start;
   const write = sink?.write;
   const close = sink?.close;

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -523,7 +523,7 @@ ObjectDefineProperties(WritableStreamDefaultWriter.prototype, {
 class WritableStreamDefaultController {
   [kType] = 'WritableStreamDefaultController';
 
-  constructor(skipThrowSymbol) {
+  constructor(skipThrowSymbol = undefined) {
     if (skipThrowSymbol !== kSkipThrow) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -81,6 +81,7 @@ const assert = require('internal/assert');
 const kAbort = Symbol('kAbort');
 const kCloseSentinel = Symbol('kCloseSentinel');
 const kError = Symbol('kError');
+const kSkipThrow = Symbol('kSkipThrow');
 
 let releasedError;
 
@@ -522,8 +523,8 @@ ObjectDefineProperties(WritableStreamDefaultWriter.prototype, {
 class WritableStreamDefaultController {
   [kType] = 'WritableStreamDefaultController';
 
-  constructor() {
-    if (new.target === WritableStreamDefaultController) {
+  constructor(skipThrowSymbol) {
+    if (new.target === WritableStreamDefaultController || skipThrowSymbol !== kSkipThrow) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
   }
@@ -572,8 +573,8 @@ ObjectDefineProperties(WritableStreamDefaultController.prototype, {
 });
 
 class WritableStreamDefaultControllerClazz extends WritableStreamDefaultController {
-  constructor() {
-    super();
+  constructor(skipThrowSymbol) {
+    super(skipThrowSymbol);
     this[kType] = 'WritableStreamDefaultController';
   }
 }
@@ -1234,7 +1235,7 @@ function setupWritableStreamDefaultControllerFromSink(
   sink,
   highWaterMark,
   sizeAlgorithm) {
-  const controller = new WritableStreamDefaultControllerClazz();
+  const controller = new WritableStreamDefaultControllerClazz(kSkipThrow);
   const start = sink?.start;
   const write = sink?.write;
   const close = sink?.close;


### PR DESCRIPTION
From my local tests, this improves the `benchmark/webstreams/creation.js` by 2 to 3 times

could someone please run the benchmark in the CI