### PR TITLE
esm: clarify ERR_REQUIRE_ESM errors

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1548,7 +1548,7 @@ E('ERR_REQUIRE_ESM',
     msg += `\n${basename} is treated as an ES module file as it is a .js ` +
       'file whose nearest parent package.json contains "type": "module" ' +
       'which declares all .js files in that package scope as ES modules.' +
-      `\nInstead rename ${basename} to end in .cjs, change the requiring ` +
+      `\nInstead either rename ${basename} to end in .cjs, change the requiring ` +
       'code to use dynamic import() which is available in all CommonJS ' +
       'modules, or change "type": "module" to "type": "commonjs" in ' +
       `${packageJsonPath} to treat all .js files as CommonJS (using .mjs for ` +

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -31,7 +31,7 @@ describe('CJS ↔︎ ESM interop warnings', { concurrency: true }, () => {
     );
     assert.ok(
       stderr.replaceAll('\r', '').includes(
-        `Instead rename ${basename} to end in .cjs, change the requiring ` +
+        `Instead either rename ${basename} to end in .cjs, change the requiring ` +
         'code to use dynamic import() which is available in all CommonJS ' +
         `modules, or change "type": "module" to "type": "commonjs" in ${pjson} to ` +
         'treat all .js files as CommonJS (using .mjs for all ES modules ' +


### PR DESCRIPTION
In #39175, better ESM errors were introduced. This commit tweaks the language in the error slightly to make it clear that there are three different options to resolve the error.

I find the current message more difficult to parse, because you only realise that you need to pick one of the three options after reading most of the (very long) sentence. Putting "either" at the start of the message should signpost that these are three options and you can pick any of them.

Before

```
[Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/me/Developer/company/repo/app/src/tracer.js not supported.
tracer.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename tracer.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /Users/me/Developer/company/repo/app/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```

After

```
[Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/me/Developer/company/repo/app/src/tracer.js not supported.
tracer.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename tracer.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /Users/me/Developer/company/repo/app/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
