### PR TITLE
src: remove duplicated code in `GenerateSingleExecutableBlob()`

### DIFF
--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -486,16 +486,15 @@ ExitCode GenerateSingleExecutableBlob(
     }
   }
 
-  std::optional<std::string> optional_code_cache =
-      GenerateCodeCache(config.main_path, main_script);
-  if (!optional_code_cache.has_value()) {
-    FPrintF(stderr, "Cannot generate V8 code cache\n");
-    return ExitCode::kGenericUserError;
-  }
-
   std::optional<std::string_view> optional_sv_code_cache;
   std::string code_cache;
   if (static_cast<bool>(config.flags & SeaFlags::kUseCodeCache)) {
+    std::optional<std::string> optional_code_cache =
+        GenerateCodeCache(config.main_path, main_script);
+    if (!optional_code_cache.has_value()) {
+      FPrintF(stderr, "Cannot generate V8 code cache\n");
+      return ExitCode::kGenericUserError;
+    }
     code_cache = optional_code_cache.value();
     optional_sv_code_cache = code_cache;
   }

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -496,12 +496,6 @@ ExitCode GenerateSingleExecutableBlob(
   std::optional<std::string_view> optional_sv_code_cache;
   std::string code_cache;
   if (static_cast<bool>(config.flags & SeaFlags::kUseCodeCache)) {
-    std::optional<std::string> optional_code_cache =
-        GenerateCodeCache(config.main_path, main_script);
-    if (!optional_code_cache.has_value()) {
-      FPrintF(stderr, "Cannot generate V8 code cache\n");
-      return ExitCode::kGenericUserError;
-    }
     code_cache = optional_code_cache.value();
     optional_sv_code_cache = code_cache;
   }


### PR DESCRIPTION
The removed `optional_code_cache` variable is already declared with the same name in the line below.
In my opinion, it was judged to be unnecessary redundant code and was removed.

https://github.com/nodejs/node/blob/32245275b50a455713ff753de6b1be494e077464/src/node_sea.cc#L489-L494

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
