### PR TITLE
stream: avoid tick in writable hot path

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -472,6 +472,8 @@ function onwrite(stream, er) {
     }
 
     if (sync) {
+      const needDrain = state.length === 0 && state.needDrain;
+
       // It is a common case that the callback passed to .write() is always
       // the same. In that case, we do not schedule a new nextTick(), but
       // rather just increase a counter, to improve performance and avoid
@@ -479,9 +481,12 @@ function onwrite(stream, er) {
       if (state.afterWriteTickInfo !== null &&
           state.afterWriteTickInfo.cb === cb) {
         state.afterWriteTickInfo.count++;
-      } else {
+      } else if (needDrain || state.destroyed || cb !== nop) {
         state.afterWriteTickInfo = { count: 1, cb, stream, state };
         process.nextTick(afterWriteTick, state.afterWriteTickInfo);
+      } else {
+        state.pendingcb--;
+        finishMaybe(stream, state, true);
       }
     } else {
       afterWrite(stream, state, 1, cb);
@@ -629,8 +634,22 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   }
 
   if (err) {
-    // Do nothing...
-  } else if (!state.errored && !state.ending) {
+    if (cb) {
+      process.nextTick(cb, err);
+    }
+  } else if (state.finished) {
+    if (cb) {
+      process.nextTick(cb, new ERR_STREAM_ALREADY_FINISHED('end'));
+    }
+  } else if (state.destroyed) {
+    if (cb) {
+      process.nextTick(cb, new ERR_STREAM_DESTROYED('end'));
+    }
+  } else if (state.ending) {
+    if (cb) {
+      state[kOnFinished].push(cb);
+    }
+  } else {
     // This is forgiving in terms of unnecessary calls to end() and can hide
     // logic errors. However, usually such errors are harmless and causing a
     // hard error can be disproportionately destructive. It is not always
@@ -638,22 +657,11 @@ Writable.prototype.end = function(chunk, encoding, cb) {
     // or not.
 
     state.ending = true;
-    finishMaybe(this, state, true);
-    state.ended = true;
-  } else if (state.finished) {
-    err = new ERR_STREAM_ALREADY_FINISHED('end');
-  } else if (state.destroyed) {
-    err = new ERR_STREAM_DESTROYED('end');
-  }
-
-  if (typeof cb === 'function') {
-    if (err) {
-      process.nextTick(cb, err);
-    } else if (state.finished) {
-      process.nextTick(cb, null);
-    } else {
+    if (cb) {
       state[kOnFinished].push(cb);
     }
+    finishMaybe(this, state, true);
+    state.ended = true;
   }
 
   return this;


### PR DESCRIPTION
This avoids a next tick in a hot path. 

I haven't been contributing so much with streams or performance lately. Hopefully this does something.