### PR TITLE
Fix JS Stream Socket finishShutdown crash

### DIFF
--- a/lib/internal/js_stream_socket.js
+++ b/lib/internal/js_stream_socket.js
@@ -149,6 +149,7 @@ class JSStreamSocket extends Socket {
     }
 
     const handle = this._handle;
+    assert(handle !== null);
 
     process.nextTick(() => {
       // Ensure that write is dispatched asynchronously.
@@ -181,6 +182,8 @@ class JSStreamSocket extends Socket {
     }
 
     const handle = this._handle;
+    assert(handle !== null);
+
     const self = this;
 
     let pending = bufs.length;

--- a/lib/internal/js_stream_socket.js
+++ b/lib/internal/js_stream_socket.js
@@ -21,6 +21,7 @@ const { ERR_STREAM_WRAP } = require('internal/errors').codes;
 const kCurrentWriteRequest = Symbol('kCurrentWriteRequest');
 const kCurrentShutdownRequest = Symbol('kCurrentShutdownRequest');
 const kPendingShutdownRequest = Symbol('kPendingShutdownRequest');
+const kPendingClose = Symbol('kPendingClose');
 
 function isClosing() { return this[owner_symbol].isClosing(); }
 
@@ -94,6 +95,7 @@ class JSStreamSocket extends Socket {
     this[kCurrentWriteRequest] = null;
     this[kCurrentShutdownRequest] = null;
     this[kPendingShutdownRequest] = null;
+    this[kPendingClose] = false;
     this.readable = stream.readable;
     this.writable = stream.writable;
 
@@ -135,9 +137,16 @@ class JSStreamSocket extends Socket {
       this[kPendingShutdownRequest] = req;
       return 0;
     }
+
     assert(this[kCurrentWriteRequest] === null);
     assert(this[kCurrentShutdownRequest] === null);
     this[kCurrentShutdownRequest] = req;
+
+    if (this[kPendingClose]) {
+      // If doClose is pending, the stream & this._handle are gone. We can't do
+      // anything. doClose will call finishShutdown with ECANCELED for us shortly.
+      return 0;
+    }
 
     const handle = this._handle;
 
@@ -163,6 +172,13 @@ class JSStreamSocket extends Socket {
   doWrite(req, bufs) {
     assert(this[kCurrentWriteRequest] === null);
     assert(this[kCurrentShutdownRequest] === null);
+
+    if (this[kPendingClose]) {
+      // If doClose is pending, the stream & this._handle are gone. We can't do
+      // anything. doClose will call finishWrite with ECANCELED for us shortly.
+      this[kCurrentWriteRequest] = req; // Store req, for doClose to cancel
+      return 0;
+    }
 
     const handle = this._handle;
     const self = this;
@@ -217,6 +233,8 @@ class JSStreamSocket extends Socket {
   }
 
   doClose(cb) {
+    this[kPendingClose] = true;
+
     const handle = this._handle;
 
     // When sockets of the "net" module destroyed, they will call
@@ -233,6 +251,8 @@ class JSStreamSocket extends Socket {
 
       this.finishWrite(handle, uv.UV_ECANCELED);
       this.finishShutdown(handle, uv.UV_ECANCELED);
+
+      this[kPendingClose] = false;
 
       cb();
     });

--- a/test/parallel/test-http2-client-connection-tunnelling.js
+++ b/test/parallel/test-http2-client-connection-tunnelling.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const net = require('net');
+const tls = require('tls');
+const h2 = require('http2');
+
+// This test sets up an H2 proxy server, and tunnels a request over one of its streams
+// back to itself, via TLS, and then closes the TLS connection. On some Node versions
+// (v18 & v20 up to 20.5.1) the resulting JS Stream Socket fails to shutdown correctly
+// in this case, and crashes due to a null pointer in finishShutdown.
+
+const tlsOptions = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+  ALPNProtocols: ['h2']
+};
+
+const netServer = net.createServer((socket) => {
+  socket.allowHalfOpen = false;
+  // ^ This allows us to trigger this reliably, but it's not strictly required
+  // for the bug and crash to happen, skipping this just fails elsewhere later.
+
+  h2Server.emit('connection', socket);
+});
+
+const h2Server = h2.createSecureServer(tlsOptions, (req, res) => {
+  res.writeHead(200);
+  res.end();
+});
+
+h2Server.on('connect', (req, res) => {
+  res.writeHead(200, {});
+  netServer.emit('connection', res.stream);
+});
+
+netServer.listen(0, common.mustCall(() => {
+  const proxyClient = h2.connect(`https://localhost:${netServer.address().port}`, {
+    rejectUnauthorized: false
+  });
+
+  const proxyReq = proxyClient.request({
+    ':method': 'CONNECT',
+    ':authority': 'example.com:443'
+  });
+
+  proxyReq.on('response', common.mustCall((response) => {
+    assert.strictEqual(response[':status'], 200);
+
+    // Create a TLS socket within the tunnel, and start sending a request:
+    const tlsSocket = tls.connect({
+      socket: proxyReq,
+      ALPNProtocols: ['h2'],
+      rejectUnauthorized: false
+    });
+
+    proxyReq.on('close', common.mustCall(() => {
+      proxyClient.close();
+      netServer.close();
+    }));
+
+    // Forcibly kill the TLS socket
+    tlsSocket.destroy();
+
+    // This results in an async error in affected Node versions, before the 'close' event
+  }));
+}));


### PR DESCRIPTION
This fixes https://github.com/nodejs/node/issues/48519
EDIT: and fixes https://github.com/nodejs/node/issues/46094

This is independent of my other related fix https://github.com/nodejs/node/pull/49327 but in most relevant scenarios you'll want both together. Each of these PRs has a test that catastrophically fails right now, but works correctly with the corresponding change included, but you'll likely want both since in production I find that either fix by itself ends up resulting in the other error crashing my application instead a little later on (i.e. these two separate issues are currently racing to crash my code).

There's a detailed breakdown of the crash fixed in this PR [here](https://github.com/nodejs/node/issues/48519#issuecomment-1690284275). To summarize:

* A JS Stream Socket (JSS) is created, wrapping an HTTP/2 stream (anything might work) and then used by a TLS stream (i.e. TLS runs on top of the JSS) with `allowHalfOpen = false` set (this is common for TLS, AFAICT).
* The underlying H2 stream closes
* This fires a 'close' event, which results in the JSS calling `doClose`, and also ends the TLS stream (which in turn closes the writable side, due to `allowHalfOpen = false`) which calls `doShutdown` on the JSS. Effectively both sides try to shut down the JSS at the same time.
* `doClose` runs first, calls `this.stream.destroy()` which sets `this._handle` to null, and schedules a `setImmediate` to cancel any pending writes or shutdowns.
* `doShutdown` then runs, picks up `this._handle` (now null), and then schedules a `finishShutdown` that will call `this._handle.finishShutdown` (=uncatchable NPE)
* Before https://github.com/nodejs/node/commit/9ccf8b2ccc1b650ba0f9749e2ffe2780e51d1000 (released in Node 18+) the `doClose` callback ran first, cleared `kCurrentShutdownRequest`, and so the null pointer was never actually read, but effectively just by luck.
* After that change, the `finishShutdown` from `doShutdown` runs first, and so _does_ use its null pointer every time, crashing everything.

Rather than just reverting to `setImmediate` or using `process.nextTick` in `doClose` too, I've fixed this properly: now, if there is any race with `doClose`, the other methods recognize it, store the `kCurrent{Shutdown,Write}Request` param to allow `doClose` to do its clean cancellation a moment later, and then they avoid reading or using the null `this._handle` value entirely.

That above example explains the `doShutdown` race. A similar race applies to `doWrite`/`finishWrite` too, which I can reliably reproduce in my application after fixing just the shutdown case, although I don't have a reliable test to repro this (https://github.com/nodejs/node/issues/46094, https://github.com/nodejs/node/issues/35695, https://github.com/nodejs/node/issues/27258 and https://github.com/microsoft/vscode/issues/188676 all appear to be examples of the same issue). With the equivalent fix included for `doWrite` here too, I can no longer reproduce that error either.

With the fixes for both methods here plus https://github.com/nodejs/node/pull/49327, I can proxy significant chunks of real HTTP/2 browser traffic through my app, including all the weird edge cases and errors of the web for at least an hour. Previously this crashed comfortably within a minute on Node 18+.

This also adds asserts to both affected methods, to more explicitly catch any other cases where this could happen (in both cases, if those asserts fail, it's very likely that there'll be an NPE next stick in the corresponding finishX methods).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
