### PR TITLE
lib: fix MIME overmatch in data URLs

### DIFF
--- a/lib/internal/modules/esm/formats.js
+++ b/lib/internal/modules/esm/formats.js
@@ -26,7 +26,7 @@ if (experimentalWasmModules) {
 function mimeToFormat(mime) {
   if (
     RegExpPrototypeExec(
-      /\s*(text|application)\/javascript\s*(;\s*charset=utf-?8\s*)?/i,
+      /^\s*(text|application)\/javascript\s*(;\s*charset=utf-?8\s*)?$/i,
       mime,
     ) !== null
   ) return 'module';

--- a/test/es-module/test-esm-invalid-data-urls.js
+++ b/test/es-module/test-esm-invalid-data-urls.js
@@ -18,4 +18,7 @@ const assert = require('assert');
     code: 'ERR_UNKNOWN_MODULE_FORMAT',
     message: 'Unknown module format: text/css for URL data:text/css,.error { color: red; }',
   });
+  await assert.rejects(import('data:WRONGtext/javascriptFORMAT,console.log("hello!");'), {
+    code: 'ERR_UNKNOWN_MODULE_FORMAT',
+  });
 })().then(common.mustCall());


### PR DESCRIPTION
This commit adds the delimiters ^ and $ to the regex that matches the MIME types for "data:URLs".
Fixes: https://github.com/nodejs/node/issues/48957

I also added a new test case that expects an `ERR_UNKNOWN_MODULE_FORMAT` message for MIME types like this: `data:WRONGtext/javascriptFORMAT`.

This is my first time contributing to node. Let me know if I did everything right :smile:.