### PR TITLE
stream: improve `ReadableStream.tee` perf by remove `ReflectConstruct` usage

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1199,34 +1199,41 @@ ObjectDefineProperties(ReadableByteStreamController.prototype, {
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(ReadableByteStreamController.name),
 });
 
+function TeeReadableStream(start, pull, cancel) {
+  markTransferMode(this, false, true);
+  this[kType] = 'ReadableStream';
+  this[kState] = {
+    disturbed: false,
+    state: 'readable',
+    storedError: undefined,
+    stream: undefined,
+    transfer: {
+      writable: undefined,
+      port: undefined,
+      promise: undefined,
+    },
+  };
+  this[kIsClosedPromise] = createDeferredPromise();
+  setupReadableStreamDefaultControllerFromSource(
+    this,
+    ObjectCreate(null, {
+      start: { __proto__: null, value: start },
+      pull: { __proto__: null, value: pull },
+      cancel: { __proto__: null, value: cancel },
+    }),
+    1,
+    () => 1);
+}
+
+ObjectSetPrototypeOf(TeeReadableStream.prototype, ReadableStream.prototype);
+ObjectSetPrototypeOf(TeeReadableStream, ReadableStream);
+
 function createTeeReadableStream(start, pull, cancel) {
-  return ReflectConstruct(
-    function() {
-      markTransferMode(this, false, true);
-      this[kType] = 'ReadableStream';
-      this[kState] = {
-        disturbed: false,
-        state: 'readable',
-        storedError: undefined,
-        stream: undefined,
-        transfer: {
-          writable: undefined,
-          port: undefined,
-          promise: undefined,
-        },
-      };
-      this[kIsClosedPromise] = createDeferredPromise();
-      setupReadableStreamDefaultControllerFromSource(
-        this,
-        ObjectCreate(null, {
-          start: { __proto__: null, value: start },
-          pull: { __proto__: null, value: pull },
-          cancel: { __proto__: null, value: cancel },
-        }),
-        1,
-        () => 1);
-    }, [], ReadableStream,
-  );
+  const tee = new TeeReadableStream(start, pull, cancel);
+
+  // For spec compliance the Tee must be a ReadableStream
+  tee.constructor = ReadableStream;
+  return tee;
 }
 
 const isReadableStream =


### PR DESCRIPTION
also added more webstream creation benchmarks

My local benchmark shows improvement of 2 times:

After:
```
webstreams/creation.js kind="ReadableStream.tee" n=50000: 126,685.06978447069 # Before
webstreams/creation.js kind="ReadableStream.tee" n=50000: 242,524.97642257062 # After
```

Benchmark CI output:
```
00:22:52.357 ++ Rscript benchmark/compare.R
00:22:53.287                                                                         confidence improvement accuracy (*)    (**)   (***)
00:22:53.287 webstreams/creation.js kind='ReadableStream.tee' n=50000                       ***     86.53 %       ±3.55%  ±4.75%  ±6.24%
00:22:53.287 webstreams/creation.js kind='ReadableStream' n=50000                                    1.83 %       ±3.38%  ±4.50%  ±5.86%
00:22:53.287 webstreams/creation.js kind='ReadableStreamBYOBReader' n=50000                         -0.23 %       ±3.61%  ±4.81%  ±6.26%
00:22:53.287 webstreams/creation.js kind='ReadableStreamDefaultReader' n=50000                       9.73 %      ±11.91% ±15.87% ±20.70%
00:22:53.287 webstreams/creation.js kind='TransformStream' n=50000                                   0.96 %       ±2.82%  ±3.75%  ±4.89%
00:22:53.287 webstreams/creation.js kind='WritableStream' n=50000                                   -1.19 %       ±4.27%  ±5.68%  ±7.40%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=1024 n=5000000                -0.19 %       ±4.53%  ±6.03%  ±7.86%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=2048 n=5000000                -3.72 %       ±4.90%  ±6.53%  ±8.53%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=4096 n=5000000                 2.64 %       ±3.81%  ±5.07%  ±6.60%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=512 n=5000000                  3.33 %       ±4.26%  ±5.70%  ±7.49%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=1024 n=5000000                 0.78 %       ±4.03%  ±5.36%  ±6.98%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=2048 n=5000000                -1.02 %       ±3.54%  ±4.71%  ±6.14%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=4096 n=5000000                -4.02 %       ±4.44%  ±5.93%  ±7.75%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=512 n=5000000                 -2.21 %       ±3.80%  ±5.06%  ±6.60%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=1024 n=5000000                -1.65 %       ±3.45%  ±4.59%  ±5.98%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=2048 n=5000000                -1.65 %       ±3.83%  ±5.11%  ±6.66%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=4096 n=5000000                 1.25 %       ±3.83%  ±5.10%  ±6.64%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=512 n=5000000                 -1.78 %       ±4.88%  ±6.50%  ±8.46%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=1024 n=5000000                  3.39 %       ±5.70%  ±7.58%  ±9.87%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=2048 n=5000000                 -2.18 %       ±5.81%  ±7.74% ±10.11%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=4096 n=5000000                 -1.72 %       ±3.33%  ±4.43%  ±5.77%
00:22:53.287 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=512 n=5000000                   1.77 %       ±4.47%  ±5.96%  ±7.77%
00:22:53.382 webstreams/readable-async-iterator.js n=100000                                          1.66 %       ±7.72% ±10.27% ±13.36%
00:22:53.383 
00:22:53.383 Be aware that when doing many comparisons the risk of a false-positive
00:22:53.383 result increases. In this case, there are 23 comparisons, you can thus
00:22:53.383 expect the following amount of false-positive results:
00:22:53.383   1.15 false positives, when considering a   5% risk acceptance (*, **, ***),
00:22:53.383   0.23 false positives, when considering a   1% risk acceptance (**, ***),
00:22:53.383   0.02 false positives, when considering a 0.1% risk acceptance (***)
```