### PR TITLE
[v20.x backport] stream: improve tee perf by reduce `ReflectConstruct` usages

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1200,34 +1200,43 @@ ObjectDefineProperties(ReadableByteStreamController.prototype, {
   [SymbolToStringTag]: getNonWritablePropertyDescriptor(ReadableByteStreamController.name),
 });
 
+function TeeReadableStream(start, pull, cancel) {
+  this[kType] = 'ReadableStream';
+  this[kState] = {
+    disturbed: false,
+    state: 'readable',
+    storedError: undefined,
+    stream: undefined,
+    transfer: {
+      writable: undefined,
+      port: undefined,
+      promise: undefined,
+    },
+  };
+  this[kIsClosedPromise] = createDeferredPromise();
+  setupReadableStreamDefaultControllerFromSource(
+    this,
+    ObjectCreate(null, {
+      start: { __proto__: null, value: start },
+      pull: { __proto__: null, value: pull },
+      cancel: { __proto__: null, value: cancel },
+    }),
+    1,
+    () => 1);
+
+
+  return makeTransferable(this);
+}
+
+ObjectSetPrototypeOf(TeeReadableStream.prototype, ReadableStream.prototype);
+ObjectSetPrototypeOf(TeeReadableStream, ReadableStream);
+
 function createTeeReadableStream(start, pull, cancel) {
-  return ReflectConstruct(
-    function() {
-      this[kType] = 'ReadableStream';
-      this[kState] = {
-        disturbed: false,
-        state: 'readable',
-        storedError: undefined,
-        stream: undefined,
-        transfer: {
-          writable: undefined,
-          port: undefined,
-          promise: undefined,
-        },
-      };
-      this[kIsClosedPromise] = createDeferredPromise();
-      setupReadableStreamDefaultControllerFromSource(
-        this,
-        ObjectCreate(null, {
-          start: { __proto__: null, value: start },
-          pull: { __proto__: null, value: pull },
-          cancel: { __proto__: null, value: cancel },
-        }),
-        1,
-        () => 1);
-      return makeTransferable(this);
-    }, [], ReadableStream,
-  );
+  const tee = new TeeReadableStream(start, pull, cancel);
+
+  // For spec compliance the Tee must be a ReadableStream
+  tee.constructor = ReadableStream;
+  return tee;
 }
 
 const isReadableStream =


### PR DESCRIPTION
also added more webstream creation benchmarks

PR-URL: https://github.com/nodejs/node/pull/49546
Reviewed-By: Yagiz Nizipli <yagiz@nizipli.com>
Reviewed-By: Matteo Collina <matteo.collina@gmail.com>

