### PR TITLE
test_runner: add support for mocking setImmediate timer

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1580,7 +1580,7 @@ Enables timer mocking for the specified timers.
 
 * `timers` {Array} An optional array containing the timers to mock.
   The currently supported timer values are `'setInterval'`, `'setTimeout'`
-  and `'setImmediate'`.  If no array is provided, all timers (`'setInterval'`,
+  and `'setImmediate'`.  If no value is provided, all timers (`'setInterval'`,
   `'clearInterval'`, `'setTimeout'`, `'clearTimeout'`, `'setImmediate'`,
   and `'clearImmediate'`) will be mocked by default.
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1579,7 +1579,7 @@ added:
 Enables timer mocking for the specified timers.
 
 * `timers` {Array} An optional array containing the timers to mock.
-  The currently supported timer values are `'setInterval'`, `'setTimeout'`
+  The currently supported timer values are `'setInterval'`, `'setTimeout'`,
   and `'setImmediate'`.  If no value is provided, all timers (`'setInterval'`,
   `'clearInterval'`, `'setTimeout'`, `'clearTimeout'`, `'setImmediate'`,
   and `'clearImmediate'`) will be mocked by default.

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1579,9 +1579,10 @@ added:
 Enables timer mocking for the specified timers.
 
 * `timers` {Array} An optional array containing the timers to mock.
-  The currently supported timer values are `'setInterval'` and `'setTimeout'`.
-  If no array is provided, all timers (`'setInterval'`, `'clearInterval'`, `'setTimeout'`,
-  and `'clearTimeout'`) will be mocked by default.
+  The currently supported timer values are `'setInterval'`, `'setTimeout'`
+  and `'setImmediate'`.  If no array is provided, all timers (`'setInterval'`,
+  `'clearInterval'`, `'setTimeout'`, `'clearTimeout'`, `'setImmediate'`,
+  and `'clearImmediate'`) will be mocked by default.
 
 **Note:** When you enable mocking for a specific timer, its associated
 clear function will also be implicitly mocked.

--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -52,7 +52,6 @@ const SUPPORTED_TIMERS = ['setTimeout', 'setInterval', 'setImmediate'];
 const TIMERS_DEFAULT_INTERVAL = {
   __proto__: null,
   setImmediate: -1,
-  nextTick: -2,
 };
 
 class MockTimers {

--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -48,13 +48,20 @@ function abortIt(signal) {
   return new AbortError(undefined, { __proto__: null, cause: signal.reason });
 }
 
-const SUPPORTED_TIMERS = ['setTimeout', 'setInterval'];
+const SUPPORTED_TIMERS = ['setTimeout', 'setInterval', 'setImmediate'];
+const TIMERS_DEFAULT_INTERVAL = {
+  __proto__: null,
+  setImmediate: -1,
+  nextTick: -2,
+};
 
 class MockTimers {
   #realSetTimeout;
   #realClearTimeout;
   #realSetInterval;
   #realClearInterval;
+  #realSetImmediate;
+  #realClearImmediate;
 
   #realPromisifiedSetTimeout;
   #realPromisifiedSetInterval;
@@ -63,6 +70,9 @@ class MockTimers {
   #realTimersClearTimeout;
   #realTimersSetInterval;
   #realTimersClearInterval;
+  #realTimersSetImmediate;
+  #realTimersClearImmediate;
+  #realPromisifiedSetImmediate;
 
   #timersInContext = [];
   #isEnabled = false;
@@ -76,6 +86,16 @@ class MockTimers {
   #setInterval = FunctionPrototypeBind(this.#createTimer, this, true);
   #clearInterval = FunctionPrototypeBind(this.#clearTimer, this);
 
+  #setImmediate = (callback, ...args) => {
+    return this.#createTimer(
+      false,
+      callback,
+      TIMERS_DEFAULT_INTERVAL.setImmediate,
+      ...args,
+    );
+  };
+
+  #clearImmediate = FunctionPrototypeBind(this.#clearTimer, this);
   constructor() {
     emitExperimentalWarning('The MockTimers API');
   }
@@ -158,7 +178,7 @@ class MockTimers {
     yield* iterator;
   }
 
-  #setTimeoutPromisified(ms, result, options) {
+  #promisifyTimer({ timerFn, clearFn, ms, result, options }) {
     return new Promise((resolve, reject) => {
       if (options?.signal) {
         try {
@@ -173,12 +193,12 @@ class MockTimers {
       }
 
       const onabort = () => {
-        this.#clearTimeout(id);
+        clearFn(id);
         return reject(abortIt(options.signal));
       };
 
-      const id = this.#setTimeout(() => {
-        return resolve(result || id);
+      const id = timerFn(() => {
+        return resolve(result);
       }, ms);
 
       if (options?.signal) {
@@ -189,6 +209,28 @@ class MockTimers {
           [kResistStopPropagation]: true,
         });
       }
+    });
+  }
+
+  #setImmediatePromisified(result, options) {
+    return this.#promisifyTimer({
+      __proto__: null,
+      timerFn: FunctionPrototypeBind(this.#setImmediate, this),
+      clearFn: FunctionPrototypeBind(this.#clearImmediate, this),
+      ms: TIMERS_DEFAULT_INTERVAL.setImmediate,
+      result,
+      options,
+    });
+  }
+
+  #setTimeoutPromisified(ms, result, options) {
+    return this.#promisifyTimer({
+      __proto__: null,
+      timerFn: FunctionPrototypeBind(this.#setTimeout, this),
+      clearFn: FunctionPrototypeBind(this.#clearTimeout, this),
+      ms,
+      result,
+      options,
     });
   }
 
@@ -233,6 +275,23 @@ class MockTimers {
             this,
           );
         },
+        setImmediate: () => {
+          this.#realSetImmediate = globalThis.setImmediate;
+          this.#realClearImmediate = globalThis.clearImmediate;
+          this.#realTimersSetImmediate = nodeTimers.setImmediate;
+          this.#realTimersClearImmediate = nodeTimers.clearImmediate;
+
+          globalThis.setImmediate = this.#setImmediate;
+          globalThis.clearImmediate = this.#clearImmediate;
+
+          nodeTimers.setImmediate = this.#setImmediate;
+          nodeTimers.clearImmediate = this.#clearImmediate;
+
+          nodeTimersPromises.setImmediate = FunctionPrototypeBind(
+            this.#setImmediatePromisified,
+            this,
+          );
+        },
       },
       toReal: {
         __proto__: null,
@@ -253,6 +312,15 @@ class MockTimers {
           nodeTimers.clearInterval = this.#realTimersClearInterval;
 
           nodeTimersPromises.setInterval = this.#realPromisifiedSetInterval;
+        },
+        setImmediate: () => {
+          globalThis.setImmediate = this.#realSetImmediate;
+          globalThis.clearImmediate = this.#realClearImmediate;
+
+          nodeTimers.setImmediate = this.#realTimersSetImmediate;
+          nodeTimers.clearImmediate = this.#realTimersClearImmediate;
+
+          nodeTimersPromises.setImmediate = this.#realPromisifiedSetImmediate;
         },
       },
     };

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -257,23 +257,15 @@ describe('Mock Timers Test Suite', () => {
       it('should not advance in time if clearImmediate was invoked', (t) => {
         t.mock.timers.enable(['setImmediate']);
 
-        const fn = mock.fn();
-        const id = global.setImmediate(fn);
+        const id = global.setImmediate(common.mustNotCall());
         global.clearImmediate(id);
         t.mock.timers.tick(200);
-
-        assert.strictEqual(fn.mock.callCount(), 0);
       });
 
       it('should advance in time and trigger timers when calling the .tick function', (t) => {
         t.mock.timers.enable(['setImmediate']);
-
-        const fn = mock.fn();
-
-        global.setImmediate(fn);
-
+        global.setImmediate(common.mustCall());
         t.mock.timers.tick(0);
-        assert.strictEqual(fn.mock.callCount(), 1);
       });
 
       it('should execute in order if setImmediate is called multiple times', (t) => {
@@ -433,54 +425,42 @@ describe('Mock Timers Test Suite', () => {
       it('should not advance in time if clearImmediate was invoked', (t) => {
         t.mock.timers.enable(['setImmediate']);
 
-        const fn = mock.fn();
-        const id = nodeTimers.setImmediate(fn);
+        const id = nodeTimers.setImmediate(common.mustNotCall());
         nodeTimers.clearImmediate(id);
         t.mock.timers.tick(200);
-
-        assert.strictEqual(fn.mock.callCount(), 0);
       });
 
       it('should advance in time and trigger timers when calling the .tick function', (t) => {
         t.mock.timers.enable(['setImmediate']);
-
-        const fn = mock.fn();
-
-        nodeTimers.setImmediate(fn);
-
+        nodeTimers.setImmediate(common.mustCall());
         t.mock.timers.tick(0);
-        assert.strictEqual(fn.mock.callCount(), 1);
       });
 
       it('should execute in order if setImmediate is called multiple times', (t) => {
         t.mock.timers.enable(['setImmediate']);
         const order = [];
-        const fn1 = t.mock.fn(() => order.push('f1'));
-        const fn2 = t.mock.fn(() => order.push('f2'));
+        const fn1 = t.mock.fn(common.mustCall(() => order.push('f1')));
+        const fn2 = t.mock.fn(common.mustCall(() => order.push('f2')));
 
         nodeTimers.setImmediate(fn1);
         nodeTimers.setImmediate(fn2);
 
         t.mock.timers.tick(0);
 
-        assert.strictEqual(fn1.mock.callCount(), 1);
-        assert.strictEqual(fn2.mock.callCount(), 1);
         assert.deepStrictEqual(order, ['f1', 'f2']);
       });
 
       it('should execute setImmediate first if setTimeout was also called', (t) => {
         t.mock.timers.enable(['setImmediate', 'setTimeout']);
         const order = [];
-        const fn1 = t.mock.fn(() => order.push('f1'));
-        const fn2 = t.mock.fn(() => order.push('f2'));
+        const fn1 = t.mock.fn(common.mustCall(() => order.push('f1')));
+        const fn2 = t.mock.fn(common.mustCall(() => order.push('f2')));
 
         nodeTimers.setTimeout(fn2, 0);
         nodeTimers.setImmediate(fn1);
 
         t.mock.timers.tick(100);
 
-        assert.strictEqual(fn1.mock.callCount(), 1);
-        assert.strictEqual(fn2.mock.callCount(), 1);
         assert.deepStrictEqual(order, ['f1', 'f2']);
       });
     });

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -264,39 +264,35 @@ describe('Mock Timers Test Suite', () => {
 
       it('should advance in time and trigger timers when calling the .tick function', (t) => {
         t.mock.timers.enable(['setImmediate']);
-        global.setImmediate(common.mustCall());
+        global.setImmediate(common.mustCall(1));
         t.mock.timers.tick(0);
       });
 
       it('should execute in order if setImmediate is called multiple times', (t) => {
         t.mock.timers.enable(['setImmediate']);
         const order = [];
-        const fn1 = t.mock.fn(() => order.push('f1'));
-        const fn2 = t.mock.fn(() => order.push('f2'));
+        const fn1 = t.mock.fn(common.mustCall(() => order.push('f1'), 1));
+        const fn2 = t.mock.fn(common.mustCall(() => order.push('f2'), 1));
 
         global.setImmediate(fn1);
         global.setImmediate(fn2);
 
         t.mock.timers.tick(0);
 
-        assert.strictEqual(fn1.mock.callCount(), 1);
-        assert.strictEqual(fn2.mock.callCount(), 1);
         assert.deepStrictEqual(order, ['f1', 'f2']);
       });
 
       it('should execute setImmediate first if setTimeout was also called', (t) => {
         t.mock.timers.enable(['setImmediate', 'setTimeout']);
         const order = [];
-        const fn1 = t.mock.fn(() => order.push('f1'));
-        const fn2 = t.mock.fn(() => order.push('f2'));
+        const fn1 = t.mock.fn(common.mustCall(() => order.push('f1'), 1));
+        const fn2 = t.mock.fn(common.mustCall(() => order.push('f2'), 1));
 
         global.setTimeout(fn2, 0);
         global.setImmediate(fn1);
 
         t.mock.timers.tick(100);
 
-        assert.strictEqual(fn1.mock.callCount(), 1);
-        assert.strictEqual(fn2.mock.callCount(), 1);
         assert.deepStrictEqual(order, ['f1', 'f2']);
       });
     });
@@ -408,7 +404,7 @@ describe('Mock Timers Test Suite', () => {
         nodeTimers.setImmediate(common.mustCall(() => {
           assert.strictEqual(now - timeout, expected());
           done();
-        }));
+        }, 1));
       });
 
       it('should work with the same params as the original setImmediate', (t) => {
@@ -432,15 +428,15 @@ describe('Mock Timers Test Suite', () => {
 
       it('should advance in time and trigger timers when calling the .tick function', (t) => {
         t.mock.timers.enable(['setImmediate']);
-        nodeTimers.setImmediate(common.mustCall());
+        nodeTimers.setImmediate(common.mustCall(1));
         t.mock.timers.tick(0);
       });
 
       it('should execute in order if setImmediate is called multiple times', (t) => {
         t.mock.timers.enable(['setImmediate']);
         const order = [];
-        const fn1 = t.mock.fn(common.mustCall(() => order.push('f1')));
-        const fn2 = t.mock.fn(common.mustCall(() => order.push('f2')));
+        const fn1 = t.mock.fn(common.mustCall(() => order.push('f1'), 1));
+        const fn2 = t.mock.fn(common.mustCall(() => order.push('f2'), 1));
 
         nodeTimers.setImmediate(fn1);
         nodeTimers.setImmediate(fn2);
@@ -453,8 +449,8 @@ describe('Mock Timers Test Suite', () => {
       it('should execute setImmediate first if setTimeout was also called', (t) => {
         t.mock.timers.enable(['setImmediate', 'setTimeout']);
         const order = [];
-        const fn1 = t.mock.fn(common.mustCall(() => order.push('f1')));
-        const fn2 = t.mock.fn(common.mustCall(() => order.push('f2')));
+        const fn1 = t.mock.fn(common.mustCall(() => order.push('f1'), 1));
+        const fn2 = t.mock.fn(common.mustCall(() => order.push('f2'), 1));
 
         nodeTimers.setTimeout(fn2, 0);
         nodeTimers.setImmediate(fn1);
@@ -724,7 +720,7 @@ describe('Mock Timers Test Suite', () => {
         p.then(common.mustCall((result) => {
           assert.strictEqual(result, undefined);
           done();
-        }));
+        }, 1));
       });
 
       it('should work with the same params as the original timers/promises/setImmediate', async (t) => {


### PR DESCRIPTION
This PR adds support for

- [x] - `setImmediate`
- [x] - `timers.setImmediate`
- [x] - `timers.promises.setImmediate`

This PR makes sure that `setImmediate` has priority higher than `setTimeout` and follows the spec defined in the docs about:
 _When multiple calls to setImmediate() are made, the callback functions are queued for execution in the order in which they are created_

cc: @nodejs/test_runner 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
