### PR TITLE
test_runner: use validateStringArray for `timers.enable()`

### DIFF
--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -23,8 +23,8 @@ const {
 
 const {
   validateAbortSignal,
-  validateArray,
   validateNumber,
+  validateStringArray,
 } = require('internal/validators');
 
 const {
@@ -676,7 +676,7 @@ class MockTimers {
    */
   /**
    * Enables the MockTimers replacing the native timers with the fake ones.
-   * @param {EnableOptions} options
+   * @param {EnableOptions} [options]
    */
   enable(options = { __proto__: null, apis: SUPPORTED_APIS, now: 0 }) {
     const internalOptions = { __proto__: null, ...options };
@@ -696,7 +696,7 @@ class MockTimers {
       internalOptions.apis = SUPPORTED_APIS;
     }
 
-    validateArray(internalOptions.apis, 'options.apis');
+    validateStringArray(internalOptions.apis, 'options.apis');
     // Check that the timers passed are supported
     ArrayPrototypeForEach(internalOptions.apis, (timer) => {
       if (!ArrayPrototypeIncludes(SUPPORTED_APIS, timer)) {

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -17,6 +17,14 @@ describe('Mock Timers Test Suite', () => {
       });
     });
 
+    it('should throw an error if data type of trying to enable a timer is not string', (t) => {
+      assert.throws(() => {
+        t.mock.timers.enable({ apis: [1] });
+      }, {
+        code: 'ERR_INVALID_ARG_TYPE',
+      });
+    });
+
     it('should throw an error if trying to enable a timer twice', (t) => {
       t.mock.timers.enable();
       assert.throws(() => {


### PR DESCRIPTION
`apis` which is argument of `timers.enable()` is string array. So use `validatStringArray` instead of `validateArray`. And
`options` is optional, so update JSDoc.
In document, some default value of `timers` are missed such as `setImmediate` and `clearImmediate`. Next, `milliseconds` which is argument of `timers.tick() is optional and default is 1.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
