### PR TITLE
test: make `test-dotenv-node-options` locale-independent

### DIFF
--- a/test/parallel/test-dotenv-node-options.js
+++ b/test/parallel/test-dotenv-node-options.js
@@ -46,7 +46,7 @@ describe('.env supports NODE_OPTIONS', () => {
 
   it('TZ environment variable', { skip: !common.hasIntl || process.config.variables.icu_small }, async () => {
     const code = `
-      require('assert')(new Date().toString().includes('Hawaii'))
+      require('assert')(new Date().toString().includes('GMT-1000'))
     `.trim();
     const child = await common.spawnPromisified(
       process.execPath,


### PR DESCRIPTION
Note: I've tried to add `LANG=C` or `LC_ALL=C` to [`test/fixtures/dotenv/node-options.env`](https://github.com/nodejs/node/blob/HEAD/test/fixtures/dotenv/node-options.env) and it didn't help. Setting `process.env.LANG = 'C'` in main process helps. Not sure if it's bug or feature.