### PR TITLE
doc: add notable-change label mention to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,9 @@ For code changes:
 2. Update documentation if relevant.
 3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.
 
+If you believe this PR should be highlighted in the Node.js CHANGELOG
+please add the `notable-change` label.
+
 Developer's Certificate of Origin 1.1
 
 By making a contribution to this project, I certify that:


### PR DESCRIPTION
A naive attempt to remind us about the `notable-change` label usage.

cc: @nodejs/tsc 