### PR TITLE
test: fix edge snapshot stack traces

### DIFF
--- a/test/common/assertSnapshot.js
+++ b/test/common/assertSnapshot.js
@@ -8,6 +8,10 @@ const assert = require('node:assert/strict');
 const stackFramesRegexp = /(?<=\n)(\s+)((.+?)\s+\()?(?:\(?(.+?):(\d+)(?::(\d+))?)\)?(\s+\{)?(\[\d+m)?(\n|$)/g;
 const windowNewlineRegexp = /\r/g;
 
+function replaceNodeVersion(str) {
+  return str.replaceAll(process.version, '*');
+}
+
 function replaceStackTrace(str, replacement = '$1*$7$8\n') {
   return str.replace(stackFramesRegexp, replacement);
 }
@@ -84,6 +88,7 @@ module.exports = {
   assertSnapshot,
   getSnapshotPath,
   replaceFullPaths,
+  replaceNodeVersion,
   replaceStackTrace,
   replaceWindowsLineEndings,
   replaceWindowsPaths,

--- a/test/fixtures/errors/force_colors.snapshot
+++ b/test/fixtures/errors/force_colors.snapshot
@@ -4,11 +4,11 @@ throw new Error('Should include grayed stack trace')
 
 Error: Should include grayed stack trace
     at Object.<anonymous> [90m(/[39mtest*force_colors.js:1:7[90m)[39m
-[90m    at Module._compile (node:internal*modules*cjs*loader:1264:14)[39m
-[90m    at Module._extensions..js (node:internal*modules*cjs*loader:1318:10)[39m
-[90m    at Module.load (node:internal*modules*cjs*loader:1113:32)[39m
-[90m    at Module._load (node:internal*modules*cjs*loader:954:12)[39m
-[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:80:12)[39m
-[90m    at node:internal*main*run_main_module:23:47[39m
+[90m    at *[39m
+[90m    at *[39m
+[90m    at *[39m
+[90m    at *[39m
+[90m    at *[39m
+[90m    at *[39m
 
 Node.js *

--- a/test/fixtures/source-map/output/source_map_sourcemapping_url_string.snapshot
+++ b/test/fixtures/source-map/output/source_map_sourcemapping_url_string.snapshot
@@ -1,3 +1,3 @@
 Error: an exception.
     at Object.<anonymous> (*typescript-sourcemapping_url_string.ts:3:7)
-    at Module._compile (node:internal*modules*cjs*loader:1264:14)
+    *

--- a/test/parallel/test-node-output-sourcemaps.mjs
+++ b/test/parallel/test-node-output-sourcemaps.mjs
@@ -4,10 +4,6 @@ import * as snapshot from '../common/assertSnapshot.js';
 import * as path from 'node:path';
 import { describe, it } from 'node:test';
 
-function replaceNodeVersion(str) {
-  return str.replaceAll(process.version, '*');
-}
-
 describe('sourcemaps output', { concurrency: true }, () => {
   function normalize(str) {
     const result = str
@@ -16,7 +12,8 @@ describe('sourcemaps output', { concurrency: true }, () => {
     .replaceAll('/Users/bencoe/oss/coffee-script-test', '')
     .replaceAll(/\/(\w)/g, '*$1')
     .replaceAll('*test*', '*')
-    .replaceAll('*fixtures*source-map*', '*');
+    .replaceAll('*fixtures*source-map*', '*')
+    .replaceAll(/(\W+).*node:internal\*modules.*/g, '$1*');
     if (common.isWindows) {
       const currentDeviceLetter = path.parse(process.cwd()).root.substring(0, 1).toLowerCase();
       const regex = new RegExp(`${currentDeviceLetter}:/?`, 'gi');
@@ -25,7 +22,8 @@ describe('sourcemaps output', { concurrency: true }, () => {
     return result;
   }
   const defaultTransform = snapshot
-    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, normalize, replaceNodeVersion);
+    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths,
+               normalize, snapshot.replaceNodeVersion);
 
   const tests = [
     { name: 'source-map/output/source_map_disabled_by_api.js' },


### PR DESCRIPTION
Working on https://github.com/nodejs/node/pull/49657, I discovered that some of the more unusual snapshot tests had stack traces that include specifics of the module loader internals. (See https://github.com/nodejs/node/actions/runs/6191368639/job/16809521748?pr=49657.) Refactoring the modules code shouldn’t break these unrelated tests; these snapshots should be like the others that exclude detailed stack traces of modules internals. These two specific cases probably slipped through because they’re edge cases, having to do with source maps and colored stack trace output. This PR updates the tests and snapshots so that future modules changes don’t break these tests. @nodejs/test_runner @nodejs/testing 