### PR TITLE
src: use exact return value for `uv_os_getenv`

### DIFF
--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -116,7 +116,7 @@ bool SafeGetenv(const char* key,
       ret = uv_os_getenv(key, *val, &init_sz);
     }
 
-    if (ret >= 0) {  // Env key value fetch success.
+    if (ret == 0) {  // Env key value fetch success.
       *text = *val;
       return true;
     }


### PR DESCRIPTION
`uv_os_getenv` returns `0` for happy path.

- [Windows implementation ref](https://github.com/libuv/libuv/blob/2f8275009854599ec7de68dbef795e82b6b5fb30/src/win/util.c#L1463)
- [Unix implementation ref](https://github.com/libuv/libuv/blob/2f8275009854599ec7de68dbef795e82b6b5fb30/src/unix/core.c#L1452)