### PR TITLE
doc: add signature for `module.register`

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1715,14 +1715,14 @@ for ESM specifiers is [commonjs-extension-resolution-loader][].
 [`import`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 [`initialize`]: #initialize
 [`module.createRequire()`]: module.md#modulecreaterequirefilename
-[`module.register()`]: module.md#moduleregister
+[`module.register()`]: module.md#moduleregisterspecifier-parenturl-options
 [`module.syncBuiltinESMExports()`]: module.md#modulesyncbuiltinesmexports
 [`package.json`]: packages.md#nodejs-packagejson-field-definitions
 [`port.postMessage`]: worker_threads.md#portpostmessagevalue-transferlist
 [`port.ref()`]: https://nodejs.org/dist/latest-v17.x/docs/api/worker_threads.html#portref
 [`port.unref()`]: https://nodejs.org/dist/latest-v17.x/docs/api/worker_threads.html#portunref
 [`process.dlopen`]: process.md#processdlopenmodule-filename-flags
-[`register`]: module.md#moduleregister
+[`register`]: module.md#moduleregisterspecifier-parenturl-options
 [`string`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
 [`util.TextDecoder`]: util.md#class-utiltextdecoder
 [cjs-module-lexer]: https://github.com/nodejs/cjs-module-lexer/tree/1.2.2

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -80,15 +80,29 @@ isBuiltin('fs'); // true
 isBuiltin('wss'); // false
 ```
 
-### `module.register()`
+### `module.register(specifier[, parentURL][, options])`
 
 <!-- YAML
 added: REPLACEME
 -->
 
-In addition to using the `--experimental-loader` option in the CLI,
-loaders can be registered programmatically using the
-`module.register()` method.
+> Stability: 1.1 - Active development
+
+* `specifier` {string} Customization hooks to be registered; this should be the
+  same string that would be passed to `import()`, except that if it is relative,
+  it is resolved relative to `parentURL`.
+* `parentURL` {string} If you want to resolve `specifier` relative to a base
+  URL, such as `import.meta.url`, you can pass that URL here. **Default:**
+  `'data:'`
+* `options` {Object}
+  * `data` {any} Any arbitrary, cloneable JavaScript value to pass into the
+    [`initialize`][] hook.
+  * `transferList` {Object\[]} [transferrable objects][] to be passed into the
+    `initialize` hook.
+* Returns: {any} returns whatever was returned by the `initialize` hook.
+
+Register a module that exports hooks that customize Node.js module resolution
+and loading behavior.
 
 ```mjs
 import { register } from 'node:module';
@@ -390,3 +404,4 @@ returned object contains the following keys:
 [`module`]: modules.md#the-module-object
 [module wrapper]: modules.md#the-module-wrapper
 [source map include directives]: https://sourcemaps.info/spec.html#h.lmz475t4mvbx
+[transferrable objects]: worker_threads.md#portpostmessagevalue-transferlist


### PR DESCRIPTION
In the recent PRs that created `register`, we neglected to define its signature. @nodejs/loaders 