### PR TITLE
node-api: enable uncaught exceptions policy by default

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -6245,6 +6245,13 @@ napi_create_threadsafe_function(napi_env env,
   [`napi_threadsafe_function_call_js`][] provides more details.
 * `[out] result`: The asynchronous thread-safe JavaScript function.
 
+**Change History:**
+
+* Experimental (`NAPI_EXPERIMENTAL` is defined):
+
+  Uncaught exceptions thrown in `call_js_cb` is handled with the
+  [`'uncaughtException'`][] event, instead of being ignored.
+
 ### `napi_get_threadsafe_function_context`
 
 <!-- YAML
@@ -6475,6 +6482,7 @@ the add-on's file name during loading.
 [Visual Studio]: https://visualstudio.microsoft.com
 [Working with JavaScript properties]: #working-with-javascript-properties
 [Xcode]: https://developer.apple.com/xcode/
+[`'uncaughtException'`]: process.md#event-uncaughtexception
 [`Number.MAX_SAFE_INTEGER`]: https://tc39.github.io/ecma262/#sec-number.max_safe_integer
 [`Number.MIN_SAFE_INTEGER`]: https://tc39.github.io/ecma262/#sec-number.min_safe_integer
 [`Worker`]: worker_threads.md#class-worker

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -6249,7 +6249,7 @@ napi_create_threadsafe_function(napi_env env,
 
 * Experimental (`NAPI_EXPERIMENTAL` is defined):
 
-  Uncaught exceptions thrown in `call_js_cb` is handled with the
+  Uncaught exceptions thrown in `call_js_cb` are handled with the
   [`'uncaughtException'`][] event, instead of being ignored.
 
 ### `napi_get_threadsafe_function_context`

--- a/test/js-native-api/test_reference/binding.gyp
+++ b/test/js-native-api/test_reference/binding.gyp
@@ -5,6 +5,12 @@
       "sources": [
         "test_reference.c"
       ]
+    },
+    {
+      "target_name": "test_finalizer",
+      "sources": [
+        "test_finalizer.c"
+      ]
     }
   ]
 }

--- a/test/js-native-api/test_reference/test_finalizer.c
+++ b/test/js-native-api/test_reference/test_finalizer.c
@@ -1,0 +1,71 @@
+#include <assert.h>
+#include <js_native_api.h>
+#include <stdlib.h>
+#include "../common.h"
+#include "../entry_point.h"
+
+static int test_value = 1;
+static int finalize_count = 0;
+
+static void FinalizeExternalCallJs(napi_env env, void* data, void* hint) {
+  int* actual_value = data;
+  NODE_API_ASSERT_RETURN_VOID(
+      env,
+      actual_value == &test_value,
+      "The correct pointer was passed to the finalizer");
+
+  napi_ref finalizer_ref = (napi_ref)hint;
+  napi_value js_finalizer;
+  napi_value recv;
+  NODE_API_CALL_RETURN_VOID(
+      env, napi_get_reference_value(env, finalizer_ref, &js_finalizer));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_global(env, &recv));
+  NODE_API_CALL_RETURN_VOID(
+      env, napi_call_function(env, recv, js_finalizer, 0, NULL, NULL));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, finalizer_ref));
+}
+
+static napi_value CreateExternalWithJsFinalize(napi_env env,
+                                               napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
+  napi_value finalizer = args[0];
+  napi_valuetype finalizer_valuetype;
+  NODE_API_CALL(env, napi_typeof(env, finalizer, &finalizer_valuetype));
+  NODE_API_ASSERT(env,
+                  finalizer_valuetype == napi_function,
+                  "Wrong type of first argument");
+  napi_ref finalizer_ref;
+  NODE_API_CALL(env, napi_create_reference(env, finalizer, 1, &finalizer_ref));
+
+  napi_value result;
+  NODE_API_CALL(env,
+                napi_create_external(env,
+                                     &test_value,
+                                     FinalizeExternalCallJs,
+                                     finalizer_ref, /* finalize_hint */
+                                     &result));
+
+  finalize_count = 0;
+  return result;
+}
+
+EXTERN_C_START
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor descriptors[] = {
+      DECLARE_NODE_API_PROPERTY("createExternalWithJsFinalize",
+                                CreateExternalWithJsFinalize),
+  };
+
+  NODE_API_CALL(
+      env,
+      napi_define_properties(env,
+                             exports,
+                             sizeof(descriptors) / sizeof(*descriptors),
+                             descriptors));
+
+  return exports;
+}
+EXTERN_C_END

--- a/test/js-native-api/test_reference/test_finalizer.js
+++ b/test/js-native-api/test_reference/test_finalizer.js
@@ -2,7 +2,7 @@
 // Flags: --expose-gc --force-node-api-uncaught-exceptions-policy
 
 const common = require('../../common');
-const test_reference = require(`./build/${common.buildType}/test_reference`);
+const binding = require(`./build/${common.buildType}/test_finalizer`);
 const assert = require('assert');
 
 process.on('uncaughtException', common.mustCall((err) => {
@@ -11,7 +11,7 @@ process.on('uncaughtException', common.mustCall((err) => {
 
 (async function() {
   {
-    test_reference.createExternalWithJsFinalize(
+    binding.createExternalWithJsFinalize(
       common.mustCall(() => {
         throw new Error('finalizer error');
       }));

--- a/test/js-native-api/test_reference/test_reference.c
+++ b/test/js-native-api/test_reference/test_reference.c
@@ -22,20 +22,6 @@ static void FinalizeExternal(napi_env env, void* data, void* hint) {
   finalize_count++;
 }
 
-static void FinalizeExternalCallJs(napi_env env, void* data, void* hint) {
-  int *actual_value = data;
-  NODE_API_ASSERT_RETURN_VOID(env, actual_value == &test_value,
-      "The correct pointer was passed to the finalizer");
-
-  napi_ref finalizer_ref = (napi_ref)hint;
-  napi_value js_finalizer;
-  napi_value recv;
-  NODE_API_CALL_RETURN_VOID(env, napi_get_reference_value(env, finalizer_ref, &js_finalizer));
-  NODE_API_CALL_RETURN_VOID(env, napi_get_global(env, &recv));
-  NODE_API_CALL_RETURN_VOID(env, napi_call_function(env, recv, js_finalizer, 0, NULL, NULL));
-  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, finalizer_ref));
-}
-
 static napi_value CreateExternal(napi_env env, napi_callback_info info) {
   int* data = &test_value;
 
@@ -112,31 +98,6 @@ CreateExternalWithFinalize(napi_env env, napi_callback_info info) {
                            &test_value,
                            FinalizeExternal,
                            NULL, /* finalize_hint */
-                           &result));
-
-  finalize_count = 0;
-  return result;
-}
-
-static napi_value
-CreateExternalWithJsFinalize(napi_env env, napi_callback_info info) {
-  size_t argc = 1;
-  napi_value args[1];
-  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
-  napi_value finalizer = args[0];
-  napi_valuetype finalizer_valuetype;
-  NODE_API_CALL(env, napi_typeof(env, finalizer, &finalizer_valuetype));
-  NODE_API_ASSERT(env, finalizer_valuetype == napi_function, "Wrong type of first argument");
-  napi_ref finalizer_ref;
-  NODE_API_CALL(env, napi_create_reference(env, finalizer, 1, &finalizer_ref));
-
-  napi_value result;
-  NODE_API_CALL(env,
-      napi_create_external(env,
-                           &test_value,
-                           FinalizeExternalCallJs,
-                           finalizer_ref, /* finalize_hint */
                            &result));
 
   finalize_count = 0;
@@ -263,24 +224,24 @@ static napi_value ValidateDeleteBeforeFinalize(napi_env env, napi_callback_info 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NODE_API_GETTER("finalizeCount", GetFinalizeCount),
-    DECLARE_NODE_API_PROPERTY("createExternal", CreateExternal),
-    DECLARE_NODE_API_PROPERTY("createExternalWithFinalize",
-        CreateExternalWithFinalize),
-    DECLARE_NODE_API_PROPERTY("createExternalWithJsFinalize",
-        CreateExternalWithJsFinalize),
-    DECLARE_NODE_API_PROPERTY("checkExternal", CheckExternal),
-    DECLARE_NODE_API_PROPERTY("createReference", CreateReference),
-    DECLARE_NODE_API_PROPERTY("createSymbol", CreateSymbol),
-    DECLARE_NODE_API_PROPERTY("createSymbolFor", CreateSymbolFor),
-    DECLARE_NODE_API_PROPERTY("createSymbolForEmptyString", CreateSymbolForEmptyString),
-    DECLARE_NODE_API_PROPERTY("createSymbolForIncorrectLength", CreateSymbolForIncorrectLength),
-    DECLARE_NODE_API_PROPERTY("deleteReference", DeleteReference),
-    DECLARE_NODE_API_PROPERTY("incrementRefcount", IncrementRefcount),
-    DECLARE_NODE_API_PROPERTY("decrementRefcount", DecrementRefcount),
-    DECLARE_NODE_API_GETTER("referenceValue", GetReferenceValue),
-    DECLARE_NODE_API_PROPERTY("validateDeleteBeforeFinalize",
-                          ValidateDeleteBeforeFinalize),
+      DECLARE_NODE_API_GETTER("finalizeCount", GetFinalizeCount),
+      DECLARE_NODE_API_PROPERTY("createExternal", CreateExternal),
+      DECLARE_NODE_API_PROPERTY("createExternalWithFinalize",
+                                CreateExternalWithFinalize),
+      DECLARE_NODE_API_PROPERTY("checkExternal", CheckExternal),
+      DECLARE_NODE_API_PROPERTY("createReference", CreateReference),
+      DECLARE_NODE_API_PROPERTY("createSymbol", CreateSymbol),
+      DECLARE_NODE_API_PROPERTY("createSymbolFor", CreateSymbolFor),
+      DECLARE_NODE_API_PROPERTY("createSymbolForEmptyString",
+                                CreateSymbolForEmptyString),
+      DECLARE_NODE_API_PROPERTY("createSymbolForIncorrectLength",
+                                CreateSymbolForIncorrectLength),
+      DECLARE_NODE_API_PROPERTY("deleteReference", DeleteReference),
+      DECLARE_NODE_API_PROPERTY("incrementRefcount", IncrementRefcount),
+      DECLARE_NODE_API_PROPERTY("decrementRefcount", DecrementRefcount),
+      DECLARE_NODE_API_GETTER("referenceValue", GetReferenceValue),
+      DECLARE_NODE_API_PROPERTY("validateDeleteBeforeFinalize",
+                                ValidateDeleteBeforeFinalize),
   };
 
   NODE_API_CALL(env, napi_define_properties(

--- a/test/node-api/test_buffer/binding.gyp
+++ b/test/node-api/test_buffer/binding.gyp
@@ -3,6 +3,10 @@
     {
       "target_name": "test_buffer",
       "sources": [ "test_buffer.c" ]
+    },
+    {
+      "target_name": "test_finalizer",
+      "sources": [ "test_finalizer.c" ]
     }
   ]
 }

--- a/test/node-api/test_buffer/test_buffer.c
+++ b/test/node-api/test_buffer/test_buffer.c
@@ -22,17 +22,6 @@ static void noopDeleter(napi_env env, void* data, void* finalize_hint) {
   deleterCallCount++;
 }
 
-static void malignDeleter(napi_env env, void* data, void* finalize_hint) {
-  NODE_API_ASSERT_RETURN_VOID(env, data != NULL && strcmp(data, theText) == 0, "invalid data");
-  napi_ref finalizer_ref = (napi_ref)finalize_hint;
-  napi_value js_finalizer;
-  napi_value recv;
-  NODE_API_CALL_RETURN_VOID(env, napi_get_reference_value(env, finalizer_ref, &js_finalizer));
-  NODE_API_CALL_RETURN_VOID(env, napi_get_global(env, &recv));
-  NODE_API_CALL_RETURN_VOID(env, napi_call_function(env, recv, js_finalizer, 0, NULL, NULL));
-  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, finalizer_ref));
-}
-
 static napi_value newBuffer(napi_env env, napi_callback_info info) {
   napi_value theBuffer;
   char* theCopy;
@@ -118,30 +107,6 @@ static napi_value staticBuffer(napi_env env, napi_callback_info info) {
   return theBuffer;
 }
 
-static napi_value malignFinalizerBuffer(napi_env env, napi_callback_info info) {
-  size_t argc = 1;
-  napi_value args[1];
-  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
-  napi_value finalizer = args[0];
-  napi_valuetype finalizer_valuetype;
-  NODE_API_CALL(env, napi_typeof(env, finalizer, &finalizer_valuetype));
-  NODE_API_ASSERT(env, finalizer_valuetype == napi_function, "Wrong type of first argument");
-  napi_ref finalizer_ref;
-  NODE_API_CALL(env, napi_create_reference(env, finalizer, 1, &finalizer_ref));
-
-  napi_value theBuffer;
-  NODE_API_CALL(
-      env,
-      napi_create_external_buffer(env,
-                                  sizeof(theText),
-                                  (void*)theText,
-                                  malignDeleter,
-                                  finalizer_ref,  // finalize_hint
-                                  &theBuffer));
-  return theBuffer;
-}
-
 static napi_value Init(napi_env env, napi_value exports) {
   napi_value theValue;
 
@@ -151,14 +116,13 @@ static napi_value Init(napi_env env, napi_value exports) {
       napi_set_named_property(env, exports, "theText", theValue));
 
   napi_property_descriptor methods[] = {
-    DECLARE_NODE_API_PROPERTY("newBuffer", newBuffer),
-    DECLARE_NODE_API_PROPERTY("newExternalBuffer", newExternalBuffer),
-    DECLARE_NODE_API_PROPERTY("getDeleterCallCount", getDeleterCallCount),
-    DECLARE_NODE_API_PROPERTY("copyBuffer", copyBuffer),
-    DECLARE_NODE_API_PROPERTY("bufferHasInstance", bufferHasInstance),
-    DECLARE_NODE_API_PROPERTY("bufferInfo", bufferInfo),
-    DECLARE_NODE_API_PROPERTY("staticBuffer", staticBuffer),
-    DECLARE_NODE_API_PROPERTY("malignFinalizerBuffer", malignFinalizerBuffer),
+      DECLARE_NODE_API_PROPERTY("newBuffer", newBuffer),
+      DECLARE_NODE_API_PROPERTY("newExternalBuffer", newExternalBuffer),
+      DECLARE_NODE_API_PROPERTY("getDeleterCallCount", getDeleterCallCount),
+      DECLARE_NODE_API_PROPERTY("copyBuffer", copyBuffer),
+      DECLARE_NODE_API_PROPERTY("bufferHasInstance", bufferHasInstance),
+      DECLARE_NODE_API_PROPERTY("bufferInfo", bufferInfo),
+      DECLARE_NODE_API_PROPERTY("staticBuffer", staticBuffer),
   };
 
   NODE_API_CALL(env, napi_define_properties(

--- a/test/node-api/test_buffer/test_finalizer.c
+++ b/test/node-api/test_buffer/test_finalizer.c
@@ -1,0 +1,61 @@
+#include <node_api.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../../js-native-api/common.h"
+
+static const char theText[] =
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+
+static void malignDeleter(napi_env env, void* data, void* finalize_hint) {
+  NODE_API_ASSERT_RETURN_VOID(
+      env, data != NULL && strcmp(data, theText) == 0, "invalid data");
+  napi_ref finalizer_ref = (napi_ref)finalize_hint;
+  napi_value js_finalizer;
+  napi_value recv;
+  NODE_API_CALL_RETURN_VOID(
+      env, napi_get_reference_value(env, finalizer_ref, &js_finalizer));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_global(env, &recv));
+  NODE_API_CALL_RETURN_VOID(
+      env, napi_call_function(env, recv, js_finalizer, 0, NULL, NULL));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, finalizer_ref));
+}
+
+static napi_value malignFinalizerBuffer(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
+  napi_value finalizer = args[0];
+  napi_valuetype finalizer_valuetype;
+  NODE_API_CALL(env, napi_typeof(env, finalizer, &finalizer_valuetype));
+  NODE_API_ASSERT(env,
+                  finalizer_valuetype == napi_function,
+                  "Wrong type of first argument");
+  napi_ref finalizer_ref;
+  NODE_API_CALL(env, napi_create_reference(env, finalizer, 1, &finalizer_ref));
+
+  napi_value theBuffer;
+  NODE_API_CALL(env,
+                napi_create_external_buffer(env,
+                                            sizeof(theText),
+                                            (void*)theText,
+                                            malignDeleter,
+                                            finalizer_ref,  // finalize_hint
+                                            &theBuffer));
+  return theBuffer;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor methods[] = {
+      DECLARE_NODE_API_PROPERTY("malignFinalizerBuffer", malignFinalizerBuffer),
+  };
+
+  NODE_API_CALL(
+      env,
+      napi_define_properties(
+          env, exports, sizeof(methods) / sizeof(methods[0]), methods));
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/node-api/test_buffer/test_finalizer.js
+++ b/test/node-api/test_buffer/test_finalizer.js
@@ -2,7 +2,7 @@
 // Flags: --expose-gc --force-node-api-uncaught-exceptions-policy
 
 const common = require('../../common');
-const binding = require(`./build/${common.buildType}/test_buffer`);
+const binding = require(`./build/${common.buildType}/test_finalizer`);
 const assert = require('assert');
 const tick = require('util').promisify(require('../../common/tick'));
 

--- a/test/node-api/test_threadsafe_function/binding.gyp
+++ b/test/node-api/test_threadsafe_function/binding.gyp
@@ -3,6 +3,20 @@
     {
       'target_name': 'binding',
       'sources': ['binding.c']
+    },
+    {
+      'target_name': 'test_uncaught_exception_v9',
+      'defines': [
+        'NAPI_VERSION=9'
+      ],
+      'sources': ['test_uncaught_exception.c']
+    },
+    {
+      'target_name': 'test_uncaught_exception',
+      'defines': [
+        'NAPI_EXPERIMENTAL'
+      ],
+      'sources': ['test_uncaught_exception.c']
     }
   ]
 }

--- a/test/node-api/test_threadsafe_function/test_legacy_uncaught_exception.js
+++ b/test/node-api/test_threadsafe_function/test_legacy_uncaught_exception.js
@@ -2,7 +2,7 @@
 // Flags: --no-force-node-api-uncaught-exceptions-policy
 
 const common = require('../../common');
-const binding = require(`./build/${common.buildType}/binding`);
+const binding = require(`./build/${common.buildType}/test_uncaught_exception_v9`);
 
 process.on(
   'uncaughtException',

--- a/test/node-api/test_threadsafe_function/test_uncaught_exception.c
+++ b/test/node-api/test_threadsafe_function/test_uncaught_exception.c
@@ -1,0 +1,62 @@
+#include <node_api.h>
+#include "../../js-native-api/common.h"
+
+// Testing calling into JavaScript
+static void ThreadSafeFunctionFinalize(napi_env env,
+                                       void* finalize_data,
+                                       void* finalize_hint) {
+  napi_ref js_func_ref = (napi_ref)finalize_data;
+  napi_value js_func;
+  napi_value recv;
+  NODE_API_CALL_RETURN_VOID(
+      env, napi_get_reference_value(env, js_func_ref, &js_func));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_global(env, &recv));
+  NODE_API_CALL_RETURN_VOID(
+      env, napi_call_function(env, recv, js_func, 0, NULL, NULL));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, js_func_ref));
+}
+
+// Testing calling into JavaScript
+static napi_value CallIntoModule(napi_env env, napi_callback_info info) {
+  size_t argc = 4;
+  napi_value argv[4];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+
+  napi_ref finalize_func;
+  NODE_API_CALL(env, napi_create_reference(env, argv[3], 1, &finalize_func));
+
+  napi_threadsafe_function tsfn;
+  NODE_API_CALL(env,
+                napi_create_threadsafe_function(env,
+                                                argv[0],
+                                                argv[1],
+                                                argv[2],
+                                                0,
+                                                1,
+                                                finalize_func,
+                                                ThreadSafeFunctionFinalize,
+                                                NULL,
+                                                NULL,
+                                                &tsfn));
+  NODE_API_CALL(env,
+                napi_call_threadsafe_function(tsfn, NULL, napi_tsfn_blocking));
+  NODE_API_CALL(env, napi_release_threadsafe_function(tsfn, napi_tsfn_release));
+  return NULL;
+}
+
+// Module init
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+      DECLARE_NODE_API_PROPERTY("CallIntoModule", CallIntoModule),
+  };
+
+  NODE_API_CALL(
+      env,
+      napi_define_properties(env,
+                             exports,
+                             sizeof(properties) / sizeof(properties[0]),
+                             properties));
+
+  return exports;
+}
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/node-api/test_threadsafe_function/test_uncaught_exception.js
+++ b/test/node-api/test_threadsafe_function/test_uncaught_exception.js
@@ -1,26 +1,7 @@
 'use strict';
 
 const common = require('../../common');
-const assert = require('assert');
 const binding = require(`./build/${common.buildType}/test_uncaught_exception`);
+const { testUncaughtException } = require('./uncaught_exception');
 
-const callbackCheck = common.mustCall((err) => {
-  assert.throws(() => { throw err; }, /callback error/);
-  process.removeListener('uncaughtException', callbackCheck);
-  process.on('uncaughtException', finalizerCheck);
-});
-const finalizerCheck = common.mustCall((err) => {
-  assert.throws(() => { throw err; }, /finalizer error/);
-});
-process.on('uncaughtException', callbackCheck);
-
-binding.CallIntoModule(
-  common.mustCall(() => {
-    throw new Error('callback error');
-  }),
-  {},
-  'resource_name',
-  common.mustCall(function finalizer() {
-    throw new Error('finalizer error');
-  }),
-);
+testUncaughtException(binding);

--- a/test/node-api/test_threadsafe_function/test_uncaught_exception_v9.js
+++ b/test/node-api/test_threadsafe_function/test_uncaught_exception_v9.js
@@ -1,8 +1,9 @@
 'use strict';
+// Flags: --force-node-api-uncaught-exceptions-policy
 
 const common = require('../../common');
 const assert = require('assert');
-const binding = require(`./build/${common.buildType}/test_uncaught_exception`);
+const binding = require(`./build/${common.buildType}/test_uncaught_exception_v9`);
 
 const callbackCheck = common.mustCall((err) => {
   assert.throws(() => { throw err; }, /callback error/);

--- a/test/node-api/test_threadsafe_function/test_uncaught_exception_v9.js
+++ b/test/node-api/test_threadsafe_function/test_uncaught_exception_v9.js
@@ -2,26 +2,7 @@
 // Flags: --force-node-api-uncaught-exceptions-policy
 
 const common = require('../../common');
-const assert = require('assert');
 const binding = require(`./build/${common.buildType}/test_uncaught_exception_v9`);
+const { testUncaughtException } = require('./uncaught_exception');
 
-const callbackCheck = common.mustCall((err) => {
-  assert.throws(() => { throw err; }, /callback error/);
-  process.removeListener('uncaughtException', callbackCheck);
-  process.on('uncaughtException', finalizerCheck);
-});
-const finalizerCheck = common.mustCall((err) => {
-  assert.throws(() => { throw err; }, /finalizer error/);
-});
-process.on('uncaughtException', callbackCheck);
-
-binding.CallIntoModule(
-  common.mustCall(() => {
-    throw new Error('callback error');
-  }),
-  {},
-  'resource_name',
-  common.mustCall(function finalizer() {
-    throw new Error('finalizer error');
-  }),
-);
+testUncaughtException(binding);

--- a/test/node-api/test_threadsafe_function/uncaught_exception.js
+++ b/test/node-api/test_threadsafe_function/uncaught_exception.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+
+function testUncaughtException(binding) {
+  const callbackCheck = common.mustCall((err) => {
+    assert.throws(() => { throw err; }, /callback error/);
+    process.removeListener('uncaughtException', callbackCheck);
+    process.on('uncaughtException', finalizerCheck);
+  });
+  const finalizerCheck = common.mustCall((err) => {
+    assert.throws(() => { throw err; }, /finalizer error/);
+  });
+  process.on('uncaughtException', callbackCheck);
+
+  binding.CallIntoModule(
+    common.mustCall(() => {
+      throw new Error('callback error');
+    }),
+    {},
+    'resource_name',
+    common.mustCall(function finalizer() {
+      throw new Error('finalizer error');
+    }),
+  );
+}
+
+module.exports = {
+  testUncaughtException,
+};


### PR DESCRIPTION
This enables the option `--force-node-api-uncaught-exceptions-policy`
for a specific Node-API addon when it is compiled with 
`NAPI_EXPERIMENTAL` (and this would be the default behavior when 
`NAPI_VERSION` 10 releases). This would not break existing Node-API
addons.

Refs: https://github.com/nodejs/node/pull/36510