### PR TITLE
lib: use internal `pathToFileURL`

### DIFF
--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -54,7 +54,7 @@ function evalModule(source, print) {
 function evalScript(name, body, breakFirstLine, print, shouldLoadESM = false) {
   const CJSModule = require('internal/modules/cjs/loader').Module;
   const { kVmBreakFirstLineSymbol } = require('internal/util');
-  const { pathToFileURL } = require('url');
+  const { pathToFileURL } = require('internal/url');
 
   const cwd = tryGetCwd();
   const origModule = globalThis.module;  // Set e.g. when called from the REPL.

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -467,7 +467,7 @@ function REPLServer(prompt,
         if (e.name === 'SyntaxError') {
           let parentURL;
           try {
-            const { pathToFileURL } = require('url');
+            const { pathToFileURL } = require('internal/url');
             // Adding `/repl` prevents dynamic imports from loading relative
             // to the parent of `process.cwd()`.
             parentURL = pathToFileURL(path.join(process.cwd(), 'repl')).href;
@@ -508,7 +508,7 @@ function REPLServer(prompt,
     if (err === null) {
       let parentURL;
       try {
-        const { pathToFileURL } = require('url');
+        const { pathToFileURL } = require('internal/url');
         // Adding `/repl` prevents dynamic imports from loading relative
         // to the parent of `process.cwd()`.
         parentURL = pathToFileURL(path.join(process.cwd(), 'repl')).href;


### PR DESCRIPTION
For internal usage, `internal/url` version should be used instead of re-exported `url`.