### PR TITLE
test: verify dynamic import call with absolute path strings

### DIFF
--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -65,5 +65,9 @@ function expectFsNamespace(result) {
     expectModuleError(import('C:\\example\\foo.mjs'),
                       'ERR_UNSUPPORTED_ESM_URL_SCHEME',
                       msg);
+  } else {
+    // If the specifier is an absolute path string without a scheme, it should
+    // be treated as a file URL.
+    expectOkNamespace(import(absolutePath));
   }
 })();

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -65,9 +65,8 @@ function expectFsNamespace(result) {
     expectModuleError(import('C:\\example\\foo.mjs'),
                       'ERR_UNSUPPORTED_ESM_URL_SCHEME',
                       msg);
-  } else {
-    // If the specifier is an absolute path string without a scheme, it should
-    // be treated as a file URL.
-    expectOkNamespace(import(absolutePath));
   }
+  // If the specifier is an origin-relative URL, it should
+  // be treated as a file: URL.
+  expectOkNamespace(import(targetURL.pathname));
 })();


### PR DESCRIPTION
Add a test case that verifies that the dynamic import call can resolve absolute path strings without a scheme as the specifier.

Refs: https://github.com/nodejs/node/pull/48655