### PR TITLE
bootstrap: build code cache from deserialized isolate

### DIFF
--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -974,7 +974,7 @@ ExitCode BuildCodeCacheFromSnapshot(SnapshotData* out,
       args,
       exec_args);
   if (!setup) {
-    for (const std::string& err : errors)
+    for (const auto& err : errors)
       fprintf(stderr, "%s: %s\n", args[0].c_str(), err.c_str());
     return ExitCode::kBootstrapFailure;
   }

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -901,7 +901,7 @@ void SnapshotBuilder::InitializeIsolateParams(const SnapshotData* data,
       const_cast<v8::StartupData*>(&(data->v8_snapshot_blob_data));
 }
 
-ExitCode SnapshotBuilder::Generate(
+ExitCode BuildSnapshotWithoutCodeCache(
     SnapshotData* out,
     const std::vector<std::string>& args,
     const std::vector<std::string>& exec_args,
@@ -923,8 +923,8 @@ ExitCode SnapshotBuilder::Generate(
       fprintf(stderr, "%s: %s\n", args[0].c_str(), err.c_str());
     return ExitCode::kBootstrapFailure;
   }
-  Isolate* isolate = setup->isolate();
 
+  Isolate* isolate = setup->isolate();
   {
     HandleScope scope(isolate);
     TryCatch bootstrapCatch(isolate);
@@ -958,7 +958,77 @@ ExitCode SnapshotBuilder::Generate(
     }
   }
 
-  return CreateSnapshot(out, setup.get(), static_cast<uint8_t>(snapshot_type));
+  return SnapshotBuilder::CreateSnapshot(
+      out, setup.get(), static_cast<uint8_t>(snapshot_type));
+}
+
+ExitCode BuildCodeCacheFromSnapshot(SnapshotData* out,
+                                    const std::vector<std::string>& args,
+                                    const std::vector<std::string>& exec_args) {
+  std::vector<std::string> errors;
+  auto data_wrapper = out->AsEmbedderWrapper();
+  auto setup = CommonEnvironmentSetup::CreateFromSnapshot(
+      per_process::v8_platform.Platform(),
+      &errors,
+      data_wrapper.get(),
+      args,
+      exec_args);
+  if (!setup) {
+    for (const std::string& err : errors)
+      fprintf(stderr, "%s: %s\n", args[0].c_str(), err.c_str());
+    return ExitCode::kBootstrapFailure;
+  }
+
+  Isolate* isolate = setup->isolate();
+  v8::Locker locker(isolate);
+  Isolate::Scope isolate_scope(isolate);
+  HandleScope handle_scope(isolate);
+  TryCatch bootstrapCatch(isolate);
+
+  auto print_Exception = OnScopeLeave([&]() {
+    if (bootstrapCatch.HasCaught()) {
+      PrintCaughtException(
+          isolate, isolate->GetCurrentContext(), bootstrapCatch);
+    }
+  });
+
+  Environment* env = setup->env();
+  // Regenerate all the code cache.
+  if (!env->builtin_loader()->CompileAllBuiltins(setup->context())) {
+    return ExitCode::kGenericUserError;
+  }
+  env->builtin_loader()->CopyCodeCache(&(out->code_cache));
+  if (per_process::enabled_debug_list.enabled(DebugCategory::MKSNAPSHOT)) {
+    for (const auto& item : out->code_cache) {
+      std::string size_str = FormatSize(item.data.length);
+      per_process::Debug(DebugCategory::MKSNAPSHOT,
+                         "Generated code cache for %d: %s\n",
+                         item.id.c_str(),
+                         size_str.c_str());
+    }
+  }
+  return ExitCode::kNoFailure;
+}
+
+ExitCode SnapshotBuilder::Generate(
+    SnapshotData* out,
+    const std::vector<std::string>& args,
+    const std::vector<std::string>& exec_args,
+    std::optional<std::string_view> main_script) {
+  ExitCode code =
+      BuildSnapshotWithoutCodeCache(out, args, exec_args, main_script);
+  if (code != ExitCode::kNoFailure) {
+    return code;
+  }
+
+#ifdef NODE_USE_NODE_CODE_CACHE
+  // Deserialize the snapshot to recompile code cache. We need to do this in the
+  // second pass because V8 requires the code cache to be compiled with a
+  // finalized read-only space.
+  return BuildCodeCacheFromSnapshot(out, args, exec_args);
+#else
+  return ExitCode::kNoFailure;
+#endif
 }
 
 ExitCode SnapshotBuilder::CreateSnapshot(SnapshotData* out,
@@ -1010,21 +1080,6 @@ ExitCode SnapshotBuilder::CreateSnapshot(SnapshotData* out,
       // Serialize the native states
       out->isolate_data_info = setup->isolate_data()->Serialize(creator);
       out->env_info = env->Serialize(creator);
-
-#ifdef NODE_USE_NODE_CODE_CACHE
-      // Regenerate all the code cache.
-      if (!env->builtin_loader()->CompileAllBuiltins(main_context)) {
-        return ExitCode::kGenericUserError;
-      }
-      env->builtin_loader()->CopyCodeCache(&(out->code_cache));
-      for (const auto& item : out->code_cache) {
-        std::string size_str = FormatSize(item.data.length);
-        per_process::Debug(DebugCategory::MKSNAPSHOT,
-                           "Generated code cache for %d: %s\n",
-                           item.id.c_str(),
-                           size_str.c_str());
-      }
-#endif
 
       ResetContextSettingsBeforeSnapshot(main_context);
     }


### PR DESCRIPTION
V8 now requires the code cache to be compiled with a finalized read-only space, so we need to serialize the snapshot to get a finalized read-only space first, then deserialize it to compile the code cache.

Refs: https://github.com/nodejs/node/issues/47636
Refs: https://bugs.chromium.org/p/v8/issues/detail?id=13789

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
