### PR TITLE
doc: update description of `percent_encode` set in `WHATWG API`

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -1740,18 +1740,18 @@ The WHATWG algorithm defines four "percent-encode sets" that describe ranges
 of characters that must be percent-encoded:
 
 * The _C0 control percent-encode set_ includes code points in range U+0000 to
-  U+001F (inclusive) and all code points greater than U+007E.
+  U+001F (inclusive) and all code points greater than U+007E (~).
 
 * The _fragment percent-encode set_ includes the _C0 control percent-encode set_
-  and code points U+0020, U+0022, U+003C, U+003E, and U+0060.
+  and code points U+0020 SPACE, U+0022 ("), U+003C (<), U+003E (>), and U+0060 (`).
 
 * The _path percent-encode set_ includes the _C0 control percent-encode set_
-  and code points U+0020, U+0022, U+0023, U+003C, U+003E, U+003F, U+0060,
-  U+007B, and U+007D.
+  and code points U+0020 SPACE, U+0022 ("), U+0023 (#), U+003C (<), U+003E (>),
+  U+003F (?), U+0060 (`), U+007B ({), and U+007D (}).
 
 * The _userinfo encode set_ includes the _path percent-encode set_ and code
-  points U+002F, U+003A, U+003B, U+003D, U+0040, U+005B, U+005C, U+005D,
-  U+005E, and U+007C.
+  points U+002F (/), U+003A (:), U+003B (;), U+003D (=), U+0040 (@),
+  U+005B ([) to U+005E(^), and U+007C (|).
 
 The _userinfo percent-encode set_ is used exclusively for username and
 passwords encoded within the URL. The _path percent-encode set_ is used for the

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -1740,18 +1740,19 @@ The WHATWG algorithm defines four "percent-encode sets" that describe ranges
 of characters that must be percent-encoded:
 
 * The _C0 control percent-encode set_ includes code points in range U+0000 to
-  U+001F (inclusive) and all code points greater than U+007E (~).
+  U+001F (inclusive) and all code points greater than U+007E (\~).
 
 * The _fragment percent-encode set_ includes the _C0 control percent-encode set_
-  and code points U+0020 SPACE, U+0022 ("), U+003C (<), U+003E (>), and U+0060 (`).
+  and code points U+0020 SPACE, U+0022 ("), U+003C (<), U+003E (>),
+  and U+0060 (\`).
 
 * The _path percent-encode set_ includes the _C0 control percent-encode set_
   and code points U+0020 SPACE, U+0022 ("), U+0023 (#), U+003C (<), U+003E (>),
-  U+003F (?), U+0060 (`), U+007B ({), and U+007D (}).
+  U+003F (?), U+0060 (\`), U+007B ({), and U+007D (}).
 
 * The _userinfo encode set_ includes the _path percent-encode set_ and code
   points U+002F (/), U+003A (:), U+003B (;), U+003D (=), U+0040 (@),
-  U+005B ([) to U+005E(^), and U+007C (|).
+  U+005B (\[) to U+005E(^), and U+007C (|).
 
 The _userinfo percent-encode set_ is used exclusively for username and
 passwords encoded within the URL. The _path percent-encode set_ is used for the


### PR DESCRIPTION
The character code is shown in the description of percent-encoded-bytes in the `WHATWG URL` Spec.
I think it would be better for readability to show the 'character code' the same as the `WHATWG URL`.

Refs: https://url.spec.whatwg.org/#percent-encoded-bytes

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
