### PR TITLE
doc: updated releasers instructions for node.js website

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -1001,9 +1001,14 @@ This script will use the promoted builds and changelog to generate the post. Run
   Refs: <full URL to your release proposal PR>
   ```
 
+* In order to trigger the CI Checks of the [nodejs.org repository][]; Please
+  attach the `github_actions:pull-request` label to the PR.
+
 * Changes to the base branch, `main`, on the [nodejs.org repository][] will
   trigger a new build of nodejs.org so your changes should appear a few minutes
-  after pushing.
+  after pushing. You can follow the 
+  [Deployments](https://github.com/nodejs/nodejs.org/deployments) page
+  to see when the build finishes and gets published.
 
 ### 18. Create the release on GitHub
 

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -1005,9 +1005,8 @@ This script will use the promoted builds and changelog to generate the post. Run
   attach the `github_actions:pull-request` label to the PR.
 
 * Changes to the base branch, `main`, on the [nodejs.org repository][] will
-  trigger a new build of nodejs.org so your changes should appear a few minutes
-  after pushing. You can follow the 
-  [Deployments](https://github.com/nodejs/nodejs.org/deployments) page
+  trigger a new build of nodejs.org, so your changes should appear a few minutes
+  after pushing. You can follow the [Deployments](https://github.com/nodejs/nodejs.org/deployments) page
   to see when the build finishes and gets published.
 
 ### 18. Create the release on GitHub


### PR DESCRIPTION
This PR updates the instructions for Node.js Releasers when publishing a new Blog Post for the Node.js Website