### PR TITLE
src: rename IsAnyByteSource to IsAnyBufferSource

### DIFF
--- a/src/crypto/crypto_aes.cc
+++ b/src/crypto/crypto_aes.cc
@@ -381,7 +381,7 @@ bool ValidateAuthTag(
     AESCipherConfig* params) {
   switch (cipher_mode) {
     case kWebCryptoCipherDecrypt: {
-      if (!IsAnyByteSource(value)) {
+      if (!IsAnyBufferSource(value)) {
         THROW_ERR_CRYPTO_INVALID_TAG_LENGTH(env);
         return false;
       }
@@ -419,7 +419,7 @@ bool ValidateAdditionalData(
     Local<Value> value,
     AESCipherConfig* params) {
   // Additional Data
-  if (IsAnyByteSource(value)) {
+  if (IsAnyBufferSource(value)) {
     ArrayBufferOrViewContents<char> additional(value);
     if (UNLIKELY(!additional.CheckSizeInt32())) {
       THROW_ERR_OUT_OF_RANGE(env, "additionalData is too big");

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -193,7 +193,7 @@ ECPointPointer ECDH::BufferToPoint(Environment* env,
 void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  CHECK(IsAnyByteSource(args[0]));
+  CHECK(IsAnyBufferSource(args[0]));
 
   ECDH* ecdh;
   ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.Holder());
@@ -347,7 +347,7 @@ void ECDH::SetPublicKey(const FunctionCallbackInfo<Value>& args) {
   ECDH* ecdh;
   ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.Holder());
 
-  CHECK(IsAnyByteSource(args[0]));
+  CHECK(IsAnyBufferSource(args[0]));
 
   MarkPopErrorOnReturn mark_pop_error_on_return;
 
@@ -393,7 +393,7 @@ void ECDH::ConvertKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   CHECK_EQ(args.Length(), 3);
-  CHECK(IsAnyByteSource(args[0]));
+  CHECK(IsAnyBufferSource(args[0]));
 
   ArrayBufferOrViewContents<char> args0(args[0]);
   if (UNLIKELY(!args0.CheckSizeInt32()))

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -51,8 +51,8 @@ Maybe<bool> HKDFTraits::AdditionalConfig(
 
   CHECK(args[offset]->IsString());  // Hash
   CHECK(args[offset + 1]->IsObject());  // Key
-  CHECK(IsAnyByteSource(args[offset + 2]));  // Salt
-  CHECK(IsAnyByteSource(args[offset + 3]));  // Info
+  CHECK(IsAnyBufferSource(args[offset + 2]));  // Salt
+  CHECK(IsAnyBufferSource(args[offset + 3]));  // Info
   CHECK(args[offset + 4]->IsUint32());  // Length
 
   Utf8Value hash(env->isolate(), args[offset]);

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -699,7 +699,7 @@ ManagedEVPPKey::GetPrivateKeyEncodingFromJs(
       (*offset)++;
     }
 
-    if (IsAnyByteSource(args[*offset])) {
+    if (IsAnyBufferSource(args[*offset])) {
       CHECK_IMPLIES(context != kKeyContextInput, result.cipher_ != nullptr);
       ArrayBufferOrViewContents<char> passphrase(args[*offset]);
       if (UNLIKELY(!passphrase.CheckSizeInt32())) {
@@ -730,7 +730,7 @@ ManagedEVPPKey ManagedEVPPKey::GetPrivateKeyFromJs(
     const FunctionCallbackInfo<Value>& args,
     unsigned int* offset,
     bool allow_key_object) {
-  if (args[*offset]->IsString() || IsAnyByteSource(args[*offset])) {
+  if (args[*offset]->IsString() || IsAnyBufferSource(args[*offset])) {
     Environment* env = Environment::GetCurrent(args);
     ByteSource key = ByteSource::FromStringOrBuffer(env, args[(*offset)++]);
     NonCopyableMaybe<PrivateKeyEncodingConfig> config =
@@ -756,7 +756,7 @@ ManagedEVPPKey ManagedEVPPKey::GetPrivateKeyFromJs(
 ManagedEVPPKey ManagedEVPPKey::GetPublicOrPrivateKeyFromJs(
     const FunctionCallbackInfo<Value>& args,
     unsigned int* offset) {
-  if (IsAnyByteSource(args[*offset])) {
+  if (IsAnyBufferSource(args[*offset])) {
     Environment* env = Environment::GetCurrent(args);
     ArrayBufferOrViewContents<char> data(args[(*offset)++]);
     if (UNLIKELY(!data.CheckSizeInt32())) {

--- a/src/crypto/crypto_random.cc
+++ b/src/crypto/crypto_random.cc
@@ -39,7 +39,7 @@ Maybe<bool> RandomBytesTraits::AdditionalConfig(
     const FunctionCallbackInfo<Value>& args,
     unsigned int offset,
     RandomBytesConfig* params) {
-  CHECK(IsAnyByteSource(args[offset]));  // Buffer to fill
+  CHECK(IsAnyBufferSource(args[offset]));  // Buffer to fill
   CHECK(args[offset + 1]->IsUint32());  // Offset
   CHECK(args[offset + 2]->IsUint32());  // Size
 

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -321,7 +321,7 @@ Maybe<bool> RSACipherTraits::AdditionalConfig(
         return Nothing<bool>();
       }
 
-      if (IsAnyByteSource(args[offset + 2])) {
+      if (IsAnyBufferSource(args[offset + 2])) {
         ArrayBufferOrViewContents<char> label(args[offset + 2]);
         if (UNLIKELY(!label.CheckSizeInt32())) {
           THROW_ERR_OUT_OF_RANGE(env, "label is too big");

--- a/src/crypto/crypto_timing.cc
+++ b/src/crypto/crypto_timing.cc
@@ -21,13 +21,13 @@ void TimingSafeEqual(const FunctionCallbackInfo<Value>& args) {
   // to V8 inlining certain parts of the wrapper. Therefore, keep them in C++.
   // Refs: https://github.com/nodejs/node/issues/34073.
   Environment* env = Environment::GetCurrent(args);
-  if (!IsAnyByteSource(args[0])) {
+  if (!IsAnyBufferSource(args[0])) {
     THROW_ERR_INVALID_ARG_TYPE(
       env, "The \"buf1\" argument must be an instance of "
       "ArrayBuffer, Buffer, TypedArray, or DataView.");
     return;
   }
-  if (!IsAnyByteSource(args[1])) {
+  if (!IsAnyBufferSource(args[1])) {
     THROW_ERR_INVALID_ARG_TYPE(
       env, "The \"buf2\" argument must be an instance of "
       "ArrayBuffer, Buffer, TypedArray, or DataView.");

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -402,8 +402,8 @@ ByteSource ByteSource::FromEncodedString(Environment* env,
 
 ByteSource ByteSource::FromStringOrBuffer(Environment* env,
                                           Local<Value> value) {
-  return IsAnyByteSource(value) ? FromBuffer(value)
-                                : FromString(env, value.As<String>());
+  return IsAnyBufferSource(value) ? FromBuffer(value)
+                                  : FromString(env, value.As<String>());
 }
 
 ByteSource ByteSource::FromString(Environment* env, Local<String> str,
@@ -429,9 +429,9 @@ ByteSource ByteSource::FromSecretKeyBytes(
   // A key can be passed as a string, buffer or KeyObject with type 'secret'.
   // If it is a string, we need to convert it to a buffer. We are not doing that
   // in JS to avoid creating an unprotected copy on the heap.
-  return value->IsString() || IsAnyByteSource(value) ?
-           ByteSource::FromStringOrBuffer(env, value) :
-           ByteSource::FromSymmetricKeyObjectHandle(value);
+  return value->IsString() || IsAnyBufferSource(value)
+             ? ByteSource::FromStringOrBuffer(env, value)
+             : ByteSource::FromSymmetricKeyObjectHandle(value);
 }
 
 ByteSource ByteSource::NullTerminatedCopy(Environment* env,

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -676,7 +676,8 @@ void array_push_back(const TypeName* evp_ref,
 }
 #endif
 
-inline bool IsAnyByteSource(v8::Local<v8::Value> arg) {
+// WebIDL AllowSharedBufferSource.
+inline bool IsAnyBufferSource(v8::Local<v8::Value> arg) {
   return arg->IsArrayBufferView() ||
          arg->IsArrayBuffer() ||
          arg->IsSharedArrayBuffer();
@@ -694,7 +695,7 @@ class ArrayBufferOrViewContents {
       return;
     }
 
-    CHECK(IsAnyByteSource(buf));
+    CHECK(IsAnyBufferSource(buf));
     if (buf->IsArrayBufferView()) {
       auto view = buf.As<v8::ArrayBufferView>();
       offset_ = view->ByteOffset();


### PR DESCRIPTION
The current name is somewhat confusing. There is an internal `ByteSource` class, which is entirely unrelated to what `IsAnyByteSource()` does, even though both exist in the crypto subsystem of the C++ code. `ByteSource` objects can also be constructed from strings, for example, for which `IsAnyByteSource()` returns false.

Web IDL calls the types for which this function returns true `BufferSource`. This type is commonly used across Web Crypto, for example. Thus, rename the function to match the Web IDL naming.

Because the function also appears to accept `BufferSource` objects backed by `SharedArrayBuffer` instances, the exact Web IDL name would be `AllowSharedBufferSource`, but that seems unnecessarily long, so I decided to stick with "any".

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
