### PR TITLE
build: expand when we run internet tests

### DIFF
--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -8,10 +8,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - 'test/internet/**'
-      - 'internal/dns/**'
-      - 'lib/dns.js'
-      - 'lib/net.js'
+      - test/internet/**
+      - internal/dns/**
+      - lib/dns.js
+      - lib/net.js
   push:
     branches:
       - main
@@ -19,10 +19,10 @@ on:
       - v[0-9]+.x-staging
       - v[0-9]+.x
     paths:
-      - 'test/internet/**'
-      - 'internal/dns/**'
-      - 'lib/dns.js'
-      - 'lib/net.js'
+      - test/internet/**
+      - internal/dns/**
+      - lib/dns.js
+      - lib/net.js
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -7,14 +7,22 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths: [test/internet/**]
+    paths:
+      - 'test/internet/**'
+      - 'internal/dns/**'
+      - 'lib/dns.js'
+      - 'lib/net.js'
   push:
     branches:
       - main
       - canary
       - v[0-9]+.x-staging
       - v[0-9]+.x
-    paths: [test/internet/**]
+    paths:
+      - 'test/internet/**'
+      - 'internal/dns/**'
+      - 'lib/dns.js'
+      - 'lib/net.js'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/49203

Changes slipped into v18.x regressed
test/internet/test-dns-ipv6 as I assume the action did not run because no test under test/internet was changed. Add some of the common paths that include code that might introduce failures in the internet tests.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
