### PR TITLE
permission: do not create symlinks if target is relative

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -58,6 +58,7 @@ const {
 } = constants;
 
 const pathModule = require('path');
+const { isAbsolute } = pathModule;
 const { isArrayBufferView } = require('internal/util/types');
 
 const binding = internalBinding('fs');
@@ -68,6 +69,7 @@ const { Buffer } = require('buffer');
 const {
   aggregateTwoErrors,
   codes: {
+    ERR_ACCESS_DENIED,
     ERR_FS_FILE_TOO_LARGE,
     ERR_INVALID_ARG_VALUE,
   },
@@ -142,6 +144,8 @@ const {
   validateString,
   kValidateObjectAllowNullable,
 } = require('internal/validators');
+
+const permission = require('internal/process/permission');
 
 let truncateWarn = true;
 let fs;
@@ -1742,6 +1746,15 @@ function symlink(target, path, type_, callback_) {
   const type = (typeof type_ === 'string' ? type_ : null);
   const callback = makeCallback(arguments[arguments.length - 1]);
 
+  if (permission.isEnabled()) {
+    // The permission model's security guarantees fall apart in the presence of
+    // relative symbolic links. Thus, we have to prevent their creation.
+    if (typeof target !== 'string' || !isAbsolute(toPathIfFileURL(target))) {
+      callback(new ERR_ACCESS_DENIED('relative symbolic link target'));
+      return;
+    }
+  }
+
   target = getValidatedPath(target, 'target');
   path = getValidatedPath(path);
 
@@ -1798,6 +1811,15 @@ function symlinkSync(target, path, type) {
       type = 'dir';
     }
   }
+
+  if (permission.isEnabled()) {
+    // The permission model's security guarantees fall apart in the presence of
+    // relative symbolic links. Thus, we have to prevent their creation.
+    if (typeof target !== 'string' || !isAbsolute(toPathIfFileURL(target))) {
+      throw new ERR_ACCESS_DENIED('relative symbolic link target');
+    }
+  }
+
   target = getValidatedPath(target, 'target');
   path = getValidatedPath(path);
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -33,6 +33,7 @@ const { Buffer } = require('buffer');
 
 const {
   codes: {
+    ERR_ACCESS_DENIED,
     ERR_FS_FILE_TOO_LARGE,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_STATE,
@@ -86,6 +87,8 @@ const {
   kValidateObjectAllowNullable,
 } = require('internal/validators');
 const pathModule = require('path');
+const { isAbsolute } = pathModule;
+const { toPathIfFileURL } = require('internal/url');
 const {
   kEmptyObject,
   lazyDOMException,
@@ -97,6 +100,8 @@ const { kFSWatchStart, watch } = require('internal/fs/watchers');
 const nonNativeWatcher = require('internal/fs/recursive_watch');
 const { isIterable } = require('internal/streams/utils');
 const assert = require('internal/assert');
+
+const permission = require('internal/process/permission');
 
 const kHandle = Symbol('kHandle');
 const kFd = Symbol('kFd');
@@ -974,6 +979,15 @@ async function symlink(target, path, type_) {
       type = 'file';
     }
   }
+
+  if (permission.isEnabled()) {
+    // The permission model's security guarantees fall apart in the presence of
+    // relative symbolic links. Thus, we have to prevent their creation.
+    if (typeof target !== 'string' || !isAbsolute(toPathIfFileURL(target))) {
+      throw new ERR_ACCESS_DENIED('relative symbolic link target');
+    }
+  }
+
   target = getValidatedPath(target, 'target');
   path = getValidatedPath(path);
   return await PromisePrototypeThen(

--- a/test/parallel/test-permission-fs-symlink-relative.js
+++ b/test/parallel/test-permission-fs-symlink-relative.js
@@ -1,0 +1,27 @@
+// Flags: --experimental-permission --allow-fs-read=* --allow-fs-write=*
+'use strict';
+
+const common = require('../common');
+common.skipIfWorker();
+
+const assert = require('assert');
+const { symlinkSync, symlink, promises: { symlink: symlinkAsync } } = require('fs');
+
+const error = {
+  code: 'ERR_ACCESS_DENIED',
+  message: /relative symbolic link target/,
+};
+
+for (const targetString of ['a', './b/c', '../d', 'e/../f', 'C:drive-relative', 'ntfs:alternate']) {
+  for (const target of [targetString, Buffer.from(targetString)]) {
+    for (const path of [__filename, __dirname, process.execPath]) {
+      assert.throws(() => symlinkSync(target, path), error);
+      symlink(target, path, common.mustCall((err) => {
+        assert(err);
+        assert.strictEqual(err.code, error.code);
+        assert.match(err.message, error.message);
+      }));
+      assert.rejects(() => symlinkAsync(target, path), error).then(common.mustCall());
+    }
+  }
+}


### PR DESCRIPTION
The permission model's security guarantees fall apart in the presence of relative symbolic links. When an application attempts to create a relative symlink, the permission model currently resolves the relative path into an absolute path based on the process's current working directory, checks whether the process has the relevant permissions, and then creates the symlink using the absolute target path. This behavior is plainly incorrect for two reasons:

1. The target path should never be resolved relative to the current working directory. If anything, it should be resolved relative to the symlink's location. (Of course, there is one insane exception to this rule: on Windows, each process has a current working directory per drive, and symlinks can be created with a target path relative to the current working directory of a specific drive. In that case, the relative path will be resolved relative to the current working directory for the respective drive, and the symlink will be created on disk with the resulting absolute path. Other relative symlinks will be stored as-is.)
2. Silently creating an absolute symlink when the user requested a relative symlink is wrong. The user may (or may not) rely on the symlink being relative. For example, npm heavily relies on relative symbolic links such that node_modules directories can be moved around without breaking.

Because we don't know the user's intentions, we don't know if creating an absolute symlink instead of a relative symlink is acceptable. This patch prevents the faulty behavior by not (incorrectly) resolving relative symlink targets when the permission model is enabled, and by instead simply refusing the create any relative symlinks.

The fs APIs accept `Uint8Array` objects for paths to be able to handle arbitrary file name charsets, however, checking whether such an object represents a relative part in a reliable and portable manner is tricky. Other parts of the permission model incorrectly convert such objects to strings and then back to an `Uint8Array` (see 1f64147eb607f82060e08884f993597774c69280), however, for now, this bug fix will simply throw on non-string symlink targets when the permission model is enabled. (The permission model already breaks existing applications in various ways, so this shouldn't be too dramatic.)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
