### PR TITLE
src: allow embedders to override NODE_MODULE_VERSION

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -83,13 +83,20 @@
  * We will, at times update the version of V8 shipped in the release line
  * if it can be made ABI compatible with the previous version.
  *
+ * Embedders building Node.js can define NODE_EMBEDDER_MODULE_VERSION to
+ * override the default value of NODE_MODULE_VERSION.
+ *
  * The registry of used NODE_MODULE_VERSION numbers is located at
  *   https://github.com/nodejs/node/blob/HEAD/doc/abi_version_registry.json
  * Extenders, embedders and other consumers of Node.js that require ABI
  * version matching should open a pull request to reserve a number in this
  * registry.
  */
+#if defined(NODE_EMBEDDER_MODULE_VERSION)
+#define NODE_MODULE_VERSION NODE_EMBEDDER_MODULE_VERSION
+#else
 #define NODE_MODULE_VERSION 115
+#endif
 
 // The NAPI_VERSION supported by the runtime. This is the inclusive range of
 // versions which the Node.js binary being built supports.


### PR DESCRIPTION
Node encourages embedders to define their own `node_module_version`, but currently the only way to modify the number is to edit the `src/node_version.h` file, which means anyone who wants to embed Node has also to fork Node, sometime merely to edit the `src/node_version.h` file.

This PR adds a new `NODE_EMBEDDER_MODULE_VERSION` macro, which allows embedders to override `NODE_MODULE_VERSION` without patching Node.