### PR TITLE
benchmark: shorten pipe-to by reducing number of chunks

### DIFF
--- a/benchmark/webstreams/pipe-to.js
+++ b/benchmark/webstreams/pipe-to.js
@@ -6,7 +6,7 @@ const {
 } = require('node:stream/web');
 
 const bench = common.createBenchmark(main, {
-  n: [5e6],
+  n: [5e5],
   highWaterMarkR: [512, 1024, 2048, 4096],
   highWaterMarkW: [512, 1024, 2048, 4096],
 });


### PR DESCRIPTION
without this, it takes 2.5 hours:

each iteration (single combination) takes 9 seconds (saw [here](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1369/)).

there are 16 possible combinations.
so 9 seconds * 16 combination * 30 default runs * 2 versions = 2 hours and 24 minutes...