### PR TITLE
process: make `exitCode` configurable again

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -129,7 +129,7 @@ process.domain = null;
       exitCode = code;
     },
     enumerable: true,
-    configurable: false,
+    configurable: true,
   });
 }
 process._exiting = false;

--- a/test/parallel/test-process-exit-code-validation.js
+++ b/test/parallel/test-process-exit-code-validation.js
@@ -110,17 +110,14 @@ if (process.argv[2] === undefined) {
 
   // Check process.exitCode
   for (const arg of invalids) {
-    debug(`invaild code: ${inspect(arg.code)}`);
+    debug(`invalid code: ${inspect(arg.code)}`);
     throws(() => (process.exitCode = arg.code), new RegExp(arg.pattern));
   }
   for (const arg of valids) {
-    debug(`vaild code: ${inspect(arg.code)}`);
+    debug(`valid code: ${inspect(arg.code)}`);
     process.exitCode = arg.code;
   }
 
-  throws(() => {
-    delete process.exitCode;
-  }, /Cannot delete property 'exitCode' of #<process>/);
   process.exitCode = 0;
 
   // Check process.exit([code])
@@ -140,4 +137,11 @@ if (process.argv[2] === undefined) {
   } else {
     process.exit(args[index].code);
   }
+}
+
+const origExitCode = Object.getOwnPropertyDescriptor(process, 'exitCode');
+try {
+  delete process.exitCode;
+} finally {
+  Object.defineProperty(process, 'exitCode', origExitCode);
 }


### PR DESCRIPTION
This change was done in #44711, and it was [unintentional](https://github.com/nodejs/node/issues/45683#issuecomment-1331595523). It caused #45683, and also makes it impossible to mock out the exitCode in tests. It affects all of node 19, and all of node 20 thus far (so it should not be backported to node 18 or earlier)

Filing this PR per https://github.com/nodejs/node/pull/44711#discussion_r1320660607

Refs: https://github.com/nodejs/node/pull/44711
Fixes: https://github.com/nodejs/node/issues/45683

cc @nodejs/process @nlf @daeyeon