### PR TITLE
esm: isolate globalPreload

### DIFF
--- a/test/es-module/test-esm-loader-globalpreload-hook.mjs
+++ b/test/es-module/test-esm-loader-globalpreload-hook.mjs
@@ -133,7 +133,11 @@ describe('globalPreload hook', () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
       '--experimental-loader',
-      `data:text/javascript,export ${function globalPreload() { if (this != null) { throw new Error('hook function must not be bound to ESMLoader instance') }} }`,
+      `data:text/javascript,export ${function globalPreload() {
+        if (this != null) {
+          throw new Error('hook function must not be bound to ESMLoader instance');
+        }
+      }}`,
       fixtures.path('empty.js'),
     ]);
 

--- a/test/es-module/test-esm-loader-globalpreload-hook.mjs
+++ b/test/es-module/test-esm-loader-globalpreload-hook.mjs
@@ -1,0 +1,145 @@
+import { spawnPromisified } from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import assert from 'node:assert';
+import os from 'node:os';
+import { execPath } from 'node:process';
+import { describe, it } from 'node:test';
+
+describe('globalPreload hook', () => {
+  it('should not emit deprecation warning when initialize is supplied', async () => {
+    const { stderr } = await spawnPromisified(execPath, [
+      '--experimental-loader',
+      'data:text/javascript,export function globalPreload(){}export function initialize(){}',
+      fixtures.path('empty.js'),
+    ]);
+
+    assert.doesNotMatch(stderr, /`globalPreload` is an experimental feature/);
+  });
+
+  it('should handle globalPreload returning undefined', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      'data:text/javascript,export function globalPreload(){}',
+      fixtures.path('empty.js'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should handle loading node:test', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      'data:text/javascript,export function globalPreload(){return `getBuiltin("node:test")()`}',
+      fixtures.path('empty.js'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.match(stdout, /\n# pass 1\r?\n/);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should handle loading node:os with node: prefix', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      'data:text/javascript,export function globalPreload(){return `console.log(getBuiltin("node:os").arch())`}',
+      fixtures.path('empty.js'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.strictEqual(stdout.trim(), os.arch());
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  // `os` is used here because it's simple and not mocked (the builtin module otherwise doesn't matter).
+  it('should handle loading builtin module without node: prefix', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      'data:text/javascript,export function globalPreload(){return `console.log(getBuiltin("os").arch())`}',
+      fixtures.path('empty.js'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.strictEqual(stdout.trim(), os.arch());
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should throw when loading node:test without node: prefix', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      'data:text/javascript,export function globalPreload(){return `getBuiltin("test")()`}',
+      fixtures.path('empty.js'),
+    ]);
+
+    assert.match(stderr, /ERR_UNKNOWN_BUILTIN_MODULE/);
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should register globals set from globalPreload', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      'data:text/javascript,export function globalPreload(){return "this.myGlobal=4"}',
+      '--print', 'myGlobal',
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.strictEqual(stdout.trim(), '4');
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should log console.log calls returned from globalPreload', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      'data:text/javascript,export function globalPreload(){return `console.log("Hello from globalPreload")`}',
+      fixtures.path('empty.js'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.strictEqual(stdout.trim(), 'Hello from globalPreload');
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should crash if globalPreload returns code that throws', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      'data:text/javascript,export function globalPreload(){return `throw new Error("error from globalPreload")`}',
+      fixtures.path('empty.js'),
+    ]);
+
+    assert.match(stderr, /error from globalPreload/);
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should have a `this` value that is not bound to the loader instance', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--experimental-loader',
+      `data:text/javascript,export ${function globalPreload() { if (this != null) { throw new Error('hook function must not be bound to ESMLoader instance') }} }`,
+      fixtures.path('empty.js'),
+    ]);
+
+    assert.strictEqual(stderr, '');
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+});

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -1,7 +1,6 @@
 import { spawnPromisified } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
-import os from 'node:os';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -423,7 +423,7 @@ describe('Loader hooks', { concurrency: true }, () => {
   });
 
   describe('globalPreload', () => {
-    it('should emit deprecation warning', async () => {
+    it('should emit warning', async () => {
       const { stderr } = await spawnPromisified(execPath, [
         '--experimental-loader',
         'data:text/javascript,export function globalPreload(){}',
@@ -433,129 +433,6 @@ describe('Loader hooks', { concurrency: true }, () => {
       ]);
 
       assert.strictEqual(stderr.match(/`globalPreload` is an experimental feature/g).length, 1);
-    });
-
-    it('should not emit deprecation warning when initialize is supplied', async () => {
-      const { stderr } = await spawnPromisified(execPath, [
-        '--experimental-loader',
-        'data:text/javascript,export function globalPreload(){}export function initialize(){}',
-        fixtures.path('empty.js'),
-      ]);
-
-      assert.doesNotMatch(stderr, /`globalPreload` is an experimental feature/);
-    });
-
-    it('should handle globalPreload returning undefined', async () => {
-      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-        '--no-warnings',
-        '--experimental-loader',
-        'data:text/javascript,export function globalPreload(){}',
-        fixtures.path('empty.js'),
-      ]);
-
-      assert.strictEqual(stderr, '');
-      assert.strictEqual(stdout, '');
-      assert.strictEqual(code, 0);
-      assert.strictEqual(signal, null);
-    });
-
-    it('should handle loading node:test', async () => {
-      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-        '--no-warnings',
-        '--experimental-loader',
-        'data:text/javascript,export function globalPreload(){return `getBuiltin("node:test")()`}',
-        fixtures.path('empty.js'),
-      ]);
-
-      assert.strictEqual(stderr, '');
-      assert.match(stdout, /\n# pass 1\r?\n/);
-      assert.strictEqual(code, 0);
-      assert.strictEqual(signal, null);
-    });
-
-    it('should handle loading node:os with node: prefix', async () => {
-      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-        '--no-warnings',
-        '--experimental-loader',
-        'data:text/javascript,export function globalPreload(){return `console.log(getBuiltin("node:os").arch())`}',
-        fixtures.path('empty.js'),
-      ]);
-
-      assert.strictEqual(stderr, '');
-      assert.strictEqual(stdout.trim(), os.arch());
-      assert.strictEqual(code, 0);
-      assert.strictEqual(signal, null);
-    });
-
-    // `os` is used here because it's simple and not mocked (the builtin module otherwise doesn't matter).
-    it('should handle loading builtin module without node: prefix', async () => {
-      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-        '--no-warnings',
-        '--experimental-loader',
-        'data:text/javascript,export function globalPreload(){return `console.log(getBuiltin("os").arch())`}',
-        fixtures.path('empty.js'),
-      ]);
-
-      assert.strictEqual(stderr, '');
-      assert.strictEqual(stdout.trim(), os.arch());
-      assert.strictEqual(code, 0);
-      assert.strictEqual(signal, null);
-    });
-
-    it('should throw when loading node:test without node: prefix', async () => {
-      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-        '--no-warnings',
-        '--experimental-loader',
-        'data:text/javascript,export function globalPreload(){return `getBuiltin("test")()`}',
-        fixtures.path('empty.js'),
-      ]);
-
-      assert.match(stderr, /ERR_UNKNOWN_BUILTIN_MODULE/);
-      assert.strictEqual(stdout, '');
-      assert.strictEqual(code, 1);
-      assert.strictEqual(signal, null);
-    });
-
-    it('should register globals set from globalPreload', async () => {
-      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-        '--no-warnings',
-        '--experimental-loader',
-        'data:text/javascript,export function globalPreload(){return "this.myGlobal=4"}',
-        '--print', 'myGlobal',
-      ]);
-
-      assert.strictEqual(stderr, '');
-      assert.strictEqual(stdout.trim(), '4');
-      assert.strictEqual(code, 0);
-      assert.strictEqual(signal, null);
-    });
-
-    it('should log console.log calls returned from globalPreload', async () => {
-      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-        '--no-warnings',
-        '--experimental-loader',
-        'data:text/javascript,export function globalPreload(){return `console.log("Hello from globalPreload")`}',
-        fixtures.path('empty.js'),
-      ]);
-
-      assert.strictEqual(stderr, '');
-      assert.strictEqual(stdout.trim(), 'Hello from globalPreload');
-      assert.strictEqual(code, 0);
-      assert.strictEqual(signal, null);
-    });
-
-    it('should crash if globalPreload returns code that throws', async () => {
-      const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
-        '--no-warnings',
-        '--experimental-loader',
-        'data:text/javascript,export function globalPreload(){return `throw new Error("error from globalPreload")`}',
-        fixtures.path('empty.js'),
-      ]);
-
-      assert.match(stderr, /error from globalPreload/);
-      assert.strictEqual(stdout, '');
-      assert.strictEqual(code, 1);
-      assert.strictEqual(signal, null);
     });
   });
 

--- a/test/fixtures/es-module-loaders/loader-this-value-inside-hook-functions.mjs
+++ b/test/fixtures/es-module-loaders/loader-this-value-inside-hook-functions.mjs
@@ -1,14 +1,21 @@
+export function initialize() {
+  if (this != null) {
+    throw new Error('hook function must not be bound to loader instance');
+  }
+}
+
 export function resolve(url, _, next) {
-  if (this != null) throw new Error('hook function must not be bound to ESMLoader instance');
+  if (this != null) {
+    throw new Error('hook function must not be bound to loader instance');
+  }
+
   return next(url);
 }
 
 export function load(url, _, next) {
-  if (this != null) throw new Error('hook function must not be bound to ESMLoader instance');
-  return next(url);
-}
+  if (this != null) {
+    throw new Error('hook function must not be bound to loader instance');
+  }
 
-export function globalPreload() {
-  if (this != null) throw new Error('hook function must not be bound to ESMLoader instance');
-  return "";
+  return next(url);
 }


### PR DESCRIPTION
From https://github.com/nodejs/node/pull/49144#issuecomment-1710835214, this PR minimizes the changes in #49144 so that if an extended period goes by before it gets backported, the potential for conflicts is as reduced as possible. The idea is that this can be merged now, without breaking anyone; and #49144 can be merged on `main` but not backported for a while, which might cause difficulties backporting later PRs but hopefully such conflicts will be fewer because of the changes in _this_ PR. @nodejs/loaders 

I left one test in `test-esm-loader-hooks.mjs` because I expect that to remain (but change) after #49144, because presumably we’ll want to emit some kind of warning or error indefinitely when this hook is defined.