### PR TITLE
util: runtime deprecate `promisify`-ing a function returning a `Promise`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3388,11 +3388,14 @@ Consider using alternatives such as the [`mock`][] helper function.
 <!-- YAML
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/49609
+    description: Runtime deprecation.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/49647
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Calling [`util.promisify`][] on a function that returns a <Promise> will ignore
 the result of said promise, which can lead to unhandled promise rejections.

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -63,7 +63,7 @@ const {
   sleep: _sleep,
   toUSVString: _toUSVString,
 } = internalBinding('util');
-const { isNativeError } = internalBinding('types');
+const { isNativeError, isPromise } = internalBinding('types');
 const { getOptionValue } = require('internal/options');
 
 const noCrypto = !process.versions.openssl;
@@ -409,7 +409,9 @@ function promisify(original) {
           resolve(values[0]);
         }
       });
-      ReflectApply(original, this, args);
+      if (isPromise(ReflectApply(original, this, args))) {
+        process.emitWarning('Calling promisify on a function that returns a Promise is likely a mistake.');
+      }
     });
   }
 

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -410,7 +410,8 @@ function promisify(original) {
         }
       });
       if (isPromise(ReflectApply(original, this, args))) {
-        process.emitWarning('Calling promisify on a function that returns a Promise is likely a mistake.');
+        process.emitWarning('Calling promisify on a function that returns a Promise is likely a mistake.',
+                            'DeprecationWarning', 'DEP0174');
       }
     });
   }

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -16,9 +16,17 @@ const { customPromisifyArgs } = require('internal/util');
   process.off('warning', warningHandler);
 }
 
-common.expectWarning('Warning', 'Calling promisify on a function that returns a Promise is likely a mistake.');
+common.expectWarning(
+  'DeprecationWarning',
+  'Calling promisify on a function that returns a Promise is likely a mistake.',
+  'DEP0174');
 promisify(async (callback) => { callback(); })().then(common.mustCall(() => {
-  common.expectWarning('Warning', 'Calling promisify on a function that returns a Promise is likely a mistake.');
+  // We must add the second `expectWarning` call in the `.then` handler, when
+  // the first warning has already been triggered.
+  common.expectWarning(
+    'DeprecationWarning',
+    'Calling promisify on a function that returns a Promise is likely a mistake.',
+    'DEP0174');
   promisify(async () => {})().then(common.mustNotCall());
 }));
 

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -7,6 +7,21 @@ const vm = require('vm');
 const { promisify } = require('util');
 const { customPromisifyArgs } = require('internal/util');
 
+{
+  const warningHandler = common.mustNotCall();
+  process.on('warning', warningHandler);
+  function foo() {}
+  foo.constructor = (async () => {}).constructor;
+  promisify(foo);
+  process.off('warning', warningHandler);
+}
+
+common.expectWarning('Warning', 'Calling promisify on a function that returns a Promise is likely a mistake.');
+promisify(async (callback) => { callback(); })().then(common.mustCall(() => {
+  common.expectWarning('Warning', 'Calling promisify on a function that returns a Promise is likely a mistake.');
+  promisify(async () => {})().then(common.mustNotCall());
+}));
+
 const stat = promisify(fs.stat);
 
 {


### PR DESCRIPTION
My goal would be for this deprecation to never reach EOL, and stay as runtime deprecated forever. The warning it produces should help folks who run into the linked issue figure out what's happening.

```js
// file.js

const promisified = promisify(async () => {});

promisified();
```

`node --trace-warnings file.js` will show `at file.js:5:1` – so not where the `promisify` call happened, but where the promisified function was called. Hopefully that will give enough info to debug it.

Fixes: https://github.com/nodejs/node/issues/49607
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
