### PR TITLE
tools: fix github reporter appended multiple times

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -317,8 +317,7 @@ class DotsProgressIndicator(SimpleProgressIndicator):
 
 class ActionsAnnotationProgressIndicator(DotsProgressIndicator):
   def AboutToRun(self, case):
-    if not hasattr(case, 'additional_flags'):
-      case.additional_flags = []
+    case.additional_flags = case.additional_flags.copy() if hasattr(case, 'additional_flags') else []
     case.additional_flags.append('--test-reporter=./tools/github_reporter/index.js')
     case.additional_flags.append('--test-reporter-destination=stdout')
 


### PR DESCRIPTION
a follow-up for https://github.com/nodejs/node/pull/49129
since `additional_flags` was shared between all tests the reporter kept being added again for each test. 
see for example https://github.com/nodejs/node/actions/runs/5870373336/job/15917272924?pr=49184