### PR TITLE
net: improve performance of isIPv4 and isIPv6

### DIFF
--- a/benchmark/net/net-is-ip-v4.js
+++ b/benchmark/net/net-is-ip-v4.js
@@ -3,9 +3,13 @@
 const common = require('../common.js');
 const { isIPv4 } = require('net');
 
-const minIPv4 = '0.0.0.0';
-const maxIPv4 = '255.255.255.255';
-const invalid = '0.0.0.0.0';
+const ips = [
+  '0.0.0.0',
+  '255.255.255.255',
+  '0.0.0.0.0',
+  '192.168.0.1',
+  '10.168.209.250',
+];
 
 const bench = common.createBenchmark(main, {
   n: [1e7],
@@ -14,9 +18,8 @@ const bench = common.createBenchmark(main, {
 function main({ n }) {
   bench.start();
   for (let i = 0; i < n; ++i) {
-    isIPv4(minIPv4);
-    isIPv4(maxIPv4);
-    isIPv4(invalid);
+    for (let j = 0; j < ips.length; ++j)
+      isIPv4(ips[j]);
   }
   bench.end(n);
 }

--- a/benchmark/net/net-is-ip-v4.js
+++ b/benchmark/net/net-is-ip-v4.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common.js');
+const { isIPv4 } = require('net');
+
+const minIPv4 = '0.0.0.0';
+const maxIPv4 = '255.255.255.255';
+const invalid = '0.0.0.0.0';
+
+const bench = common.createBenchmark(main, {
+  n: [1e7],
+});
+
+function main({ n }) {
+  bench.start();
+  for (let i = 0; i < n; ++i) {
+    isIPv4(minIPv4);
+    isIPv4(maxIPv4);
+    isIPv4(invalid);
+  }
+  bench.end(n);
+}

--- a/benchmark/net/net-is-ip-v6.js
+++ b/benchmark/net/net-is-ip-v6.js
@@ -6,7 +6,7 @@ const { isIPv6 } = require('net');
 const ips = [
   '::1',
   'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
-  '0.0.0.0'
+  '0.0.0.0',
 ];
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/net/net-is-ip-v6.js
+++ b/benchmark/net/net-is-ip-v6.js
@@ -3,9 +3,11 @@
 const common = require('../common.js');
 const { isIPv6 } = require('net');
 
-const minIPv6 = '::1';
-const maxIPv6 = 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff';
-const invalid = '0.0.0.0';
+const ips = [
+  '::1',
+  'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+  '0.0.0.0'
+];
 
 const bench = common.createBenchmark(main, {
   n: [1e7],
@@ -14,9 +16,8 @@ const bench = common.createBenchmark(main, {
 function main({ n }) {
   bench.start();
   for (let i = 0; i < n; ++i) {
-    isIPv6(minIPv6);
-    isIPv6(maxIPv6);
-    isIPv6(invalid);
+    for (let j = 0; j < ips.length; ++j)
+      isIPv6(ips[j]);
   }
   bench.end(n);
 }

--- a/benchmark/net/net-is-ip-v6.js
+++ b/benchmark/net/net-is-ip-v6.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common.js');
+const { isIPv6 } = require('net');
+
+const minIPv6 = '::1';
+const maxIPv6 = 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff';
+const invalid = '0.0.0.0';
+
+const bench = common.createBenchmark(main, {
+  n: [1e7],
+});
+
+function main({ n }) {
+  bench.start();
+  for (let i = 0; i < n; ++i) {
+    isIPv6(minIPv6);
+    isIPv6(maxIPv6);
+    isIPv6(invalid);
+  }
+  bench.end(n);
+}

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -11,22 +11,22 @@ const { writeBuffer } = internalBinding('fs');
 const errors = require('internal/errors');
 
 // IPv4 Segment
-const v4Seg = '(?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
-const v4Str = `(${v4Seg}[.]){3}${v4Seg}`;
+const v4Seg = '(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])';
+const v4Str = `(?:${v4Seg}\.){3}${v4Seg}`;
 const IPv4Reg = new RegExp(`^${v4Str}$`);
 
 // IPv6 Segment
 const v6Seg = '(?:[0-9a-fA-F]{1,4})';
-const IPv6Reg = new RegExp('^(' +
+const IPv6Reg = new RegExp('^(?:' +
   `(?:${v6Seg}:){7}(?:${v6Seg}|:)|` +
   `(?:${v6Seg}:){6}(?:${v4Str}|:${v6Seg}|:)|` +
-  `(?:${v6Seg}:){5}(?::${v4Str}|(:${v6Seg}){1,2}|:)|` +
-  `(?:${v6Seg}:){4}(?:(:${v6Seg}){0,1}:${v4Str}|(:${v6Seg}){1,3}|:)|` +
-  `(?:${v6Seg}:){3}(?:(:${v6Seg}){0,2}:${v4Str}|(:${v6Seg}){1,4}|:)|` +
-  `(?:${v6Seg}:){2}(?:(:${v6Seg}){0,3}:${v4Str}|(:${v6Seg}){1,5}|:)|` +
-  `(?:${v6Seg}:){1}(?:(:${v6Seg}){0,4}:${v4Str}|(:${v6Seg}){1,6}|:)|` +
-  `(?::((?::${v6Seg}){0,5}:${v4Str}|(?::${v6Seg}){1,7}|:))` +
-')(%[0-9a-zA-Z-.:]{1,})?$');
+  `(?:${v6Seg}:){5}(?::${v4Str}|(?::${v6Seg}){1,2}|:)|` +
+  `(?:${v6Seg}:){4}(?:(?::${v6Seg}){0,1}:${v4Str}|(?::${v6Seg}){1,3}|:)|` +
+  `(?:${v6Seg}:){3}(?:(?::${v6Seg}){0,2}:${v4Str}|(?::${v6Seg}){1,4}|:)|` +
+  `(?:${v6Seg}:){2}(?:(?::${v6Seg}){0,3}:${v4Str}|(?::${v6Seg}){1,5}|:)|` +
+  `(?:${v6Seg}:){1}(?:(?::${v6Seg}){0,4}:${v4Str}|(?::${v6Seg}){1,6}|:)|` +
+  `(?::(?:(?::${v6Seg}){0,5}:${v4Str}|(?::${v6Seg}){1,7}|:))` +
+')(?:%[0-9a-zA-Z-.:]{1,})?$');
 
 function isIPv4(s) {
   // TODO(aduh95): Replace RegExpPrototypeTest with RegExpPrototypeExec when it

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -12,7 +12,7 @@ const errors = require('internal/errors');
 
 // IPv4 Segment
 const v4Seg = '(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])';
-const v4Str = `(?:${v4Seg}\.){3}${v4Seg}`;
+const v4Str = `(?:${v4Seg}\\.){3}${v4Seg}`;
 const IPv4Reg = new RegExp(`^${v4Str}$`);
 
 // IPv6 Segment


### PR DESCRIPTION
Basically making the a capturing group to be non capturing.

I dont know how to bench the performance on nodejs

This is my benchmark:

```js
'use strict'

const { isIPv4: isIPv4builtIn } = require('net')
const benchmark = require('benchmark')
const suite = new benchmark.Suite()

const ipMax = '255.255.255.255'
const ipMin = '0.0.0.0'
const invalid = '0.0.0.0.0'

const isIPv4RE = /^(?:(?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])[.]){3}(?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$/

suite.add('RE', function () {
  isIPv4RE.test(ipMin)
  isIPv4RE.test(ipMax)
  isIPv4RE.test(invalid)
})
suite.add('builtIn', function () {
  isIPv4builtIn(ipMin)
  isIPv4builtIn(ipMax)
  isIPv4builtIn(invalid)
})


suite.on('cycle', function onCycle(event) {
  console.log(String(event.target))
})

suite.run({ async: false })

```

result:

aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/proxy-addr$ node benchmark/is-ipv4.js 
RE x 12,055,141 ops/sec ±1.49% (93 runs sampled)
builtIn x 8,672,332 ops/sec ±0.70% (94 runs sampled)