### PR TITLE
src: remove unused PromiseWrap-related code

### DIFF
--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -43,28 +43,6 @@ static Maybe<double> GetAssignedPromiseAsyncId(Environment* env,
       : v8::Just(AsyncWrap::kInvalidAsyncId);
 }
 
-static Maybe<double> GetAssignedPromiseWrapAsyncId(Environment* env,
-                                                   Local<Promise> promise,
-                                                   Local<Value> id_symbol) {
-  // This check is imperfect. If the internal field is set, it should
-  // be an object. If it's not, we just ignore it. Ideally v8 would
-  // have had GetInternalField returning a MaybeLocal but this works
-  // for now.
-  Local<Value> promiseWrap = promise->GetInternalField(0).As<Value>();
-  if (promiseWrap->IsObject()) {
-        Local<Value> maybe_async_id;
-    if (!promiseWrap.As<Object>()->Get(env->context(), id_symbol)
-        .ToLocal(&maybe_async_id)) {
-      return v8::Just(AsyncWrap::kInvalidAsyncId);
-    }
-    return maybe_async_id->IsNumber()
-        ? maybe_async_id->NumberValue(env->context())
-        : v8::Just(AsyncWrap::kInvalidAsyncId);
-  } else {
-      return v8::Just(AsyncWrap::kInvalidAsyncId);
-  }
-}
-
 void PromiseRejectCallback(PromiseRejectMessage message) {
   static std::atomic<uint64_t> unhandledRejections{0};
   static std::atomic<uint64_t> rejectionsHandledAfter{0};
@@ -121,17 +99,6 @@ void PromiseRejectCallback(PromiseRejectMessage message) {
           .To(&async_id)) return;
   if (!GetAssignedPromiseAsyncId(env, promise, env->trigger_async_id_symbol())
           .To(&trigger_async_id)) return;
-
-  if (async_id == AsyncWrap::kInvalidAsyncId &&
-      trigger_async_id == AsyncWrap::kInvalidAsyncId) {
-    // That means that promise might be a PromiseWrap, so we'll
-    // check there as well.
-    if (!GetAssignedPromiseWrapAsyncId(env, promise, env->async_id_symbol())
-              .To(&async_id)) return;
-    if (!GetAssignedPromiseWrapAsyncId(
-          env, promise, env->trigger_async_id_symbol())
-              .To(&trigger_async_id)) return;
-  }
 
   if (async_id != AsyncWrap::kInvalidAsyncId &&
       trigger_async_id != AsyncWrap::kInvalidAsyncId) {


### PR DESCRIPTION
PromiseWrap has been removed in
https://github.com/nodejs/node/pull/39135 and we do not have any internal object setting the internal field at 0 as a promise (we always set the first field as an aligned pointer to the embedder ID). As result GetAssignedPromiseWrapAsyncId() always just returns AsyncWrap::kInvalidAsyncId and turn the removed block into noops. So the block just can be removed.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
