### PR TITLE
doc: Fix Script with 'process,' 'path,' and 'run' Requires

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -916,7 +916,9 @@ run({ files: [path.resolve('./tests/test.js')] })
 ```
 
 ```cjs
-const { tap } = require('node:test/reporters');
+const { tap, run } = require('node:test/reporters');
+const process = require('process');
+const path = require('path');
 
 run({ files: [path.resolve('./tests/test.js')] })
   .compose(tap)


### PR DESCRIPTION
This commit enhances the script by addressing missing imports for the 'run' function and the 'path' module, which previously resulted in script failure. The following improvements have been made:

- Imported 'run' from the appropriate module via require to ensure correct functionality.
- Imported 'path' via require to facilitate proper file path resolution.
- Imported 'process' via require to include this essential module.


These changes resolve the issue of missing dependencies execution.

This pr is a continuation of pr #49489