### PR TITLE
test: refactor `test-esm-loader-hooks` for easier debugging

### DIFF
--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -10,8 +10,8 @@ describe('Loader hooks', { concurrency: true }, () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
       '--experimental-loader',
-      fixtures.fileURL('/es-module-loaders/hooks-input.mjs'),
-      fixtures.path('/es-modules/json-modules.mjs'),
+      fixtures.fileURL('es-module-loaders/hooks-input.mjs'),
+      fixtures.path('es-modules/json-modules.mjs'),
     ]);
 
     assert.strictEqual(stderr, '');
@@ -23,6 +23,8 @@ describe('Loader hooks', { concurrency: true }, () => {
     assert.match(lines[1], /{"source":{"type":"Buffer","data":\[.*\]},"format":"module","shortCircuit":true}/);
     assert.match(lines[2], /{"url":"file:\/\/\/.*\/experimental\.json","format":"test","shortCircuit":true}/);
     assert.match(lines[3], /{"source":{"type":"Buffer","data":\[.*\]},"format":"json","shortCircuit":true}/);
+    assert.strictEqual(lines[4], '');
+    assert.strictEqual(lines.length, 5);
   });
 
   it('are called with all expected arguments using register function', async () => {
@@ -32,8 +34,8 @@ describe('Loader hooks', { concurrency: true }, () => {
       '--input-type=module',
       '--eval',
       "import { register } from 'node:module';" +
-      `register(${JSON.stringify(fixtures.fileURL('/es-module-loaders/hooks-input.mjs'))});` +
-      `await import(${JSON.stringify(fixtures.fileURL('/es-modules/json-modules.mjs'))});`,
+      `register(${JSON.stringify(fixtures.fileURL('es-module-loaders/hooks-input.mjs'))});` +
+      `await import(${JSON.stringify(fixtures.fileURL('es-modules/json-modules.mjs'))});`,
     ]);
 
     assert.strictEqual(stderr, '');
@@ -45,6 +47,8 @@ describe('Loader hooks', { concurrency: true }, () => {
     assert.match(lines[1], /{"source":{"type":"Buffer","data":\[.*\]},"format":"module","shortCircuit":true}/);
     assert.match(lines[2], /{"url":"file:\/\/\/.*\/experimental\.json","format":"test","shortCircuit":true}/);
     assert.match(lines[3], /{"source":{"type":"Buffer","data":\[.*\]},"format":"json","shortCircuit":true}/);
+    assert.strictEqual(lines[4], '');
+    assert.strictEqual(lines.length, 5);
   });
 
   describe('should handle never-settling hooks in ESM files', { concurrency: true }, () => {
@@ -392,7 +396,6 @@ describe('Loader hooks', { concurrency: true }, () => {
 
     it('should handle symbol', async () => {
       const { code, signal, stdout } = await spawnPromisified(execPath, [
-        '--no-warnings',
         '--experimental-loader',
         'data:text/javascript,throw Symbol("symbol descriptor")',
         fixtures.path('empty.js'),
@@ -564,19 +567,14 @@ describe('Loader hooks', { concurrency: true }, () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
       '--experimental-loader',
-      fixtures.fileURL('/es-module-loaders/hooks-initialize.mjs'),
+      fixtures.fileURL('es-module-loaders/hooks-initialize.mjs'),
       '--input-type=module',
       '--eval',
       'import os from "node:os";',
     ]);
 
-    const lines = stdout.trim().split('\n');
-
-    assert.strictEqual(lines.length, 1);
-    assert.strictEqual(lines[0], 'hooks initialize 1');
-
     assert.strictEqual(stderr, '');
-
+    assert.deepStrictEqual(stdout.split('\n'), ['hooks initialize 1', '']);
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
   });
@@ -607,7 +605,10 @@ describe('Loader hooks', { concurrency: true }, () => {
     ]);
 
     assert.strictEqual(stderr, '');
-    assert.deepStrictEqual(stdout.split('\n'), ['register ok', 'message initialize', 'message resolve node:os', '']);
+    assert.deepStrictEqual(stdout.split('\n'), [ 'register ok',
+                                                 'message initialize',
+                                                 'message resolve node:os',
+                                                 '' ]);
 
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
@@ -645,18 +646,14 @@ describe('Loader hooks', { concurrency: true }, () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
       '--require',
-      fixtures.path('/es-module-loaders/register-loader.cjs'),
+      fixtures.path('es-module-loaders/register-loader.cjs'),
       '--input-type=module',
       '--eval',
       'import "node:os";',
     ]);
 
-    const lines = stdout.split('\n');
-
-    assert.strictEqual(lines[0], 'resolve passthru');
-
     assert.strictEqual(stderr, '');
-
+    assert.deepStrictEqual(stdout.split('\n'), ['resolve passthru', 'resolve passthru', '']);
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
   });
@@ -665,7 +662,7 @@ describe('Loader hooks', { concurrency: true }, () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
       '--import',
-      fixtures.fileURL('/es-module-loaders/register-loader.mjs'),
+      fixtures.fileURL('es-module-loaders/register-loader.mjs'),
       '--input-type=module',
       '--eval',
       `
@@ -673,12 +670,8 @@ describe('Loader hooks', { concurrency: true }, () => {
       `,
     ]);
 
-    const lines = stdout.split('\n');
-
-    assert.strictEqual(lines[0], 'resolve passthru');
-
     assert.strictEqual(stderr, '');
-
+    assert.deepStrictEqual(stdout.split('\n'), ['resolve passthru', '']);
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
   });
@@ -691,24 +684,22 @@ describe('Loader hooks', { concurrency: true }, () => {
       `
         import {register} from 'node:module';
         console.log('result', register(
-          ${JSON.stringify(fixtures.fileURL('/es-module-loaders/hooks-initialize.mjs'))}
+          ${JSON.stringify(fixtures.fileURL('es-module-loaders/hooks-initialize.mjs'))}
         ));
         console.log('result', register(
-          ${JSON.stringify(fixtures.fileURL('/es-module-loaders/hooks-initialize.mjs'))}
+          ${JSON.stringify(fixtures.fileURL('es-module-loaders/hooks-initialize.mjs'))}
         ));
 
         await import('node:os');
       `,
     ]);
 
-    const lines = stdout.split('\n');
-
-    assert.strictEqual(lines[0], 'result 1');
-    assert.strictEqual(lines[1], 'result 2');
-    assert.strictEqual(lines[2], 'hooks initialize 1');
-    assert.strictEqual(lines[3], 'hooks initialize 2');
-
     assert.strictEqual(stderr, '');
+    assert.deepStrictEqual(stdout.split('\n'), [ 'result 1',
+                                                 'result 2',
+                                                 'hooks initialize 1',
+                                                 'hooks initialize 2',
+                                                 '' ]);
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
   });


### PR DESCRIPTION
- Always check stderr before stdout as the former would contain error information.
- Always match the full stdout to avoid surprises.
- Use `deepStrictEqual` when appropriate to get more informative test failures.
- Remove leading slashes from relative paths/URLs to not confuse them with absolute paths.
- Remove unnecessary `--no-warnings` flag.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
