### PR TITLE
Fix statically linking error against libopenssl.a

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -376,8 +376,8 @@
               'conditions': [
                 ['OS in "linux freebsd" and node_shared=="false"', {
                   'ldflags': [
-                    '-Wl,--whole-archive,'
-                      '<(obj_dir)/deps/openssl/<(openssl_product)',
+                    '-Wl,--whole-archive',
+                    '<(obj_dir)/deps/openssl/<(openssl_product)',
                     '-Wl,--no-whole-archive',
                   ],
                 }],


### PR DESCRIPTION
When statically linking against libopenssl.a there is a [linking error](https://github.com/ziglang/zig/issues/16813#issue-1849057023) e.g. when compiling node with CC="zig cc" and CXX="zig c++".

It looks like the ',' was mistakenly put inside the '-Wl,--whole-archive,' linker flag string, which means that the strings '-Wl,--whole-archive,' and '<(obj_dir)/deps/openssl/<(openssl_product)' will just get appended without a space character in between causing
the linking step to fail.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
