### PR TITLE
fs: deprecate file handle `close`

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -215,6 +215,7 @@ class FileHandle extends EventEmitter {
   }
 
   close = () => {
+    throw new Error('lets see what breaks and what needed to be removed');
     if (this[kFd] === -1) {
       return PromiseResolve();
     }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -1111,4 +1111,5 @@ module.exports = {
   FileHandle,
   kRef,
   kUnref,
+  kRefs,
 };

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -215,7 +215,6 @@ class FileHandle extends EventEmitter {
   }
 
   close = () => {
-    throw new Error('lets see what breaks and what needed to be removed');
     if (this[kFd] === -1) {
       return PromiseResolve();
     }

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -41,6 +41,7 @@ const kIsPerformingIO = Symbol('kIsPerformingIO');
 
 const kFs = Symbol('kFs');
 const kHandle = Symbol('kHandle');
+const kCloseWithoutDeprecation = Symbol('kCloseWithoutDeprecation');
 
 function _construct(callback) {
   const stream = this;
@@ -152,7 +153,7 @@ function importFd(stream, options) {
     stream[kHandle] = options.fd;
     stream[kFs] = FileHandleOperations(stream[kHandle]);
     stream[kFs].ref();
-    options.fd.on('close', FunctionPrototypeBind(stream.close, stream));
+    options.fd.on('close', FunctionPrototypeBind(stream[kCloseWithoutDeprecation], stream));
     return options.fd.fd;
   }
 
@@ -308,8 +309,11 @@ ReadStream.prototype._destroy = function(err, cb) {
   }
 };
 
-ReadStream.prototype.close = function(cb) {
-  // Throw new Error('ReadStream.prototype.close lets see what breaks and what needed to be removed');
+ReadStream.prototype.close = deprecate(function(cb) {
+  this[kCloseWithoutDeprecation](cb);
+}, 'ReadStream.prototype.close() is deprecated', '===TODO===');
+
+ReadStream.prototype[kCloseWithoutDeprecation] = function(cb) {
   if (typeof cb === 'function') finished(this, cb);
   this.destroy();
 };
@@ -477,9 +481,11 @@ WriteStream.prototype._destroy = function(err, cb) {
   }
 };
 
-WriteStream.prototype.close = function(cb) {
-  // Throw new Error('WriteStream.prototype.close lets see what breaks and what needed to be removed');
+WriteStream.prototype.close = deprecate(function(cb) {
+  this[kCloseWithoutDeprecation](cb);
+}, 'WriteStream.prototype.close() is deprecated', '===TODO===');
 
+WriteStream.prototype[kCloseWithoutDeprecation] = function(cb) {
   if (cb) {
     if (this.closed) {
       process.nextTick(cb);

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -120,7 +120,9 @@ function close(stream, err, cb) {
     return;
   }
 
-  if(stream[kHandle]?.[kRefs] > 1) {
+  // Greater than 2 as when file handle is being created the refs is 1
+  // and when the stream is using that file handle the refs is 2
+  if(stream[kHandle]?.[kRefs] > 2) {
     stream[kFs].unref();
     cb();
     return;
@@ -149,6 +151,7 @@ function importFd(stream, options) {
     }
     stream[kHandle] = options.fd;
     stream[kFs] = FileHandleOperations(stream[kHandle]);
+    stream[kFs].ref();
     options.fd.on('close', FunctionPrototypeBind(stream.close, stream));
     return options.fd.fd;
   }

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -106,11 +106,11 @@ const FileHandleOperations = (handle) => {
                            (err) => cb(err, 0, buffers));
     },
     ref: (fd) => {
-        handle[kRef]();
+      handle[kRef]();
     },
     unref: (fd) => {
-        handle[kUnref]();
-    }
+      handle[kUnref]();
+    },
   };
 };
 
@@ -122,7 +122,7 @@ function close(stream, err, cb) {
 
   // Greater than 2 as when file handle is being created the refs is 1
   // and when the stream is using that file handle the refs is 2
-  if(stream[kHandle]?.[kRefs] > 2) {
+  if (stream[kHandle]?.[kRefs] > 2) {
     stream[kFs].unref();
     cb();
     return;
@@ -309,7 +309,7 @@ ReadStream.prototype._destroy = function(err, cb) {
 };
 
 ReadStream.prototype.close = function(cb) {
-  // throw new Error('ReadStream.prototype.close lets see what breaks and what needed to be removed');
+  // Throw new Error('ReadStream.prototype.close lets see what breaks and what needed to be removed');
   if (typeof cb === 'function') finished(this, cb);
   this.destroy();
 };
@@ -478,7 +478,7 @@ WriteStream.prototype._destroy = function(err, cb) {
 };
 
 WriteStream.prototype.close = function(cb) {
-  // throw new Error('WriteStream.prototype.close lets see what breaks and what needed to be removed');
+  // Throw new Error('WriteStream.prototype.close lets see what breaks and what needed to be removed');
 
   if (cb) {
     if (this.closed) {

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -294,6 +294,7 @@ ReadStream.prototype._destroy = function(err, cb) {
 };
 
 ReadStream.prototype.close = function(cb) {
+  throw new Error('ReadStream.prototype.close lets see what breaks and what needed to be removed');
   if (typeof cb === 'function') finished(this, cb);
   this.destroy();
 };
@@ -462,6 +463,8 @@ WriteStream.prototype._destroy = function(err, cb) {
 };
 
 WriteStream.prototype.close = function(cb) {
+  throw new Error('WriteStream.prototype.close lets see what breaks and what needed to be removed');
+
   if (cb) {
     if (this.closed) {
       process.nextTick(cb);

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -26,7 +26,7 @@ const {
 } = require('internal/validators');
 const { errorOrDestroy } = require('internal/streams/destroy');
 const fs = require('fs');
-const { kRef, kUnref, FileHandle } = require('internal/fs/promises');
+const { kRefs, kRef, kUnref, FileHandle } = require('internal/fs/promises');
 const { Buffer } = require('buffer');
 const {
   copyObject,
@@ -105,18 +105,31 @@ const FileHandleOperations = (handle) => {
                            (r) => cb(null, r.bytesWritten, r.buffers),
                            (err) => cb(err, 0, buffers));
     },
+    ref: (fd) => {
+        handle[kRef]();
+    },
+    unref: (fd) => {
+        handle[kUnref]();
+    }
   };
 };
 
 function close(stream, err, cb) {
   if (!stream.fd) {
     cb(err);
-  } else {
-    stream[kFs].close(stream.fd, (er) => {
-      cb(er || err);
-    });
-    stream.fd = null;
+    return;
   }
+
+  if(stream[kHandle]?.[kRefs] > 1) {
+    stream[kFs].unref();
+    cb();
+    return;
+  }
+
+  stream[kFs].close(stream.fd, (er) => {
+    cb(er || err);
+  });
+  stream.fd = null;
 }
 
 function importFd(stream, options) {
@@ -136,7 +149,6 @@ function importFd(stream, options) {
     }
     stream[kHandle] = options.fd;
     stream[kFs] = FileHandleOperations(stream[kHandle]);
-    stream[kHandle][kRef]();
     options.fd.on('close', FunctionPrototypeBind(stream.close, stream));
     return options.fd.fd;
   }
@@ -294,7 +306,7 @@ ReadStream.prototype._destroy = function(err, cb) {
 };
 
 ReadStream.prototype.close = function(cb) {
-  throw new Error('ReadStream.prototype.close lets see what breaks and what needed to be removed');
+  // throw new Error('ReadStream.prototype.close lets see what breaks and what needed to be removed');
   if (typeof cb === 'function') finished(this, cb);
   this.destroy();
 };
@@ -463,7 +475,7 @@ WriteStream.prototype._destroy = function(err, cb) {
 };
 
 WriteStream.prototype.close = function(cb) {
-  throw new Error('WriteStream.prototype.close lets see what breaks and what needed to be removed');
+  // throw new Error('WriteStream.prototype.close lets see what breaks and what needed to be removed');
 
   if (cb) {
     if (this.closed) {

--- a/test/parallel/test-fs-file-handle-stream.js
+++ b/test/parallel/test-fs-file-handle-stream.js
@@ -2,57 +2,57 @@
 
 const common = require('../common');
 
-const {open, readFile} = require('node:fs/promises');
-const {pipeline} = require('node:stream/promises');
+const { open, readFile } = require('node:fs/promises');
+const { pipeline } = require('node:stream/promises');
 const path = require('path');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const tmpDir = tmpdir.path;
-const {it} = require('node:test');
+const { it } = require('node:test');
 
 tmpdir.refresh();
 
 // TODO - add test to check if can write to file handle itself after it was closed
 it('should write allow writing from the 2nd write stream of file handle after the 1st stream destroyed', async () => {
-    const filePathForHandle = path.resolve(tmpDir, 'tmp-write.txt');
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-write.txt');
 
-    // TODO - allow closing the fd when signal is aborted
-    const stream0Text = "Hello world from stream0";
-    const stream1Text = "Hello world from stream1";
+  // TODO - allow closing the fd when signal is aborted
+  const stream0Text = 'Hello world from stream0';
+  const stream1Text = 'Hello world from stream1';
 
-    const destFile = await open(filePathForHandle, 'w')
-    await destFile.truncate(stream0Text.length + stream1Text.length + 20);
+  const destFile = await open(filePathForHandle, 'w');
+  await destFile.truncate(stream0Text.length + stream1Text.length + 20);
 
-    const stream0 = destFile.createWriteStream({start: 0, autoClose: false, emitClose: false})
-    const stream1 = destFile.createWriteStream({start: stream0Text.length + 10, autoClose: false, emitClose: false})
+  const stream0 = destFile.createWriteStream({ start: 0, autoClose: false, emitClose: false });
+  const stream1 = destFile.createWriteStream({ start: stream0Text.length + 10, autoClose: false, emitClose: false });
 
-    await pipeline(stream0Text, stream0);
-    await pipeline(stream1Text, stream1);
+  await pipeline(stream0Text, stream0);
+  await pipeline(stream1Text, stream1);
 
-    stream0.destroy(new Error('destroyed'));
-    stream1.destroy(new Error('destroyed'));
+  stream0.destroy(new Error('destroyed'));
+  stream1.destroy(new Error('destroyed'));
 
-    const spaceBetween = "\x00".repeat(10);
-    const readFileData = (await readFile(filePathForHandle)).toString();
-    assert.deepStrictEqual(`${stream0Text}${spaceBetween}${stream1Text}${spaceBetween}`, readFileData);
+  const spaceBetween = '\x00'.repeat(10);
+  const readFileData = (await readFile(filePathForHandle)).toString();
+  assert.deepStrictEqual(`${stream0Text}${spaceBetween}${stream1Text}${spaceBetween}`, readFileData);
 });
 
 it('should close the file handle when no more streams referencing it', async () => {
-    const filePathForHandle = path.resolve(tmpDir, 'tmp-write.txt');
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-write.txt');
 
-    const stream0Text = "Hello world from stream0";
+  const stream0Text = 'Hello world from stream0';
 
-    const destFile = await open(filePathForHandle, 'w')
-    await destFile.truncate(stream0Text.length + 100);
+  const destFile = await open(filePathForHandle, 'w');
+  await destFile.truncate(stream0Text.length + 100);
 
-    const stream0 = destFile.createWriteStream({start: 0});
-    stream0.on('error', common.mustNotCall());
-    await pipeline(stream0Text, stream0);
+  const stream0 = destFile.createWriteStream({ start: 0 });
+  stream0.on('error', common.mustNotCall());
+  await pipeline(stream0Text, stream0);
 
-    assert.throws(() => {
-        destFile.createWriteStream({start: stream0Text.length + 10})
-    }, /ERR_OUT_OF_RANGE/);
+  assert.throws(() => {
+    destFile.createWriteStream({ start: stream0Text.length + 10 });
+  }, /ERR_OUT_OF_RANGE/);
 
-    const readFileData = (await readFile(filePathForHandle)).toString();
-    assert.deepStrictEqual(`${stream0Text}${"\x00".repeat(100)}`, readFileData);
-})
+  const readFileData = (await readFile(filePathForHandle)).toString();
+  assert.deepStrictEqual(`${stream0Text}${'\x00'.repeat(100)}`, readFileData);
+});

--- a/test/parallel/test-fs-file-handle-stream.js
+++ b/test/parallel/test-fs-file-handle-stream.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const common = require('../common');
+
+const {open, readFile} = require('node:fs/promises');
+const {pipeline} = require('node:stream/promises');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const tmpDir = tmpdir.path;
+const {it} = require('node:test');
+
+tmpdir.refresh();
+
+// TODO - add test to check if can write to file handle itself after it was closed
+it('should write allow writing from the 2nd write stream of file handle after the 1st stream destroyed', async () => {
+    const filePathForHandle = path.resolve(tmpDir, 'tmp-write.txt');
+
+    // TODO - allow closing the fd when signal is aborted
+    const stream0Text = "Hello world from stream0";
+    const stream1Text = "Hello world from stream1";
+
+    const destFile = await open(filePathForHandle, 'w')
+    await destFile.truncate(stream0Text.length + stream1Text.length + 20);
+
+    const stream0 = destFile.createWriteStream({start: 0, autoClose: false, emitClose: false})
+    const stream1 = destFile.createWriteStream({start: stream0Text.length + 10, autoClose: false, emitClose: false})
+
+    await pipeline(stream0Text, stream0);
+    await pipeline(stream1Text, stream1);
+
+    stream0.destroy(new Error('destroyed'));
+    stream1.destroy(new Error('destroyed'));
+
+    const spaceBetween = "\x00".repeat(10);
+    const readFileData = (await readFile(filePathForHandle)).toString();
+    assert.deepStrictEqual(`${stream0Text}${spaceBetween}${stream1Text}${spaceBetween}`, readFileData);
+});
+
+it('should close the file handle when no more streams referencing it', async () => {
+    const filePathForHandle = path.resolve(tmpDir, 'tmp-write.txt');
+
+    const stream0Text = "Hello world from stream0";
+
+    const destFile = await open(filePathForHandle, 'w')
+    await destFile.truncate(stream0Text.length + 100);
+
+    const stream0 = destFile.createWriteStream({start: 0});
+    stream0.on('error', common.mustNotCall());
+    await pipeline(stream0Text, stream0);
+
+    assert.throws(() => {
+        destFile.createWriteStream({start: stream0Text.length + 10})
+    }, /ERR_OUT_OF_RANGE/);
+
+    const readFileData = (await readFile(filePathForHandle)).toString();
+    assert.deepStrictEqual(`${stream0Text}${"\x00".repeat(100)}`, readFileData);
+})

--- a/test/parallel/test-fs-file-handle-stream.js
+++ b/test/parallel/test-fs-file-handle-stream.js
@@ -13,7 +13,7 @@ const { it } = require('node:test');
 tmpdir.refresh();
 
 // TODO - add test to check if can write to file handle itself after it was closed
-it('should write allow writing from the 2nd write stream of file handle after the 1st stream destroyed', async () => {
+it('should allow writing from the 2nd write stream of file handle after the 1st stream destroyed', async () => {
   const filePathForHandle = path.resolve(tmpDir, 'tmp-write.txt');
 
   // TODO - allow closing the fd when signal is aborted


### PR DESCRIPTION
> **Warning**
> 
> Work in Progress

Created after @ronag comment:

https://github.com/nodejs/node/issues/49241#issuecomment-1685716909
> `.close` should be deprecated.



---- 
same suggestion from @mcollina to remove the `.close`
- https://github.com/nodejs/node/issues/2006#issuecomment-314070986
