### PR TITLE
esm: refactor `globalPreload` tests

### DIFF
--- a/test/es-module/test-esm-loader-resolve-type.mjs
+++ b/test/es-module/test-esm-loader-resolve-type.mjs
@@ -16,7 +16,7 @@ try {
     { recursive: true }
   );
 
-  deepStrictEqual(await spawnPromisified(
+  const output = await spawnPromisified(
     execPath,
     [
       '--no-warnings',
@@ -29,15 +29,17 @@ try {
       console.log(JSON.stringify({ before, after }));`,
     ],
     { cwd: base },
-  ), {
+  );
+
+  deepStrictEqual(output, {
+    code: 0,
+    signal: null,
     stderr: '',
     stdout: JSON.stringify({
       before: { importedESM: 0, importedCJS: 0 },
       // Dynamic import in the eval script should increment ESM counter but not CJS counter
       after: { importedESM: 1, importedCJS: 0 },
     }) + '\n',
-    code: 0,
-    signal: null,
   });
 } finally {
   await rm(base, { recursive: true, force: true });

--- a/test/es-module/test-esm-loader-resolve-type.mjs
+++ b/test/es-module/test-esm-loader-resolve-type.mjs
@@ -1,44 +1,44 @@
-// Flags: --loader ./test/fixtures/es-module-loaders/hook-resolve-type.mjs
-import { allowGlobals } from '../common/index.mjs';
+import { spawnPromisified } from '../common/index.mjs';
+import * as tmpdir from '../common/tmpdir.js';
 import * as fixtures from '../common/fixtures.mjs';
-import { strict as assert } from 'assert';
-import * as fs from 'fs';
+import { deepStrictEqual } from 'node:assert';
+import { mkdir, rm, cp } from 'node:fs/promises';
+import { execPath } from 'node:process';
 
-allowGlobals(global.getModuleTypeStats);
-
-const { importedESM: importedESMBefore,
-        importedCJS: importedCJSBefore } = await global.getModuleTypeStats();
-
-const basePath =
-  new URL('./node_modules/', import.meta.url);
-
-const rel = (file) => new URL(file, basePath);
-const createDir = (path) => {
-  if (!fs.existsSync(path)) {
-    fs.mkdirSync(path);
-  }
-};
-
+const base = tmpdir.fileURL(`test-esm-loader-resolve-type-${(Math.random() * Date.now()).toFixed(0)}`);
 const moduleName = 'module-counter-by-type';
-const moduleDir = rel(`${moduleName}`);
+const moduleURL = new URL(`${base}/node_modules/${moduleName}`);
 try {
-  createDir(basePath);
-  createDir(moduleDir);
-  fs.cpSync(
-    fixtures.path('es-modules', moduleName),
-    moduleDir,
+  await mkdir(moduleURL, { recursive: true });
+  await cp(
+    fixtures.path('es-modules', 'module-counter-by-type'),
+    moduleURL,
     { recursive: true }
   );
 
-
-  await import(`${moduleName}`);
+  deepStrictEqual(await spawnPromisified(
+    execPath,
+    [
+      '--no-warnings',
+      '--input-type=module',
+      '--eval',
+      `import { getModuleTypeStats } from ${JSON.stringify(fixtures.fileURL('es-module-loaders', 'hook-resolve-type.mjs'))};
+      const before = getModuleTypeStats();
+      await import(${JSON.stringify(moduleName)});
+      const after = getModuleTypeStats();
+      console.log(JSON.stringify({ before, after }));`,
+    ],
+    { cwd: base },
+  ), {
+    stderr: '',
+    stdout: JSON.stringify({
+      before: { importedESM: 0, importedCJS: 0 },
+      // Dynamic import in the eval script should increment ESM counter but not CJS counter
+      after: { importedESM: 1, importedCJS: 0 },
+    }) + '\n',
+    code: 0,
+    signal: null,
+  });
 } finally {
-  fs.rmSync(basePath, { recursive: true, force: true });
+  await rm(base, { recursive: true, force: true });
 }
-
-const { importedESM: importedESMAfter,
-        importedCJS: importedCJSAfter } = await global.getModuleTypeStats();
-
-// Dynamic import above should increment ESM counter but not CJS counter
-assert.strictEqual(importedESMBefore + 1, importedESMAfter);
-assert.strictEqual(importedCJSBefore, importedCJSAfter);

--- a/test/es-module/test-esm-named-exports.js
+++ b/test/es-module/test-esm-named-exports.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-loader ./test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
+// Flags: --import ./test/fixtures/es-module-loaders/builtin-named-exports.mjs
 'use strict';
 
 require('../common');

--- a/test/es-module/test-esm-named-exports.mjs
+++ b/test/es-module/test-esm-named-exports.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-loader ./test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
+// Flags: --import ./test/fixtures/es-module-loaders/builtin-named-exports.mjs
 import '../common/index.mjs';
 import { readFile, __fromLoader } from 'fs';
 import assert from 'assert';

--- a/test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
+++ b/test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
@@ -1,17 +1,10 @@
-import module from 'module';
+import module from 'node:module';
 import { readFileSync } from 'node:fs';
 
-const GET_BUILTIN = `$__get_builtin_hole_${Date.now()}`;
-
-export function globalPreload() {
-  return `Object.defineProperty(globalThis, ${JSON.stringify(GET_BUILTIN)}, {
-  value: (builtinName) => {
-    return getBuiltin(builtinName);
-  },
-  enumerable: false,
-  configurable: false,
-});
-`;
+/** @type {string} */
+let GET_BUILTIN;
+export function initialize(data) {
+  GET_BUILTIN = data.GET_BUILTIN;
 }
 
 export async function resolve(specifier, context, next) {
@@ -56,7 +49,7 @@ const $builtinInstance = ${GET_BUILTIN}(${JSON.stringify(builtinName)});
 module.exports = $builtinInstance;
 module.exports.__fromLoader = true;
 
-// We need this for CJS-module-lexer can parse the exported names. 
+// We need this for CJS-module-lexer can parse the exported names.
 ${
   builtinExports
     .map(name => `exports.${name} = $builtinInstance.${name};`)

--- a/test/fixtures/es-module-loaders/builtin-named-exports.mjs
+++ b/test/fixtures/es-module-loaders/builtin-named-exports.mjs
@@ -1,0 +1,17 @@
+import * as fixtures from '../../common/fixtures.mjs';
+import { createRequire, register } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const GET_BUILTIN = `$__get_builtin_hole_${Date.now()}`;
+Object.defineProperty(globalThis, GET_BUILTIN, {
+  value: builtinName => require(builtinName),
+  enumerable: false,
+  configurable: false,
+});
+
+register(fixtures.fileURL('es-module-loaders/builtin-named-exports-loader.mjs'), {
+  data: {
+    GET_BUILTIN,
+  },
+});

--- a/test/fixtures/es-module-loaders/hook-resolve-type-loader.mjs
+++ b/test/fixtures/es-module-loaders/hook-resolve-type-loader.mjs
@@ -1,0 +1,18 @@
+/** @type {MessagePort} */
+let port;
+export function initialize(data) {
+  port = data.port;
+}
+
+export async function resolve(specifier, context, next) {
+  const nextResult = await next(specifier, context);
+  const { format } = nextResult;
+
+  if (format === 'module' || specifier.endsWith('.mjs')) {
+    port.postMessage({ type: 'module' });
+  } else if (format == null || format === 'commonjs') {
+    port.postMessage({ type: 'commonjs' });
+  }
+
+  return nextResult;
+}

--- a/test/fixtures/es-module-loaders/hook-resolve-type.mjs
+++ b/test/fixtures/es-module-loaders/hook-resolve-type.mjs
@@ -1,44 +1,30 @@
+import * as fixtures from '../../common/fixtures.mjs';
+import { register } from 'node:module';
+import { MessageChannel } from 'node:worker_threads';
+
 let importedESM = 0;
 let importedCJS = 0;
+export function getModuleTypeStats() {
+  return { importedESM, importedCJS };
+};
 
-export function globalPreload({ port }) {
-  port.on('message', (int32) => {
-    port.postMessage({ importedESM, importedCJS });
-    Atomics.store(int32, 0, 1);
-    Atomics.notify(int32, 0);
-  });
-  port.unref();
-  return `
-    const { receiveMessageOnPort } = getBuiltin('worker_threads');
-    global.getModuleTypeStats = async function getModuleTypeStats() {
-      const sab = new SharedArrayBuffer(4);
-      const int32 = new Int32Array(sab);
-      port.postMessage(int32);
-      // Artificial timeout to keep the event loop alive.
-      // https://bugs.chromium.org/p/v8/issues/detail?id=13238
-      // TODO(targos) Remove when V8 issue is resolved.
-      const timeout = setTimeout(() => { throw new Error('timeout'); }, 1_000);
-      await Atomics.waitAsync(int32, 0, 0).value;
-      clearTimeout(timeout);
-      return receiveMessageOnPort(port).message;
-    };
-  `;
-}
+const { port1, port2 } = new MessageChannel();
 
-export async function load(url, context, next) {
-  return next(url);
-}
+register(fixtures.fileURL('es-module-loaders/hook-resolve-type-loader.mjs'), {
+  data: { port: port2 },
+  transferList: [port2],
+});
 
-export async function resolve(specifier, context, next) {
-  const nextResult = await next(specifier, context);
-  const { format } = nextResult;
-
-  if (format === 'module' || specifier.endsWith('.mjs')) {
-    importedESM++;
-  } else if (format == null || format === 'commonjs') {
-    importedCJS++;
+port1.on('message', ({ type }) => {
+  switch (type) {
+    case 'module':
+      importedESM++;
+      break;
+    case 'commonjs':
+      importedCJS++;
+      break;
   }
+});
 
-  return nextResult;
-}
-
+port1.unref();
+port2.unref();


### PR DESCRIPTION
Similar to #49465 and supporting #49144, this PR refactors two tests that currently use the module customization hook `globalPreload` to use its replacement `register` / `initialize` instead. This spins off work from #49144 into a standalone PR so that we have examples to direct people to to show how they can do similar refactors. In that vein, after discussion with @aduh95 we would like to land this PR as two distinct commits, so that we can share either the link to this PR (to cite both tests) or the links to the two commits to reference one refactored test or the other. @nodejs/loaders 