### PR TITLE
doc: fix documentation for fs.createWriteStream highWaterMark option

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2581,6 +2581,18 @@ file descriptor leak.
 By default, the stream will emit a `'close'` event after it has been
 destroyed.  Set the `emitClose` option to `false` to change this behavior.
 
+By providing the `fs` option it is possible to override the corresponding `fs`
+implementations for `open`, `write`, `writev`, and `close`. Overriding `write()`
+without `writev()` can reduce performance as some optimizations (`_writev()`)
+will be disabled. When providing the `fs` option, overrides for at least one of
+`write` and `writev` are required. If no `fd` option is supplied, an override
+for `open` is also required. If `autoClose` is `true`, an override for `close`
+is also required.
+Like {fs.ReadStream}, if `fd` is specified, {fs.WriteStream} will ignore the
+`path` argument and will use the specified file descriptor. This means that no
+`'open'` event will be emitted. `fd` should be blocking; non-blocking `fd`s
+should be passed to {net.Socket}.
+If `options` is a string, then it specifies the encoding.
 
 ### `fs.exists(path, callback)`
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2563,6 +2563,7 @@ changes:
   * `start` {integer}
   * `fs` {Object|null} **Default:** `null`
   * `signal` {AbortSignal|null} **Default:** `null`
+  * `highWaterMark` {number} **Default:** `16384`
 * Returns: {fs.WriteStream}
 
 `options` may also include a `start` option to allow writing data at some
@@ -2580,20 +2581,6 @@ file descriptor leak.
 By default, the stream will emit a `'close'` event after it has been
 destroyed.  Set the `emitClose` option to `false` to change this behavior.
 
-By providing the `fs` option it is possible to override the corresponding `fs`
-implementations for `open`, `write`, `writev`, and `close`. Overriding `write()`
-without `writev()` can reduce performance as some optimizations (`_writev()`)
-will be disabled. When providing the `fs` option, overrides for at least one of
-`write` and `writev` are required. If no `fd` option is supplied, an override
-for `open` is also required. If `autoClose` is `true`, an override for `close`
-is also required.
-
-Like {fs.ReadStream}, if `fd` is specified, {fs.WriteStream} will ignore the
-`path` argument and will use the specified file descriptor. This means that no
-`'open'` event will be emitted. `fd` should be blocking; non-blocking `fd`s
-should be passed to {net.Socket}.
-
-If `options` is a string, then it specifies the encoding.
 
 ### `fs.exists(path, callback)`
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1258,7 +1258,6 @@ changes:
     performance but higher memory usage. **Default:** `32`
   * `recursive` {boolean} Resolved `Dir` will be an {AsyncIterable}
     containing all sub files and directories. **Default:** `false`
-  * `highWaterMark` {number} **Default:** `16384`
 * Returns: {Promise}  Fulfills with an {fs.Dir}.
 
 Asynchronously open a directory for iterative scanning. See the POSIX

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2588,10 +2588,12 @@ will be disabled. When providing the `fs` option, overrides for at least one of
 `write` and `writev` are required. If no `fd` option is supplied, an override
 for `open` is also required. If `autoClose` is `true`, an override for `close`
 is also required.
+
 Like {fs.ReadStream}, if `fd` is specified, {fs.WriteStream} will ignore the
 `path` argument and will use the specified file descriptor. This means that no
 `'open'` event will be emitted. `fd` should be blocking; non-blocking `fd`s
 should be passed to {net.Socket}.
+
 If `options` is a string, then it specifies the encoding.
 
 ### `fs.exists(path, callback)`

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1258,6 +1258,7 @@ changes:
     performance but higher memory usage. **Default:** `32`
   * `recursive` {boolean} Resolved `Dir` will be an {AsyncIterable}
     containing all sub files and directories. **Default:** `false`
+  * `highWaterMark` {number} **Default:** `16384`
 * Returns: {Promise}  Fulfills with an {fs.Dir}.
 
 Asynchronously open a directory for iterative scanning. See the POSIX

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -325,6 +325,7 @@ added: v16.11.0
   * `autoClose` {boolean} **Default:** `true`
   * `emitClose` {boolean} **Default:** `true`
   * `start` {integer}
+  * `highWaterMark` {number} **Default:** `16384`
 * Returns: {fs.WriteStream}
 
 `options` may also include a `start` option to allow writing data at some


### PR DESCRIPTION
Updated the documentation for the fs.createWriteStream function to clarify the usage of the highWaterMark option. The highWaterMark option was missing from the API docs but is a valid option that can be used with the function. This commit adds a description of the highWaterMark option to the API documentation to improve clarity for developers, especially those using TypeScript.

issue:#49420