### PR TITLE
test: use spawnSyncAndExitWithoutError in sea tests

### DIFF
--- a/test/sequential/test-single-executable-application-snapshot.js
+++ b/test/sequential/test-single-executable-application-snapshot.js
@@ -13,7 +13,10 @@ skipIfSingleExecutableIsNotSupported();
 
 const tmpdir = require('../common/tmpdir');
 const { copyFileSync, writeFileSync, existsSync } = require('fs');
-const { spawnSync } = require('child_process');
+const {
+  spawnSyncAndExit,
+  spawnSyncAndExitWithoutError
+} = require('../common/child_process');
 const assert = require('assert');
 
 const configFile = tmpdir.resolve('sea-config.json');
@@ -32,16 +35,17 @@ const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'se
   }
   `);
 
-  const child = spawnSync(
+  spawnSyncAndExit(
     process.execPath,
     ['--experimental-sea-config', 'sea-config.json'],
     {
       cwd: tmpdir.path
+    },
+    {
+      status: 1,
+      signal: null,
+      stderr: /snapshot\.js does not invoke v8\.startupSnapshot\.setDeserializeMainFunction\(\)/
     });
-
-  assert.match(
-    child.stderr.toString(),
-    /snapshot\.js does not invoke v8\.startupSnapshot\.setDeserializeMainFunction\(\)/);
 }
 
 {
@@ -65,24 +69,31 @@ const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'se
   }
   `);
 
-  let child = spawnSync(
+  spawnSyncAndExitWithoutError(
     process.execPath,
     ['--experimental-sea-config', 'sea-config.json'],
     {
       cwd: tmpdir.path
+    },
+    {
+      stderr: /Single executable application is an experimental feature/
     });
-  assert.match(
-    child.stderr.toString(),
-    /Single executable application is an experimental feature/);
 
   assert(existsSync(seaPrepBlob));
 
   copyFileSync(process.execPath, outputFile);
   injectAndCodeSign(outputFile, seaPrepBlob);
 
-  child = spawnSync(outputFile);
-  assert.strictEqual(child.stdout.toString().trim(), 'Hello from snapshot');
-  assert.doesNotMatch(
-    child.stderr.toString(),
-    /Single executable application is an experimental feature/);
+  spawnSyncAndExitWithoutError(
+    outputFile,
+    {
+      trim: true,
+      stdout: 'Hello from snapshot',
+      stderr(output) {
+        assert.doesNotMatch(
+          output,
+          /Single executable application is an experimental feature/);
+      }
+    }
+  );
 }


### PR DESCRIPTION
### test: use spawnSyncAndExitWithoutError in test/common/sea.js

To display more information when the command fails.

### test: use spawnSyncAndExitWithoutError in sea tests

To display more information when the command fails.

Refs: https://github.com/nodejs/reliability/issues/658

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
