### PR TITLE
doc,test: add known path resolution issue in permission model

### DIFF
--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -560,6 +560,8 @@ Wildcards are supported too:
 
 There are constraints you need to know before using this system:
 
+* When the permission model is enabled, Node.js may resolve some paths
+  differently than when it is disabled.
 * Native modules are restricted by default when using the Permission Model.
 * OpenSSL engines currently cannot be requested at runtime when the Permission
   Model is enabled, affecting the built-in crypto, https, and tls modules.

--- a/test/known_issues/test-permission-model-path-resolution.js
+++ b/test/known_issues/test-permission-model-path-resolution.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// The permission model resolves paths to avoid path traversals, but in doing so
+// it potentially interprets paths differently than the operating system would.
+// This test demonstrates that merely enabling the permission model causes the
+// application to potentially access a different file than it would without the
+// permission model.
+
+const common = require('../common');
+
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+const { mkdirSync, symlinkSync, writeFileSync } = require('fs');
+const path = require('path');
+
+if (common.isWindows)
+  assert.fail('not applicable to Windows');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+const a = path.join(tmpdir.path, 'a');
+const b = path.join(tmpdir.path, 'b');
+const c = path.join(tmpdir.path, 'c');
+const d = path.join(tmpdir.path, 'c/d');
+
+writeFileSync(a, 'bad');
+symlinkSync('c/d', b);
+mkdirSync(c);
+mkdirSync(d);
+writeFileSync(path.join(c, 'a'), 'good');
+
+function run(...args) {
+  const interestingPath = `${tmpdir.path}/b/../a`;
+  args = [...args, '-p', `fs.readFileSync(${JSON.stringify(interestingPath)}, 'utf8')`];
+  return execFileSync(process.execPath, args, { encoding: 'utf8' }).trim();
+}
+
+// Because this is a known_issues test, we cannot assert any assumptions besides
+// the known issue itself. Instead, do a sanity check and report success if the
+// sanity check fails.
+if (run() !== 'good') {
+  process.exit(0);
+}
+
+assert.strictEqual(run('--experimental-permission', `--allow-fs-read=${tmpdir.path}`), 'good');


### PR DESCRIPTION
As a side effect of 205f1e643e25648173239b2de885fec430268492, Node.js now resolves some paths differently when the permission model is enabled. While these are mostly edge cases, they are worth mentioning in the documentation. This commit also adds a known_issues test that demonstrates one such difference.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
