### PR TITLE
meta: mention nodejs/tsc when changing GH templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,8 @@
 # tsc
 
 /.github/CODEOWNERS @nodejs/tsc
+/.github/PULL_REQUEST_TEMPLATE.md @nodejs/tsc
+/.github/ISSUE_TEMPLATE/* @nodejs/tsc
 /CODE_OF_CONDUCT.md @nodejs/tsc
 /CONTRIBUTING.md @nodejs/tsc
 /doc/contributing/*.md @nodejs/tsc


### PR DESCRIPTION
I noticed while creating https://github.com/nodejs/node/pull/49188 that no one is notified when a PR is created attempting to change our GitHub templates. I believe makes sense to mention nodejs/tsc in this case.