### PR TITLE
doc: fix `Type` notation in webstreams

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -895,7 +895,7 @@ added: v16.5.0
 
 * Returns: {WritableStreamDefaultWriter}
 
-Creates and creates a new writer instance that can be used to write
+Creates and returns a new writer instance that can be used to write
 data into the `WritableStream`.
 
 #### `writableStream.locked`
@@ -995,8 +995,8 @@ The amount of data required to fill the {WritableStream}'s queue.
 added: v16.5.0
 -->
 
-* type: A promise that is fulfilled with `undefined` when the
-  writer is ready to be used.
+* Type: {Promise} Fulfilled with `undefined` when the writer is ready
+  to be used.
 
 #### `writableStreamDefaultWriter.releaseLock()`
 


### PR DESCRIPTION
Replace `type` with `Type: {Promise}`. Plus, fix incorrect verb(`creates` -> `returns`) in description.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
