### PR TITLE
doc: fix documentation for input option in child_process methods [execFile, execFileSync, spawnSync]

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -925,8 +925,8 @@ changes:
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.
   * `input` {string|Buffer|TypedArray|DataView} The value which will be passed
-    as stdin to the spawned process. Supplying this value will override
-    `stdio[0]`.
+    as stdin to the spawned process. If `stdio[0]` is set to `'pipe'`, Supplying
+    this value will override `stdio[0]`.
   * `stdio` {string|Array} Child's stdio configuration. `stderr` by default will
     be output to the parent process' stderr unless `stdio` is specified.
     **Default:** `'pipe'`.
@@ -995,8 +995,8 @@ changes:
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.
   * `input` {string|Buffer|TypedArray|DataView} The value which will be passed
-    as stdin to the spawned process. Supplying this value will override
-    `stdio[0]`.
+    as stdin to the spawned process. If `stdio[0]` is set to `'pipe'`, Supplying
+    this value will override `stdio[0]`.
   * `stdio` {string|Array} Child's stdio configuration. `stderr` by default will
     be output to the parent process' stderr unless `stdio` is specified.
     **Default:** `'pipe'`.
@@ -1071,11 +1071,11 @@ changes:
 * `options` {Object}
   * `cwd` {string|URL} Current working directory of the child process.
   * `input` {string|Buffer|TypedArray|DataView} The value which will be passed
-    as stdin to the spawned process. Supplying this value will override
-    `stdio[0]`.
+    as stdin to the spawned process. If `stdio[0]` is set to `'pipe'`, Supplying
+    this value will override `stdio[0]`.
   * `argv0` {string} Explicitly set the value of `argv[0]` sent to the child
     process. This will be set to `command` if not specified.
-  * `stdio` {string|Array} Child's stdio configuration.
+  * `stdio` {string|Array} Child's stdio configuration. **Default:** `'pipe'`.
   * `env` {Object} Environment key-value pairs. **Default:** `process.env`.
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).


### PR DESCRIPTION
Updated the documentation for the `input` option in child_process file, at execFile, execFileSync, spawnSync functions.
This update now clarify that supplying value to the `input` option will override `stdio[0]`, only if `stdio[0]` is set to `'pipe'`.
This will help avoid confusion when using the `input` option in any of the functions above.
Also updated the default value for the `stdio` option in the docs for the child_process.spawnSync function, to complete the picture.

Fixes: https://github.com/nodejs/node/issues/49417
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
