### PR TITLE
inspector: update `--inspect` hint text

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -16,7 +16,7 @@ script to debug.
 ```console
 $ node inspect myscript.js
 < Debugger listening on ws://127.0.0.1:9229/621111f9-ffcb-4e82-b718-48a145fa5db8
-< For help, see: https://nodejs.org/en/docs/inspector
+< For help, see: https://nodejs.org/en/docs/guides/debugging-getting-started
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -45,7 +45,7 @@ setTimeout(() => {
 console.log('hello');
 $ NODE_INSPECT_RESUME_ON_START=1 node inspect myscript.js
 < Debugger listening on ws://127.0.0.1:9229/f1ed133e-7876-495b-83ae-c32c6fc319c2
-< For help, see: https://nodejs.org/en/docs/inspector
+< For help, see: https://nodejs.org/en/docs/guides/debugging-getting-started
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -131,7 +131,7 @@ is not loaded yet:
 ```console
 $ node inspect main.js
 < Debugger listening on ws://127.0.0.1:9229/48a5b28a-550c-471b-b5e1-d13dd7165df9
-< For help, see: https://nodejs.org/en/docs/inspector
+< For help, see: https://nodejs.org/en/docs/guides/debugging-getting-started
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -158,7 +158,7 @@ given expression evaluates to `true`:
 ```console
 $ node inspect main.js
 < Debugger listening on ws://127.0.0.1:9229/ce24daa8-3816-44d4-b8ab-8273c8a66d35
-< For help, see: https://nodejs.org/en/docs/inspector
+< For help, see: https://nodejs.org/en/docs/guides/debugging-getting-started
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -240,7 +240,7 @@ flag instead of `--inspect`.
 ```console
 $ node --inspect index.js
 Debugger listening on ws://127.0.0.1:9229/dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
-For help, see: https://nodejs.org/en/docs/inspector
+For help, see: https://nodejs.org/en/docs/guides/debugging-getting-started
 ```
 
 (In the example above, the UUID dc9010dd-f8b8-4ac5-a510-c1a114ec7d29

--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -453,12 +453,12 @@ Return the URL of the active inspector, or `undefined` if there is none.
 ```console
 $ node --inspect -p 'inspector.url()'
 Debugger listening on ws://127.0.0.1:9229/166e272e-7a30-4d09-97ce-f1c012b43c34
-For help, see: https://nodejs.org/en/docs/inspector
+For help, see: https://nodejs.org/en/docs/guides/debugging-getting-started
 ws://127.0.0.1:9229/166e272e-7a30-4d09-97ce-f1c012b43c34
 
 $ node --inspect=localhost:3000 -p 'inspector.url()'
 Debugger listening on ws://localhost:3000/51cf8d0e-3c36-4c59-8efd-54519839e56a
-For help, see: https://nodejs.org/en/docs/inspector
+For help, see: https://nodejs.org/en/docs/guides/debugging-getting-started
 ws://localhost:3000/51cf8d0e-3c36-4c59-8efd-54519839e56a
 
 $ node -p 'inspector.url()'

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -248,7 +248,7 @@ void PrintDebuggerReadyMessage(
     }
   }
   fprintf(out, "For help, see: %s\n",
-          "https://nodejs.org/en/docs/inspector");
+          "https://nodejs.org/en/docs/guides/debugging-getting-started");
   fflush(out);
 }
 


### PR DESCRIPTION
Changes link hint text:
```console
$ node --inspect -e ""
Debugger listening on ws://127.0.0.1:9229/0f2c936f-b1cd-4ac9-aab3-f63b0f33d55e
For help, see: https://nodejs.org/en/docs/inspector
```

This would temporarily unbreak [test/internet/test-inspector-help-page.js](https://github.com/nodejs/node/blob/f1b3ade9480b43273bd66f9039118a8b842db703/test/internet/test-inspector-help-page.js)

Refs: https://github.com/nodejs/nodejs.org/issues/5624
The guide link might be gone in foreseeable future, so this hint should probably be replaced with something else.
Suggestions are very welcome.