### PR TITLE
errors: improve formatList in errors.js

### DIFF
--- a/benchmark/error/format-list.js
+++ b/benchmark/error/format-list.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [1e7],
+  input: [
+    '',
+    'a',
+    'a,b',
+    'a,b,c',
+    'a,b,c,d',
+  ],
+  type: [
+    'undefined',
+    'and',
+    'or',
+  ],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function main({ n, input, type }) {
+  const {
+    formatList,
+  } = require('internal/errors');
+
+  const list = input.split(',');
+
+  if (type === 'undefined') {
+    bench.start();
+    for (let i = 0; i < n; ++i) {
+      formatList(list);
+    }
+    bench.end(n);
+    return;
+  }
+
+  bench.start();
+  for (let i = 0; i < n; ++i) {
+    formatList(list, type);
+  }
+  bench.end(n);
+}

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -902,8 +902,14 @@ function determineSpecificType(value) {
  * @returns {string}
  */
 function formatList(array, type = 'and') {
-  return array.length < 3 ? ArrayPrototypeJoin(array, ` ${type} `) :
-    `${ArrayPrototypeJoin(ArrayPrototypeSlice(array, 0, -1), ', ')}, ${type} ${array[array.length - 1]}`;
+  switch (array.length) {
+    case 0: return '';
+    case 1: return `${array[0]}`;
+    case 2: return `${array[0]} ${type} ${array[1]}`;
+    case 3: return `${array[0]}, ${array[1]}, ${type} ${array[2]}`;
+    default:
+      return `${ArrayPrototypeJoin(ArrayPrototypeSlice(array, 0, -1), ', ')}, ${type} ${array[array.length - 1]}`;
+  }
 }
 
 module.exports = {

--- a/test/parallel/test-error-format-list.js
+++ b/test/parallel/test-error-format-list.js
@@ -11,7 +11,7 @@ if (!common.hasIntl) common.skip('missing Intl');
   const and = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
   const or = new Intl.ListFormat('en', { style: 'long', type: 'disjunction' });
 
-  const input = ['apple', 'banana', 'orange'];
+  const input = ['apple', 'banana', 'orange', 'pear'];
   for (let i = 0; i < input.length; i++) {
     const slicedInput = input.slice(0, i);
     strictEqual(formatList(slicedInput), and.format(slicedInput));


### PR DESCRIPTION
This PR improves formatLIst in errors.js
The benchmarks:

main: 
```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/node$ ./node benchmark/error/format-list.js 
error/format-list.js input="" n=10000000: 19,674,229.0009035
error/format-list.js input="a" n=10000000: 17,898,703.51886578
error/format-list.js input="a,b" n=10000000: 8,773,227.708163619
error/format-list.js input="a,b,c" n=10000000: 5,988,210.708969075
```

PR:
```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/node$ ./node benchmark/error/format-list.js 
error/format-list.js input="" n=10000000: 544,845,141.1173433
error/format-list.js input="a" n=10000000: 543,086,471.205501
error/format-list.js input="a,b" n=10000000: 37,940,629.811950795
error/format-list.js input="a,b,c" n=10000000: 6,147,421.564903789
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
