### PR TITLE
esm: improve error when calling `import.meta.resolve` from `data:` URL

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2959,6 +2959,17 @@ import 'package-name'; // supported
 
 `import` with URL schemes other than `file` and `data` is unsupported.
 
+<a id="ERR_UNSUPPORTED_RESOLVE_REQUEST"></a>
+
+### `ERR_UNSUPPORTED_RESOLVE_REQUEST`
+
+An attempt was made to resolve an invalid module referrer. This can happen when
+calling `import()` or `import.meta.resolve()` with either:
+
+* a bare specifier that is not a builtin module from a module whose URL scheme
+  is not `file`.
+* a [relative URL][] from a module whose URL scheme is not a [special scheme][].
+
 <a id="ERR_USE_AFTER_CLOSE"></a>
 
 ### `ERR_USE_AFTER_CLOSE`
@@ -3710,7 +3721,9 @@ The native call from `process.cpuUsage` could not be processed.
 [event emitter-based]: events.md#class-eventemitter
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
 [policy]: permissions.md#policies
+[relative URL]: https://url.spec.whatwg.org/#relative-url-string
 [self-reference a package using its name]: packages.md#self-referencing-a-package-using-its-name
+[special scheme]: https://url.spec.whatwg.org/#special-scheme
 [stream-based]: stream.md
 [syscall]: https://man7.org/linux/man-pages/man2/syscalls.2.html
 [try-catch]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2970,11 +2970,11 @@ importing or calling `import.meta.resolve()` with either:
   is not `file`.
 * a [relative URL][] from a module whose URL scheme is not a [special scheme][].
 
-```js
+```mjs
 try {
   // Trying to import the package 'bare-specifier' from a `data:` URL module:
-  await import("data:text/javascript,import%22bare-specifier%22");
-} catch(e) {
+  await import('data:text/javascript,import "bare-specifier"');
+} catch (e) {
   console.log(e.code); // ERR_UNSUPPORTED_RESOLVE_REQUEST
 }
 ```

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2964,11 +2964,20 @@ import 'package-name'; // supported
 ### `ERR_UNSUPPORTED_RESOLVE_REQUEST`
 
 An attempt was made to resolve an invalid module referrer. This can happen when
-calling `import()` or `import.meta.resolve()` with either:
+importing or calling `import.meta.resolve()` with either:
 
 * a bare specifier that is not a builtin module from a module whose URL scheme
   is not `file`.
 * a [relative URL][] from a module whose URL scheme is not a [special scheme][].
+
+```js
+try {
+  // Trying to import the package 'bare-specifier' from a `data:` URL module:
+  await import("data:text/javascript,import%22bare-specifier%22");
+} catch(e) {
+  console.log(e.code); // ERR_UNSUPPORTED_RESOLVE_REQUEST
+}
+```
 
 <a id="ERR_USE_AFTER_CLOSE"></a>
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1864,7 +1864,7 @@ E('ERR_UNSUPPORTED_ESM_URL_SCHEME', (url, supported) => {
   return msg;
 }, Error);
 E('ERR_UNSUPPORTED_RESOLVE_REQUEST',
-  'Failed to resolve module specifier "%s" from "%s": Invalid relative url or base scheme is not hierarchical.',
+  'Failed to resolve module specifier "%s" from "%s": Invalid relative URL or base scheme is not hierarchical.',
   TypeError);
 E('ERR_USE_AFTER_CLOSE', '%s was closed', Error);
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1863,6 +1863,9 @@ E('ERR_UNSUPPORTED_ESM_URL_SCHEME', (url, supported) => {
   msg += `. Received protocol '${url.protocol}'`;
   return msg;
 }, Error);
+E('ERR_UNSUPPORTED_RESOLVE_REQUEST',
+  'Failed to resolve module specifier "%s" from "%s": Invalid relative url or base scheme is not hierarchical.',
+  TypeError);
 E('ERR_USE_AFTER_CLOSE', '%s was closed', Error);
 
 // This should probably be a `TypeError`.

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -51,6 +51,7 @@ const {
   ERR_PACKAGE_IMPORT_NOT_DEFINED,
   ERR_PACKAGE_PATH_NOT_EXPORTED,
   ERR_UNSUPPORTED_DIR_IMPORT,
+  ERR_UNSUPPORTED_RESOLVE_REQUEST,
   ERR_NETWORK_IMPORT_DISALLOWED,
 } = require('internal/errors').codes;
 
@@ -884,22 +885,37 @@ function shouldBeTreatedAsRelativeOrAbsolutePath(specifier) {
  * @param {boolean} preserveSymlinks - Whether to preserve symlinks in the resolved URL.
  */
 function moduleResolve(specifier, base, conditions, preserveSymlinks) {
-  const isRemote = base.protocol === 'http:' ||
-    base.protocol === 'https:';
+  const protocol = typeof base === 'string' ?
+    StringPrototypeSlice(base, 0, StringPrototypeIndexOf(base, ':') + 1) :
+    base.protocol;
+  const isData = protocol === 'data:';
+  const isRemote =
+    isData ||
+    protocol === 'http:' ||
+    protocol === 'https:';
   // Order swapped from spec for minor perf gain.
   // Ok since relative URLs cannot parse as URLs.
   let resolved;
   if (shouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
-    resolved = new URL(specifier, base);
-  } else if (!isRemote && specifier[0] === '#') {
+    try {
+      resolved = new URL(specifier, base);
+    } catch (cause) {
+      const error = new ERR_UNSUPPORTED_RESOLVE_REQUEST(specifier, base);
+      setOwnProperty(error, 'cause', cause);
+      throw error;
+    }
+  } else if (protocol === 'file:' && specifier[0] === '#') {
     resolved = packageImportsResolve(specifier, base, conditions);
   } else {
     try {
       resolved = new URL(specifier);
-    } catch {
-      if (!isRemote) {
-        resolved = packageResolve(specifier, base, conditions);
+    } catch (cause) {
+      if (isRemote && !BuiltinModule.canBeRequiredWithoutScheme(specifier)) {
+        const error = new ERR_UNSUPPORTED_RESOLVE_REQUEST(specifier, base);
+        setOwnProperty(error, 'cause', cause);
+        throw error;
       }
+      resolved = packageResolve(specifier, base, conditions);
     }
   }
   if (resolved.protocol !== 'file:') {
@@ -1073,7 +1089,7 @@ function defaultResolve(specifier, context = {}) {
     }
   }
 
-  let parsed;
+  let parsed, protocol;
   try {
     if (shouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
       parsed = new URL(specifier, parsedParentURL);
@@ -1082,7 +1098,7 @@ function defaultResolve(specifier, context = {}) {
     }
 
     // Avoid accessing the `protocol` property due to the lazy getters.
-    const protocol = parsed.protocol;
+    protocol = parsed.protocol;
     if (protocol === 'data:' ||
       (experimentalNetworkImports &&
         (
@@ -1109,7 +1125,8 @@ function defaultResolve(specifier, context = {}) {
   if (maybeReturn) { return maybeReturn; }
 
   // This must come after checkIfDisallowedImport
-  if (parsed && parsed.protocol === 'node:') { return { __proto__: null, url: specifier }; }
+  protocol ??= parsed?.protocol;
+  if (protocol === 'node:') { return { __proto__: null, url: specifier }; }
 
 
   const isMain = parentURL === undefined;
@@ -1190,6 +1207,7 @@ module.exports = {
 const {
   defaultGetFormatWithoutErrors,
 } = require('internal/modules/esm/get_format');
+const { setOwnProperty } = require('internal/util');
 
 if (policy) {
   const $defaultResolve = defaultResolve;

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -37,7 +37,7 @@ const experimentalNetworkImports =
   getOptionValue('--experimental-network-imports');
 const inputTypeFlag = getOptionValue('--input-type');
 const { URL, pathToFileURL, fileURLToPath, isURL } = require('internal/url');
-const { getCWDURL } = require('internal/util');
+const { getCWDURL, setOwnProperty } = require('internal/util');
 const { canParse: URLCanParse } = internalBinding('url');
 const { legacyMainResolve: FSLegacyMainResolve } = internalBinding('fs');
 const {
@@ -1207,7 +1207,6 @@ module.exports = {
 const {
   defaultGetFormatWithoutErrors,
 } = require('internal/modules/esm/get_format');
-const { setOwnProperty } = require('internal/util');
 
 if (policy) {
   const $defaultResolve = defaultResolve;

--- a/test/es-module/test-esm-import-meta-resolve.mjs
+++ b/test/es-module/test-esm-import-meta-resolve.mjs
@@ -36,6 +36,28 @@ assert.strictEqual(import.meta.resolve('http://some-absolute/url'), 'http://some
 assert.strictEqual(import.meta.resolve('some://weird/protocol'), 'some://weird/protocol');
 assert.strictEqual(import.meta.resolve('baz/', fixtures),
                    fixtures + 'node_modules/baz/');
+assert.deepStrictEqual(
+  { ...await import('data:text/javascript,export default import.meta.resolve("http://some-absolute/url")') },
+  { default: 'http://some-absolute/url' },
+);
+assert.deepStrictEqual(
+  { ...await import('data:text/javascript,export default import.meta.resolve("some://weird/protocol")') },
+  { default: 'some://weird/protocol' },
+);
+assert.deepStrictEqual(
+  { ...await import(`data:text/javascript,export default import.meta.resolve("baz/", ${JSON.stringify(fixtures)})`) },
+  { default: fixtures + 'node_modules/baz/' },
+);
+assert.deepStrictEqual(
+  { ...await import('data:text/javascript,export default import.meta.resolve("fs")') },
+  { default: 'node:fs' },
+);
+await assert.rejects(import('data:text/javascript,export default import.meta.resolve("does-not-exist")'), {
+  code: 'ERR_UNSUPPORTED_RESOLVE_REQUEST',
+});
+await assert.rejects(import('data:text/javascript,export default import.meta.resolve("./relative")'), {
+  code: 'ERR_UNSUPPORTED_RESOLVE_REQUEST',
+});
 
 {
   const cp = spawn(execPath, [


### PR DESCRIPTION
Not sure about the error code (`ERR_UNSUPPORTED_RESOLVE_REQUEST`). For reference, here are what error message other runtimes emit when doing `import('data:text/javascript,export default import.meta.resolve("bare-package-name")').catch(console.error)`:

- Chromium: `TypeError: Failed to execute 'resolve' on 'import.meta': Failed to resolve module specifier bare-package-name: Relative references must start with either "/", "./", or "../".`
- Safari: `TypeError: Module name, 'bare-package-name' does not resolve to a valid URL.`
- Firefox: `TypeError: The specifier “bare-package-name” was a bare specifier, but was not remapped to anything. Relative module specifiers must start with “./”, “../” or “/”.`
- Deno: `TypeError: Relative import path "bare-package-name" not prefixed with / or ./ or ../`
- Node.js with this PR: `TypeError [ERR_UNSUPPORTED_RESOLVE_REQUEST]: Failed to resolve module specifier "bare-package-name" from "data:text/javascript,export default import.meta.resolve("bare-package-name")": Invalid relative url or base scheme is not hierarchical.`

Here are the error messages for `import('data:text/javascript,export default import.meta.resolve("./relative")').catch(console.error)`:

- Chromium: `TypeError: Failed to execute 'resolve' on 'import.meta': Failed to resolve module specifier ./relative: Invalid relative url or base scheme isn't hierarchical.`
- Safari: `TypeError: Module name, './relative' does not resolve to a valid URL`
- Firefox: `TypeError: Error resolving module specifier “./relative”.`
- Deno: `TypeError: invalid URL: relative URL with a cannot-be-a-base base`
- Node.js with this PR: `TypeError [ERR_UNSUPPORTED_RESOLVE_REQUEST]: Failed to resolve module specifier "./relative" from "data:text/javascript,export default import.meta.resolve("./relative")": Invalid relative url or base scheme is not hierarchical.`
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
