### PR TITLE
sea: generate code cache with deserialized isolate

### DIFF
--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -411,7 +411,7 @@ ExitCode GenerateSnapshotForSEA(const SeaConfig& config,
 
 std::optional<std::string> GenerateCodeCache(std::string_view main_path,
                                              std::string_view main_script) {
-  RAIIIsolate raii_isolate;
+  RAIIIsolate raii_isolate(SnapshotBuilder::GetEmbeddedSnapshotData());
   Isolate* isolate = raii_isolate.get();
 
   HandleScope handle_scope(isolate);
@@ -489,14 +489,19 @@ ExitCode GenerateSingleExecutableBlob(
   std::optional<std::string_view> optional_sv_code_cache;
   std::string code_cache;
   if (static_cast<bool>(config.flags & SeaFlags::kUseCodeCache)) {
-    std::optional<std::string> optional_code_cache =
-        GenerateCodeCache(config.main_path, main_script);
-    if (!optional_code_cache.has_value()) {
-      FPrintF(stderr, "Cannot generate V8 code cache\n");
-      return ExitCode::kGenericUserError;
+    if (builds_snapshot_from_main) {
+      FPrintF(stderr,
+              "\"useCodeCache\" is redundant when \"useSnapshot\" is true\n");
+    } else {
+      std::optional<std::string> optional_code_cache =
+          GenerateCodeCache(config.main_path, main_script);
+      if (!optional_code_cache.has_value()) {
+        FPrintF(stderr, "Cannot generate V8 code cache\n");
+        return ExitCode::kGenericUserError;
+      }
+      code_cache = optional_code_cache.value();
+      optional_sv_code_cache = code_cache;
     }
-    code_cache = optional_code_cache.value();
-    optional_sv_code_cache = code_cache;
   }
 
   SeaResource sea{

--- a/src/util.cc
+++ b/src/util.cc
@@ -27,6 +27,7 @@
 #include "node_buffer.h"
 #include "node_errors.h"
 #include "node_internals.h"
+#include "node_snapshot_builder.h"
 #include "node_v8_platform-inl.h"
 #include "string_bytes.h"
 #include "uv.h"
@@ -677,13 +678,16 @@ Local<String> UnionBytes::ToStringChecked(Isolate* isolate) const {
   }
 }
 
-RAIIIsolate::RAIIIsolate()
+RAIIIsolate::RAIIIsolate(const SnapshotData* data)
     : allocator_{ArrayBuffer::Allocator::NewDefaultAllocator()} {
   isolate_ = Isolate::Allocate();
   CHECK_NOT_NULL(isolate_);
   per_process::v8_platform.Platform()->RegisterIsolate(isolate_,
                                                        uv_default_loop());
   Isolate::CreateParams params;
+  if (data != nullptr) {
+    SnapshotBuilder::InitializeIsolateParams(data, &params);
+  }
   params.array_buffer_allocator = allocator_.get();
   Isolate::Initialize(isolate_, params);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -971,7 +971,7 @@ void SetConstructorFunction(v8::Isolate* isolate,
 // Simple RAII class to spin up a v8::Isolate instance.
 class RAIIIsolate {
  public:
-  RAIIIsolate();
+  explicit RAIIIsolate(const SnapshotData* data = nullptr);
   ~RAIIIsolate();
 
   v8::Isolate* get() const { return isolate_; }

--- a/test/sequential/test-single-executable-application-snapshot-and-code-cache.js
+++ b/test/sequential/test-single-executable-application-snapshot-and-code-cache.js
@@ -1,0 +1,63 @@
+'use strict';
+
+require('../common');
+
+const {
+  injectAndCodeSign,
+  skipIfSingleExecutableIsNotSupported,
+} = require('../common/sea');
+
+skipIfSingleExecutableIsNotSupported();
+
+// This tests "useCodeCache" is ignored when "useSnapshot" is true.
+
+const tmpdir = require('../common/tmpdir');
+const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const { spawnSync } = require('child_process');
+const { join } = require('path');
+const assert = require('assert');
+
+const configFile = join(tmpdir.path, 'sea-config.json');
+const seaPrepBlob = join(tmpdir.path, 'sea-prep.blob');
+const outputFile = join(tmpdir.path, process.platform === 'win32' ? 'sea.exe' : 'sea');
+
+{
+  tmpdir.refresh();
+  const code = `
+  const {
+    setDeserializeMainFunction,
+  } = require('v8').startupSnapshot;
+
+  setDeserializeMainFunction(() => {
+    console.log('Hello from snapshot');
+  });
+  `;
+
+  writeFileSync(join(tmpdir.path, 'snapshot.js'), code, 'utf-8');
+  writeFileSync(configFile, `
+  {
+    "main": "snapshot.js",
+    "output": "sea-prep.blob",
+    "useSnapshot": true,
+    "useCodeCache": true
+  }
+  `);
+
+  let child = spawnSync(
+    process.execPath,
+    ['--experimental-sea-config', 'sea-config.json'],
+    {
+      cwd: tmpdir.path
+    });
+  assert.match(
+    child.stderr.toString(),
+    /"useCodeCache" is redundant when "useSnapshot" is true/);
+
+  assert(existsSync(seaPrepBlob));
+
+  copyFileSync(process.execPath, outputFile);
+  injectAndCodeSign(outputFile, seaPrepBlob);
+
+  child = spawnSync(outputFile);
+  assert.strictEqual(child.stdout.toString().trim(), 'Hello from snapshot');
+}


### PR DESCRIPTION
V8 now requires code cache to be compiled from an isolate with the same RO space layout as the one that's going to deserialize the cache, so for a binary built with snapshot, we need to compile the code cache using a deserialized isolate.

Drive-by: ignore "useCodeCache" when "useSnapshot" is true because the compilation would've been done during build time anyway in that case, and print a warning for it.

Refs: https://github.com/nodejs/node-v8/issues/252

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
