### PR TITLE
esm: require braces for modules code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,10 +53,10 @@ module.exports = {
   overrides: [
     {
       files: [
-        'test/es-module/test-esm-type-flag.js',
-        'test/es-module/test-esm-type-flag-alias.js',
         '*.mjs',
         'test/es-module/test-esm-example-loader.js',
+        'test/es-module/test-esm-type-flag.js',
+        'test/es-module/test-esm-type-flag-alias.js',
       ],
       parserOptions: { sourceType: 'module' },
     },
@@ -110,6 +110,14 @@ module.exports = {
           message: 'Import process instead of using the global',
         },
       ] },
+    },
+    {
+      files: [
+        'lib/internal/modules/**/*.js',
+      ],
+      rules: {
+        'curly': 'error',
+      },
     },
     {
       files: [

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -197,7 +197,9 @@ ObjectDefineProperty(Module, '_stat', {
 
 function updateChildren(parent, child, scan) {
   const children = parent?.children;
-  if (children && !(scan && ArrayPrototypeIncludes(children, child))) { ArrayPrototypePush(children, child); }
+  if (children && !(scan && ArrayPrototypeIncludes(children, child))) {
+    ArrayPrototypePush(children, child);
+  }
 }
 
 function reportModuleToWatchMode(filename) {
@@ -385,7 +387,9 @@ function readPackageScope(checkPath) {
     if (enabledPermission && !permission.has('fs.read', checkPath + sep)) {
       return false;
     }
-    if (StringPrototypeEndsWith(checkPath, sep + 'node_modules')) { return false; }
+    if (StringPrototypeEndsWith(checkPath, sep + 'node_modules')) {
+      return false;
+    }
     const pjson = _readPackage(checkPath + sep);
     if (pjson.exists) {
       return {
@@ -523,7 +527,9 @@ function trySelf(parentPath, request) {
       pathToFileURL(pkgPath + '/package.json'), expansion, pkg,
       pathToFileURL(parentPath), getCjsConditions()), parentPath, pkgPath);
   } catch (e) {
-    if (e.code === 'ERR_MODULE_NOT_FOUND') { throw createEsmNotFoundErr(request, pkgPath + '/package.json'); }
+    if (e.code === 'ERR_MODULE_NOT_FOUND') {
+      throw createEsmNotFoundErr(request, pkgPath + '/package.json');
+    }
     throw e;
   }
 }
@@ -546,7 +552,9 @@ function resolveExports(nmPath, request) {
         pathToFileURL(pkgPath + '/package.json'), '.' + expansion, pkg, null,
         getCjsConditions()), null, pkgPath);
     } catch (e) {
-      if (e.code === 'ERR_MODULE_NOT_FOUND') { throw createEsmNotFoundErr(request, pkgPath + '/package.json'); }
+      if (e.code === 'ERR_MODULE_NOT_FOUND') {
+        throw createEsmNotFoundErr(request, pkgPath + '/package.json');
+      }
       throw e;
     }
   }
@@ -568,7 +576,9 @@ Module._findPath = function(request, paths, isMain) {
 
   const cacheKey = request + '\x00' + ArrayPrototypeJoin(paths, '\x00');
   const entry = Module._pathCache[cacheKey];
-  if (entry) { return entry; }
+  if (entry) {
+    return entry;
+  }
 
   let exts;
   const trailingSlash = request.length > 0 &&
@@ -615,7 +625,9 @@ Module._findPath = function(request, paths, isMain) {
 
     if (!absoluteRequest) {
       const exportsResolved = resolveExports(curPath, request);
-      if (exportsResolved) { return exportsResolved; }
+      if (exportsResolved) {
+        return exportsResolved;
+      }
     }
 
     const basePath = path.resolve(curPath, request);
@@ -647,14 +659,18 @@ Module._findPath = function(request, paths, isMain) {
 
       if (!filename) {
         // Try it with each of the extensions
-        if (exts === undefined) { exts = ObjectKeys(Module._extensions); }
+        if (exts === undefined) {
+          exts = ObjectKeys(Module._extensions);
+        }
         filename = tryExtensions(basePath, exts, isMain);
       }
     }
 
     if (!filename && rc === 1) {  // Directory.
       // try it with each of the extensions at "index"
-      if (exts === undefined) { exts = ObjectKeys(Module._extensions); }
+      if (exts === undefined) {
+        exts = ObjectKeys(Module._extensions);
+      }
       filename = tryPackage(basePath, exts, isMain, request);
     }
 
@@ -690,7 +706,9 @@ if (isWindows) {
     // path.resolve will make sure from.length >=3 in Windows.
     if (StringPrototypeCharCodeAt(from, from.length - 1) ===
           CHAR_BACKWARD_SLASH &&
-        StringPrototypeCharCodeAt(from, from.length - 2) === CHAR_COLON) { return [from + 'node_modules']; }
+        StringPrototypeCharCodeAt(from, from.length - 2) === CHAR_COLON) {
+          return [from + 'node_modules'];
+        }
 
     const paths = [];
     for (let i = from.length - 1, p = 0, last = from.length; i >= 0; --i) {
@@ -729,7 +747,9 @@ if (isWindows) {
     from = path.resolve(from);
     // Return early not only to avoid unnecessary work, but to *avoid* returning
     // an array of two items for a root: [ '//node_modules', '/node_modules' ]
-    if (from === '/') { return ['/node_modules']; }
+    if (from === '/') {
+      return ['/node_modules'];
+    }
 
     // note: this approach *only* works when the path is guaranteed
     // to be absolute.  Doing a fully-edge-case-correct path.split
@@ -872,7 +892,9 @@ Module._load = function(request, parent, isMain) {
       const cachedModule = Module._cache[filename];
       if (cachedModule !== undefined) {
         updateChildren(parent, cachedModule, true);
-        if (!cachedModule.loaded) { return getExportsForCircularRequire(cachedModule); }
+        if (!cachedModule.loaded) {
+          return getExportsForCircularRequire(cachedModule);
+        }
         return cachedModule.exports;
       }
       delete relativeResolveCache[relResolveCacheIdentifier];
@@ -897,7 +919,9 @@ Module._load = function(request, parent, isMain) {
     updateChildren(parent, cachedModule, true);
     if (!cachedModule.loaded) {
       const parseCachedModule = cjsParseCache.get(cachedModule);
-      if (!parseCachedModule || parseCachedModule.loaded) { return getExportsForCircularRequire(cachedModule); }
+      if (!parseCachedModule || parseCachedModule.loaded) {
+        return getExportsForCircularRequire(cachedModule);
+      }
       parseCachedModule.loaded = true;
     } else {
       return cachedModule.exports;
@@ -980,7 +1004,9 @@ Module._resolveFilename = function(request, parent, isMain, options) {
           const lookupPaths = Module._resolveLookupPaths(request, fakeParent);
 
           for (let j = 0; j < lookupPaths.length; j++) {
-            if (!ArrayPrototypeIncludes(paths, lookupPaths[j])) { ArrayPrototypePush(paths, lookupPaths[j]); }
+            if (!ArrayPrototypeIncludes(paths, lookupPaths[j])) {
+              ArrayPrototypePush(paths, lookupPaths[j]);
+            }
           }
         }
       }
@@ -1004,7 +1030,9 @@ Module._resolveFilename = function(request, parent, isMain, options) {
                                 getCjsConditions()), parentPath,
           pkg.path);
       } catch (e) {
-        if (e.code === 'ERR_MODULE_NOT_FOUND') { throw createEsmNotFoundErr(request); }
+        if (e.code === 'ERR_MODULE_NOT_FOUND') {
+          throw createEsmNotFoundErr(request);
+        }
         throw e;
       }
     }
@@ -1049,7 +1077,9 @@ function finalizeEsmResolution(resolved, parentPath, pkgPath) {
   }
   const filename = fileURLToPath(resolved);
   const actual = tryFile(filename);
-  if (actual) { return actual; }
+  if (actual) {
+    return actual;
+  }
   const err = createEsmNotFoundErr(filename,
                                    path.resolve(pkgPath, 'package.json'));
   throw err;
@@ -1059,7 +1089,9 @@ function createEsmNotFoundErr(request, path) {
   // eslint-disable-next-line no-restricted-syntax
   const err = new Error(`Cannot find module '${request}'`);
   err.code = 'MODULE_NOT_FOUND';
-  if (path) { err.path = path; }
+  if (path) {
+    err.path = path;
+  }
   // TODO(BridgeAR): Add the requireStack as well.
   return err;
 }
@@ -1087,7 +1119,9 @@ Module.prototype.load = function(filename) {
   // Preemptively cache
   if ((module?.module === undefined ||
        module.module.getStatus() < kEvaluated) &&
-      !cascadedLoader.cjsCache.has(this)) { cascadedLoader.cjsCache.set(this, exports); }
+      !cascadedLoader.cjsCache.has(this)) {
+    cascadedLoader.cjsCache.set(this, exports);
+  }
 };
 
 // Loads a module at the given file path. Returns that module's
@@ -1404,7 +1438,9 @@ Module._preloadModules = function(requests) {
       throw e;
     }
   }
-  for (let n = 0; n < requests.length; n++) { internalRequire(parent, requests[n]); }
+  for (let n = 0; n < requests.length; n++) {
+    internalRequire(parent, requests[n]);
+  }
   isPreloading = false;
 };
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -707,8 +707,8 @@ if (isWindows) {
     if (StringPrototypeCharCodeAt(from, from.length - 1) ===
           CHAR_BACKWARD_SLASH &&
         StringPrototypeCharCodeAt(from, from.length - 2) === CHAR_COLON) {
-          return [from + 'node_modules'];
-        }
+      return [from + 'node_modules'];
+    }
 
     const paths = [];
     for (let i = from.length - 1, p = 0, last = from.length; i >= 0; --i) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -173,7 +173,7 @@ function stat(filename) {
   filename = path.toNamespacedPath(filename);
   if (statCache !== null) {
     const result = statCache.get(filename);
-    if (result !== undefined) return result;
+    if (result !== undefined) { return result; }
   }
   const result = internalModuleStat(filename);
   if (statCache !== null && result >= 0) {
@@ -197,8 +197,7 @@ ObjectDefineProperty(Module, '_stat', {
 
 function updateChildren(parent, child, scan) {
   const children = parent?.children;
-  if (children && !(scan && ArrayPrototypeIncludes(children, child)))
-    ArrayPrototypePush(children, child);
+  if (children && !(scan && ArrayPrototypeIncludes(children, child))) { ArrayPrototypePush(children, child); }
 }
 
 function reportModuleToWatchMode(filename) {
@@ -386,13 +385,14 @@ function readPackageScope(checkPath) {
     if (enabledPermission && !permission.has('fs.read', checkPath + sep)) {
       return false;
     }
-    if (StringPrototypeEndsWith(checkPath, sep + 'node_modules'))
-      return false;
+    if (StringPrototypeEndsWith(checkPath, sep + 'node_modules')) { return false; }
     const pjson = _readPackage(checkPath + sep);
-    if (pjson.exists) return {
-      data: pjson,
-      path: checkPath,
-    };
+    if (pjson.exists) {
+      return {
+        data: pjson,
+        path: checkPath,
+      };
+    }
   } while (separatorIndex > rootSeparatorIndex);
   return false;
 }
@@ -445,7 +445,7 @@ const realpathCache = new SafeMap();
 // absolute realpath.
 function tryFile(requestPath, isMain) {
   const rc = _stat(requestPath);
-  if (rc !== 0) return;
+  if (rc !== 0) { return; }
   if (getOptionValue('--preserve-symlinks') && !isMain) {
     return path.resolve(requestPath);
   }
@@ -479,15 +479,15 @@ function findLongestRegisteredExtension(filename) {
   let startIndex = 0;
   while ((index = StringPrototypeIndexOf(name, '.', startIndex)) !== -1) {
     startIndex = index + 1;
-    if (index === 0) continue; // Skip dotfiles like .gitignore
+    if (index === 0) { continue; } // Skip dotfiles like .gitignore
     currentExtension = StringPrototypeSlice(name, index);
-    if (Module._extensions[currentExtension]) return currentExtension;
+    if (Module._extensions[currentExtension]) { return currentExtension; }
   }
   return '.js';
 }
 
 function trySelfParentPath(parent) {
-  if (!parent) return false;
+  if (!parent) { return false; }
 
   if (parent.filename) {
     return parent.filename;
@@ -501,7 +501,7 @@ function trySelfParentPath(parent) {
 }
 
 function trySelf(parentPath, request) {
-  if (!parentPath) return false;
+  if (!parentPath) { return false; }
 
   const { data: pkg, path: pkgPath } = readPackageScope(parentPath);
   if (!pkg || pkg.exports == null || pkg.name === undefined) {
@@ -523,8 +523,7 @@ function trySelf(parentPath, request) {
       pathToFileURL(pkgPath + '/package.json'), expansion, pkg,
       pathToFileURL(parentPath), getCjsConditions()), parentPath, pkgPath);
   } catch (e) {
-    if (e.code === 'ERR_MODULE_NOT_FOUND')
-      throw createEsmNotFoundErr(request, pkgPath + '/package.json');
+    if (e.code === 'ERR_MODULE_NOT_FOUND') { throw createEsmNotFoundErr(request, pkgPath + '/package.json'); }
     throw e;
   }
 }
@@ -537,8 +536,7 @@ function resolveExports(nmPath, request) {
   // The implementation's behavior is meant to mirror resolution in ESM.
   const { 1: name, 2: expansion = '' } =
     RegExpPrototypeExec(EXPORTS_PATTERN, request) || kEmptyObject;
-  if (!name)
-    return;
+  if (!name) { return; }
   const pkgPath = path.resolve(nmPath, name);
   const pkg = _readPackage(pkgPath);
   if (pkg.exists && pkg.exports != null) {
@@ -548,8 +546,7 @@ function resolveExports(nmPath, request) {
         pathToFileURL(pkgPath + '/package.json'), '.' + expansion, pkg, null,
         getCjsConditions()), null, pkgPath);
     } catch (e) {
-      if (e.code === 'ERR_MODULE_NOT_FOUND')
-        throw createEsmNotFoundErr(request, pkgPath + '/package.json');
+      if (e.code === 'ERR_MODULE_NOT_FOUND') { throw createEsmNotFoundErr(request, pkgPath + '/package.json'); }
       throw e;
     }
   }
@@ -571,8 +568,7 @@ Module._findPath = function(request, paths, isMain) {
 
   const cacheKey = request + '\x00' + ArrayPrototypeJoin(paths, '\x00');
   const entry = Module._pathCache[cacheKey];
-  if (entry)
-    return entry;
+  if (entry) { return entry; }
 
   let exts;
   const trailingSlash = request.length > 0 &&
@@ -619,8 +615,7 @@ Module._findPath = function(request, paths, isMain) {
 
     if (!absoluteRequest) {
       const exportsResolved = resolveExports(curPath, request);
-      if (exportsResolved)
-        return exportsResolved;
+      if (exportsResolved) { return exportsResolved; }
     }
 
     const basePath = path.resolve(curPath, request);
@@ -652,16 +647,14 @@ Module._findPath = function(request, paths, isMain) {
 
       if (!filename) {
         // Try it with each of the extensions
-        if (exts === undefined)
-          exts = ObjectKeys(Module._extensions);
+        if (exts === undefined) { exts = ObjectKeys(Module._extensions); }
         filename = tryExtensions(basePath, exts, isMain);
       }
     }
 
     if (!filename && rc === 1) {  // Directory.
       // try it with each of the extensions at "index"
-      if (exts === undefined)
-        exts = ObjectKeys(Module._extensions);
+      if (exts === undefined) { exts = ObjectKeys(Module._extensions); }
       filename = tryPackage(basePath, exts, isMain, request);
     }
 
@@ -697,8 +690,7 @@ if (isWindows) {
     // path.resolve will make sure from.length >=3 in Windows.
     if (StringPrototypeCharCodeAt(from, from.length - 1) ===
           CHAR_BACKWARD_SLASH &&
-        StringPrototypeCharCodeAt(from, from.length - 2) === CHAR_COLON)
-      return [from + 'node_modules'];
+        StringPrototypeCharCodeAt(from, from.length - 2) === CHAR_COLON) { return [from + 'node_modules']; }
 
     const paths = [];
     for (let i = from.length - 1, p = 0, last = from.length; i >= 0; --i) {
@@ -711,11 +703,12 @@ if (isWindows) {
       if (code === CHAR_BACKWARD_SLASH ||
           code === CHAR_FORWARD_SLASH ||
           code === CHAR_COLON) {
-        if (p !== nmLen)
+        if (p !== nmLen) {
           ArrayPrototypePush(
             paths,
             StringPrototypeSlice(from, 0, last) + '\\node_modules',
           );
+        }
         last = i;
         p = 0;
       } else if (p !== -1) {
@@ -736,8 +729,7 @@ if (isWindows) {
     from = path.resolve(from);
     // Return early not only to avoid unnecessary work, but to *avoid* returning
     // an array of two items for a root: [ '//node_modules', '/node_modules' ]
-    if (from === '/')
-      return ['/node_modules'];
+    if (from === '/') { return ['/node_modules']; }
 
     // note: this approach *only* works when the path is guaranteed
     // to be absolute.  Doing a fully-edge-case-correct path.split
@@ -746,11 +738,12 @@ if (isWindows) {
     for (let i = from.length - 1, p = 0, last = from.length; i >= 0; --i) {
       const code = StringPrototypeCharCodeAt(from, i);
       if (code === CHAR_FORWARD_SLASH) {
-        if (p !== nmLen)
+        if (p !== nmLen) {
           ArrayPrototypePush(
             paths,
             StringPrototypeSlice(from, 0, last) + '/node_modules',
           );
+        }
         last = i;
         p = 0;
       } else if (p !== -1) {
@@ -827,14 +820,15 @@ const CircularRequirePrototypeWarningProxy = new Proxy({}, {
     // Allow __esModule access in any case because it is used in the output
     // of transpiled code to determine whether something comes from an
     // ES module, and is not used as a regular key of `module.exports`.
-    if (prop in target || prop === '__esModule') return target[prop];
+    if (prop in target || prop === '__esModule') { return target[prop]; }
     emitCircularRequireWarning(prop);
     return undefined;
   },
 
   getOwnPropertyDescriptor(target, prop) {
-    if (ObjectPrototypeHasOwnProperty(target, prop) || prop === '__esModule')
+    if (ObjectPrototypeHasOwnProperty(target, prop) || prop === '__esModule') {
       return ObjectGetOwnPropertyDescriptor(target, prop);
+    }
     emitCircularRequireWarning(prop);
     return undefined;
   },
@@ -878,8 +872,7 @@ Module._load = function(request, parent, isMain) {
       const cachedModule = Module._cache[filename];
       if (cachedModule !== undefined) {
         updateChildren(parent, cachedModule, true);
-        if (!cachedModule.loaded)
-          return getExportsForCircularRequire(cachedModule);
+        if (!cachedModule.loaded) { return getExportsForCircularRequire(cachedModule); }
         return cachedModule.exports;
       }
       delete relativeResolveCache[relResolveCacheIdentifier];
@@ -904,8 +897,7 @@ Module._load = function(request, parent, isMain) {
     updateChildren(parent, cachedModule, true);
     if (!cachedModule.loaded) {
       const parseCachedModule = cjsParseCache.get(cachedModule);
-      if (!parseCachedModule || parseCachedModule.loaded)
-        return getExportsForCircularRequire(cachedModule);
+      if (!parseCachedModule || parseCachedModule.loaded) { return getExportsForCircularRequire(cachedModule); }
       parseCachedModule.loaded = true;
     } else {
       return cachedModule.exports;
@@ -988,8 +980,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
           const lookupPaths = Module._resolveLookupPaths(request, fakeParent);
 
           for (let j = 0; j < lookupPaths.length; j++) {
-            if (!ArrayPrototypeIncludes(paths, lookupPaths[j]))
-              ArrayPrototypePush(paths, lookupPaths[j]);
+            if (!ArrayPrototypeIncludes(paths, lookupPaths[j])) { ArrayPrototypePush(paths, lookupPaths[j]); }
           }
         }
       }
@@ -1013,8 +1004,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
                                 getCjsConditions()), parentPath,
           pkg.path);
       } catch (e) {
-        if (e.code === 'ERR_MODULE_NOT_FOUND')
-          throw createEsmNotFoundErr(request);
+        if (e.code === 'ERR_MODULE_NOT_FOUND') { throw createEsmNotFoundErr(request); }
         throw e;
       }
     }
@@ -1032,7 +1022,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 
   // Look up the filename first, since that's the cache key.
   const filename = Module._findPath(request, paths, isMain);
-  if (filename) return filename;
+  if (filename) { return filename; }
   const requireStack = [];
   for (let cursor = parent;
     cursor;
@@ -1053,13 +1043,13 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 
 function finalizeEsmResolution(resolved, parentPath, pkgPath) {
   const { encodedSepRegEx } = require('internal/modules/esm/resolve');
-  if (RegExpPrototypeExec(encodedSepRegEx, resolved) !== null)
+  if (RegExpPrototypeExec(encodedSepRegEx, resolved) !== null) {
     throw new ERR_INVALID_MODULE_SPECIFIER(
       resolved, 'must not include encoded "/" or "\\" characters', parentPath);
+  }
   const filename = fileURLToPath(resolved);
   const actual = tryFile(filename);
-  if (actual)
-    return actual;
+  if (actual) { return actual; }
   const err = createEsmNotFoundErr(filename,
                                    path.resolve(pkgPath, 'package.json'));
   throw err;
@@ -1069,8 +1059,7 @@ function createEsmNotFoundErr(request, path) {
   // eslint-disable-next-line no-restricted-syntax
   const err = new Error(`Cannot find module '${request}'`);
   err.code = 'MODULE_NOT_FOUND';
-  if (path)
-    err.path = path;
+  if (path) { err.path = path; }
   // TODO(BridgeAR): Add the requireStack as well.
   return err;
 }
@@ -1085,8 +1074,9 @@ Module.prototype.load = function(filename) {
 
   const extension = findLongestRegisteredExtension(filename);
   // allow .mjs to be overridden
-  if (StringPrototypeEndsWith(filename, '.mjs') && !Module._extensions['.mjs'])
+  if (StringPrototypeEndsWith(filename, '.mjs') && !Module._extensions['.mjs']) {
     throw new ERR_REQUIRE_ESM(filename, true);
+  }
 
   Module._extensions[extension](this, filename);
   this.loaded = true;
@@ -1097,8 +1087,7 @@ Module.prototype.load = function(filename) {
   // Preemptively cache
   if ((module?.module === undefined ||
        module.module.getStatus() < kEvaluated) &&
-      !cascadedLoader.cjsCache.has(this))
-    cascadedLoader.cjsCache.set(this, exports);
+      !cascadedLoader.cjsCache.has(this)) { cascadedLoader.cjsCache.set(this, exports); }
 };
 
 // Loads a module at the given file path. Returns that module's
@@ -1233,7 +1222,7 @@ Module.prototype._compile = function(content, filename) {
   const exports = this.exports;
   const thisValue = exports;
   const module = this;
-  if (requireDepth === 0) statCache = new SafeMap();
+  if (requireDepth === 0) { statCache = new SafeMap(); }
   if (inspectorWrapper) {
     result = inspectorWrapper(compiledWrapper, thisValue, exports,
                               require, module, filename, dirname);
@@ -1242,7 +1231,7 @@ Module.prototype._compile = function(content, filename) {
                           [exports, require, module, filename, dirname]);
   }
   hasLoadedAnyUserCJSModule = true;
-  if (requireDepth === 0) statCache = null;
+  if (requireDepth === 0) { statCache = null; }
   return result;
 };
 
@@ -1399,8 +1388,7 @@ Module._initPaths = function() {
 };
 
 Module._preloadModules = function(requests) {
-  if (!ArrayIsArray(requests))
-    return;
+  if (!ArrayIsArray(requests)) { return; }
 
   isPreloading = true;
 
@@ -1416,8 +1404,7 @@ Module._preloadModules = function(requests) {
       throw e;
     }
   }
-  for (let n = 0; n < requests.length; n++)
-    internalRequire(parent, requests[n]);
+  for (let n = 0; n < requests.length; n++) { internalRequire(parent, requests[n]); }
   isPreloading = false;
 };
 

--- a/lib/internal/modules/esm/create_dynamic_module.js
+++ b/lib/internal/modules/esm/create_dynamic_module.js
@@ -43,15 +43,13 @@ import.meta.done();
     onReady: (cb) => { readyfns.add(cb); },
   };
 
-  if (imports.length)
-    reflect.imports = { __proto__: null };
+  if (imports.length) { reflect.imports = { __proto__: null }; }
   const { registerModule } = require('internal/modules/esm/utils');
   registerModule(m, {
     __proto__: null,
     initializeImportMeta: (meta, wrap) => {
       meta.exports = reflect.exports;
-      if (reflect.imports)
-        meta.imports = reflect.imports;
+      if (reflect.imports) { meta.imports = reflect.imports; }
       meta.done = () => {
         evaluate(reflect);
         reflect.onReady = (cb) => cb(reflect);

--- a/lib/internal/modules/esm/create_dynamic_module.js
+++ b/lib/internal/modules/esm/create_dynamic_module.js
@@ -43,13 +43,17 @@ import.meta.done();
     onReady: (cb) => { readyfns.add(cb); },
   };
 
-  if (imports.length) { reflect.imports = { __proto__: null }; }
+  if (imports.length) {
+    reflect.imports = { __proto__: null };
+  }
   const { registerModule } = require('internal/modules/esm/utils');
   registerModule(m, {
     __proto__: null,
     initializeImportMeta: (meta, wrap) => {
       meta.exports = reflect.exports;
-      if (reflect.imports) { meta.imports = reflect.imports; }
+      if (reflect.imports) {
+        meta.imports = reflect.imports;
+      }
       meta.done = () => {
         evaluate(reflect);
         reflect.onReady = (cb) => cb(reflect);

--- a/lib/internal/modules/esm/formats.js
+++ b/lib/internal/modules/esm/formats.js
@@ -29,9 +29,9 @@ function mimeToFormat(mime) {
       /^\s*(text|application)\/javascript\s*(;\s*charset=utf-?8\s*)?$/i,
       mime,
     ) !== null
-  ) return 'module';
-  if (mime === 'application/json') return 'json';
-  if (experimentalWasmModules && mime === 'application/wasm') return 'wasm';
+  ) { return 'module'; }
+  if (mime === 'application/json') { return 'json'; }
+  if (experimentalWasmModules && mime === 'application/wasm') { return 'wasm'; }
   return null;
 }
 

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -79,7 +79,7 @@ function getFileProtocolModuleFormat(url, context, ignoreErrors) {
   }
 
   const format = extensionFormatMap[ext];
-  if (format) return format;
+  if (format) { return format; }
 
   // Explicit undefined return indicates load hook should rerun format check
   if (ignoreErrors) { return undefined; }

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -197,7 +197,7 @@ class Hooks {
         `${hookErrIdentifier} specifier`,
       ); // non-strings can be coerced to a URL string
 
-      if (ctx) validateObject(ctx, `${hookErrIdentifier} context`);
+      if (ctx) { validateObject(ctx, `${hookErrIdentifier} context`); }
     };
     const validateOutput = (hookErrIdentifier, output) => {
       if (typeof output !== 'object' || output === null) { // [2]
@@ -597,7 +597,7 @@ class HooksProxy {
     }
     const { status, body } = response.message;
     if (status === 'error') {
-      if (body == null || typeof body !== 'object') throw body;
+      if (body == null || typeof body !== 'object') { throw body; }
       if (body.serializationFailed || body.serialized == null) {
         throw ERR_WORKER_UNSERIALIZABLE_ERROR();
       }

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -87,7 +87,9 @@ class ModuleJob {
         return job.modulePromise;
       });
 
-      if (promises !== undefined) { await SafePromiseAllReturnVoid(promises); }
+      if (promises !== undefined) {
+        await SafePromiseAllReturnVoid(promises);
+      }
 
       return SafePromiseAllReturnArrayLike(dependencyJobs);
     };

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -87,8 +87,7 @@ class ModuleJob {
         return job.modulePromise;
       });
 
-      if (promises !== undefined)
-        await SafePromiseAllReturnVoid(promises);
+      if (promises !== undefined) { await SafePromiseAllReturnVoid(promises); }
 
       return SafePromiseAllReturnArrayLike(dependencyJobs);
     };

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -68,8 +68,7 @@ const emittedPackageWarnings = new SafeSet();
 
 function emitTrailingSlashPatternDeprecation(match, pjsonUrl, base) {
   const pjsonPath = fileURLToPath(pjsonUrl);
-  if (emittedPackageWarnings.has(pjsonPath + '|' + match))
-    return;
+  if (emittedPackageWarnings.has(pjsonPath + '|' + match)) { return; }
   emittedPackageWarnings.add(pjsonPath + '|' + match);
   process.emitWarning(
     `Use of deprecated trailing slash pattern mapping "${match}" in the ` +
@@ -106,8 +105,7 @@ function emitInvalidSegmentDeprecation(target, request, match, pjsonUrl, interna
  */
 function emitLegacyIndexDeprecation(url, packageJSONUrl, base, main) {
   const format = defaultGetFormatWithoutErrors(url);
-  if (format !== 'module')
-    return;
+  if (format !== 'module') { return; }
   const path = fileURLToPath(url);
   const pkgPath = fileURLToPath(new URL('.', packageJSONUrl));
   const basePath = fileURLToPath(base);
@@ -203,10 +201,11 @@ const encodedSepRegEx = /%2F|%5C/i;
  * @returns {URL | undefined}
  */
 function finalizeResolution(resolved, base, preserveSymlinks) {
-  if (RegExpPrototypeExec(encodedSepRegEx, resolved.pathname) !== null)
+  if (RegExpPrototypeExec(encodedSepRegEx, resolved.pathname) !== null) {
     throw new ERR_INVALID_MODULE_SPECIFIER(
       resolved.pathname, 'must not include encoded "/" or "\\" characters',
       fileURLToPath(base));
+  }
 
   const path = fileURLToPath(resolved);
 
@@ -319,8 +318,9 @@ function resolvePackageTargetString(
   conditions,
 ) {
 
-  if (subpath !== '' && !pattern && target[target.length - 1] !== '/')
+  if (subpath !== '' && !pattern && target[target.length - 1] !== '/') {
     throw invalidPackageTarget(match, target, packageJSONUrl, internal, base);
+  }
 
   if (!StringPrototypeStartsWith(target, './')) {
     if (internal && !StringPrototypeStartsWith(target, '../') &&
@@ -357,10 +357,11 @@ function resolvePackageTargetString(
   const resolvedPath = resolved.pathname;
   const packagePath = new URL('.', packageJSONUrl).pathname;
 
-  if (!StringPrototypeStartsWith(resolvedPath, packagePath))
+  if (!StringPrototypeStartsWith(resolvedPath, packagePath)) {
     throw invalidPackageTarget(match, target, packageJSONUrl, internal, base);
+  }
 
-  if (subpath === '') return resolved;
+  if (subpath === '') { return resolved; }
 
   if (RegExpPrototypeExec(invalidSegmentRegEx, subpath) !== null) {
     const request = pattern ? StringPrototypeReplace(match, '*', () => subpath) : match + subpath;
@@ -391,7 +392,7 @@ function resolvePackageTargetString(
  */
 function isArrayIndex(key) {
   const keyNum = +key;
-  if (`${keyNum}` !== key) return false;
+  if (`${keyNum}` !== key) { return false; }
   return keyNum >= 0 && keyNum < 0xFFFF_FFFF;
 }
 
@@ -443,8 +444,7 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
       }
       return resolveResult;
     }
-    if (lastException === undefined || lastException === null)
-      return lastException;
+    if (lastException === undefined || lastException === null) { return lastException; }
     throw lastException;
   } else if (typeof target === 'object' && target !== null) {
     const keys = ObjectGetOwnPropertyNames(target);
@@ -463,8 +463,7 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
         const resolveResult = resolvePackageTarget(
           packageJSONUrl, conditionalTarget, subpath, packageSubpath, base,
           pattern, internal, isPathMap, conditions);
-        if (resolveResult === undefined)
-          continue;
+        if (resolveResult === undefined) { continue; }
         return resolveResult;
       }
     }
@@ -484,8 +483,8 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
  * @returns {boolean}
  */
 function isConditionalExportsMainSugar(exports, packageJSONUrl, base) {
-  if (typeof exports === 'string' || ArrayIsArray(exports)) return true;
-  if (typeof exports !== 'object' || exports === null) return false;
+  if (typeof exports === 'string' || ArrayIsArray(exports)) { return true; }
+  if (typeof exports !== 'object' || exports === null) { return false; }
 
   const keys = ObjectGetOwnPropertyNames(exports);
   let isConditionalSugar = false;
@@ -517,8 +516,7 @@ function isConditionalExportsMainSugar(exports, packageJSONUrl, base) {
 function packageExportsResolve(
   packageJSONUrl, packageSubpath, packageConfig, base, conditions) {
   let exports = packageConfig.exports;
-  if (isConditionalExportsMainSugar(exports, packageJSONUrl, base))
-    exports = { '.': exports };
+  if (isConditionalExportsMainSugar(exports, packageJSONUrl, base)) { exports = { '.': exports }; }
 
   if (ObjectPrototypeHasOwnProperty(exports, packageSubpath) &&
       !StringPrototypeIncludes(packageSubpath, '*') &&
@@ -551,9 +549,10 @@ function packageExportsResolve(
       //   throwInvalidSubpath(packageSubpath)
       //
       // To match "imports" and the spec.
-      if (StringPrototypeEndsWith(packageSubpath, '/'))
+      if (StringPrototypeEndsWith(packageSubpath, '/')) {
         emitTrailingSlashPatternDeprecation(packageSubpath, packageJSONUrl,
                                             base);
+      }
       const patternTrailer = StringPrototypeSlice(key, patternIndex + 1);
       if (packageSubpath.length >= key.length &&
           StringPrototypeEndsWith(packageSubpath, patternTrailer) &&
@@ -594,12 +593,12 @@ function patternKeyCompare(a, b) {
   const bPatternIndex = StringPrototypeIndexOf(b, '*');
   const baseLenA = aPatternIndex === -1 ? a.length : aPatternIndex + 1;
   const baseLenB = bPatternIndex === -1 ? b.length : bPatternIndex + 1;
-  if (baseLenA > baseLenB) return -1;
-  if (baseLenB > baseLenA) return 1;
-  if (aPatternIndex === -1) return 1;
-  if (bPatternIndex === -1) return -1;
-  if (a.length > b.length) return -1;
-  if (b.length > a.length) return 1;
+  if (baseLenA > baseLenB) { return -1; }
+  if (baseLenB > baseLenA) { return 1; }
+  if (aPatternIndex === -1) { return 1; }
+  if (bPatternIndex === -1) { return -1; }
+  if (a.length > b.length) { return -1; }
+  if (b.length > a.length) { return 1; }
   return 0;
 }
 
@@ -702,8 +701,7 @@ function parsePackageName(specifier, base) {
 
   // Package name cannot have leading . and cannot have percent-encoding or
   // \\ separators.
-  if (RegExpPrototypeExec(invalidPackageNameRegEx, packageName) !== null)
-    validPackageName = false;
+  if (RegExpPrototypeExec(invalidPackageNameRegEx, packageName) !== null) { validPackageName = false; }
 
   if (!validPackageName) {
     throw new ERR_INVALID_MODULE_SPECIFIER(
@@ -790,17 +788,17 @@ function isBareSpecifier(specifier) {
 
 function isRelativeSpecifier(specifier) {
   if (specifier[0] === '.') {
-    if (specifier.length === 1 || specifier[1] === '/') return true;
+    if (specifier.length === 1 || specifier[1] === '/') { return true; }
     if (specifier[1] === '.') {
-      if (specifier.length === 2 || specifier[2] === '/') return true;
+      if (specifier.length === 2 || specifier[2] === '/') { return true; }
     }
   }
   return false;
 }
 
 function shouldBeTreatedAsRelativeOrAbsolutePath(specifier) {
-  if (specifier === '') return false;
-  if (specifier[0] === '/') return true;
+  if (specifier === '') { return false; }
+  if (specifier[0] === '/') { return true; }
   return isRelativeSpecifier(specifier);
 }
 
@@ -1009,10 +1007,10 @@ function defaultResolve(specifier, context = {}) {
     parsedParentURL,
   );
 
-  if (maybeReturn) return maybeReturn;
+  if (maybeReturn) { return maybeReturn; }
 
   // This must come after checkIfDisallowedImport
-  if (parsed && parsed.protocol === 'node:') return { __proto__: null, url: specifier };
+  if (parsed && parsed.protocol === 'node:') { return { __proto__: null, url: specifier }; }
 
 
   const isMain = parentURL === undefined;
@@ -1025,7 +1023,7 @@ function defaultResolve(specifier, context = {}) {
     // input, to avoid user confusion over how expansive the effect of the
     // flag should be (i.e. entry point only, package scope surrounding the
     // entry point, etc.).
-    if (typeFlag) throw new ERR_INPUT_TYPE_NOT_ALLOWED();
+    if (typeFlag) { throw new ERR_INPUT_TYPE_NOT_ALLOWED(); }
   }
 
   conditions = getConditionsSet(conditions);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -444,7 +444,9 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
       }
       return resolveResult;
     }
-    if (lastException === undefined || lastException === null) { return lastException; }
+    if (lastException === undefined || lastException === null) {
+      return lastException;
+    }
     throw lastException;
   } else if (typeof target === 'object' && target !== null) {
     const keys = ObjectGetOwnPropertyNames(target);
@@ -516,7 +518,9 @@ function isConditionalExportsMainSugar(exports, packageJSONUrl, base) {
 function packageExportsResolve(
   packageJSONUrl, packageSubpath, packageConfig, base, conditions) {
   let exports = packageConfig.exports;
-  if (isConditionalExportsMainSugar(exports, packageJSONUrl, base)) { exports = { '.': exports }; }
+  if (isConditionalExportsMainSugar(exports, packageJSONUrl, base)) {
+    exports = { '.': exports };
+  }
 
   if (ObjectPrototypeHasOwnProperty(exports, packageSubpath) &&
       !StringPrototypeIncludes(packageSubpath, '*') &&
@@ -701,7 +705,9 @@ function parsePackageName(specifier, base) {
 
   // Package name cannot have leading . and cannot have percent-encoding or
   // \\ separators.
-  if (RegExpPrototypeExec(invalidPackageNameRegEx, packageName) !== null) { validPackageName = false; }
+  if (RegExpPrototypeExec(invalidPackageNameRegEx, packageName) !== null) {
+    validPackageName = false;
+  }
 
   if (!validPackageName) {
     throw new ERR_INVALID_MODULE_SPECIFIER(

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -243,7 +243,9 @@ function createCJSModuleWrap(url, source, isMain, loadCJS = loadCJSModule) {
     }
     for (const exportName of exportNames) {
       if (!ObjectPrototypeHasOwnProperty(exports, exportName) ||
-          exportName === 'default') { continue; }
+          exportName === 'default') {
+        continue;
+      }
       // We might trigger a getter -> dont fail.
       let value;
       try {
@@ -302,7 +304,9 @@ function cjsPreparseModuleExports(filename, source) {
   let module = CJSModule._cache[filename];
   if (module) {
     const cached = cjsParseCache.get(module);
-    if (cached) { return { module, exportNames: cached.exportNames }; }
+    if (cached) {
+      return { module, exportNames: cached.exportNames };
+    }
   }
   const loaded = Boolean(module);
   if (!loaded) {
@@ -353,7 +357,9 @@ function cjsPreparseModuleExports(filename, source) {
         // (and fallback to reading the FS only if the source is nullish).
         const source = readFileSync(resolved, 'utf-8');
         const { exportNames: reexportNames } = cjsPreparseModuleExports(resolved, source);
-        for (const name of reexportNames) { exportNames.add(name); }
+        for (const name of reexportNames) {
+          exportNames.add(name);
+        }
       }
     }
   }
@@ -462,6 +468,8 @@ translators.set('wasm', async function(url, source) {
     'internal/modules/esm/create_dynamic_module');
   return createDynamicModule(imports, exports, url, (reflect) => {
     const { exports } = new WebAssembly.Instance(compiled, reflect.imports);
-    for (const expt of ObjectKeys(exports)) { reflect.exports[expt].set(exports[expt]); }
+    for (const expt of ObjectKeys(exports)) {
+      reflect.exports[expt].set(exports[expt]);
+    }
   }).module;
 });

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -20,7 +20,7 @@ const {
 
 let _TYPES = null;
 function lazyTypes() {
-  if (_TYPES !== null) return _TYPES;
+  if (_TYPES !== null) { return _TYPES; }
   return _TYPES = require('internal/util/types');
 }
 
@@ -90,7 +90,7 @@ function assertBufferSource(body, allowString, hookName) {
 }
 
 function stringify(body) {
-  if (typeof body === 'string') return body;
+  if (typeof body === 'string') { return body; }
   assertBufferSource(body, false, 'transformSource');
   const { TextDecoder } = require('internal/encoding');
   DECODER = DECODER === null ? new TextDecoder() : DECODER;
@@ -243,8 +243,7 @@ function createCJSModuleWrap(url, source, isMain, loadCJS = loadCJSModule) {
     }
     for (const exportName of exportNames) {
       if (!ObjectPrototypeHasOwnProperty(exports, exportName) ||
-          exportName === 'default')
-        continue;
+          exportName === 'default') { continue; }
       // We might trigger a getter -> dont fail.
       let value;
       try {
@@ -303,8 +302,7 @@ function cjsPreparseModuleExports(filename, source) {
   let module = CJSModule._cache[filename];
   if (module) {
     const cached = cjsParseCache.get(module);
-    if (cached)
-      return { module, exportNames: cached.exportNames };
+    if (cached) { return { module, exportNames: cached.exportNames }; }
   }
   const loaded = Boolean(module);
   if (!loaded) {
@@ -355,8 +353,7 @@ function cjsPreparseModuleExports(filename, source) {
         // (and fallback to reading the FS only if the source is nullish).
         const source = readFileSync(resolved, 'utf-8');
         const { exportNames: reexportNames } = cjsPreparseModuleExports(resolved, source);
-        for (const name of reexportNames)
-          exportNames.add(name);
+        for (const name of reexportNames) { exportNames.add(name); }
       }
     }
   }
@@ -465,7 +462,6 @@ translators.set('wasm', async function(url, source) {
     'internal/modules/esm/create_dynamic_module');
   return createDynamicModule(imports, exports, url, (reflect) => {
     const { exports } = new WebAssembly.Instance(compiled, reflect.imports);
-    for (const expt of ObjectKeys(exports))
-      reflect.exports[expt].set(exports[expt]);
+    for (const expt of ObjectKeys(exports)) { reflect.exports[expt].set(exports[expt]); }
   }).module;
 });

--- a/lib/internal/modules/esm/worker.js
+++ b/lib/internal/modules/esm/worker.js
@@ -33,7 +33,7 @@ const { initializeHooks } = require('internal/modules/esm/utils');
 const { isMarkedAsUntransferable } = require('internal/buffer');
 
 function transferArrayBuffer(hasError, source) {
-  if (hasError || source == null) return;
+  if (hasError || source == null) { return; }
   let arrayBuffer;
   if (isArrayBuffer(source)) {
     arrayBuffer = source;

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -16,7 +16,9 @@ function resolveMainPath(main) {
   if (!mainPath) { return; }
 
   const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
-  if (!preserveSymlinksMain) { mainPath = toRealPath(mainPath); }
+  if (!preserveSymlinksMain) {
+    mainPath = toRealPath(mainPath);
+  }
 
   return mainPath;
 }

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -13,12 +13,10 @@ function resolveMainPath(main) {
   // Module._findPath is monkey-patchable here.
   const { Module, toRealPath } = require('internal/modules/cjs/loader');
   let mainPath = Module._findPath(path.resolve(main), null, true);
-  if (!mainPath)
-    return;
+  if (!mainPath) { return; }
 
   const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
-  if (!preserveSymlinksMain)
-    mainPath = toRealPath(mainPath);
+  if (!preserveSymlinksMain) { mainPath = toRealPath(mainPath); }
 
   return mainPath;
 }
@@ -34,14 +32,11 @@ function shouldUseESMLoader(mainPath) {
    * (or an empty list when none have been registered).
    */
   const userImports = getOptionValue('--import');
-  if (userLoaders.length > 0 || userImports.length > 0)
-    return true;
+  if (userLoaders.length > 0 || userImports.length > 0) { return true; }
   const { readPackageScope } = require('internal/modules/cjs/loader');
   // Determine the module format of the main
-  if (mainPath && StringPrototypeEndsWith(mainPath, '.mjs'))
-    return true;
-  if (!mainPath || StringPrototypeEndsWith(mainPath, '.cjs'))
-    return false;
+  if (mainPath && StringPrototypeEndsWith(mainPath, '.mjs')) { return true; }
+  if (!mainPath || StringPrototypeEndsWith(mainPath, '.cjs')) { return false; }
   const pkg = readPackageScope(mainPath);
   return pkg && pkg.data.type === 'module';
 }

--- a/test/fixtures/errors/force_colors.snapshot
+++ b/test/fixtures/errors/force_colors.snapshot
@@ -4,11 +4,11 @@ throw new Error('Should include grayed stack trace')
 
 Error: Should include grayed stack trace
     at Object.<anonymous> [90m(/[39mtest*force_colors.js:1:7[90m)[39m
-[90m    at Module._compile (node:internal*modules*cjs*loader:1241:14)[39m
-[90m    at Module._extensions..js (node:internal*modules*cjs*loader:1295:10)[39m
-[90m    at Module.load (node:internal*modules*cjs*loader:1091:32)[39m
-[90m    at Module._load (node:internal*modules*cjs*loader:938:12)[39m
-[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:83:12)[39m
+[90m    at Module._compile (node:internal*modules*cjs*loader:1264:14)[39m
+[90m    at Module._extensions..js (node:internal*modules*cjs*loader:1318:10)[39m
+[90m    at Module.load (node:internal*modules*cjs*loader:1113:32)[39m
+[90m    at Module._load (node:internal*modules*cjs*loader:954:12)[39m
+[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:80:12)[39m
 [90m    at node:internal*main*run_main_module:23:47[39m
 
 Node.js *

--- a/test/fixtures/source-map/output/source_map_sourcemapping_url_string.snapshot
+++ b/test/fixtures/source-map/output/source_map_sourcemapping_url_string.snapshot
@@ -1,3 +1,3 @@
 Error: an exception.
     at Object.<anonymous> (*typescript-sourcemapping_url_string.ts:3:7)
-    at Module._compile (node:internal*modules*cjs*loader:1241:14)
+    at Module._compile (node:internal*modules*cjs*loader:1264:14)


### PR DESCRIPTION
> Split out from https://github.com/nodejs/node/pull/49523 per https://github.com/nodejs/node/pull/49523#discussion_r1326244760.

This PR adds a lint rule to formalize our informal rule for modules code, where we try to always use braces to enclose blocks (so no implicit blocks after things like `if` conditions).