### PR TITLE
url: refactor magic number for `slashedProtocols` into const variable

### DIFF
--- a/lib/internal/constants.js
+++ b/lib/internal/constants.js
@@ -4,14 +4,17 @@ const isWindows = process.platform === 'win32';
 
 module.exports = {
   // Alphabet chars.
-  CHAR_UPPERCASE_A: 65, /* A */
-  CHAR_LOWERCASE_A: 97, /* a */
-  CHAR_UPPERCASE_Z: 90, /* Z */
-  CHAR_LOWERCASE_Z: 122, /* z */
-  CHAR_UPPERCASE_C: 67, /* C */
-  CHAR_LOWERCASE_B: 98, /* b */
+  CHAR_UPPERCASE_A: 65,  /* A */
+  CHAR_UPPERCASE_C: 67,  /* C */
+  CHAR_UPPERCASE_Z: 90,  /* Z */
+  CHAR_LOWERCASE_A: 97,  /* a */
+  CHAR_LOWERCASE_B: 98,  /* b */
   CHAR_LOWERCASE_E: 101, /* e */
+  CHAR_LOWERCASE_F: 102, /* f */
+  CHAR_LOWERCASE_I: 105, /* i */
+  CHAR_LOWERCASE_L: 108, /* l */
   CHAR_LOWERCASE_N: 110, /* n */
+  CHAR_LOWERCASE_Z: 122, /* z */
 
   // Non-alphabetic chars.
   CHAR_DOT: 46, /* . */

--- a/lib/url.js
+++ b/lib/url.js
@@ -94,6 +94,10 @@ const simplePathPattern = /^(\/\/?(?!\/)[^?\s]*)(\?[^\s]*)?$/;
 
 const hostnameMaxLen = 255;
 const {
+  CHAR_LOWERCASE_E,
+  CHAR_LOWERCASE_F,
+  CHAR_LOWERCASE_I,
+  CHAR_LOWERCASE_L,
   CHAR_SPACE,
   CHAR_TAB,
   CHAR_CARRIAGE_RETURN,
@@ -696,10 +700,10 @@ Url.prototype.format = function format() {
         pathname = '/' + pathname;
       host = '//' + host;
     } else if (protocol.length >= 4 &&
-               protocol.charCodeAt(0) === 102/* f */ &&
-               protocol.charCodeAt(1) === 105/* i */ &&
-               protocol.charCodeAt(2) === 108/* l */ &&
-               protocol.charCodeAt(3) === 101/* e */) {
+               protocol.charCodeAt(0) === CHAR_LOWERCASE_F &&
+               protocol.charCodeAt(1) === CHAR_LOWERCASE_I &&
+               protocol.charCodeAt(2) === CHAR_LOWERCASE_L &&
+               protocol.charCodeAt(3) === CHAR_LOWERCASE_E) {
       host = '//';
     }
   }


### PR DESCRIPTION
Fix to define and use magic numbers for `slashedProtocols` as const variables.
Also, the order of const variables for Character has been arranged.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
