### PR TITLE
crypto: remove default encoding from DiffieHellman

### DIFF
--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -51,7 +51,6 @@ const {
 
 const {
   getArrayBufferOrView,
-  getDefaultEncoding,
   jobPromise,
   toBuf,
   kHandle,
@@ -96,10 +95,6 @@ function DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
     generator = keyEncoding;
     keyEncoding = false;
   }
-
-  const encoding = getDefaultEncoding();
-  keyEncoding = keyEncoding || encoding;
-  genEncoding = genEncoding || encoding;
 
   if (typeof sizeOrKey !== 'number')
     sizeOrKey = toBuf(sizeOrKey, keyEncoding);
@@ -148,7 +143,6 @@ DiffieHellmanGroup.prototype.generateKeys =
 
 function dhGenerateKeys(encoding) {
   const keys = this[kHandle].generateKeys();
-  encoding = encoding || getDefaultEncoding();
   return encode(keys, encoding);
 }
 
@@ -158,9 +152,6 @@ DiffieHellmanGroup.prototype.computeSecret =
     dhComputeSecret;
 
 function dhComputeSecret(key, inEnc, outEnc) {
-  const encoding = getDefaultEncoding();
-  inEnc = inEnc || encoding;
-  outEnc = outEnc || encoding;
   key = getArrayBufferOrView(key, 'key', inEnc);
   const ret = this[kHandle].computeSecret(key);
   if (typeof ret === 'string')
@@ -175,7 +166,6 @@ DiffieHellmanGroup.prototype.getPrime =
 
 function dhGetPrime(encoding) {
   const prime = this[kHandle].getPrime();
-  encoding = encoding || getDefaultEncoding();
   return encode(prime, encoding);
 }
 
@@ -186,7 +176,6 @@ DiffieHellmanGroup.prototype.getGenerator =
 
 function dhGetGenerator(encoding) {
   const generator = this[kHandle].getGenerator();
-  encoding = encoding || getDefaultEncoding();
   return encode(generator, encoding);
 }
 
@@ -197,7 +186,6 @@ DiffieHellmanGroup.prototype.getPublicKey =
 
 function dhGetPublicKey(encoding) {
   const key = this[kHandle].getPublicKey();
-  encoding = encoding || getDefaultEncoding();
   return encode(key, encoding);
 }
 
@@ -208,13 +196,11 @@ DiffieHellmanGroup.prototype.getPrivateKey =
 
 function dhGetPrivateKey(encoding) {
   const key = this[kHandle].getPrivateKey();
-  encoding = encoding || getDefaultEncoding();
   return encode(key, encoding);
 }
 
 
 DiffieHellman.prototype.setPublicKey = function setPublicKey(key, encoding) {
-  encoding = encoding || getDefaultEncoding();
   key = getArrayBufferOrView(key, 'key', encoding);
   this[kHandle].setPublicKey(key);
   return this;
@@ -222,7 +208,6 @@ DiffieHellman.prototype.setPublicKey = function setPublicKey(key, encoding) {
 
 
 DiffieHellman.prototype.setPrivateKey = function setPrivateKey(key, encoding) {
-  encoding = encoding || getDefaultEncoding();
   key = getArrayBufferOrView(key, 'key', encoding);
   this[kHandle].setPrivateKey(key);
   return this;
@@ -251,15 +236,12 @@ ECDH.prototype.generateKeys = function generateKeys(encoding, format) {
 ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
   const f = getFormat(format);
   const key = this[kHandle].getPublicKey(f);
-  encoding = encoding || getDefaultEncoding();
   return encode(key, encoding);
 };
 
 ECDH.convertKey = function convertKey(key, curve, inEnc, outEnc, format) {
   validateString(curve, 'curve');
-  const encoding = inEnc || getDefaultEncoding();
-  key = getArrayBufferOrView(key, 'key', encoding);
-  outEnc = outEnc || encoding;
+  key = getArrayBufferOrView(key, 'key', inEnc);
   const f = getFormat(format);
   const convertedKey = _ECDHConvertKey(key, curve, f);
   return encode(convertedKey, outEnc);


### PR DESCRIPTION
`getDefaultEncoding()` always returns `'buffer'` in Node.js 20.

In `diffiehellman.js`, this value is always used as input to either `toBuf()`, `encode()`, or `getArrayBufferOrView()`. All of these functions treat any falsy encoding just like `'buffer'`, so we can safely remove the calls to `getDefaultEncoding()`.

This partially addresses:

https://github.com/nodejs/node/blob/af9b48a2f17b11b66a8b81beeaba3c408b863795/lib/internal/crypto/util.js#L77-L80

Refs: https://github.com/nodejs/node/pull/47182

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
