### PR TITLE
test: fix compiler warning in NodeCryptoEnv

### DIFF
--- a/test/cctest/test_node_crypto_env.cc
+++ b/test/cctest/test_node_crypto_env.cc
@@ -23,8 +23,9 @@ TEST_F(NodeCryptoEnv, LoadBIO) {
   Local<String> key = String::NewFromUtf8(isolate_, "abcdef").ToLocalChecked();
   node::crypto::BIOPointer bio(node::crypto::LoadBIO(*env, key));
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-  BIO_seek(bio.get(), 2);
-  ASSERT_EQ(BIO_tell(bio.get()), 2);
+  const int ofs = 2;
+  ASSERT_EQ(BIO_seek(bio.get(), ofs), ofs);
+  ASSERT_EQ(BIO_tell(bio.get()), ofs);
 #endif
   ASSERT_EQ(ERR_peek_error(), 0UL) << "There should not have left "
                                       "any errors on the OpenSSL error stack\n";


### PR DESCRIPTION
This fixes `warning: value computed is not used` when calling `BIO_seek()`:

```
../test/cctest/test_node_crypto_env.cc: In member function ‘virtual void NodeCryptoEnv_LoadBIO_Test::TestBody()’:
../deps/openssl/openssl/include/openssl/../../../config/././archs/linux-x86_64/asm/include/openssl/bio.h:495:26: warning: value computed is not used [-Wunused-value]
  495 | # define BIO_seek(b,ofs) (int)BIO_ctrl(b,BIO_C_FILE_SEEK,ofs,NULL)
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../test/cctest/test_node_crypto_env.cc:26:3: note: in expansion of macro ‘BIO_seek’
   26 |   BIO_seek(bio.get(), 2);
      |   ^~~~~~~~
```

Refs: https://github.com/nodejs/node/pull/47160

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
