### PR TITLE
bootstrap: use `internal.url` instead of `url`

### DIFF
--- a/lib/internal/bootstrap/switches/is_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_main_thread.js
@@ -290,7 +290,7 @@ rawMethods.resetStdioForTesting = function() {
 // Needed by the module loader and generally needed everywhere.
 require('fs');
 require('util');
-require('url'); // eslint-disable-line no-restricted-modules
+require('internal/url');
 
 require('internal/modules/cjs/loader');
 require('internal/modules/esm/utils');

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -95,12 +95,7 @@ const expectedModules = new Set([
   'NativeModule internal/process/pre_execution',
 ]);
 
-if (common.isMainThread) {
-  [
-    'NativeModule internal/idna',
-    'NativeModule url',
-  ].forEach(expectedModules.add.bind(expectedModules));
-} else {
+if (!common.isMainThread) {
   [
     'NativeModule diagnostics_channel',
     'NativeModule internal/abort_controller',


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/49590#discussion_r1321260548

Not sure if it might break any binary compatibility that would cause high semverness, or cause any significant regression.

cc @nodejs/process 