### PR TITLE
http: support FetchEvent API

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -109,6 +109,7 @@ const {
   startPerf,
   stopPerf,
 } = require('internal/perf/observe');
+const { makeFetchHandler } = require('internal/fetch_event');
 
 const STATUS_CODES = {
   100: 'Continue',                   // RFC 7231 6.2.1
@@ -557,6 +558,15 @@ function Server(options, requestListener) {
 }
 ObjectSetPrototypeOf(Server.prototype, net.Server.prototype);
 ObjectSetPrototypeOf(Server, net.Server);
+
+Server.prototype.on = function(event, handler) {
+  if (event === 'fetch') {
+    event = 'request';
+    handler = makeFetchHandler(handler);
+  }
+
+  return FunctionPrototypeCall(net.Server.prototype.on, this, event, handler);
+};
 
 Server.prototype.close = function() {
   httpServerPreClose(this);

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -27,6 +27,7 @@ const {
     ERR_INVALID_ARG_TYPE,
     ERR_EVENT_RECURSION,
     ERR_MISSING_ARGS,
+    ERR_INVALID_STATE,
     ERR_INVALID_THIS,
   },
 } = require('internal/errors');
@@ -397,6 +398,46 @@ class NodeCustomEvent extends Event {
       this.detail = options.detail;
     }
   }
+}
+
+const kExtendedLifetimePromises = Symbol('kExtendedLifetimePromises');
+const kPendingPromiseCount = Symbol('kPendingPromiseCount');
+const kTimedOut = Symbol('kTimedOut');
+
+class ExtendableEvent extends Event {
+  constructor(type, options) {
+    super(type, options);
+
+    this[kExtendedLifetimePromises] = [];
+    this[kPendingPromiseCount] = 0;
+    this[kTimedOut] = false;
+  }
+
+  waitUntil(promise) {
+    if (!this.isTrusted) {
+      throw new ERR_INVALID_STATE('ExtendableEvent is not trusted.');
+    }
+
+    if (!isExtendableEventActive(this)) {
+      throw new ERR_INVALID_STATE('ExtendableEvent is not active.');
+    }
+
+    this[kExtendedLifetimePromises].push(promise);
+    this[kPendingPromiseCount]++;
+
+    promise.finally(() => {
+      this[kPendingPromiseCount]--;
+
+      // TODO(qard): ServiceWorkers unregister at this point. Does this need to
+      // be surfaced to FetchEvent somehow?
+      // if (this[kPendingPromiseCount] === 0) {}
+    });
+  }
+}
+
+function isExtendableEventActive(event) {
+  return !event[kTimedOut] &&
+    (event[kPendingPromiseCount] > 0 || event[kIsBeingDispatched]);
 }
 
 // Weak listener cleanup
@@ -1141,6 +1182,7 @@ function defineEventHandler(emitter, name, event = name) {
 
 module.exports = {
   Event,
+  ExtendableEvent,
   CustomEvent,
   EventTarget,
   NodeEventTarget,
@@ -1155,4 +1197,5 @@ module.exports = {
   kWeakHandler,
   kResistStopPropagation,
   isEventTarget,
+  isExtendableEventActive,
 };

--- a/lib/internal/fetch_event.js
+++ b/lib/internal/fetch_event.js
@@ -1,0 +1,213 @@
+'use strict';
+
+const {
+  ObjectDefineProperty,
+  ObjectFromEntries,
+  Promise,
+  PromiseResolve,
+  SafePromiseRace,
+  Symbol,
+  globalThis,
+} = primordials;
+
+const {
+  codes: {
+    ERR_HTTP_REQUEST_TIMEOUT,
+    ERR_INVALID_STATE,
+  },
+} = require('internal/errors');
+const { setTimeout } = require('timers');
+const { Readable } = require('internal/streams/readable');
+const { URL } = require('url');
+const { Event, EventTarget, ExtendableEvent, kTrustEvent } = require('internal/event_target');
+
+const kResponse = Symbol('kResponse');
+
+class FetchEvent extends ExtendableEvent {
+  #waitToRespond;
+  #respondWithEntered;
+  #respondWithError;
+
+  // Handled promise fulfillment
+  #resolve;
+  #reject;
+
+  constructor(type = 'fetch', fetchOptions = {}) {
+    const {
+      request,
+      preloadResponse,
+      clientId,
+      resultingClientId,
+      replacesClientId,
+      ...options
+    } = fetchOptions;
+
+    super(type, {
+      ...options,
+      [kTrustEvent]: true,
+    });
+
+    this.#waitToRespond = false;
+    this.#respondWithEntered = false;
+    this.#respondWithError = false;
+
+    this[kResponse] = undefined;
+
+    ObjectDefineProperty(this, 'handled', {
+      __proto__: null,
+      value: new Promise((resolve, reject) => {
+        this.#resolve = resolve;
+        this.#reject = reject;
+      }),
+    });
+
+    ObjectDefineProperty(this, 'request', {
+      __proto__: null,
+      value: request,
+      enumerable: true,
+    });
+
+    ObjectDefineProperty(this, 'preloadResponse', {
+      __proto__: null,
+      value: PromiseResolve(preloadResponse),
+      enumerable: true,
+    });
+
+    // Per the spec, client IDs should be passed through or be empty strings.
+    ObjectDefineProperty(this, 'clientId', {
+      __proto__: null,
+      value: clientId || '',
+      enumerable: true,
+    });
+    ObjectDefineProperty(this, 'resultingClientId', {
+      __proto__: null,
+      value: resultingClientId || '',
+      enumerable: true,
+    });
+    ObjectDefineProperty(this, 'replacesClientId', {
+      __proto__: null,
+      value: replacesClientId || '',
+      enumerable: true,
+    });
+  }
+
+  respondWith(response) {
+    // 1. Let event be this.
+    const event = this;
+
+    // 2. If event's dispatch flag is unset, throw an "InvalidStateError"
+    // DOMException.
+    if (event.eventPhase !== Event.AT_TARGET) {
+      throw new ERR_INVALID_STATE('FetchEvent has not been dispatched');
+    }
+
+    // 3. If event's respond-with entered flag is set, throw an
+    // "InvalidStateError" DOMException.
+    if (event.#respondWithEntered) {
+      throw new ERR_INVALID_STATE('FetchEvent respond-with already entered');
+    }
+
+    // 4. Add lifetime promise r to event.
+    const promise = PromiseResolve(response);
+    event.waitUntil(promise);
+
+    // 5. Set event's stop propagation flag and stop immediate propagation
+    // flag.
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+
+    // 6. Set event's respond-with entered flag.
+    event.#respondWithEntered = true;
+
+    // 7. Set event's wait to respond flag.
+    event.#waitToRespond = true;
+
+    // 8. Let targetRealm be event's relevant Realm.
+    // NOTE: Nothing to do here...
+
+    // 9. Upon rejection of r:
+    promise.catch((err) => {
+      // 9.1. Set event's respond-with error flag.
+      this.#respondWithError = true;
+
+      // 9.2. Unset event's wait to respond flag.
+      this.#waitToRespond = false;
+
+      this.#reject(err);
+    });
+
+    // 10. Upon fulfillment of r with response:
+    promise.then((response) => {
+      // 10.1. If response is not a Response object, then set the respond-with
+      // error flag.
+      if (!(response instanceof globalThis.Response)) {
+        this.#respondWithError = true;
+
+        this.#reject();
+      // 10.2. Else:
+      } else {
+        // NOTE: This deviates from spec as we don't need to reproduce the
+        // streaming behaviour without a ServiceWorker in the middle.
+        this[kResponse] = response;
+        this.#resolve();
+      }
+
+      // 10.3. Unset event's wait to respond flag.
+      this.#waitToRespond = false;
+    });
+  }
+}
+
+function toWebRequest(req) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const headers = new globalThis.Headers(req.headers);
+
+  const options = {
+    duplex: 'half',
+    body: undefined,
+    method: req.method,
+    headers,
+  };
+
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    options.body = Readable.toWeb(req);
+  }
+
+  return new globalThis.Request(url.href, options);
+}
+
+function toFetchEvent(req) {
+  return new FetchEvent('fetch', {
+    request: toWebRequest(req),
+  });
+}
+
+function makeFetchHandler(handler, timeout = 30000) {
+  const target = new EventTarget();
+  target.addEventListener('fetch', handler);
+
+  return async function(req, res) {
+    // Make FetchEvent instance
+    const event = toFetchEvent(req);
+    target.dispatchEvent(event);
+
+    await SafePromiseRace([
+      event.handled,
+      new Promise((_, reject) => {
+        const error = new ERR_HTTP_REQUEST_TIMEOUT();
+        setTimeout(reject, timeout, error).unref();
+      }),
+    ]);
+
+    const response = event[kResponse];
+
+    const resHeaders = ObjectFromEntries(response.headers.entries());
+    res.writeHead(response.status, resHeaders);
+
+    Readable.fromWeb(response.body).pipe(res);
+  };
+}
+
+module.exports = {
+  makeFetchHandler,
+};

--- a/test/parallel/test-http-fetch-event.js
+++ b/test/parallel/test-http-fetch-event.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { createServer } = require('http');
+
+const server = createServer();
+
+server.on('fetch', common.mustCall((event) => {
+  event.respondWith(event.request.json().then(({ name }) => {
+    return new Response(`Hello, ${name}!`, {
+      status: 200,
+      headers: {
+        'content-type': 'text/plain'
+      }
+    });
+  }));
+}));
+
+server.listen(common.mustCall(async () => {
+  try {
+    const { port } = server.address();
+
+    const req = await fetch(`http://localhost:${port}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        name: 'world'
+      }),
+    });
+
+    const body = await req.text();
+
+    assert.strictEqual(body, 'Hello, world!');
+  } finally {
+    server.close();
+  }
+}));


### PR DESCRIPTION
This is an experiment to see if it would be reasonable to support the [FetchEvent](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent) interface on an http server. My thinking was to start with a named event directly on the server for the moment and then extend that with more ServiceWorker style thread isolation as a layer on top of that later. Could also consider a separate `createFetchServer` factory or modifying the existing `createServer` to mode switch by function parameter count. Just wanted to share my little MVP first though to see what people think and discuss direction or if we want to pursue this at all. 🤔 

Note that this is still very much an experiment so probably lots of bugs and usability issues. Also no docs yet, you can see the test for an example of how it works. Just want to get feedback before I put more work into it.

I was also thinking of pulling out the [Handle Fetch](https://www.w3.org/TR/service-workers/#on-fetch-request-algorithm) part of the spec to something that could be used both for processing incoming HTTP requests and _also_ put it on `http.Agent` to allow ServiceWorker style request mocking or caching. Could be a useful tool.

cc @nodejs/http @nodejs/undici @nodejs/whatwg-stream 