### PR TITLE
perf_hooks: fix for redundant validation check for number

### DIFF
--- a/lib/internal/histogram.js
+++ b/lib/internal/histogram.js
@@ -2,7 +2,6 @@
 
 const {
   MapPrototypeEntries,
-  NumberIsNaN,
   NumberMAX_SAFE_INTEGER,
   ObjectFromEntries,
   ReflectConstruct,
@@ -27,7 +26,6 @@ const {
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_THIS,
-    ERR_OUT_OF_RANGE,
   },
 } = require('internal/errors');
 
@@ -184,9 +182,7 @@ class Histogram {
   percentile(percentile) {
     if (!isHistogram(this))
       throw new ERR_INVALID_THIS('Histogram');
-    validateNumber(percentile, 'percentile');
-    if (NumberIsNaN(percentile) || percentile <= 0 || percentile > 100)
-      throw new ERR_OUT_OF_RANGE('percentile', '> 0 && <= 100', percentile);
+    validateNumber(percentile, 'percentile', 1, 100);
 
     return this[kHandle]?.percentile(percentile);
   }
@@ -198,9 +194,7 @@ class Histogram {
   percentileBigInt(percentile) {
     if (!isHistogram(this))
       throw new ERR_INVALID_THIS('Histogram');
-    validateNumber(percentile, 'percentile');
-    if (NumberIsNaN(percentile) || percentile <= 0 || percentile > 100)
-      throw new ERR_OUT_OF_RANGE('percentile', '> 0 && <= 100', percentile);
+    validateNumber(percentile, 'percentile', 1, 100);
 
     return this[kHandle]?.percentileBigInt(percentile);
   }


### PR DESCRIPTION
It has been modified so that Type and range can be checked only with `validateNumber`.
Below is a modified reference to a similar case.

Refs: https://github.com/nodejs/node/pull/45770

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
