### PR TITLE
node-api: fix compiler warning in node_api.h

### DIFF
--- a/src/node_api.h
+++ b/src/node_api.h
@@ -30,7 +30,7 @@ struct uv_loop_s;  // Forward declaration.
 
 typedef napi_value(NAPI_CDECL* napi_addon_register_func)(napi_env env,
                                                          napi_value exports);
-typedef int32_t(NAPI_CDECL* node_api_addon_get_api_version_func)();
+typedef int32_t(NAPI_CDECL* node_api_addon_get_api_version_func)(void);
 
 // Used by deprecated registration method napi_module_register.
 typedef struct napi_module {
@@ -66,7 +66,7 @@ typedef struct napi_module {
 
 #define NAPI_MODULE_INIT()                                                     \
   EXTERN_C_START                                                               \
-  NAPI_MODULE_EXPORT int32_t NODE_API_MODULE_GET_API_VERSION() {               \
+  NAPI_MODULE_EXPORT int32_t NODE_API_MODULE_GET_API_VERSION(void) {           \
     return NAPI_VERSION;                                                       \
   }                                                                            \
   NAPI_MODULE_EXPORT napi_value NAPI_MODULE_INITIALIZER(napi_env env,          \


### PR DESCRIPTION
Fix `-Wstrict-prototypes` warning from AppleClang 14.0.3.14030022, compiling C.

My team tests our C addon with `-Werror` and recent changes to node_api.h [broke our build](https://github.com/awslabs/aws-crt-nodejs/actions/runs/5826936867/job/15801950085?pr=487#step:3:443).
```
/Users/runner/.cmake-js/node-arm64/v18.17.0/include/node/node_api.h:33:65: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
typedef int32_t(NAPI_CDECL* node_api_addon_get_api_version_func)();
                                                                ^
                                                                 void
typedef int32_t(NAPI_CDECL* node_api_addon_get_api_version_func)();
                                                                ^
                                                                 void
```

The break started when the build machines started using [node v18.17.0](https://github.com/awslabs/aws-crt-nodejs/actions/runs/5826936867/job/15801950085?pr=487#step:3:22). Builds from a week ago, using [node v18.16.1](https://github.com/awslabs/aws-crt-nodejs/actions/runs/5729783291/job/15528466602#step:3:22) were successful.