### PR TITLE
crypto: do not overwrite _writableState.defaultEncoding

### DIFF
--- a/lib/internal/streams/lazy_transform.js
+++ b/lib/internal/streams/lazy_transform.js
@@ -23,11 +23,6 @@ function makeGetter(name) {
   return function() {
     stream.Transform.call(this, this._options);
     this._writableState.decodeStrings = false;
-
-    if (!this._options || !this._options.defaultEncoding) {
-      this._writableState.defaultEncoding = 'buffer';  // TODO(tniessen): remove
-    }
-
     return this[name];
   };
 }

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -298,6 +298,9 @@ function testEncoding(options, assertionHash) {
   let hashValue = '';
 
   hash.on('data', (data) => {
+    // The defaultEncoding has no effect on the hash value. It only affects data
+    // consumed by the Hash transform stream.
+    assert(Buffer.isBuffer(data));
     hashValue += data.toString('hex');
   });
 
@@ -307,6 +310,8 @@ function testEncoding(options, assertionHash) {
 
   hash.write('öäü');
   hash.end();
+
+  assert.strictEqual(hash._writableState.defaultEncoding, options?.defaultEncoding ?? 'utf8');
 }
 
 // Hash of "öäü" in utf8 format


### PR DESCRIPTION
This only affects the writable side of `LazyTransform` and should not change the behavior of any `LazyTransform` streams (`Cipher`, `Decipher`, `Cipheriv`, `Decipheriv`, `Hash`, `Hmac`).

If the user does not set `defaultEncoding` when creating a transform stream, `WritableState` uses `'utf8'` by default. Only `LazyTransform` overwrites this with `'buffer'` for strict backward compatibility. This was necessary when `crypto.DEFAULT_ENCODING` still existed. Now that `DEFAULT_ENCODING` has been removed, `defaultEncoding` is always `'buffer'`. The writable side of `LazyTransform` appears to treat `'utf8'` and `'buffer'` in exactly the same way. Therefore, there seems to be no need to overwrite `_writableState.defaultEncoding` at this point.

Nevertheless, because Node.js has failed to hide implementation details such as `_writableState` from the ecosystem, we may want to consider this a breaking change.

I am not very familiar with the internals of Node.js streams, so please review carefully @nodejs/streams.

Refs: https://github.com/nodejs/node/pull/47182
Refs: https://github.com/nodejs/node/pull/8611

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
