### PR TITLE
repl: Don't accumulate excess indentation in .load

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -204,6 +204,7 @@ const domainSet = new SafeWeakSet();
 
 const kBufferedCommandSymbol = Symbol('bufferedCommand');
 const kContextId = Symbol('contextId');
+const kLoadingSymbol = Symbol('loading');
 
 let addedNewListener = false;
 
@@ -882,7 +883,7 @@ function REPLServer(prompt,
       self[kBufferedCommandSymbol] += cmd + '\n';
 
       // code alignment
-      const matches = self._sawKeyPress ?
+      const matches = self._sawKeyPress && !self[kLoadingSymbol] ?
         RegExpPrototypeExec(/^\s+/, cmd) : null;
       if (matches) {
         const prefix = matches[0];
@@ -1801,8 +1802,10 @@ function defineDefaultCommands(repl) {
         const stats = fs.statSync(file);
         if (stats && stats.isFile()) {
           _turnOnEditorMode(this);
+          this[kLoadingSymbol] = true;
           const data = fs.readFileSync(file, 'utf8');
           this.write(data);
+          this[kLoadingSymbol] = false;
           _turnOffEditorMode(this);
           this.write('\n');
         } else {

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -67,8 +67,13 @@ testMe.complete('inner.o', common.mustSucceed((data) => {
 // Clear the REPL.
 putIn.run(['.clear']);
 
+testMe._sawKeyPress = true;
 // Load the file back in.
 putIn.run([`.load ${saveFileName}`]);
+
+// Make sure loading doesn't insert extra indentation
+// https://github.com/nodejs/node/issues/47673
+assert.strictEqual(testMe.line, '');
 
 // Make sure that the REPL data is "correct".
 testMe.complete('inner.o', common.mustSucceed((data) => {


### PR DESCRIPTION
When using .load the REPL would accumulate indentation with each line
including the indentation from all previous lines. Now it keeps the
indentation at the correct level.

Fixes: https://github.com/nodejs/node/issues/47673