### PR TITLE
crypto: remove default encoding from sign/verify

### DIFF
--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -34,7 +34,6 @@ const {
 
 const {
   getArrayBufferOrView,
-  getDefaultEncoding,
   kHandle,
 } = require('internal/crypto/util');
 
@@ -70,8 +69,6 @@ Sign.prototype._write = function _write(chunk, encoding, callback) {
 };
 
 Sign.prototype.update = function update(data, encoding) {
-  encoding = encoding || getDefaultEncoding();
-
   if (typeof data === 'string') {
     validateEncoding(data, encoding);
   } else if (!isArrayBufferView(data)) {
@@ -131,7 +128,6 @@ Sign.prototype.sign = function sign(options, encoding) {
   const ret = this[kHandle].sign(data, format, type, passphrase, rsaPadding,
                                  pssSaltLength, dsaSigEnc);
 
-  encoding = encoding || getDefaultEncoding();
   if (encoding && encoding !== 'buffer')
     return ret.toString(encoding);
 
@@ -215,8 +211,6 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
     type,
     passphrase,
   } = preparePublicOrPrivateKey(options, true);
-
-  sigEncoding = sigEncoding || getDefaultEncoding();
 
   // Options specific to RSA
   const rsaPadding = getPadding(options);


### PR DESCRIPTION
`getDefaultEncoding()` always returns `'buffer'` in Node.js 20. It requires some careful justification but the default encoding can be eliminated from `sig.js` entirely.

In `Sign.prototype.update`, we can safely remove the conditional assignment of `getDefaultEncoding()` to `encoding`. This is because `SignUpdate()` in `crypto_sig.cc` internally calls `node::crypto::Decode`, which returns `UTF8` for falsy `encoding` values. In other words, with the conditional assignment, `StringBytes::Write()` ultimately receives the encoding `BUFFER`, and without the conditional assignment, it receives the encoding `UTF8`. However, `StringBytes::Write()` treats both encodings identically, so there is no need to deviate from the internal default encoding `UTF8`.

In `Sign.prototype.sign`, we can also safely remove the conditional assignment of `getDefaultEncoding()` to encoding. Whether encoding is falsy or `'buffer'` makes no difference.

In `Verify.prototype.verify`, we can also safely remove the conditional assignment of `getDefaultEncoding()` to `sigEncoding`. This is because the function passes the `sigEncoding` to `getArrayBufferOrView()`, which passes it to `Buffer.from()`. If `sigEncoding` is `'buffer'`, `getArrayBufferOrView()` instead passes `'utf8'` to `Buffer.from()`. Because the default encoding of `Buffer.from()` is `'utf8'`, passing a falsy encoding to `getArrayBufferOrView()` instead of `'buffer'` results in the same behavior.

This partially addresses:

https://github.com/nodejs/node/blob/af9b48a2f17b11b66a8b81beeaba3c408b863795/lib/internal/crypto/util.js#L77-L80

Refs: https://github.com/nodejs/node/pull/47182

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
