### PR TITLE
src: remove unused function `GetName()` in node_perf

### DIFF
--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -265,7 +265,7 @@ void CreateELDHistogram(const FunctionCallbackInfo<Value>& args) {
       IntervalHistogram::Create(env, interval, [](Histogram& histogram) {
         uint64_t delta = histogram.RecordDelta();
         TRACE_COUNTER1(TRACING_CATEGORY_NODE2(perf, event_loop),
-                      "delay", delta);
+                        "delay", delta);
         TRACE_COUNTER1(TRACING_CATEGORY_NODE2(perf, event_loop),
                       "min", histogram.Min());
         TRACE_COUNTER1(TRACING_CATEGORY_NODE2(perf, event_loop),

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -236,18 +236,6 @@ static void RemoveGarbageCollectionTracking(
   GarbageCollectionCleanupHook(env);
 }
 
-// Gets the name of a function
-inline Local<Value> GetName(Local<Function> fn) {
-  Local<Value> val = fn->GetDebugName();
-  if (val.IsEmpty() || val->IsUndefined()) {
-    Local<Value> boundFunction = fn->GetBoundFunction();
-    if (!boundFunction.IsEmpty() && !boundFunction->IsUndefined()) {
-      val = GetName(boundFunction.As<Function>());
-    }
-  }
-  return val;
-}
-
 // Notify a custom PerformanceEntry to observers
 void Notify(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -277,7 +265,7 @@ void CreateELDHistogram(const FunctionCallbackInfo<Value>& args) {
       IntervalHistogram::Create(env, interval, [](Histogram& histogram) {
         uint64_t delta = histogram.RecordDelta();
         TRACE_COUNTER1(TRACING_CATEGORY_NODE2(perf, event_loop),
-                        "delay", delta);
+                      "delay", delta);
         TRACE_COUNTER1(TRACING_CATEGORY_NODE2(perf, event_loop),
                       "min", histogram.Min());
         TRACE_COUNTER1(TRACING_CATEGORY_NODE2(perf, event_loop),


### PR DESCRIPTION
I looked through the code, but couldn't find where `GetName()` is used.
Both test and build passed, I think it can be deleted.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
