### PR TITLE
test_runner: preserve original property descriptor when mutating objects

### DIFF
--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -11,6 +11,8 @@ const {
   DateNow,
   FunctionPrototypeApply,
   FunctionPrototypeBind,
+  ObjectDefineProperty,
+  ObjectGetOwnPropertyDescriptor,
   Promise,
   SymbolAsyncIterator,
   SymbolDispose,
@@ -239,11 +241,26 @@ class MockTimers {
       toFake: {
         __proto__: null,
         setTimeout: () => {
-          this.#realSetTimeout = globalThis.setTimeout;
-          this.#realClearTimeout = globalThis.clearTimeout;
-          this.#realTimersSetTimeout = nodeTimers.setTimeout;
-          this.#realTimersClearTimeout = nodeTimers.clearTimeout;
-          this.#realPromisifiedSetTimeout = nodeTimersPromises.setTimeout;
+          this.#realSetTimeout = ObjectGetOwnPropertyDescriptor(
+            globalThis,
+            'setTimeout',
+          );
+          this.#realClearTimeout = ObjectGetOwnPropertyDescriptor(
+            globalThis,
+            'clearTimeout',
+          );
+          this.#realTimersSetTimeout = ObjectGetOwnPropertyDescriptor(
+            nodeTimers,
+            'setTimeout',
+          );
+          this.#realTimersClearTimeout = ObjectGetOwnPropertyDescriptor(
+            nodeTimers,
+            'clearTimeout',
+          );
+          this.#realPromisifiedSetTimeout = ObjectGetOwnPropertyDescriptor(
+            nodeTimersPromises,
+            'setTimeout',
+          );
 
           globalThis.setTimeout = this.#setTimeout;
           globalThis.clearTimeout = this.#clearTimeout;
@@ -257,11 +274,26 @@ class MockTimers {
           );
         },
         setInterval: () => {
-          this.#realSetInterval = globalThis.setInterval;
-          this.#realClearInterval = globalThis.clearInterval;
-          this.#realTimersSetInterval = nodeTimers.setInterval;
-          this.#realTimersClearInterval = nodeTimers.clearInterval;
-          this.#realPromisifiedSetInterval = nodeTimersPromises.setInterval;
+          this.#realSetInterval = ObjectGetOwnPropertyDescriptor(
+            globalThis,
+            'setInterval',
+          );
+          this.#realClearInterval = ObjectGetOwnPropertyDescriptor(
+            globalThis,
+            'clearInterval',
+          );
+          this.#realTimersSetInterval = ObjectGetOwnPropertyDescriptor(
+            nodeTimers,
+            'setInterval',
+          );
+          this.#realTimersClearInterval = ObjectGetOwnPropertyDescriptor(
+            nodeTimers,
+            'clearInterval',
+          );
+          this.#realPromisifiedSetInterval = ObjectGetOwnPropertyDescriptor(
+            nodeTimersPromises,
+            'setInterval',
+          );
 
           globalThis.setInterval = this.#setInterval;
           globalThis.clearInterval = this.#clearInterval;
@@ -275,10 +307,26 @@ class MockTimers {
           );
         },
         setImmediate: () => {
-          this.#realSetImmediate = globalThis.setImmediate;
-          this.#realClearImmediate = globalThis.clearImmediate;
-          this.#realTimersSetImmediate = nodeTimers.setImmediate;
-          this.#realTimersClearImmediate = nodeTimers.clearImmediate;
+          this.#realSetImmediate = ObjectGetOwnPropertyDescriptor(
+            globalThis,
+            'setImmediate',
+          );
+          this.#realClearImmediate = ObjectGetOwnPropertyDescriptor(
+            globalThis,
+            'clearImmediate',
+          );
+          this.#realTimersSetImmediate = ObjectGetOwnPropertyDescriptor(
+            nodeTimers,
+            'setImmediate',
+          );
+          this.#realTimersClearImmediate = ObjectGetOwnPropertyDescriptor(
+            nodeTimers,
+            'clearImmediate',
+          );
+          this.#realPromisifiedSetImmediate = ObjectGetOwnPropertyDescriptor(
+            nodeTimersPromises,
+            'setImmediate',
+          );
 
           globalThis.setImmediate = this.#setImmediate;
           globalThis.clearImmediate = this.#clearImmediate;
@@ -295,31 +343,85 @@ class MockTimers {
       toReal: {
         __proto__: null,
         setTimeout: () => {
-          globalThis.setTimeout = this.#realSetTimeout;
-          globalThis.clearTimeout = this.#realClearTimeout;
-
-          nodeTimers.setTimeout = this.#realTimersSetTimeout;
-          nodeTimers.clearTimeout = this.#realTimersClearTimeout;
-
-          nodeTimersPromises.setTimeout = this.#realPromisifiedSetTimeout;
+          ObjectDefineProperty(
+            globalThis,
+            'setTimeout',
+            this.#realSetTimeout,
+          );
+          ObjectDefineProperty(
+            globalThis,
+            'clearTimeout',
+            this.#realClearTimeout,
+          );
+          ObjectDefineProperty(
+            nodeTimers,
+            'setTimeout',
+            this.#realSetTimeout,
+          );
+          ObjectDefineProperty(
+            nodeTimers,
+            'clearTimeout',
+            this.#realTimersClearTimeout,
+          );
+          ObjectDefineProperty(
+            nodeTimersPromises,
+            'setTimeout',
+            this.#realPromisifiedSetTimeout,
+          );
         },
         setInterval: () => {
-          globalThis.setInterval = this.#realSetInterval;
-          globalThis.clearInterval = this.#realClearInterval;
-
-          nodeTimers.setInterval = this.#realTimersSetInterval;
-          nodeTimers.clearInterval = this.#realTimersClearInterval;
-
-          nodeTimersPromises.setInterval = this.#realPromisifiedSetInterval;
+          ObjectDefineProperty(
+            globalThis,
+            'setInterval',
+            this.#realSetInterval,
+          );
+          ObjectDefineProperty(
+            globalThis,
+            'clearInterval',
+            this.#realClearInterval,
+          );
+          ObjectDefineProperty(
+            nodeTimers,
+            'setInterval',
+            this.#realTimersSetInterval,
+          );
+          ObjectDefineProperty(
+            nodeTimers,
+            'clearInterval',
+            this.#realTimersClearInterval,
+          );
+          ObjectDefineProperty(
+            nodeTimersPromises,
+            'setInterval',
+            this.#realPromisifiedSetInterval,
+          );
         },
         setImmediate: () => {
-          globalThis.setImmediate = this.#realSetImmediate;
-          globalThis.clearImmediate = this.#realClearImmediate;
-
-          nodeTimers.setImmediate = this.#realTimersSetImmediate;
-          nodeTimers.clearImmediate = this.#realTimersClearImmediate;
-
-          nodeTimersPromises.setImmediate = this.#realPromisifiedSetImmediate;
+          ObjectDefineProperty(
+            globalThis,
+            'setImmediate',
+            this.#realSetImmediate,
+          );
+          ObjectDefineProperty(
+            globalThis,
+            'clearImmediate',
+            this.#realClearImmediate,
+          );
+          ObjectDefineProperty(
+            nodeTimers,
+            'setImmediate',
+            this.#realTimersSetImmediate,
+          );
+          ObjectDefineProperty(
+            nodeTimers,
+            'clearImmediate',
+            this.#realTimersClearImmediate,
+          );
+          ObjectDefineProperty(
+            nodeTimersPromises,
+            'setImmediate',
+            this.#realPromisifiedSetImmediate,
+          );
         },
       },
     };

--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -241,26 +241,7 @@ class MockTimers {
       toFake: {
         __proto__: null,
         setTimeout: () => {
-          this.#realSetTimeout = ObjectGetOwnPropertyDescriptor(
-            globalThis,
-            'setTimeout',
-          );
-          this.#realClearTimeout = ObjectGetOwnPropertyDescriptor(
-            globalThis,
-            'clearTimeout',
-          );
-          this.#realTimersSetTimeout = ObjectGetOwnPropertyDescriptor(
-            nodeTimers,
-            'setTimeout',
-          );
-          this.#realTimersClearTimeout = ObjectGetOwnPropertyDescriptor(
-            nodeTimers,
-            'clearTimeout',
-          );
-          this.#realPromisifiedSetTimeout = ObjectGetOwnPropertyDescriptor(
-            nodeTimersPromises,
-            'setTimeout',
-          );
+          this.#storeOriginalSetTimeout();
 
           globalThis.setTimeout = this.#setTimeout;
           globalThis.clearTimeout = this.#clearTimeout;
@@ -274,26 +255,7 @@ class MockTimers {
           );
         },
         setInterval: () => {
-          this.#realSetInterval = ObjectGetOwnPropertyDescriptor(
-            globalThis,
-            'setInterval',
-          );
-          this.#realClearInterval = ObjectGetOwnPropertyDescriptor(
-            globalThis,
-            'clearInterval',
-          );
-          this.#realTimersSetInterval = ObjectGetOwnPropertyDescriptor(
-            nodeTimers,
-            'setInterval',
-          );
-          this.#realTimersClearInterval = ObjectGetOwnPropertyDescriptor(
-            nodeTimers,
-            'clearInterval',
-          );
-          this.#realPromisifiedSetInterval = ObjectGetOwnPropertyDescriptor(
-            nodeTimersPromises,
-            'setInterval',
-          );
+          this.#storeOriginalSetInterval();
 
           globalThis.setInterval = this.#setInterval;
           globalThis.clearInterval = this.#clearInterval;
@@ -307,26 +269,7 @@ class MockTimers {
           );
         },
         setImmediate: () => {
-          this.#realSetImmediate = ObjectGetOwnPropertyDescriptor(
-            globalThis,
-            'setImmediate',
-          );
-          this.#realClearImmediate = ObjectGetOwnPropertyDescriptor(
-            globalThis,
-            'clearImmediate',
-          );
-          this.#realTimersSetImmediate = ObjectGetOwnPropertyDescriptor(
-            nodeTimers,
-            'setImmediate',
-          );
-          this.#realTimersClearImmediate = ObjectGetOwnPropertyDescriptor(
-            nodeTimers,
-            'clearImmediate',
-          );
-          this.#realPromisifiedSetImmediate = ObjectGetOwnPropertyDescriptor(
-            nodeTimersPromises,
-            'setImmediate',
-          );
+          this.#storeOriginalSetImmediate();
 
           globalThis.setImmediate = this.#setImmediate;
           globalThis.clearImmediate = this.#clearImmediate;
@@ -343,85 +286,13 @@ class MockTimers {
       toReal: {
         __proto__: null,
         setTimeout: () => {
-          ObjectDefineProperty(
-            globalThis,
-            'setTimeout',
-            this.#realSetTimeout,
-          );
-          ObjectDefineProperty(
-            globalThis,
-            'clearTimeout',
-            this.#realClearTimeout,
-          );
-          ObjectDefineProperty(
-            nodeTimers,
-            'setTimeout',
-            this.#realSetTimeout,
-          );
-          ObjectDefineProperty(
-            nodeTimers,
-            'clearTimeout',
-            this.#realTimersClearTimeout,
-          );
-          ObjectDefineProperty(
-            nodeTimersPromises,
-            'setTimeout',
-            this.#realPromisifiedSetTimeout,
-          );
+          this.#restoreOriginalSetTimeout();
         },
         setInterval: () => {
-          ObjectDefineProperty(
-            globalThis,
-            'setInterval',
-            this.#realSetInterval,
-          );
-          ObjectDefineProperty(
-            globalThis,
-            'clearInterval',
-            this.#realClearInterval,
-          );
-          ObjectDefineProperty(
-            nodeTimers,
-            'setInterval',
-            this.#realTimersSetInterval,
-          );
-          ObjectDefineProperty(
-            nodeTimers,
-            'clearInterval',
-            this.#realTimersClearInterval,
-          );
-          ObjectDefineProperty(
-            nodeTimersPromises,
-            'setInterval',
-            this.#realPromisifiedSetInterval,
-          );
+          this.#restoreOriginalSetInterval();
         },
         setImmediate: () => {
-          ObjectDefineProperty(
-            globalThis,
-            'setImmediate',
-            this.#realSetImmediate,
-          );
-          ObjectDefineProperty(
-            globalThis,
-            'clearImmediate',
-            this.#realClearImmediate,
-          );
-          ObjectDefineProperty(
-            nodeTimers,
-            'setImmediate',
-            this.#realTimersSetImmediate,
-          );
-          ObjectDefineProperty(
-            nodeTimers,
-            'clearImmediate',
-            this.#realTimersClearImmediate,
-          );
-          ObjectDefineProperty(
-            nodeTimersPromises,
-            'setImmediate',
-            this.#realPromisifiedSetImmediate,
-          );
+          this.#restoreSetImmediate();
         },
       },
     };
@@ -429,6 +300,159 @@ class MockTimers {
     const target = activate ? options.toFake : options.toReal;
     ArrayPrototypeForEach(this.#timersInContext, (timer) => target[timer]());
     this.#isEnabled = activate;
+  }
+
+  #restoreSetImmediate() {
+    ObjectDefineProperty(
+      globalThis,
+      'setImmediate',
+      this.#realSetImmediate,
+    );
+    ObjectDefineProperty(
+      globalThis,
+      'clearImmediate',
+      this.#realClearImmediate,
+    );
+    ObjectDefineProperty(
+      nodeTimers,
+      'setImmediate',
+      this.#realTimersSetImmediate,
+    );
+    ObjectDefineProperty(
+      nodeTimers,
+      'clearImmediate',
+      this.#realTimersClearImmediate,
+    );
+    ObjectDefineProperty(
+      nodeTimersPromises,
+      'setImmediate',
+      this.#realPromisifiedSetImmediate,
+    );
+  }
+
+  #restoreOriginalSetInterval() {
+    ObjectDefineProperty(
+      globalThis,
+      'setInterval',
+      this.#realSetInterval,
+    );
+    ObjectDefineProperty(
+      globalThis,
+      'clearInterval',
+      this.#realClearInterval,
+    );
+    ObjectDefineProperty(
+      nodeTimers,
+      'setInterval',
+      this.#realTimersSetInterval,
+    );
+    ObjectDefineProperty(
+      nodeTimers,
+      'clearInterval',
+      this.#realTimersClearInterval,
+    );
+    ObjectDefineProperty(
+      nodeTimersPromises,
+      'setInterval',
+      this.#realPromisifiedSetInterval,
+    );
+  }
+
+  #restoreOriginalSetTimeout() {
+    ObjectDefineProperty(
+      globalThis,
+      'setTimeout',
+      this.#realSetTimeout,
+    );
+    ObjectDefineProperty(
+      globalThis,
+      'clearTimeout',
+      this.#realClearTimeout,
+    );
+    ObjectDefineProperty(
+      nodeTimers,
+      'setTimeout',
+      this.#realSetTimeout,
+    );
+    ObjectDefineProperty(
+      nodeTimers,
+      'clearTimeout',
+      this.#realTimersClearTimeout,
+    );
+    ObjectDefineProperty(
+      nodeTimersPromises,
+      'setTimeout',
+      this.#realPromisifiedSetTimeout,
+    );
+  }
+
+  #storeOriginalSetImmediate() {
+    this.#realSetImmediate = ObjectGetOwnPropertyDescriptor(
+      globalThis,
+      'setImmediate',
+    );
+    this.#realClearImmediate = ObjectGetOwnPropertyDescriptor(
+      globalThis,
+      'clearImmediate',
+    );
+    this.#realTimersSetImmediate = ObjectGetOwnPropertyDescriptor(
+      nodeTimers,
+      'setImmediate',
+    );
+    this.#realTimersClearImmediate = ObjectGetOwnPropertyDescriptor(
+      nodeTimers,
+      'clearImmediate',
+    );
+    this.#realPromisifiedSetImmediate = ObjectGetOwnPropertyDescriptor(
+      nodeTimersPromises,
+      'setImmediate',
+    );
+  }
+
+  #storeOriginalSetInterval() {
+    this.#realSetInterval = ObjectGetOwnPropertyDescriptor(
+      globalThis,
+      'setInterval',
+    );
+    this.#realClearInterval = ObjectGetOwnPropertyDescriptor(
+      globalThis,
+      'clearInterval',
+    );
+    this.#realTimersSetInterval = ObjectGetOwnPropertyDescriptor(
+      nodeTimers,
+      'setInterval',
+    );
+    this.#realTimersClearInterval = ObjectGetOwnPropertyDescriptor(
+      nodeTimers,
+      'clearInterval',
+    );
+    this.#realPromisifiedSetInterval = ObjectGetOwnPropertyDescriptor(
+      nodeTimersPromises,
+      'setInterval',
+    );
+  }
+
+  #storeOriginalSetTimeout() {
+    this.#realSetTimeout = ObjectGetOwnPropertyDescriptor(
+      globalThis,
+      'setTimeout',
+    );
+    this.#realClearTimeout = ObjectGetOwnPropertyDescriptor(
+      globalThis,
+      'clearTimeout',
+    );
+    this.#realTimersSetTimeout = ObjectGetOwnPropertyDescriptor(
+      nodeTimers,
+      'setTimeout',
+    );
+    this.#realTimersClearTimeout = ObjectGetOwnPropertyDescriptor(
+      nodeTimers,
+      'clearTimeout',
+    );
+    this.#realPromisifiedSetTimeout = ObjectGetOwnPropertyDescriptor(
+      nodeTimersPromises,
+      'setTimeout',
+    );
   }
 
   tick(time = 1) {

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -57,7 +57,7 @@ describe('Mock Timers Test Suite', () => {
           'clearInterval',
           'setImmediate',
           'clearImmediate',
-        ]
+        ];
 
         const globalTimersDescriptors = timers.map((fn) => getDescriptor(global, fn));
         const nodeTimersDescriptors = timers.map((fn) => getDescriptor(nodeTimers, fn));
@@ -69,8 +69,8 @@ describe('Mock Timers Test Suite', () => {
           global: globalTimersDescriptors,
           nodeTimers: nodeTimersDescriptors,
           nodeTimersPromises: nodeTimersPromisesDescriptors,
-        }
-      }
+        };
+      };
       const before = getCurrentTimersDescriptors();
       t.mock.timers.enable();
       const during = getCurrentTimersDescriptors();
@@ -80,19 +80,16 @@ describe('Mock Timers Test Suite', () => {
       assert.deepStrictEqual(
         before,
         after,
-        'after reseting timers, the original propertyDescriptor should be preserved',
       );
 
       assert.notDeepStrictEqual(
         before,
         during,
-        'after enabling timers, the original propertyDescriptor should be changed',
       );
 
       assert.notDeepStrictEqual(
         during,
         after,
-        'after reseting timers, the original propertyDescriptor should be changed',
       );
     });
 

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -47,6 +47,55 @@ describe('Mock Timers Test Suite', () => {
       });
     });
 
+    it('should check that propertyDescriptor gets back after reseting timers', (t) => {
+      const getDescriptor = (ctx, fn) => Object.getOwnPropertyDescriptor(ctx, fn);
+      const getCurrentTimersDescriptors = () => {
+        const timers = [
+          'setTimeout',
+          'clearTimeout',
+          'setInterval',
+          'clearInterval',
+          'setImmediate',
+          'clearImmediate',
+        ]
+
+        const globalTimersDescriptors = timers.map((fn) => getDescriptor(global, fn));
+        const nodeTimersDescriptors = timers.map((fn) => getDescriptor(nodeTimers, fn));
+        const nodeTimersPromisesDescriptors = timers
+          .filter((fn) => !fn.includes('clear'))
+          .map((fn) => getDescriptor(nodeTimersPromises, fn));
+
+        return {
+          global: globalTimersDescriptors,
+          nodeTimers: nodeTimersDescriptors,
+          nodeTimersPromises: nodeTimersPromisesDescriptors,
+        }
+      }
+      const before = getCurrentTimersDescriptors();
+      t.mock.timers.enable();
+      const during = getCurrentTimersDescriptors();
+      t.mock.timers.reset();
+      const after = getCurrentTimersDescriptors();
+
+      assert.deepStrictEqual(
+        before,
+        after,
+        'after reseting timers, the original propertyDescriptor should be preserved',
+      );
+
+      assert.notDeepStrictEqual(
+        before,
+        during,
+        'after enabling timers, the original propertyDescriptor should be changed',
+      );
+
+      assert.notDeepStrictEqual(
+        during,
+        after,
+        'after reseting timers, the original propertyDescriptor should be changed',
+      );
+    });
+
     it('should reset all timers when calling .reset function', (t) => {
       t.mock.timers.enable();
       const fn = t.mock.fn();


### PR DESCRIPTION
In this comment, https://github.com/nodejs/node/pull/49397#discussion_r1309308550 @ljharb suggested preserving the behavior and attributes of properties as they were before the modification

cc @nodejs/test_runner 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
