### PR TITLE
src,lib: fix assert when `Error.prepareStackTrace` not overridden

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -23,8 +23,6 @@ rules:
       message: Use an error exported by the internal/errors module.
     - selector: CallExpression[callee.object.name='Error'][callee.property.name='captureStackTrace']
       message: Please use `require('internal/errors').hideStackFrames()` instead.
-    - selector: AssignmentExpression:matches([left.name='prepareStackTrace'], [left.property.name='prepareStackTrace'])
-      message: Use 'overrideStackTrace' from 'lib/internal/errors.js' instead of 'Error.prepareStackTrace'.
     - selector: ThrowStatement > NewExpression[callee.name=/^ERR_[A-Z_]+$/] > ObjectExpression:first-child:not(:has([key.name='message']):has([key.name='code']):has([key.name='syscall']))
       message: The context passed into SystemError constructor must have .code, .syscall and .message.
   no-restricted-globals:

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -65,6 +65,7 @@ const { openSync, closeSync, readSync } = require('fs');
 const { inspect } = require('internal/util/inspect');
 const { isPromise, isRegExp } = require('internal/util/types');
 const { EOL } = require('internal/constants');
+const { getEmbedderOptions } = require('internal/options');
 const { BuiltinModule } = require('internal/bootstrap/realm');
 const { isError, deprecate } = require('internal/util');
 
@@ -293,8 +294,16 @@ function getErrMessage(message, fn) {
   ErrorCaptureStackTrace(err, fn);
   if (errorStackTraceLimitIsWritable) Error.stackTraceLimit = tmpLimit;
 
-  overrideStackTrace.set(err, (_, stack) => stack);
-  const call = err.stack[0];
+  let call;
+  if (getEmbedderOptions().hasPrepareStackTraceCallback) {
+    overrideStackTrace.set(err, (_, stack) => stack);
+    call = err.stack[0];
+  } else {
+    const tmpPrepare = Error.prepareStackTrace;
+    Error.prepareStackTrace = (_, stack) => stack;
+    call = err.stack[0];
+    Error.prepareStackTrace = tmpPrepare;
+  }
 
   const filename = call.getFileName();
   const line = call.getLineNumber() - 1;

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -269,6 +269,9 @@ void SetIsolateErrorHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
     auto* prepare_stack_trace_cb = s.prepare_stack_trace_callback ?
         s.prepare_stack_trace_callback : PrepareStackTraceCallback;
     isolate->SetPrepareStackTraceCallback(prepare_stack_trace_cb);
+  } else {
+    auto env = Environment::GetCurrent(isolate);
+    env->set_prepare_stack_trace_callback(Local<Function>());
   }
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1234,6 +1234,13 @@ void GetEmbedderOptions(const FunctionCallbackInfo<Value>& args) {
   Local<Object> ret = Object::New(isolate);
 
   if (ret->Set(context,
+           FIXED_ONE_BYTE_STRING(
+            env->isolate(), "hasPrepareStackTraceCallback"),
+           Boolean::New(isolate,
+            !env->prepare_stack_trace_callback().IsEmpty()))
+      .IsNothing()) return;
+
+  if (ret->Set(context,
            FIXED_ONE_BYTE_STRING(env->isolate(), "shouldNotRegisterESMLoader"),
            Boolean::New(isolate, env->should_not_register_esm_loader()))
       .IsNothing()) return;


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/23926

Fixes an issue caused when embedders choose to set up the `v8::Isolate` without a prepareStackTrace callback. In this event, several `assert` methods stop working because [stack trace formatting](https://github.com/nodejs/node/blob/189d584244610063dfe3dd5cb8ffd439b0c17855/lib/assert.js#L292-L293) relies on a `SafeWeakMap` that's only populated in the overridden `prepareStackTrace` callback.

Fix this by exposing override status under `getEmbedderOptions`  and falling back to the default implementation of `Error.prepareStackTrace` if it's not been overridden.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
