### PR TITLE
doc: use NODE_API_SUPPORTED_VERSION_MAX in release doc

### DIFF
--- a/doc/contributing/releases-node-api.md
+++ b/doc/contributing/releases-node-api.md
@@ -9,7 +9,7 @@ release process.
   * [0. Pre-release steps](#0-pre-release-steps)
   * [1. Update the main branch](#1-update-the-main-branch)
   * [2. Create a new branch for the release](#2-create-a-new-branch-for-the-release)
-  * [3. Update `NAPI_VERSION`](#3-update-napi_version)
+  * [3. Update `NODE_API_SUPPORTED_VERSION_MAX`](#3-update-node_api_supported_version_max)
   * [4. Define `addon_context_register_func`](#4-define-addon_context_register_func)
   * [5. Update version guards](#5-update-version-guards)
   * [6. Create release commit](#6-create-release-commit)
@@ -55,13 +55,13 @@ Create a new branch named `node-api-x-proposal`, off the main branch.
 git checkout -b node-api-10-proposal upstream/main
 ```
 
-### 3. Update `NAPI_VERSION`
+### 3. Update `NODE_API_SUPPORTED_VERSION_MAX`
 
 Set the version for the proposed release using the following macros, which are
 already defined in `src/node_version.h`:
 
 ```c
-#define NAPI_VERSION x
+#define NODE_API_SUPPORTED_VERSION_MAX x
 ```
 
 > Note: Do not update the `NAPI_VERSION` defined in `src/js_native_api.h`. It


### PR DESCRIPTION
Update the doc for the changes in https://github.com/nodejs/node/pull/48501.