### PR TITLE
test: show more info on failure in test-cli-syntax-require.js

### DIFF
--- a/test/sequential/test-cli-syntax-require.js
+++ b/test/sequential/test-cli-syntax-require.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const { spawn } = require('child_process');
+const { spawnSyncAndExit } = require('../common/child_process');
 const fixtures = require('../common/fixtures');
 
 const node = process.execPath;
@@ -17,25 +17,18 @@ const syntaxErrorRE = /^SyntaxError: \b/m;
     const preloadFile = fixtures.path('no-wrapper.js');
     const file = fixtures.path('syntax', 'illegal_if_not_wrapped.js');
     const args = [requireFlag, preloadFile, checkFlag, file];
-    const cp = spawn(node, args);
-
-    // No stdout should be produced
-    cp.stdout.on('data', common.mustNotCall('stdout data event'));
-
-    const stderrBuffer = [];
-    cp.stderr.on('data', (chunk) => stderrBuffer.push(chunk));
-
-    cp.on('exit', common.mustCall((code, signal) => {
-      assert.strictEqual(code, 1);
-      assert.strictEqual(signal, null);
-
-      const stderr = Buffer.concat(stderrBuffer).toString('utf-8');
-      // stderr should have a syntax error message
-      assert.match(stderr, syntaxErrorRE);
-
-      // stderr should include the filename
-      assert(stderr.startsWith(file), `${stderr} starts with ${file}`);
-    }));
-
+    spawnSyncAndExit(node, args, {
+      status: 1,
+      signal: null,
+      trim: true,
+      stdout: '',
+      stderr(output) {
+        // stderr should have a syntax error message
+        assert.match(output, syntaxErrorRE);
+  
+        // stderr should include the filename
+        assert(output.startsWith(file), `${output} starts with ${file}`);
+      }
+    });
   });
 });

--- a/test/sequential/test-cli-syntax-require.js
+++ b/test/sequential/test-cli-syntax-require.js
@@ -25,7 +25,7 @@ const syntaxErrorRE = /^SyntaxError: \b/m;
       stderr(output) {
         // stderr should have a syntax error message
         assert.match(output, syntaxErrorRE);
-  
+
         // stderr should include the filename
         assert(output.startsWith(file), `${output} starts with ${file}`);
       }


### PR DESCRIPTION
Use spawnSyncAndExit() to show more info when the tes fails.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
