### PR TITLE
update fs doc for filter

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1003,6 +1003,15 @@ changes:
   * `filter` {Function} Function to filter copied files/directories. Return
     `true` to copy the item, `false` to ignore it. Can also return a `Promise`
     that resolves to `true` or `false` **Default:** `undefined`.
+
+    When using the `recursive` option, please note the following caveat:
+
+    If the filter function is configured to skip certain files based on a
+    condition, and you are performing a recursive copy operation, be aware that
+    directories that do not match the filter condition will also be skipped.
+    This is because the filter function is applied to both files and
+    directories during recursion.
+
     * `src` {string} source path to copy.
     * `dest` {string} destination path to copy to.
     * Returns: {boolean|Promise}
@@ -2353,6 +2362,15 @@ changes:
   * `filter` {Function} Function to filter copied files/directories. Return
     `true` to copy the item, `false` to ignore it. Can also return a `Promise`
     that resolves to `true` or `false` **Default:** `undefined`.
+
+    When using the `recursive` option, please note the following caveat:
+
+    If the filter function is configured to skip certain files based on a
+    condition, and you are performing a recursive copy operation, be aware that
+    directories that do not match the filter condition will also be skipped.
+    This is because the filter function is applied to both files and
+    directories during recursion.
+
     * `src` {string} source path to copy.
     * `dest` {string} destination path to copy to.
     * Returns: {boolean|Promise}
@@ -5279,6 +5297,15 @@ changes:
     exists, throw an error. **Default:** `false`.
   * `filter` {Function} Function to filter copied files/directories. Return
     `true` to copy the item, `false` to ignore it. **Default:** `undefined`
+
+    When using the `recursive` option, please note the following caveat:
+
+    If the filter function is configured to skip certain files based on a
+    condition, and you are performing a recursive copy operation, be aware that
+    directories that do not match the filter condition will also be skipped.
+    This is because the filter function is applied to both files and
+    directories during recursion.
+
     * `src` {string} source path to copy.
     * `dest` {string} destination path to copy to.
     * Returns: {boolean}

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1001,17 +1001,9 @@ changes:
   * `errorOnExist` {boolean} when `force` is `false`, and the destination
     exists, throw an error. **Default:** `false`.
   * `filter` {Function} Function to filter copied files/directories. Return
-    `true` to copy the item, `false` to ignore it. Can also return a `Promise`
+    `true` to copy the item, `false` to ignore it. When ignoring a directory,
+    all of its contents will be skipped as well. Can also return a `Promise`
     that resolves to `true` or `false` **Default:** `undefined`.
-
-    When using the `recursive` option, please note the following caveat:
-
-    If the filter function is configured to skip certain files based on a
-    condition, and you are performing a recursive copy operation, be aware that
-    directories that do not match the filter condition will also be skipped.
-    This is because the filter function is applied to both files and
-    directories during recursion.
-
     * `src` {string} source path to copy.
     * `dest` {string} destination path to copy to.
     * Returns: {boolean|Promise}
@@ -2360,17 +2352,9 @@ changes:
   * `errorOnExist` {boolean} when `force` is `false`, and the destination
     exists, throw an error. **Default:** `false`.
   * `filter` {Function} Function to filter copied files/directories. Return
-    `true` to copy the item, `false` to ignore it. Can also return a `Promise`
+    `true` to copy the item, `false` to ignore it. When ignoring a directory,
+    all of its contents will be skipped as well. Can also return a `Promise`
     that resolves to `true` or `false` **Default:** `undefined`.
-
-    When using the `recursive` option, please note the following caveat:
-
-    If the filter function is configured to skip certain files based on a
-    condition, and you are performing a recursive copy operation, be aware that
-    directories that do not match the filter condition will also be skipped.
-    This is because the filter function is applied to both files and
-    directories during recursion.
-
     * `src` {string} source path to copy.
     * `dest` {string} destination path to copy to.
     * Returns: {boolean|Promise}
@@ -5296,16 +5280,8 @@ changes:
   * `errorOnExist` {boolean} when `force` is `false`, and the destination
     exists, throw an error. **Default:** `false`.
   * `filter` {Function} Function to filter copied files/directories. Return
-    `true` to copy the item, `false` to ignore it. **Default:** `undefined`
-
-    When using the `recursive` option, please note the following caveat:
-
-    If the filter function is configured to skip certain files based on a
-    condition, and you are performing a recursive copy operation, be aware that
-    directories that do not match the filter condition will also be skipped.
-    This is because the filter function is applied to both files and
-    directories during recursion.
-
+    `true` to copy the item, `false` to ignore it. When ignoring a directory,
+    all of its contents will be skipped as well. **Default:** `undefined`
     * `src` {string} source path to copy.
     * `dest` {string} destination path to copy to.
     * Returns: {boolean}


### PR DESCRIPTION
Updating doc for `fs.cp`, `fsPromises.cp` and `fs.cpSync`.

Added the caveat that filter will be applied to both files and dirs. 

Fixes: https://github.com/nodejs/node/issues/49092 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
