### PR TITLE
build,module: add `node-esm` support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ EXEEXT := $(shell $(PYTHON) -c \
 		"import sys; print('.exe' if sys.platform == 'win32' else '')")
 
 NODE_EXE = node$(EXEEXT)
+NODE_ESM_EXE = node-esm${EXEEXT}
 NODE ?= ./$(NODE_EXE)
 NODE_G_EXE = node_g$(EXEEXT)
 NPM ?= ./deps/npm/bin/npm-cli.js
@@ -132,6 +133,7 @@ $(NODE_EXE): build_type:=Release
 $(NODE_G_EXE): build_type:=Debug
 $(NODE_EXE) $(NODE_G_EXE): config.gypi out/Makefile
 	$(MAKE) -C out BUILDTYPE=${build_type} V=$(V)
+	ln -fs $(NODE_EXE) out/${build_type}/$(NODE_ESM_EXE)
 	if [ ! -r $@ ] || [ ! -L $@ ]; then \
 	  ln -fs out/${build_type}/$(NODE_EXE) $@; fi
 else
@@ -147,10 +149,12 @@ else
 endif
 $(NODE_EXE): config.gypi out/Release/build.ninja
 	$(NINJA) -C out/Release $(NINJA_ARGS)
+	ln -fs $(NODE_EXE) out/Release/$(NODE_ESM_EXE)
 	if [ ! -r $@ ] || [ ! -L $@ ]; then ln -fs out/Release/$(NODE_EXE) $@; fi
 
 $(NODE_G_EXE): config.gypi out/Debug/build.ninja
 	$(NINJA) -C out/Debug $(NINJA_ARGS)
+	ln -fs $(NODE_EXE) out/Debug/$(NODE_ESM_EXE)
 	if [ ! -r $@ ] || [ ! -L $@ ]; then ln -fs out/Debug/$(NODE_EXE) $@; fi
 else
 $(NODE_EXE) $(NODE_G_EXE):

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -13,6 +13,7 @@ const {
   extensionFormatMap,
   mimeToFormat,
 } = require('internal/modules/esm/formats');
+const { isNodeESM } = require('internal/modules/helpers');
 
 const experimentalNetworkImports =
   getOptionValue('--experimental-network-imports');
@@ -73,8 +74,13 @@ function extname(url) {
  * @returns {string}
  */
 function getFileProtocolModuleFormat(url, context, ignoreErrors) {
+  const defaultESM = isNodeESM();
+
   const ext = extname(url);
   if (ext === '.js') {
+    if (defaultESM) {
+      return getPackageType(url) === 'commonjs' ? 'commonjs' : 'module';
+    }
     return getPackageType(url) === 'module' ? 'module' : 'commonjs';
   }
 
@@ -83,6 +89,11 @@ function getFileProtocolModuleFormat(url, context, ignoreErrors) {
 
   // Explicit undefined return indicates load hook should rerun format check
   if (ignoreErrors) { return undefined; }
+
+  if (defaultESM) {
+    return 'module';
+  }
+
   const filepath = fileURLToPath(url);
   let suggestion = '';
   if (getPackageType(url) === 'module' && ext === '') {

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -256,11 +256,17 @@ function hasEsmSyntax(code) {
     stmt.type === 'ExportAllDeclaration');
 }
 
+function isNodeESM() {
+  const execname = path.basename(process.argv0);
+  return execname === 'node-esm' || execname === 'node-esm.exe';
+}
+
 module.exports = {
   addBuiltinLibsToObject,
   getCjsConditions,
   initializeCjsConditions,
   hasEsmSyntax,
+  isNodeESM,
   loadBuiltinModule,
   makeRequireFunction,
   normalizeReferrerURL,

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -5,6 +5,7 @@ const {
 } = primordials;
 
 const { getOptionValue } = require('internal/options');
+const { isNodeESM } = require('internal/modules/helpers');
 const path = require('path');
 
 function resolveMainPath(main) {
@@ -42,8 +43,13 @@ function shouldUseESMLoader(mainPath) {
     return true;
   if (!mainPath || StringPrototypeEndsWith(mainPath, '.cjs'))
     return false;
+
   const pkg = readPackageScope(mainPath);
-  return pkg && pkg.data.type === 'module';
+
+  if (isNodeESM())
+    return pkg.data?.type !== 'commonjs';
+
+  return pkg.data?.type === 'module';
 }
 
 function runMainESM(mainPath) {

--- a/test/fixtures/errors/force_colors.snapshot
+++ b/test/fixtures/errors/force_colors.snapshot
@@ -8,7 +8,7 @@ Error: Should include grayed stack trace
 [90m    at Module._extensions..js (node:internal*modules*cjs*loader:1295:10)[39m
 [90m    at Module.load (node:internal*modules*cjs*loader:1091:32)[39m
 [90m    at Module._load (node:internal*modules*cjs*loader:938:12)[39m
-[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:83:12)[39m
+[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:89:12)[39m
 [90m    at node:internal*main*run_main_module:23:47[39m
 
 Node.js *

--- a/test/parallel/test-node-esm.mjs
+++ b/test/parallel/test-node-esm.mjs
@@ -1,0 +1,68 @@
+import '../common/index.mjs';
+import { strictEqual } from 'node:assert';
+import fs from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+const tmpdir = createRequire(import.meta.url)('../common/tmpdir.js');
+
+tmpdir.refresh();
+
+const code = 'process.stdout.write(this === undefined ? "module" : "commonjs");\n';
+
+// Copying would be significantly slower
+const copyMethod = async (src, dest) => fs.link(src, dest);
+
+const pathJS = tmpdir.resolve('blep.js');
+await fs.writeFile(pathJS, code);
+const pathMJS = tmpdir.resolve('blep.mjs');
+await fs.writeFile(pathMJS, code);
+const pathCJS = tmpdir.resolve('blep.cjs');
+await fs.writeFile(pathCJS, code);
+const path = tmpdir.resolve('blep');
+await fs.writeFile(path, code);
+const pathIDK = tmpdir.resolve('blep.idontknowthistype');
+await fs.writeFile(pathIDK, code);
+
+{
+  const execPath = tmpdir.resolve('node');
+  await copyMethod(process.execPath, execPath);
+
+  strictEqual(execFileSync(execPath, [pathJS]).toString(), 'commonjs');
+  strictEqual(execFileSync(execPath, [pathMJS]).toString(), 'module');
+  strictEqual(execFileSync(execPath, [pathCJS]).toString(), 'commonjs');
+  strictEqual(execFileSync(execPath, [path]).toString(), 'commonjs');
+  strictEqual(execFileSync(execPath, [pathIDK]).toString(), 'commonjs');
+}
+
+{
+  const execPath = tmpdir.resolve('node-esm');
+  await copyMethod(process.execPath, execPath);
+
+  strictEqual(execFileSync(execPath, [pathJS]).toString(), 'module');
+  strictEqual(execFileSync(execPath, [pathMJS]).toString(), 'module');
+  strictEqual(execFileSync(execPath, [pathCJS]).toString(), 'commonjs');
+  strictEqual(execFileSync(execPath, [path]).toString(), 'module');
+  strictEqual(execFileSync(execPath, [pathIDK]).toString(), 'module');
+}
+
+{
+  const execPath = tmpdir.resolve('node.exe');
+  await copyMethod(process.execPath, execPath);
+
+  strictEqual(execFileSync(execPath, [pathJS]).toString(), 'commonjs');
+  strictEqual(execFileSync(execPath, [pathMJS]).toString(), 'module');
+  strictEqual(execFileSync(execPath, [pathCJS]).toString(), 'commonjs');
+  strictEqual(execFileSync(execPath, [path]).toString(), 'commonjs');
+  strictEqual(execFileSync(execPath, [pathIDK]).toString(), 'commonjs');
+}
+
+{
+  const execPath = tmpdir.resolve('node-esm.exe');
+  await copyMethod(process.execPath, execPath);
+
+  strictEqual(execFileSync(execPath, [pathJS]).toString(), 'module');
+  strictEqual(execFileSync(execPath, [pathMJS]).toString(), 'module');
+  strictEqual(execFileSync(execPath, [pathCJS]).toString(), 'commonjs');
+  strictEqual(execFileSync(execPath, [path]).toString(), 'module');
+  strictEqual(execFileSync(execPath, [pathIDK]).toString(), 'module');
+}


### PR DESCRIPTION
This PR adds `node-esm` (or `node-esm.exe`) support

`node-esm` is ESM-first version of `node`
It resolves unscoped `.js` files, extensionless files and unknown-extension files as ES modules

Supports shebang OOTB
```console
$ cat blep
#!/usr/bin/env node-esm
console.log(import.meta.url);
$ ./blep
file:///home/livia/blep
```

To use this feature, user can rename `node` to `node-esm`
Or just create symlink: `ln -s "$(which node)" /usr/local/bin/node-esm`
Or it can be done by packaging system maintainer so users will have the symlink in `/usr/bin/`

For convenience, build process creates `node-esm` symlink in `out/Release/`

Any feedback is welcome.

Fixes: https://github.com/nodejs/node/issues/32316
Fixes: https://github.com/nodejs/node/issues/33223
Fixes:: https://github.com/nodejs/node/issues/34049
Fixes: https://github.com/nodejs/node/issues/37512
Fixes: https://github.com/nodejs/node/issues/42469
Refs: https://github.com/nodejs/node/pull/49295#issuecomment-1697776757