### PR TITLE
doc: remove `@anonrig` from performance initiative

### DIFF
--- a/doc/contributing/strategic-initiatives.md
+++ b/doc/contributing/strategic-initiatives.md
@@ -15,7 +15,7 @@ agenda to ensure they are active and have the support they need.
 | V8 Currency            | [Michaël Zasso][targos]     |                                               |
 | Next-10                | [Michael Dawson][mhdawson]  | <https://github.com/nodejs/next-10>           |
 | Single executable apps | [Darshan Sen][RaisinTen]    | <https://github.com/nodejs/node/issues/43432> |
-| Performance            | [Yagiz Nizipli][anonrig]    | <https://github.com/nodejs/performance>       |
+| Performance            |                             | <https://github.com/nodejs/performance>       |
 
 <details>
 <summary>List of completed initiatives</summary>
@@ -40,7 +40,6 @@ agenda to ensure they are active and have the support they need.
 
 [RaisinTen]: https://github.com/RaisinTen
 [aduh95]: https://github.com/aduh95
-[anonrig]: https://github.com/anonrig
 [jasnell]: https://github.com/jasnell
 [joyeecheung]: https://github.com/joyeecheung
 [legendecas]: https://github.com/legendecas


### PR DESCRIPTION
I'll continue working on performance but I don't feel comfortable being the champion of the performance strategic initiative anymore.