### PR TITLE
test: use setImmediate() in test-heapdump-shadowrealm.js

### DIFF
--- a/test/pummel/test-heapdump-shadow-realm.js
+++ b/test/pummel/test-heapdump-shadow-realm.js
@@ -4,29 +4,39 @@ require('../common');
 const { validateSnapshotNodes } = require('../common/heap');
 
 validateSnapshotNodes('Node / ShadowRealm', []);
-const realm = new ShadowRealm();
-{
-  // Create a bunch of un-referenced ShadowRealms to make sure the heap
-  // snapshot can handle it.
-  for (let i = 0; i < 100; i++) {
-    const realm = new ShadowRealm();
+
+let realm;
+let counter = 0;
+// Create a bunch of un-referenced ShadowRealms to make sure the heap
+// snapshot can handle it.
+function createRealms() {
+  // Use setImmediate to give GC some time to kick in to avoid OOM.
+  if (counter++ < 100) {
+    realm = new ShadowRealm();
+    realm.evaluate('undefined');
+    setImmediate(createRealms);
+  } else {
+    validateHeap();
+    // Keep the realm alive.
     realm.evaluate('undefined');
   }
 }
-validateSnapshotNodes('Node / Environment', [
-  {
-    children: [
-      { node_name: 'Node / shadow_realms', edge_name: 'shadow_realms' },
-    ],
-  },
-]);
-validateSnapshotNodes('Node / shadow_realms', [
-  {
-    children: [
-      { node_name: 'Node / ShadowRealm' },
-    ],
-  },
-]);
 
-// Keep the realm alive.
-realm.evaluate('undefined');
+function validateHeap() {
+  validateSnapshotNodes('Node / Environment', [
+    {
+      children: [
+        { node_name: 'Node / shadow_realms', edge_name: 'shadow_realms' },
+      ],
+    },
+  ]);
+  validateSnapshotNodes('Node / shadow_realms', [
+    {
+      children: [
+        { node_name: 'Node / ShadowRealm' },
+      ],
+    },
+  ]);
+}
+
+createRealms();


### PR DESCRIPTION
With a tight loop the GC may not have enough time to kick in. Try setImmediate() instead.

Refs: https://github.com/nodejs/node/issues/49572

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
