### PR TITLE
test: add and use spawnSyncAndExit() and spawnSyncAndExitWithoutError()

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -40,17 +40,16 @@ The `benchmark` module is used by tests to run benchmarks.
 
 The `child_process` module is used by tests that launch child processes.
 
-### `expectSyncExit(child, options)`
+### `spawnSyncAndExit(command[, args][, spawnOptions], expectations)`
 
-Checks if a _synchronous_ child process runs in the way expected. If it does
-not, print the stdout and stderr output from the child process and additional
-information about it to the stderr of the current process before throwing
-and error. This helps gathering more information about test failures
-coming from child processes.
+Spawns a child process synchronously using [`child_process.spawnSync()`][] and
+check if it runs in the way expected. If it does not, print the stdout and
+stderr output from the child process and additional information about it to
+the stderr of the current process before throwing and error. This helps
+gathering more information about test failures coming from child processes.
 
-* `child` [\<ChildProcess>][<ChildProcess>]: a `ChildProcess` instance
-  returned by `child_process.spawnSync()`.
-* `options` [\<Object>][<Object>]
+* `command`, `args`, `spawnOptions` See [`child_process.spawnSync()`][]
+* `expectations` [\<Object>][<Object>]
   * `status` [\<number>][<number>] Expected `child.status`
   * `signal` [\<string>][<string>] | `null` Expected `child.signal`
   * `stderr` [\<string>][<string>] | [\<RegExp>][<RegExp>] |
@@ -65,8 +64,13 @@ coming from child processes.
   * `trim` [\<boolean>][<boolean>] Optional. Whether this method should trim
     out the whitespace characters when checking `stderr` and `stdout` outputs.
     Defaults to `false`.
+* return [\<Object>][<Object>]
+  * `child` [\<ChildProcess>][<ChildProcess>] The child process returned by
+    [`child_process.spawnSync()`][].
+  * `stderr` [\<string>][<string>] The output from the child process to stderr.
+  * `stdout` [\<string>][<string>] The output from the child process to stdout.
 
-### `expectSyncExitWithoutError(child[, options])`
+### `spawnSyncAndExitWithoutError(command[, args][, spawnOptions], expectations)`
 
 Similar to `expectSyncExit()` with the `status` expected to be 0 and
 `signal` expected to be `null`. Any other optional options are passed
@@ -1160,6 +1164,7 @@ See [the WPT tests README][] for details.
 [<number>]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type
 [<string>]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type
 [Web Platform Tests]: https://github.com/web-platform-tests/wpt
+[`child_process.spawnSync()`]: ../../doc/api/child_process.md#child_processspawnsynccommand-args-options
 [`hijackstdio.hijackStdErr()`]: #hijackstderrlistener
 [`hijackstdio.hijackStdOut()`]: #hijackstdoutlistener
 [internationalization]: ../../doc/api/intl.md

--- a/test/common/child_process.js
+++ b/test/common/child_process.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { spawnSync } = require('child_process');
 const common = require('./');
 const util = require('util');
 
@@ -111,11 +112,21 @@ function expectSyncExit(child, {
   return { child, stderr: stderrStr, stdout: stdoutStr };
 }
 
-function expectSyncExitWithoutError(child, options) {
+function spawnSyncAndExit(...args) {
+  const spawnArgs = args.slice(0, args.length - 1);
+  const expectations = args[args.length - 1];
+  const child = spawnSync(...spawnArgs);
+  return expectSyncExit(child, expectations);
+}
+
+function spawnSyncAndExitWithoutError(...args) {
+  const spawnArgs = args.slice(0, args.length);
+  const expectations = args[args.length - 1];
+  const child = spawnSync(...spawnArgs);
   return expectSyncExit(child, {
     status: 0,
     signal: null,
-    ...options,
+    ...expectations,
   });
 }
 
@@ -124,6 +135,6 @@ module.exports = {
   logAfterTime,
   kExpiringChildRunTime,
   kExpiringParentTimer,
-  expectSyncExit,
-  expectSyncExitWithoutError,
+  spawnSyncAndExit,
+  spawnSyncAndExitWithoutError,
 };

--- a/test/common/child_process.js
+++ b/test/common/child_process.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const { spawnSync } = require('child_process');
+const { spawnSync, execFileSync } = require('child_process');
 const common = require('./');
 const util = require('util');
 
@@ -15,14 +15,13 @@ function cleanupStaleProcess(filename) {
   process.once('beforeExit', () => {
     const basename = filename.replace(/.*[/\\]/g, '');
     try {
-      require('child_process')
-        .execFileSync(`${process.env.SystemRoot}\\System32\\wbem\\WMIC.exe`, [
-          'process',
-          'where',
-          `commandline like '%${basename}%child'`,
-          'delete',
-          '/nointeractive',
-        ]);
+      execFileSync(`${process.env.SystemRoot}\\System32\\wbem\\WMIC.exe`, [
+        'process',
+        'where',
+        `commandline like '%${basename}%child'`,
+        'delete',
+        '/nointeractive',
+      ]);
     } catch {
       // Ignore failures, there might not be any stale process to clean up.
     }

--- a/test/parallel/test-snapshot-api.js
+++ b/test/parallel/test-snapshot-api.js
@@ -4,10 +4,9 @@
 
 require('../common');
 const assert = require('assert');
-const { spawnSync } = require('child_process');
 const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
-const { expectSyncExitWithoutError } = require('../common/child_process');
+const { spawnSyncAndExitWithoutError } = require('../common/child_process');
 const fs = require('fs');
 
 const v8 = require('v8');
@@ -29,7 +28,7 @@ const entry = fixtures.path('snapshot', 'v8-startup-snapshot-api.js');
     fs.writeFileSync(tmpdir.resolve(book), content, 'utf8');
   }
   fs.copyFileSync(entry, tmpdir.resolve('entry.js'));
-  const child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--build-snapshot',
@@ -37,14 +36,12 @@ const entry = fixtures.path('snapshot', 'v8-startup-snapshot-api.js');
   ], {
     cwd: tmpdir.path
   });
-
-  expectSyncExitWithoutError(child);
   const stats = fs.statSync(tmpdir.resolve('snapshot.blob'));
   assert(stats.isFile());
 }
 
 {
-  const child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     'book1',
@@ -54,9 +51,7 @@ const entry = fixtures.path('snapshot', 'v8-startup-snapshot-api.js');
       ...process.env,
       BOOK_LANG: 'en_US',
     }
-  });
-
-  expectSyncExitWithoutError(child, {
+  }, {
     stderr: 'Reading book1.en_US.txt',
     stdout: 'This is book1.en_US.txt',
     trim: true

--- a/test/parallel/test-snapshot-basic.js
+++ b/test/parallel/test-snapshot-basic.js
@@ -5,10 +5,12 @@
 
 require('../common');
 const assert = require('assert');
-const { spawnSync } = require('child_process');
 const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
-const { expectSyncExitWithoutError, expectSyncExit } = require('../common/child_process');
+const {
+  spawnSyncAndExitWithoutError,
+  spawnSyncAndExit,
+} = require('../common/child_process');
 const fs = require('fs');
 
 tmpdir.refresh();
@@ -18,14 +20,12 @@ if (!process.config.variables.node_use_node_snapshot) {
   // Check that Node.js built without an embedded snapshot
   // exits with 9 when node:embedded_snapshot_main is specified
   // as snapshot entry point.
-  const child = spawnSync(process.execPath, [
+  spawnSyncAndExit(process.execPath, [
     '--build-snapshot',
     snapshotScript,
   ], {
     cwd: tmpdir.path
-  });
-
-  expectSyncExit(child, {
+  }, {
     status: 9,
     signal: null,
     stderr: /Node\.js was built without embedded snapshot/
@@ -37,13 +37,12 @@ if (!process.config.variables.node_use_node_snapshot) {
 // By default, the snapshot blob path is cwd/snapshot.blob.
 {
   // Create the snapshot.
-  const child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--build-snapshot',
     snapshotScript,
   ], {
     cwd: tmpdir.path
   });
-  expectSyncExitWithoutError(child);
   const stats = fs.statSync(tmpdir.resolve('snapshot.blob'));
   assert(stats.isFile());
 }
@@ -52,7 +51,7 @@ tmpdir.refresh();
 const blobPath = tmpdir.resolve('my-snapshot.blob');
 {
   // Create the snapshot.
-  const child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--build-snapshot',
@@ -60,38 +59,33 @@ const blobPath = tmpdir.resolve('my-snapshot.blob');
   ], {
     cwd: tmpdir.path
   });
-  expectSyncExitWithoutError(child);
   const stats = fs.statSync(blobPath);
   assert(stats.isFile());
 }
 
 {
   // Check --help.
-  const child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--help',
   ], {
     cwd: tmpdir.path
+  }, {
+    stdout: /--help/
   });
-  expectSyncExitWithoutError(child);
-
-  assert(child.stdout.toString().includes('--help'));
 }
 
 {
   // Check -c.
-  const child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '-c',
     fixtures.path('snapshot', 'marked.js'),
   ], {
     cwd: tmpdir.path
-  });
-
-  // Check that it is a noop.
-  expectSyncExitWithoutError(child, {
+  }, {
     stderr: '',
     stdout: '',
     trim: true

--- a/test/parallel/test-snapshot-warning.js
+++ b/test/parallel/test-snapshot-warning.js
@@ -7,10 +7,9 @@
 require('../common');
 
 const assert = require('assert');
-const { spawnSync } = require('child_process');
 const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
-const { expectSyncExitWithoutError } = require('../common/child_process');
+const { spawnSyncAndExitWithoutError } = require('../common/child_process');
 const fs = require('fs');
 
 const warningScript = fixtures.path('snapshot', 'warning.js');
@@ -20,7 +19,7 @@ const empty = fixtures.path('empty.js');
 tmpdir.refresh();
 {
   console.log('\n# Check snapshot scripts that do not emit warnings.');
-  let child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--build-snapshot',
@@ -28,40 +27,36 @@ tmpdir.refresh();
   ], {
     cwd: tmpdir.path
   });
-  expectSyncExitWithoutError(child);
   const stats = fs.statSync(blobPath);
   assert(stats.isFile());
 
-  child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     warningScript,
   ], {
     cwd: tmpdir.path
-  });
-  expectSyncExitWithoutError(child, {
+  }, {
     stderr(output) {
       const match = output.match(/Warning: test warning/g);
       assert.strictEqual(match.length, 1);
       return true;
     }
   });
-
 }
 
 tmpdir.refresh();
 {
   console.log('\n# Check snapshot scripts that emit ' +
               'warnings and --trace-warnings hint.');
-  let child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--build-snapshot',
     warningScript,
   ], {
     cwd: tmpdir.path
-  });
-  expectSyncExitWithoutError(child, {
+  }, {
     stderr(output) {
       let match = output.match(/Warning: test warning/g);
       assert.strictEqual(match.length, 1);
@@ -73,15 +68,13 @@ tmpdir.refresh();
   const stats = fs.statSync(blobPath);
   assert(stats.isFile());
 
-  child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     warningScript,
   ], {
     cwd: tmpdir.path
-  });
-
-  expectSyncExitWithoutError(child, {
+  }, {
     stderr(output) {
       // Warnings should not be handled more than once.
       let match = output.match(/Warning: test warning/g);
@@ -99,7 +92,7 @@ tmpdir.refresh();
   const warningFile1 = tmpdir.resolve('warnings.txt');
   const warningFile2 = tmpdir.resolve('warnings2.txt');
 
-  let child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--redirect-warnings',
@@ -108,9 +101,7 @@ tmpdir.refresh();
     warningScript,
   ], {
     cwd: tmpdir.path
-  });
-
-  expectSyncExitWithoutError(child, {
+  }, {
     stderr(output) {
       assert.doesNotMatch(output, /Warning: test warning/);
     }
@@ -129,7 +120,7 @@ tmpdir.refresh();
     maxRetries: 3, recursive: false, force: true
   });
 
-  child = spawnSync(process.execPath, [
+  spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--redirect-warnings',
@@ -137,9 +128,7 @@ tmpdir.refresh();
     warningScript,
   ], {
     cwd: tmpdir.path
-  });
-
-  expectSyncExitWithoutError(child, {
+  }, {
     stderr(output) {
       assert.doesNotMatch(output, /Warning: test warning/);
       return true;


### PR DESCRIPTION
Replaces expectSyncExit() and expectSyncExitWithoutError(). Since
we usually just check the child process right after its spawned,
these shorthands also takes care of the spawning. This makes the
tests more concise.

---

I just realized that these shorthands may be more handy in some cases, so added them and switched to these instead (before we start to use them everywhere)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
