### PR TITLE
errors: use `determineSpecificType` in more error messages

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1349,17 +1349,11 @@ E('ERR_INVALID_REPL_EVAL_CONFIG',
 E('ERR_INVALID_REPL_INPUT', '%s', TypeError);
 E('ERR_INVALID_RETURN_PROPERTY', (input, name, prop, value) => {
   return `Expected a valid ${input} to be returned for the "${prop}" from the` +
-         ` "${name}" function but got ${value}.`;
+         ` "${name}" function but got ${determineSpecificType(value)}.`;
 }, TypeError);
 E('ERR_INVALID_RETURN_PROPERTY_VALUE', (input, name, prop, value) => {
-  let type;
-  if (value?.constructor?.name) {
-    type = `instance of ${value.constructor.name}`;
-  } else {
-    type = `type ${typeof value}`;
-  }
   return `Expected ${input} to be returned for the "${prop}" from the` +
-         ` "${name}" function but got ${type}.`;
+         ` "${name}" function but got ${determineSpecificType(value)}.`;
 }, TypeError);
 E('ERR_INVALID_RETURN_VALUE', (input, name, value) => {
   const type = determineSpecificType(value);


### PR DESCRIPTION
Before it would have say something like `Expected a … to be returned for the "…" from the function but got an instance of String.`, and with this PR it would say the more useful and more correct `Expected a … to be returned for the "…" from the function but got type string ('the input string')`.

Fixes: https://github.com/nodejs/node/issues/49576
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
