### PR TITLE
url: validate `pathToFileURL(path)` argument as string

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1449,14 +1449,14 @@ function pathToFileURL(filepath) {
     const hostnameEndIndex = StringPrototypeIndexOf(filepath, '\\', 2);
     if (hostnameEndIndex === -1) {
       throw new ERR_INVALID_ARG_VALUE(
-        'filepath',
+        'path',
         filepath,
         'Missing UNC resource path',
       );
     }
     if (hostnameEndIndex === 2) {
       throw new ERR_INVALID_ARG_VALUE(
-        'filepath',
+        'path',
         filepath,
         'Empty UNC servername',
       );

--- a/lib/url.js
+++ b/lib/url.js
@@ -53,7 +53,7 @@ const {
   domainToASCII,
   domainToUnicode,
   fileURLToPath,
-  pathToFileURL,
+  pathToFileURL: _pathToFileURL,
   urlToHttpOptions,
   unsafeProtocol,
   hostlessProtocol,
@@ -1016,6 +1016,15 @@ Url.prototype.parseHost = function parseHost() {
   }
   if (host) this.hostname = host;
 };
+
+// When used internally, we are not obligated to associate TypeError with
+// this function, so non-strings can be rejected by underlying implementation.
+// Public API has to validate input and throw appropriate error.
+function pathToFileURL(path) {
+  validateString(path, 'path');
+
+  return _pathToFileURL(path);
+}
 
 module.exports = {
   // Original API


### PR DESCRIPTION
Since `url.pathToFileURL()` is exposed as a part of public API, it should validate input value.

Before this change, non-strings were rejected in `path.resolve()` with confusing `The "paths[0]" argument must be of type string.` message.
On Windows, input was directly passed into `StringPrototypeStartsWith()`, causing either confusing errors or implicit coercion to string.