### PR TITLE
doc: document dangerous symlink behavior

### DIFF
--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -568,6 +568,11 @@ There are constraints you need to know before using this system:
 * Relative paths are not supported through the CLI (`--allow-fs-*`).
 * The model does not inherit to a child node process.
 * The model does not inherit to a worker thread.
+* Symbolic links will be followed even to locations outside of the set of paths
+  that access has been granted to. Relative symbolic links may allow access to
+  arbitrary files and directories. When starting applications with the
+  permission model enabled, you must ensure that no paths to which access has
+  been granted contain relative symbolic links.
 * When creating symlinks the target (first argument) should have read and
   write access.
 * Permission changes are not retroactively applied to existing resources.


### PR DESCRIPTION
Much earlier, a design decision was made that the permission model should not prevent following symbolic links to presumably inaccessible locations. Recently, after some back and forth, it had been decided that it is indeed a vulnerability that symbolic links, which currently point to an accessible location, can potentially be re-targeted to point to a presumably inaccessible location. Nevertheless, months later, no solution has been found and the issue is deemed unfixable in the context of the current permission model implementation, so it was decided to disclose the ~vulnerability~ _peculiarity_ and to shift responsibiliy onto users who are now responsible for ensuring that no potentially dangerous symlinks exist in any directories that they grant access to.

I believe that this design issue might be surprising and that it comes with significant security implications for users, so it should be documented.

Original vulnerability report: https://hackerone.com/reports/1961655

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
