### PR TITLE
websocket: proposal for a new core module

### DIFF
--- a/doc/api/websocket.md
+++ b/doc/api/websocket.md
@@ -225,7 +225,7 @@ will be destroyed.
     handshake to complete.
   * `callbackListener` {Function} A callback that executes once the server
     starts listening for incoming socket connections. Provides 1 argument:
-    `server` {Server}.
+    `server` {net.Server|tls.Server}.
   * `callbackOpen` {Function} If present will execute upon completion of
     WebSocket connection handshake. Receives two arguments: `err`
     {errors.Error} and `socket` {websocketClient}.

--- a/doc/api/websocket.md
+++ b/doc/api/websocket.md
@@ -19,23 +19,23 @@ callbacks only.
 ### Client TLS Socket example
 ```mjs
 const options = {
-  callbackOpen: function(err, socket) {
+  'callbackOpen': function(err, socket) {
     console.log('client callbackOpen');
     if (err === null) {
       socket.messageSend('hello from client');
     }
   },
-  extensions: 'extensions here',
-  masking: false,
-  messageHandler: function(message){
+  'extensions': 'extensions here',
+  'masking': false,
+  'messageHandler': function(message) {
     console.log('message received at client');
     console.log(message.toString());
   },
   'proxy-authorization': 'proxy-auth',
-  subProtocol: 'sub-proto',
-  type: 'type-string',
-  secure: true,
-  socketOptions: {
+  'subProtocol': 'sub-proto',
+  'type': 'type-string',
+  'secure': true,
+  'socketOptions': {
     host: host,
     port: port,
     rejectUnauthorized: false,
@@ -47,23 +47,23 @@ websocket.clientConnect(options);
 ### Client Net Socket example
 ```mjs
 const options = {
-  callbackOpen: function(err, socket) {
+  'callbackOpen': function(err, socket) {
     console.log('client callbackOpen');
     if (err === null) {
       socket.messageSend('hello from client');
     }
   },
-  extensions: 'extensions here',
-  masking: false,
-  messageHandler: function(message){
+  'extensions': 'extensions here',
+  'masking': false,
+  'messageHandler': function(message) {
     console.log('message received at client');
     console.log(message.toString());
   },
   'proxy-authorization': 'proxy-auth',
-  subProtocol: 'sub-proto',
-  type: 'type-string',
-  secure: false,
-  socketOptions: {
+  'subProtocol': 'sub-proto',
+  'type': 'type-string',
+  'secure': false,
+  'socketOptions': {
     host: host,
     port: port,
   },
@@ -79,18 +79,18 @@ const options = {
     ready();
   },
   callbackListener: function(server) {
-      console.log('server callbackListener');
+    console.log('server callbackListener');
   },
   callbackOpen: function(err, socket) {
-      console.log('server callbackOpen');
+    console.log('server callbackOpen');
   },
   messageHandler: function(message) {
-      console.log('message received at server');
-      console.log(message.toString());
+    console.log('message received at server');
+    console.log(message.toString());
   },
   listenerOptions: {
-      host: host,
-      port: port,
+    host: host,
+    port: port,
   },
   secure: true,
   serverOptions: {
@@ -110,18 +110,18 @@ const options = {
     ready();
   },
   callbackListener: function(server) {
-      console.log('server callbackListener');
+    console.log('server callbackListener');
   },
   callbackOpen: function(err, socket) {
-      console.log('server callbackOpen');
+    console.log('server callbackOpen');
   },
   messageHandler: function(message) {
-      console.log('message received at server');
-      console.log(message.toString());
+    console.log('message received at server');
+    console.log(message.toString());
   },
   listenerOptions: {
-      host: host,
-      port: port,
+    host: host,
+    port: port,
   },
   secure: false,
   serverOptions: {},

--- a/doc/api/websocket.md
+++ b/doc/api/websocket.md
@@ -19,17 +19,16 @@ callbacks only.
 ### Client TLS Socket example
 ```mjs
 const options = {
-  authentication: 'auth-string',
   callbackOpen: function(err, socket) {
-    console.log("client callbackOpen");
+    console.log('client callbackOpen');
     if (err === null) {
-      socket.messageSend("hello from client");
+      socket.messageSend('hello from client');
     }
   },
+  extensions: 'extensions here',
   masking: false,
-  id: 'id-string',
   messageHandler: function(message){
-    console.log("message received at client");
+    console.log('message received at client');
     console.log(message.toString());
   },
   'proxy-authorization': 'proxy-auth',
@@ -39,8 +38,8 @@ const options = {
   socketOptions: {
     host: host,
     port: port,
-    rejectUnauthorized: false
-  }
+    rejectUnauthorized: false,
+  },
 };
 websocket.clientConnect(options);
 ```
@@ -48,17 +47,16 @@ websocket.clientConnect(options);
 ### Client Net Socket example
 ```mjs
 const options = {
-  authentication: 'auth-string',
   callbackOpen: function(err, socket) {
-    console.log("client callbackOpen");
+    console.log('client callbackOpen');
     if (err === null) {
-      socket.messageSend("hello from client");
+      socket.messageSend('hello from client');
     }
   },
+  extensions: 'extensions here',
   masking: false,
-  id: 'id-string',
   messageHandler: function(message){
-    console.log("message received at client");
+    console.log('message received at client');
     console.log(message.toString());
   },
   'proxy-authorization': 'proxy-auth',
@@ -67,8 +65,8 @@ const options = {
   secure: false,
   socketOptions: {
     host: host,
-    port: port
-  }
+    port: port,
+  },
 };
 websocket.clientConnect(options);
 ```
@@ -81,25 +79,25 @@ const options = {
     ready();
   },
   callbackListener: function(server) {
-      console.log("server callbackListener");
+      console.log('server callbackListener');
   },
   callbackOpen: function(err, socket) {
-      console.log("server callbackOpen");
+      console.log('server callbackOpen');
   },
   messageHandler: function(message) {
-      console.log("message received at server");
+      console.log('message received at server');
       console.log(message.toString());
   },
   listenerOptions: {
       host: host,
-      port: port
+      port: port,
   },
   secure: true,
   serverOptions: {
     ca: caCertificate,
     cert: domainCertificate,
-    key: domainKey
-  }
+    key: domainKey,
+  },
 };
 const server = ws.server(options);
 ```
@@ -112,21 +110,21 @@ const options = {
     ready();
   },
   callbackListener: function(server) {
-      console.log("server callbackListener");
+      console.log('server callbackListener');
   },
   callbackOpen: function(err, socket) {
-      console.log("server callbackOpen");
+      console.log('server callbackOpen');
   },
   messageHandler: function(message) {
-      console.log("message received at server");
+      console.log('message received at server');
       console.log(message.toString());
   },
   listenerOptions: {
       host: host,
-      port: port
+      port: port,
   },
   secure: false,
-  serverOptions: {}
+  serverOptions: {},
 };
 const server = ws.server(options);
 ```

--- a/doc/api/websocket.md
+++ b/doc/api/websocket.md
@@ -217,10 +217,10 @@ will be destroyed.
   * `callbackConnect` {Function} A callback to execute when a socket connects
     to the server, but before the handshake completes. This function provides a
     means to apply authentication or additional description before completing
-    the handshake and allowing messaging. Receives 3 arguments: `headerValues`
+    the handshake and allowing messaging. Receives 3 arguments: `connectOptions`
     {Object}, `socket` {websocketClient}, `ready` {Function}. The third
     argument must be called by the callbackConnect function in order for the
-    handshake to complete.
+    handshake to complete and a `connectOptions` object must be passed into it.
   * `callbackListener` {Function} A callback that executes once the server
     starts listening for incoming socket connections. Provides 1 argument:
     `server` {net.Server|tls.Server}.
@@ -240,6 +240,40 @@ will be destroyed.
     [tls.createServer](https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#tlscreateserveroptions-secureconnectionlistener).
 
 ## Common Objects
+
+### connectOptions
+
+<!-- YAML
+added: REPLACEME
+-->
+
+This object is used internally to extend a `Socket` object type into a
+`websocketClient` type based upon client options or headers in the handshake at
+the server. This is also passed into the `callbackConnect` function on the
+server to allow custom modification and authentication for a `websocketClient`
+socket before the handshake completes.
+
+* `callbackOpen` {Function} The callback to execute once the handshake
+  completes.
+* `extensions` {string} Value of the optional extensions HTTP header used in
+  the handshake process.
+* `masking` {boolean} Whether to forcefully impose message masking,
+  forcefully prevent message masking, or leave to the default. By default
+  all sockets with role *client* will perform message masking and all sockets
+  with role *server* will not.
+* `messageHandler` {Function} The function to process received messages. On
+  the client side this function is defined as an option passed into
+  `clientConnect`. On the server side it is also defined as an option passed
+  into the `server` method but can be redefined in the `callbackConnect`
+  callback per socket.
+* `proxy-authorization` {string} An optional value to define a security token
+  to proxies that require such.
+* `role` {string} A read only value of *client* or *server* that cannot be
+  customized or manually populated.
+* `subprotocol` {string} An subprotocol value passed into `clientConnect` or
+  received on the server as a header in the handshake.
+* `userAgent` {string} A user agent identifier populated by the client for the
+  server.
 
 ### websocketClient
 

--- a/doc/api/websocket.md
+++ b/doc/api/websocket.md
@@ -152,7 +152,7 @@ or
 [tls.TLSSocket](https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#class-tlstlssocket)
 to create a WebSocket socket and connects it to a WebSocket server.
 
-* `options` {object}
+* `options` {Object}
   * `callbackOpen` {Function} If present will execute upon completion of
     WebSocket connection handshake. Receives two arguments: `err`
     {NodeJS.ErrnoException} and `socket` {websocketClient}.
@@ -168,7 +168,7 @@ to create a WebSocket socket and connects it to a WebSocket server.
     authorization mechanism.
   * `secure` {boolean} Whether to create a TLS based socket or Net based
     socket. **Default:** `true`
-  * `socketOptions` {object} See
+  * `socketOptions` {Object} See
     [net.connect](https://nodejs.org/dist/latest-v20.x/docs/api/net.html#netconnect)
     or
     [tls.connect](https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#tlsconnectoptions-callback).
@@ -184,7 +184,7 @@ added: REPLACEME
 A convenience utility for attaining addressing data from any network socket.
 
 * `socket` {websocketClient}
-* Returns {object} of form:
+* Returns {Object} of form:
   * `local`
     * `address` {string} An IP address.
     * `port` {number} A port.
@@ -215,12 +215,12 @@ to create a WebSocket server listening for connecting sockets. Any socket that
 fails to complete the handshake within 5 seconds of connecting to the server
 will be destroyed.
 
-* `options` {object}
+* `options` {Object}
   * `callbackConnect` {Function} A callback to execute when a socket connects
     to the server, but before the handshake completes. This function provides a
     means to apply authentication or additional description before completing
     the handshake and allowing messaging. Receives 3 arguments: `headerValues`
-    {object}, `socket` {websocketClient}, `ready` {Function}. The third
+    {Object}, `socket` {websocketClient}, `ready` {Function}. The third
     argument must be called by the callbackConnect function in order for the
     handshake to complete.
   * `callbackListener` {Function} A callback that executes once the server
@@ -232,11 +232,69 @@ will be destroyed.
   * `messageHandler` {Function} Received messages are passed into this function
     for custom processing. When this function is absent received messages are
     discarded. Receives one argument: `message` {Buffer}.
-  * `listenerOptions` {object} See
+  * `listenerOptions` {Object} See
     [net.server.listen](https://nodejs.org/dist/latest-v20.x/docs/api/net.html#serverlistenoptions-callback).
   * `secure` Whether to create a net.Server or a tls.TLSServer. **Default:**
     true
-  * `serverOptions` {object} See
+  * `serverOptions` {Object} See
     [net.createServer](https://nodejs.org/dist/latest-v20.x/docs/api/net.html#netcreateserveroptions-connectionlistener)
     or
     [tls.createServer](https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#tlscreateserveroptions-secureconnectionlistener).
+
+## Common Objects
+
+### websocketClient
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The `websocketClient` object inherits from either
+[net.Socket](https://nodejs.org/dist/latest-v20.x/docs/api/net.html#class-netsocket)
+or
+[tls.TLSSocket](https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#class-tlstlssocket)
+with these additional object properties:
+
+* `ping` {Function} Performs an arbitrary connection test that a user may call
+  at their liberty.
+* `websocket` {Object}
+  * `callbackOpen` {Function} If present will execute upon completion of
+    WebSocket connection handshake. Receives two arguments: `err`
+    {NodeJS.ErrnoException} and `socket` {websocketClient}.
+  * `extensions` {string} Any additional instructions, identifiers, or custom
+    descriptive data.
+  * `fragment` {Buffer} Stores complete message frames sufficient to assemble a
+    complete message.
+  * `frame` {Buffer} Stores pieces of a frame sufficient to assemble a complete
+    frame.
+  * `frameExtended` {number} Stores the extended length value of the current
+    message.
+  * `masking` {boolean} Determines whether to mask messages before sending them.
+    Defaults to `true` for client roles and `false` for server roles, but default
+    behavior can be changes with options.
+  * `messageHandler` {Function} Received messages are passed into this function
+    for custom processing. When this function is absent received messages are
+    discarded. Receives one argument: `message` {Buffer}.
+  * `pong` Stores an object with metadata sufficient to test connectivity
+    initiated as a ping from the remote end.
+  * `proxy-authorization` Any identifier required by proxy authorization
+    mechanism.
+  * `queue` {Buffer[]} Stores messages in order so that they are sent one at a
+    time exactly in the order sent.
+  * `role` {'client'|'server'} Whether the socket is instantiated as a client
+    or server connection.
+  * `status` {'closed'|'open'|'pending'} Current transfer status of the socket.
+    * `closed` - Socket is not destroyed but is no longer receiving or
+      transmitting.
+    * `open` - Socket is available to send and receive messages.
+    * `pending` - Socket can receive messages, but is halted from sending
+      messages. This typically occurs because the socket is writing a message and
+      others are stacked up in queue.
+  * `subprotocol`: {string} Any sub-protocols defined by the client.
+  * `userAgent` {string} User agent identifier populated by the client.
+* `write` {Function} Sends WebSocket messages.
+  * `message` {Buffer|string} The message to send.
+  * `opcode` {Integer} an RFC 6455 message code. **Default:** 1 if the message is
+    text or 2 if the message is a Buffer.
+  * `fragmentSize` Determines the size of message fragmentation. **Default:** 0,
+    which means no message fragmentation.

--- a/doc/api/websocket.md
+++ b/doc/api/websocket.md
@@ -1,0 +1,242 @@
+# WebSocket
+
+<!--introduced_in=REPLACEME-->
+
+> Stability: 1 - Experimental
+
+<!--name=websocket-->
+
+<!-- source_link=lib/websocket.js -->
+
+The `node:websocket` library allows for the creation of RFC 6455 conformant
+WebSocket client sockets and servers both secure and insecure.
+
+This module supports, as currently written, asynchronous execution with
+callbacks only.
+
+## Callback example
+
+### Client TLS Socket example
+```javascript
+const options = {
+  authentication: 'auth-string',
+  callbackOpen: function(err, socket) {
+    console.log("client callbackOpen");
+    if (err === null) {
+      socket.messageSend("hello from client");
+    }
+  },
+  masking: false,
+  id: 'id-string',
+  messageHandler: function(message){
+    console.log("message received at client");
+    console.log(message.toString());
+  },
+  'proxy-authorization': 'proxy-auth',
+  subProtocol: 'sub-proto',
+  type: 'type-string',
+  secure: true,
+  socketOptions: {
+    host: host,
+    port: port,
+    rejectUnauthorized: false
+  }
+};
+websocket.clientConnect(options);
+```
+
+### Client Net Socket example
+```javascript
+const options = {
+  authentication: 'auth-string',
+  callbackOpen: function(err, socket) {
+    console.log("client callbackOpen");
+    if (err === null) {
+      socket.messageSend("hello from client");
+    }
+  },
+  masking: false,
+  id: 'id-string',
+  messageHandler: function(message){
+    console.log("message received at client");
+    console.log(message.toString());
+  },
+  'proxy-authorization': 'proxy-auth',
+  subProtocol: 'sub-proto',
+  type: 'type-string',
+  secure: false,
+  socketOptions: {
+    host: host,
+    port: port
+  }
+};
+websocket.clientConnect(options);
+```
+
+### Server TLS example
+```javascript
+const options = {
+  callbackConnect: function(headerValues, socket, ready) {
+    console.log(headerValues);
+    ready();
+  },
+  callbackListener: function(server) {
+      console.log("server callbackListener");
+  },
+  callbackOpen: function(err, socket) {
+      console.log("server callbackOpen");
+  },
+  messageHandler: function(message) {
+      console.log("message received at server");
+      console.log(message.toString());
+  },
+  listenerOptions: {
+      host: host,
+      port: port
+  },
+  secure: true,
+  serverOptions: {
+    ca: caCertificate,
+    cert: domainCertificate,
+    key: domainKey
+  }
+};
+const server = ws.server(options);
+```
+
+### Server Net example
+```javascript
+const options = {
+  callbackConnect: function(headerValues, socket, ready) {
+    console.log(headerValues);
+    ready();
+  },
+  callbackListener: function(server) {
+      console.log("server callbackListener");
+  },
+  callbackOpen: function(err, socket) {
+      console.log("server callbackOpen");
+  },
+  messageHandler: function(message) {
+      console.log("message received at server");
+      console.log(message.toString());
+  },
+  listenerOptions: {
+      host: host,
+      port: port
+  },
+  secure: false,
+  serverOptions: {}
+};
+const server = ws.server(options);
+```
+
+## API
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The websocket module exists to provide primitive WebSocket protocol support as
+defined by [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455).
+
+### Class: `clientConnect`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The `clientConnect` class extends class
+[net.Socket](https://nodejs.org/dist/latest-v20.x/docs/api/net.html#class-netsocket)
+or
+[tls.TLSSocket](https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#class-tlstlssocket)
+to create a WebSocket socket and connects it to a WebSocket server.
+
+* `options` {object}
+  * `callbackOpen` {Function} If present will execute upon completion of
+    WebSocket connection handshake. Receives two arguments: `err`
+    {NodeJS.ErrnoException} and `socket` {websocketClient}.
+    **Default:** `undefined`
+  * `extensions` {string} Any additional instructions, identifiers, or custom
+    descriptive data.
+  * `masking` {boolean} Whether to apply RFC 6455 message masking.
+    **Default:** `true`
+  * `messageHandler` {Function} Received messages are passed into this function
+    for custom processing. When this function is absent received messages are
+    discarded. Receives one argument: `message` {Buffer}.
+  * `proxy-authorization` {string} Any identifier required by proxy
+    authorization mechanism.
+  * `secure` {boolean} Whether to create a TLS based socket or Net based
+    socket. **Default:** `true`
+  * `socketOptions` {object} See
+    [net.connect](https://nodejs.org/dist/latest-v20.x/docs/api/net.html#netconnect)
+    or
+    [tls.connect](https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#tlsconnectoptions-callback).
+  * `subProtocol` {string} Any one or more RFC 6455 identified sub-protocols. 
+* Returns {websocketClient}
+
+### Class: `getAddress`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+A convenience utility for attaining addressing data from any network socket.
+
+* `socket` {websocketClient}
+* Returns {object} of form:
+  * `local`
+    * `address` {string} An IP address.
+    * `port` {number} A port.
+  * `remote`
+    * `address` {string} An IP address.
+    * `port` {number} A port.
+
+### `magicString`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string} A static string required by RFC 6455 to internally create and prove
+  the connection handshake.
+
+### Class: `server`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The `server` class extends class
+[net.Server](https://nodejs.org/dist/latest-v20.x/docs/api/net.html#class-netserver)
+or
+[tls.Server](https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#class-tlsserver)
+to create a WebSocket server listening for connecting sockets. Any socket that
+fails to complete the handshake within 5 seconds of connecting to the server
+will be destroyed.
+
+* `options` {object}
+  * `callbackConnect` {Function} A callback to execute when a socket connects
+    to the server, but before the handshake completes. This function provides a
+    means to apply authentication or additional description before completing
+    the handshake and allowing messaging. Receives 3 arguments: `headerValues`
+    {object}, `socket` {websocketClient}, `ready` {Function}. The third
+    argument must be called by the callbackConnect function in order for the
+    handshake to complete.
+  * `callbackListener` {Function} A callback that executes once the server
+    starts listening for incoming socket connections. Provides 1 argument:
+    `server` {Server}.
+  * `callbackOpen` {Function} If present will execute upon completion of
+    WebSocket connection handshake. Receives two arguments: `err`
+    {NodeJS.ErrnoException} and `socket` {websocketClient}.
+  * `messageHandler` {Function} Received messages are passed into this function
+    for custom processing. When this function is absent received messages are
+    discarded. Receives one argument: `message` {Buffer}.
+  * `listenerOptions` {object} See
+    [net.server.listen](https://nodejs.org/dist/latest-v20.x/docs/api/net.html#serverlistenoptions-callback).
+  * `secure` Whether to create a net.Server or a tls.TLSServer. **Default:**
+    true
+  * `serverOptions` {object} See
+    [net.createServer](https://nodejs.org/dist/latest-v20.x/docs/api/net.html#netcreateserveroptions-connectionlistener)
+    or
+    [tls.createServer](https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#tlscreateserveroptions-secureconnectionlistener).

--- a/doc/api/websocket.md
+++ b/doc/api/websocket.md
@@ -252,7 +252,7 @@ The `websocketClient` object inherits from either
 or
 [tls.TLSSocket](https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#class-tlstlssocket)
 with these additional object properties:
-
+* `close` {Function} A convenience method to initiate the closing process.
 * `ping` {Function} Performs an arbitrary connection test that a user may call
   at their liberty.
 * `websocket` {Object}
@@ -282,10 +282,12 @@ with these additional object properties:
   * `role` {string} Whether the socket is instantiated as a `'client'` or
     `'server'` connection.
   * `status` {string} Current transfer status of the socket.
-    * `'closed'` - Socket is not destroyed but is no longer receiving or
+    * `'CLOSED'` - Socket is not destroyed but is no longer receiving or
       transmitting.
-    * `'open'` - Socket is available to send and receive messages.
-    * `'pending'` - Socket can receive messages, but is halted from sending
+    * `'CLOSING'` - Socket has sent a *close* type control frame and is
+      awaiting a response to complete its closing handshake.
+    * `'OPEN'` - Socket is available to send and receive messages.
+    * `'PENDING'` - Socket can receive messages, but is halted from sending
       messages. This typically occurs because the socket is writing a message
       and others are stacked up in queue.
   * `subprotocol`: {string} Any sub-protocols defined by the client.

--- a/doc/api/websocket.md
+++ b/doc/api/websocket.md
@@ -170,7 +170,7 @@ to create a WebSocket socket and connects it to a WebSocket server.
     [net.connect](https://nodejs.org/dist/latest-v20.x/docs/api/net.html#netconnect)
     or
     [tls.connect](https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#tlsconnectoptions-callback).
-  * `subProtocol` {string} Any one or more RFC 6455 identified sub-protocols. 
+  * `subProtocol` {string} Any one or more RFC 6455 identified sub-protocols.
 * Returns {websocketClient}
 
 ### Class: `getAddress`

--- a/doc/api/websocket.md
+++ b/doc/api/websocket.md
@@ -17,7 +17,7 @@ callbacks only.
 ## Callback example
 
 ### Client TLS Socket example
-```javascript
+```mjs
 const options = {
   authentication: 'auth-string',
   callbackOpen: function(err, socket) {
@@ -46,7 +46,7 @@ websocket.clientConnect(options);
 ```
 
 ### Client Net Socket example
-```javascript
+```mjs
 const options = {
   authentication: 'auth-string',
   callbackOpen: function(err, socket) {
@@ -74,7 +74,7 @@ websocket.clientConnect(options);
 ```
 
 ### Server TLS example
-```javascript
+```mjs
 const options = {
   callbackConnect: function(headerValues, socket, ready) {
     console.log(headerValues);
@@ -105,7 +105,7 @@ const server = ws.server(options);
 ```
 
 ### Server Net example
-```javascript
+```mjs
 const options = {
   callbackConnect: function(headerValues, socket, ready) {
     console.log(headerValues);
@@ -270,8 +270,8 @@ with these additional object properties:
   * `frameExtended` {integer} Stores the extended length value of the current
     message.
   * `masking` {boolean} Determines whether to mask messages before sending them.
-    Defaults to `true` for client roles and `false` for server roles, but default
-    behavior can be changes with options.
+    Defaults to `true` for client roles and `false` for server roles, but
+    default behavior can be changes with options.
   * `messageHandler` {Function} Received messages are passed into this function
     for custom processing. When this function is absent received messages are
     discarded. Receives one argument: `message` {Buffer}.
@@ -288,13 +288,13 @@ with these additional object properties:
       transmitting.
     * `'open'` - Socket is available to send and receive messages.
     * `'pending'` - Socket can receive messages, but is halted from sending
-      messages. This typically occurs because the socket is writing a message and
-      others are stacked up in queue.
+      messages. This typically occurs because the socket is writing a message
+      and others are stacked up in queue.
   * `subprotocol`: {string} Any sub-protocols defined by the client.
   * `userAgent` {string} User agent identifier populated by the client.
 * `write` {Function} Sends WebSocket messages.
   * `message` {Buffer|string} The message to send.
-  * `opcode` {integer} an RFC 6455 message code. **Default:** 1 if the message is
-    text or 2 if the message is a Buffer.
+  * `opcode` {integer} an RFC 6455 message code. **Default:** 1 if the message
+    is text or 2 if the message is a Buffer.
   * `fragmentSize` Determines the size of message fragmentation. **Default:** 0,
     which means no message fragmentation.

--- a/doc/api/websocket.md
+++ b/doc/api/websocket.md
@@ -155,7 +155,7 @@ to create a WebSocket socket and connects it to a WebSocket server.
 * `options` {Object}
   * `callbackOpen` {Function} If present will execute upon completion of
     WebSocket connection handshake. Receives two arguments: `err`
-    {NodeJS.ErrnoException} and `socket` {websocketClient}.
+    {errors.Error} and `socket` {websocketClient}.
     **Default:** `undefined`
   * `extensions` {string} Any additional instructions, identifiers, or custom
     descriptive data.
@@ -228,7 +228,7 @@ will be destroyed.
     `server` {Server}.
   * `callbackOpen` {Function} If present will execute upon completion of
     WebSocket connection handshake. Receives two arguments: `err`
-    {NodeJS.ErrnoException} and `socket` {websocketClient}.
+    {errors.Error} and `socket` {websocketClient}.
   * `messageHandler` {Function} Received messages are passed into this function
     for custom processing. When this function is absent received messages are
     discarded. Receives one argument: `message` {Buffer}.
@@ -260,14 +260,14 @@ with these additional object properties:
 * `websocket` {Object}
   * `callbackOpen` {Function} If present will execute upon completion of
     WebSocket connection handshake. Receives two arguments: `err`
-    {NodeJS.ErrnoException} and `socket` {websocketClient}.
+    {errors.Error} and `socket` {websocketClient}.
   * `extensions` {string} Any additional instructions, identifiers, or custom
     descriptive data.
   * `fragment` {Buffer} Stores complete message frames sufficient to assemble a
     complete message.
   * `frame` {Buffer} Stores pieces of a frame sufficient to assemble a complete
     frame.
-  * `frameExtended` {number} Stores the extended length value of the current
+  * `frameExtended` {integer} Stores the extended length value of the current
     message.
   * `masking` {boolean} Determines whether to mask messages before sending them.
     Defaults to `true` for client roles and `false` for server roles, but default
@@ -294,7 +294,7 @@ with these additional object properties:
   * `userAgent` {string} User agent identifier populated by the client.
 * `write` {Function} Sends WebSocket messages.
   * `message` {Buffer|string} The message to send.
-  * `opcode` {Integer} an RFC 6455 message code. **Default:** 1 if the message is
+  * `opcode` {integer} an RFC 6455 message code. **Default:** 1 if the message is
     text or 2 if the message is a Buffer.
   * `fragmentSize` Determines the size of message fragmentation. **Default:** 0,
     which means no message fragmentation.

--- a/doc/api/websocket.md
+++ b/doc/api/websocket.md
@@ -281,13 +281,13 @@ with these additional object properties:
     mechanism.
   * `queue` {Buffer[]} Stores messages in order so that they are sent one at a
     time exactly in the order sent.
-  * `role` {'client'|'server'} Whether the socket is instantiated as a client
-    or server connection.
-  * `status` {'closed'|'open'|'pending'} Current transfer status of the socket.
-    * `closed` - Socket is not destroyed but is no longer receiving or
+  * `role` {string} Whether the socket is instantiated as a `'client'` or
+    `'server'` connection.
+  * `status` {string} Current transfer status of the socket.
+    * `'closed'` - Socket is not destroyed but is no longer receiving or
       transmitting.
-    * `open` - Socket is available to send and receive messages.
-    * `pending` - Socket can receive messages, but is halted from sending
+    * `'open'` - Socket is available to send and receive messages.
+    * `'pending'` - Socket can receive messages, but is halted from sending
       messages. This typically occurs because the socket is writing a message and
       others are stacked up in queue.
   * `subprotocol`: {string} Any sub-protocols defined by the client.

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -1,0 +1,844 @@
+
+const crypto = require('node:crypto');
+const net = require('node:net');
+const os = require('node:os');
+const tls = require('node:tls');
+
+
+/**
+ * ```typescript
+ * interface extensions {
+ *     // A callback that fires once the connection handshake completes.
+ *   callbackOpen?: (
+ *     err:NodeJS.ErrnoException,
+ *     socket:Socket|TLSSocket
+ *   ) => void;
+ *     // Extensions are the place to provide custom identifiers, security
+ *     // tokens, and other descriptors.
+ *   extensions?: string;
+ *     // eliminates use of message masking as required by default for
+ *     // client-side sockets.
+ *     // Default: `true`
+ *   masking?: boolean;
+ *     // Arbitrary unique identifier of user's choosing.
+ *   messageHandler?: (message:Buffer) => void;
+ *     // If connecting through a proxy that requires an authentication token.
+ *   proxy-authorization?: string;
+ *     // A comma separated list of one or more known subprotocol values per
+ *     // RFC 6455 11.2.
+ *   subProtocol?: string;
+ * }
+ * interface clientOptions extends extensions {
+ *     // Whether to create a Socket or TLSSocket type socket. Defaults to
+ *     // `true`
+ *   secure?: boolean;
+ *     // Required options to create a Node socket.
+ *   socketOptions: net.NetConnectOpts | tls.ConnectionOptions;
+ * }
+ * (options:clientOptions) => Socket | TLSSocket;
+ * ``` */
+
+// creates and connects a websocket client
+function clientConnect(options) {
+  const socket = (options.secure === false) ?
+    net.connect(options.socketOptions) :
+    tls.connect(options.socketOptions);
+  // RFC 6455 1.7 says the only relation to HTTP is that a valid handshake
+  // be sent and received in the form of a HTTP 1.1 GET header, so this
+  // application will send the conforming header text and otherwise avoid
+  // the overhead of HTTP, which will greatly boost execution performance.
+  function handlerReady() {
+    // response from server
+    socket.once('data', function(responseData) {
+      const hash = crypto.createHash('sha1');
+      const responseString = responseData.toString();
+      const response = responseString.replace(/\r\n/g, '\n').split('\n');
+      const len = response.length;
+      function callbackCheck() {
+        if (typeof options.callbackOpen === 'function') {
+          options.callbackOpen(errorObject(
+            'ECONNABORTED',
+            'WebSocket server handshake response returned no ' +
+              'Sec-WebSocket-Accept header or one which is malformed.',
+            socket,
+            'websocket.clientConnect'
+          ), null);
+        }
+      }
+      // check if response contains required HTTP header
+      if (len > 1 && responseString.includes('HTTP/1.1 101 Switching Protocols')) {
+        let index = 0;
+        let key = '';
+        let colon = 0;
+        do {
+          colon = response[index].indexOf(':');
+          // find the header dealing with the handshake
+          if (response[index].slice(0, colon).toLowerCase() === 'sec-websocket-accept') {
+            key = response[index].slice(colon + 1).replace(/^\s+/, '').replace(/\s+$/, '');
+            break;
+          }
+          index = index + 1;
+        } while (index < len);
+        hash.update(nonceSource + websocket.magicString);
+        const digest = hash.digest('hex');//console.log(digest);console.log(key);
+        // validate handshake
+        if (digest === key) {
+          delete options.secure;
+          delete options.socketOptions;
+          socketExtend(socket, options);
+        } else {
+          callbackCheck();
+        }
+      } else {
+        callbackCheck();
+      }
+    });
+    const addresses = getAddress(socket);
+    const resourceName = (typeof options.socketOptions.host === 'string') ?
+      (function() {
+        const host = options.socketOptions.host;
+        const scheme = (/^\w+:\/\//);
+        if (typeof host !== 'string') {
+          return '/';
+        }
+        if (scheme.test(host) === false) {
+          return '/';
+        }
+        host.replace(scheme, '');
+        if (host.indexOf('/') < 0 || host.indexOf('/') === host.length - 1) {
+          return '/';
+        }
+        return `/${host.slice(host.indexOf('/') + 1)}`;
+      }()) :
+      '/';
+    const nonceSource = Buffer.from(Date.now().toString() + os.hostname()).toString('base64');
+    const header = [
+      `GET ${resourceName} HTTP/1.1`,
+      (addresses.remote.address.indexOf(':') > -1) ?
+        // RFC 6455 4.1. request host be defined according to RFC 3986 (URI)
+        // however it also requires the socket be already established and open
+        // at layer 4 (TCP/TLS) and layer 4 cares only for IP address as URI
+        // is layer 7. For sanity ip/port is fully sufficient if derived from
+        // the established socket
+        `Host: [${addresses.remote.address}]:${addresses.remote.port}` :
+        `Host: ${addresses.remote.address}:${addresses.remote.port}`,
+      'Upgrade: websocket',
+      'Connection: Upgrade',
+      'Sec-WebSocket-Version: 13',
+      `Sec-WebSocket-Key: ${nonceSource}`,
+      `User-Agent: Node.js--${process.version}--${os.version()}--${os.release()}`
+    ];
+    function headingCheck(heading) {
+      if (typeof options[heading] === 'string') {
+        if (heading === 'extensions') {
+          header.push(`Sec-WebSocket-Extensions: ${options.extensions}`);
+        } else if (heading === 'subProtocol') {
+          header.push(`Sec-WebSocket-Protocol: ${options[heading]}`);
+        } else {
+          header.push(`Proxy-Authorization: ${options[heading]}`);
+        }
+      }
+    }
+    headingCheck('extensions');
+    headingCheck('proxy-authorization');
+    headingCheck('subProtocol');
+    options.role = 'client';
+
+    header.push('');
+    header.push('');
+    // last use of socket.write before its hidden in socket extensions
+    socket.write(header.join('\r\n'));
+  }
+
+  // prevents a crashing server from breaking the client node instance
+  socket.on('error', function() {});
+
+  // wait for layer 4 socket connection
+  socket.once('ready', handlerReady);
+  return socket;
+}
+
+// a uniform convenience function for generating error objects
+function errorObject(code, message, socket, syscall) {
+  const addresses = getAddress(socket).remote;
+  return new Error({
+    address: addresses.address,
+    code: code,
+    errno: 0,
+    message: message,
+    port: addresses.port,
+    syscall: syscall
+  });
+}
+
+// a handy utility to conveniently gather a socket's connection identity
+function getAddress(socket) {
+  function parse(input) {
+    if (input === undefined) {
+      return 'undefined, possibly due to socket closing';
+    }
+    if (input.indexOf('::ffff:') === 0) {
+      return input.replace('::ffff:', '');
+    }
+    if (input.indexOf(':') > 0 && input.indexOf('.') > 0) {
+      return input.slice(0, input.lastIndexOf(':'));
+    }
+    return input;
+  }
+  return {
+    local: {
+      address: parse(socket.localAddress),
+      port: socket.localPort
+    },
+    remote: {
+      address: parse(socket.remoteAddress),
+      port: socket.remotePort
+    }
+  };
+}
+
+// send a message payload in conformance to RFC 6455
+function messageSend(message, opcode, fragmentSize) {
+  const socket = this;
+  function writeFrame() {
+    function writeCallback() {
+      socket.websocket.queue.splice(0, 1);
+      if (socket.websocket.queue.length > 0) {
+        writeFrame();
+      } else {
+        socket.websocket.status = 'open';
+      }
+    };
+    if (socket.websocket.status === 'open') {
+      socket.websocket.status = 'pending';
+    }
+    if (socket.internalWrite(socket.websocket.queue[0]) === true) {
+      writeCallback();
+    } else {
+      socket.once('drain', writeCallback);
+    }
+  };
+  function mask(body) {
+    const mask = Buffer.alloc(4);
+    const rand = Buffer.from(Math.random().toString());
+    mask[0] = rand[4];
+    mask[1] = rand[5];
+    mask[2] = rand[6];
+    mask[3] = rand[7];
+    // RFC 6455, 5.3.  Client-to-Server Masking
+    // j                   = i MOD 4
+    // transformed-octet-i = original-octet-i XOR masking-key-octet-j
+    body.forEach(function(value, index) {
+      body[index] = value ^ mask[index % 4];
+    });
+    return [body, mask];
+  }
+  // OPCODES
+  // ## Messages
+  // 0 - continuation - fragments of a message payload following an initial
+  //     fragment
+  // 1 - text message
+  // 2 - binary message
+  // 3-7 - reserved for future use
+  //
+  // ## Control Frames
+  // 8 - close, the remote is destroying the socket
+  // 9 - ping, a connectivity health check
+  // a - pong, a response to a ping
+  // b-f - reserved for future use
+  //
+  // ## Notes
+  // * Message frame fragments must be transmitted in order and not interleaved
+  //   with other messages.
+  // * Message types may be supplied as buffer or socketData types, but will
+  //   always be transmitted as buffers.
+  // * Control frames are always granted priority and may occur between fragments
+  //   of a single message.
+  // * Control frames will always be supplied as buffer data types.
+  //
+  // ## Masking
+  // * All traffic coming from the browser will be websocket masked.
+  // * I have not tested if the browsers will process masked data as they
+  //   shouldn't according to RFC 6455.
+  // * This application supports both masked and unmasked transmission so long
+  //   as the mask bit is set and a 32bit mask key is supplied.
+  // * Mask bit is set as payload length (up to 127) + 128 assigned to frame
+  //   header second byte.
+  // * Mask key is first 4 bytes following payload length bytes (if any).
+  if (typeof opcode !== 'number') {
+    opcode = 1;
+  } else {
+    opcode = Math.floor(opcode);
+    if (opcode < 0 || opcode > 15) {
+      opcode = 1;
+    }
+  }
+  if (opcode === 1 && Buffer.isBuffer(message) === true) {
+    opcode = 2;
+  }
+  if (typeof fragmentSize !== 'number' || fragmentSize < 1) {
+    fragmentSize = 0;
+  }
+  if (opcode === 1 || opcode === 2 || opcode === 3 || opcode === 4 || opcode === 5 || opcode === 6 || opcode === 7) {
+    let maskKey = null;
+    function fragmentation(first) {
+      let finish = false;
+      const frameBody = (function() {
+        if (fragmentSize < 1 || len === fragmentSize) {
+          finish = true;
+          if (socket.websocket.masking === true) {
+            const masked = mask(dataPackage);
+            maskKey = masked[1];
+            return masked[0];
+          }
+          return dataPackage;
+        }
+        const fragment = dataPackage.subarray(0, fragmentSize);
+        dataPackage = dataPackage.subarray(fragmentSize);
+        len = dataPackage.length;
+        if (len < fragmentSize) {
+          finish = true;
+        }
+        if (socket.websocket.masking === true) {
+          const masked = mask(fragment);
+          maskKey = masked[1];
+          return masked[0];
+        }
+        return fragment;
+      }());
+      const size = frameBody.length;
+      const frameHeader = (function() {
+        // frame 0 is:
+        // * 128 bits for fin, 0 for unfinished plus opcode
+        // * opcode 0 - continuation of fragments
+        // * opcode 1 - text (total payload must be UTF8 and probably not contain hidden
+        //              control characters)
+        // * opcode 2 - supposed to be binary, really anything that isn't 100& UTF8 text
+        // ** for fragmented data only first data frame gets a data opcode, others
+        //              receive 0 (continuity)
+        const frame = (size < 126) ?
+          (socket.websocket.masking === true) ?
+            Buffer.alloc(6) :
+            Buffer.alloc(2) :
+          (size < 65536) ?
+            (socket.websocket.masking === true) ?
+              Buffer.alloc(8) :
+              Buffer.alloc(4) :
+            (socket.websocket.masking === true) ?
+              Buffer.alloc(14) :
+              Buffer.alloc(10);
+        frame[0] = (finish === true) ?
+          (first === true) ?
+            128 + opcode :
+            128 :
+          (first === true) ?
+            opcode :
+            0;
+        // frame 1 is mask bit + length flag
+        frame[1] = (size < 126) ?
+          (socket.websocket.masking === true) ?
+            size + 128 :
+            size :
+          (size < 65536) ?
+            (socket.websocket.masking === true) ?
+              254 :
+              126 :
+            (socket.websocket.masking === true) ?
+              255 :
+              127;
+        // write payload length followed by mask key
+        if (size > 125) {
+          if (size < 65536) {
+            frame.writeUInt16BE(size, 2);
+            if (socket.websocket.masking === true) {
+              frame[6] = maskKey[0];
+              frame[7] = maskKey[1];
+              frame[8] = maskKey[2];
+              frame[9] = maskKey[3];
+            }
+          } else {
+            frame.writeUIntBE(size, 4, 6);
+            if (socket.websocket.masking === true) {
+              frame[10] = maskKey[0];
+              frame[11] = maskKey[1];
+              frame[12] = maskKey[2];
+              frame[13] = maskKey[3];
+            }
+          }
+        } else if (socket.websocket.masking === true) {
+          frame[2] = maskKey[0];
+          frame[3] = maskKey[1];
+          frame[4] = maskKey[2];
+          frame[5] = maskKey[3];
+        }
+        return frame;
+      }());
+      socket.websocket.queue.push(Buffer.concat([frameHeader, frameBody]));
+      if (finish === true) {
+        if (socket.websocket.status === 'open') {
+          writeFrame();
+        }
+      } else {
+        fragmentation(false);
+      }
+    };
+    let dataPackage = (Buffer.isBuffer === true) ?
+      message :
+      Buffer.from(message);
+    let len = dataPackage.length;
+    fragmentation(true);
+  } else if (opcode === 8 || opcode === 9 || opcode === 10 || opcode === 11 || opcode === 12 || opcode === 13 || opcode === 14 || opcode === 15) {
+    let frameBody = message.subarray(0, 125);
+    let frameHeader = null;
+    if (socket.websocket.masking === true) {
+      const masked = mask(frameBody);
+      frameHeader = Buffer.alloc(6);
+      // opcode + fin bit, rsv bits set to 0
+      frameHeader[0] = 128 + opcode;
+      // set the mask bit
+      frameHeader[1] = 128 + frameBody.length;
+      // set the mask key
+      frameHeader[2] = masked[1][0];
+      frameHeader[3] = masked[1][1];
+      frameHeader[4] = masked[1][2];
+      frameHeader[5] = masked[1][3];
+      // assign the masked payload
+      frameBody = masked[0];
+    } else {
+      frameHeader = Buffer.alloc(2);
+      // opcode + fin bit, rsv bits set to 0
+      frameHeader[0] = 128 + opcode;
+      frameHeader[1] = frameBody.length;
+    }
+    // control frames send immediately, out of sequence
+    socket.websocket.queue.unshift(Buffer.concat([frameHeader, frameBody]));
+
+    if (socket.websocket.status === 'open') {
+      writeFrame();
+    }
+  }
+}
+
+// arbitrary ping function, which may be called by any means at any time
+function ping(ttl, callback) {
+  const socket = this;
+  function errorObject(code, message) {
+    const err = new Error();
+    err.code = code;
+    err.message = `${message} Socket type ${config.socket.type} and name ${name}.`;
+    return err;
+  }
+  if (socket.websocket.status !== 'open' && socket.websocket.status !== 'pending') {
+    callback(errorObject(
+      'ECONNABORTED',
+      'Ping error on websocket without \'open\' or \'pending\' status.',
+      socket,
+      'websocket.ping'
+    ), null);
+  } else {
+    const nameSlice = socket.hash.slice(0, 125);
+    // send ping
+    transmit_ws.queue(Buffer.from(nameSlice), config.socket, 9);
+    socket.pong = {
+        callback: callback,
+        start: process.hrtime.bigint(),
+        timeOut: setTimeout(function() {
+            callback(socket.websocket.pong.timeOutMessage, null);
+            delete socket.websocket.pong;
+        }, ttl),
+        timeOutMessage: errorObject('ETIMEDOUT', 'Ping timeout on websocket.'),
+        ttl: BigInt(ttl * 1e6)
+    };
+  }
+}
+
+// processes incoming messages
+function receive(socket) {
+  function processor(buf) {
+    //    RFC 6455, 5.2.  Base Framing Protocol
+    //     0                   1                   2                   3
+    //     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    //    +-+-+-+-+-------+-+-------------+-------------------------------+
+    //    |F|R|R|R| opcode|M| Payload len |    Extended payload length    |
+    //    |I|S|S|S|  (4)  |A|     (7)     |             (16/64)           |
+    //    |N|V|V|V|       |S|             |   (if payload len==126/127)   |
+    //    | |1|2|3|       |K|             |                               |
+    //    +-+-+-+-+-------+-+-------------+ - - - - - - - - - - - - - - - +
+    //    |     Extended payload length continued, if payload len == 127  |
+    //    + - - - - - - - - - - - - - - - +-------------------------------+
+    //    |                               |Masking-key, if MASK set to 1  |
+    //    +-------------------------------+-------------------------------+
+    //    | Masking-key (continued)       |          Payload Data         |
+    //    +-------------------------------- - - - - - - - - - - - - - - - +
+    //    :                     Payload Data continued ...                :
+    //    + - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - +
+    //    |                     Payload Data continued ...                |
+    //    +---------------------------------------------------------------+
+
+    function unmask(input) {
+      if (frame.mask === true) {
+        // RFC 6455, 5.3.  Client-to-Server Masking
+        // j                   = i MOD 4
+        // transformed-octet-i = original-octet-i XOR masking-key-octet-j
+        input.forEach(function(value, index) {
+          input[index] = value ^ frame.maskKey[index % 4];
+        });
+      }
+      return input;
+    };
+    // identify payload extended length
+    const extended = function(input) {
+      const mask = (input[1] > 127),
+        len = (mask === true) ?
+          input[1] - 128 :
+          input[1],
+        keyOffset = (mask === true) ?
+          4 :
+          0;
+      if (len < 126) {
+        return {
+          lengthExtended: len,
+          lengthShort: len,
+          mask: mask,
+          startByte: 2 + keyOffset
+        };
+      }
+      if (len < 127) {
+        return {
+          lengthExtended: input.subarray(2, 4).readUInt16BE(0),
+          lengthShort: len,
+          mask: mask,
+          startByte: 4 + keyOffset
+        };
+      }
+      return {
+        lengthExtended: input.subarray(4, 10).readUIntBE(0, 6),
+        lengthShort: len,
+        mask: mask,
+        startByte: 10 + keyOffset
+      };
+    };
+    // populates data from the incoming network buffer with no assumptions of
+    // completeness
+    const data = (function() {
+      if (buf !== null && buf !== undefined) {
+        socket.websocket.frame = Buffer.concat([socket.websocket.frame, buf]);
+      }
+      if (socket.websocket.frame.length < 2) {
+        return null;
+      }
+      return socket.websocket.frame;
+    }());
+    // interprets the frame header from Buffer to an object
+    const frame = (function() {
+      if (data === null) {
+        return null;
+      }
+      // bit string - convert byte number (0 - 255) to 8 bits
+      const bits0 = data[0].toString(2).padStart(8, '0');
+      const meta = extended(data);
+      return {
+        fin: (data[0] > 127),
+        rsv1: (bits0.charAt(1) === '1'),
+        rsv2: (bits0.charAt(2) === '1'),
+        rsv3: (bits0.charAt(3) === '1'),
+        opcode: (
+          (Number(bits0.charAt(4)) * 8) +
+          (Number(bits0.charAt(5)) * 4) +
+          (Number(bits0.charAt(6)) * 2) +
+          Number(bits0.charAt(7))
+        ),
+        mask: meta.mask,
+        len: meta.lengthShort,
+        extended: meta.lengthExtended,
+        maskKey: (meta.mask === true) ?
+          data.subarray(meta.startByte - 4, meta.startByte) :
+          null,
+        startByte: meta.startByte
+      };
+    }());
+    const payload = (function() {
+      // Payload processing must contend with these 4 constraints:
+      // 1. Message Fragmentation - RFC6455 allows messages to be fragmented from a
+      //                            single transmission into multiple transmission
+      //                            frames independently sent and received.
+      // 2. Header Separation     - Firefox sends frame headers separated from frame
+      //                            bodies.
+      // 3. Node Concatenation    - If Node.js receives message frames too quickly the
+      //                            various binary buffers are concatenated into a
+      //                            single deliverable to the processing application.
+      // 4. TLS Max Packet Size   - TLS forces a maximum payload size of 65536 bytes.
+      if (frame === null) {
+        return null;
+      }
+      let complete = null;
+      const size = frame.extended + frame.startByte;
+      const len = socket.websocket.frame.length;
+      if (len < size) {
+        return null;
+      }
+      complete = unmask(socket.websocket.frame.subarray(frame.startByte, size));
+      socket.websocket.frame = socket.websocket.frame.subarray(size);
+
+      return complete;
+    }());
+
+    if (payload === null) {
+      return;
+    }
+
+    if (frame.opcode === 8) {
+      // socket close
+      data[0] = 136;
+      data[1] = (data[1] > 127) ?
+        data[1] - 128 :
+        data[1];
+      const payload = Buffer.concat([data.subarray(0, 2), unmask(data.subarray(2))]);
+      socket.write(payload);
+      socket.off('data', processor);
+    } else if (frame.opcode === 9) {
+      // respond to 'ping' as 'pong'
+      socket.send(data.subarray(frame.startByte), socket, 10);
+    } else if (frame.opcode === 10) {
+      // pong
+      const payloadString = payload.toString();
+      const pong = socket.websocket.pong[payloadString];
+      const time = process.hrtime.bigint();
+      if (pong !== undefined) {
+        if (time < pong.start + pong.ttl) {
+          clearTimeout(pong.timeOut);
+          pong.callback(null, time - pong.start);
+        }
+        delete socket.websocket.pong[payloadString];
+      }
+    } else {
+      const segment = Buffer.concat([socket.websocket.fragment, payload]);
+      // this block may include frame.opcode === 0 - a continuation frame
+      socket.websocket.frameExtended = frame.extended;
+      if (frame.fin === true) {
+        if (typeof socket.websocket.messageHandler === 'function') {
+          socket.websocket.messageHandler(segment.subarray(0, socket.websocket.frameExtended));
+        }
+        socket.websocket.fragment = segment.subarray(socket.websocket.frameExtended);
+      } else {
+        socket.websocket.fragment = segment;
+      }
+    }
+    if (socket.websocket.frame.length > 2) {
+      processor(null);
+    }
+  };
+  socket.on('data', processor);
+}
+
+/**
+ * ```typescript
+ * interface serverOptions {
+ *     // Optional callback for when a socket connects to the server, before
+ *     // completion of the handshake.
+ *     // Insert custom socket extensions or authentication logic here.
+ *     // The callbackConnect function must call `extend()` in order to
+ *     // complete the connection handshake.
+ *   callbackConnect?: (
+ *     headerValues:headerValues,
+ *     socket:Socket|TLSSocket,
+ *     ready:() => void,
+ *   ) => void;
+ *     // Optional callback for when server begins to listen for sockets.
+ *   callbackListener?: (server:Server) => void;
+ *     // Optional callback that fires once the connection handshake completes.
+ *   callbackOpen?: (err:NodeJS.ErrnoException, socket:Socket|TLSSocket) => void;
+ *     // A handler to receive processed messages. If not a function incoming
+ *     // messages are ignored.
+ *   messageHandler?: (message:Buffer) => void;
+ *     // Options for the server's listener event emitter.
+ *   listenerOptions: ListenerOptions;
+ *     // Whether to invoke tls.createServer or net.createServer.
+ *   secure?: boolean;
+ *     // Node core options object for net.createServer or tls.createServer.
+ *   serverOptions?: ServerOpts | TlsOptions;
+ * }
+ * (options:serverOptions) => Server;
+ * ``` */
+// creates a websocket server
+function server(options) {
+  function connection(socket) {
+    // prevents a closing socket from crashing the server
+    socket.on('error', function () {});
+    // socket handshake must be processed within 5 seconds of connection
+    // this is a security precaution to prevent overloading servers
+    const deathDelay = setTimeout(function() {
+      socket.destroy();
+    }, 5000);
+    // the first data must be the HTTP handshake, otherwise destroy
+    socket.once('data', function(data) {
+      // we expect data to be the handshake payload in HTTP form
+      const headerValues = {
+        authentication: '',
+        id: '',
+        key: '',
+        subprotocol: '',
+        type: '',
+        userAgent: '',
+      };
+      const dataString = data.toString();
+      const lowString = dataString.toLowerCase();
+      const headerList = dataString.split('\r\n');
+      const flags = {
+        complete: false,
+        extensions: (lowString.includes('\r\nsec-websocket-extensions:')) ?
+          false :
+          true,
+        key: false,
+        subprotocol: (lowString.includes('\r\nsec-webSocket-protocol:')) ?
+          false :
+          true,
+        userAgent: (lowString.includes('\r\nuser-agent:')) ?
+          false :
+          true,
+      };
+      function complete() {
+        if (
+          flags.authentication === true &&
+          flags.extensions === true &&
+          flags.subprotocol === true &&
+          flags.userAgent === true &&
+          flags.complete === false
+        ) {
+          function extend() {
+            // send the handshake response
+            const headers = [
+              'HTTP/1.1 101 Switching Protocols',
+              'Upgrade: websocket',
+              'Connection: Upgrade',
+              `Sec-WebSocket-Accept: ${headerValues.key}`,
+              `Sec-WebSocket-Protocol: ${headerValues
+                .subprotocol.split(',')[0]
+                .replace(/^\s+/, '')
+                .replace(/\s+$/, '')
+              }`,
+            ];
+            headers.push('');
+            headers.push('');
+            socket.write(headers.join('\r\n'));
+
+            // extend the socket
+            socketExtend(socket, {
+              callbackOpen: options.callbackOpen,
+              extensions: headerValues.extensions,
+              messageHandler: options.messageHandler,
+              'proxy-authorization': '',
+              'role': 'server',
+              subprotocol: headerValues.subprotocol,
+              userAgent: headerValues.userAgent,
+            });
+          }
+          flags.complete = true;
+          clearTimeout(deathDelay);
+          if (typeof options.callbackConnect === 'function') {
+            options.callbackConnect(headerValues, socket, extend);
+          } else {
+            extend();
+          }
+        }
+      }
+      headerList.forEach(function(header) {
+        const index = header.indexOf(':');
+        const lowHeader = header.toLowerCase().slice(0, index);
+        const value = header.slice(index + 1).replace(/^\s+/, '');
+        if (lowHeader === 'sec-websocket-key') {
+          const hash = crypto.createHash('sha1');
+          const key = value + websocket.magicString;
+          hash.update(key);
+          headerValues.key = hash.digest('hex');
+          flags.key = true;
+        } else if (lowHeader === 'sec-webSocket-protocol') {
+          headerValues.subprotocol = value;
+          flags.subprotocol = true;
+        } else if (lowHeader === 'sec-websocket-extensions') {
+          headerValues.extensions = value;
+          flags.extensions = true;
+        } else if (lowHeader === 'user-agent') {
+          headerValues.userAgent = value;
+          flags.userAgent = true;
+        }
+        complete();
+      });
+      if (flags.complete === false) {
+        socket.destroy();
+        clearTimeout(deathDelay);
+      }
+    });
+  }
+  const serverInstance = (options.secure === false) ?
+    net.createServer(options.serverOptions) :
+    tls.createServer(options.serverOptions, connection);
+  if (options.secure === false) {
+    serverInstance.on('connection', connection);
+  }
+  serverInstance.listen(options.listenerOptions, function () {
+    if (typeof options.callbackListener === 'function') {
+      options.callbackListener(serverInstance);
+    }
+  });
+  return serverInstance;
+}
+
+// extends a net Socket type with additional features specific for WebSocket
+function socketExtend(socket, extensions) {
+  function stringExtensions(name) {
+    socket.websocket[name] = (typeof extensions[name] === 'string') ?
+      extensions[name] :
+      '';
+  }
+  socket.websocket = (
+    extensions === null ||
+    extensions === undefined ||
+    typeof extensions !== 'object'
+  ) ?
+    {} :
+    extensions;
+  if (typeof socket.websocket.messageHandler === 'function') {
+    receive(socket);
+  }
+  // arbitrary ping utility
+  socket.ping = ping;
+  // send a message
+  socket.messageSend = messageSend;
+  socket.setKeepAlive(true, 0);
+  stringExtensions('extensions');
+  stringExtensions('proxy-authorization');
+  stringExtensions('role');
+  stringExtensions('userAgent');
+  socket.websocket.masking = (typeof extensions.masking === 'boolean') ?
+    extensions.masking :
+    extensions.role === 'client' ?
+      true :
+      false;
+  // storehouse of complete received data frames
+  // a frame is a message fragment considering for continuation frames
+  socket.websocket.fragment = Buffer.from([]);
+  // stores pieces of frames for assembly into complete frames
+  socket.websocket.frame = Buffer.from([]);
+  // stores the payload size of current received message payload
+  socket.websocket.frameExtended = 0;
+  // stores termination times and callbacks for pong handling
+  socket.websocket.pong = {};
+  // stores messages for transmit in order,
+  // because websocket protocol cannot intermix messages
+  socket.websocket.queue = [];
+  socket.websocket.status = 'open';
+  // hides the generic socket.write method to encourage use of messageSend
+  socket.internalWrite = socket.write;
+  socket.write = messageSend;
+  if (typeof extensions.callbackOpen === 'function') {
+    extensions.callbackOpen(null, socket);
+  }
+}
+
+module.exports = websocket = {
+  clientConnect,
+  getAddress,
+  magicString: '258EAFA5-E914-47DA-95CA-C5AB0DC85B11',
+  server: server
+};

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -1,5 +1,5 @@
 'use strict';
-const { Buffer } = require('node:buffer');
+const { Buffer } = require('buffer');
 const crypto = require('node:crypto');
 const net = require('node:net');
 const os = require('node:os');
@@ -12,7 +12,7 @@ const {
   Number,
 } = primordials;
 const {
-  SystemError,
+  errnoException,
 } = require('internal/errors');
 const {
   clearTimeout,
@@ -73,13 +73,7 @@ function clientConnect(options) {
       const len = response.length;
       function callbackCheck() {
         if (typeof options.callbackOpen === 'function') {
-          options.callbackOpen(errorObject(
-            'ECONNABORTED',
-            'WebSocket server handshake response returned no ' +
-              'Sec-WebSocket-Accept header or one which is malformed.',
-            socket,
-            'websocket.clientConnect',
-          ), null);
+          // REPLACEME - error handling here for handshake failure at client
         }
       }
       // Check if response contains required HTTP header
@@ -173,19 +167,6 @@ function clientConnect(options) {
   // Wait for layer 4 socket connection
   socket.once('ready', handlerReady);
   return socket;
-}
-
-// A uniform convenience function for generating error objects
-function errorObject(code, message, socket, syscall) {
-  const addresses = getAddress(socket).remote;
-  return new SystemError({
-    address: addresses.address,
-    code: code,
-    errno: 0,
-    message: message,
-    port: addresses.port,
-    syscall: syscall,
-  });
 }
 
 // A handy utility to conveniently gather a socket's connection identity
@@ -458,12 +439,9 @@ function messageSend(message, opcode, fragmentSize) {
 function ping(ttl, callback) {
   const socket = this;
   if (socket.websocket.status !== 'open' && socket.websocket.status !== 'pending') {
-    callback(errorObject(
-      'ECONNABORTED',
-      'Ping error on websocket without \'open\' or \'pending\' status.',
-      socket,
-      'websocket.ping',
-    ), null);
+    // REPLACEME - first null should be error object equivalent to write to a closed
+    // socket
+    callback(null, null);
   } else {
     const nameSlice = socket.hash.slice(0, 125);
     // Send ping
@@ -475,7 +453,8 @@ function ping(ttl, callback) {
         callback(socket.websocket.pong.timeOutMessage, null);
         delete socket.websocket.pong;
       }, ttl),
-      timeOutMessage: errorObject('ETIMEDOUT', 'Ping timeout on websocket.'),
+      // REPLACEME - null value should be an error object for ping timeout
+      timeOutMessage: null,
       ttl: BigInt(ttl * 1e6),
     };
   }

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -214,7 +214,7 @@ function getAddress(socket) {
   };
 }
 
-// send a message payload in conformance to RFC 6455
+// Send a message payload in conformance to RFC 6455
 function messageSend(message, opcode, fragmentSize) {
   const socket = this;
   function writeFrame() {
@@ -235,6 +235,7 @@ function messageSend(message, opcode, fragmentSize) {
       socket.once('drain', writeCallback);
     }
   }
+
   function mask(body) {
     const mask = Buffer.alloc(4);
     const rand = Buffer.from(MathRandom().toString());
@@ -436,7 +437,7 @@ function messageSend(message, opcode, fragmentSize) {
       frameHeader[3] = masked[1][1];
       frameHeader[4] = masked[1][2];
       frameHeader[5] = masked[1][3];
-      // assign the masked payload
+      // Assign the masked payload
       frameBody = masked[0];
     } else {
       frameHeader = Buffer.alloc(2);
@@ -461,7 +462,7 @@ function ping(ttl, callback) {
       'ECONNABORTED',
       'Ping error on websocket without \'open\' or \'pending\' status.',
       socket,
-      'websocket.ping'
+      'websocket.ping',
     ), null);
   } else {
     const nameSlice = socket.hash.slice(0, 125);
@@ -514,6 +515,7 @@ function receive(socket) {
       }
       return input;
     }
+
     // Identify payload extended length
     function extended(input) {
       const mask = (input[1] > 127);
@@ -811,7 +813,7 @@ function server(options) {
   if (options.secure === false) {
     serverInstance.on('connection', connection);
   }
-  serverInstance.listen(options.listenerOptions, function () {
+  serverInstance.listen(options.listenerOptions, function() {
     if (typeof options.callbackListener === 'function') {
       options.callbackListener(serverInstance);
     }

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -195,245 +195,247 @@ function getAddress(socket) {
 // Send a message payload in conformance to RFC 6455
 function messageSend(message, opcode, fragmentSize) {
   const socket = this;
-  if (socket.websocket.status === 'CLOSED' || socket.websocket.status === 'CLOSING') {
-    return;
-  }
-  function writeFrame() {
-    function writeCallback() {
-      socket.websocket.queue.splice(0, 1);
-      if (socket.websocket.queue.length > 0) {
-        writeFrame();
-      } else if (socket.websocket.status === 'PENDING') {
-        socket.websocket.status = 'OPEN';
+  if (socket.websocket.status !== "OPEN" && socket.websocket.status !== "PENDING") {
+    // REPLACEME - emit error on socket here
+  } else if (typeof message !== 'string' && Buffer.isBuffer(message) === false) {
+    // REPLACEME - emit error on socket here
+  } else {
+    function writeFrame() {
+      function writeCallback() {
+        socket.websocket.queue.splice(0, 1);
+        if (socket.websocket.queue.length > 0) {
+          writeFrame();
+        } else if (socket.websocket.status === 'PENDING') {
+          socket.websocket.status = 'OPEN';
+        }
+      }
+      if (socket.websocket.status === 'OPEN') {
+        socket.websocket.status = 'PENDING';
+      }
+      if (socket.internalWrite(socket.websocket.queue[0]) === true) {
+        writeCallback();
+      } else {
+        socket.once('drain', writeCallback);
       }
     }
-    if (socket.websocket.status === 'OPEN') {
-      socket.websocket.status = 'PENDING';
-    }
-    if (socket.internalWrite(socket.websocket.queue[0]) === true) {
-      writeCallback();
-    } else {
-      socket.once('drain', writeCallback);
-    }
-  }
 
-  function mask(body) {
-    const mask = Buffer.alloc(4);
-    const rand = Buffer.from(MathRandom().toString());
-    mask[0] = rand[4];
-    mask[1] = rand[5];
-    mask[2] = rand[6];
-    mask[3] = rand[7];
-    // RFC 6455, 5.3.  Client-to-Server Masking
-    // j                   = i MOD 4
-    // transformed-octet-i = original-octet-i XOR masking-key-octet-j
-    body.forEach(function(value, index) {
-      body[index] = value ^ mask[index % 4];
-    });
-    return [body, mask];
-  }
-  // OPCODES
-  // ## Messages
-  // 0 - continuation - fragments of a message payload following an initial
-  //     fragment
-  // 1 - text message
-  // 2 - binary message
-  // 3-7 - reserved for future use
-  //
-  // ## Control Frames
-  // 8 - close, the remote is destroying the socket
-  // 9 - ping, a connectivity health check
-  // a - pong, a response to a ping
-  // b-f - reserved for future use
-  //
-  // ## Notes
-  // * Message frame fragments must be transmitted in order and not interleaved
-  //   with other messages.
-  // * Message types may be supplied as buffer or socketData types, but will
-  //   always be transmitted as buffers.
-  // * Control frames are always granted priority and may occur between fragments
-  //   of a single message.
-  // * Control frames will always be supplied as buffer data types.
-  //
-  // ## Masking
-  // * All traffic coming from the browser will be websocket masked.
-  // * I have not tested if the browsers will process masked data as they
-  //   shouldn't according to RFC 6455.
-  // * This application supports both masked and unmasked transmission so long
-  //   as the mask bit is set and a 32bit mask key is supplied.
-  // * Mask bit is set as payload length (up to 127) + 128 assigned to frame
-  //   header second byte.
-  // * Mask key is first 4 bytes following payload length bytes (if any).
-  if (typeof opcode !== 'number') {
-    opcode = 1;
-  } else {
-    opcode = MathFloor(opcode);
-    if (opcode < 0 || opcode > 15) {
-      opcode = 1;
+    function mask(body) {
+      const mask = Buffer.alloc(4);
+      const rand = Buffer.from(MathRandom().toString());
+      mask[0] = rand[4];
+      mask[1] = rand[5];
+      mask[2] = rand[6];
+      mask[3] = rand[7];
+      // RFC 6455, 5.3.  Client-to-Server Masking
+      // j                   = i MOD 4
+      // transformed-octet-i = original-octet-i XOR masking-key-octet-j
+      body.forEach(function(value, index) {
+        body[index] = value ^ mask[index % 4];
+      });
+      return [body, mask];
     }
-  }
-  if (opcode === 1 && Buffer.isBuffer(message) === true) {
-    opcode = 2;
-  }
-  if (typeof fragmentSize !== 'number' || fragmentSize < 1) {
-    fragmentSize = 0;
-  }
-  if (
-    opcode === 1 ||
-    opcode === 2 ||
-    opcode === 3 ||
-    opcode === 4 ||
-    opcode === 5 ||
-    opcode === 6 ||
-    opcode === 7
-  ) {
-    let maskKey = null;
-    function fragmentation(first) {
-      let finish = false;
-      const frameBody = (function() {
-        if (fragmentSize < 1 || len === fragmentSize) {
-          finish = true;
+    // OPCODES
+    // ## Messages
+    // 0 - continuation - fragments of a message payload following an initial
+    //     fragment
+    // 1 - text message
+    // 2 - binary message
+    // 3-7 - reserved for future use
+    //
+    // ## Control Frames
+    // 8 - close, the remote is destroying the socket
+    // 9 - ping, a connectivity health check
+    // a - pong, a response to a ping
+    // b-f - reserved for future use
+    //
+    // ## Notes
+    // * Message frame fragments must be transmitted in order and not interleaved
+    //   with other messages.
+    // * Message types may be supplied as buffer or socketData types, but will
+    //   always be transmitted as buffers.
+    // * Control frames are always granted priority and may occur between fragments
+    //   of a single message.
+    // * Control frames will always be supplied as buffer data types.
+    //
+    // ## Masking
+    // * All traffic coming from the browser will be websocket masked.
+    // * I have not tested if the browsers will process masked data as they
+    //   shouldn't according to RFC 6455.
+    // * This application supports both masked and unmasked transmission so long
+    //   as the mask bit is set and a 32bit mask key is supplied.
+    // * Mask bit is set as payload length (up to 127) + 128 assigned to frame
+    //   header second byte.
+    // * Mask key is first 4 bytes following payload length bytes (if any).
+    if (typeof opcode !== 'number') {
+      opcode = (Buffer.isBuffer(message)) ?
+        2 :
+        1;
+    } else {
+      opcode = MathFloor(opcode);
+      if (opcode < 1 || opcode > 15) {
+        opcode = 1;
+      }
+    }
+    if (typeof fragmentSize !== 'number' || fragmentSize < 1) {
+      fragmentSize = 0;
+    }
+    if (
+      opcode === 1 ||
+      opcode === 2 ||
+      opcode === 3 ||
+      opcode === 4 ||
+      opcode === 5 ||
+      opcode === 6 ||
+      opcode === 7
+    ) {
+      let maskKey = null;
+      function fragmentation(first) {
+        let finish = false;
+        const frameBody = (function() {
+          if (fragmentSize < 1 || len === fragmentSize) {
+            finish = true;
+            if (socket.websocket.masking === true) {
+              const masked = mask(dataPackage);
+              maskKey = masked[1];
+              return masked[0];
+            }
+            return dataPackage;
+          }
+          const fragment = dataPackage.subarray(0, fragmentSize);
+          dataPackage = dataPackage.subarray(fragmentSize);
+          len = dataPackage.length;
+          if (len < fragmentSize) {
+            finish = true;
+          }
           if (socket.websocket.masking === true) {
-            const masked = mask(dataPackage);
+            const masked = mask(fragment);
             maskKey = masked[1];
             return masked[0];
           }
-          return dataPackage;
-        }
-        const fragment = dataPackage.subarray(0, fragmentSize);
-        dataPackage = dataPackage.subarray(fragmentSize);
-        len = dataPackage.length;
-        if (len < fragmentSize) {
-          finish = true;
-        }
-        if (socket.websocket.masking === true) {
-          const masked = mask(fragment);
-          maskKey = masked[1];
-          return masked[0];
-        }
-        return fragment;
-      }());
-      const size = frameBody.length;
-      const frameHeader = (function() {
-        // Frame 0 is:
-        // * 128 bits for fin, 0 for unfinished plus opcode
-        // * opcode 0 - continuation of fragments
-        // * opcode 1 - text (total payload must be UTF8 and probably not contain hidden
-        //              control characters)
-        // * opcode 2 - supposed to be binary, really anything that isn't 100& UTF8 text
-        // ** for fragmented data only first data frame gets a data opcode, others
-        //              receive 0 (continuity)
-        const frame = (size < 126) ?
-          (socket.websocket.masking === true) ?
-            Buffer.alloc(6) :
-            Buffer.alloc(2) :
-          (size < 65536) ?
+          return fragment;
+        }());
+        const size = frameBody.length;
+        const frameHeader = (function() {
+          // Frame 0 is:
+          // * 128 bits for fin, 0 for unfinished plus opcode
+          // * opcode 0 - continuation of fragments
+          // * opcode 1 - text (total payload must be UTF8 and probably not contain hidden
+          //              control characters)
+          // * opcode 2 - supposed to be binary, really anything that isn't 100& UTF8 text
+          // ** for fragmented data only first data frame gets a data opcode, others
+          //              receive 0 (continuity)
+          const frame = (size < 126) ?
             (socket.websocket.masking === true) ?
-              Buffer.alloc(8) :
-              Buffer.alloc(4) :
+              Buffer.alloc(6) :
+              Buffer.alloc(2) :
+            (size < 65536) ?
+              (socket.websocket.masking === true) ?
+                Buffer.alloc(8) :
+                Buffer.alloc(4) :
+              (socket.websocket.masking === true) ?
+                Buffer.alloc(14) :
+                Buffer.alloc(10);
+          frame[0] = (finish === true) ?
+            (first === true) ?
+              128 + opcode :
+              128 :
+            (first === true) ?
+              opcode :
+              0;
+          // Frame 1 is mask bit + length flag
+          frame[1] = (size < 126) ?
             (socket.websocket.masking === true) ?
-              Buffer.alloc(14) :
-              Buffer.alloc(10);
-        frame[0] = (finish === true) ?
-          (first === true) ?
-            128 + opcode :
-            128 :
-          (first === true) ?
-            opcode :
-            0;
-        // Frame 1 is mask bit + length flag
-        frame[1] = (size < 126) ?
-          (socket.websocket.masking === true) ?
-            size + 128 :
-            size :
-          (size < 65536) ?
-            (socket.websocket.masking === true) ?
-              254 :
-              126 :
-            (socket.websocket.masking === true) ?
-              255 :
-              127;
-        // Write payload length followed by mask key
-        if (size > 125) {
-          if (size < 65536) {
-            frame.writeUInt16BE(size, 2);
-            if (socket.websocket.masking === true) {
-              frame[6] = maskKey[0];
-              frame[7] = maskKey[1];
-              frame[8] = maskKey[2];
-              frame[9] = maskKey[3];
+              size + 128 :
+              size :
+            (size < 65536) ?
+              (socket.websocket.masking === true) ?
+                254 :
+                126 :
+              (socket.websocket.masking === true) ?
+                255 :
+                127;
+          // Write payload length followed by mask key
+          if (size > 125) {
+            if (size < 65536) {
+              frame.writeUInt16BE(size, 2);
+              if (socket.websocket.masking === true) {
+                frame[6] = maskKey[0];
+                frame[7] = maskKey[1];
+                frame[8] = maskKey[2];
+                frame[9] = maskKey[3];
+              }
+            } else {
+              frame.writeUIntBE(size, 4, 6);
+              if (socket.websocket.masking === true) {
+                frame[10] = maskKey[0];
+                frame[11] = maskKey[1];
+                frame[12] = maskKey[2];
+                frame[13] = maskKey[3];
+              }
             }
-          } else {
-            frame.writeUIntBE(size, 4, 6);
-            if (socket.websocket.masking === true) {
-              frame[10] = maskKey[0];
-              frame[11] = maskKey[1];
-              frame[12] = maskKey[2];
-              frame[13] = maskKey[3];
-            }
+          } else if (socket.websocket.masking === true) {
+            frame[2] = maskKey[0];
+            frame[3] = maskKey[1];
+            frame[4] = maskKey[2];
+            frame[5] = maskKey[3];
           }
-        } else if (socket.websocket.masking === true) {
-          frame[2] = maskKey[0];
-          frame[3] = maskKey[1];
-          frame[4] = maskKey[2];
-          frame[5] = maskKey[3];
+          return frame;
+        }());
+        socket.websocket.queue.push(Buffer.concat([frameHeader, frameBody]));
+        if (finish === true) {
+          if (socket.websocket.status === 'OPEN') {
+            writeFrame();
+          }
+        } else {
+          fragmentation(false);
         }
-        return frame;
-      }());
-      socket.websocket.queue.push(Buffer.concat([frameHeader, frameBody]));
-      if (finish === true) {
-        if (socket.websocket.status === 'OPEN') {
-          writeFrame();
-        }
-      } else {
-        fragmentation(false);
       }
-    }
-    let dataPackage = (Buffer.isBuffer === true) ?
-      message :
-      Buffer.from(message);
-    let len = dataPackage.length;
-    fragmentation(true);
-  } else if (
-    opcode === 8 ||
-    opcode === 9 ||
-    opcode === 10 ||
-    opcode === 11 ||
-    opcode === 12 ||
-    opcode === 13 ||
-    opcode === 14 ||
-    opcode === 15
-  ) {
-    let frameBody = message.subarray(0, 125);
-    let frameHeader = null;
-    if (opcode === 8) {
-      socket.websocket.status = 'CLOSING';
-    }
-    if (socket.websocket.masking === true) {
-      const masked = mask(frameBody);
-      frameHeader = Buffer.alloc(6);
-      // Opcode + fin bit, rsv bits set to 0
-      frameHeader[0] = 128 + opcode;
-      // Set the mask bit
-      frameHeader[1] = 128 + frameBody.length;
-      // Set the mask key
-      frameHeader[2] = masked[1][0];
-      frameHeader[3] = masked[1][1];
-      frameHeader[4] = masked[1][2];
-      frameHeader[5] = masked[1][3];
-      // Assign the masked payload
-      frameBody = masked[0];
-    } else {
-      frameHeader = Buffer.alloc(2);
-      // Opcode + fin bit, rsv bits set to 0
-      frameHeader[0] = 128 + opcode;
-      frameHeader[1] = frameBody.length;
-    }
-    // Control frames send immediately, out of sequence
-    socket.websocket.queue.unshift(Buffer.concat([frameHeader, frameBody]));
+      let dataPackage = (Buffer.isBuffer === true) ?
+        message :
+        Buffer.from(message);
+      let len = dataPackage.length;
+      fragmentation(true);
+    } else if (
+      opcode === 8 ||
+      opcode === 9 ||
+      opcode === 10 ||
+      opcode === 11 ||
+      opcode === 12 ||
+      opcode === 13 ||
+      opcode === 14 ||
+      opcode === 15
+    ) {
+      let frameBody = message.subarray(0, 125);
+      let frameHeader = null;
+      if (opcode === 8) {
+        socket.websocket.status = 'CLOSING';
+      }
+      if (socket.websocket.masking === true) {
+        const masked = mask(frameBody);
+        frameHeader = Buffer.alloc(6);
+        // Opcode + fin bit, rsv bits set to 0
+        frameHeader[0] = 128 + opcode;
+        // Set the mask bit
+        frameHeader[1] = 128 + frameBody.length;
+        // Set the mask key
+        frameHeader[2] = masked[1][0];
+        frameHeader[3] = masked[1][1];
+        frameHeader[4] = masked[1][2];
+        frameHeader[5] = masked[1][3];
+        // Assign the masked payload
+        frameBody = masked[0];
+      } else {
+        frameHeader = Buffer.alloc(2);
+        // Opcode + fin bit, rsv bits set to 0
+        frameHeader[0] = 128 + opcode;
+        frameHeader[1] = frameBody.length;
+      }
+      // Control frames send immediately, out of sequence
+      socket.websocket.queue.unshift(Buffer.concat([frameHeader, frameBody]));
 
-    if (socket.websocket.status === 'OPEN') {
-      writeFrame();
+      if (socket.websocket.status === 'OPEN') {
+        writeFrame();
+      }
     }
   }
 }

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -52,7 +52,7 @@ const websocket = {};
  * ```
  */
 
-// creates and connects a websocket client
+// Creates and connects a websocket client
 function clientConnect(options) {
   const socket = (options.secure === false) ?
     net.connect(options.socketOptions) :
@@ -195,17 +195,20 @@ function getAddress(socket) {
 // Send a message payload in conformance to RFC 6455
 function messageSend(message, opcode, fragmentSize) {
   const socket = this;
+  if (socket.websocket.status === 'CLOSED' || socket.websocket.status === 'CLOSING') {
+    return;
+  }
   function writeFrame() {
     function writeCallback() {
       socket.websocket.queue.splice(0, 1);
       if (socket.websocket.queue.length > 0) {
         writeFrame();
-      } else {
-        socket.websocket.status = 'open';
+      } else if (socket.websocket.status === 'PENDING') {
+        socket.websocket.status = 'OPEN';
       }
     }
-    if (socket.websocket.status === 'open') {
-      socket.websocket.status = 'pending';
+    if (socket.websocket.status === 'OPEN') {
+      socket.websocket.status = 'PENDING';
     }
     if (socket.internalWrite(socket.websocket.queue[0]) === true) {
       writeCallback();
@@ -379,7 +382,7 @@ function messageSend(message, opcode, fragmentSize) {
       }());
       socket.websocket.queue.push(Buffer.concat([frameHeader, frameBody]));
       if (finish === true) {
-        if (socket.websocket.status === 'open') {
+        if (socket.websocket.status === 'OPEN') {
           writeFrame();
         }
       } else {
@@ -403,6 +406,9 @@ function messageSend(message, opcode, fragmentSize) {
   ) {
     let frameBody = message.subarray(0, 125);
     let frameHeader = null;
+    if (opcode === 8) {
+      socket.websocket.status = 'CLOSING';
+    }
     if (socket.websocket.masking === true) {
       const masked = mask(frameBody);
       frameHeader = Buffer.alloc(6);
@@ -426,7 +432,7 @@ function messageSend(message, opcode, fragmentSize) {
     // Control frames send immediately, out of sequence
     socket.websocket.queue.unshift(Buffer.concat([frameHeader, frameBody]));
 
-    if (socket.websocket.status === 'open') {
+    if (socket.websocket.status === 'OPEN') {
       writeFrame();
     }
   }
@@ -435,7 +441,7 @@ function messageSend(message, opcode, fragmentSize) {
 // Arbitrary ping function, which may be called by any means at any time
 function ping(ttl, callback) {
   const socket = this;
-  if (socket.websocket.status !== 'open' && socket.websocket.status !== 'pending') {
+  if (socket.websocket.status !== 'OPEN' && socket.websocket.status !== 'PENDING') {
     // REPLACEME - first null should be error object equivalent to write to a closed
     // socket
     callback(null, null);
@@ -600,8 +606,12 @@ function receive(socket) {
         data[1] - 128 :
         data[1];
       const payload = Buffer.concat([data.subarray(0, 2), unmask(data.subarray(2))]);
-      socket.write(payload);
+      if (socket.websocket.status !== 'CLOSING') {
+        socket.write(payload, 8, 0);
+      }
+      socket.websocket.status = 'CLOSED';
       socket.off('data', processor);
+      socket.destroy();
     } else if (frame.opcode === 9) {
       // Respond to 'ping' as 'pong'
       socket.send(data.subarray(frame.startByte), socket, 10);
@@ -814,6 +824,9 @@ function socketExtend(socket, extensions) {
   if (typeof socket.websocket.messageHandler === 'function') {
     receive(socket);
   }
+  socket.close = function() {
+    this.write('CLOSE', 8, 0);
+  }
   // Arbitrary ping utility
   socket.ping = ping;
   socket.setKeepAlive(true, 0);
@@ -838,7 +851,7 @@ function socketExtend(socket, extensions) {
   // Stores messages for transmit in order,
   // Because websocket protocol cannot intermix messages
   socket.websocket.queue = [];
-  socket.websocket.status = 'open';
+  socket.websocket.status = 'OPEN';
   // Hides the generic socket.write method to encourage use of messageSend
   socket.internalWrite = socket.write;
   socket.write = messageSend;

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -26,6 +26,8 @@ const websocket = {};
  *     err:NodeJS.ErrnoException,
  *     socket:Socket|TLSSocket
  *   ) => void;
+ *     // A custom string value.
+ *   customHeader: string;
  *     // Extensions are the place to provide custom identifiers, security
  *     // tokens, and other descriptors.
  *   extensions?: string;
@@ -142,14 +144,19 @@ function clientConnect(options) {
           header.push(`Sec-WebSocket-Extensions: ${options.extensions}`);
         } else if (heading === 'subProtocol') {
           header.push(`Sec-WebSocket-Protocol: ${options[heading]}`);
+        } else if (heading === 'customHeader') {
+          header.push(`Custom-Header: ${options[header]}`);
         } else {
           header.push(`Proxy-Authorization: ${options[heading]}`);
         }
+      } else {
+        options[heading] = '';
       }
     }
     headingCheck('extensions');
     headingCheck('proxy-authorization');
     headingCheck('subProtocol');
+    headingCheck('customHeader');
     options.role = 'client';
 
     header.push('');
@@ -696,11 +703,10 @@ function server(options) {
     socket.once('data', function(data) {
       // We expect data to be the handshake payload in HTTP form
       const headerValues = {
-        authentication: '',
-        id: '',
+        customHeader: '',
+        extensions: '',
         key: '',
         subprotocol: '',
-        type: '',
         userAgent: '',
       };
       const dataString = data.toString();
@@ -708,6 +714,9 @@ function server(options) {
       const headerList = dataString.split('\r\n');
       const flags = {
         complete: false,
+        customHeader: (lowString.includes('\r\ncustom-header:')) ?
+          false :
+          true,
         extensions: (lowString.includes('\r\nsec-websocket-extensions:')) ?
           false :
           true,
@@ -727,7 +736,20 @@ function server(options) {
           flags.userAgent === true &&
           flags.complete === false
         ) {
-          function extend() {
+          const connectOptions = {
+            'callbackOpen': options.callbackOpen,
+            'customHeader': headerValues.customHeader,
+            'extensions': headerValues.extensions,
+            'masking': (typeof options.masking === 'boolean') ?
+              options.masking :
+              false,
+            'messageHandler': options.messageHandler,
+            'proxy-authorization': '',
+            'role': '',
+            'subprotocol': headerValues.subprotocol,
+            'userAgent': headerValues.userAgent,
+          };
+          function extend(connectObject) {
             // Send the handshake response
             const headers = [
               'HTTP/1.1 101 Switching Protocols',
@@ -745,25 +767,15 @@ function server(options) {
             socket.write(headers.join('\r\n'));
 
             // Extend the socket
-            socketExtend(socket, {
-              'callbackOpen': options.callbackOpen,
-              'extensions': headerValues.extensions,
-              'masking': (typeof options.masking === 'boolean') ?
-                options.masking :
-                false,
-              'messageHandler': options.messageHandler,
-              'proxy-authorization': '',
-              'role': 'server',
-              'subprotocol': headerValues.subprotocol,
-              'userAgent': headerValues.userAgent,
-            });
+            connectObject.role = 'server';
+            socketExtend(socket, connectObject);
           }
           flags.complete = true;
           clearTimeout(deathDelay);
           if (typeof options.callbackConnect === 'function') {
-            options.callbackConnect(headerValues, socket, extend);
+            options.callbackConnect(connectOptions, socket, extend);
           } else {
-            extend();
+            extend(connectOptions);
           }
         }
       }
@@ -786,6 +798,9 @@ function server(options) {
         } else if (lowHeader === 'user-agent') {
           headerValues.userAgent = value;
           flags.userAgent = true;
+        } else if (lowHeader === 'custom-header') {
+          headerValues.customHeader = value;
+          flags.customHeader = true;
         }
         complete();
       });
@@ -823,7 +838,8 @@ function socketExtend(socket, extensions) {
   ) ?
     {} :
     extensions;
-  if (typeof socket.websocket.messageHandler === 'function') {
+  if (typeof extensions.messageHandler === 'function') {
+    socket.websocket.messageHandler = extensions.messageHandler;
     receive(socket);
   }
   socket.close = function() {

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -1,9 +1,25 @@
-
+'use strict';
+const { Buffer } = require('node:buffer');
 const crypto = require('node:crypto');
 const net = require('node:net');
 const os = require('node:os');
 const tls = require('node:tls');
+const {
+  BigInt,
+  DateNow,
+  MathFloor,
+  MathRandom,
+  Number,
+} = primordials;
+const {
+  SystemError,
+} = require('internal/errors');
+const {
+  clearTimeout,
+  setTimeout,
+} = require('timers');
 
+const websocket = {};
 
 /**
  * ```typescript
@@ -36,7 +52,8 @@ const tls = require('node:tls');
  *   socketOptions: net.NetConnectOpts | tls.ConnectionOptions;
  * }
  * (options:clientOptions) => Socket | TLSSocket;
- * ``` */
+ * ```
+ */
 
 // creates and connects a websocket client
 function clientConnect(options) {
@@ -61,18 +78,18 @@ function clientConnect(options) {
             'WebSocket server handshake response returned no ' +
               'Sec-WebSocket-Accept header or one which is malformed.',
             socket,
-            'websocket.clientConnect'
+            'websocket.clientConnect',
           ), null);
         }
       }
-      // check if response contains required HTTP header
+      // Check if response contains required HTTP header
       if (len > 1 && responseString.includes('HTTP/1.1 101 Switching Protocols')) {
         let index = 0;
         let key = '';
         let colon = 0;
         do {
           colon = response[index].indexOf(':');
-          // find the header dealing with the handshake
+          // Find the header dealing with the handshake
           if (response[index].slice(0, colon).toLowerCase() === 'sec-websocket-accept') {
             key = response[index].slice(colon + 1).replace(/^\s+/, '').replace(/\s+$/, '');
             break;
@@ -80,8 +97,8 @@ function clientConnect(options) {
           index = index + 1;
         } while (index < len);
         hash.update(nonceSource + websocket.magicString);
-        const digest = hash.digest('hex');//console.log(digest);console.log(key);
-        // validate handshake
+        const digest = hash.digest('hex');
+        // Validate handshake
         if (digest === key) {
           delete options.secure;
           delete options.socketOptions;
@@ -111,11 +128,11 @@ function clientConnect(options) {
         return `/${host.slice(host.indexOf('/') + 1)}`;
       }()) :
       '/';
-    const nonceSource = Buffer.from(Date.now().toString() + os.hostname()).toString('base64');
+    const nonceSource = Buffer.from(DateNow().toString() + os.hostname()).toString('base64');
     const header = [
       `GET ${resourceName} HTTP/1.1`,
       (addresses.remote.address.indexOf(':') > -1) ?
-        // RFC 6455 4.1. request host be defined according to RFC 3986 (URI)
+        // RFC 6455 4.1 request host be defined according to RFC 3986 (URI)
         // however it also requires the socket be already established and open
         // at layer 4 (TCP/TLS) and layer 4 cares only for IP address as URI
         // is layer 7. For sanity ip/port is fully sufficient if derived from
@@ -126,7 +143,7 @@ function clientConnect(options) {
       'Connection: Upgrade',
       'Sec-WebSocket-Version: 13',
       `Sec-WebSocket-Key: ${nonceSource}`,
-      `User-Agent: Node.js--${process.version}--${os.version()}--${os.release()}`
+      `User-Agent: Node.js--${process.version}--${os.version()}--${os.release()}`,
     ];
     function headingCheck(heading) {
       if (typeof options[heading] === 'string') {
@@ -146,32 +163,32 @@ function clientConnect(options) {
 
     header.push('');
     header.push('');
-    // last use of socket.write before its hidden in socket extensions
+    // Last use of socket.write before its hidden in socket extensions
     socket.write(header.join('\r\n'));
   }
 
-  // prevents a crashing server from breaking the client node instance
+  // Prevents a crashing server from breaking the client node instance
   socket.on('error', function() {});
 
-  // wait for layer 4 socket connection
+  // Wait for layer 4 socket connection
   socket.once('ready', handlerReady);
   return socket;
 }
 
-// a uniform convenience function for generating error objects
+// A uniform convenience function for generating error objects
 function errorObject(code, message, socket, syscall) {
   const addresses = getAddress(socket).remote;
-  return new Error({
+  return new SystemError({
     address: addresses.address,
     code: code,
     errno: 0,
     message: message,
     port: addresses.port,
-    syscall: syscall
+    syscall: syscall,
   });
 }
 
-// a handy utility to conveniently gather a socket's connection identity
+// A handy utility to conveniently gather a socket's connection identity
 function getAddress(socket) {
   function parse(input) {
     if (input === undefined) {
@@ -188,12 +205,12 @@ function getAddress(socket) {
   return {
     local: {
       address: parse(socket.localAddress),
-      port: socket.localPort
+      port: socket.localPort,
     },
     remote: {
       address: parse(socket.remoteAddress),
-      port: socket.remotePort
-    }
+      port: socket.remotePort,
+    },
   };
 }
 
@@ -208,7 +225,7 @@ function messageSend(message, opcode, fragmentSize) {
       } else {
         socket.websocket.status = 'open';
       }
-    };
+    }
     if (socket.websocket.status === 'open') {
       socket.websocket.status = 'pending';
     }
@@ -217,10 +234,10 @@ function messageSend(message, opcode, fragmentSize) {
     } else {
       socket.once('drain', writeCallback);
     }
-  };
+  }
   function mask(body) {
     const mask = Buffer.alloc(4);
-    const rand = Buffer.from(Math.random().toString());
+    const rand = Buffer.from(MathRandom().toString());
     mask[0] = rand[4];
     mask[1] = rand[5];
     mask[2] = rand[6];
@@ -268,7 +285,7 @@ function messageSend(message, opcode, fragmentSize) {
   if (typeof opcode !== 'number') {
     opcode = 1;
   } else {
-    opcode = Math.floor(opcode);
+    opcode = MathFloor(opcode);
     if (opcode < 0 || opcode > 15) {
       opcode = 1;
     }
@@ -279,7 +296,15 @@ function messageSend(message, opcode, fragmentSize) {
   if (typeof fragmentSize !== 'number' || fragmentSize < 1) {
     fragmentSize = 0;
   }
-  if (opcode === 1 || opcode === 2 || opcode === 3 || opcode === 4 || opcode === 5 || opcode === 6 || opcode === 7) {
+  if (
+    opcode === 1 ||
+    opcode === 2 ||
+    opcode === 3 ||
+    opcode === 4 ||
+    opcode === 5 ||
+    opcode === 6 ||
+    opcode === 7
+  ) {
     let maskKey = null;
     function fragmentation(first) {
       let finish = false;
@@ -308,7 +333,7 @@ function messageSend(message, opcode, fragmentSize) {
       }());
       const size = frameBody.length;
       const frameHeader = (function() {
-        // frame 0 is:
+        // Frame 0 is:
         // * 128 bits for fin, 0 for unfinished plus opcode
         // * opcode 0 - continuation of fragments
         // * opcode 1 - text (total payload must be UTF8 and probably not contain hidden
@@ -334,7 +359,7 @@ function messageSend(message, opcode, fragmentSize) {
           (first === true) ?
             opcode :
             0;
-        // frame 1 is mask bit + length flag
+        // Frame 1 is mask bit + length flag
         frame[1] = (size < 126) ?
           (socket.websocket.masking === true) ?
             size + 128 :
@@ -346,7 +371,7 @@ function messageSend(message, opcode, fragmentSize) {
             (socket.websocket.masking === true) ?
               255 :
               127;
-        // write payload length followed by mask key
+        // Write payload length followed by mask key
         if (size > 125) {
           if (size < 65536) {
             frame.writeUInt16BE(size, 2);
@@ -381,23 +406,32 @@ function messageSend(message, opcode, fragmentSize) {
       } else {
         fragmentation(false);
       }
-    };
+    }
     let dataPackage = (Buffer.isBuffer === true) ?
       message :
       Buffer.from(message);
     let len = dataPackage.length;
     fragmentation(true);
-  } else if (opcode === 8 || opcode === 9 || opcode === 10 || opcode === 11 || opcode === 12 || opcode === 13 || opcode === 14 || opcode === 15) {
+  } else if (
+    opcode === 8 ||
+    opcode === 9 ||
+    opcode === 10 ||
+    opcode === 11 ||
+    opcode === 12 ||
+    opcode === 13 ||
+    opcode === 14 ||
+    opcode === 15
+  ) {
     let frameBody = message.subarray(0, 125);
     let frameHeader = null;
     if (socket.websocket.masking === true) {
       const masked = mask(frameBody);
       frameHeader = Buffer.alloc(6);
-      // opcode + fin bit, rsv bits set to 0
+      // Opcode + fin bit, rsv bits set to 0
       frameHeader[0] = 128 + opcode;
-      // set the mask bit
+      // Set the mask bit
       frameHeader[1] = 128 + frameBody.length;
-      // set the mask key
+      // Set the mask key
       frameHeader[2] = masked[1][0];
       frameHeader[3] = masked[1][1];
       frameHeader[4] = masked[1][2];
@@ -406,11 +440,11 @@ function messageSend(message, opcode, fragmentSize) {
       frameBody = masked[0];
     } else {
       frameHeader = Buffer.alloc(2);
-      // opcode + fin bit, rsv bits set to 0
+      // Opcode + fin bit, rsv bits set to 0
       frameHeader[0] = 128 + opcode;
       frameHeader[1] = frameBody.length;
     }
-    // control frames send immediately, out of sequence
+    // Control frames send immediately, out of sequence
     socket.websocket.queue.unshift(Buffer.concat([frameHeader, frameBody]));
 
     if (socket.websocket.status === 'open') {
@@ -419,15 +453,9 @@ function messageSend(message, opcode, fragmentSize) {
   }
 }
 
-// arbitrary ping function, which may be called by any means at any time
+// Arbitrary ping function, which may be called by any means at any time
 function ping(ttl, callback) {
   const socket = this;
-  function errorObject(code, message) {
-    const err = new Error();
-    err.code = code;
-    err.message = `${message} Socket type ${config.socket.type} and name ${name}.`;
-    return err;
-  }
   if (socket.websocket.status !== 'open' && socket.websocket.status !== 'pending') {
     callback(errorObject(
       'ECONNABORTED',
@@ -437,22 +465,22 @@ function ping(ttl, callback) {
     ), null);
   } else {
     const nameSlice = socket.hash.slice(0, 125);
-    // send ping
-    transmit_ws.queue(Buffer.from(nameSlice), config.socket, 9);
+    // Send ping
+    socket.messageSend(Buffer.from(nameSlice), socket, 9);
     socket.pong = {
-        callback: callback,
-        start: process.hrtime.bigint(),
-        timeOut: setTimeout(function() {
-            callback(socket.websocket.pong.timeOutMessage, null);
-            delete socket.websocket.pong;
-        }, ttl),
-        timeOutMessage: errorObject('ETIMEDOUT', 'Ping timeout on websocket.'),
-        ttl: BigInt(ttl * 1e6)
+      callback: callback,
+      start: process.hrtime.bigint(),
+      timeOut: setTimeout(function() {
+        callback(socket.websocket.pong.timeOutMessage, null);
+        delete socket.websocket.pong;
+      }, ttl),
+      timeOutMessage: errorObject('ETIMEDOUT', 'Ping timeout on websocket.'),
+      ttl: BigInt(ttl * 1e6),
     };
   }
 }
 
-// processes incoming messages
+// Processes incoming messages
 function receive(socket) {
   function processor(buf) {
     //    RFC 6455, 5.2.  Base Framing Protocol
@@ -485,22 +513,22 @@ function receive(socket) {
         });
       }
       return input;
-    };
-    // identify payload extended length
-    const extended = function(input) {
-      const mask = (input[1] > 127),
-        len = (mask === true) ?
-          input[1] - 128 :
-          input[1],
-        keyOffset = (mask === true) ?
-          4 :
-          0;
+    }
+    // Identify payload extended length
+    function extended(input) {
+      const mask = (input[1] > 127);
+      const len = (mask === true) ?
+        input[1] - 128 :
+        input[1];
+      const keyOffset = (mask === true) ?
+        4 :
+        0;
       if (len < 126) {
         return {
           lengthExtended: len,
           lengthShort: len,
           mask: mask,
-          startByte: 2 + keyOffset
+          startByte: 2 + keyOffset,
         };
       }
       if (len < 127) {
@@ -508,17 +536,17 @@ function receive(socket) {
           lengthExtended: input.subarray(2, 4).readUInt16BE(0),
           lengthShort: len,
           mask: mask,
-          startByte: 4 + keyOffset
+          startByte: 4 + keyOffset,
         };
       }
       return {
         lengthExtended: input.subarray(4, 10).readUIntBE(0, 6),
         lengthShort: len,
         mask: mask,
-        startByte: 10 + keyOffset
+        startByte: 10 + keyOffset,
       };
-    };
-    // populates data from the incoming network buffer with no assumptions of
+    }
+    // Populates data from the incoming network buffer with no assumptions of
     // completeness
     const data = (function() {
       if (buf !== null && buf !== undefined) {
@@ -529,12 +557,12 @@ function receive(socket) {
       }
       return socket.websocket.frame;
     }());
-    // interprets the frame header from Buffer to an object
+    // Interprets the frame header from Buffer to an object
     const frame = (function() {
       if (data === null) {
         return null;
       }
-      // bit string - convert byte number (0 - 255) to 8 bits
+      // Bit string - convert byte number (0 - 255) to 8 bits
       const bits0 = data[0].toString(2).padStart(8, '0');
       const meta = extended(data);
       return {
@@ -554,7 +582,7 @@ function receive(socket) {
         maskKey: (meta.mask === true) ?
           data.subarray(meta.startByte - 4, meta.startByte) :
           null,
-        startByte: meta.startByte
+        startByte: meta.startByte,
       };
     }());
     const payload = (function() {
@@ -588,7 +616,7 @@ function receive(socket) {
     }
 
     if (frame.opcode === 8) {
-      // socket close
+      // Socket close
       data[0] = 136;
       data[1] = (data[1] > 127) ?
         data[1] - 128 :
@@ -597,10 +625,10 @@ function receive(socket) {
       socket.write(payload);
       socket.off('data', processor);
     } else if (frame.opcode === 9) {
-      // respond to 'ping' as 'pong'
+      // Respond to 'ping' as 'pong'
       socket.send(data.subarray(frame.startByte), socket, 10);
     } else if (frame.opcode === 10) {
-      // pong
+      // Pong
       const payloadString = payload.toString();
       const pong = socket.websocket.pong[payloadString];
       const time = process.hrtime.bigint();
@@ -613,7 +641,7 @@ function receive(socket) {
       }
     } else {
       const segment = Buffer.concat([socket.websocket.fragment, payload]);
-      // this block may include frame.opcode === 0 - a continuation frame
+      // This block may include frame.opcode === 0 - a continuation frame
       socket.websocket.frameExtended = frame.extended;
       if (frame.fin === true) {
         if (typeof socket.websocket.messageHandler === 'function') {
@@ -627,7 +655,7 @@ function receive(socket) {
     if (socket.websocket.frame.length > 2) {
       processor(null);
     }
-  };
+  }
   socket.on('data', processor);
 }
 
@@ -648,6 +676,9 @@ function receive(socket) {
  *   callbackListener?: (server:Server) => void;
  *     // Optional callback that fires once the connection handshake completes.
  *   callbackOpen?: (err:NodeJS.ErrnoException, socket:Socket|TLSSocket) => void;
+ *     // Whether to apply RFC 6455 masking before sending messages. Defaults
+ *     // to false.
+ *   masking?: boolean;
  *     // A handler to receive processed messages. If not a function incoming
  *     // messages are ignored.
  *   messageHandler?: (message:Buffer) => void;
@@ -659,20 +690,21 @@ function receive(socket) {
  *   serverOptions?: ServerOpts | TlsOptions;
  * }
  * (options:serverOptions) => Server;
- * ``` */
-// creates a websocket server
+ * ```
+ */
+// Creates a websocket server
 function server(options) {
   function connection(socket) {
-    // prevents a closing socket from crashing the server
-    socket.on('error', function () {});
-    // socket handshake must be processed within 5 seconds of connection
-    // this is a security precaution to prevent overloading servers
+    // Prevents a closing socket from crashing the server
+    socket.on('error', function() {});
+    // Socket handshake must be processed within 5 seconds of connection.
+    // This is a security precaution to prevent overloading servers.
     const deathDelay = setTimeout(function() {
       socket.destroy();
     }, 5000);
-    // the first data must be the HTTP handshake, otherwise destroy
+    // The first data must be the HTTP handshake, otherwise destroy
     socket.once('data', function(data) {
-      // we expect data to be the handshake payload in HTTP form
+      // We expect data to be the handshake payload in HTTP form
       const headerValues = {
         authentication: '',
         id: '',
@@ -706,7 +738,7 @@ function server(options) {
           flags.complete === false
         ) {
           function extend() {
-            // send the handshake response
+            // Send the handshake response
             const headers = [
               'HTTP/1.1 101 Switching Protocols',
               'Upgrade: websocket',
@@ -722,15 +754,18 @@ function server(options) {
             headers.push('');
             socket.write(headers.join('\r\n'));
 
-            // extend the socket
+            // Extend the socket
             socketExtend(socket, {
-              callbackOpen: options.callbackOpen,
-              extensions: headerValues.extensions,
-              messageHandler: options.messageHandler,
+              'callbackOpen': options.callbackOpen,
+              'extensions': headerValues.extensions,
+              'masking': (typeof options.masking === 'boolean') ?
+                options.masking :
+                false,
+              'messageHandler': options.messageHandler,
               'proxy-authorization': '',
               'role': 'server',
-              subprotocol: headerValues.subprotocol,
-              userAgent: headerValues.userAgent,
+              'subprotocol': headerValues.subprotocol,
+              'userAgent': headerValues.userAgent,
             });
           }
           flags.complete = true;
@@ -784,7 +819,7 @@ function server(options) {
   return serverInstance;
 }
 
-// extends a net Socket type with additional features specific for WebSocket
+// Extends a net Socket type with additional features specific for WebSocket
 function socketExtend(socket, extensions) {
   function stringExtensions(name) {
     socket.websocket[name] = (typeof extensions[name] === 'string') ?
@@ -801,10 +836,8 @@ function socketExtend(socket, extensions) {
   if (typeof socket.websocket.messageHandler === 'function') {
     receive(socket);
   }
-  // arbitrary ping utility
+  // Arbitrary ping utility
   socket.ping = ping;
-  // send a message
-  socket.messageSend = messageSend;
   socket.setKeepAlive(true, 0);
   stringExtensions('extensions');
   stringExtensions('proxy-authorization');
@@ -815,20 +848,20 @@ function socketExtend(socket, extensions) {
     extensions.role === 'client' ?
       true :
       false;
-  // storehouse of complete received data frames
-  // a frame is a message fragment considering for continuation frames
+  // Storehouse of complete received data frames
+  // A frame is a message fragment considering for continuation frames
   socket.websocket.fragment = Buffer.from([]);
-  // stores pieces of frames for assembly into complete frames
+  // Stores pieces of frames for assembly into complete frames
   socket.websocket.frame = Buffer.from([]);
-  // stores the payload size of current received message payload
+  // Stores the payload size of current received message payload
   socket.websocket.frameExtended = 0;
-  // stores termination times and callbacks for pong handling
+  // Stores termination times and callbacks for pong handling
   socket.websocket.pong = {};
-  // stores messages for transmit in order,
-  // because websocket protocol cannot intermix messages
+  // Stores messages for transmit in order,
+  // Because websocket protocol cannot intermix messages
   socket.websocket.queue = [];
   socket.websocket.status = 'open';
-  // hides the generic socket.write method to encourage use of messageSend
+  // Hides the generic socket.write method to encourage use of messageSend
   socket.internalWrite = socket.write;
   socket.write = messageSend;
   if (typeof extensions.callbackOpen === 'function') {
@@ -836,9 +869,8 @@ function socketExtend(socket, extensions) {
   }
 }
 
-module.exports = websocket = {
-  clientConnect,
-  getAddress,
-  magicString: '258EAFA5-E914-47DA-95CA-C5AB0DC85B11',
-  server: server
-};
+websocket.clientConnect = clientConnect;
+websocket.getAddress = getAddress;
+websocket.magicString = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+websocket.server = server;
+module.exports = websocket;

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -12,9 +12,6 @@ const {
   Number,
 } = primordials;
 const {
-  errnoException,
-} = require('internal/errors');
-const {
   clearTimeout,
   setTimeout,
 } = require('timers');

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -228,6 +228,8 @@ const customTypesMap = {
   'vm.Script': 'vm.html#class-vmscript',
   'vm.SourceTextModule': 'vm.html#class-vmsourcetextmodule',
 
+  'websocketClient': 'websocket.html#websocketClient',
+
   'MessagePort': 'worker_threads.html#class-messageport',
   'Worker': 'worker_threads.html#class-worker',
 


### PR DESCRIPTION
This is a proposal to add websockets as a new module for Node.js.

## Standards Conformance
This implementation attempts to adhere to RFC 6455. If differences are identified I will supply the necessary changes. This implementation does not attempt to parse connection header values, such as extensions or sub-protocols values.

## API
This proposal focuses exclusively on Node's APIs from its core modules and then supplies additional options as necessary to populate callbacks and RFC 6455 connection header values.

This proposal does not attempt to emulate any WHJATWG specification or execute with regards to HTTP.  Node is not a web browser.  The operating constraints are wildly different, therefore in the best interests of design a WebSocket implementation must adhere to the protocol standard closely, but otherwise isolated from other API concerns.  All other API concerns represent additional constraints not necessary for the transport of messages over this protocol.

According to RFC 6455 section 1.7: **The WebSocket Protocol is an independent TCP-based protocol.  Its only relationship to HTTP is that its handshake is interpreted by HTTP servers as an Upgrade request.** That means so long as the as the handshake completes according to the syntax provided HTTP remains completely unrelated.  HTTP is a layer 7 (application) technology where WebSocket is defined as a TCP transport mechanism (layer 4).  Executing WebSockets over HTTP then creates unnecessary overhead dramatically impacting maintenance, scale, and performance.

## Performance
Some notes about performance.

Everybody that writes a websocket library wants to measure performance in terms of message sent speed, which seems to be a red herring. Message send speed is trivial compared to message receive speed.

Message send speed appears to be a memory bound operation. Using this approach to websockets I send at about 180,000 messages per second on my old desktop computer with slow DDR3 memory. On my newer laptop with faster DDR4 memory I can send at about 460,000 - 480,000 messages per second. This speed is largely irrelevant though because at around 460,000 messages garbage collection kicks in and message send speed slows to a crawl at around 5,000 per second.

Message receive speed is much slower and far more dependent upon the speed of the CPU. On my old desktop I can receive messages at a speed of around 18,000 messages per second while on my laptop its a bit slower at around 12,000-15,000 messages per second because the desktop has a more powerful CPU. The speed penalty on message reception appears to be due to analysis for message fragmentation. This approach accounts for 4 types of message fragmentation.

## Origin
This implementation is based upon my own logic for my personal application.  I have been experimenting with a faster native Node WebSocket implementation for more than 2 years.  Origin code at https://github.com/prettydiff/share-file-systems/blob/master/lib/terminal/server/transmission/transmit_ws.ts

## Test logic
A means to test and experiment with this proposal with minimal overhead.

```javascript
const net = require("net");
const ws = require('./websocket.js');
const port = 567;
const host = '';
const secure = true;
const serverOpts = {
    ca: `-----BEGIN CERTIFICATE-----
    MIIF4jCCA8qgAwIBAgIJAODpjHdE+mQyMA0GCSqGSIb3DQEBDQUAMEQxGDAWBgNV
    BAMMD3NoYXJlLWZpbGUtcm9vdDETMBEGA1UECgwKc2hhcmUtZmlsZTETMBEGA1UE
    CwwKc2hhcmUtZmlsZTAgFw0yMzA3MTYyMzE3MTlaGA8yMDY4MDUyNDIzMTcxOVow
    QjEWMBQGA1UEAwwNc2hhcmUtZmlsZS1jYTETMBEGA1UECgwKc2hhcmUtZmlsZTET
    MBEGA1UECwwKc2hhcmUtZmlsZTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC
    ggIBAPMrUIbWSZpn6XeasO57WNF5lYmpOxEOb61GdYq/tawxiRGj6e7wHXmL2ToQ
    62rQCGHQ0ylPr9yeUIxDDLwKL85H+kjzZSZzQg/+7shuiNRUBc6sumQuB34ldY/w
    vbqv1FnYtLfxFn45WnVFbRmZe3wxHr18cSfWPzb5s7/oga586pY6lcYJO1Y+xGhy
    3/jyEr+PAdqV3qSb/yU9qF+TNgaA2sAiDte4Bt5WYeQU7AQFgWflqdT6Dzr+NPin
    cTRtXBDe2rIwrdS+gOsuwEqG7OUiac/Ex32hBuDbR3qgpwzVGWRCbW+w31YBr4oY
    dPik1gg667ueqH4Jx5YN8YuisjoIouCc4/FJ2Vokh32udfY7Hdb3JSe6PyNvHjTt
    qtNYcIzU8bq5rREDuFHNmLDoKD1L0ycZcbO1ftPz3VXXJ8W5R+8/WsUnJx5gZN8k
    rnp3Ziq5KnUkCQwqgmqG7f4cQLB7h3Lq6znHjFrrwnauD1+ypHLa+Q7m6L1t4n5P
    J2QDOYQSy9J5mfTNXYl99VMB5Xclc0GTak9ymKzKr45yZepeNGmJT9K4GVDNjbHE
    GXt+1FX4uwncBlk4jSNKiqnXc9sEAPZ5wClSWOgboOdMTrN1Isi9ZPEzQ2owlUxX
    p+QVnh5blot6OhgL77KtM6a+Fs6Dz3mR3cEqv+WZwd0mn7+XAgMBAAGjgdYwgdMw
    EgYDVR0TAQH/BAgwBgEB/wIBATAdBgNVHQ4EFgQUqmfvp44Q4p0+BaQhXobyxEDb
    Az8wRwYDVR0RBEAwPoIJbG9jYWxob3N0ghhsb2NhbGhvc3QucHJldHR5ZGlmZi5j
    b22CEXNoYXJlZmlsZS5zeXN0ZW1zhwR/AAABMFUGA1UdHgROMEygSjALgglsb2Nh
    bGhvc3QwGoIYbG9jYWxob3N0LnByZXR0eWRpZmYuY29tMBOCEXNoYXJlZmlsZS5z
    eXN0ZW1zMAqHCH8AAAH/AAAAMA0GCSqGSIb3DQEBDQUAA4ICAQADH8+0kYtLBUaM
    CET/WTw21AvQgVMNAQil+QbFt0rz567cSL5uM2EVTK2+ERCuXcMBxECTzMz+nYsK
    z7nqrA5q9SE9M6q0weOULF/zPETXWAQLmRC2ej67pRIbRn10PoVTJIiyCTXKLEjR
    zRgRIiaC1vAxgVq+U7udo6MzpCyVo6JdCIlJQpF7aA9XjQJYbtKSO1cDHYM2dJUc
    fw3bzq0yYUodDscM7vD8SNJY+eynsApVFXi6h1TNGj283mVBvihnPq4PTOiRc4KK
    iyFIJsT5/mJ3XD+pAHI3dPwe95zz6G1afdL2EGU3OAf7SGQ46LhLMV9L+izcE6zR
    SnjaXzjk2rho1XtAityV82GJSUCE71Xv/ePQuEDNV4u0jFzF/uVHjIW40zzLFTYS
    hjBf6SdsjwXxOHu/7RgDgRGuYJfabX/CcbpxlocFCLeJUNE0SHcrFpfW4piiFD/o
    KPs2UNmuHSorUc7k6UTB8gQSqIjMSEeF6MHhVMcD5dgBCCEMhVWs5tRL/comCRTK
    BcRlCOouZJZaBMrseWpAdTl3GTSqLNAsCtqMakvOyxFOTrk/kGhPz3jLs1BTZZQ8
    b/boToH371317pu+k0eJ10CXr+W4+xUL9pBSMzaNw96/n5H7sCrWx9DUk3LUoXKN
    rYmowESTH/PehBFm3ndXq+zyoX7UGg==
    -----END CERTIFICATE-----`,
    cert: `-----BEGIN CERTIFICATE-----
    MIIF9TCCA92gAwIBAgIJAPAQEdC51VH5MA0GCSqGSIb3DQEBDQUAMEIxFjAUBgNV
    BAMMDXNoYXJlLWZpbGUtY2ExEzARBgNVBAoMCnNoYXJlLWZpbGUxEzARBgNVBAsM
    CnNoYXJlLWZpbGUwIBcNMjMwNzE2MjMxNzIyWhgPMjA2ODA1MjQyMzE3MjJaMD8x
    EzARBgNVBAMMCnNoYXJlLWZpbGUxEzARBgNVBAoMCnNoYXJlLWZpbGUxEzARBgNV
    BAsMCnNoYXJlLWZpbGUwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCf
    nPdeUGUzUekm3heIyA1lPdqFHQZy5sipxwuJEu5ySV4RJExt+AcHwyj0gMS3olDZ
    vMAQspJp05IACJGJ+boeYoTU3WqXHFCf2vxNNFKVZsfE4BuZwICpycB1/Wycj7zF
    OJbaqeybnNaNIA9LeNexKL6AN8ngvWlQAlTW4YWpULsqSNz57wyoil6QV55G5WqF
    vFCutL1IH8ccYihJnKk28kVvwK58taxOneGfQ8rCwQ/TIW2s+zsX2mzPoA1IXFPE
    P2io3X9XjVp/ejotFfHIXsFBWI2wdDZozxObZegQkIQ9xaHnypPVyZO7uzMYNFC2
    D8rC3+umZ1jqmiVaUF8Q31Lh38JaHr30Vaq87yMlzA0ouvEmz+3eW88MnOTcS3Pv
    CyEW+Yfh2efh01+cfb7nDOGil4GbimAqJj7lPNq8eG84Lv4VBn2pN9ViGTsG1Z97
    PItbg3rz+M46adNLKDmGON4UX2fdI3mJgBstuFokcvvNydnXXYLykSobdlzbuUgx
    yXD1TfW7Kq5yQWdmeiYwjBhiO4LbszWnhNdOo13fqkYEFTe4Y8CjhF3I96ElZvqH
    KBAHqY/VZQ5l0JLdULAGgtdXqHuKbkg5wKnC5TK9Hps/kXUyweNrBfBY5c4j/TWw
    +F1IR3gsNY++YnfRzM7QdhmKMeagkbKvTs1CYm8u1QIDAQABo4HuMIHrMAkGA1Ud
    EwQCMAAwHQYDVR0OBBYEFNB6IlDpbv18fv34YNsjk+mRv/ugMB8GA1UdIwQYMBaA
    FKpn76eOEOKdPgWkIV6G8sRA2wM/MEcGA1UdEQRAMD6CCWxvY2FsaG9zdIIYbG9j
    YWxob3N0LnByZXR0eWRpZmYuY29tghFzaGFyZWZpbGUuc3lzdGVtc4cEfwAAATBV
    BgNVHR4ETjBMoEowC4IJbG9jYWxob3N0MBqCGGxvY2FsaG9zdC5wcmV0dHlkaWZm
    LmNvbTATghFzaGFyZWZpbGUuc3lzdGVtczAKhwh/AAAB/wAAADANBgkqhkiG9w0B
    AQ0FAAOCAgEAXMm7ADfL+GJTcj93zMIz8yUFr3IqDgzFRopgh4n9JEDlDmN5FC67
    mRomGZ9GfTvkOoct0vdJc54MPmNaxb5ydCtM4/JeeA05zLcG83OWeh4CIGbUoDmf
    dResaLeTHNI/Uf+0vuvliQvV/fhSAGU+Ai3EaC4ErYWW1lF4sq7uH06Ru2DoKZcR
    ohdLWUAIxIqfYoEXrLQHjJnqXJ2UWQ7Fb1x2sryKsoR02sL/7FvhTAMNj2HdJxqf
    thwrA011EzFw0Et14XrigRh136KkmWz2c/PC2UHobixN+cazaN5gWuXdySI43Vqv
    GmBzyHV5kTorIS4ACUPweutn5pELKSCtaWcMDT8dlZnIN9nHety3TflAGL7w94Pp
    R6GPaus0UP5UVGxy9HbD01EyvT90dO+eA4aYA3XlWKx0HZl78p4MvrHv1A7O2Arm
    GYWkhJsz2uyq5HScxUQVTuBQ0yGVvy31eiGgIZWGIWBEVnAHJ8o9VRSqWcWnHrrS
    fYKBStVx/kCCG/oY9NVPivIQ2YpYOWpL0fdbRaZTnEfb9TZhfFQtR/2tgBFq40eh
    wFtdV2lk6MwjwENxci7w0kdi1YStBDBGHgyQALz3fhLNQy2JFTM6aFVmQoq1/iUB
    /X/2uBo7Kl581WjgkBsAVGapwSiK+jSJY5i7wJ9CmOYPrmp0zRPDLus=
    -----END CERTIFICATE-----`,
    key: `-----BEGIN RSA PRIVATE KEY-----
    MIIJKAIBAAKCAgEAn5z3XlBlM1HpJt4XiMgNZT3ahR0GcubIqccLiRLuckleESRM
    bfgHB8Mo9IDEt6JQ2bzAELKSadOSAAiRifm6HmKE1N1qlxxQn9r8TTRSlWbHxOAb
    mcCAqcnAdf1snI+8xTiW2qnsm5zWjSAPS3jXsSi+gDfJ4L1pUAJU1uGFqVC7Kkjc
    +e8MqIpekFeeRuVqhbxQrrS9SB/HHGIoSZypNvJFb8CufLWsTp3hn0PKwsEP0yFt
    rPs7F9psz6ANSFxTxD9oqN1/V41af3o6LRXxyF7BQViNsHQ2aM8Tm2XoEJCEPcWh
    58qT1cmTu7szGDRQtg/Kwt/rpmdY6polWlBfEN9S4d/CWh699FWqvO8jJcwNKLrx
    Js/t3lvPDJzk3Etz7wshFvmH4dnn4dNfnH2+5wzhopeBm4pgKiY+5TzavHhvOC7+
    FQZ9qTfVYhk7BtWfezyLW4N68/jOOmnTSyg5hjjeFF9n3SN5iYAbLbhaJHL7zcnZ
    112C8pEqG3Zc27lIMclw9U31uyquckFnZnomMIwYYjuC27M1p4TXTqNd36pGBBU3
    uGPAo4RdyPehJWb6hygQB6mP1WUOZdCS3VCwBoLXV6h7im5IOcCpwuUyvR6bP5F1
    MsHjawXwWOXOI/01sPhdSEd4LDWPvmJ30czO0HYZijHmoJGyr07NQmJvLtUCAwEA
    AQKCAgAgFlcob7MYkRP1C1rh1Y3T145xijc8rCaU8v3frZ2f/h3aBlkTFnSbW+GE
    3couPIRScX6PHMcQXUcRmKdhfIGtEBMyE90Uyc1vhX+JKcacYFAyxPbnfuqet39o
    eOz3wHGrmEfDZ7u4QNxk/Jf2jTGXXOCHOC/ubUWZnw5dMHNFaYRm6MT7vdHmpAKE
    tAiOqhozDnuN06nlsPW/QABnZAYklKne4HZzfbZJC7ZK5T8CzfsXb7Xzu4HStsd/
    KebhsCXq4vBwWi76c+FIlVLSs4GqzVm+gEXjvkkd4ttHN0Ji6hqbrHpy9aeop+B6
    MhUAfavoHd6eNJPUHRyj9R8jO9sQYP6eoGdYghk9HtnvG2RicgO7oGCfLj6ibUrm
    rA2ZpWt7BVfTgufTCbzHSIkD245JGkSkMVvjX4fbL87bbtNPddJ0TW4VQKT9r0c2
    4EH6LQgxyYZMaLpYJgPN2iUXHnPxght1kQQwVmSg5s1uQC9XAzbulYVOZu2g5/wz
    Gd+EePV1SYoleEymDeQKUkzMxPwSE2cD8dL/HU4hQDltcwq0q/btzWlW5xvHampq
    JGjsztRZKB1sznE2qqhUkYCzPqPfHkOecZW4Qwuif9xlHe+oAGU3ObcvgBNjO7t/
    bPgADEsmKrSjijfVz8CN1JcymB+m9C6vsmbkQNbWumLLrgytYQKCAQEAymji6h8m
    gv2RDnAeJ/cu79Ri601bQqdpbul9JDxK3w6U/SF74w5NIXPr33bf5JcPQp9Cj6fr
    SdQYy1XxhTSirGm9STvymY0CKki67Kpd3zQoY40yLsRgPw0ZCwSWXnoDXl04/GA0
    N6RvXOSJ76RCiQd0M/Lvz2yvOmISdne5LQRPk7SgHyJurmMk7ocl3yh4EJH0FHpf
    ulodhLGi7ptRPIhMQ3m2bKtVmXWokQtoZCixpb08DbPNbVOpCrZSrcinwg+AtSnG
    wE3XR8IpW7qGmFVvmqgs4nRQcM/goxazIHU+bO2dZx0sepI9li5AUtdpp08QrKn0
    I4LOp5/oOWXmXQKCAQEAyd9f6yBCceIYi72fgpJZGCSIaGZEPSCDz4zINcDN1UzN
    XDDTou7no9cseCYhVecvHtikvN2UcEi09+3OFhFaV+KyVeysrjj8nuSw0m3BBITN
    A59ITZFFvjlytVpjf61JLp6hly/Q+eGrBjJnIPQTkW3asauuXaVBz7xWD3xlhDPo
    IuYb0JCHIu4qmCnkvbeJHuCo7v772/+IjkoNKVxgK6U9ZibFqbJfTejfnz5fnLo+
    0I9I5pvySRYExFwv3mYBROU0hmMyXJWvGPUuqVckoLa2Ww41eRgvI06Jd5lItnMu
    jzCrEs9Pj1d5veh4IevC1cENmbSgT5Tx+xuXWcfy2QKCAQB9dD0Qt3X7Qoah2EQY
    qVBiPdWB2lRyH6ltoTJ7PxN45WTa7+IFfVu5HExaGSf0WtyOgn+S4pUnEVq8zOwB
    j/ozuuYjehCHs6pf4uxYu8+rBHz0FxO/gN/WtJuNBK7ep+lml4k2g7pZsoWDofMM
    oVbL797KRAz3F3oUSaz/2HzhtgZMmmuUYJcRZ0oAvatvgXnJa21JNAAZVLlvAVrn
    YUUcq635NHspJ5jKoO512Ag/7CkPfRa3t3XgCTaA+TiNlgzEby9rGhWiI50HUQSp
    YhcCXBHsXchUI5uoEHA/JVapC4JBqZUh0Cc9YV7ispATyIgntw2ytzQmvnCv3KDm
    0o3RAoIBAQCZ1q9LCGd6T/myrEvdfleFDXoiTSTdjGTGixub0xVI4mFxSwhNF1DR
    S83ote4bf7UqBaDtCNLxCodWlRPDP3Agn3KWBmnFz0m8cLzLb7ZzEh0GEKFR8045
    25+t0ncWumCVtW+hPmA7vRzO+SQcOcSbxCKv2Qxk8uYHQBg5buwR5liWF9PEig9h
    sCwnj21womhNbpluoEQg8EgJXydOiMYFHMSAjzV8z6DPR5L60NaeIlRyLW85xkfK
    KIxzc2lLS2LWNPFlJD0hzzQDif0IMY+JJhQrqdVYNfTeLCCYUujVmUs29bi4+eFA
    dEIjVgAOoZL1wEv0AXFVlEUfvnQFiFlpAoIBAAxBPddDn/0KvDdctIE6L1XWPQkc
    qfijyaQzrvdaEsrI9qZfl9fkub7q2DAZ5WBA+EDG972LtO8DiekOirHdGuMYI6/y
    81Lk09z8pFL8GojrYAZgDMv6dA93xNVe+sMxGj40DakVXrAFDsMWCKFvfkdTNDHR
    vlnznkTSibKhgVS+06j7vzglC1SqxY45TR4azVoSfDm+gkBSVouO70pR48lOREde
    tjZ7ebCYzw7V6PDc13QfdIJfStWxgkPH2WrTcWJgUXm0dv+vmdDn+ERkA/XZZfkO
    HfpjsSNvOKaKb9oaq5RH+DRBnexJAqholn8kTKYpxpfw2s4Bg7bZXIrMC+E=
    -----END RSA PRIVATE KEY-----`
            };
// change the value of variable 'secure' to switch between net and tls operation

// server logic, execute as:
// node ./tester.js server
if (process.argv.includes('server')) {
    const server = ws.server({
        callbackConnect: function(headerValues, socket, ready) {
            //console.log("server callbackConnect, followed by header values");
            //console.log(headerValues);
            ready();
        },
        callbackListener: function(server) {
            console.log("server callbackListener");
        },
        callbackOpen: function(err, socket) {
            console.log("server callbackOpen");
        },
        messageHandler: function(message) {
            console.log("message received at server");
            console.log(message.toString());
        },
        listenerOptions: {
            host: host,
            port: port
        },
        secure: secure,
        serverOptions: serverOpts
    });
}

// client logic, execute as:
// node ./tester.js client
if (process.argv.includes('client')) {
    // unused throwaway server to halt thread termination
    const server = ws.server({
        callbackConnect: function(headerValues, socket, ready) {
            //console.log("server callbackConnect, followed by header values");
            //console.log(headerValues);
            // ready();
        },
        callbackListener: function(server) {
            // console.log("server callbackListener");
        },
        callbackOpen: function(err, data) {
            console.log("server callbackOpen, followed by http string");
            console.log(data);
        },
        messageHandler: function(message) {
            console.log("message received at server");
            console.log(message.toString());
        },
        listenerOptions: {
            host: host,
            port: 777
        },
        secure: secure,
        serverOptions: serverOpts
    });
    const client = ws.clientConnect({
        authentication: 'auth-string',
        callbackOpen: function(err, socket) {
            console.log("client callbackOpen");
            if (err === null) {
                socket.messageSend("hello from client");
            }
        },
        masking: false,
        id: 'id-string',
        messageHandler: function(message){
            console.log("message received at client");
            console.log(message.toString());
        },
        'proxy-authorization': 'proxy-auth',
        subProtocol: 'sub-proto',
        type: 'type-string',
        secure: secure,
        socketOptions: {
            host: host,
            port: port,
            rejectUnauthorized: false
        }
    });
}
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
