### PR TITLE
doc: fix name of the flag in `initialize()` docs

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -766,7 +766,7 @@ added: REPLACEME
 The `initialize` hook provides a way to define a custom function that runs
 in the loader's thread when the loader is initialized. Initialization happens
 when the loader is registered via [`register`][] or registered via the
-`--loader` command line option.
+`--experimental-loader` command line option.
 
 This hook can send and receive data from a [`register`][] invocation, including
 ports and other transferrable objects. The return value of `initialize` must be


### PR DESCRIPTION
`--loader` is an undocumented flag, the rest of the docs uses `--experimental-loader` to design that flag (`--loader` was kept as an undocumented alias to avoid a breaking change).
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
