### PR TITLE
crypto: remove webcrypto EdDSA key checks and properties

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -1641,7 +1641,7 @@ added: v15.0.0
 The length (in bytes) of the random salt to use.
 
 [^1]: An experimental implementation of
-    [Secure Curves in the Web Cryptography API][] as of 05 May 2022
+    [Secure Curves in the Web Cryptography API][] as of 30 August 2023
 
 [JSON Web Key]: https://tools.ietf.org/html/rfc7517
 [Key usages]: #cryptokeyusages

--- a/lib/internal/crypto/cfrg.js
+++ b/lib/internal/crypto/cfrg.js
@@ -272,17 +272,6 @@ async function cfrgImportKey(
           'DataError');
       }
 
-      if (keyData.alg !== undefined) {
-        if (
-          (name === 'Ed25519' || name === 'Ed448') &&
-          keyData.alg !== 'EdDSA'
-        ) {
-          throw lazyDOMException(
-            'JWK "alg" does not match the requested algorithm',
-            'DataError');
-        }
-      }
-
       if (!isPublic && typeof keyData.x !== 'string') {
         throw lazyDOMException('Invalid JWK', 'DataError');
       }

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -475,7 +475,6 @@ async function exportKeyJWK(key) {
       // Fall through
     case 'Ed448':
       jwk.crv ||= key.algorithm.name;
-      jwk.alg = 'EdDSA';
       return jwk;
     case 'AES-CTR':
       // Fall through

--- a/test/parallel/test-webcrypto-export-import-cfrg.js
+++ b/test/parallel/test-webcrypto-export-import-cfrg.js
@@ -251,13 +251,8 @@ async function testImportJwk({ name, publicUsages, privateUsages }, extractable)
     assert.strictEqual(pvtJwk.crv, jwk.crv);
     assert.strictEqual(pvtJwk.d, jwk.d);
 
-    if (jwk.crv.startsWith('Ed')) {
-      assert.strictEqual(pubJwk.alg, 'EdDSA');
-      assert.strictEqual(pvtJwk.alg, 'EdDSA');
-    } else {
-      assert.strictEqual(pubJwk.alg, undefined);
-      assert.strictEqual(pvtJwk.alg, undefined);
-    }
+    assert.strictEqual(pubJwk.alg, undefined);
+    assert.strictEqual(pvtJwk.alg, undefined);
   } else {
     await assert.rejects(
       subtle.exportKey('jwk', publicKey), {
@@ -281,24 +276,22 @@ async function testImportJwk({ name, publicUsages, privateUsages }, extractable)
       { message: 'Invalid JWK "use" Parameter' });
   }
 
+  // The JWK alg member is ignored
+  // https://github.com/WICG/webcrypto-secure-curves/pull/24
   if (name.startsWith('Ed')) {
-    await assert.rejects(
-      subtle.importKey(
-        'jwk',
-        { kty: jwk.kty, x: jwk.x, crv: jwk.crv, alg: 'foo' },
-        { name },
-        extractable,
-        publicUsages),
-      { message: 'JWK "alg" does not match the requested algorithm' });
+    await subtle.importKey(
+      'jwk',
+      { kty: jwk.kty, x: jwk.x, crv: jwk.crv, alg: 'foo' },
+      { name },
+      extractable,
+      publicUsages);
 
-    await assert.rejects(
-      subtle.importKey(
-        'jwk',
-        { ...jwk, alg: 'foo' },
-        { name },
-        extractable,
-        privateUsages),
-      { message: 'JWK "alg" does not match the requested algorithm' });
+    await subtle.importKey(
+      'jwk',
+      { ...jwk, alg: 'foo' },
+      { name },
+      extractable,
+      privateUsages);
   }
 
   for (const crv of [undefined, name === 'Ed25519' ? 'Ed448' : 'Ed25519']) {


### PR DESCRIPTION
As per https://github.com/WICG/webcrypto-secure-curves/pull/24 this removes the check for EdDSA `alg` during JWK importKey and removes the `alg` for Ed25519 and Ed448 keys during JWK exportKey.

The algorithms from https://github.com/WICG/webcrypto-secure-curves/ are marked as experimental  in our implementation which is why this can forgo semver-major and also be easily backported.