### PR TITLE
deps: V8: backport 0aa622e12893

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.15',
+    'v8_embedder_string': '-node.16',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-object.h
+++ b/deps/v8/include/v8-object.h
@@ -474,11 +474,20 @@ class V8_EXPORT Object : public Value {
     return object->InternalFieldCount();
   }
 
-  /** Gets the value from an internal field. */
-  V8_INLINE Local<Value> GetInternalField(int index);
+  /**
+   * Gets the data from an internal field.
+   * To cast the return value into v8::Value subtypes, it needs to be
+   * casted to a v8::Value first. For example, to cast it into v8::External:
+   *
+   * object->GetInternalField(index).As<v8::Value>().As<v8::External>();
+   *
+   * The embedder should make sure that the internal field being retrieved
+   * using this method has already been set with SetInternalField() before.
+   **/
+  V8_INLINE Local<Data> GetInternalField(int index);
 
-  /** Sets the value in an internal field. */
-  void SetInternalField(int index, Local<Value> value);
+  /** Sets the data in an internal field. */
+  void SetInternalField(int index, Local<Data> data);
 
   /**
    * Gets a 2-byte-aligned native pointer from an internal field. This field
@@ -710,13 +719,13 @@ class V8_EXPORT Object : public Value {
  private:
   Object();
   static void CheckCast(Value* obj);
-  Local<Value> SlowGetInternalField(int index);
+  Local<Data> SlowGetInternalField(int index);
   void* SlowGetAlignedPointerFromInternalField(int index);
 };
 
 // --- Implementation ---
 
-Local<Value> Object::GetInternalField(int index) {
+Local<Data> Object::GetInternalField(int index) {
 #ifndef V8_ENABLE_CHECKS
   using A = internal::Address;
   using I = internal::Internals;
@@ -734,12 +743,12 @@ Local<Value> Object::GetInternalField(int index) {
 #endif
 
 #ifdef V8_ENABLE_CONSERVATIVE_STACK_SCANNING
-    return Local<Value>(reinterpret_cast<Value*>(value));
+    return Local<Data>(reinterpret_cast<Data*>(value));
 #else
     internal::Isolate* isolate =
         internal::IsolateFromNeverReadOnlySpaceObject(obj);
     A* result = HandleScope::CreateHandle(isolate, value);
-    return Local<Value>(reinterpret_cast<Value*>(result));
+    return Local<Data>(reinterpret_cast<Data*>(result));
 #endif
   }
 #endif

--- a/deps/v8/samples/process.cc
+++ b/deps/v8/samples/process.cc
@@ -388,7 +388,7 @@ Local<Object> JsHttpRequestProcessor::WrapMap(map<string, string>* obj) {
 // Utility function that extracts the C++ map pointer from a wrapper
 // object.
 map<string, string>* JsHttpRequestProcessor::UnwrapMap(Local<Object> obj) {
-  Local<External> field = obj->GetInternalField(0).As<External>();
+  Local<External> field = obj->GetInternalField(0).As<Value>().As<External>();
   void* ptr = field->Value();
   return static_cast<map<string, string>*>(ptr);
 }
@@ -504,7 +504,7 @@ Local<Object> JsHttpRequestProcessor::WrapRequest(HttpRequest* request) {
  * wrapper object.
  */
 HttpRequest* JsHttpRequestProcessor::UnwrapRequest(Local<Object> obj) {
-  Local<External> field = obj->GetInternalField(0).As<External>();
+  Local<External> field = obj->GetInternalField(0).As<Value>().As<External>();
   void* ptr = field->Value();
   return static_cast<HttpRequest*>(ptr);
 }

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -6342,16 +6342,16 @@ static bool InternalFieldOK(i::Handle<i::JSReceiver> obj, int index,
       location, "Internal field out of bounds");
 }
 
-Local<Value> v8::Object::SlowGetInternalField(int index) {
+Local<Data> v8::Object::SlowGetInternalField(int index) {
   i::Handle<i::JSReceiver> obj = Utils::OpenHandle(this);
   const char* location = "v8::Object::GetInternalField()";
   if (!InternalFieldOK(obj, index, location)) return Local<Value>();
   i::Handle<i::Object> value(i::JSObject::cast(*obj).GetEmbedderField(index),
                              obj->GetIsolate());
-  return Utils::ToLocal(value);
+  return ToApiHandle<Data>(value);
 }
 
-void v8::Object::SetInternalField(int index, v8::Local<Value> value) {
+void v8::Object::SetInternalField(int index, v8::Local<Data> value) {
   i::Handle<i::JSReceiver> obj = Utils::OpenHandle(this);
   const char* location = "v8::Object::SetInternalField()";
   if (!InternalFieldOK(obj, index, location)) return;

--- a/deps/v8/test/cctest/test-api.h
+++ b/deps/v8/test/cctest/test-api.h
@@ -44,9 +44,11 @@ template <typename T>
 static void CheckInternalFieldsAreZero(v8::Local<T> value) {
   CHECK_EQ(T::kInternalFieldCount, value->InternalFieldCount());
   for (int i = 0; i < value->InternalFieldCount(); i++) {
-    CHECK_EQ(0, value->GetInternalField(i)
-                    ->Int32Value(CcTest::isolate()->GetCurrentContext())
-                    .FromJust());
+    v8::Local<v8::Value> field =
+        value->GetInternalField(i).template As<v8::Value>();
+    CHECK_EQ(
+        0,
+        field->Int32Value(CcTest::isolate()->GetCurrentContext()).FromJust());
   }
 }
 

--- a/deps/v8/test/cctest/test-serialize.cc
+++ b/deps/v8/test/cctest/test-serialize.cc
@@ -3577,23 +3577,27 @@ UNINITIALIZED_TEST(SnapshotCreatorTemplates) {
                                       .ToLocalChecked()
                                       ->ToObject(context)
                                       .ToLocalChecked();
-        v8::Local<v8::Object> b =
-            a->GetInternalField(0)->ToObject(context).ToLocalChecked();
-        v8::Local<v8::Object> c =
-            b->GetInternalField(0)->ToObject(context).ToLocalChecked();
+        v8::Local<v8::Object> b = a->GetInternalField(0)
+                                      .As<v8::Value>()
+                                      ->ToObject(context)
+                                      .ToLocalChecked();
+        v8::Local<v8::Object> c = b->GetInternalField(0)
+                                      .As<v8::Value>()
+                                      ->ToObject(context)
+                                      .ToLocalChecked();
 
         InternalFieldData* a1 = reinterpret_cast<InternalFieldData*>(
             a->GetAlignedPointerFromInternalField(1));
-        v8::Local<v8::Value> a2 = a->GetInternalField(2);
+        v8::Local<v8::Value> a2 = a->GetInternalField(2).As<v8::Value>();
 
         InternalFieldData* b1 = reinterpret_cast<InternalFieldData*>(
             b->GetAlignedPointerFromInternalField(1));
-        v8::Local<v8::Value> b2 = b->GetInternalField(2);
+        v8::Local<v8::Value> b2 = b->GetInternalField(2).As<v8::Value>();
 
-        v8::Local<v8::Value> c0 = c->GetInternalField(0);
+        v8::Local<v8::Value> c0 = c->GetInternalField(0).As<v8::Value>();
         InternalFieldData* c1 = reinterpret_cast<InternalFieldData*>(
             c->GetAlignedPointerFromInternalField(1));
-        v8::Local<v8::Value> c2 = c->GetInternalField(2);
+        v8::Local<v8::Value> c2 = c->GetInternalField(2).As<v8::Value>();
 
         CHECK(c0->IsUndefined());
 

--- a/deps/v8/test/unittests/objects/value-serializer-unittest.cc
+++ b/deps/v8/test/unittests/objects/value-serializer-unittest.cc
@@ -61,12 +61,14 @@ class ValueSerializerTest : public TestWithIsolate {
     function_template->InstanceTemplate()->SetAccessor(
         StringFromUtf8("value"),
         [](Local<String> property, const PropertyCallbackInfo<Value>& args) {
-          args.GetReturnValue().Set(args.Holder()->GetInternalField(0));
+          args.GetReturnValue().Set(
+              args.Holder()->GetInternalField(0).As<v8::Value>());
         });
     function_template->InstanceTemplate()->SetAccessor(
         StringFromUtf8("value2"),
         [](Local<String> property, const PropertyCallbackInfo<Value>& args) {
-          args.GetReturnValue().Set(args.Holder()->GetInternalField(1));
+          args.GetReturnValue().Set(
+              args.Holder()->GetInternalField(1).As<v8::Value>());
         });
     for (Local<Context> context :
          {serialization_context_, deserialization_context_}) {
@@ -2897,6 +2899,7 @@ TEST_F(ValueSerializerTestWithHostObject, RoundTripUint32) {
       .WillRepeatedly(Invoke([this](Isolate*, Local<Object> object) {
         uint32_t value = 0;
         EXPECT_TRUE(object->GetInternalField(0)
+                        .As<v8::Value>()
                         ->Uint32Value(serialization_context())
                         .To(&value));
         WriteExampleHostObjectTag();
@@ -2928,9 +2931,11 @@ TEST_F(ValueSerializerTestWithHostObject, RoundTripUint64) {
       .WillRepeatedly(Invoke([this](Isolate*, Local<Object> object) {
         uint32_t value = 0, value2 = 0;
         EXPECT_TRUE(object->GetInternalField(0)
+                        .As<v8::Value>()
                         ->Uint32Value(serialization_context())
                         .To(&value));
         EXPECT_TRUE(object->GetInternalField(1)
+                        .As<v8::Value>()
                         ->Uint32Value(serialization_context())
                         .To(&value2));
         WriteExampleHostObjectTag();
@@ -2968,6 +2973,7 @@ TEST_F(ValueSerializerTestWithHostObject, RoundTripDouble) {
       .WillRepeatedly(Invoke([this](Isolate*, Local<Object> object) {
         double value = 0;
         EXPECT_TRUE(object->GetInternalField(0)
+                        .As<v8::Value>()
                         ->NumberValue(serialization_context())
                         .To(&value));
         WriteExampleHostObjectTag();


### PR DESCRIPTION
Original commit message:

    [api] allow v8::Data as internal field

    Previously only v8::Value can be stored as internal fields.
    In some cases, however, it's necessary for the embedder to
    tie the lifetime of a v8::Data with the lifetime of a
    JS object, and that v8::Data may not be a v8::Value, as
    it can be something returned from the V8 API. One way to
    keep the v8::Data alive may be to use a v8::Persistent<v8::Data>
    but that can easily lead to leaks.

    This patch changes v8::Object::GetInternalField() and
    v8::Object::SetInernalField() to accept v8::Data instead of just
    v8::Value, so that v8::Data can kept alive by a JS object in
    a way that the GC can be aware of to address this problem.
    This is a breaking change for embedders
    using v8::Object::GetInternalField() as it changes the return
    type. Since most v8::Value subtypes only support direct casts
    from v8::Value but not v8::Data, calls like

    object->GetInternalField(index).As<v8::External>()

    needs to be updated to cast the value to v8::Value first:

    object->GetInternalField(index).As<v8::Value>().As<v8::External>()

    Bug: v8:14120
    Change-Id: I731c958d1756b9d5ee4a3e78813416cd60d1b7ca
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4707972
    Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
    Commit-Queue: Joyee Cheung <joyee@igalia.com>
    Cr-Commit-Position: refs/heads/main@{#89718}

Refs: https://github.com/v8/v8/commit/0aa622e12893e9921c01a34ce9507b544e599c4a

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
