### PR TITLE
test: use gcUntil() in test-v8-serialize-leak

### DIFF
--- a/test/parallel/test-v8-serialize-leak.js
+++ b/test/parallel/test-v8-serialize-leak.js
@@ -8,7 +8,6 @@ if (common.isIBMi)
   common.skip('On IBMi, the rss memory always returns zero');
 
 const v8 = require('v8');
-const assert = require('assert');
 
 const before = process.memoryUsage.rss();
 
@@ -16,14 +15,19 @@ for (let i = 0; i < 1000000; i++) {
   v8.serialize('');
 }
 
-global.gc();
-
-const after = process.memoryUsage.rss();
-
-if (process.config.variables.asan) {
-  assert(after < before * 10, `asan: before=${before} after=${after}`);
-} else if (process.config.variables.node_builtin_modules_path) {
-  assert(after < before * 4, `node_builtin_modules_path: before=${before} after=${after}`);
-} else {
-  assert(after < before * 2, `before=${before} after=${after}`);
+async function main() {
+  await common.gcUntil('RSS should go down', () => {
+    const after = process.memoryUsage.rss();
+    if (process.config.variables.asan) {
+      console.log(`asan: before=${before} after=${after}`);
+      return after < before * 10;
+    } else if (process.config.variables.node_builtin_modules_path) {
+      console.log(`node_builtin_modules_path: before=${before} after=${after}`);
+      return after < before * 10;
+    }
+    console.log(`before=${before} after=${after}`);
+    return after < before * 10;
+  });
 }
+
+main();


### PR DESCRIPTION
Previously this can be flaky because the there could be a delay of the deallocation after gc() is invoked. Use gcUntil() to run the GC multiple times to make the test more robust.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
