### PR TITLE
doc: close a parenthesis

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -251,7 +251,7 @@ both CommonJS and ES modules in a single package please consult
 
 Existing packages introducing the [`"exports"`][] field will prevent consumers
 of the package from using any entry points that are not defined, including the
-[`package.json`][] (e.g. `require('your-package/package.json')`. **This will
+[`package.json`][] (e.g. `require('your-package/package.json')`). **This will
 likely be a breaking change.**
 
 To make the introduction of [`"exports"`][] non-breaking, ensure that every


### PR DESCRIPTION
Close parenthesis in [_Package entry points_](https://nodejs.org/api/packages.html#package-entry-points) chapter:

> Existing packages introducing the [`"exports"`](https://nodejs.org/api/packages.html#exports) field will prevent consumers of the package from using any entry points that are not defined, including the [`package.json`](https://nodejs.org/api/packages.html#nodejs-packagejson-field-definitions) (e.g. `require('your-package/package.json')`. **This will likely be a breaking change.**