### PR TITLE
fs: remove redundant code in readableWebStream()

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -446,7 +446,7 @@ Reads data from the file and stores that in the given buffer.
 If the file is not modified concurrently, the end-of-file is reached when the
 number of bytes read is zero.
 
-#### `filehandle.readableWebStream(options)`
+#### `filehandle.readableWebStream([options])`
 
 <!-- YAML
 added: v17.0.0

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -282,17 +282,8 @@ class FileHandle extends EventEmitter {
         this[kHandle],
         undefined,
         { ondone: () => this[kUnref]() });
-
-      const {
-        readableStreamCancel,
-      } = require('internal/webstreams/readablestream');
-      this[kRef]();
-      this.once('close', () => {
-        readableStreamCancel(readable);
-      });
     } else {
       const {
-        readableStreamCancel,
         ReadableStream,
       } = require('internal/webstreams/readablestream');
 
@@ -319,13 +310,15 @@ class FileHandle extends EventEmitter {
           ondone();
         },
       });
-
-      this[kRef]();
-
-      this.once('close', () => {
-        readableStreamCancel(readable);
-      });
     }
+
+    const {
+      readableStreamCancel,
+    } = require('internal/webstreams/readablestream');
+    this[kRef]();
+    this.once('close', () => {
+      readableStreamCancel(readable);
+    });
 
     return readable;
   }


### PR DESCRIPTION
Remove redundant code by moving it to outside of `if/else`. Plus, make `options` optional in doc.

Below code is duplicated because it exists on both `if` and `else`.
```
    const {
      readableStreamCancel,
    } = require('internal/webstreams/readablestream');
    this[kRef]();
    this.once('close', () => {
      readableStreamCancel(readable);
    });
```
And `options` param is optional like below.
```
  /**
   * @typedef {import('../webstreams/readablestream').ReadableStream
   * } ReadableStream
   * @param {{
   *   type?: string;
   *   }} [options]
   * @returns {ReadableStream}
   */
  readableWebStream(options = kEmptyObject) {
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
