### PR TITLE
doc: edit `import.meta.resolve` documentation

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -329,6 +329,9 @@ added:
   - v13.9.0
   - v12.16.2
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/49028
+    description: No longer behind the `--experimental-import-meta-resolve` flag.
   - version: v20.0.0
     pr-url: https://github.com/nodejs/node/pull/44710
     description: This API now returns a string synchronously instead of a Promise.
@@ -348,7 +351,7 @@ changes:
 
 * `specifier` {string} The module specifier to resolve relative to the
   current module.
-* Returns: {string} The absolute (`file:`) URL string for the resolved module.
+* Returns: {string} The absolute URL string that the specifier would resolve to.
 
 [`import.meta.resolve`][] is a module-relative resolution function scoped to
 each module, returning the URL string.
@@ -356,18 +359,16 @@ each module, returning the URL string.
 ```js
 const dependencyAsset = import.meta.resolve('component-lib/asset.css');
 // file:///app/node_modules/component-lib/asset.css
+import.meta.resolve('./dep');
+// file:///app/dep
 ```
 
 All features of the Node.js module resolution are supported. Dependency
 resolutions are subject to the permitted exports resolutions within the package.
 
-```js
-import.meta.resolve('./dep', import.meta.url);
-// file:///app/dep
-```
-
 > **Caveat** This can result in synchronous file-system operations, which
-> can impact performance similarly to `require.resolve`.
+> can impact performance similarly to `require.resolve`. This feature is not
+> available within custom loaders (it would create a deadlock).
 
 Previously, Node.js implemented an asynchronous resolver which also permitted
 a second contextual argument. The implementation has since been updated to be
@@ -375,9 +376,6 @@ synchronous, with the second contextual `parent` argument still accessible
 behind the `--experimental-import-meta-resolve` flag:
 
 * `parent` {string|URL} An optional absolute parent module URL to resolve from.
-
-> **Caveat** This feature is not available within module customization hooks (it
-> would create a deadlock).
 
 ## Interoperability with CommonJS
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -359,23 +359,27 @@ each module, returning the URL string.
 ```js
 const dependencyAsset = import.meta.resolve('component-lib/asset.css');
 // file:///app/node_modules/component-lib/asset.css
-import.meta.resolve('./dep');
-// file:///app/dep
+import.meta.resolve('./dep.js');
+// file:///app/dep.js
 ```
 
 All features of the Node.js module resolution are supported. Dependency
 resolutions are subject to the permitted exports resolutions within the package.
 
-> **Caveat** This can result in synchronous file-system operations, which
-> can impact performance similarly to `require.resolve`. This feature is not
-> available within custom loaders (it would create a deadlock).
+**Caveats**:
 
-Previously, Node.js implemented an asynchronous resolver which also permitted
-a second contextual argument. The implementation has since been updated to be
-synchronous, with the second contextual `parent` argument still accessible
-behind the `--experimental-import-meta-resolve` flag:
+* This can result in synchronous file-system operations, which
+  can impact performance similarly to `require.resolve`.
+* This feature is not available within custom loaders (it would
+  create a deadlock).
+
+**Non-standard API**:
+
+When using the `--experimental-import-meta-resolve` flag, that function accepts
+a second argument:
 
 * `parent` {string|URL} An optional absolute parent module URL to resolve from.
+  **Default:** `import.meta.url`
 
 ## Interoperability with CommonJS
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -329,7 +329,7 @@ added:
   - v13.9.0
   - v12.16.2
 changes:
-  - version: REPLACEME
+  - version: 20.6.0
     pr-url: https://github.com/nodejs/node/pull/49028
     description: No longer behind the `--experimental-import-meta-resolve` flag.
   - version: v20.0.0


### PR DESCRIPTION
- add missing history entry.
- fix the return value description:
  - The return value doesn't have to be a `file:` URL, it can be of any scheme.
  - The return value doesn't have to correspond to a module, it can be a directory or something that doesn't exist.
- merge the two code examples, remove the use of the non-standard second argument.
- merge the two caveats.
- do not mention the old implementation, the history section is already there for that.

Refs: https://github.com/nodejs/node/pull/49028
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
