### PR TITLE
worker: handle detached `MessagePort` from a different context

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -789,6 +789,13 @@ MaybeLocal<Value> MessagePort::ReceiveMessage(Local<Context> context,
 
 void MessagePort::OnMessage(MessageProcessingMode mode) {
   Debug(this, "Running MessagePort::OnMessage()");
+  // Maybe the async handle was triggered empty or more than needed.
+  // The data_ could be freed or, the handle has been/is being closed.
+  // A possible case for this, is transfer the MessagePort to another
+  // context, it will call the constructor and trigger the async handle empty.
+  // Because all data was sent from the preivous context.
+  if (IsDetached()) return;
+
   HandleScope handle_scope(env()->isolate());
   Local<Context> context =
       object(env()->isolate())->GetCreationContext().ToLocalChecked();

--- a/test/parallel/test-worker-workerdata-messageport.js
+++ b/test/parallel/test-worker-workerdata-messageport.js
@@ -1,11 +1,11 @@
 'use strict';
 
 require('../common');
-const assert = require('assert');
+const assert = require('node:assert');
 
 const {
   Worker, MessageChannel
-} = require('worker_threads');
+} = require('node:worker_threads');
 
 const channel = new MessageChannel();
 const workerData = { mesage: channel.port1 };
@@ -58,4 +58,30 @@ const meowScript = () => 'meow';
     message: 'Object that needs transfer was found in message but not ' +
              'listed in transferList'
   });
+}
+
+{
+  // Should not crash when MessagePort is transferred to another context.
+  // https://github.com/nodejs/node/issues/49075
+  const channel = new MessageChannel();
+  new Worker(`
+    const { runInContext, createContext } = require('node:vm')
+    const { workerData } = require('worker_threads');
+    const context = createContext(Object.create(null));
+    context.messagePort = workerData.messagePort;
+    runInContext(
+      \`messagePort.postMessage("Meow")\`,
+      context,
+      { displayErrors: true }
+    );
+    `, {
+    eval: true,
+    workerData: { messagePort: channel.port2 },
+    transferList: [channel.port2]
+  });
+  channel.port1.on(
+    'message',
+    (message) =>
+      assert.strictEqual(message, 'Meow')
+  );
 }


### PR DESCRIPTION
When `worker.moveMessagePortToContext` is used, the async handle associated with the port, will be triggered more than needed (at least one more time) and with null data. That can be avoided by simply checking that the data is present and the port is not detached.

Fixes: https://github.com/nodejs/node/issues/49075

---------
Note aside, this could be fixed as well by the next diff:

```diff
diff --git a/src/node_messaging.cc b/src/node_messaging.cc
index 00e1db3bab..b46ae022ce 100644
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -741,9 +741,6 @@ MessagePort* MessagePort::New(
     // but it's better to be safe than sorry.)
     Mutex::ScopedLock lock(port->data_->mutex_);
     port->data_->owner_ = port;
-    // If the existing MessagePortData object had pending messages, this is
-    // the easiest way to run that queue.
-    port->TriggerAsync();
   } else if (sibling_group) {
     sibling_group->Entangle(port->data_.get());
   }
```

IMO that could change how the workers behave, then I prefer a "handle case" approach.