### PR TITLE
esm: set all module customization hooks as release candidate

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -86,7 +86,7 @@ isBuiltin('wss'); // false
 added: v20.6.0
 -->
 
-> Stability: 1.1 - Active development
+> Stability: 1.2 - Release candidate
 
 * `specifier` {string} Customization hooks to be registered; this should be the
   same string that would be passed to `import()`, except that if it is relative,
@@ -166,7 +166,7 @@ changes:
                  `globalPreload`; added `load` hook and `getGlobalPreload` hook.
 -->
 
-> Stability: 1.1 - Active development
+> Stability: 1.2 - Release candidate
 
 <!-- type=misc -->
 
@@ -385,7 +385,7 @@ asynchronous operations (like `console.log`) to complete.
 added: v20.6.0
 -->
 
-> Stability: 1.1 - Active development
+> Stability: 1.2 - Release candidate
 
 * `data` {any} The data from `register(loader, import.meta.url, { data })`.
 


### PR DESCRIPTION
With #49144, we have completed the [loaders roadmap Milestone 2](https://github.com/nodejs/loaders#milestone-2-stability). That milestone included everything that we thought needed to be done before potentially calling the module customization hooks stable. The hooks API as currently described in the documentation is hopefully the final design. It can get additions in the future, like any Node API, but we hope that there will be no more breaking changes to what’s there now.

This PR changes the stability levels for `register`, `initialize` and the hooks generally to stability index 1.2, release candidate. Once they have been at this level for a while with no reported bugs or issues, another PR will move them to stable. @nodejs/loaders 

### Notable changes

#### Module customization hooks nearing stability

The [module customization hooks](https://nodejs.org/api/module.html#customization-hooks), formerly the Loaders API, have been classified as “release candidate.” We hope there are no further breaking changes to these APIs, which include the `node:module` API [`register`](https://nodejs.org/api/module.html#moduleregister) and the hooks [`initialize`](https://nodejs.org/api/module.html#initialize), [`resolve`](https://nodejs.org/api/module.html#resolve), and [`load`](https://nodejs.org/api/module.html#load).