### PR TITLE
module: add `--module` option

### DIFF
--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -16,6 +16,7 @@ const {
 
 const experimentalNetworkImports =
   getOptionValue('--experimental-network-imports');
+const isESModule = !!getOptionValue('--module');
 const { getPackageType, getPackageScopeConfig } = require('internal/modules/esm/resolve');
 const { fileURLToPath } = require('internal/url');
 const { ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
@@ -73,6 +74,9 @@ function extname(url) {
  * @returns {string}
  */
 function getFileProtocolModuleFormat(url, context, ignoreErrors) {
+  if (isESModule)
+    return 'module';
+
   const ext = extname(url);
   if (ext === '.js') {
     return getPackageType(url) === 'module' ? 'module' : 'commonjs';

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -74,7 +74,7 @@ function extname(url) {
  * @returns {string}
  */
 function getFileProtocolModuleFormat(url, context, ignoreErrors) {
-  if (isESModule)
+  if (isESModule && context.parentURL === undefined)
     return 'module';
 
   const ext = extname(url);

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -46,12 +46,12 @@ function shouldUseESMLoader(mainPath) {
   return pkg && pkg.data.type === 'module';
 }
 
-function runMainESM(mainPath) {
+function runMainESM(mainPath, isPath = true) {
   const { loadESM } = require('internal/process/esm_loader');
   const { pathToFileURL } = require('internal/url');
 
   handleMainPromise(loadESM((esmLoader) => {
-    const main = path.isAbsolute(mainPath) ?
+    const main = isPath && path.isAbsolute(mainPath) ?
       pathToFileURL(mainPath).href : mainPath;
     return esmLoader.import(main, undefined, { __proto__: null });
   }));
@@ -73,6 +73,13 @@ async function handleMainPromise(promise) {
 // monkey-patchable code that belongs to the CJS loader (exposed by
 // `require('module')`) even when the entry point is ESM.
 function executeUserEntryPoint(main = process.argv[1]) {
+  const mainModule = getOptionValue('--module');
+  if (mainModule) {
+    const { pathToFileURL, URL } = require('internal/url');
+    const mainModuleURL = new URL(mainModule, pathToFileURL(process.cwd() + path.sep)).href;
+    return void runMainESM(mainModuleURL, false);
+  }
+
   const resolvedMain = resolveMainPath(main);
   const useESMLoader = shouldUseESMLoader(resolvedMain);
   if (useESMLoader) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -360,7 +360,8 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
     return StartExecution(env, "internal/main/watch_mode");
   }
 
-  if (!first_argv.empty() && first_argv != "-") {
+  if ((!first_argv.empty() && first_argv != "-") ||
+      env->options()->main_esm_module != "") {
     return StartExecution(env, "internal/main/run_main_module");
   }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -701,6 +701,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "ES module to preload (option can be repeated)",
             &EnvironmentOptions::preload_esm_modules,
             kAllowedInEnvvar);
+  AddOption("--module",
+            "Main ES module to load by absolute or relative URL",
+            &EnvironmentOptions::main_esm_module);
   AddOption("--interactive",
             "always enter the REPL even if stdin does not appear "
             "to be a terminal",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -211,6 +211,8 @@ class EnvironmentOptions : public Options {
 
   std::vector<std::string> preload_esm_modules;
 
+  std::string main_esm_module;
+
   std::vector<std::string> user_argv;
 
   inline DebugOptions* get_debug_options() { return &debug_options_; }


### PR DESCRIPTION
This adds an option to directly load ESM entry point by absolute or relative URL.

Allows:
```console
$ node --module file.mjs?qwe=rty#uio
$ node --module relative/url/to/file.mjs?qwe=rty#uio
$ node --module /absolute/url/to/file.mjs?qwe=rty#uio
$ node --module win32_style\\url\\to\\file.mjs?qwe=rty#uio
$ node --module file:///wellformed/url/to/file.mjs?qwe=rty#uio
$ node --module file%20with%20spaces.mjs?qwe=rty#uio
$ node --module "file with spaces.mjs?qwe=rty#uio"
$ node --experimental-network-imports --module "https://example.com/module.js"
$ node --module esm_file_without_extension?qwe=rty#uio
$ node --module "data:text/javascript,console.log(new URL(import.meta.url));"?qwe=rty#uio
```

Doesn't allow:
```console
use `node --import my-package` instead
$ node --module my-package
```

I.e. most importantly, it allows to
- load ES module as entry point with user-defined `search` and `hash`
- load ES module explicitly in ESM mode no matter what file extension it has
- load it explicitly as URL, with consistent percent-decoding

Without breaking changes to how `node path/to/file.js` works.

Might be related to: https://github.com/nodejs/node/issues/34049
Fixes: https://github.com/nodejs/node/issues/46009
Fixes: https://github.com/nodejs/node/issues/49204

I'm not sure if this is the most correct way to implement it (or if a better alternative is planned), hence draft.

cc @nodejs/modules