### PR TITLE
test: deflake test-http-regr-gh-2928

### DIFF
--- a/test/sequential/test-http-regr-gh-2928.js
+++ b/test/sequential/test-http-regr-gh-2928.js
@@ -25,7 +25,7 @@ function execAndClose() {
   const parser = parsers.pop();
   parser.initialize(HTTPParser.RESPONSE, {});
 
-  const socket = net.connect(common.PORT);
+  const socket = net.connect(common.PORT, common.localhostIPv4);
   socket.on('error', (e) => {
     // If SmartOS and ECONNREFUSED, then retry. See
     // https://github.com/nodejs/node/issues/2663.
@@ -57,7 +57,7 @@ const server = net.createServer(function(c) {
   c.end('HTTP/1.1 200 OK\r\n\r\n', function() {
     c.destroySoon();
   });
-}).listen(common.PORT, execAndClose);
+}).listen(common.PORT, common.localhostIPv4, execAndClose);
 
 process.on('exit', function() {
   assert.strictEqual(gotResponses, COUNT);


### PR DESCRIPTION
Hard code the value of the host parameter to `common.localhostIPv4` in
`server.listen()` and `net.connect()`. This

1. ensures that the client `socket._handle` is not reinitialized during
   connection due to the family autodetection algorithm, preventing
   `parser.consume()` from being called with an invalid `socket._handle`
   parameter.
2. works around an issue in the FreeBSD 12 machine where the stress test
   is run where some sockets get stuck after connection.

Closes: https://github.com/nodejs/node/pull/49565
Fixes: https://github.com/nodejs/node/issues/49564

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
