### PR TITLE
benchmark: add a benchmark for read() of ReadableStreams

### DIFF
--- a/benchmark/webstreams/readable-read.js
+++ b/benchmark/webstreams/readable-read.js
@@ -11,7 +11,7 @@ async function main({ n, type }) {
   switch (type) {
     case 'normal': {
       const rs = new ReadableStream({
-        pull: function (controller) {
+        pull: function(controller) {
           controller.enqueue('a');
         },
       });
@@ -30,7 +30,7 @@ async function main({ n, type }) {
       const encode = new TextEncoder();
       const rs = new ReadableStream({
         type: 'bytes',
-        pull: function (controller) {
+        pull: function(controller) {
           controller.enqueue(encode.encode('a'));
         },
       });

--- a/benchmark/webstreams/readable-read.js
+++ b/benchmark/webstreams/readable-read.js
@@ -1,0 +1,49 @@
+'use strict';
+const common = require('../common.js');
+const { ReadableStream } = require('node:stream/web');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+  type: ['normal', 'byob'],
+});
+
+async function main({ n, type }) {
+  switch (type) {
+    case 'normal': {
+      const rs = new ReadableStream({
+        pull: function (controller) {
+          controller.enqueue('a');
+        },
+      });
+      const reader = rs.getReader();
+      let x = null;
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        const { value } = await reader.read();
+        x = value;
+      }
+      bench.end(n);
+      console.assert(x);
+      break;
+    }
+    case 'byob': {
+      const encode = new TextEncoder();
+      const rs = new ReadableStream({
+        type: 'bytes',
+        pull: function (controller) {
+          controller.enqueue(encode.encode('a'));
+        },
+      });
+      const reader = rs.getReader({ mode: 'byob' });
+      let x = null;
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        const { value } = await reader.read(new Uint8Array(1));
+        x = value;
+      }
+      bench.end(n);
+      console.assert(x);
+      break;
+    }
+  }
+}


### PR DESCRIPTION
While looking at https://github.com/nodejs/performance/issues/82 and trying to find a way to optimise read() realised that there is no specific benchmark for the read() function and the byob variant of read too

Refs: https://github.com/nodejs/performance/issues/82

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
