### PR TITLE
test_runner: add support for nextTick on mock timers

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1586,7 +1586,7 @@ Enables timer mocking for the specified timers.
   The currently supported timer values are `'setInterval'`, `'setTimeout'`,
   and `'setImmediate'`.  If no value is provided, all timers (`'setInterval'`,
   `'clearInterval'`, `'setTimeout'`, `'clearTimeout'`, `'setImmediate'`,
-  and `'clearImmediate'`) will be mocked by default.
+  `'clearImmediate'` and `'process.nextTick'`) will be mocked by default.
 
 **Note:** When you enable mocking for a specific timer, its associated
 clear function will also be implicitly mocked.
@@ -1611,10 +1611,11 @@ and `clearInterval` functions from [node:timers](./timers.md),
 
 Alternatively, if you call `mock.timers.enable()` without any parameters:
 
-All timers (`'setInterval'`, `'clearInterval'`, `'setTimeout'`, and `'clearTimeout'`)
+All timers (`'setInterval'`, `'clearInterval'`, `'setTimeout'`,
+`'clearTimeout'` and `process.nextTick`)
 will be mocked. The `setInterval`, `clearInterval`, `setTimeout`, and `clearTimeout`
 functions from `node:timers`, `node:timers/promises`,
-and `globalThis` will be mocked.
+and `globalThis` as well as `nextTick` from `node:process` will be mocked.
 
 ### `timers.reset()`
 

--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -34,6 +34,7 @@ const {
 const PriorityQueue = require('internal/priority_queue');
 const nodeTimers = require('timers');
 const nodeTimersPromises = require('timers/promises');
+const nodeProcess = require('process');
 const EventEmitter = require('events');
 
 let kResistStopPropagation;
@@ -50,9 +51,16 @@ function abortIt(signal) {
   return new AbortError(undefined, { __proto__: null, cause: signal.reason });
 }
 
-const SUPPORTED_TIMERS = ['setTimeout', 'setInterval', 'setImmediate'];
+const SUPPORTED_TIMERS = [
+  'nextTick',
+  'setTimeout',
+  'setInterval',
+  'setImmediate',
+];
+
 const TIMERS_DEFAULT_INTERVAL = {
   __proto__: null,
+  nextTick: -2,
   setImmediate: -1,
 };
 
@@ -63,6 +71,9 @@ class MockTimers {
   #realClearInterval;
   #realSetImmediate;
   #realClearImmediate;
+
+  #realProcessNextTick;
+  #realNodeProcessNextTick;
 
   #realPromisifiedSetTimeout;
   #realPromisifiedSetInterval;
@@ -92,6 +103,15 @@ class MockTimers {
       false,
       callback,
       TIMERS_DEFAULT_INTERVAL.setImmediate,
+      ...args,
+    );
+  };
+
+  #nextTick = (callback, ...args) => {
+    return this.#createTimer(
+      false,
+      callback,
+      TIMERS_DEFAULT_INTERVAL.nextTick,
       ...args,
     );
   };
@@ -240,6 +260,12 @@ class MockTimers {
       __proto__: null,
       toFake: {
         __proto__: null,
+        nextTick: () => {
+          this.#storeOriginalNextTick();
+
+          nodeProcess.nextTick = this.#nextTick;
+          process.nextTick = this.#nextTick;
+        },
         setTimeout: () => {
           this.#storeOriginalSetTimeout();
 
@@ -285,6 +311,9 @@ class MockTimers {
       },
       toReal: {
         __proto__: null,
+        nextTick: () => {
+          this.#restoreNextTick();
+        },
         setTimeout: () => {
           this.#restoreOriginalSetTimeout();
         },
@@ -302,6 +331,31 @@ class MockTimers {
     this.#isEnabled = activate;
   }
 
+  #storeOriginalNextTick() {
+    this.#realProcessNextTick = ObjectGetOwnPropertyDescriptor(
+      process,
+      'nextTick',
+    );
+
+    this.#realNodeProcessNextTick = ObjectGetOwnPropertyDescriptor(
+      nodeProcess,
+      'nextTick',
+    );
+  }
+
+  #restoreNextTick() {
+    ObjectDefineProperty(
+      process,
+      'nextTick',
+      this.#realProcessNextTick,
+    );
+
+    ObjectDefineProperty(
+      nodeProcess,
+      'nextTick',
+      this.#realNodeProcessNextTick,
+    );
+  }
   #restoreSetImmediate() {
     ObjectDefineProperty(
       globalThis,


### PR DESCRIPTION
Add support for process.nextTick and require('node:process').nextTick to MockTimers

cc @nodejs/test_runner 

As a reference, I got into Sinon's docs and found out this:

>By default it will automatically fake all methods except `process.nextTick`. You could, however, still fake `nextTick` by providing it explicitly

Do you people happen to know why?

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
