### PR TITLE
crypto: remove getDefaultEncoding()

### DIFF
--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -75,11 +75,6 @@ const {
 const kHandle = Symbol('kHandle');
 const kKeyObject = Symbol('kKeyObject');
 
-// TODO(tniessen): remove all call sites and this function
-function getDefaultEncoding() {
-  return 'buffer';
-}
-
 // This is here because many functions accepted binary strings without
 // any explicit encoding in older versions of node, and we don't want
 // to break them unnecessarily.
@@ -555,7 +550,6 @@ module.exports = {
   getCiphers,
   getCurves,
   getDataViewOrTypedArrayBuffer,
-  getDefaultEncoding,
   getHashes,
   kHandle,
   kKeyObject,

--- a/lib/internal/streams/lazy_transform.js
+++ b/lib/internal/streams/lazy_transform.js
@@ -11,10 +11,6 @@ const {
 
 const stream = require('stream');
 
-const {
-  getDefaultEncoding,
-} = require('internal/crypto/util');
-
 module.exports = LazyTransform;
 
 function LazyTransform(options) {
@@ -29,7 +25,7 @@ function makeGetter(name) {
     this._writableState.decodeStrings = false;
 
     if (!this._options || !this._options.defaultEncoding) {
-      this._writableState.defaultEncoding = getDefaultEncoding();
+      this._writableState.defaultEncoding = 'buffer';  // TODO(tniessen): remove
     }
 
     return this[name];


### PR DESCRIPTION
This is a follow-up to https://github.com/nodejs/node/pull/47182, https://github.com/nodejs/node/pull/47869, https://github.com/nodejs/node/pull/47943, https://github.com/nodejs/node/pull/47998, https://github.com/nodejs/node/pull/49140, https://github.com/nodejs/node/pull/49145, https://github.com/nodejs/node/pull/49167, and https://github.com/nodejs/node/pull/49169. All of these changes can be merged into Node.js 20.

Out of caution, we are not going to remove the last remaining occurrence, which is in `lazy_transform.js`, in Node.js 20 (see https://github.com/nodejs/node/pull/49140). However, to minimize the non-backportable patch, this commit inlines `getDefaultEncoding()` by replacing the call with the constant `'buffer'`. https://github.com/nodejs/node/pull/49140 then simply needs to drop those three lines, but the function itself can be removed on the main branch and in both Node.js 20 and in Node.js 21.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
