### PR TITLE
src: merge env-file and env vars of `NODE_OPTIONS`

### DIFF
--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -1,6 +1,7 @@
 #include "node_dotenv.h"
 #include "env-inl.h"
 #include "node_file.h"
+#include "node_options.h"
 #include "uv.h"
 
 namespace node {
@@ -101,12 +102,15 @@ void Dotenv::ParsePath(const std::string_view path) {
   }
 }
 
-void Dotenv::AssignNodeOptionsIfAvailable(std::string* node_options) {
+void Dotenv::AssignNodeOptionsIfAvailable(std::vector<std::string>* env_argv,
+                                          std::vector<std::string>* errors) {
   auto match = store_.find("NODE_OPTIONS");
 
-  if (match != store_.end()) {
-    *node_options = match->second;
+  if (match == store_.end()) {
+    return;
   }
+
+  ParseNodeOptionsEnvVar(match->second, env_argv, errors);
 }
 
 void Dotenv::ParseLine(const std::string_view line) {

--- a/src/node_dotenv.h
+++ b/src/node_dotenv.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <optional>
+#include <vector>
 
 namespace node {
 
@@ -20,7 +21,8 @@ class Dotenv {
   ~Dotenv() = default;
 
   void ParsePath(const std::string_view path);
-  void AssignNodeOptionsIfAvailable(std::string* node_options);
+  void AssignNodeOptionsIfAvailable(std::vector<std::string>* node_options,
+                                    std::vector<std::string>* errors);
   void SetEnvironment(Environment* env);
 
   static std::optional<std::string> GetPathFromArgs(

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1316,13 +1316,12 @@ void HandleEnvOptions(std::shared_ptr<EnvironmentOptions> env_options,
     env_options->redirect_warnings = opt_getter("NODE_REDIRECT_WARNINGS");
 }
 
-std::vector<std::string> ParseNodeOptionsEnvVar(
-    const std::string& node_options, std::vector<std::string>* errors) {
-  std::vector<std::string> env_argv;
-
+void ParseNodeOptionsEnvVar(const std::string& node_options,
+                            std::vector<std::string>* env_argv,
+                            std::vector<std::string>* errors) {
   bool is_in_string = false;
   bool will_start_new_arg = true;
-  for (std::string::size_type index = 0; index < node_options.size(); ++index) {
+  for (size_t index = 0; index < node_options.size(); ++index) {
     char c = node_options.at(index);
 
     // Backslashes escape the following character
@@ -1330,7 +1329,7 @@ std::vector<std::string> ParseNodeOptionsEnvVar(
       if (index + 1 == node_options.size()) {
         errors->push_back("invalid value for NODE_OPTIONS "
                           "(invalid escape)\n");
-        return env_argv;
+        break;
       } else {
         c = node_options.at(++index);
       }
@@ -1343,10 +1342,10 @@ std::vector<std::string> ParseNodeOptionsEnvVar(
     }
 
     if (will_start_new_arg) {
-      env_argv.emplace_back(std::string(1, c));
+      env_argv->emplace_back(std::string(1, c));
       will_start_new_arg = false;
     } else {
-      env_argv.back() += c;
+      env_argv->back() += c;
     }
   }
 
@@ -1354,7 +1353,6 @@ std::vector<std::string> ParseNodeOptionsEnvVar(
     errors->push_back("invalid value for NODE_OPTIONS "
                       "(unterminated string)\n");
   }
-  return env_argv;
 }
 }  // namespace node
 

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -529,8 +529,9 @@ void HandleEnvOptions(std::shared_ptr<EnvironmentOptions> env_options);
 void HandleEnvOptions(std::shared_ptr<EnvironmentOptions> env_options,
                       std::function<std::string(const char*)> opt_getter);
 
-std::vector<std::string> ParseNodeOptionsEnvVar(
-    const std::string& node_options, std::vector<std::string>* errors);
+void ParseNodeOptionsEnvVar(const std::string& node_options,
+                            std::vector<std::string>* env_argv,
+                            std::vector<std::string>* errors);
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -537,8 +537,8 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
     if (maybe_node_opts.ToLocal(&node_opts)) {
       std::string node_options(*String::Utf8Value(isolate, node_opts));
       std::vector<std::string> errors{};
-      std::vector<std::string> env_argv =
-          ParseNodeOptionsEnvVar(node_options, &errors);
+      std::vector<std::string> env_argv{};
+      ParseNodeOptionsEnvVar(node_options, &env_argv, &errors);
       // [0] is expected to be the program name, add dummy string.
       env_argv.insert(env_argv.begin(), "");
       std::vector<std::string> invalid_args{};


### PR DESCRIPTION
Follow-up for https://github.com/nodejs/node/issues/49148. Prior to this change, we were preferring the environment variables over `.env` file. Right now, we merge them.

Ref: https://github.com/nodejs/node/issues/49148

cc @GeoffreyBooth @ljharb @tniessen @gireeshpunathil 