### PR TITLE
stream: replace queue and readRequests with buffer list for performance improvement

### DIFF
--- a/benchmark/webstreams/pipe-to.js
+++ b/benchmark/webstreams/pipe-to.js
@@ -6,7 +6,7 @@ const {
 } = require('node:stream/web');
 
 const bench = common.createBenchmark(main, {
-  n: [5e6],
+  n: [1e5],
   highWaterMarkR: [512, 1024, 2048, 4096],
   highWaterMarkW: [512, 1024, 2048, 4096],
 });

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -815,7 +815,6 @@ class ReadIntoRequest {
 }
 
 
-
 class ReadableStreamDefaultReader {
   [kType] = 'ReadableStreamDefaultReader';
 
@@ -2823,7 +2822,7 @@ function readableByteStreamControllerEnqueueChunkToQueue(
     buffer,
     byteOffset,
     byteLength,
-  })
+  });
   controller[kState].queueTotalSize += byteLength;
 }
 

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -26,6 +26,7 @@ const {
   SymbolToStringTag,
   Uint8Array,
 } = primordials;
+const BufferList = require('internal/streams/buffer_list');
 
 const {
   AbortError,
@@ -813,6 +814,8 @@ class ReadIntoRequest {
   get promise() { return this[kState].promise; }
 }
 
+
+
 class ReadableStreamDefaultReader {
   [kType] = 'ReadableStreamDefaultReader';
 
@@ -823,7 +826,7 @@ class ReadableStreamDefaultReader {
     if (!isReadableStream(stream))
       throw new ERR_INVALID_ARG_TYPE('stream', 'ReadableStream', stream);
     this[kState] = {
-      readRequests: [],
+      readRequests: new BufferList(),
       stream: undefined,
       close: {
         promise: undefined,
@@ -1958,9 +1961,12 @@ function readableStreamClose(stream) {
   reader[kState].close.resolve();
 
   if (readableStreamHasDefaultReader(stream)) {
-    for (let n = 0; n < reader[kState].readRequests.length; n++)
-      reader[kState].readRequests[n][kClose]();
-    reader[kState].readRequests = [];
+    let start = reader[kState].readRequests.head;
+    while (start !== null) {
+      start.data[kClose]();
+      start = start.next;
+    }
+    reader[kState].readRequests.clear();
   }
 }
 
@@ -1982,9 +1988,12 @@ function readableStreamError(stream, error) {
   setPromiseHandled(reader[kState].close.promise);
 
   if (readableStreamHasDefaultReader(stream)) {
-    for (let n = 0; n < reader[kState].readRequests.length; n++)
-      reader[kState].readRequests[n][kError](error);
-    reader[kState].readRequests = [];
+    let start = reader[kState].readRequests.head;
+    while (start !== null) {
+      start.data[kError](error);
+      start = start.next;
+    }
+    reader[kState].readRequests.clear();
   } else {
     assert(readableStreamHasBYOBReader(stream));
     for (let n = 0; n < reader[kState].readIntoRequests.length; n++)
@@ -2033,7 +2042,7 @@ function readableStreamFulfillReadRequest(stream, chunk, done) {
     reader,
   } = stream[kState];
   assert(reader[kState].readRequests.length);
-  const readRequest = ArrayPrototypeShift(reader[kState].readRequests);
+  const readRequest = reader[kState].readRequests.shift();
 
   // TODO(@jasnell): It's not clear under what exact conditions done
   // will be true here. The spec requires this check but none of the
@@ -2061,7 +2070,7 @@ function readableStreamFulfillReadIntoRequest(stream, chunk, done) {
 function readableStreamAddReadRequest(stream, readRequest) {
   assert(readableStreamHasDefaultReader(stream));
   assert(stream[kState].state === 'readable');
-  ArrayPrototypePush(stream[kState].reader[kState].readRequests, readRequest);
+  stream[kState].reader[kState].readRequests.push(readRequest);
 }
 
 function readableStreamAddReadIntoRequest(stream, readIntoRequest) {
@@ -2114,10 +2123,12 @@ function readableStreamDefaultReaderRelease(reader) {
 }
 
 function readableStreamDefaultReaderErrorReadRequests(reader, e) {
-  for (let n = 0; n < reader[kState].readRequests.length; ++n) {
-    reader[kState].readRequests[n][kError](e);
+  let start = reader[kState].readRequests.head;
+  while (start !== null) {
+    start.data[kError](e);
+    start = start.next;
   }
-  reader[kState].readRequests = [];
+  reader[kState].readRequests.clear();
 }
 
 function readableStreamBYOBReaderRelease(reader) {
@@ -2210,7 +2221,7 @@ function setupReadableStreamDefaultReader(reader, stream) {
   if (isReadableStreamLocked(stream))
     throw new ERR_INVALID_STATE.TypeError('ReadableStream is locked');
   readableStreamReaderGenericInitialize(reader, stream);
-  reader[kState].readRequests = [];
+  reader[kState].readRequests.clear();
 }
 
 function readableStreamDefaultControllerClose(controller) {
@@ -2379,7 +2390,7 @@ function setupReadableStreamDefaultController(
     pullAgain: false,
     pullAlgorithm,
     pulling: false,
-    queue: [],
+    queue: new BufferList(),
     queueTotalSize: 0,
     started: false,
     sizeAlgorithm,
@@ -2808,13 +2819,11 @@ function readableByteStreamControllerEnqueueChunkToQueue(
   buffer,
   byteOffset,
   byteLength) {
-  ArrayPrototypePush(
-    controller[kState].queue,
-    {
-      buffer,
-      byteOffset,
-      byteLength,
-    });
+  controller[kState].queue.push({
+    buffer,
+    byteOffset,
+    byteLength,
+  })
   controller[kState].queueTotalSize += byteLength;
 }
 
@@ -2868,7 +2877,7 @@ function readableByteStreamControllerFillPullIntoDescriptorFromQueue(
   } = controller[kState];
 
   while (totalBytesToCopyRemaining) {
-    const headOfQueue = queue[0];
+    const headOfQueue = queue.head.data;
     const bytesToCopy = MathMin(
       totalBytesToCopyRemaining,
       headOfQueue.byteLength);
@@ -2886,7 +2895,7 @@ function readableByteStreamControllerFillPullIntoDescriptorFromQueue(
       headOfQueue.byteOffset,
       bytesToCopy);
     if (headOfQueue.byteLength === bytesToCopy) {
-      ArrayPrototypeShift(queue);
+      queue.shift();
     } else {
       headOfQueue.byteOffset += bytesToCopy;
       headOfQueue.byteLength -= bytesToCopy;
@@ -3087,7 +3096,7 @@ function readableByteStreamControllerFillReadRequestFromQueue(controller, readRe
     buffer,
     byteOffset,
     byteLength,
-  } = ArrayPrototypeShift(queue);
+  } = queue.shift();
 
   controller[kState].queueTotalSize -= byteLength;
   readableByteStreamControllerHandleQueueDrain(controller);
@@ -3103,13 +3112,15 @@ function readableByteStreamControllerProcessReadRequestsUsingQueue(controller) {
   const { reader } = stream[kState];
   assert(isReadableStreamDefaultReader(reader));
 
+  // TODO - may be able to change this to next next next
   while (reader[kState].readRequests.length > 0) {
+    // TODO - why this is in the while loop?
     if (queueTotalSize === 0) {
       return;
     }
     readableByteStreamControllerFillReadRequestFromQueue(
       controller,
-      ArrayPrototypeShift(reader[kState].readRequests),
+      reader[kState].readRequests.shift(),
     );
   }
 }
@@ -3177,7 +3188,7 @@ function setupReadableByteStreamController(
     pulling: false,
     started: false,
     stream,
-    queue: [],
+    queue: new BufferList(),
     queueTotalSize: 0,
     highWaterMark,
     pullAlgorithm,

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -146,7 +146,7 @@ function dequeueValue(controller) {
   const {
     value,
     size,
-  } = ArrayPrototypeShift(controller[kState].queue);
+  } = controller[kState].queue.shift();
   controller[kState].queueTotalSize =
     MathMax(0, controller[kState].queueTotalSize - size);
   return value;
@@ -155,7 +155,7 @@ function dequeueValue(controller) {
 function resetQueue(controller) {
   assert(controller[kState].queue !== undefined);
   assert(controller[kState].queueTotalSize !== undefined);
-  controller[kState].queue = [];
+  controller[kState].queue.clear();
   controller[kState].queueTotalSize = 0;
 }
 
@@ -163,7 +163,8 @@ function peekQueueValue(controller) {
   assert(controller[kState].queue !== undefined);
   assert(controller[kState].queueTotalSize !== undefined);
   assert(controller[kState].queue.length);
-  return controller[kState].queue[0].value;
+  debugger;
+  return controller[kState].queue.head.data.value;
 }
 
 function enqueueValueWithSize(controller, value, size) {
@@ -176,7 +177,7 @@ function enqueueValueWithSize(controller, value, size) {
       size === Infinity) {
     throw new ERR_INVALID_ARG_VALUE.RangeError('size', size);
   }
-  ArrayPrototypePush(controller[kState].queue, { value, size });
+  controller[kState].queue.push({ value, size });
   controller[kState].queueTotalSize += size;
 }
 

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -2,8 +2,6 @@
 
 const {
   ArrayBufferPrototypeSlice,
-  ArrayPrototypePush,
-  ArrayPrototypeShift,
   AsyncIteratorPrototype,
   FunctionPrototypeCall,
   MathMax,

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -78,6 +78,8 @@ const {
 
 const assert = require('internal/assert');
 
+const BufferList = require('internal/streams/buffer_list');
+
 const kAbort = Symbol('kAbort');
 const kCloseSentinel = Symbol('kCloseSentinel');
 const kError = Symbol('kError');
@@ -1269,7 +1271,7 @@ function setupWritableStreamDefaultController(
     abortAlgorithm,
     closeAlgorithm,
     highWaterMark,
-    queue: [],
+    queue: new BufferList(),
     queueTotalSize: 0,
     abortController: new AbortController(),
     sizeAlgorithm,


### PR DESCRIPTION
webstream possible improvement:

## `BufferList` implementation

```
00:24:29.343                                                                        confidence improvement accuracy (*)   (**)   (***)
00:24:29.343 webstreams/creation.js kind='ReadableStream' n=50000                                   1.04 %       ±3.94% ±5.25%  ±6.83%
00:24:29.343 webstreams/creation.js kind='TransformStream' n=50000                                  0.06 %       ±2.59% ±3.45%  ±4.52%
00:24:29.343 webstreams/creation.js kind='WritableStream' n=50000                                   0.19 %       ±4.60% ±6.12%  ±7.98%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=1024 n=100000                 1.58 %       ±4.24% ±5.64%  ±7.34%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=2048 n=100000                 1.13 %       ±4.28% ±5.69%  ±7.41%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=4096 n=100000                 1.50 %       ±4.50% ±5.99%  ±7.79%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=512 n=100000                  1.04 %       ±5.26% ±7.00%  ±9.12%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=1024 n=100000                 2.24 %       ±5.31% ±7.07%  ±9.20%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=2048 n=100000                 3.03 %       ±4.62% ±6.15%  ±8.00%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=4096 n=100000                 2.97 %       ±5.12% ±6.81%  ±8.86%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=512 n=100000                  3.92 %       ±4.65% ±6.19%  ±8.06%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=1024 n=100000                -0.04 %       ±4.14% ±5.50%  ±7.16%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=2048 n=100000                -1.05 %       ±4.87% ±6.48%  ±8.43%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=4096 n=100000                 2.22 %       ±4.57% ±6.07%  ±7.91%
00:24:29.343 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=512 n=100000                 -2.14 %       ±4.71% ±6.27%  ±8.16%
00:24:29.344 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=1024 n=100000                  1.56 %       ±4.40% ±5.85%  ±7.62%
00:24:29.344 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=2048 n=100000                  0.54 %       ±4.56% ±6.06%  ±7.89%
00:24:29.344 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=4096 n=100000                  3.16 %       ±4.44% ±5.91%  ±7.70%
00:24:29.344 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=512 n=100000                   0.90 %       ±4.70% ±6.26%  ±8.16%
00:24:29.344 webstreams/readable-async-iterator.js n=100000                                         0.03 %       ±7.40% ±9.84% ±12.81%
00:24:29.344 
00:24:29.344 Be aware that when doing many comparisons the risk of a false-positive
00:24:29.344 result increases. In this case, there are 20 comparisons, you can thus
00:24:29.344 expect the following amount of false-positive results:
00:24:29.344   1.00 false positives, when considering a   5% risk acceptance (*, **, ***),
00:24:29.344   0.20 false positives, when considering a   1% risk acceptance (**, ***),
00:24:29.344   0.02 false positives, when considering a 0.1% risk acceptance (***)
```

From my local tests:

Before
```
❯ ./node ./benchmark/webstreams/pipe-to.js
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=512 n=5000000: 1,073,259.5235043082
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=512 n=5000000: 1,112,582.388083188
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=512 n=5000000: 1,130,721.9334553012
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=512 n=5000000: 1,137,875.2107408328
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=1024 n=5000000: 1,145,415.4228369598
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=1024 n=5000000: 1,119,071.6166112064
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=1024 n=5000000: 1,112,401.620591177
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=1024 n=5000000: 1,122,177.222643778
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=2048 n=5000000: 1,154,120.0021085772
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=2048 n=5000000: 1,137,931.8271974607
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=2048 n=5000000: 1,150,085.2975136968
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=2048 n=5000000: 1,120,964.4298001872
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=4096 n=5000000: 1,126,744.873505527
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=4096 n=5000000: 1,148,843.5697545216
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=4096 n=5000000: 1,133,865.2778680783
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=4096 n=5000000: 1,132,648.4636818648
```

After
```
❯ ./node ./benchmark/webstreams/pipe-to.js
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=512 n=5000000: 1,191,920.5427624737
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=512 n=5000000: 1,199,980.044139869
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=512 n=5000000: 1,196,830.8757150145
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=512 n=5000000: 1,209,921.9163751516
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=1024 n=5000000: 1,199,785.7782492938
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=1024 n=5000000: 1,191,548.2411812833
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=1024 n=5000000: 1,205,993.3892632995
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=1024 n=5000000: 1,191,874.810445273
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=2048 n=5000000: 1,209,462.7154360572
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=2048 n=5000000: 1,187,768.408534668
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=2048 n=5000000: 1,195,187.8509158778
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=2048 n=5000000: 1,201,572.702366821
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=4096 n=5000000: 1,197,150.4825638772
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=4096 n=5000000: 1,179,266.3281946357
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=4096 n=5000000: 1,205,445.1767767125
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=4096 n=5000000: 1,235,058.8880696953
```
