### PR TITLE
test: fix warning for comment in embedtest

### DIFF
--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -64,12 +64,12 @@ int RunNodeInstance(MultiIsolatePlatform* platform,
 
   // Format of the arguments of this binary:
   // Building snapshot:
-  // embedtest js_code_to_eval arg1 arg2... \
-  //           --embedder-snapshot-blob blob-path \
+  // embedtest js_code_to_eval arg1 arg2...
+  //           --embedder-snapshot-blob blob-path
   //           --embedder-snapshot-create
   //           [--embedder-snapshot-as-file]
   // Running snapshot:
-  // embedtest --embedder-snapshot-blob blob-path \
+  // embedtest --embedder-snapshot-blob blob-path
   //           [--embedder-snapshot-as-file]
   //           arg1 arg2...
   // No snapshot:


### PR DESCRIPTION
- Build log(Ubuntu 20.04)
```shell
...
../test/embedding/embedtest.cc:67:3: warning: multi-line comment [-Wcomment]
   67 |   // embedtest js_code_to_eval arg1 arg2... \
      |   ^
../test/embedding/embedtest.cc:72:3: warning: multi-line comment [-Wcomment]
   72 |   // embedtest --embedder-snapshot-blob blob-path \
...
```

Warning messages are occurring due to a comments on the following line.
https://github.com/nodejs/node/blob/3a6a80a4e1ad3fc3f1b181e1c94ecfd0b17e6dd1/test/embedding/embedtest.cc#L65-L76

A line of comment starting with `//` is supposed to end at the newline character. 
However, if a backslash(`\`) is placed at the end of the line, the comment is extended to the next line. This is because the backslash at the end of a line is a line-continuation character, which tells the compiler to treat the next line as a continuation of the current line. This can lead to unexpected behavior, hence the compiler warning.

There are several suggestions for solving this, but I suggest a simple way to remove the backslash(`\`).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
