### PR TITLE
fix: do not wrongfully match application/javascript mime

### DIFF
--- a/lib/internal/modules/esm/formats.js
+++ b/lib/internal/modules/esm/formats.js
@@ -24,12 +24,7 @@ if (experimentalWasmModules) {
  * @returns {string | null}
  */
 function mimeToFormat(mime) {
-  if (
-    RegExpPrototypeExec(
-      /\s*(text|application)\/javascript\s*(;\s*charset=utf-?8\s*)?/i,
-      mime,
-    ) !== null
-  ) return 'module';
+  if (mime === 'text/javascript') return 'module';
   if (mime === 'application/json') return 'json';
   if (experimentalWasmModules && mime === 'application/wasm') return 'wasm';
   return null;


### PR DESCRIPTION
The previous implementation was accepting both `application/javascript` and `text/javascript` while the doc stands that only `text/javascript` is matching : https://nodejs.org/api/esm.html#data-imports

On top of that, current notice https://datatracker.ietf.org/doc/html/rfc9239 co-authored by TSC member @MylesBorins and collaborator @bmeck stands that `text/javascript` is now common while `application/javascript` and other historically used MIME types are obsolete.

This PR is a proposal to drop undocumented and untested `application/json` support. If you think this consideration must be adressed otherwise, I'll edit this PR and correct the documentation accordingly.

Also, should I amend the commit to indicate it's a breaking change, even if the "feature" is both untested and undocumented?

Fixes: https://github.com/nodejs/node/issues/48957
