### PR TITLE
v8: refactor to handle `if` to `switch` for `ArrayBufferViewType`

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -278,36 +278,65 @@ Deserializer.prototype.readRawBytes = function readRawBytes(length) {
 
 function arrayBufferViewTypeToIndex(abView) {
   const type = ObjectPrototypeToString(abView);
-  if (type === '[object Int8Array]') return 0;
-  if (type === '[object Uint8Array]') return 1;
-  if (type === '[object Uint8ClampedArray]') return 2;
-  if (type === '[object Int16Array]') return 3;
-  if (type === '[object Uint16Array]') return 4;
-  if (type === '[object Int32Array]') return 5;
-  if (type === '[object Uint32Array]') return 6;
-  if (type === '[object Float32Array]') return 7;
-  if (type === '[object Float64Array]') return 8;
-  if (type === '[object DataView]') return 9;
-  // Index 10 is FastBuffer.
-  if (type === '[object BigInt64Array]') return 11;
-  if (type === '[object BigUint64Array]') return 12;
+  switch (type) {
+    case '[object Int8Array]':
+      return 0;
+    case '[object Uint8Array]':
+      return 1;
+    case '[object Uint8ClampedArray]':
+      return 2;
+    case '[object Int16Array]':
+      return 3;
+    case '[object Uint16Array]':
+      return 4;
+    case '[object Int32Array]':
+      return 5;
+    case '[object Uint32Array]':
+      return 6;
+    case '[object Float32Array]':
+      return 7;
+    case '[object Float64Array]':
+      return 8;
+    case '[object DataView]':
+      return 9;
+    // Index 10 is FastBuffer.
+    case '[object BigInt64Array]':
+      return 11;
+    case '[object BigUint64Array]':
+      return 12;
+  }
   return -1;
 }
 
 function arrayBufferViewIndexToType(index) {
-  if (index === 0) return Int8Array;
-  if (index === 1) return Uint8Array;
-  if (index === 2) return Uint8ClampedArray;
-  if (index === 3) return Int16Array;
-  if (index === 4) return Uint16Array;
-  if (index === 5) return Int32Array;
-  if (index === 6) return Uint32Array;
-  if (index === 7) return Float32Array;
-  if (index === 8) return Float64Array;
-  if (index === 9) return DataView;
-  if (index === 10) return FastBuffer;
-  if (index === 11) return BigInt64Array;
-  if (index === 12) return BigUint64Array;
+  switch (index) {
+    case 0:
+      return Int8Array;
+    case 1:
+      return Uint8Array;
+    case 2:
+      return Uint8ClampedArray;
+    case 3:
+      return Int16Array;
+    case 4:
+      return Uint16Array;
+    case 5:
+      return Int32Array;
+    case 6:
+      return Uint32Array;
+    case 7:
+      return Float32Array;
+    case 8:
+      return Float64Array;
+    case 9:
+      return DataView;
+    case 10:
+      return FastBuffer;
+    case 11:
+      return BigInt64Array;
+    case 12:
+      return BigUint64Array;
+  }
   return undefined;
 }
 


### PR DESCRIPTION
When there are many if statements, it is common to use switches for readability or performance.
Unless there is a specific reason, i think would be better to change it.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
