### PR TITLE
errors: improve performance of classRegExp in errors.js

### DIFF
--- a/benchmark/error/error-class-reg-exp.js
+++ b/benchmark/error/error-class-reg-exp.js
@@ -8,7 +8,7 @@ const bench = common.createBenchmark(main, {
   flags: ['--expose-internals'],
 });
 
-const instances = Array.from({ length: 1000 }).map(() => 'Uint8Array')
+const instances = Array.from({ length: 1000 }).map(() => 'Uint8Array');
 
 function main({ n }) {
   const {
@@ -18,6 +18,6 @@ function main({ n }) {
   } = require('internal/errors');
   bench.start();
   for (let i = 0; i < n; ++i)
-    new ERR_INVALID_ARG_TYPE('target', instances, 'test')
+    new ERR_INVALID_ARG_TYPE('target', instances, 'test');
   bench.end(n);
 }

--- a/benchmark/error/error-class-reg-exp.js
+++ b/benchmark/error/error-class-reg-exp.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+}, {
+  flags: ['--expose-internals'],
+});
+
+const instances = Array.from({ length: 1000 }).map(() => 'Uint8Array')
+
+function main({ n }) {
+  const {
+    codes: {
+      ERR_INVALID_ARG_TYPE,
+    },
+  } = require('internal/errors');
+  bench.start();
+  for (let i = 0; i < n; ++i)
+    new ERR_INVALID_ARG_TYPE('target', instances, 'test')
+  bench.end(n);
+}

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -66,7 +66,8 @@ const isWindows = process.platform === 'win32';
 const messages = new SafeMap();
 const codes = {};
 
-const classRegExp = /^([A-Z][a-z0-9]*)+$/;
+const classRegExp = /^[A-Z][a-zA-Z0-9]*$/;
+
 // Sorted by a rough estimate on most frequently used entries.
 const kTypes = [
   'string',


### PR DESCRIPTION
This PR simplifies the RegExp for detecting class names

Main:
error/error-class-reg-exp.js n=100000: 9,114.045930023383

PR:
error/error-class-reg-exp.js n=100000: 11,002.079862772853


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
