### PR TITLE
Doc: update crypto.randomUUID deprecation text

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5113,7 +5113,7 @@ added:
 * `options` {Object}
   * `disableEntropyCache` {boolean} By default, to improve performance,
     Node.js generates and caches enough
-    random data to generate up to 128 random UUIDs. To generate a UUID
+    random data to generate up to 128 bits long random UUIDs. To generate a UUID
     without using the cache, set `disableEntropyCache` to `true`.
     **Default:** `false`.
 * Returns: {string}


### PR DESCRIPTION
`"generate up to 128 random UUIDs"`

It seems to say: The total number of generated UUIDs is 128


I think it should be clear that 128 refers to the byte length
so...


`"generate up to 128 bits long random UUIDs"`

