### PR TITLE
url: fix toPathIfFileUrl with string URL input

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1491,7 +1491,7 @@ function pathToFileURL(filepath) {
 }
 
 function toPathIfFileURL(fileURLOrPath) {
-  if (!isURL(fileURLOrPath))
+  if (!isURL(fileURLOrPath) && !(typeof fileURLOrPath === 'string' && fileURLOrPath.startsWith('file://')))
     return fileURLOrPath;
   return fileURLToPath(fileURLOrPath);
 }


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Functions using `toPathIfFileURL` (such as `fs.readdir`) would have unexpected behavior when a string of a file URL was input such as `import.meta.url`, `fileURLToPath` supports string input so there is no reason to not convert file URL strings. 