### PR TITLE
test: skip test-child-process-stdio-reuse-readable-stdio on Windows

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -11,9 +11,6 @@ prefix parallel
 test-crypto-keygen: PASS,FLAKY
 # https://github.com/nodejs/node/issues/41201
 test-fs-rmdir-recursive: PASS, FLAKY
-# https://github.com/nodejs/node/issues/48300
-test-child-process-pipe-dataflow: SKIP
-test-child-process-stdio-reuse-readable-stdio: PASS, FLAKY
 
 # Windows on ARM
 [$system==win32 && $arch==arm64]

--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -1,5 +1,11 @@
 'use strict';
 const common = require('../common');
+
+if (common.isWindows) {
+  // https://github.com/nodejs/node/issues/48300
+  common.skip('Does not work with cygwin quirks on Windows');
+}
+
 const assert = require('assert');
 const fs = require('fs');
 const spawn = require('child_process').spawn;

--- a/test/parallel/test-child-process-stdio-reuse-readable-stdio.js
+++ b/test/parallel/test-child-process-stdio-reuse-readable-stdio.js
@@ -1,5 +1,11 @@
 'use strict';
 const common = require('../common');
+
+if (common.isWindows) {
+  // https://github.com/nodejs/node/issues/48300
+  common.skip('Does not work with cygwin quirks on Windows');
+}
+
 const assert = require('assert');
 const { spawn } = require('child_process');
 


### PR DESCRIPTION
It is flaky due to the same cause of test-child-process-pipe-dataflow being flaky - cygwin quirks - so skip it on Windows too.

Drive-by: remove the skip mark of test-child-process-pipe-dataflow in the status file and directly skip it in the test with a comment.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
