### PR TITLE
test: adjust common/internet `addresses.CNAME_HOST`

### DIFF
--- a/test/common/internet.js
+++ b/test/common/internet.js
@@ -35,7 +35,7 @@ const addresses = {
   // A host with CAA record registered
   CAA_HOST: 'google.com',
   // A host with CNAME records registered
-  CNAME_HOST: 'blog.nodejs.org',
+  CNAME_HOST: 'www.github.com',
   // A host with NS records registered
   NS_HOST: 'nodejs.org',
   // A host with TXT records registered


### PR DESCRIPTION
Right now `blog.nodejs.org` doesn't have CNAME records.