### PR TITLE
bootstrap: only use the isolate snapshot when compiling code cache

### DIFF
--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -975,21 +975,8 @@ ExitCode BuildSnapshotWithoutCodeCache(
 ExitCode BuildCodeCacheFromSnapshot(SnapshotData* out,
                                     const std::vector<std::string>& args,
                                     const std::vector<std::string>& exec_args) {
-  std::vector<std::string> errors;
-  auto data_wrapper = out->AsEmbedderWrapper();
-  auto setup = CommonEnvironmentSetup::CreateFromSnapshot(
-      per_process::v8_platform.Platform(),
-      &errors,
-      data_wrapper.get(),
-      args,
-      exec_args);
-  if (!setup) {
-    for (const auto& err : errors)
-      fprintf(stderr, "%s: %s\n", args[0].c_str(), err.c_str());
-    return ExitCode::kBootstrapFailure;
-  }
-
-  Isolate* isolate = setup->isolate();
+  RAIIIsolate raii_isolate(out);
+  Isolate* isolate = raii_isolate.get();
   v8::Locker locker(isolate);
   Isolate::Scope isolate_scope(isolate);
   HandleScope handle_scope(isolate);
@@ -1002,12 +989,14 @@ ExitCode BuildCodeCacheFromSnapshot(SnapshotData* out,
     }
   });
 
-  Environment* env = setup->env();
+  Local<Context> context = Context::New(isolate);
+  Context::Scope context_scope(context);
+  builtins::BuiltinLoader builtin_loader;
   // Regenerate all the code cache.
-  if (!env->builtin_loader()->CompileAllBuiltins(setup->context())) {
+  if (!builtin_loader.CompileAllBuiltins(context)) {
     return ExitCode::kGenericUserError;
   }
-  env->builtin_loader()->CopyCodeCache(&(out->code_cache));
+  builtin_loader.CopyCodeCache(&(out->code_cache));
   if (per_process::enabled_debug_list.enabled(DebugCategory::MKSNAPSHOT)) {
     for (const auto& item : out->code_cache) {
       std::string size_str = FormatSize(item.data.length);


### PR DESCRIPTION
We do not actually need to deserialize the context and the whole environment to compile the code cache, since code cache are not context-dependent anyway, deserializing just the isolate snapshot is enough.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
