### PR TITLE
esm: refactor mocking test

### DIFF
--- a/test/es-module/test-esm-loader-mock.mjs
+++ b/test/es-module/test-esm-loader-mock.mjs
@@ -1,73 +1,6 @@
-// Flags: --no-warnings
-import '../common/index.mjs';
-import * as fixtures from '../common/fixtures.mjs';
+// Flags: --no-warnings --import ./test/fixtures/es-module-loaders/mock.mjs
 import assert from 'node:assert/strict';
-import { register } from 'node:module';
-import { MessageChannel } from 'node:worker_threads';
-
-const { port1, port2 } = new MessageChannel();
-
-register(fixtures.fileURL('es-module-loaders/mock-loader.mjs'), {
-  parentURL: import.meta.url,
-  data: { port: port2 },
-  transferList: [port2],
-});
-
-/**
- * This is the Map that saves *all* the mocked URL -> replacement Module
- * mappings
- * @type {Map<string, {namespace, listeners}>}
- */
-globalThis.mockedModules = new Map();
-let mockVersion = 0;
-
-/**
- * @param {string} resolved an absolute URL HREF string
- * @param {object} replacementProperties an object to pick properties from
- *                                       to act as a module namespace
- * @returns {object} a mutator object that can update the module namespace
- *                   since we can't do something like old Object.observe
- */
-function mock(resolved, replacementProperties) {
-  const exportNames = Object.keys(replacementProperties);
-  const namespace = { __proto__: null };
-  /**
-   * @type {Array<(name: string)=>void>} functions to call whenever an
-   *                                     export name is updated
-   */
-  const listeners = [];
-  for (const name of exportNames) {
-    let currentValueForPropertyName = replacementProperties[name];
-    Object.defineProperty(namespace, name, {
-      enumerable: true,
-      get() {
-        return currentValueForPropertyName;
-      },
-      set(v) {
-        currentValueForPropertyName = v;
-        for (const fn of listeners) {
-          try {
-            fn(name);
-          } catch {
-            /* noop */
-          }
-        }
-      }
-    });
-  }
-  globalThis.mockedModules.set(encodeURIComponent(resolved), {
-    namespace,
-    listeners
-  });
-  mockVersion++;
-  // Inform the loader that the `resolved` URL should now use the specific
-  // `mockVersion` and has export names of `exportNames`
-  //
-  // This allows the loader to generate a fake module for that version
-  // and names the next time it resolves a specifier to equal `resolved`
-  port1.postMessage({ mockVersion, resolved, exports: exportNames });
-  return namespace;
-}
+import { mock } from '../fixtures/es-module-loaders/mock.mjs';
 
 mock('node:events', {
   EventEmitter: 'This is mocked!'
@@ -107,5 +40,3 @@ assert.deepStrictEqual(mockedV2, Object.defineProperty({
   enumerable: false,
   value: 'Module'
 }));
-
-delete globalThis.mockedModules;

--- a/test/es-module/test-esm-loader-mock.mjs
+++ b/test/es-module/test-esm-loader-mock.mjs
@@ -1,4 +1,4 @@
-// Flags: --no-warnings --import ./test/fixtures/es-module-loaders/mock.mjs
+// Flags: --import ./test/fixtures/es-module-loaders/mock.mjs
 import assert from 'node:assert/strict';
 import { mock } from '../fixtures/es-module-loaders/mock.mjs';
 

--- a/test/es-module/test-esm-loader-mock.mjs
+++ b/test/es-module/test-esm-loader-mock.mjs
@@ -1,4 +1,4 @@
-// Flags: --import ./test/fixtures/es-module-loaders/mock.mjs
+import '../common/index.mjs';
 import assert from 'node:assert/strict';
 import { mock } from '../fixtures/es-module-loaders/mock.mjs';
 

--- a/test/es-module/test-esm-loader-mock.mjs
+++ b/test/es-module/test-esm-loader-mock.mjs
@@ -1,9 +1,73 @@
-// Flags: --loader ./test/fixtures/es-module-loaders/mock-loader.mjs
+// Flags: --no-warnings
 import '../common/index.mjs';
-import assert from 'assert/strict';
+import * as fixtures from '../common/fixtures.mjs';
+import assert from 'node:assert/strict';
+import { register } from 'node:module';
+import { MessageChannel } from 'node:worker_threads';
 
-// This is provided by test/fixtures/es-module-loaders/mock-loader.mjs
-import mock from 'node:mock';
+const { port1, port2 } = new MessageChannel();
+
+register(fixtures.fileURL('es-module-loaders/mock-loader.mjs'), {
+  parentURL: import.meta.url,
+  data: { port: port2 },
+  transferList: [port2],
+});
+
+/**
+ * This is the Map that saves *all* the mocked URL -> replacement Module
+ * mappings
+ * @type {Map<string, {namespace, listeners}>}
+ */
+globalThis.mockedModules = new Map();
+let mockVersion = 0;
+
+/**
+ * @param {string} resolved an absolute URL HREF string
+ * @param {object} replacementProperties an object to pick properties from
+ *                                       to act as a module namespace
+ * @returns {object} a mutator object that can update the module namespace
+ *                   since we can't do something like old Object.observe
+ */
+function mock(resolved, replacementProperties) {
+  const exportNames = Object.keys(replacementProperties);
+  const namespace = { __proto__: null };
+  /**
+   * @type {Array<(name: string)=>void>} functions to call whenever an
+   *                                     export name is updated
+   */
+  const listeners = [];
+  for (const name of exportNames) {
+    let currentValueForPropertyName = replacementProperties[name];
+    Object.defineProperty(namespace, name, {
+      enumerable: true,
+      get() {
+        return currentValueForPropertyName;
+      },
+      set(v) {
+        currentValueForPropertyName = v;
+        for (const fn of listeners) {
+          try {
+            fn(name);
+          } catch {
+            /* noop */
+          }
+        }
+      }
+    });
+  }
+  globalThis.mockedModules.set(encodeURIComponent(resolved), {
+    namespace,
+    listeners
+  });
+  mockVersion++;
+  // Inform the loader that the `resolved` URL should now use the specific
+  // `mockVersion` and has export names of `exportNames`
+  //
+  // This allows the loader to generate a fake module for that version
+  // and names the next time it resolves a specifier to equal `resolved`
+  port1.postMessage({ mockVersion, resolved, exports: exportNames });
+  return namespace;
+}
 
 mock('node:events', {
   EventEmitter: 'This is mocked!'
@@ -43,3 +107,5 @@ assert.deepStrictEqual(mockedV2, Object.defineProperty({
   enumerable: false,
   value: 'Module'
 }));
+
+delete globalThis.mockedModules;

--- a/test/fixtures/es-module-loaders/mock-loader.mjs
+++ b/test/fixtures/es-module-loaders/mock-loader.mjs
@@ -45,7 +45,7 @@ function onPreloadPortMessage({
 }
 
 /** @type {URL['href']} */
-let mainImportURL
+let mainImportURL;
 /** @type {MessagePort} */
 let preloadPort;
 export async function initialize(data) {

--- a/test/fixtures/es-module-loaders/mock-loader.mjs
+++ b/test/fixtures/es-module-loaders/mock-loader.mjs
@@ -75,6 +75,7 @@ export async function load(url, context, defaultLoad) {
   return defaultLoad(url, context);
 }
 
+const mainImportURL = new URL('./mock.mjs', import.meta.url);
 /**
  * Generate the source code for a mocked module.
  * @param {string} encodedTargetURL the module being mocked
@@ -85,12 +86,13 @@ function generateModule(encodedTargetURL) {
     decodeURIComponent(encodedTargetURL)
   );
   let body = [
+    `import { mockedModules } from '${mainImportURL}';`,
     'export {};',
     'let mapping = {__proto__: null};'
   ];
   for (const [i, name] of Object.entries(exports)) {
     let key = JSON.stringify(name);
-    body.push(`import.meta.mock = globalThis.mockedModules.get('${encodedTargetURL}');`);
+    body.push(`import.meta.mock = mockedModules.get(${JSON.stringify(encodedTargetURL)});`);
     body.push(`var _${i} = import.meta.mock.namespace[${key}];`);
     body.push(`Object.defineProperty(mapping, ${key}, { enumerable: true, set(v) {_${i} = v;}, get() {return _${i};} });`);
     body.push(`export {_${i} as ${name}};`);

--- a/test/fixtures/es-module-loaders/mock-loader.mjs
+++ b/test/fixtures/es-module-loaders/mock-loader.mjs
@@ -55,8 +55,9 @@ export async function initialize(data) {
 }
 
 /**
- * FIXME: this is a hack to workaround loaders being
- * single threaded for now, just ensures that the MessagePort drains
+ * Because Node.js internals use a separate MessagePort for cross-thread
+ * communication, there could be some messages pending that we should handle
+ * before continuing.
  */
 function doDrainPort() {
   let msg;

--- a/test/fixtures/es-module-loaders/mock-loader.mjs
+++ b/test/fixtures/es-module-loaders/mock-loader.mjs
@@ -33,9 +33,11 @@ let currentMockVersion = 0;
 // assert(namespace1 === namespace2);
 // ```
 
-
-export async function initialize({ port }) {
-  port.on('message', ({ mockVersion, resolved, exports }) => {
+/** @type {string} */
+let mainImportURL;
+export async function initialize(data) {
+  mainImportURL = data.mainImportURL;
+  data.port.on('message', ({ mockVersion, resolved, exports }) => {
     currentMockVersion = mockVersion;
     mockedModuleExports.set(resolved, exports);
   });
@@ -75,7 +77,6 @@ export async function load(url, context, defaultLoad) {
   return defaultLoad(url, context);
 }
 
-const mainImportURL = new URL('./mock.mjs', import.meta.url);
 /**
  * Generate the source code for a mocked module.
  * @param {string} encodedTargetURL the module being mocked
@@ -86,7 +87,7 @@ function generateModule(encodedTargetURL) {
     decodeURIComponent(encodedTargetURL)
   );
   let body = [
-    `import { mockedModules } from '${mainImportURL}';`,
+    `import { mockedModules } from ${JSON.stringify(mainImportURL)};`,
     'export {};',
     'let mapping = {__proto__: null};'
   ];

--- a/test/fixtures/es-module-loaders/mock-loader.mjs
+++ b/test/fixtures/es-module-loaders/mock-loader.mjs
@@ -1,8 +1,7 @@
-import { receiveMessageOnPort } from 'node:worker_threads';
 const mockedModuleExports = new Map();
 let currentMockVersion = 0;
 
-// This loader causes a new module `node:mock` to become available as a way to
+// This loader enables code running on the application thread to
 // swap module resolution results for mocking purposes. It uses this instead
 // of import.meta so that CommonJS can still use the functionality.
 //
@@ -22,7 +21,7 @@ let currentMockVersion = 0;
 //       it cannot be changed. So things like the following DO NOT WORK:
 //
 // ```mjs
-// import mock from 'node:mock';
+// import mock from 'test-esm-loader-mock'; // See test-esm-loader-mock.mjs
 // mock('file:///app.js', {x:1});
 // const namespace1 = await import('file:///app.js');
 // namespace1.x; // 1
@@ -34,148 +33,16 @@ let currentMockVersion = 0;
 // assert(namespace1 === namespace2);
 // ```
 
-/**
- * FIXME: this is a hack to workaround loaders being
- * single threaded for now, just ensures that the MessagePort drains
- */
-function doDrainPort() {
-  let msg;
-  while (msg = receiveMessageOnPort(preloadPort)) {
-    onPreloadPortMessage(msg.message);
-  }
-}
 
-/**
- * @param param0 message from the application context
- */
-function onPreloadPortMessage({
-  mockVersion, resolved, exports
-}) {
-  currentMockVersion = mockVersion;
-  mockedModuleExports.set(resolved, exports);
+export async function initialize({ port }) {
+  port.on('message', ({ mockVersion, resolved, exports }) => {
+    currentMockVersion = mockVersion;
+    mockedModuleExports.set(resolved, exports);
+  });
 }
-let preloadPort;
-export function globalPreload({port}) {
-  // Save the communication port to the application context to send messages
-  // to it later
-  preloadPort = port;
-  // Every time the application context sends a message over the port
-  port.on('message', onPreloadPortMessage);
-  // This prevents the port that the Loader/application talk over
-  // from keeping the process alive, without this, an application would be kept
-  // alive just because a loader is waiting for messages
-  port.unref();
-
-  const insideAppContext = (getBuiltin, port, setImportMetaCallback) => {
-    /**
-     * This is the Map that saves *all* the mocked URL -> replacement Module
-     * mappings
-     * @type {Map<string, {namespace, listeners}>}
-     */
-    let mockedModules = new Map();
-    let mockVersion = 0;
-    /**
-     * This is the value that is placed into the `node:mock` default export
-     *
-     * @example
-     * ```mjs
-     * import mock from 'node:mock';
-     * const mutator = mock('file:///app.js', {x:1});
-     * const namespace = await import('file:///app.js');
-     * namespace.x; // 1;
-     * mutator.x = 2;
-     * namespace.x; // 2;
-     * ```
-     *
-     * @param {string} resolved an absolute URL HREF string
-     * @param {object} replacementProperties an object to pick properties from
-     *                                       to act as a module namespace
-     * @returns {object} a mutator object that can update the module namespace
-     *                   since we can't do something like old Object.observe
-     */
-    const doMock = (resolved, replacementProperties) => {
-      let exportNames = Object.keys(replacementProperties);
-      let namespace = Object.create(null);
-      /**
-       * @type {Array<(name: string)=>void>} functions to call whenever an
-       *                                     export name is updated
-       */
-      let listeners = [];
-      for (const name of exportNames) {
-        let currentValueForPropertyName = replacementProperties[name];
-        Object.defineProperty(namespace, name, {
-          enumerable: true,
-          get() {
-            return currentValueForPropertyName;
-          },
-          set(v) {
-            currentValueForPropertyName = v;
-            for (let fn of listeners) {
-              try {
-                fn(name);
-              } catch {
-              }
-            }
-          }
-        });
-      }
-      mockedModules.set(resolved, {
-        namespace,
-        listeners
-      });
-      mockVersion++;
-      // Inform the loader that the `resolved` URL should now use the specific
-      // `mockVersion` and has export names of `exportNames`
-      //
-      // This allows the loader to generate a fake module for that version
-      // and names the next time it resolves a specifier to equal `resolved`
-      port.postMessage({ mockVersion, resolved, exports: exportNames });
-      return namespace;
-    }
-    // Sets the import.meta properties up
-    // has the normal chaining workflow with `defaultImportMetaInitializer`
-    setImportMetaCallback((meta, context, defaultImportMetaInitializer) => {
-      /**
-       * 'node:mock' creates its default export by plucking off of import.meta
-       * and must do so in order to get the communications channel from inside
-       * preloadCode
-       */
-      if (context.url === 'node:mock') {
-        meta.doMock = doMock;
-        return;
-      }
-      /**
-       * Fake modules created by `node:mock` get their meta.mock utility set
-       * to the corresponding value keyed off `mockedModules` and use this
-       * to setup their exports/listeners properly
-       */
-      if (context.url.startsWith('mock-facade:')) {
-        let [proto, version, encodedTargetURL] = context.url.split(':');
-        let decodedTargetURL = decodeURIComponent(encodedTargetURL);
-        if (mockedModules.has(decodedTargetURL)) {
-          meta.mock = mockedModules.get(decodedTargetURL);
-          return;
-        }
-      }
-      /**
-       * Ensure we still get things like `import.meta.url`
-       */
-      defaultImportMetaInitializer(meta, context);
-    });
-  };
-  return `(${insideAppContext})(getBuiltin, port, setImportMetaCallback)`
-}
-
 
 // Rewrites node: loading to mock-facade: so that it can be intercepted
 export async function resolve(specifier, context, defaultResolve) {
-  if (specifier === 'node:mock') {
-    return {
-      shortCircuit: true,
-      url: specifier
-    };
-  }
-  doDrainPort();
   const def = await defaultResolve(specifier, context);
   if (context.parentURL?.startsWith('mock-facade:')) {
     // Do nothing, let it get the "real" module
@@ -192,30 +59,16 @@ export async function resolve(specifier, context, defaultResolve) {
 }
 
 export async function load(url, context, defaultLoad) {
-  doDrainPort();
-  if (url === 'node:mock') {
-    /**
-     * Simply grab the import.meta.doMock to establish the communication
-     * channel with preloadCode
-     */
-    return {
-      shortCircuit: true,
-      source: 'export default import.meta.doMock',
-      format: 'module'
-    };
-  }
   /**
    * Mocked fake module, not going to be handled in default way so it
    * generates the source text, then short circuits
    */
   if (url.startsWith('mock-facade:')) {
-    let [proto, version, encodedTargetURL] = url.split(':');
-    let ret = generateModule(mockedModuleExports.get(
-      decodeURIComponent(encodedTargetURL)
-    ));
+    let [_proto, _version, encodedTargetURL] = url.split(':');
+    let source = generateModule(encodedTargetURL);
     return {
       shortCircuit: true,
-      source: ret,
+      source,
       format: 'module'
     };
   }
@@ -223,17 +76,21 @@ export async function load(url, context, defaultLoad) {
 }
 
 /**
- *
- * @param {Array<string>} exports name of the exports of the module
+ * Generate the source code for a mocked module.
+ * @param {string} encodedTargetURL the module being mocked
  * @returns {string}
  */
-function generateModule(exports) {
+function generateModule(encodedTargetURL) {
+  const exports = mockedModuleExports.get(
+    decodeURIComponent(encodedTargetURL)
+  );
   let body = [
     'export {};',
     'let mapping = {__proto__: null};'
   ];
   for (const [i, name] of Object.entries(exports)) {
     let key = JSON.stringify(name);
+    body.push(`import.meta.mock = globalThis.mockedModules.get('${encodedTargetURL}');`);
     body.push(`var _${i} = import.meta.mock.namespace[${key}];`);
     body.push(`Object.defineProperty(mapping, ${key}, { enumerable: true, set(v) {_${i} = v;}, get() {return _${i};} });`);
     body.push(`export {_${i} as ${name}};`);

--- a/test/fixtures/es-module-loaders/mock.mjs
+++ b/test/fixtures/es-module-loaders/mock.mjs
@@ -1,11 +1,10 @@
-import * as fixtures from '../../common/fixtures.mjs';
 import { register } from 'node:module';
 import { MessageChannel } from 'node:worker_threads';
 
 
 const { port1, port2 } = new MessageChannel();
 
-register(fixtures.fileURL('es-module-loaders/mock-loader.mjs'), {
+register('./mock-loader.mjs', import.meta.url, {
   data: {
     port: port2,
     mainImportURL: import.meta.url,
@@ -53,12 +52,12 @@ export function mock(resolved, replacementProperties) {
             /* noop */
           }
         }
-      }
+      },
     });
   }
   mockedModules.set(encodeURIComponent(resolved), {
     namespace,
-    listeners
+    listeners,
   });
   mockVersion++;
   // Inform the loader that the `resolved` URL should now use the specific

--- a/test/fixtures/es-module-loaders/mock.mjs
+++ b/test/fixtures/es-module-loaders/mock.mjs
@@ -1,0 +1,68 @@
+import * as fixtures from '../../common/fixtures.mjs';
+import { register } from 'node:module';
+import { MessageChannel } from 'node:worker_threads';
+
+
+const { port1, port2 } = new MessageChannel();
+
+register(fixtures.fileURL('es-module-loaders/mock-loader.mjs'), {
+  data: { port: port2 },
+  transferList: [port2],
+});
+
+/**
+ * This is the Map that saves *all* the mocked URL -> replacement Module
+ * mappings
+ * @type {Map<string, {namespace, listeners}>}
+ */
+export const mockedModules = new Map();
+let mockVersion = 0;
+
+/**
+ * @param {string} resolved an absolute URL HREF string
+ * @param {object} replacementProperties an object to pick properties from
+ *                                       to act as a module namespace
+ * @returns {object} a mutator object that can update the module namespace
+ *                   since we can't do something like old Object.observe
+ */
+export function mock(resolved, replacementProperties) {
+  const exportNames = Object.keys(replacementProperties);
+  const namespace = { __proto__: null };
+  /**
+   * @type {Array<(name: string)=>void>} functions to call whenever an
+   *                                     export name is updated
+   */
+  const listeners = [];
+  for (const name of exportNames) {
+    let currentValueForPropertyName = replacementProperties[name];
+    Object.defineProperty(namespace, name, {
+      __proto__: null,
+      enumerable: true,
+      get() {
+        return currentValueForPropertyName;
+      },
+      set(v) {
+        currentValueForPropertyName = v;
+        for (const fn of listeners) {
+          try {
+            fn(name);
+          } catch {
+            /* noop */
+          }
+        }
+      }
+    });
+  }
+  mockedModules.set(encodeURIComponent(resolved), {
+    namespace,
+    listeners
+  });
+  mockVersion++;
+  // Inform the loader that the `resolved` URL should now use the specific
+  // `mockVersion` and has export names of `exportNames`
+  //
+  // This allows the loader to generate a fake module for that version
+  // and names the next time it resolves a specifier to equal `resolved`
+  port1.postMessage({ mockVersion, resolved, exports: exportNames });
+  return namespace;
+}

--- a/test/fixtures/es-module-loaders/mock.mjs
+++ b/test/fixtures/es-module-loaders/mock.mjs
@@ -6,7 +6,10 @@ import { MessageChannel } from 'node:worker_threads';
 const { port1, port2 } = new MessageChannel();
 
 register(fixtures.fileURL('es-module-loaders/mock-loader.mjs'), {
-  data: { port: port2 },
+  data: {
+    port: port2,
+    mainImportURL: import.meta.url,
+  },
   transferList: [port2],
 });
 


### PR DESCRIPTION
This PR refactors `test/es-module/test-esm-loader-mock.mjs` to use the new `register` and `initialize` APIs instead of `globalPreload` and `setImportMetaCallback`. I tried to preserve as much of the previous test as possible; all of the assertions from the earlier version are unchanged. This test passes both here, on `main`, and within #49144.

The largest addition to `test-esm-loader-mock.mjs` was code that just moved there from within the `insideAppContext` function in `mock-loader.mjs`.

@nodejs/loaders 