### PR TITLE
Fix a segfault by ensuring TLS Sockets are closed if the underlying stream closes

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -704,6 +704,9 @@ TLSSocket.prototype._wrapHandle = function(wrap, handle, wrapHasActiveWriteFromP
   defineHandleReading(this, handle);
 
   this.on('close', onSocketCloseDestroySSL);
+  if (wrap) {
+    wrap.on('close', () => this.destroy());
+  }
 
   return res;
 };

--- a/test/parallel/test-http2-socket-close.js
+++ b/test/parallel/test-http2-socket-close.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const net = require('net');
+const h2 = require('http2');
+
+const tlsOptions = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+  ALPNProtocols: ['h2']
+};
+
+// Create a net server that upgrades sockets to HTTP/2 manually, but with two
+// different shutdown timeouts: a short socket timeout, and a longer H2 session timeout.
+// Since the only request is complete, the session should shutdown cleanly when the
+// socket shuts down (and should _not_ segfault, as it does in Node v20.5.1)
+
+const netServer = net.createServer((socket) => {
+  setTimeout(() => {
+    socket.destroy();
+  }, 10);
+
+  h2Server.emit('connection', socket);
+});
+
+const h2Server = h2.createSecureServer(tlsOptions, (req, res) => {
+  res.writeHead(200);
+  res.end();
+});
+
+h2Server.on('session', (session) => {
+  setTimeout(() => {
+    session.close();
+  }, 20);
+});
+
+netServer.listen(0, common.mustCall(() => {
+  const proxyClient = h2.connect(`https://localhost:${netServer.address().port}`, {
+    rejectUnauthorized: false
+  });
+
+  proxyClient.on('close', common.mustCall(() => {
+    netServer.close();
+  }));
+
+  const req = proxyClient.request({
+    ':method': 'GET',
+    ':path': '/'
+  });
+
+  req.on('response', common.mustCall((response) => {
+    assert.strictEqual(response[':status'], 200);
+  }));
+}));

--- a/test/parallel/test-tls-socket-close.js
+++ b/test/parallel/test-tls-socket-close.js
@@ -8,37 +8,18 @@ const tls = require('tls');
 const net = require('net');
 const fixtures = require('../common/fixtures');
 
-// Regression test for https://github.com/nodejs/node/issues/8074
-//
-// This test has a dependency on the order in which the TCP connection is made,
-// and TLS server handshake completes. It assumes those server side events occur
-// before the client side write callback, which is not guaranteed by the TLS
-// API. It usually passes with TLS1.3, but TLS1.3 didn't exist at the time the
-// bug existed.
-//
-// Pin the test to TLS1.2, since the test shouldn't be changed in a way that
-// doesn't trigger a segfault in Node.js 7.7.3:
-//   https://github.com/nodejs/node/issues/13184#issuecomment-303700377
-tls.DEFAULT_MAX_VERSION = 'TLSv1.2';
-
 const key = fixtures.readKey('agent2-key.pem');
 const cert = fixtures.readKey('agent2-cert.pem');
 
-let tlsSocket;
-// tls server
+let serverTlsSocket;
 const tlsServer = tls.createServer({ cert, key }, (socket) => {
-  tlsSocket = socket;
-  socket.on('error', common.mustCall((error) => {
-    assert.strictEqual(error.code, 'EINVAL');
-    tlsServer.close();
-    netServer.close();
-  }));
+  serverTlsSocket = socket;
 });
 
+// A plain net server, that manually passes connections to the TLS
+// server to be upgraded
 let netSocket;
-// plain tcp server
 const netServer = net.createServer((socket) => {
-  // If client wants to use tls
   tlsServer.emit('connection', socket);
 
   netSocket = socket;
@@ -46,35 +27,32 @@ const netServer = net.createServer((socket) => {
   connectClient(netServer);
 }));
 
+// A client that connects, sends one message, and closes the raw connection:
 function connectClient(server) {
-  const tlsConnection = tls.connect({
+  const clientTlsSocket = tls.connect({
     host: 'localhost',
     port: server.address().port,
     rejectUnauthorized: false
   });
 
-  tlsConnection.write('foo', 'utf8', common.mustCall(() => {
+  clientTlsSocket.write('foo', 'utf8', common.mustCall(() => {
     assert(netSocket);
     netSocket.setTimeout(common.platformTimeout(10), common.mustCall(() => {
-      assert(tlsSocket);
-      // This breaks if TLSSocket is already managing the socket:
+      assert(serverTlsSocket);
+
       netSocket.destroy();
-      const interval = setInterval(() => {
-        // Checking this way allows us to do the write at a time that causes a
-        // segmentation fault (not always, but often) in Node.js 7.7.3 and
-        // earlier. If we instead, for example, wait on the `close` event, then
-        // it will not segmentation fault, which is what this test is all about.
-        if (tlsSocket._handle._parent.bytesRead === 0) {
-          tlsSocket.write('bar');
-          clearInterval(interval);
-        }
-      }, 1);
+
+      setImmediate(() => {
+        assert.strictEqual(netSocket.destroyed, true);
+        assert.strictEqual(clientTlsSocket.destroyed, true);
+
+        setImmediate(() => {
+          assert.strictEqual(serverTlsSocket.destroyed, true);
+
+          tlsServer.close();
+          netServer.close();
+        });
+      });
     }));
   }));
-  tlsConnection.on('error', (e) => {
-    // Tolerate the occasional ECONNRESET.
-    // Ref: https://github.com/nodejs/node/issues/13184
-    if (e.code !== 'ECONNRESET')
-      throw e;
-  });
 }


### PR DESCRIPTION
This fixes a potential HTTP/2 segfault (https://github.com/nodejs/node/issues/49307, https://github.com/nodejs/node/issues/48567) caused by underlying TLS behaviour, and likely fixes various other apparently related issues (https://github.com/nodejs/node/issues/46094, https://github.com/nodejs/node/issues/35695).

I found this while investigating https://github.com/nodejs/node/issues/48519, which this doesn't _directly_ fix, but definitely relates to, as the JS Stream Sockets there have all sorts of issues directly caused by TLS interactions after the JSS is closed.

The underlying problem here is that TLS sockets which are created by passing an existing socket (either `tlsServer.emit('connection', socket)` or `tls.createConnection({ ..., socket })`) do not listen to whether the underlying socket was closed elsewhere. This is easy to demo:

```javascript
const tlsOptions = {
  key: // Any key, e.g. fixtures.readKey('agent1-key.pem'),
  cert: // Any cert, e.g. fixtures.readKey('agent1-cert.pem')
};

const net = require('net');
const tls = require('tls');

const server = tls.createServer(tlsOptions, () => {
    console.log('Got TLS connection');
});

server.listen(0, () => {
    const socket = net.createConnection({
        port: server.address().port
    });

    socket.on('connect', () => {
        const tlsSocket = tls.connect({
            socket,
            rejectUnauthorized: false
        });

        tlsSocket.on('secureConnect', () => {
            console.log('TLS client connected');

            setImmediate(() => {
                socket.destroy();

                setTimeout(() => {
                    console.log('Is the socket alive?', !socket.destroyed);
                    console.log('Is TLS readable & writable?', tlsSocket.writable, tlsSocket.readable);
                }, 100);
            });
        });
    });
});
```

This prints:

```
TLS client connected
Got TLS connection
Is the socket alive? false
Is TLS readable & writable? true true
```

With this change, the last line is instead `false false`.

Clearly the TLS socket should not be readable or writeable 100ms after it's definitely disconnected. This happens even if something is reading data - the data just stops, and the affected TLS socket (the client in this case) never closes.

These TLSSockets do seem to shut down correctly if the _remote_ side closes the connection, but in any other scenario, the TLS connection will remain happily active like this even when the underlying socket is gone, until something more serious interacts with its internals, which then explode (either segfaults in normal cases, or the various `finishWrite` errors in the issues above in JS Stream Socket cases).

The first segfault is definitely caused by this case, and I've added a new test for that.

I'm _fairly_ confident this is the underlying issue for the other cases too - note that both cases use the manual socket handling pattern (with HTTP/2, but implicitly on top of TLS) - but neither has a reliable repro to confirm that.

This change notably significantly modifies an existing TLS test too. Unfortunately with this change in place, that test no longer works at all, as it tries to mess with internals to trigger a race condition that crashed in some Node v7 versions, and those internals are now cleaned up before they can be messed with. This test has been simplified to a more general TLS shutdown test instead.

There is some history to this - very similar code did used to exist!

* It was added [here](https://github.com/nodejs/node/commit/4cdb0e89d8daf7e1371c3b8d3f057940aa327d4a)
* It was then reverted [here](https://github.com/nodejs/node/commit/595efd8b9a463886c20fb04103c508bd9c3630e7) on the basis (discussed [here](https://github.com/nodejs/node/pull/11947#pullrequestreview-27980092)) that it was now unnecessary, due to other changes.
* That caused issues, which were fixed for the StreamWrap case only [here](https://github.com/nodejs/node/pull/24290)
* That was reverted as an unnecessary special case [here](https://github.com/nodejs/node/pull/34105)

@addaleax and @ronag will likely be interested in this, since they were involved at various stages of that.

I think there's a good case here that something explicitly handling this _is_ necessary. Somehow, TLS sockets need to be informed if the underlying socket is closed. Note that this change as here is _not_ specific to StreamWraps, unless some past changes. AFAICT this is required here for all manually constructed TLS cases - the new test here just passes a net.Socket directly and it still crashes on all current Node versions.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
