### PR TITLE
test: use env variable to pass value containing user controlled value

### DIFF
--- a/test/abort/test-abort-fatal-error.js
+++ b/test/abort/test-abort-fatal-error.js
@@ -27,21 +27,13 @@ if (common.isWindows)
 const assert = require('assert');
 const exec = require('child_process').exec;
 
-let cmdline = `ulimit -c 0; ${process.execPath}`;
-cmdline += ' --max-old-space-size=16 --max-semi-space-size=4';
-cmdline += ' -e "a = []; for (i = 0; i < 1e9; i++) { a.push({}) }"';
+const cmdline =
+  'ulimit -c 0; "$NODE" --max-old-space-size=16 --max-semi-space-size=4' +
+  ' -e "a = []; for (i = 0; i < 1e9; i++) { a.push({}) }"';
 
-exec(cmdline, function(err, stdout, stderr) {
-  if (!err) {
-    console.log(stdout);
-    console.log(stderr);
-    assert(false, 'this test should fail');
+exec(cmdline, { env: { NODE: process.execPath } }, common.mustCall((err, stdout, stderr) => {
+  if (err?.code !== 134 && err?.signal !== 'SIGABRT') {
+    console.log({ err, stdout, stderr });
+    assert.fail(err?.message);
   }
-
-  if (err.code !== 134 && err.signal !== 'SIGABRT') {
-    console.log(stdout);
-    console.log(stderr);
-    console.log(err);
-    assert(false, err);
-  }
-});
+}));

--- a/test/abort/test-abort-fatal-error.js
+++ b/test/abort/test-abort-fatal-error.js
@@ -31,7 +31,7 @@ const cmdline =
   'ulimit -c 0; "$NODE" --max-old-space-size=16 --max-semi-space-size=4' +
   ' -e "a = []; for (i = 0; i < 1e9; i++) { a.push({}) }"';
 
-exec(cmdline, { env: { NODE: process.execPath } }, common.mustCall((err, stdout, stderr) => {
+exec(cmdline, { env: { ...process.env, NODE: process.execPath } }, common.mustCall((err, stdout, stderr) => {
   if (err?.code !== 134 && err?.signal !== 'SIGABRT') {
     console.log({ err, stdout, stderr });
     assert.fail(err?.message);

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -64,9 +64,10 @@ assert.ok(!arg);
     '--abort-on-uncaught-exception', __filename, 'test_callback_abort' ];
   const options = { encoding: 'utf8' };
   if (!common.isWindows) {
-    program = `ulimit -c 0 && exec ${program} ${args.join(' ')}`;
+    program = `ulimit -c 0 && exec "$NODE" ${args[0]} "$FILE" ${args[2]}`;
     args = [];
     options.shell = true;
+    options.env = { NODE: process.execPath, FILE: __filename };
   }
   const child = spawnSync(program, args, options);
   if (common.isWindows) {

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -67,7 +67,7 @@ assert.ok(!arg);
     program = `ulimit -c 0 && exec "$NODE" ${args[0]} "$FILE" ${args[2]}`;
     args = [];
     options.shell = true;
-    options.env = { NODE: process.execPath, FILE: __filename };
+    options.env = { ...process.env, NODE: process.execPath, FILE: __filename };
   }
   const child = spawnSync(program, args, options);
   if (common.isWindows) {

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -244,9 +244,9 @@ function childShouldThrowAndAbort() {
     // continuous testing and developers' machines
     testCmd += 'ulimit -c 0 && ';
   }
-  testCmd += `"${process.argv[0]}" --abort-on-uncaught-exception `;
-  testCmd += `"${process.argv[1]}" child`;
-  const child = exec(testCmd);
+  testCmd += '"$NODE" --abort-on-uncaught-exception ';
+  testCmd += '"$FILE" child';
+  const child = exec(testCmd, { env: { NODE: process.argv[0], FILE: process.argv[1] } });
   child.on('exit', function onExit(exitCode, signal) {
     const errMsg = 'Test should have aborted ' +
                    `but instead exited with exit code ${exitCode}` +
@@ -1062,6 +1062,15 @@ const common = {
    */
   get checkoutEOL() {
     return fs.readFileSync(__filename).includes('\r\n') ? '\r\n' : '\n';
+  },
+
+  get isInsideCWDWithUnusualChars() {
+    const cwd = process.cwd();
+    return cwd.includes('%') ||
+           (!isWindows && cwd.includes('\\')) ||
+           cwd.includes('\n') ||
+           cwd.includes('\r') ||
+           cwd.includes('\t');
   },
 };
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -246,7 +246,7 @@ function childShouldThrowAndAbort() {
   }
   testCmd += '"$NODE" --abort-on-uncaught-exception ';
   testCmd += '"$FILE" child';
-  const child = exec(testCmd, { env: { NODE: process.argv[0], FILE: process.argv[1] } });
+  const child = exec(testCmd, { env: { ...process.env, NODE: process.argv[0], FILE: process.argv[1] } });
   child.on('exit', function onExit(exitCode, signal) {
     const errMsg = 'Test should have aborted ' +
                    `but instead exited with exit code ${exitCode}` +
@@ -1062,15 +1062,6 @@ const common = {
    */
   get checkoutEOL() {
     return fs.readFileSync(__filename).includes('\r\n') ? '\r\n' : '\n';
-  },
-
-  get isInsideCWDWithUnusualChars() {
-    const cwd = process.cwd();
-    return cwd.includes('%') ||
-           (!isWindows && cwd.includes('\\')) ||
-           cwd.includes('\n') ||
-           cwd.includes('\r') ||
-           cwd.includes('\t');
   },
 };
 

--- a/test/parallel/test-child-process-bad-stdio.js
+++ b/test/parallel/test-child-process-bad-stdio.js
@@ -27,7 +27,8 @@ ChildProcess.prototype.spawn = function() {
 };
 
 function createChild(options, callback) {
-  const cmd = `"${process.execPath}" "${__filename}" child`;
+  const cmd = '"$NODE" "$FILE" child';
+  options = { ...options, env: { ...options.env, NODE: process.execPath, FILE: __filename } };
 
   return cp.exec(cmd, options, common.mustCall(callback));
 }

--- a/test/parallel/test-child-process-exec-encoding.js
+++ b/test/parallel/test-child-process-exec-encoding.js
@@ -13,7 +13,8 @@ if (process.argv[2] === 'child') {
   const expectedStdout = `${stdoutData}\n`;
   const expectedStderr = `${stderrData}\n`;
   function run(options, callback) {
-    const cmd = `"${process.execPath}" "${__filename}" child`;
+    const cmd = '"$NODE" "$FILE" child';
+    options = { ...options, env: { ...options.env, NODE: process.execPath, FILE: __filename } };
 
     cp.exec(cmd, options, common.mustSucceed((stdout, stderr) => {
       callback(stdout, stderr);

--- a/test/parallel/test-child-process-exec-maxbuf.js
+++ b/test/parallel/test-child-process-exec-maxbuf.js
@@ -10,12 +10,14 @@ function runChecks(err, stdio, streamName, expected) {
   assert.deepStrictEqual(stdio[streamName], expected);
 }
 
+const env = { NODE: process.execPath };
+
 // default value
 {
   const cmd =
-    `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024))"`;
+    '"$NODE" -e "console.log(\'a\'.repeat(1024 * 1024))"';
 
-  cp.exec(cmd, common.mustCall((err) => {
+  cp.exec(cmd, { env }, common.mustCall((err) => {
     assert(err instanceof RangeError);
     assert.strictEqual(err.message, 'stdout maxBuffer length exceeded');
     assert.strictEqual(err.code, 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER');
@@ -25,17 +27,17 @@ function runChecks(err, stdio, streamName, expected) {
 // default value
 {
   const cmd =
-    `${process.execPath} -e "console.log('a'.repeat(1024 * 1024 - 1))"`;
+    '"$NODE" -e "console.log(\'a\'.repeat(1024 * 1024 - 1))"';
 
-  cp.exec(cmd, common.mustSucceed((stdout, stderr) => {
+  cp.exec(cmd, { env }, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), 'a'.repeat(1024 * 1024 - 1));
     assert.strictEqual(stderr, '');
   }));
 }
 
 {
-  const cmd = `"${process.execPath}" -e "console.log('hello world');"`;
-  const options = { maxBuffer: Infinity };
+  const cmd = '"$NODE" -e "console.log(\'hello world\');"';
+  const options = { env, maxBuffer: Infinity };
 
   cp.exec(cmd, options, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), 'hello world');
@@ -58,10 +60,11 @@ function runChecks(err, stdio, streamName, expected) {
 // default value
 {
   const cmd =
-    `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024))"`;
+    '"$NODE" -e "console.log(\'a\'.repeat(1024 * 1024))"';
 
   cp.exec(
     cmd,
+    { env },
     common.mustCall((err, stdout, stderr) => {
       runChecks(
         err,
@@ -76,9 +79,9 @@ function runChecks(err, stdio, streamName, expected) {
 // default value
 {
   const cmd =
-    `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024 - 1))"`;
+    '"$NODE" -e "console.log(\'a\'.repeat(1024 * 1024 - 1))"';
 
-  cp.exec(cmd, common.mustSucceed((stdout, stderr) => {
+  cp.exec(cmd, { env }, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), 'a'.repeat(1024 * 1024 - 1));
     assert.strictEqual(stderr, '');
   }));
@@ -87,11 +90,11 @@ function runChecks(err, stdio, streamName, expected) {
 const unicode = '中文测试'; // length = 4, byte length = 12
 
 {
-  const cmd = `"${process.execPath}" -e "console.log('${unicode}');"`;
+  const cmd = `"$NODE" -e "console.log('${unicode}');"`;
 
   cp.exec(
     cmd,
-    { maxBuffer: 10 },
+    { env, maxBuffer: 10 },
     common.mustCall((err, stdout, stderr) => {
       runChecks(err, { stdout, stderr }, 'stdout', '中文测试\n');
     })
@@ -99,11 +102,11 @@ const unicode = '中文测试'; // length = 4, byte length = 12
 }
 
 {
-  const cmd = `"${process.execPath}" -e "console.error('${unicode}');"`;
+  const cmd = `"$NODE" -e "console.error('${unicode}');"`;
 
   cp.exec(
     cmd,
-    { maxBuffer: 3 },
+    { env, maxBuffer: 3 },
     common.mustCall((err, stdout, stderr) => {
       runChecks(err, { stdout, stderr }, 'stderr', '中文测');
     })
@@ -111,11 +114,11 @@ const unicode = '中文测试'; // length = 4, byte length = 12
 }
 
 {
-  const cmd = `"${process.execPath}" -e "console.log('${unicode}');"`;
+  const cmd = `"$NODE" -e "console.log('${unicode}');"`;
 
   const child = cp.exec(
     cmd,
-    { encoding: null, maxBuffer: 10 },
+    { encoding: null, env, maxBuffer: 10 },
     common.mustCall((err, stdout, stderr) => {
       runChecks(err, { stdout, stderr }, 'stdout', '中文测试\n');
     })
@@ -125,11 +128,11 @@ const unicode = '中文测试'; // length = 4, byte length = 12
 }
 
 {
-  const cmd = `"${process.execPath}" -e "console.error('${unicode}');"`;
+  const cmd = `"$NODE" -e "console.error('${unicode}');"`;
 
   const child = cp.exec(
     cmd,
-    { encoding: null, maxBuffer: 3 },
+    { encoding: null, env, maxBuffer: 3 },
     common.mustCall((err, stdout, stderr) => {
       runChecks(err, { stdout, stderr }, 'stderr', '中文测');
     })
@@ -139,11 +142,11 @@ const unicode = '中文测试'; // length = 4, byte length = 12
 }
 
 {
-  const cmd = `"${process.execPath}" -e "console.error('${unicode}');"`;
+  const cmd = `"$NODE" -e "console.error('${unicode}');"`;
 
   cp.exec(
     cmd,
-    { encoding: null, maxBuffer: 5 },
+    { encoding: null, env, maxBuffer: 5 },
     common.mustCall((err, stdout, stderr) => {
       const buf = Buffer.from(unicode).slice(0, 5);
       runChecks(err, { stdout, stderr }, 'stderr', buf);

--- a/test/parallel/test-child-process-exec-maxbuf.js
+++ b/test/parallel/test-child-process-exec-maxbuf.js
@@ -10,7 +10,7 @@ function runChecks(err, stdio, streamName, expected) {
   assert.deepStrictEqual(stdio[streamName], expected);
 }
 
-const env = { NODE: process.execPath };
+const env = { ...process.env, NODE: process.execPath };
 
 // default value
 {

--- a/test/parallel/test-child-process-exec-std-encoding.js
+++ b/test/parallel/test-child-process-exec-std-encoding.js
@@ -12,8 +12,9 @@ if (process.argv[2] === 'child') {
   console.log(stdoutData);
   console.error(stderrData);
 } else {
-  const cmd = `"${process.execPath}" "${__filename}" child`;
-  const child = cp.exec(cmd, common.mustSucceed((stdout, stderr) => {
+  const cmd = '"$NODE" "$FILE" child';
+  const env = { NODE: process.execPath, FILE: __filename };
+  const child = cp.exec(cmd, { env }, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout, expectedStdout);
     assert.strictEqual(stderr, expectedStderr);
   }));

--- a/test/parallel/test-child-process-exec-std-encoding.js
+++ b/test/parallel/test-child-process-exec-std-encoding.js
@@ -13,7 +13,7 @@ if (process.argv[2] === 'child') {
   console.error(stderrData);
 } else {
   const cmd = '"$NODE" "$FILE" child';
-  const env = { NODE: process.execPath, FILE: __filename };
+  const env = { ...process.env, NODE: process.execPath, FILE: __filename };
   const child = cp.exec(cmd, { env }, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout, expectedStdout);
     assert.strictEqual(stderr, expectedStderr);

--- a/test/parallel/test-child-process-exec-timeout-expire.js
+++ b/test/parallel/test-child-process-exec-timeout-expire.js
@@ -18,9 +18,10 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-const cmd = `"${process.execPath}" "${__filename}" child`;
+const cmd = '"$NODE" "$FILE" child';
 
 cp.exec(cmd, {
+  env: { NODE: process.execPath, FILE: __filename },
   timeout: kExpiringParentTimer,
 }, common.mustCall((err, stdout, stderr) => {
   console.log('[stdout]', stdout.trim());

--- a/test/parallel/test-child-process-exec-timeout-expire.js
+++ b/test/parallel/test-child-process-exec-timeout-expire.js
@@ -21,7 +21,7 @@ if (process.argv[2] === 'child') {
 const cmd = '"$NODE" "$FILE" child';
 
 cp.exec(cmd, {
-  env: { NODE: process.execPath, FILE: __filename },
+  env: { ...process.env, NODE: process.execPath, FILE: __filename },
   timeout: kExpiringParentTimer,
 }, common.mustCall((err, stdout, stderr) => {
   console.log('[stdout]', stdout.trim());

--- a/test/parallel/test-child-process-exec-timeout-kill.js
+++ b/test/parallel/test-child-process-exec-timeout-kill.js
@@ -18,10 +18,11 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-const cmd = `"${process.execPath}" "${__filename}" child`;
+const cmd = '"$NODE" "$FILE" child';
 
 // Test with a different kill signal.
 cp.exec(cmd, {
+  env: { NODE: process.execPath, FILE: __filename },
   timeout: kExpiringParentTimer,
   killSignal: 'SIGKILL'
 }, common.mustCall((err, stdout, stderr) => {

--- a/test/parallel/test-child-process-exec-timeout-kill.js
+++ b/test/parallel/test-child-process-exec-timeout-kill.js
@@ -22,7 +22,7 @@ const cmd = '"$NODE" "$FILE" child';
 
 // Test with a different kill signal.
 cp.exec(cmd, {
-  env: { NODE: process.execPath, FILE: __filename },
+  env: { ...process.env, NODE: process.execPath, FILE: __filename },
   timeout: kExpiringParentTimer,
   killSignal: 'SIGKILL'
 }, common.mustCall((err, stdout, stderr) => {

--- a/test/parallel/test-child-process-exec-timeout-not-expired.js
+++ b/test/parallel/test-child-process-exec-timeout-not-expired.js
@@ -22,9 +22,10 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-const cmd = `"${process.execPath}" "${__filename}" child`;
+const cmd = '"$NODE" "$FILE" child';
 
 cp.exec(cmd, {
+  env: { NODE: process.execPath, FILE: __filename },
   timeout: kTimeoutNotSupposedToExpire
 }, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(stdout.trim(), 'child stdout');

--- a/test/parallel/test-child-process-exec-timeout-not-expired.js
+++ b/test/parallel/test-child-process-exec-timeout-not-expired.js
@@ -25,7 +25,7 @@ if (process.argv[2] === 'child') {
 const cmd = '"$NODE" "$FILE" child';
 
 cp.exec(cmd, {
-  env: { NODE: process.execPath, FILE: __filename },
+  env: { ...process.env, NODE: process.execPath, FILE: __filename },
   timeout: kTimeoutNotSupposedToExpire
 }, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(stdout.trim(), 'child stdout');

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -10,7 +10,7 @@ const os = require('os');
 
 const fixture = fixtures.path('exit.js');
 const echoFixture = fixtures.path('echo.js');
-const execOpts = { encoding: 'utf8', shell: true };
+const execOpts = { encoding: 'utf8', shell: true, env: { NODE: process.execPath, FIXTURE: fixture } };
 
 {
   execFile(
@@ -46,7 +46,7 @@ const execOpts = { encoding: 'utf8', shell: true };
 
 {
   // Verify the shell option works properly
-  execFile(process.execPath, [fixture, 0], execOpts, common.mustSucceed());
+  execFile('"$NODE"', ['"$FIXTURE"', 0], execOpts, common.mustSucceed());
 }
 
 {

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -10,7 +10,7 @@ const os = require('os');
 
 const fixture = fixtures.path('exit.js');
 const echoFixture = fixtures.path('echo.js');
-const execOpts = { encoding: 'utf8', shell: true, env: { NODE: process.execPath, FIXTURE: fixture } };
+const execOpts = { encoding: 'utf8', shell: true, env: { ...process.env, NODE: process.execPath, FIXTURE: fixture } };
 
 {
   execFile(

--- a/test/parallel/test-child-process-execsync-maxbuf.js
+++ b/test/parallel/test-child-process-execsync-maxbuf.js
@@ -18,7 +18,7 @@ const args = [
 // Verify that an error is returned if maxBuffer is surpassed.
 {
   assert.throws(() => {
-    execSync(`"${process.execPath}" ${args.join(' ')}`, { maxBuffer: 1 });
+    execSync(`"$NODE" ${args.join(' ')}`, { env: { NODE: process.execPath }, maxBuffer: 1 });
   }, (e) => {
     assert.ok(e, 'maxBuffer should error');
     assert.strictEqual(e.code, 'ENOBUFS');
@@ -33,8 +33,8 @@ const args = [
 // Verify that a maxBuffer size of Infinity works.
 {
   const ret = execSync(
-    `"${process.execPath}" ${args.join(' ')}`,
-    { maxBuffer: Infinity }
+    `"$NODE" ${args.join(' ')}`,
+    { env: { NODE: process.execPath }, maxBuffer: Infinity },
   );
 
   assert.deepStrictEqual(ret, msgOutBuf);
@@ -44,7 +44,8 @@ const args = [
 {
   assert.throws(() => {
     execSync(
-      `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024))"`
+      '"$NODE" -e "console.log(\'a\'.repeat(1024 * 1024))"',
+      { env: { NODE: process.execPath } },
     );
   }, (e) => {
     assert.ok(e, 'maxBuffer should error');
@@ -57,7 +58,8 @@ const args = [
 // Default maxBuffer size is 1024 * 1024.
 {
   const ret = execSync(
-    `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024 - 1))"`
+    '"$NODE" -e "console.log(\'a\'.repeat(1024 * 1024 - 1))"',
+    { env: { NODE: process.execPath } },
   );
 
   assert.deepStrictEqual(

--- a/test/parallel/test-child-process-execsync-maxbuf.js
+++ b/test/parallel/test-child-process-execsync-maxbuf.js
@@ -18,7 +18,7 @@ const args = [
 // Verify that an error is returned if maxBuffer is surpassed.
 {
   assert.throws(() => {
-    execSync(`"$NODE" ${args.join(' ')}`, { env: { NODE: process.execPath }, maxBuffer: 1 });
+    execSync(`"$NODE" ${args.join(' ')}`, { env: { ...process.env, NODE: process.execPath }, maxBuffer: 1 });
   }, (e) => {
     assert.ok(e, 'maxBuffer should error');
     assert.strictEqual(e.code, 'ENOBUFS');
@@ -34,7 +34,7 @@ const args = [
 {
   const ret = execSync(
     `"$NODE" ${args.join(' ')}`,
-    { env: { NODE: process.execPath }, maxBuffer: Infinity },
+    { env: { ...process.env, NODE: process.execPath }, maxBuffer: Infinity },
   );
 
   assert.deepStrictEqual(ret, msgOutBuf);
@@ -45,7 +45,7 @@ const args = [
   assert.throws(() => {
     execSync(
       '"$NODE" -e "console.log(\'a\'.repeat(1024 * 1024))"',
-      { env: { NODE: process.execPath } },
+      { env: { ...process.env, NODE: process.execPath } },
     );
   }, (e) => {
     assert.ok(e, 'maxBuffer should error');
@@ -59,7 +59,7 @@ const args = [
 {
   const ret = execSync(
     '"$NODE" -e "console.log(\'a\'.repeat(1024 * 1024 - 1))"',
-    { env: { NODE: process.execPath } },
+    { env: { ...process.env, NODE: process.execPath } },
   );
 
   assert.deepStrictEqual(

--- a/test/parallel/test-child-process-promisified.js
+++ b/test/parallel/test-child-process-promisified.js
@@ -8,7 +8,7 @@ const exec = promisify(child_process.exec);
 const execFile = promisify(child_process.execFile);
 
 {
-  const promise = exec(`${process.execPath} -p 42`);
+  const promise = exec('"$NODE" -p 42', { env: { NODE: process.execPath } });
 
   assert(promise.child instanceof child_process.ChildProcess);
   promise.then(common.mustCall((obj) => {
@@ -45,7 +45,7 @@ const execFile = promisify(child_process.execFile);
 const failingCodeWithStdoutErr =
   'console.log(42);console.error(43);process.exit(1)';
 {
-  exec(`${process.execPath} -e "${failingCodeWithStdoutErr}"`)
+  exec(`"$NODE" -e "${failingCodeWithStdoutErr}"`, { env: { NODE: process.execPath } })
     .catch(common.mustCall((err) => {
       assert.strictEqual(err.code, 1);
       assert.strictEqual(err.stdout, '42\n');

--- a/test/parallel/test-child-process-promisified.js
+++ b/test/parallel/test-child-process-promisified.js
@@ -8,7 +8,7 @@ const exec = promisify(child_process.exec);
 const execFile = promisify(child_process.execFile);
 
 {
-  const promise = exec('"$NODE" -p 42', { env: { NODE: process.execPath } });
+  const promise = exec('"$NODE" -p 42', { env: { ...process.env, NODE: process.execPath } });
 
   assert(promise.child instanceof child_process.ChildProcess);
   promise.then(common.mustCall((obj) => {
@@ -45,7 +45,7 @@ const execFile = promisify(child_process.execFile);
 const failingCodeWithStdoutErr =
   'console.log(42);console.error(43);process.exit(1)';
 {
-  exec(`"$NODE" -e "${failingCodeWithStdoutErr}"`, { env: { NODE: process.execPath } })
+  exec(`"$NODE" -e "${failingCodeWithStdoutErr}"`, { env: { ...process.env, NODE: process.execPath } })
     .catch(common.mustCall((err) => {
       assert.strictEqual(err.code, 1);
       assert.strictEqual(err.stdout, '42\n');

--- a/test/parallel/test-child-process-spawn-shell.js
+++ b/test/parallel/test-child-process-spawn-shell.js
@@ -49,8 +49,8 @@ command.on('close', common.mustCall((code, signal) => {
 }));
 
 // Verify that the environment is properly inherited
-const env = cp.spawn(`"${process.execPath}" -pe process.env.BAZ`, {
-  env: { ...process.env, BAZ: 'buzz' },
+const env = cp.spawn('"$NODE" -pe process.env.BAZ', {
+  env: { ...process.env, NODE: process.execPath, BAZ: 'buzz' },
   encoding: 'utf8',
   shell: true
 });

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -36,8 +36,8 @@ const command = cp.spawnSync(cmd, { shell: true });
 assert.strictEqual(command.stdout.toString().trim(), 'bar');
 
 // Verify that the environment is properly inherited
-const env = cp.spawnSync(`"${process.execPath}" -pe process.env.BAZ`, {
-  env: { ...process.env, BAZ: 'buzz' },
+const env = cp.spawnSync('"$NODE" -pe process.env.BAZ', {
+  env: { ...process.env, NODE: process.execPath, BAZ: 'buzz' },
   shell: true
 });
 

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -32,7 +32,7 @@ const assert = require('assert');
 const child = require('child_process');
 const path = require('path');
 const fixtures = require('../common/fixtures');
-const env = { NODE: process.execPath };
+const env = { ...process.env, NODE: process.execPath };
 
 if (process.argv.length > 2) {
   console.log(process.argv.slice(2).join(' '));
@@ -75,7 +75,7 @@ child.exec('"$NODE" --eval "console.error(42)"',
   const filename = __filename.replace(/\\/g, '/');
 
   child.exec('"$NODE" --eval "$SCRIPT"',
-             { env: { NODE: process.execPath, SCRIPT: `require(${JSON.stringify(filename)})` } },
+             { env: { ...process.env, NODE: process.execPath, SCRIPT: `require(${JSON.stringify(filename)})` } },
              common.mustCall((err, stdout, stderr) => {
                assert.strictEqual(err.code, 42);
                assert.strictEqual(
@@ -139,7 +139,7 @@ child.exec('"$NODE" --use-strict -p process.execArgv',
   }
 
   child.exec('"$NODE" -e "$SCRIPT"',
-             { env: { NODE: process.execPath, SCRIPT: `require("child_process").fork(${JSON.stringify(emptyFile)})` } },
+             { env: { ...process.env, NODE: process.execPath, SCRIPT: `require("child_process").fork(${JSON.stringify(emptyFile)})` } },
              common.mustSucceed((stdout, stderr) => {
                assert.strictEqual(stdout, '');
                assert.strictEqual(stderr, '');
@@ -147,7 +147,7 @@ child.exec('"$NODE" --use-strict -p process.execArgv',
 
   // Make sure that monkey-patching process.execArgv doesn't cause child_process
   // to incorrectly munge execArgv.
-  child.exec('"$NODE" -e "$SCRIPT"', { env: { NODE: process.execPath, SCRIPT:
+  child.exec('"$NODE" -e "$SCRIPT"', { env: { ...process.env, NODE: process.execPath, SCRIPT:
               'process.execArgv = [\'-e\', \'console.log(42)\', \'thirdArg\'];' +
               `require('child_process').fork(${JSON.stringify(emptyFile)})` } },
              common.mustSucceed((stdout, stderr) => {
@@ -219,7 +219,7 @@ child.exec('"$NODE" --use-strict -p process.execArgv',
   // filename.
   const filecmd = `"$NODE" -- "$FILE" ${args}`;
   child.exec(filecmd,
-             { env: { NODE: process.execPath, FILE: __filename } },
+             { env: { ...process.env, NODE: process.execPath, FILE: __filename } },
              common.mustCall(function(err, stdout, stderr) {
                assert.strictEqual(stdout, `${args}\n`);
                assert.strictEqual(stderr, '');

--- a/test/parallel/test-cli-node-print-help.js
+++ b/test/parallel/test-cli-node-print-help.js
@@ -12,7 +12,7 @@ let stdOut;
 
 
 function startPrintHelpTest() {
-  exec(`${process.execPath} --help`, common.mustSucceed((stdout, stderr) => {
+  exec('"$NODE" --help', { env: { NODE: process.execPath } }, common.mustSucceed((stdout, stderr) => {
     stdOut = stdout;
     validateNodePrintHelp();
   }));

--- a/test/parallel/test-cli-node-print-help.js
+++ b/test/parallel/test-cli-node-print-help.js
@@ -12,7 +12,7 @@ let stdOut;
 
 
 function startPrintHelpTest() {
-  exec('"$NODE" --help', { env: { NODE: process.execPath } }, common.mustSucceed((stdout, stderr) => {
+  exec('"$NODE" --help', { env: { ...process.env, NODE: process.execPath } }, common.mustSucceed((stdout, stderr) => {
     stdOut = stdout;
     validateNodePrintHelp();
   }));

--- a/test/parallel/test-cli-syntax-eval.js
+++ b/test/parallel/test-cli-syntax-eval.js
@@ -10,8 +10,8 @@ const node = process.execPath;
 ['-c', '--check'].forEach(function(checkFlag) {
   ['-e', '--eval'].forEach(function(evalFlag) {
     const args = [checkFlag, evalFlag, 'foo'];
-    const cmd = [node, ...args].join(' ');
-    exec(cmd, common.mustCall((err, stdout, stderr) => {
+    const cmd = ['"$NODE"', ...args].join(' ');
+    exec(cmd, { env: { NODE: node } }, common.mustCall((err, stdout, stderr) => {
       assert.strictEqual(err instanceof Error, true);
       assert.strictEqual(err.code, 9);
       assert(

--- a/test/parallel/test-cli-syntax-eval.js
+++ b/test/parallel/test-cli-syntax-eval.js
@@ -11,7 +11,7 @@ const node = process.execPath;
   ['-e', '--eval'].forEach(function(evalFlag) {
     const args = [checkFlag, evalFlag, 'foo'];
     const cmd = ['"$NODE"', ...args].join(' ');
-    exec(cmd, { env: { NODE: node } }, common.mustCall((err, stdout, stderr) => {
+    exec(cmd, { env: { ...process.env, NODE: node } }, common.mustCall((err, stdout, stderr) => {
       assert.strictEqual(err instanceof Error, true);
       assert.strictEqual(err.code, 9);
       assert(

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -622,12 +622,17 @@ assert.throws(
   const msgfile = path.join(tmpdir.path, 's5.msg');
   fs.writeFileSync(msgfile, msg);
 
-  const cmd =
-    `"${common.opensslCli}" dgst -sha256 -verify "${pubfile}" -signature "${
-      sigfile}" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-2 "${
-      msgfile}"`;
+  const cmd = [
+    '"$OPENSSL" dgst -sha256',
+    '-verify "$PUBFILE"',
+    '-signature "$SIGFILE" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-2',
+    '"$MSGFILE"',
+  ].join(' ');
 
-  exec(cmd, common.mustCall((err, stdout, stderr) => {
+  exec(cmd, { env: { OPENSSL: common.opensslCli,
+                     PUBFILE: pubfile,
+                     SIGFILE: sigfile,
+                     MSGFILE: msgfile } }, common.mustCall((err, stdout, stderr) => {
     assert(stdout.includes('Verified OK'));
   }));
 }

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -629,7 +629,8 @@ assert.throws(
     '"$MSGFILE"',
   ].join(' ');
 
-  exec(cmd, { env: { OPENSSL: common.opensslCli,
+  exec(cmd, { env: { ...process.env,
+                     OPENSSL: common.opensslCli,
                      PUBFILE: pubfile,
                      SIGFILE: sigfile,
                      MSGFILE: msgfile } }, common.mustCall((err, stdout, stderr) => {

--- a/test/parallel/test-domain-abort-on-uncaught.js
+++ b/test/parallel/test-domain-abort-on-uncaught.js
@@ -209,11 +209,11 @@ if (process.argv[2] === 'child') {
       testCmd += 'ulimit -c 0 && ';
     }
 
-    testCmd += `"${process.argv[0]}" --abort-on-uncaught-exception ` +
-               `"${process.argv[1]}" child ${testIndex}`;
+    testCmd += '"$NODE" --abort-on-uncaught-exception ' +
+               `"$FILE" child ${testIndex}`;
 
     try {
-      child_process.execSync(testCmd);
+      child_process.execSync(testCmd, { env: { NODE: process.execPath, FILE: __filename } });
     } catch (e) {
       assert.fail(`Test index ${testIndex} failed: ${e}`);
     }

--- a/test/parallel/test-domain-abort-on-uncaught.js
+++ b/test/parallel/test-domain-abort-on-uncaught.js
@@ -213,7 +213,7 @@ if (process.argv[2] === 'child') {
                `"$FILE" child ${testIndex}`;
 
     try {
-      child_process.execSync(testCmd, { env: { NODE: process.execPath, FILE: __filename } });
+      child_process.execSync(testCmd, { env: { ...process.env, NODE: process.execPath, FILE: __filename } });
     } catch (e) {
       assert.fail(`Test index ${testIndex} failed: ${e}`);
     }

--- a/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -13,6 +13,7 @@ const domain = require('domain');
 const uncaughtExceptionHandlerErrMsg = 'boom from uncaughtException handler';
 const domainErrMsg = 'boom from domain';
 
+const env = { NODE: process.execPath, FILE: __filename };
 const RAN_UNCAUGHT_EXCEPTION_HANDLER_EXIT_CODE = 42;
 
 if (process.argv[2] === 'child') {
@@ -51,6 +52,7 @@ if (process.argv[2] === 'child') {
 function runTestWithoutAbortOnUncaughtException() {
   child_process.exec(
     createTestCmdLine(),
+    { env },
     function onTestDone(err, stdout, stderr) {
       // When _not_ passing --abort-on-uncaught-exception, the process'
       // uncaughtException handler _must_ be called, and thus the error
@@ -72,7 +74,7 @@ function runTestWithoutAbortOnUncaughtException() {
 function runTestWithAbortOnUncaughtException() {
   child_process.exec(createTestCmdLine({
     withAbortOnUncaughtException: true
-  }), function onTestDone(err, stdout, stderr) {
+  }), { env }, function onTestDone(err, stdout, stderr) {
     assert.notStrictEqual(err.code, RAN_UNCAUGHT_EXCEPTION_HANDLER_EXIT_CODE,
                           'child process should not have run its ' +
                           'uncaughtException event handler');
@@ -90,13 +92,13 @@ function createTestCmdLine(options) {
     testCmd += 'ulimit -c 0 && ';
   }
 
-  testCmd += `"${process.argv[0]}"`;
+  testCmd += '"$NODE"';
 
   if (options && options.withAbortOnUncaughtException) {
     testCmd += ' --abort-on-uncaught-exception';
   }
 
-  testCmd += ` "${process.argv[1]}" child`;
+  testCmd += ' "$FILE" child';
 
   return testCmd;
 }

--- a/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -13,7 +13,7 @@ const domain = require('domain');
 const uncaughtExceptionHandlerErrMsg = 'boom from uncaughtException handler';
 const domainErrMsg = 'boom from domain';
 
-const env = { NODE: process.execPath, FILE: __filename };
+const env = { ...process.env, NODE: process.execPath, FILE: __filename };
 const RAN_UNCAUGHT_EXCEPTION_HANDLER_EXIT_CODE = 42;
 
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -102,10 +102,9 @@ if (process.argv[2] === 'child') {
     if (options.useTryCatch)
       useTryCatchOpt = 'useTryCatch';
 
-    cmdToExec += `"${process.argv[0]}" ${cmdLineOption ? cmdLineOption : ''} "${
-      process.argv[1]}" child ${throwInDomainErrHandlerOpt} ${useTryCatchOpt}`;
+    cmdToExec += `"$NODE" ${cmdLineOption ? cmdLineOption : ''} "$FILE" child ${throwInDomainErrHandlerOpt} ${useTryCatchOpt}`;
 
-    const child = exec(cmdToExec);
+    const child = exec(cmdToExec, { env: { NODE: process.execPath, FILE: __filename } });
 
     if (child) {
       child.on('exit', function onChildExited(exitCode, signal) {

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -104,7 +104,7 @@ if (process.argv[2] === 'child') {
 
     cmdToExec += `"$NODE" ${cmdLineOption ? cmdLineOption : ''} "$FILE" child ${throwInDomainErrHandlerOpt} ${useTryCatchOpt}`;
 
-    const child = exec(cmdToExec, { env: { NODE: process.execPath, FILE: __filename } });
+    const child = exec(cmdToExec, { env: { ...process.env, NODE: process.execPath, FILE: __filename } });
 
     if (child) {
       child.on('exit', function onChildExited(exitCode, signal) {

--- a/test/parallel/test-env-var-no-warnings.js
+++ b/test/parallel/test-env-var-no-warnings.js
@@ -7,8 +7,8 @@ if (process.argv[2] === 'child') {
   process.emitWarning('foo');
 } else {
   function test(newEnv) {
-    const env = { ...process.env, ...newEnv };
-    const cmd = `"${process.execPath}" "${__filename}" child`;
+    const env = { ...process.env, ...newEnv, NODE: process.execPath, FILE: __filename };
+    const cmd = '"$NODE" "$FILE" child';
 
     cp.exec(cmd, { env }, common.mustCall((err, stdout, stderr) => {
       assert.strictEqual(err, null);

--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -28,8 +28,8 @@ const fixtures = require('../common/fixtures');
 function errExec(script, option, callback) {
   callback = typeof option === 'function' ? option : callback;
   option = typeof option === 'string' ? option : '';
-  const cmd = `"${process.argv[0]}" ${option} "${fixtures.path(script)}"`;
-  return exec(cmd, (err, stdout, stderr) => {
+  const cmd = `"$NODE" ${option} "$SCRIPT"`;
+  return exec(cmd, { env: { NODE: process.execPath, SCRIPT: fixtures.path(script) } }, (err, stdout, stderr) => {
     // There was some error
     assert.ok(err);
 

--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -29,7 +29,8 @@ function errExec(script, option, callback) {
   callback = typeof option === 'function' ? option : callback;
   option = typeof option === 'string' ? option : '';
   const cmd = `"$NODE" ${option} "$SCRIPT"`;
-  return exec(cmd, { env: { NODE: process.execPath, SCRIPT: fixtures.path(script) } }, (err, stdout, stderr) => {
+  const env = { ...process.env, NODE: process.execPath, SCRIPT: fixtures.path(script) };
+  return exec(cmd, { env }, (err, stdout, stderr) => {
     // There was some error
     assert.ok(err);
 

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -198,7 +198,7 @@ if (!common.isWindows) {
   const filename = `${tmpdir.path}/foo.pipe`;
   const mkfifoResult = child_process.spawnSync('mkfifo', [filename]);
   if (!mkfifoResult.error) {
-    child_process.exec(`echo "xyz foobar" > '${filename}'`);
+    child_process.exec('echo "xyz foobar" > "$FILE"', { env: { FILE: filename } });
     const stream = new fs.createReadStream(filename, common.mustNotMutateObjectDeep({ end: 1 }));
     stream.data = '';
 

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -198,7 +198,7 @@ if (!common.isWindows) {
   const filename = `${tmpdir.path}/foo.pipe`;
   const mkfifoResult = child_process.spawnSync('mkfifo', [filename]);
   if (!mkfifoResult.error) {
-    child_process.exec('echo "xyz foobar" > "$FILE"', { env: { FILE: filename } });
+    child_process.exec('echo "xyz foobar" > "$FILE"', { env: { ...process.env, FILE: filename } });
     const stream = new fs.createReadStream(filename, common.mustNotMutateObjectDeep({ end: 1 }));
     stream.data = '';
 

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -36,8 +36,8 @@ const fixtures = require('../common/fixtures');
 
 function test(env, cb) {
   const filename = fixtures.path('test-fs-readfile-error.js');
-  const execPath = `"${process.execPath}" "${filename}"`;
-  const options = { env: { ...process.env, ...env } };
+  const execPath = '"$NODE" "$FILE"';
+  const options = { env: { ...process.env, ...env, NODE: process.execPath, FILE: filename } };
   exec(execPath, options, (err, stdout, stderr) => {
     assert(err);
     assert.strictEqual(stdout, '');

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -26,10 +26,12 @@ tmpdir.refresh();
 fs.writeFileSync(filename, dataExpected);
 
 const exec = require('child_process').exec;
-const f = JSON.stringify(__filename);
-const node = JSON.stringify(process.execPath);
-const cmd = `cat ${filename} | ${node} ${f} child`;
-exec(cmd, { maxBuffer: 1000000 }, common.mustSucceed((stdout, stderr) => {
+const cmd = '"$NODE" "$FILE" child < "$TMP_FILE"';
+exec(cmd, { maxBuffer: 1000000, env: {
+  NODE: process.execPath,
+  FILE: __filename,
+  TMP_FILE: filename,
+} }, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(
     stdout,
     dataExpected,

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -28,6 +28,7 @@ fs.writeFileSync(filename, dataExpected);
 const exec = require('child_process').exec;
 const cmd = '"$NODE" "$FILE" child < "$TMP_FILE"';
 exec(cmd, { maxBuffer: 1000000, env: {
+  ...process.env,
   NODE: process.execPath,
   FILE: __filename,
   TMP_FILE: filename,

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -43,10 +43,10 @@ const filename = fixtures.path('readfile_pipe_test.txt');
 const dataExpected = fs.readFileSync(filename).toString();
 
 const exec = require('child_process').exec;
-const f = JSON.stringify(__filename);
-const node = JSON.stringify(process.execPath);
-const cmd = `cat ${filename} | ${node} ${f} child`;
-exec(cmd, common.mustSucceed((stdout, stderr) => {
+const cmd = '"$NODE" "$FILE" child < "$TMP_FILE"';
+exec(cmd, {
+  env: { NODE: process.execPath, FILE: __filename, TMP_FILE: filename }
+}, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(
     stdout,
     dataExpected,

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -45,7 +45,7 @@ const dataExpected = fs.readFileSync(filename).toString();
 const exec = require('child_process').exec;
 const cmd = '"$NODE" "$FILE" child < "$TMP_FILE"';
 exec(cmd, {
-  env: { NODE: process.execPath, FILE: __filename, TMP_FILE: filename }
+  env: { ...process.env, NODE: process.execPath, FILE: __filename, TMP_FILE: filename }
 }, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(
     stdout,

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -23,12 +23,10 @@ tmpdir.refresh();
 fs.writeFileSync(filename, dataExpected);
 
 const exec = require('child_process').exec;
-const f = JSON.stringify(__filename);
-const node = JSON.stringify(process.execPath);
-const cmd = `cat ${filename} | ${node} ${f} child`;
+const cmd = '"$NODE" "$FILE" child < "$TMP_FILE"';
 exec(
   cmd,
-  { maxBuffer: 1000000 },
+  { maxBuffer: 1000000, env: { NODE: process.execPath, FILE: __filename, TMP_FILE: filename } },
   common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout, dataExpected);
     assert.strictEqual(stderr, '');

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -26,7 +26,7 @@ const exec = require('child_process').exec;
 const cmd = '"$NODE" "$FILE" child < "$TMP_FILE"';
 exec(
   cmd,
-  { maxBuffer: 1000000, env: { NODE: process.execPath, FILE: __filename, TMP_FILE: filename } },
+  { maxBuffer: 1000000, env: { ...process.env, NODE: process.execPath, FILE: __filename, TMP_FILE: filename } },
   common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout, dataExpected);
     assert.strictEqual(stderr, '');

--- a/test/parallel/test-fs-write-sigxfsz.js
+++ b/test/parallel/test-fs-write-sigxfsz.js
@@ -20,8 +20,8 @@ if (process.argv[2] === 'child') {
   tmpdir.refresh();
   fs.writeFileSync(filename, '.'.repeat(1 << 16));  // Exceeds RLIMIT_FSIZE.
 } else {
-  const cmd = `ulimit -f 1 && '${process.execPath}' '${__filename}' child`;
-  const result = child_process.spawnSync('/bin/sh', ['-c', cmd]);
+  const cmd = 'ulimit -f 1 && "$NODE" "$FILE" child';
+  const result = child_process.spawnSync('/bin/sh', ['-c', cmd], { env: { NODE: process.execPath, FILE: __filename } });
   const haystack = result.stderr.toString();
   const needle = 'Error: EFBIG: file too large, write';
   const ok = haystack.includes(needle);

--- a/test/parallel/test-fs-write-sigxfsz.js
+++ b/test/parallel/test-fs-write-sigxfsz.js
@@ -21,7 +21,8 @@ if (process.argv[2] === 'child') {
   fs.writeFileSync(filename, '.'.repeat(1 << 16));  // Exceeds RLIMIT_FSIZE.
 } else {
   const cmd = 'ulimit -f 1 && "$NODE" "$FILE" child';
-  const result = child_process.spawnSync('/bin/sh', ['-c', cmd], { env: { NODE: process.execPath, FILE: __filename } });
+  const env = { ...process.env, NODE: process.execPath, FILE: __filename };
+  const result = child_process.spawnSync('/bin/sh', ['-c', cmd], { env });
   const haystack = result.stderr.toString();
   const needle = 'Error: EFBIG: file too large, write';
   const ok = haystack.includes(needle);

--- a/test/parallel/test-http-chunk-problem.js
+++ b/test/parallel/test-http-chunk-problem.js
@@ -43,14 +43,8 @@ const filename = require('path').join(tmpdir.path, 'big');
 let server;
 
 function executeRequest(cb) {
-  cp.exec([`"${process.execPath}"`,
-           `"${__filename}"`,
-           'request',
-           server.address().port,
-           '|',
-           `"${process.execPath}"`,
-           `"${__filename}"`,
-           'shasum' ].join(' '),
+  cp.exec('"$NODE" "$FILE" request "$PORT" | "$NODE" "$FILE" shasum',
+          { env: { NODE: process.execPath, FILE: __filename, PORT: server.address().port } },
           (err, stdout, stderr) => {
             if (stderr.trim() !== '') {
               console.log(stderr);

--- a/test/parallel/test-http-chunk-problem.js
+++ b/test/parallel/test-http-chunk-problem.js
@@ -44,7 +44,7 @@ let server;
 
 function executeRequest(cb) {
   cp.exec('"$NODE" "$FILE" request "$PORT" | "$NODE" "$FILE" shasum',
-          { env: { NODE: process.execPath, FILE: __filename, PORT: server.address().port } },
+          { env: { ...process.env, NODE: process.execPath, FILE: __filename, PORT: server.address().port } },
           (err, stdout, stderr) => {
             if (stderr.trim() !== '') {
               console.log(stderr);

--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -39,6 +39,8 @@ const pkgPath = path.join(installDir, 'package.json');
 fs.writeFileSync(pkgPath, pkgContent);
 
 const env = { ...process.env,
+              NODE: process.execPath,
+              NPM: npmPath,
               PATH: path.dirname(process.execPath),
               NPM_CONFIG_PREFIX: path.join(npmSandbox, 'npm-prefix'),
               NPM_CONFIG_TMP: path.join(npmSandbox, 'npm-tmp'),
@@ -46,7 +48,7 @@ const env = { ...process.env,
               NPM_CONFIG_UPDATE_NOTIFIER: false,
               HOME: homeDir };
 
-exec(`${process.execPath} ${npmPath} install`, {
+exec('"$NODE" "$NPM" install', {
   cwd: installDir,
   env: env
 }, common.mustCall(handleExit));
@@ -61,5 +63,5 @@ function handleExit(error, stdout, stderr) {
 
   assert.strictEqual(code, 0, `npm install got error code ${code}`);
   assert.strictEqual(signalCode, null, `unexpected signal: ${signalCode}`);
-  assert(fs.existsSync(`${installDir}/node_modules/package-name`));
+  assert(fs.existsSync(path.join(installDir, 'node_modules/package-name')));
 }

--- a/test/parallel/test-permission-allow-child-process-cli.js
+++ b/test/parallel/test-permission-allow-child-process-cli.js
@@ -20,7 +20,7 @@ if (process.argv[2] === 'child') {
 {
   // doesNotThrow
   childProcess.spawnSync(process.execPath, ['--version']);
-  childProcess.execSync(process.execPath, ['--version']);
+  childProcess.execSync('"$NODE" --version', { env: { NODE: process.execPath } });
   childProcess.fork(__filename, ['child']);
   childProcess.execFileSync(process.execPath, ['--version']);
 }

--- a/test/parallel/test-permission-allow-child-process-cli.js
+++ b/test/parallel/test-permission-allow-child-process-cli.js
@@ -20,7 +20,7 @@ if (process.argv[2] === 'child') {
 {
   // doesNotThrow
   childProcess.spawnSync(process.execPath, ['--version']);
-  childProcess.execSync('"$NODE" --version', { env: { NODE: process.execPath } });
+  childProcess.execSync('"$NODE" --version', { env: { ...process.env, NODE: process.execPath } });
   childProcess.fork(__filename, ['child']);
   childProcess.execFileSync(process.execPath, ['--version']);
 }

--- a/test/parallel/test-pipe-head.js
+++ b/test/parallel/test-pipe-head.js
@@ -8,9 +8,9 @@ const exec = require('child_process').exec;
 const nodePath = process.argv[0];
 const script = fixtures.path('print-10-lines.js');
 
-const cmd = `"${nodePath}" "${script}" | head -2`;
+const cmd = '"$NODE" "$FILE" | head -2';
 
-exec(cmd, common.mustSucceed((stdout, stderr) => {
+exec(cmd, { env: { NODE: nodePath, FILE: script } }, common.mustSucceed((stdout, stderr) => {
   const lines = stdout.split('\n');
   assert.strictEqual(lines.length, 3);
 }));

--- a/test/parallel/test-pipe-head.js
+++ b/test/parallel/test-pipe-head.js
@@ -10,7 +10,7 @@ const script = fixtures.path('print-10-lines.js');
 
 const cmd = '"$NODE" "$FILE" | head -2';
 
-exec(cmd, { env: { NODE: nodePath, FILE: script } }, common.mustSucceed((stdout, stderr) => {
+exec(cmd, { env: { ...process.env, NODE: nodePath, FILE: script } }, common.mustSucceed((stdout, stderr) => {
   const lines = stdout.split('\n');
   assert.strictEqual(lines.length, 3);
 }));

--- a/test/parallel/test-preload-self-referential.js
+++ b/test/parallel/test-preload-self-referential.js
@@ -13,8 +13,7 @@ if (!common.isMainThread)
 const selfRefModule = fixtures.path('self_ref_module');
 const fixtureA = fixtures.path('printA.js');
 
-exec(`"${nodeBinary}" -r self_ref "${fixtureA}"`, { cwd: selfRefModule },
-     (err, stdout, stderr) => {
-       assert.ifError(err);
+exec('"$NODE" -r self_ref "$FIXTURE_A"', { cwd: selfRefModule, env: { NODE: nodeBinary, FIXTURE_A: fixtureA } },
+     common.mustSucceed((stdout, stderr) => {
        assert.strictEqual(stdout, 'A\n');
-     });
+     }));

--- a/test/parallel/test-preload-self-referential.js
+++ b/test/parallel/test-preload-self-referential.js
@@ -13,7 +13,8 @@ if (!common.isMainThread)
 const selfRefModule = fixtures.path('self_ref_module');
 const fixtureA = fixtures.path('printA.js');
 
-exec('"$NODE" -r self_ref "$FIXTURE_A"', { cwd: selfRefModule, env: { NODE: nodeBinary, FIXTURE_A: fixtureA } },
+exec('"$NODE" -r self_ref "$FIXTURE_A"',
+     { cwd: selfRefModule, env: { ...process.env, NODE: nodeBinary, FIXTURE_A: fixtureA } },
      common.mustSucceed((stdout, stderr) => {
        assert.strictEqual(stdout, 'A\n');
      }));

--- a/test/parallel/test-preload-worker.js
+++ b/test/parallel/test-preload-worker.js
@@ -7,4 +7,4 @@ const { exec } = require('child_process');
 const kNodeBinary = process.argv[0];
 
 
-exec(`"${kNodeBinary}" -r "${worker}" -pe "1+1"`, common.mustSucceed());
+exec('"$NODE" -r "$WORKER" -pe "1+1"', { env: { NODE: kNodeBinary, WORKER: worker } }, common.mustSucceed());

--- a/test/parallel/test-preload-worker.js
+++ b/test/parallel/test-preload-worker.js
@@ -7,4 +7,6 @@ const { exec } = require('child_process');
 const kNodeBinary = process.argv[0];
 
 
-exec('"$NODE" -r "$WORKER" -pe "1+1"', { env: { NODE: kNodeBinary, WORKER: worker } }, common.mustSucceed());
+exec('"$NODE" -r "$WORKER" -pe "1+1"',
+     { env: { ...process.env, NODE: kNodeBinary, WORKER: worker } },
+     common.mustSucceed());

--- a/test/parallel/test-stdin-from-file-spawn.js
+++ b/test/parallel/test-stdin-from-file-spawn.js
@@ -39,4 +39,5 @@ setTimeout(() => {
 }, 100);
 `);
 
-execSync(`${process.argv[0]} ${tmpJsFile} < ${tmpCmdFile}`);
+execSync('"$NODE" "$JS_FILE" < "$CMD_FILE"',
+         { env: { NODE: process.argv0, JS_FILE: tmpJsFile, CMD_FILE: tmpCmdFile } });

--- a/test/parallel/test-stdin-from-file-spawn.js
+++ b/test/parallel/test-stdin-from-file-spawn.js
@@ -40,4 +40,4 @@ setTimeout(() => {
 `);
 
 execSync('"$NODE" "$JS_FILE" < "$CMD_FILE"',
-         { env: { NODE: process.argv0, JS_FILE: tmpJsFile, CMD_FILE: tmpCmdFile } });
+         { env: { ...process.env, NODE: process.argv0, JS_FILE: tmpJsFile, CMD_FILE: tmpCmdFile } });

--- a/test/parallel/test-stdin-from-file.js
+++ b/test/parallel/test-stdin-from-file.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const stdoutScript = fixtures.path('echo-close-check.js');
 const tmpFile = join(tmpdir.path, 'stdin.txt');
 
-const cmd = `"${process.argv[0]}" "${stdoutScript}" < "${tmpFile}"`;
+const cmd = '"$NODE" "$STDOUT_SCRIPT" < "$TMP_FILE"';
 
 const string = 'abc\nümlaut.\nsomething else\n' +
                '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，' +
@@ -31,7 +31,9 @@ console.log(`${cmd}\n\n`);
 
 fs.writeFileSync(tmpFile, string);
 
-childProcess.exec(cmd, common.mustCall(function(err, stdout, stderr) {
+childProcess.exec(cmd, { env: {
+  NODE: process.argv0, STDOUT_SCRIPT: stdoutScript, TMP_FILE: tmpFile
+} }, common.mustCall(function(err, stdout, stderr) {
   fs.unlinkSync(tmpFile);
 
   assert.ifError(err);

--- a/test/parallel/test-stdin-from-file.js
+++ b/test/parallel/test-stdin-from-file.js
@@ -32,7 +32,7 @@ console.log(`${cmd}\n\n`);
 fs.writeFileSync(tmpFile, string);
 
 childProcess.exec(cmd, { env: {
-  NODE: process.argv0, STDOUT_SCRIPT: stdoutScript, TMP_FILE: tmpFile
+  ...process.env, NODE: process.argv0, STDOUT_SCRIPT: stdoutScript, TMP_FILE: tmpFile,
 } }, common.mustCall(function(err, stdout, stderr) {
   fs.unlinkSync(tmpFile);
 

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -29,8 +29,8 @@ if (process.argv[2] === 'child') {
 }
 
 // Run the script in a shell but close stdout and stderr.
-const cmd = `"${process.execPath}" "${__filename}" child 1>&- 2>&-`;
-const proc = spawn('/bin/sh', ['-c', cmd], { stdio: 'inherit' });
+const cmd = '"$NODE" "$FILE" child 1>&- 2>&-';
+const proc = spawn('/bin/sh', ['-c', cmd], { stdio: 'inherit', env: { NODE: process.execPath, FILE: __filename } });
 
 proc.on('exit', common.mustCall(function(exitCode) {
   assert.strictEqual(exitCode, 0);

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -30,7 +30,8 @@ if (process.argv[2] === 'child') {
 
 // Run the script in a shell but close stdout and stderr.
 const cmd = '"$NODE" "$FILE" child 1>&- 2>&-';
-const proc = spawn('/bin/sh', ['-c', cmd], { stdio: 'inherit', env: { NODE: process.execPath, FILE: __filename } });
+const proc = spawn('/bin/sh', ['-c', cmd],
+                   { stdio: 'inherit', env: { ...process.env, NODE: process.execPath, FILE: __filename } });
 
 proc.on('exit', common.mustCall(function(exitCode) {
   assert.strictEqual(exitCode, 0);

--- a/test/parallel/test-stdout-close-catch.js
+++ b/test/parallel/test-stdout-close-catch.js
@@ -7,12 +7,12 @@ const { getSystemErrorName } = require('util');
 
 const testScript = fixtures.path('catch-stdout-error.js');
 
-const cmd = `${JSON.stringify(process.execPath)} ` +
-            `${JSON.stringify(testScript)} | ` +
-            `${JSON.stringify(process.execPath)} ` +
+const cmd = '"$NODE" ' +
+            '"$TEST_SCRIPT" | ' +
+            '"$NODE" ' +
             '-pe "process.stdin.on(\'data\' , () => process.exit(1))"';
 
-const child = child_process.exec(cmd);
+const child = child_process.exec(cmd, { env: { NODE: process.execPath, TEST_SCRIPT: testScript } });
 let output = '';
 
 child.stderr.on('data', function(c) {

--- a/test/parallel/test-stdout-close-catch.js
+++ b/test/parallel/test-stdout-close-catch.js
@@ -12,7 +12,7 @@ const cmd = '"$NODE" ' +
             '"$NODE" ' +
             '-pe "process.stdin.on(\'data\' , () => process.exit(1))"';
 
-const child = child_process.exec(cmd, { env: { NODE: process.execPath, TEST_SCRIPT: testScript } });
+const child = child_process.exec(cmd, { env: { ...process.env, NODE: process.execPath, TEST_SCRIPT: testScript } });
 let output = '';
 
 child.stderr.on('data', function(c) {

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -14,8 +14,7 @@ const tmpFile = path.join(tmpdir.path, 'stdout.txt');
 tmpdir.refresh();
 
 function test(size, useBuffer, cb) {
-  const cmd = `"${process.argv[0]}" "${
-    useBuffer ? scriptBuffer : scriptString}" ${size} > "${tmpFile}"`;
+  const cmd = `"$NODE" "$SCRIPT" ${size} > "$TMP_FILE"`;
 
   try {
     fs.unlinkSync(tmpFile);
@@ -25,7 +24,11 @@ function test(size, useBuffer, cb) {
 
   console.log(`${size} chars to ${tmpFile}...`);
 
-  childProcess.exec(cmd, common.mustSucceed(() => {
+  childProcess.exec(cmd, { env: {
+    NODE: process.execPath,
+    SCRIPT: useBuffer ? scriptBuffer : scriptString,
+    TMP_FILE: tmpFile,
+  } }, common.mustSucceed(() => {
     console.log('done!');
 
     const stat = fs.statSync(tmpFile);

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -25,6 +25,7 @@ function test(size, useBuffer, cb) {
   console.log(`${size} chars to ${tmpFile}...`);
 
   childProcess.exec(cmd, { env: {
+    ...process.env,
     NODE: process.execPath,
     SCRIPT: useBuffer ? scriptBuffer : scriptString,
     TMP_FILE: tmpFile,

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -13,14 +13,9 @@ if (process.argv[2] === 'child') {
   );
 } else {
   const cp = require('child_process');
-  cp.exec([
-    'echo',
-    'hello',
-    '|',
-    `"${process.execPath}"`,
-    `"${__filename}"`,
-    'child',
-  ].join(' '), common.mustSucceed((stdout) => {
+  cp.exec('echo hello | "$NODE" "$FILE" child', {
+    env: { NODE: process.execPath, FILE: __filename }
+  }, common.mustSucceed((stdout) => {
     assert.strictEqual(stdout.split(os.EOL).shift().trim(), 'hello');
   }));
 }

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -14,7 +14,7 @@ if (process.argv[2] === 'child') {
 } else {
   const cp = require('child_process');
   cp.exec('echo hello | "$NODE" "$FILE" child', {
-    env: { NODE: process.execPath, FILE: __filename }
+    env: { ...process.env, NODE: process.execPath, FILE: __filename }
   }, common.mustSucceed((stdout) => {
     assert.strictEqual(stdout.split(os.EOL).shift().trim(), 'hello');
   }));

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -49,10 +49,10 @@ const server = tls.createServer(options, common.mustCall(function(conn) {
 }));
 
 server.listen(0, '127.0.0.1', common.mustCall(function() {
-  const cmd = `"${common.opensslCli}" s_client -cipher ${
+  const cmd = `"$OPENSSL" s_client -cipher ${
     options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
-  exec(cmd, common.mustSucceed((stdout, stderr) => {
+  exec(cmd, { env: { OPENSSL: common.opensslCli } }, common.mustSucceed((stdout, stderr) => {
     assert(stdout.includes(reply));
     server.close();
   }));

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -52,7 +52,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
   const cmd = `"$OPENSSL" s_client -cipher ${
     options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
-  exec(cmd, { env: { OPENSSL: common.opensslCli } }, common.mustSucceed((stdout, stderr) => {
+  exec(cmd, { env: { ...process.env, OPENSSL: common.opensslCli } }, common.mustSucceed((stdout, stderr) => {
     assert(stdout.includes(reply));
     server.close();
   }));

--- a/test/parallel/test-worker-init-failure.js
+++ b/test/parallel/test-worker-init-failure.js
@@ -48,8 +48,8 @@ if (process.argv[2] === 'child') {
 } else {
   // Limit the number of open files, to force workers to fail.
   let testCmd = `ulimit -n ${OPENFILES} && `;
-  testCmd += `${process.execPath} ${__filename} child`;
-  const cp = child_process.exec(testCmd);
+  testCmd += '"$NODE" "$FILE" child';
+  const cp = child_process.exec(testCmd, { env: { NODE: process.execPath, FILE: __filename } });
 
   // Turn on the child streams for debugging purposes.
   let stdout = '';

--- a/test/parallel/test-worker-init-failure.js
+++ b/test/parallel/test-worker-init-failure.js
@@ -49,7 +49,7 @@ if (process.argv[2] === 'child') {
   // Limit the number of open files, to force workers to fail.
   let testCmd = `ulimit -n ${OPENFILES} && `;
   testCmd += '"$NODE" "$FILE" child';
-  const cp = child_process.exec(testCmd, { env: { NODE: process.execPath, FILE: __filename } });
+  const cp = child_process.exec(testCmd, { env: { ...process.env, NODE: process.execPath, FILE: __filename } });
 
   // Turn on the child streams for debugging purposes.
   let stdout = '';

--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -35,7 +35,8 @@ if (ulimit > 64 || Number.isNaN(ulimit)) {
   // ever happens.
   const result = child_process.spawnSync(
     '/bin/sh',
-    ['-c', `ulimit -n 64 && '${process.execPath}' '${__filename}'`]
+    ['-c', 'ulimit -n 64 && "$NODE" "$FILENAME"'],
+    { env: { NODE: process.execPath, FILENAME: __filename } }
   );
   assert.strictEqual(result.stdout.toString(), '');
   assert.strictEqual(result.stderr.toString(), '');

--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -36,7 +36,7 @@ if (ulimit > 64 || Number.isNaN(ulimit)) {
   const result = child_process.spawnSync(
     '/bin/sh',
     ['-c', 'ulimit -n 64 && "$NODE" "$FILENAME"'],
-    { env: { NODE: process.execPath, FILENAME: __filename } }
+    { env: { ...process.env, NODE: process.execPath, FILENAME: __filename } }
   );
   assert.strictEqual(result.stdout.toString(), '');
   assert.strictEqual(result.stderr.toString(), '');

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -38,7 +38,7 @@ if (common.isWindows) {
   SLEEP = 10000;
 }
 
-const execOpts = { encoding: 'utf8', shell: true };
+const execOpts = { encoding: 'utf8', shell: true, env: { NODE: process.execPath } };
 
 // Verify that stderr is not accessed when a bad shell is used
 assert.throws(
@@ -54,8 +54,8 @@ let caught = false;
 let ret, err;
 const start = Date.now();
 try {
-  const cmd = `"${process.execPath}" -e "setTimeout(function(){}, ${SLEEP});"`;
-  ret = execSync(cmd, { timeout: TIMER });
+  const cmd = `"$NODE" -e "setTimeout(function(){}, ${SLEEP});"`;
+  ret = execSync(cmd, { env: { NODE: process.execPath }, timeout: TIMER });
 } catch (e) {
   caught = true;
   assert.strictEqual(getSystemErrorName(e.errno), 'ETIMEDOUT');
@@ -78,16 +78,16 @@ const msgBuf = Buffer.from(`${msg}\n`);
 
 // console.log ends every line with just '\n', even on Windows.
 
-const cmd = `"${process.execPath}" -e "console.log('${msg}');"`;
+const cmd = `"$NODE" -e 'console.log(${JSON.stringify(msg)})'`;
 
 {
-  const ret = execSync(cmd);
+  const ret = execSync(cmd, { env: { NODE: process.execPath } });
   assert.strictEqual(ret.length, msgBuf.length);
   assert.deepStrictEqual(ret, msgBuf);
 }
 
 {
-  const ret = execSync(cmd, { encoding: 'utf8' });
+  const ret = execSync(cmd, { encoding: 'utf8', env: { NODE: process.execPath } });
   assert.strictEqual(ret, `${msg}\n`);
 }
 
@@ -156,4 +156,4 @@ const args = [
 }
 
 // Verify the shell option works properly
-execFileSync(process.execPath, [], execOpts);
+execFileSync('"$NODE"', [], execOpts);

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -38,7 +38,7 @@ if (common.isWindows) {
   SLEEP = 10000;
 }
 
-const execOpts = { encoding: 'utf8', shell: true, env: { NODE: process.execPath } };
+const execOpts = { encoding: 'utf8', shell: true, env: { ...process.env, NODE: process.execPath } };
 
 // Verify that stderr is not accessed when a bad shell is used
 assert.throws(
@@ -55,7 +55,7 @@ let ret, err;
 const start = Date.now();
 try {
   const cmd = `"$NODE" -e "setTimeout(function(){}, ${SLEEP});"`;
-  ret = execSync(cmd, { env: { NODE: process.execPath }, timeout: TIMER });
+  ret = execSync(cmd, { env: { ...process.env, NODE: process.execPath }, timeout: TIMER });
 } catch (e) {
   caught = true;
   assert.strictEqual(getSystemErrorName(e.errno), 'ETIMEDOUT');
@@ -81,13 +81,13 @@ const msgBuf = Buffer.from(`${msg}\n`);
 const cmd = `"$NODE" -e 'console.log(${JSON.stringify(msg)})'`;
 
 {
-  const ret = execSync(cmd, { env: { NODE: process.execPath } });
+  const ret = execSync(cmd, { env: { ...process.env, NODE: process.execPath } });
   assert.strictEqual(ret.length, msgBuf.length);
   assert.deepStrictEqual(ret, msgBuf);
 }
 
 {
-  const ret = execSync(cmd, { encoding: 'utf8', env: { NODE: process.execPath } });
+  const ret = execSync(cmd, { encoding: 'utf8', env: { ...process.env, NODE: process.execPath } });
   assert.strictEqual(ret, `${msg}\n`);
 }
 

--- a/test/sequential/test-cli-syntax-bad.js
+++ b/test/sequential/test-cli-syntax-bad.js
@@ -28,9 +28,9 @@ const syntaxErrorRE = /^SyntaxError: \b/m;
 
   // Loop each possible option, `-c` or `--check`
   syntaxArgs.forEach(function(args) {
-    const _args = args.concat(file);
-    const cmd = [node, ..._args].join(' ');
-    exec(cmd, common.mustCall((err, stdout, stderr) => {
+    const _args = args.concat('"$FILE"');
+    const cmd = ['"$NODE"', ..._args].join(' ');
+    exec(cmd, { env: { NODE: node, FILE: file } }, common.mustCall((err, stdout, stderr) => {
       assert.strictEqual(err instanceof Error, true);
       assert.strictEqual(err.code, 1,
                          `code ${err.code} !== 1 for error:\n\n${err}`);

--- a/test/sequential/test-cli-syntax-bad.js
+++ b/test/sequential/test-cli-syntax-bad.js
@@ -30,7 +30,7 @@ const syntaxErrorRE = /^SyntaxError: \b/m;
   syntaxArgs.forEach(function(args) {
     const _args = args.concat('"$FILE"');
     const cmd = ['"$NODE"', ..._args].join(' ');
-    exec(cmd, { env: { NODE: node, FILE: file } }, common.mustCall((err, stdout, stderr) => {
+    exec(cmd, { env: { ...process.env, NODE: node, FILE: file } }, common.mustCall((err, stdout, stderr) => {
       assert.strictEqual(err instanceof Error, true);
       assert.strictEqual(err.code, 1,
                          `code ${err.code} !== 1 for error:\n\n${err}`);

--- a/test/sequential/test-cli-syntax-file-not-found.js
+++ b/test/sequential/test-cli-syntax-file-not-found.js
@@ -24,9 +24,9 @@ const notFoundRE = /^Error: Cannot find module/m;
 
   // Loop each possible option, `-c` or `--check`
   syntaxArgs.forEach(function(args) {
-    const _args = args.concat(file);
-    const cmd = [node, ..._args].join(' ');
-    exec(cmd, common.mustCall((err, stdout, stderr) => {
+    const _args = args.concat('"$FILE"');
+    const cmd = ['"$NODE"', ..._args].join(' ');
+    exec(cmd, { env: { NODE: node, FILE: file } }, common.mustCall((err, stdout, stderr) => {
       // No stdout should be produced
       assert.strictEqual(stdout, '');
 

--- a/test/sequential/test-cli-syntax-file-not-found.js
+++ b/test/sequential/test-cli-syntax-file-not-found.js
@@ -26,7 +26,7 @@ const notFoundRE = /^Error: Cannot find module/m;
   syntaxArgs.forEach(function(args) {
     const _args = args.concat('"$FILE"');
     const cmd = ['"$NODE"', ..._args].join(' ');
-    exec(cmd, { env: { NODE: node, FILE: file } }, common.mustCall((err, stdout, stderr) => {
+    exec(cmd, { env: { ...process.env, NODE: node, FILE: file } }, common.mustCall((err, stdout, stderr) => {
       // No stdout should be produced
       assert.strictEqual(stdout, '');
 

--- a/test/sequential/test-cli-syntax-good.js
+++ b/test/sequential/test-cli-syntax-good.js
@@ -26,10 +26,10 @@ const syntaxArgs = [
 
   // Loop each possible option, `-c` or `--check`
   syntaxArgs.forEach(function(args) {
-    const _args = args.concat(file);
+    const _args = args.concat('"$FILE"');
 
-    const cmd = [node, ..._args].join(' ');
-    exec(cmd, common.mustCall((err, stdout, stderr) => {
+    const cmd = ['"$NODE"', ..._args].join(' ');
+    exec(cmd, { env: { NODE: node, FILE: file } }, common.mustCall((err, stdout, stderr) => {
       if (err) {
         console.log('-- stdout --');
         console.log(stdout);

--- a/test/sequential/test-cli-syntax-good.js
+++ b/test/sequential/test-cli-syntax-good.js
@@ -29,7 +29,7 @@ const syntaxArgs = [
     const _args = args.concat('"$FILE"');
 
     const cmd = ['"$NODE"', ..._args].join(' ');
-    exec(cmd, { env: { NODE: node, FILE: file } }, common.mustCall((err, stdout, stderr) => {
+    exec(cmd, { env: { ...process.env, NODE: node, FILE: file } }, common.mustCall((err, stdout, stderr) => {
       if (err) {
         console.log('-- stdout --');
         console.log(stdout);

--- a/test/sequential/test-init.js
+++ b/test/sequential/test-init.js
@@ -33,9 +33,10 @@ if (process.env.TEST_INIT) {
 }
 
 process.env.TEST_INIT = 1;
+process.env.NODE = process.execPath;
 
 function test(file, expected) {
-  const path = `"${process.execPath}" ${file}`;
+  const path = `"$NODE" ${file}`;
   child.exec(path, { env: process.env }, common.mustSucceed((out) => {
     assert.strictEqual(out, expected, `'node ${file}' failed!`);
   }));


### PR DESCRIPTION
When tests are run from a cwd that contains special characters in its path, those would be misinterpreted by the shell and make the test fail.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
