### PR TITLE
esm: update loaders warning

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -499,7 +499,6 @@ class CustomizedModuleLoader {
   }
 }
 
-let emittedExperimentalWarning = false;
 /**
  * A loader instance is used as the main entry point for loading ES modules. Currently, this is a singleton; there is
  * only one used for loading the main module and everything in its dependency graph, though separate instances of this
@@ -515,10 +514,6 @@ function createModuleLoader(useCustomLoadersIfPresent = true) {
       !require('internal/modules/esm/utils').isLoaderWorker()) {
     const userLoaderPaths = getOptionValue('--experimental-loader');
     if (userLoaderPaths.length > 0) {
-      if (!emittedExperimentalWarning) {
-        emitExperimentalWarning('Custom ESM Loaders');
-        emittedExperimentalWarning = true;
-      }
       customizations = new CustomizedModuleLoader();
     }
   }

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -6,6 +6,7 @@ require('internal/modules/cjs/loader');
 const {
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
+  encodeURI,
   FunctionPrototypeCall,
   JSONStringify,
   ObjectSetPrototypeOf,
@@ -523,7 +524,7 @@ function createModuleLoader(useCustomLoadersIfPresent = true) {
           '`--experimental-loader` may be removed in the future; instead use `register()`:\n' +
           `--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; ${ArrayPrototypeJoin(
             ArrayPrototypeMap(userLoaderPaths, (loader) => `register(${JSONStringify(encodeURI(loader))}, pathToFileURL("./"))`),
-            "; ",
+            '; ',
           )};'`,
           'ExperimentalWarning',
         );

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -499,6 +499,7 @@ class CustomizedModuleLoader {
   }
 }
 
+let emittedLoaderFlagWarning = false;
 /**
  * A loader instance is used as the main entry point for loading ES modules. Currently, this is a singleton; there is
  * only one used for loading the main module and everything in its dependency graph, though separate instances of this
@@ -514,6 +515,13 @@ function createModuleLoader(useCustomLoadersIfPresent = true) {
       !require('internal/modules/esm/utils').isLoaderWorker()) {
     const userLoaderPaths = getOptionValue('--experimental-loader');
     if (userLoaderPaths.length > 0) {
+      if (!emittedLoaderFlagWarning) {
+        process.emitWarning(
+          '`--experimental-loader` may be removed in the future; instead use `--import` to reference a file that calls `register()`',
+          'ExperimentalWarning',
+        );
+        emittedLoaderFlagWarning = true;
+      }
       customizations = new CustomizedModuleLoader();
     }
   }

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -4,7 +4,10 @@
 require('internal/modules/cjs/loader');
 
 const {
+  ArrayPrototypeJoin,
+  ArrayPrototypeMap,
   FunctionPrototypeCall,
+  JSONStringify,
   ObjectSetPrototypeOf,
   SafeWeakMap,
 } = primordials;
@@ -517,7 +520,11 @@ function createModuleLoader(useCustomLoadersIfPresent = true) {
     if (userLoaderPaths.length > 0) {
       if (!emittedLoaderFlagWarning) {
         process.emitWarning(
-          '`--experimental-loader` may be removed in the future; instead use `--import` to reference a file that calls `register()`',
+          '`--experimental-loader` may be removed in the future; instead use `register()`:\n' +
+          `--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; ${ArrayPrototypeJoin(
+            ArrayPrototypeMap(userLoaderPaths, (loader) => `register(${JSONStringify(encodeURI(loader))}, pathToFileURL("./"))`),
+            "; ",
+          )};'`,
           'ExperimentalWarning',
         );
         emittedLoaderFlagWarning = true;

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -6,11 +6,14 @@ require('internal/modules/cjs/loader');
 const {
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
-  encodeURI,
+  ArrayPrototypeReduce,
   FunctionPrototypeCall,
   JSONStringify,
   ObjectSetPrototypeOf,
+  RegExpPrototypeSymbolReplace,
   SafeWeakMap,
+  encodeURIComponent,
+  hardenRegExp,
 } = primordials;
 
 const {
@@ -520,10 +523,18 @@ function createModuleLoader(useCustomLoadersIfPresent = true) {
     const userLoaderPaths = getOptionValue('--experimental-loader');
     if (userLoaderPaths.length > 0) {
       if (!emittedLoaderFlagWarning) {
+        const readableURIEncode = (string) => ArrayPrototypeReduce(
+          [
+            [/'/g, '%27'], // We need to URL-encode the single quote as it's the delimiter for the --import flag.
+            [/%22/g, '"'], // We can decode the double quotes to improve readability.
+            [/%2F/ig, '/'], // We can decode the slashes to improve readability.
+          ],
+          (str, { 0: regex, 1: replacement }) => RegExpPrototypeSymbolReplace(hardenRegExp(regex), str, replacement),
+          encodeURIComponent(string));
         process.emitWarning(
           '`--experimental-loader` may be removed in the future; instead use `register()`:\n' +
           `--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; ${ArrayPrototypeJoin(
-            ArrayPrototypeMap(userLoaderPaths, (loader) => `register(${JSONStringify(encodeURI(loader))}, pathToFileURL("./"))`),
+            ArrayPrototypeMap(userLoaderPaths, (loader) => `register(${readableURIEncode(JSONStringify(loader))}, pathToFileURL("./"))`),
             '; ',
           )};'`,
           'ExperimentalWarning',

--- a/test/es-module/test-esm-experimental-warnings.mjs
+++ b/test/es-module/test-esm-experimental-warnings.mjs
@@ -25,7 +25,6 @@ describe('ESM: warn for obsolete hooks provided', { concurrency: true }, () => {
   describe('experimental warnings for enabled experimental feature', () => {
     for (
       const [experiment, arg] of [
-        [/Custom ESM Loaders/, `--experimental-loader=${fileURL('es-module-loaders', 'hooks-custom.mjs')}`],
         [/Network Imports/, '--experimental-network-imports'],
       ]
     ) {

--- a/test/es-module/test-esm-experimental-warnings.mjs
+++ b/test/es-module/test-esm-experimental-warnings.mjs
@@ -27,7 +27,8 @@ describe('ESM: warn for obsolete hooks provided', { concurrency: true }, () => {
       const [experiment, arg] of [
         [
           /`--experimental-loader` may be removed in the future/,
-          `--experimental-loader=${fileURL('es-module-loaders', 'hooks-custom.mjs')}`
+          '--experimental-loader',
+          fileURL('es-module-loaders', 'hooks-custom.mjs'),
         ],
         [/Network Imports/, '--experimental-network-imports'],
       ]

--- a/test/es-module/test-esm-experimental-warnings.mjs
+++ b/test/es-module/test-esm-experimental-warnings.mjs
@@ -35,7 +35,7 @@ describe('ESM: warn for obsolete hooks provided', { concurrency: true }, () => {
     ) {
       it(`should print for ${experiment.toString().replaceAll('/', '')}`, async () => {
         const { code, signal, stderr } = await spawnPromisified(execPath, [
-          arg,
+          ...args,
           '--input-type=module',
           '--eval',
           `import ${JSON.stringify(fileURL('es-module-loaders', 'module-named-exports.mjs'))}`,

--- a/test/es-module/test-esm-experimental-warnings.mjs
+++ b/test/es-module/test-esm-experimental-warnings.mjs
@@ -24,7 +24,7 @@ describe('ESM: warn for obsolete hooks provided', { concurrency: true }, () => {
 
   describe('experimental warnings for enabled experimental feature', () => {
     for (
-      const [experiment, arg] of [
+      const [experiment, ...args] of [
         [
           /`--experimental-loader` may be removed in the future/,
           '--experimental-loader',

--- a/test/es-module/test-esm-experimental-warnings.mjs
+++ b/test/es-module/test-esm-experimental-warnings.mjs
@@ -25,6 +25,10 @@ describe('ESM: warn for obsolete hooks provided', { concurrency: true }, () => {
   describe('experimental warnings for enabled experimental feature', () => {
     for (
       const [experiment, arg] of [
+        [
+          /`--experimental-loader` may be removed in the future/,
+          `--experimental-loader=${fileURL('es-module-loaders', 'hooks-custom.mjs')}`
+        ],
         [/Network Imports/, '--experimental-network-imports'],
       ]
     ) {


### PR DESCRIPTION
Following up https://github.com/nodejs/node/pull/49597, this PR edits the warning when `--experimental-loader` / `--loader` is used to tell people to use `--import` / `register()` instead, which has no warning. The separate warning about `globalPreload` remains.