### PR TITLE
test: use `tmpdir.resolve()` in fs tests #1

### DIFF
--- a/test/parallel/test-fs-promises-file-handle-aggregate-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-aggregate-errors.js
@@ -7,7 +7,6 @@ const tmpdir = require('../common/tmpdir');
 // The following tests validate aggregate errors are thrown correctly
 // when both an operation and close throw.
 
-const path = require('path');
 const {
   readFile,
   writeFile,
@@ -23,7 +22,7 @@ const originalFd = Object.getOwnPropertyDescriptor(FileHandle.prototype, 'fd');
 
 let count = 0;
 async function createFile() {
-  const filePath = path.join(tmpdir.path, `aggregate_errors_${++count}.txt`);
+  const filePath = tmpdir.resolve(`aggregate_errors_${++count}.txt`);
   await writeFile(filePath, 'content');
   return filePath;
 }

--- a/test/parallel/test-fs-promises-file-handle-close-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-close-errors.js
@@ -7,7 +7,6 @@ const tmpdir = require('../common/tmpdir');
 // The following tests validate aggregate errors are thrown correctly
 // when both an operation and close throw.
 
-const path = require('path');
 const {
   readFile,
   writeFile,
@@ -23,7 +22,7 @@ const originalFd = Object.getOwnPropertyDescriptor(FileHandle.prototype, 'fd');
 
 let count = 0;
 async function createFile() {
-  const filePath = path.join(tmpdir.path, `close_errors_${++count}.txt`);
+  const filePath = tmpdir.resolve(`close_errors_${++count}.txt`);
   await writeFile(filePath, 'content');
   return filePath;
 }

--- a/test/parallel/test-fs-promises-file-handle-op-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-op-errors.js
@@ -7,7 +7,6 @@ const tmpdir = require('../common/tmpdir');
 // The following tests validate aggregate errors are thrown correctly
 // when both an operation and close throw.
 
-const path = require('path');
 const {
   readFile,
   writeFile,
@@ -23,7 +22,7 @@ const originalFd = Object.getOwnPropertyDescriptor(FileHandle.prototype, 'fd');
 
 let count = 0;
 async function createFile() {
-  const filePath = path.join(tmpdir.path, `op_errors_${++count}.txt`);
+  const filePath = tmpdir.resolve(`op_errors_${++count}.txt`);
   await writeFile(filePath, 'content');
   return filePath;
 }

--- a/test/parallel/test-fs-promises-file-handle-read-worker.js
+++ b/test/parallel/test-fs-promises-file-handle-read-worker.js
@@ -2,9 +2,8 @@
 const common = require('../common');
 const fs = require('fs');
 const assert = require('assert');
-const path = require('path');
 const tmpdir = require('../common/tmpdir');
-const file = path.join(tmpdir.path, 'read_stream_filehandle_worker.txt');
+const file = tmpdir.resolve('read_stream_filehandle_worker.txt');
 const input = 'hello world';
 const { Worker, isMainThread, workerData } = require('worker_threads');
 

--- a/test/parallel/test-fs-promises-file-handle-readLines.mjs
+++ b/test/parallel/test-fs-promises-file-handle-readLines.mjs
@@ -3,11 +3,10 @@ import tmpdir from '../common/tmpdir.js';
 
 import assert from 'node:assert';
 import { open, writeFile } from 'node:fs/promises';
-import path from 'node:path';
 
 tmpdir.refresh();
 
-const filePath = path.join(tmpdir.path, 'file.txt');
+const filePath = tmpdir.resolve('file.txt');
 
 await writeFile(filePath, '1\n\n2\n');
 

--- a/test/parallel/test-fs-promises-file-handle-stat.js
+++ b/test/parallel/test-fs-promises-file-handle-stat.js
@@ -6,14 +6,13 @@ const common = require('../common');
 // FileHandle.stat method.
 
 const { open } = require('fs').promises;
-const path = require('path');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 
 tmpdir.refresh();
 
 async function validateStat() {
-  const filePath = path.resolve(tmpdir.path, 'tmp-read-file.txt');
+  const filePath = tmpdir.resolve('tmp-read-file.txt');
   const fileHandle = await open(filePath, 'w+');
   const stats = await fileHandle.stat();
   assert.ok(stats.mtime instanceof Date);

--- a/test/parallel/test-fs-promises-file-handle-sync.js
+++ b/test/parallel/test-fs-promises-file-handle-sync.js
@@ -5,11 +5,10 @@ const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
 
 const { access, copyFile, open } = require('fs').promises;
-const path = require('path');
 
 async function validate() {
   tmpdir.refresh();
-  const dest = path.resolve(tmpdir.path, 'baz.js');
+  const dest = tmpdir.resolve('baz.js');
   await assert.rejects(
     copyFile(fixtures.path('baz.js'), dest, 'r'),
     {

--- a/test/parallel/test-fs-promises-file-handle-truncate.js
+++ b/test/parallel/test-fs-promises-file-handle-truncate.js
@@ -2,7 +2,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const { open, readFile } = require('fs').promises;
 const tmpdir = require('../common/tmpdir');
 
@@ -10,7 +9,7 @@ tmpdir.refresh();
 
 async function validateTruncate() {
   const text = 'Hello world';
-  const filename = path.resolve(tmpdir.path, 'truncate-file.txt');
+  const filename = tmpdir.resolve('truncate-file.txt');
   const fileHandle = await open(filename, 'w+');
 
   const buffer = Buffer.from(text, 'utf8');

--- a/test/parallel/test-fs-promises-readfile-with-fd.js
+++ b/test/parallel/test-fs-promises-readfile-with-fd.js
@@ -5,14 +5,13 @@
 
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const { writeFileSync } = require('fs');
 const { open } = require('fs').promises;
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-const fn = path.join(tmpdir.path, 'test.txt');
+const fn = tmpdir.resolve('test.txt');
 writeFileSync(fn, 'Hello World');
 
 async function readFileTest() {

--- a/test/parallel/test-fs-promises-readfile.js
+++ b/test/parallel/test-fs-promises-readfile.js
@@ -4,14 +4,13 @@
 const common = require('../common');
 
 const assert = require('assert');
-const path = require('path');
 const { writeFile, readFile } = require('fs').promises;
 const tmpdir = require('../common/tmpdir');
 const { internalBinding } = require('internal/test/binding');
 const fsBinding = internalBinding('fs');
 tmpdir.refresh();
 
-const fn = path.join(tmpdir.path, 'large-file');
+const fn = tmpdir.resolve('large-file');
 
 // Creating large buffer with random content
 const largeBuffer = Buffer.from(

--- a/test/parallel/test-fs-promises-watch.js
+++ b/test/parallel/test-fs-promises-watch.js
@@ -17,7 +17,7 @@ class WatchTestCase {
     this.field = field;
     this.shouldSkip = !shouldInclude;
   }
-  get dirPath() { return join(tmpdir.path, this.dirName); }
+  get dirPath() { return tmpdir.resolve(this.dirName); }
   get filePath() { return join(this.dirPath, this.fileName); }
 }
 

--- a/test/parallel/test-fs-promises-write-optional-params.js
+++ b/test/parallel/test-fs-promises-write-optional-params.js
@@ -7,12 +7,11 @@ const common = require('../common');
 
 const assert = require('assert');
 const fsPromises = require('fs').promises;
-const path = require('path');
 const tmpdir = require('../common/tmpdir');
 
 tmpdir.refresh();
 
-const dest = path.resolve(tmpdir.path, 'tmp.txt');
+const dest = tmpdir.resolve('tmp.txt');
 const buffer = Buffer.from('zyx');
 
 async function testInvalid(dest, expectedCode, ...params) {

--- a/test/parallel/test-fs-promises-writefile-with-fd.js
+++ b/test/parallel/test-fs-promises-writefile-with-fd.js
@@ -5,14 +5,13 @@
 
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const { readFileSync } = require('fs');
 const { open } = require('fs').promises;
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-const fn = path.join(tmpdir.path, 'test.txt');
+const fn = tmpdir.resolve('test.txt');
 
 async function writeFileTest() {
   const handle = await open(fn, 'w');

--- a/test/parallel/test-fs-read-stream-autoClose.js
+++ b/test/parallel/test-fs-read-stream-autoClose.js
@@ -2,10 +2,9 @@
 
 const common = require('../common');
 const fs = require('fs');
-const path = require('path');
 const assert = require('assert');
 const tmpdir = require('../common/tmpdir');
-const writeFile = path.join(tmpdir.path, 'write-autoClose.txt');
+const writeFile = tmpdir.resolve('write-autoClose.txt');
 tmpdir.refresh();
 
 const file = fs.createWriteStream(writeFile, { autoClose: true });

--- a/test/parallel/test-fs-read-stream-fd.js
+++ b/test/parallel/test-fs-read-stream-fd.js
@@ -23,9 +23,8 @@
 const common = require('../common');
 const fs = require('fs');
 const assert = require('assert');
-const path = require('path');
 const tmpdir = require('../common/tmpdir');
-const file = path.join(tmpdir.path, '/read_stream_fd_test.txt');
+const file = tmpdir.resolve('read_stream_fd_test.txt');
 const input = 'hello world';
 
 let output = '';

--- a/test/parallel/test-fs-read-stream-file-handle.js
+++ b/test/parallel/test-fs-read-stream-file-handle.js
@@ -2,9 +2,8 @@
 const common = require('../common');
 const fs = require('fs');
 const assert = require('assert');
-const path = require('path');
 const tmpdir = require('../common/tmpdir');
-const file = path.join(tmpdir.path, 'read_stream_filehandle_test.txt');
+const file = tmpdir.resolve('read_stream_filehandle_test.txt');
 const input = 'hello world';
 
 tmpdir.refresh();

--- a/test/parallel/test-fs-read-stream-pos.js
+++ b/test/parallel/test-fs-read-stream-pos.js
@@ -6,11 +6,10 @@ const common = require('../common');
 const tmpdir = require('../common/tmpdir');
 const fs = require('fs');
 const assert = require('assert');
-const path = require('path');
 
 tmpdir.refresh();
 
-const file = path.join(tmpdir.path, '/read_stream_pos_test.txt');
+const file = tmpdir.resolve('read_stream_pos_test.txt');
 
 fs.writeFileSync(file, '');
 

--- a/test/parallel/test-fs-readfile-fd.js
+++ b/test/parallel/test-fs-readfile-fd.js
@@ -7,7 +7,6 @@ const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const fs = require('fs');
 const fn = fixtures.path('empty.txt');
-const join = require('path').join;
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
@@ -55,7 +54,7 @@ function tempFdSync(callback) {
   // position of the file, instead of reading from the beginning of the file,
   // when used with file descriptors.
 
-  const filename = join(tmpdir.path, 'test.txt');
+  const filename = tmpdir.resolve('test.txt');
   fs.writeFileSync(filename, 'Hello World');
 
   {

--- a/test/parallel/test-fs-readfile-flags.js
+++ b/test/parallel/test-fs-readfile-flags.js
@@ -4,13 +4,12 @@
 const common = require('../common');
 const fs = require('fs');
 const assert = require('assert');
-const path = require('path');
 const tmpdir = require('../common/tmpdir');
 
 tmpdir.refresh();
 
 {
-  const emptyFile = path.join(tmpdir.path, 'empty.txt');
+  const emptyFile = tmpdir.resolve('empty.txt');
   fs.closeSync(fs.openSync(emptyFile, 'w'));
 
   fs.readFile(
@@ -29,7 +28,7 @@ tmpdir.refresh();
 }
 
 {
-  const willBeCreated = path.join(tmpdir.path, 'will-be-created');
+  const willBeCreated = tmpdir.resolve('will-be-created');
 
   fs.readFile(
     willBeCreated,
@@ -40,7 +39,7 @@ tmpdir.refresh();
 }
 
 {
-  const willNotBeCreated = path.join(tmpdir.path, 'will-not-be-created');
+  const willNotBeCreated = tmpdir.resolve('will-not-be-created');
 
   fs.readFile(
     willNotBeCreated,

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -7,7 +7,6 @@ if (common.isWindows || common.isAIX)
   common.skip(`No /dev/stdin on ${process.platform}.`);
 
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 if (process.argv[2] === 'child') {
@@ -20,7 +19,7 @@ if (process.argv[2] === 'child') {
 
 const tmpdir = require('../common/tmpdir');
 
-const filename = path.join(tmpdir.path, '/readfile_pipe_large_test.txt');
+const filename = tmpdir.resolve('readfile_pipe_large_test.txt');
 const dataExpected = 'a'.repeat(999999);
 tmpdir.refresh();
 fs.writeFileSync(filename, dataExpected);

--- a/test/parallel/test-fs-readfile-unlink.js
+++ b/test/parallel/test-fs-readfile-unlink.js
@@ -26,11 +26,10 @@ const common = require('../common');
 
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 
 const tmpdir = require('../common/tmpdir');
 
-const fileName = path.resolve(tmpdir.path, 'test.bin');
+const fileName = tmpdir.resolve('test.bin');
 const buf = Buffer.alloc(512 * 1024, 42);
 
 tmpdir.refresh();

--- a/test/parallel/test-fs-readfile.js
+++ b/test/parallel/test-fs-readfile.js
@@ -7,22 +7,21 @@ const common = require('../common');
 const tmpdir = require('../../test/common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 
 const prefix = `.removeme-fs-readfile-${process.pid}`;
 
 tmpdir.refresh();
 
 const fileInfo = [
-  { name: path.join(tmpdir.path, `${prefix}-1K.txt`),
+  { name: tmpdir.resolve(`${prefix}-1K.txt`),
     len: 1024 },
-  { name: path.join(tmpdir.path, `${prefix}-64K.txt`),
+  { name: tmpdir.resolve(`${prefix}-64K.txt`),
     len: 64 * 1024 },
-  { name: path.join(tmpdir.path, `${prefix}-64KLessOne.txt`),
+  { name: tmpdir.resolve(`${prefix}-64KLessOne.txt`),
     len: (64 * 1024) - 1 },
-  { name: path.join(tmpdir.path, `${prefix}-1M.txt`),
+  { name: tmpdir.resolve(`${prefix}-1M.txt`),
     len: 1 * 1024 * 1024 },
-  { name: path.join(tmpdir.path, `${prefix}-1MPlusOne.txt`),
+  { name: tmpdir.resolve(`${prefix}-1MPlusOne.txt`),
     len: (1 * 1024 * 1024) + 1 },
 ];
 
@@ -61,7 +60,7 @@ for (const e of fileInfo) {
     // truncateSync() will fail with ENOSPC if there is not enough space.
     common.printSkipMessage(`Not enough space in ${tmpdir.path}`);
   } else {
-    const file = path.join(tmpdir.path, `${prefix}-too-large.txt`);
+    const file = tmpdir.resolve(`${prefix}-too-large.txt`);
     fs.writeFileSync(file, Buffer.from('0'));
     fs.truncateSync(file, kIoMaxLength + 1);
 

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -7,7 +7,6 @@ if (common.isWindows || common.isAIX)
   common.skip(`No /dev/stdin on ${process.platform}.`);
 
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 if (process.argv[2] === 'child') {
@@ -17,7 +16,7 @@ if (process.argv[2] === 'child') {
 
 const tmpdir = require('../common/tmpdir');
 
-const filename = path.join(tmpdir.path, '/readfilesync_pipe_large_test.txt');
+const filename = tmpdir.resolve('readfilesync_pipe_large_test.txt');
 const dataExpected = 'a'.repeat(999999);
 tmpdir.refresh();
 fs.writeFileSync(filename, dataExpected);

--- a/test/parallel/test-fs-readv-promises.js
+++ b/test/parallel/test-fs-readv-promises.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs').promises;
 const tmpdir = require('../common/tmpdir');
 
@@ -12,7 +11,7 @@ const exptectedBuff = Buffer.from(expected);
 
 let cnt = 0;
 function getFileName() {
-  return path.join(tmpdir.path, `readv_promises_${++cnt}.txt`);
+  return tmpdir.resolve(`readv_promises_${++cnt}.txt`);
 }
 
 const allocateEmptyBuffers = (combinedLength) => {

--- a/test/parallel/test-fs-readv-sync.js
+++ b/test/parallel/test-fs-readv-sync.js
@@ -3,7 +3,6 @@
 require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 const tmpdir = require('../common/tmpdir');
 
 tmpdir.refresh();
@@ -13,7 +12,7 @@ const expected = 'ümlaut. Лорем 運務ホソモ指及 आपको कर�
 const exptectedBuff = Buffer.from(expected);
 const expectedLength = exptectedBuff.length;
 
-const filename = path.join(tmpdir.path, 'readv_sync.txt');
+const filename = tmpdir.resolve('readv_sync.txt');
 fs.writeFileSync(filename, exptectedBuff);
 
 const allocateEmptyBuffers = (combinedLength) => {

--- a/test/parallel/test-fs-readv.js
+++ b/test/parallel/test-fs-readv.js
@@ -2,7 +2,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 const tmpdir = require('../common/tmpdir');
 
@@ -11,7 +10,7 @@ tmpdir.refresh();
 const expected = 'ümlaut. Лорем 運務ホソモ指及 आपको करने विकास 紙読決多密所 أضف';
 
 let cnt = 0;
-const getFileName = () => path.join(tmpdir.path, `readv_${++cnt}.txt`);
+const getFileName = () => tmpdir.resolve(`readv_${++cnt}.txt`);
 const exptectedBuff = Buffer.from(expected);
 
 const allocateEmptyBuffers = (combinedLength) => {

--- a/test/parallel/test-fs-ready-event-stream.js
+++ b/test/parallel/test-fs-ready-event-stream.js
@@ -2,7 +2,6 @@
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 const tmpdir = require('../common/tmpdir');
 
 const readStream = fs.createReadStream(__filename);
@@ -11,7 +10,7 @@ readStream.on('ready', common.mustCall(() => {
   assert.strictEqual(readStream.pending, false);
 }));
 
-const writeFile = path.join(tmpdir.path, 'write-fsreadyevent.txt');
+const writeFile = tmpdir.resolve('write-fsreadyevent.txt');
 tmpdir.refresh();
 const writeStream = fs.createWriteStream(writeFile, { autoClose: true });
 assert.strictEqual(writeStream.pending, true);

--- a/test/parallel/test-fs-sir-writes-alot.js
+++ b/test/parallel/test-fs-sir-writes-alot.js
@@ -23,11 +23,10 @@
 require('../common');
 const fs = require('fs');
 const assert = require('assert');
-const join = require('path').join;
 
 const tmpdir = require('../common/tmpdir');
 
-const filename = join(tmpdir.path, 'out.txt');
+const filename = tmpdir.resolve('out.txt');
 
 tmpdir.refresh();
 

--- a/test/parallel/test-fs-syncwritestream.js
+++ b/test/parallel/test-fs-syncwritestream.js
@@ -4,7 +4,6 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 const stream = require('stream');
 const fs = require('fs');
-const path = require('path');
 
 // require('internal/fs/utils').SyncWriteStream is used as a stdio
 // implementation when stdout/stderr point to files.
@@ -24,7 +23,7 @@ if (process.argv[2] === 'child') {
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-const filename = path.join(tmpdir.path, 'stdout');
+const filename = tmpdir.resolve('stdout');
 const stdoutFd = fs.openSync(filename, 'w');
 
 const proc = spawn(process.execPath, [__filename, 'child'], {

--- a/test/parallel/test-fs-write-buffer-large.js
+++ b/test/parallel/test-fs-write-buffer-large.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 const tmpdir = require('../common/tmpdir');
@@ -20,7 +19,7 @@ try {
   common.skip('skipped due to memory requirements');
 }
 
-const filename = path.join(tmpdir.path, 'write9.txt');
+const filename = tmpdir.resolve('write9.txt');
 fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
   assert.throws(() => {
     fs.write(fd,

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -22,7 +22,6 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 const expected = Buffer.from('hello');
 
@@ -31,7 +30,7 @@ tmpdir.refresh();
 
 // fs.write with all parameters provided:
 {
-  const filename = path.join(tmpdir.path, 'write1.txt');
+  const filename = tmpdir.resolve('write1.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
     const cb = common.mustSucceed((written) => {
       assert.strictEqual(written, expected.length);
@@ -47,7 +46,7 @@ tmpdir.refresh();
 
 // fs.write with a buffer, without the length parameter:
 {
-  const filename = path.join(tmpdir.path, 'write2.txt');
+  const filename = tmpdir.resolve('write2.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
     const cb = common.mustSucceed((written) => {
       assert.strictEqual(written, 2);
@@ -63,7 +62,7 @@ tmpdir.refresh();
 
 // fs.write with a buffer, without the offset and length parameters:
 {
-  const filename = path.join(tmpdir.path, 'write3.txt');
+  const filename = tmpdir.resolve('write3.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
     const cb = common.mustSucceed((written) => {
       assert.strictEqual(written, expected.length);
@@ -79,7 +78,7 @@ tmpdir.refresh();
 
 // fs.write with the offset passed as undefined followed by the callback:
 {
-  const filename = path.join(tmpdir.path, 'write4.txt');
+  const filename = tmpdir.resolve('write4.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
     const cb = common.mustSucceed((written) => {
       assert.strictEqual(written, expected.length);
@@ -95,7 +94,7 @@ tmpdir.refresh();
 
 // fs.write with offset and length passed as undefined followed by the callback:
 {
-  const filename = path.join(tmpdir.path, 'write5.txt');
+  const filename = tmpdir.resolve('write5.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
     const cb = common.mustSucceed((written) => {
       assert.strictEqual(written, expected.length);
@@ -111,7 +110,7 @@ tmpdir.refresh();
 
 // fs.write with a Uint8Array, without the offset and length parameters:
 {
-  const filename = path.join(tmpdir.path, 'write6.txt');
+  const filename = tmpdir.resolve('write6.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
     const cb = common.mustSucceed((written) => {
       assert.strictEqual(written, expected.length);
@@ -127,7 +126,7 @@ tmpdir.refresh();
 
 // fs.write with invalid offset type
 {
-  const filename = path.join(tmpdir.path, 'write7.txt');
+  const filename = tmpdir.resolve('write7.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
     assert.throws(() => {
       fs.write(fd,
@@ -149,7 +148,7 @@ tmpdir.refresh();
 
 // fs.write with a DataView, without the offset and length parameters:
 {
-  const filename = path.join(tmpdir.path, 'write8.txt');
+  const filename = tmpdir.resolve('write8.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
     const cb = common.mustSucceed((written) => {
       assert.strictEqual(written, expected.length);

--- a/test/parallel/test-fs-write-file-buffer.js
+++ b/test/parallel/test-fs-write-file-buffer.js
@@ -21,7 +21,6 @@
 
 'use strict';
 require('../common');
-const join = require('path').join;
 const util = require('util');
 const fs = require('fs');
 
@@ -50,6 +49,6 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 const buf = Buffer.from(data, 'base64');
-fs.writeFileSync(join(tmpdir.path, 'test.jpg'), buf);
+fs.writeFileSync(tmpdir.resolve('test.jpg'), buf);
 
 util.log('Done!');

--- a/test/parallel/test-fs-write-file-invalid-path.js
+++ b/test/parallel/test-fs-write-file-invalid-path.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 
 if (!common.isWindows)
   common.skip('This test is for Windows only.');
@@ -18,7 +17,7 @@ const DATA_VALUE = 'hello';
 const RESERVED_CHARACTERS = '<>"|?*';
 
 [...RESERVED_CHARACTERS].forEach((ch) => {
-  const pathname = path.join(tmpdir.path, `somefile_${ch}`);
+  const pathname = tmpdir.resolve(`somefile_${ch}`);
   assert.throws(
     () => {
       fs.writeFileSync(pathname, DATA_VALUE);
@@ -29,7 +28,7 @@ const RESERVED_CHARACTERS = '<>"|?*';
 
 // Test for ':' (NTFS data streams).
 // Refs: https://msdn.microsoft.com/en-us/library/windows/desktop/bb540537.aspx
-const pathname = path.join(tmpdir.path, 'foo:bar');
+const pathname = tmpdir.resolve('foo:bar');
 fs.writeFileSync(pathname, DATA_VALUE);
 
 let content = '';

--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -26,7 +26,6 @@ if (!common.isMainThread)
   common.skip('Setting process.umask is not supported in Workers');
 
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 // On Windows chmod is only able to manipulate read-only bit. Test if creating
@@ -41,7 +40,7 @@ tmpdir.refresh();
 
 // Test writeFileSync
 {
-  const file = path.join(tmpdir.path, 'testWriteFileSync.txt');
+  const file = tmpdir.resolve('testWriteFileSync.txt');
 
   fs.writeFileSync(file, '123', { mode });
   const content = fs.readFileSync(file, { encoding: 'utf8' });
@@ -51,7 +50,7 @@ tmpdir.refresh();
 
 // Test appendFileSync
 {
-  const file = path.join(tmpdir.path, 'testAppendFileSync.txt');
+  const file = tmpdir.resolve('testAppendFileSync.txt');
 
   fs.appendFileSync(file, 'abc', { mode });
   const content = fs.readFileSync(file, { encoding: 'utf8' });
@@ -77,7 +76,7 @@ tmpdir.refresh();
     return _closeSync(...args);
   };
 
-  const file = path.join(tmpdir.path, 'testWriteFileSyncFd.txt');
+  const file = tmpdir.resolve('testWriteFileSyncFd.txt');
   const fd = fs.openSync(file, 'w+', mode);
 
   fs.writeFileSync(fd, '123');
@@ -94,7 +93,7 @@ tmpdir.refresh();
 
 // Test writeFileSync with flags
 {
-  const file = path.join(tmpdir.path, 'testWriteFileSyncFlags.txt');
+  const file = tmpdir.resolve('testWriteFileSyncFlags.txt');
 
   fs.writeFileSync(file, 'hello ', { encoding: 'utf8', flag: 'a' });
   fs.writeFileSync(file, 'world!', { encoding: 'utf8', flag: 'a' });
@@ -104,7 +103,7 @@ tmpdir.refresh();
 
 // Test writeFileSync with an invalid input
 {
-  const file = path.join(tmpdir.path, 'testWriteFileSyncInvalid.txt');
+  const file = tmpdir.resolve('testWriteFileSyncInvalid.txt');
   for (const data of [
     false, 5, {}, [], null, undefined, true, 5n, () => {}, Symbol(), new Map(),
     new String('notPrimitive'),

--- a/test/parallel/test-fs-write-file-typedarrays.js
+++ b/test/parallel/test-fs-write-file-typedarrays.js
@@ -2,12 +2,11 @@
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const join = require('path').join;
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-const filename = join(tmpdir.path, 'test.txt');
+const filename = tmpdir.resolve('test.txt');
 
 const s = '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，疆域包括今天中国的广东、' +
           '广西两省区的大部份地区，福建省、湖南、贵州、云南的一小部份地区和越南的北部。' +

--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -23,12 +23,11 @@
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const join = require('path').join;
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-const filename = join(tmpdir.path, 'test.txt');
+const filename = tmpdir.resolve('test.txt');
 
 const s = '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，疆域包括今天中国的广东、' +
           '广西两省区的大部份地区，福建省、湖南、贵州、云南的一小部份地区和越南的北部。' +
@@ -45,7 +44,7 @@ fs.writeFile(filename, s, common.mustSucceed(() => {
 }));
 
 // Test that writeFile accepts buffers.
-const filename2 = join(tmpdir.path, 'test2.txt');
+const filename2 = tmpdir.resolve('test2.txt');
 const buf = Buffer.from(s, 'utf8');
 
 fs.writeFile(filename2, buf, common.mustSucceed(() => {
@@ -55,7 +54,7 @@ fs.writeFile(filename2, buf, common.mustSucceed(() => {
 }));
 
 // Test that writeFile accepts file descriptors.
-const filename4 = join(tmpdir.path, 'test4.txt');
+const filename4 = tmpdir.resolve('test4.txt');
 
 fs.open(filename4, 'w+', common.mustSucceed((fd) => {
   fs.writeFile(fd, s, common.mustSucceed(() => {
@@ -73,7 +72,7 @@ fs.open(filename4, 'w+', common.mustSucceed((fd) => {
   // Before the operation has started
   const controller = new AbortController();
   const signal = controller.signal;
-  const filename3 = join(tmpdir.path, 'test3.txt');
+  const filename3 = tmpdir.resolve('test3.txt');
 
   fs.writeFile(filename3, s, { signal }, common.mustCall((err) => {
     assert.strictEqual(err.name, 'AbortError');
@@ -87,7 +86,7 @@ fs.open(filename4, 'w+', common.mustSucceed((fd) => {
   // After the operation has started
   const controller = new AbortController();
   const signal = controller.signal;
-  const filename4 = join(tmpdir.path, 'test5.txt');
+  const filename4 = tmpdir.resolve('test5.txt');
 
   fs.writeFile(filename4, s, { signal }, common.mustCall((err) => {
     assert.strictEqual(err.name, 'AbortError');
@@ -98,7 +97,7 @@ fs.open(filename4, 'w+', common.mustSucceed((fd) => {
 
 {
   // Test read-only mode
-  const filename = join(tmpdir.path, 'test6.txt');
+  const filename = tmpdir.resolve('test6.txt');
   fs.writeFileSync(filename, '');
   fs.writeFile(filename, s, { flag: 'r' }, common.expectsError(/EBADF/));
 }

--- a/test/parallel/test-fs-write-negativeoffset.js
+++ b/test/parallel/test-fs-write-negativeoffset.js
@@ -5,10 +5,6 @@
 const common = require('../common');
 
 const {
-  join,
-} = require('path');
-
-const {
   closeSync,
   open,
   write,
@@ -20,7 +16,7 @@ const assert = require('assert');
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-const filename = join(tmpdir.path, 'test.txt');
+const filename = tmpdir.resolve('test.txt');
 
 open(filename, 'w+', common.mustSucceed((fd) => {
   assert.throws(() => {
@@ -36,7 +32,7 @@ open(filename, 'w+', common.mustSucceed((fd) => {
   closeSync(fd);
 }));
 
-const filename2 = join(tmpdir.path, 'test2.txt');
+const filename2 = tmpdir.resolve('test2.txt');
 
 // Make sure negative length's don't cause aborts either
 

--- a/test/parallel/test-fs-write-optional-params.js
+++ b/test/parallel/test-fs-write-optional-params.js
@@ -7,13 +7,12 @@ const common = require('../common');
 
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 const tmpdir = require('../common/tmpdir');
 const util = require('util');
 
 tmpdir.refresh();
 
-const destInvalid = path.resolve(tmpdir.path, 'rwopt_invalid');
+const destInvalid = tmpdir.resolve('rwopt_invalid');
 const buffer = Buffer.from('zyx');
 
 function testInvalidCb(fd, expectedCode, buffer, options, callback) {
@@ -28,7 +27,7 @@ function testValidCb(buffer, options, index, callback) {
   options = common.mustNotMutateObjectDeep(options);
   const length = options?.length;
   const offset = options?.offset;
-  const dest = path.resolve(tmpdir.path, `rwopt_valid_${index}`);
+  const dest = tmpdir.resolve(`rwopt_valid_${index}`);
   fs.open(dest, 'w', common.mustSucceed((fd) => {
     fs.write(fd, buffer, options, common.mustSucceed((bytesWritten, bufferWritten) => {
       const writeBufCopy = Uint8Array.prototype.slice.call(bufferWritten);

--- a/test/parallel/test-fs-write-reuse-callback.js
+++ b/test/parallel/test-fs-write-reuse-callback.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
-const path = require('path');
 
 // Regression test for https://github.com/nodejs/node-v0.x-archive/issues/814:
 // Make sure that Buffers passed to fs.write() are not garbage-collected
@@ -12,7 +11,7 @@ const path = require('path');
 const fs = require('fs');
 
 tmpdir.refresh();
-const filename = path.join(tmpdir.path, 'test.txt');
+const filename = tmpdir.resolve('test.txt');
 const fd = fs.openSync(filename, 'w');
 
 const size = 16 * 1024;

--- a/test/parallel/test-fs-write-sigxfsz.js
+++ b/test/parallel/test-fs-write-sigxfsz.js
@@ -7,7 +7,6 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const child_process = require('child_process');
 const fs = require('fs');
-const path = require('path');
 
 if (common.isWindows)
   common.skip('no RLIMIT_FSIZE on Windows');
@@ -16,7 +15,7 @@ if (process.config.variables.node_shared)
   common.skip('SIGXFSZ signal handler not installed in shared library mode');
 
 if (process.argv[2] === 'child') {
-  const filename = path.join(tmpdir.path, 'efbig.txt');
+  const filename = tmpdir.resolve('efbig.txt');
   tmpdir.refresh();
   fs.writeFileSync(filename, '.'.repeat(1 << 16));  // Exceeds RLIMIT_FSIZE.
 } else {

--- a/test/parallel/test-fs-write-stream-autoclose-option.js
+++ b/test/parallel/test-fs-write-stream-autoclose-option.js
@@ -1,12 +1,11 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 const tmpdir = require('../common/tmpdir');
 
-const file = path.join(tmpdir.path, 'write-autoclose-opt1.txt');
+const file = tmpdir.resolve('write-autoclose-opt1.txt');
 tmpdir.refresh();
 let stream = fs.createWriteStream(file, { flags: 'w+', autoClose: false });
 stream.write('Test1');

--- a/test/parallel/test-fs-write-stream-change-open.js
+++ b/test/parallel/test-fs-write-stream-change-open.js
@@ -22,12 +22,11 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 const tmpdir = require('../common/tmpdir');
 
-const file = path.join(tmpdir.path, 'write.txt');
+const file = tmpdir.resolve('write.txt');
 
 tmpdir.refresh();
 

--- a/test/parallel/test-fs-write-stream-close-without-callback.js
+++ b/test/parallel/test-fs-write-stream-close-without-callback.js
@@ -2,12 +2,11 @@
 
 require('../common');
 const fs = require('fs');
-const path = require('path');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-const s = fs.createWriteStream(path.join(tmpdir.path, 'nocallback'));
+const s = fs.createWriteStream(tmpdir.resolve('nocallback'));
 
 s.end('hello world');
 s.close();

--- a/test/parallel/test-fs-write-stream-double-close.js
+++ b/test/parallel/test-fs-write-stream-double-close.js
@@ -3,20 +3,19 @@
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 {
-  const s = fs.createWriteStream(path.join(tmpdir.path, 'rw'));
+  const s = fs.createWriteStream(tmpdir.resolve('rw'));
 
   s.close(common.mustCall());
   s.close(common.mustCall());
 }
 
 {
-  const s = fs.createWriteStream(path.join(tmpdir.path, 'rw2'));
+  const s = fs.createWriteStream(tmpdir.resolve('rw2'));
 
   let emits = 0;
   s.on('close', () => {
@@ -37,7 +36,7 @@ tmpdir.refresh();
 }
 
 {
-  const s = fs.createWriteStream(path.join(tmpdir.path, 'rw'), {
+  const s = fs.createWriteStream(tmpdir.resolve('rw'), {
     autoClose: false
   });
 

--- a/test/parallel/test-fs-write-stream-encoding.js
+++ b/test/parallel/test-fs-write-stream-encoding.js
@@ -3,14 +3,13 @@ require('../common');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
 const fs = require('fs');
-const path = require('path');
 const stream = require('stream');
 const tmpdir = require('../common/tmpdir');
 const firstEncoding = 'base64';
 const secondEncoding = 'latin1';
 
 const examplePath = fixtures.path('x.txt');
-const dummyPath = path.join(tmpdir.path, 'x.txt');
+const dummyPath = tmpdir.resolve('x.txt');
 
 tmpdir.refresh();
 

--- a/test/parallel/test-fs-write-stream-end.js
+++ b/test/parallel/test-fs-write-stream-end.js
@@ -22,21 +22,20 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 {
-  const file = path.join(tmpdir.path, 'write-end-test0.txt');
+  const file = tmpdir.resolve('write-end-test0.txt');
   const stream = fs.createWriteStream(file);
   stream.end();
   stream.on('close', common.mustCall());
 }
 
 {
-  const file = path.join(tmpdir.path, 'write-end-test1.txt');
+  const file = tmpdir.resolve('write-end-test1.txt');
   const stream = fs.createWriteStream(file);
   stream.end('a\n', 'utf8');
   stream.on('close', common.mustCall(function() {
@@ -46,7 +45,7 @@ tmpdir.refresh();
 }
 
 {
-  const file = path.join(tmpdir.path, 'write-end-test2.txt');
+  const file = tmpdir.resolve('write-end-test2.txt');
   const stream = fs.createWriteStream(file);
   stream.end();
 

--- a/test/parallel/test-fs-write-stream-file-handle-2.js
+++ b/test/parallel/test-fs-write-stream-file-handle-2.js
@@ -1,10 +1,9 @@
 'use strict';
 const common = require('../common');
 const fs = require('fs');
-const path = require('path');
 const assert = require('assert');
 const tmpdir = require('../common/tmpdir');
-const file = path.join(tmpdir.path, 'write_stream_filehandle_test.txt');
+const file = tmpdir.resolve('write_stream_filehandle_test.txt');
 const input = 'hello world';
 
 tmpdir.refresh();

--- a/test/parallel/test-fs-write-stream-file-handle.js
+++ b/test/parallel/test-fs-write-stream-file-handle.js
@@ -1,10 +1,9 @@
 'use strict';
 const common = require('../common');
 const fs = require('fs');
-const path = require('path');
 const assert = require('assert');
 const tmpdir = require('../common/tmpdir');
-const file = path.join(tmpdir.path, 'write_stream_filehandle_test.txt');
+const file = tmpdir.resolve('write_stream_filehandle_test.txt');
 const input = 'hello world';
 
 tmpdir.refresh();

--- a/test/parallel/test-fs-write-stream-fs.js
+++ b/test/parallel/test-fs-write-stream-fs.js
@@ -1,13 +1,12 @@
 'use strict';
 const common = require('../common');
-const path = require('path');
 const fs = require('fs');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 {
-  const file = path.join(tmpdir.path, 'write-end-test0.txt');
+  const file = tmpdir.resolve('write-end-test0.txt');
   const stream = fs.createWriteStream(file, {
     fs: {
       open: common.mustCall(fs.open),
@@ -21,7 +20,7 @@ tmpdir.refresh();
 
 
 {
-  const file = path.join(tmpdir.path, 'write-end-test1.txt');
+  const file = tmpdir.resolve('write-end-test1.txt');
   const stream = fs.createWriteStream(file, {
     fs: {
       open: common.mustCall(fs.open),

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -2,11 +2,10 @@
 require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 
 const tmpdir = require('../common/tmpdir');
 
-const example = path.join(tmpdir.path, 'dummy');
+const example = tmpdir.resolve('dummy');
 
 tmpdir.refresh();
 // Should not throw.

--- a/test/parallel/test-fs-write-stream.js
+++ b/test/parallel/test-fs-write-stream.js
@@ -22,12 +22,11 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 const tmpdir = require('../common/tmpdir');
 
-const file = path.join(tmpdir.path, 'write.txt');
+const file = tmpdir.resolve('write.txt');
 
 tmpdir.refresh();
 

--- a/test/parallel/test-fs-write-sync-optional-params.js
+++ b/test/parallel/test-fs-write-sync-optional-params.js
@@ -7,12 +7,11 @@ const common = require('../common');
 
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 const tmpdir = require('../common/tmpdir');
 
 tmpdir.refresh();
 
-const dest = path.resolve(tmpdir.path, 'tmp.txt');
+const dest = tmpdir.resolve('tmp.txt');
 const buffer = Buffer.from('zyx');
 
 function testInvalid(dest, expectedCode, ...bufferAndOptions) {

--- a/test/parallel/test-fs-write-sync.js
+++ b/test/parallel/test-fs-write-sync.js
@@ -22,10 +22,9 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 const tmpdir = require('../common/tmpdir');
-const filename = path.join(tmpdir.path, 'write.txt');
+const filename = tmpdir.resolve('write.txt');
 
 tmpdir.refresh();
 

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -23,16 +23,15 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 const tmpdir = require('../common/tmpdir');
 
 tmpdir.refresh();
 
-const fn = path.join(tmpdir.path, 'write.txt');
-const fn2 = path.join(tmpdir.path, 'write2.txt');
-const fn3 = path.join(tmpdir.path, 'write3.txt');
-const fn4 = path.join(tmpdir.path, 'write4.txt');
+const fn = tmpdir.resolve('write.txt');
+const fn2 = tmpdir.resolve('write2.txt');
+const fn3 = tmpdir.resolve('write3.txt');
+const fn4 = tmpdir.resolve('write4.txt');
 const expected = 'ümlaut.';
 const constants = fs.constants;
 

--- a/test/parallel/test-fs-writefile-with-fd.js
+++ b/test/parallel/test-fs-writefile-with-fd.js
@@ -7,14 +7,13 @@
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const join = require('path').join;
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 {
   /* writeFileSync() test. */
-  const filename = join(tmpdir.path, 'test.txt');
+  const filename = tmpdir.resolve('test.txt');
 
   /* Open the file descriptor. */
   const fd = fs.openSync(filename, 'w');
@@ -46,7 +45,7 @@ process.on('beforeExit', common.mustCall(() => {
 
 {
   /* writeFile() test. */
-  const file = join(tmpdir.path, 'test1.txt');
+  const file = tmpdir.resolve('test1.txt');
 
   /* Open the file descriptor. */
   fs.open(file, 'w', common.mustSucceed((fd) => {
@@ -68,7 +67,7 @@ process.on('beforeExit', common.mustCall(() => {
 
 // Test read-only file descriptor
 {
-  const file = join(tmpdir.path, 'test.txt');
+  const file = tmpdir.resolve('test.txt');
 
   fs.open(file, 'r', common.mustSucceed((fd) => {
     fdsToCloseOnExit.push(fd);
@@ -80,7 +79,7 @@ process.on('beforeExit', common.mustCall(() => {
 {
   const controller = new AbortController();
   const signal = controller.signal;
-  const file = join(tmpdir.path, 'test.txt');
+  const file = tmpdir.resolve('test.txt');
 
   fs.open(file, 'w', common.mustSucceed((fd) => {
     fdsToCloseOnExit.push(fd);

--- a/test/parallel/test-fs-writev-promises.js
+++ b/test/parallel/test-fs-writev-promises.js
@@ -1,14 +1,13 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs').promises;
 const tmpdir = require('../common/tmpdir');
 const expected = 'ümlaut. Лорем 運務ホソモ指及 आपको करने विकास 紙読決多密所 أضف';
 let cnt = 0;
 
 function getFileName() {
-  return path.join(tmpdir.path, `writev_promises_${++cnt}.txt`);
+  return tmpdir.resolve(`writev_promises_${++cnt}.txt`);
 }
 
 tmpdir.refresh();

--- a/test/parallel/test-fs-writev-sync.js
+++ b/test/parallel/test-fs-writev-sync.js
@@ -2,7 +2,6 @@
 
 require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 const tmpdir = require('../common/tmpdir');
 
@@ -10,7 +9,7 @@ tmpdir.refresh();
 
 const expected = 'ümlaut. Лорем 運務ホソモ指及 आपको करने विकास 紙読決多密所 أضف';
 
-const getFileName = (i) => path.join(tmpdir.path, `writev_sync_${i}.txt`);
+const getFileName = (i) => tmpdir.resolve(`writev_sync_${i}.txt`);
 
 /**
  * Testing with a array of buffers input

--- a/test/parallel/test-fs-writev.js
+++ b/test/parallel/test-fs-writev.js
@@ -2,7 +2,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 const tmpdir = require('../common/tmpdir');
 
@@ -10,7 +9,7 @@ tmpdir.refresh();
 
 const expected = 'ümlaut. Лорем 運務ホソモ指及 आपको करने विकास 紙読決多密所 أضف';
 
-const getFileName = (i) => path.join(tmpdir.path, `writev_${i}.txt`);
+const getFileName = (i) => tmpdir.resolve(`writev_${i}.txt`);
 
 /**
  * Testing with a array of buffers input


### PR DESCRIPTION
Extracted from: https://github.com/nodejs/node/pull/49079