### PR TITLE
doc: Fix missing imports in script

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -907,8 +907,9 @@ changes:
 * Returns: {TestsStream}
 
 ```mjs
-import { tap } from 'node:test/reporters';
+import { tap, run } from 'node:test/reporters';
 import process from 'node:process';
+import path from 'path';
 
 run({ files: [path.resolve('./tests/test.js')] })
   .compose(tap)

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -917,7 +917,9 @@ run({ files: [path.resolve('./tests/test.js')] })
 ```
 
 ```cjs
-const { tap } = require('node:test/reporters');
+const { tap, run } = require('node:test/reporters');
+const process = require('process');
+const path = require('path');
 
 run({ files: [path.resolve('./tests/test.js')] })
   .compose(tap)

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -910,7 +910,7 @@ changes:
 import { tap } from 'node:test/reporters';
 import { run } from 'node:test';
 import process from 'node:process';
-import path from 'path';
+import path from 'node:path';
 
 run({ files: [path.resolve('./tests/test.js')] })
   .compose(tap)
@@ -920,7 +920,7 @@ run({ files: [path.resolve('./tests/test.js')] })
 ```cjs
 const { tap } = require('node:test/reporters');
 const { run } = require('node:test');
-const path = require('path');
+const path = require('node:path');
 
 run({ files: [path.resolve('./tests/test.js')] })
   .compose(tap)

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -907,7 +907,8 @@ changes:
 * Returns: {TestsStream}
 
 ```mjs
-import { tap, run } from 'node:test/reporters';
+import { tap } from 'node:test/reporters';
+import { run } from 'node:test';
 import process from 'node:process';
 import path from 'path';
 
@@ -917,8 +918,8 @@ run({ files: [path.resolve('./tests/test.js')] })
 ```
 
 ```cjs
-const { tap, run } = require('node:test/reporters');
-const process = require('process');
+const { tap } = require('node:test/reporters');
+const { run } = require('node:test');
 const path = require('path');
 
 run({ files: [path.resolve('./tests/test.js')] })


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/49488

The script was missing necessary imports for the 'run' function and the 'path' module, causing it to fail. This commit adds the missing imports and resolves the issue.

- Import 'run' from the appropriate module.
- Import 'path' to resolve file paths.

The script should now run without errors.