### PR TITLE
doc: use same name in the doc as in the code

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -1219,13 +1219,13 @@ changes:
     description: This class is now exposed on the global object.
 -->
 
-#### `new ByteLengthQueuingStrategy(options)`
+#### `new ByteLengthQueuingStrategy(init)`
 
 <!-- YAML
 added: v16.5.0
 -->
 
-* `options` {Object}
+* `init` {Object}
   * `highWaterMark` {number}
 
 #### `byteLengthQueuingStrategy.highWaterMark`
@@ -1256,13 +1256,13 @@ changes:
     description: This class is now exposed on the global object.
 -->
 
-#### `new CountQueuingStrategy(options)`
+#### `new CountQueuingStrategy(init)`
 
 <!-- YAML
 added: v16.5.0
 -->
 
-* `options` {Object}
+* `init` {Object}
   * `highWaterMark` {number}
 
 #### `countQueuingStrategy.highWaterMark`

--- a/lib/internal/webstreams/queuingstrategies.js
+++ b/lib/internal/webstreams/queuingstrategies.js
@@ -69,7 +69,7 @@ class ByteLengthQueuingStrategy {
   constructor(init) {
     validateObject(init, 'init');
     if (init.highWaterMark === undefined)
-      throw new ERR_MISSING_OPTION('options.highWaterMark');
+      throw new ERR_MISSING_OPTION('init.highWaterMark');
 
     // The highWaterMark value is not checked until the strategy
     // is actually used, per the spec.
@@ -121,7 +121,7 @@ class CountQueuingStrategy {
   constructor(init) {
     validateObject(init, 'init');
     if (init.highWaterMark === undefined)
-      throw new ERR_MISSING_OPTION('options.highWaterMark');
+      throw new ERR_MISSING_OPTION('init.highWaterMark');
 
     // The highWaterMark value is not checked until the strategy
     // is actually used, per the spec.


### PR DESCRIPTION
Since the specification and code explicitly use the name  `init`, I think it would be clearer to use `init` in error message and documentation as well.

Refs: https://streams.spec.whatwg.org/#bytelengthqueuingstrategy
