### PR TITLE
crypto: remove default encoding from Hash/Hmac

### DIFF
--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -14,7 +14,6 @@ const {
 } = internalBinding('crypto');
 
 const {
-  getDefaultEncoding,
   getStringOption,
   jobPromise,
   normalizeHashName,
@@ -95,8 +94,6 @@ Hash.prototype._flush = function _flush(callback) {
 };
 
 Hash.prototype.update = function update(data, encoding) {
-  encoding = encoding || getDefaultEncoding();
-
   const state = this[kState];
   if (state[kFinalized])
     throw new ERR_CRYPTO_HASH_FINALIZED();
@@ -118,10 +115,9 @@ Hash.prototype.digest = function digest(outputEncoding) {
   const state = this[kState];
   if (state[kFinalized])
     throw new ERR_CRYPTO_HASH_FINALIZED();
-  outputEncoding = outputEncoding || getDefaultEncoding();
 
-  // Explicit conversion for backward compatibility.
-  const ret = this[kHandle].digest(`${outputEncoding}`);
+  // Explicit conversion of truthy values for backward compatibility.
+  const ret = this[kHandle].digest(outputEncoding && `${outputEncoding}`);
   state[kFinalized] = true;
   return ret;
 };
@@ -147,15 +143,16 @@ Hmac.prototype.update = Hash.prototype.update;
 
 Hmac.prototype.digest = function digest(outputEncoding) {
   const state = this[kState];
-  outputEncoding = outputEncoding || getDefaultEncoding();
 
   if (state[kFinalized]) {
     const buf = Buffer.from('');
-    return outputEncoding === 'buffer' ? buf : buf.toString(outputEncoding);
+    if (outputEncoding && outputEncoding !== 'buffer')
+      return buf.toString(outputEncoding);
+    return buf;
   }
 
-  // Explicit conversion for backward compatibility.
-  const ret = this[kHandle].digest(`${outputEncoding}`);
+  // Explicit conversion of truthy values for backward compatibility.
+  const ret = this[kHandle].digest(outputEncoding && `${outputEncoding}`);
   state[kFinalized] = true;
   return ret;
 };


### PR DESCRIPTION
`getDefaultEncoding()` always returns `'buffer'` in Node.js 20. It requires some careful justification but the default encoding can be eliminated from `hash.js` entirely. The reasoning is almost identical with that in https://github.com/nodejs/node/pull/49145 so I won't repeat it here. The main thing to note here is that `digest()` conveniently defaults to `BUFFER` for falsy encodings.

This partially addresses:

https://github.com/nodejs/node/blob/af9b48a2f17b11b66a8b81beeaba3c408b863795/lib/internal/crypto/util.js#L77-L80

Refs: https://github.com/nodejs/node/pull/47182

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
