### PR TITLE
deps: add missing thread-common.c in uv.gyp

### DIFF
--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -51,6 +51,7 @@
       'src/strscpy.h',
       'src/strtok.c',
       'src/strtok.h',
+      'src/thread-common.c',
       'src/threadpool.c',
       'src/timer.c',
       'src/uv-data-getter-setters.c',


### PR DESCRIPTION
This should fix https://github.com/nodejs/node/issues/49409