### PR TITLE
stream: improve webstream readable async iterator performance

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -241,33 +241,6 @@ const getNonWritablePropertyDescriptor = (value) => {
  * }} UnderlyingSource
  */
 
-class ReadRequestData {
-  constructor(reader, state, promise) {
-    this.reader = reader;
-    this.state = state;
-    this.promise = promise;
-  }
-
-  [kChunk](chunk) {
-    this.state.current = undefined;
-    this.promise.resolve({value: chunk, done: false});
-  }
-
-  [kClose]() {
-    this.state.current = undefined;
-    this.state.done = true;
-    readableStreamReaderGenericRelease(this.reader);
-    this.promise.resolve({ done: true, value: undefined });
-  }
-
-  [kError](error) {
-    this.state.current = undefined;
-    this.state.done = true;
-    readableStreamReaderGenericRelease(this.reader);
-    this.promise.reject(error);
-  }
-}
-
 class ReadableStream {
   [kType] = 'ReadableStream';
 
@@ -506,12 +479,10 @@ class ReadableStream {
     const reader = new ReadableStreamDefaultReader(this);
 
     const state = {
-        done: false,
-        current: undefined,
+      done: false,
+      current: undefined,
     };
-    // let done = false;
     let started = false;
-    // let current;
 
     // The nextSteps function is not an async function in order
     // to make it more efficient. Because nextSteps explicitly
@@ -530,7 +501,8 @@ class ReadableStream {
       }
       const promise = createDeferredPromise();
 
-      const readRequest = new ReadRequestData(reader, state, promise);
+      // eslint-disable-next-line no-use-before-define
+      const readRequest = new ReadableStreamAsyncIteratorReadRequest(reader, state, promise);
 
       readableStreamDefaultReaderRead(reader, readRequest);
       return promise.promise;
@@ -588,7 +560,7 @@ class ReadableStream {
       return(error) {
         return state.current ?
           PromisePrototypeThen(
-              state.current,
+            state.current,
             () => returnSteps(error),
             () => returnSteps(error)) :
           returnSteps(error);
@@ -788,6 +760,33 @@ function createReadableStreamBYOBRequest(controller, view) {
   };
 
   return stream;
+}
+
+class ReadableStreamAsyncIteratorReadRequest {
+  constructor(reader, state, promise) {
+    this.reader = reader;
+    this.state = state;
+    this.promise = promise;
+  }
+
+  [kChunk](chunk) {
+    this.state.current = undefined;
+    this.promise.resolve({ value: chunk, done: false });
+  }
+
+  [kClose]() {
+    this.state.current = undefined;
+    this.state.done = true;
+    readableStreamReaderGenericRelease(this.reader);
+    this.promise.resolve({ done: true, value: undefined });
+  }
+
+  [kError](error) {
+    this.state.current = undefined;
+    this.state.done = true;
+    readableStreamReaderGenericRelease(this.reader);
+    this.promise.reject(error);
+  }
 }
 
 class DefaultReadRequest {

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -503,9 +503,7 @@ class ReadableStream {
       const promise = createDeferredPromise();
 
       // eslint-disable-next-line no-use-before-define
-      const readRequest = new ReadableStreamAsyncIteratorReadRequest(reader, state, promise);
-
-      readableStreamDefaultReaderRead(reader, readRequest);
+      readableStreamDefaultReaderRead(reader, new ReadableStreamAsyncIteratorReadRequest(reader, state, promise));
       return promise.promise;
     }
 

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -481,6 +481,7 @@ class ReadableStream {
     const state = {
       done: false,
       current: undefined,
+      __proto__: null,
     };
     let started = false;
 

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -478,10 +478,10 @@ class ReadableStream {
     // eslint-disable-next-line no-use-before-define
     const reader = new ReadableStreamDefaultReader(this);
 
+    // No __proto__ here to avoid the performance hit.
     const state = {
       done: false,
       current: undefined,
-      __proto__: null,
     };
     let started = false;
 

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -241,6 +241,33 @@ const getNonWritablePropertyDescriptor = (value) => {
  * }} UnderlyingSource
  */
 
+class ReadRequestData {
+  constructor(reader, state, promise) {
+    this.reader = reader;
+    this.state = state;
+    this.promise = promise;
+  }
+
+  [kChunk](chunk) {
+    this.state.current = undefined;
+    this.promise.resolve({value: chunk, done: false});
+  }
+
+  [kClose]() {
+    this.state.current = undefined;
+    this.state.done = true;
+    readableStreamReaderGenericRelease(this.reader);
+    this.promise.resolve({ done: true, value: undefined });
+  }
+
+  [kError](error) {
+    this.state.current = undefined;
+    this.state.done = true;
+    readableStreamReaderGenericRelease(this.reader);
+    this.promise.reject(error);
+  }
+}
+
 class ReadableStream {
   [kType] = 'ReadableStream';
 
@@ -477,9 +504,14 @@ class ReadableStream {
 
     // eslint-disable-next-line no-use-before-define
     const reader = new ReadableStreamDefaultReader(this);
-    let done = false;
+
+    const state = {
+        done: false,
+        current: undefined,
+    };
+    // let done = false;
     let started = false;
-    let current;
+    // let current;
 
     // The nextSteps function is not an async function in order
     // to make it more efficient. Because nextSteps explicitly
@@ -488,7 +520,7 @@ class ReadableStream {
     // unnecessary Promise allocations to occur, which just add
     // cost.
     function nextSteps() {
-      if (done)
+      if (state.done)
         return PromiseResolve({ done: true, value: undefined });
 
       if (reader[kState].stream === undefined) {
@@ -498,31 +530,16 @@ class ReadableStream {
       }
       const promise = createDeferredPromise();
 
-      readableStreamDefaultReaderRead(reader, {
-        [kChunk](chunk) {
-          current = undefined;
-          promise.resolve({ value: chunk, done: false });
-        },
-        [kClose]() {
-          current = undefined;
-          done = true;
-          readableStreamReaderGenericRelease(reader);
-          promise.resolve({ done: true, value: undefined });
-        },
-        [kError](error) {
-          current = undefined;
-          done = true;
-          readableStreamReaderGenericRelease(reader);
-          promise.reject(error);
-        },
-      });
+      const readRequest = new ReadRequestData(reader, state, promise);
+
+      readableStreamDefaultReaderRead(reader, readRequest);
       return promise.promise;
     }
 
     async function returnSteps(value) {
-      if (done)
+      if (state.done)
         return { done: true, value }; // eslint-disable-line node-core/avoid-prototype-pollution
-      done = true;
+      state.done = true;
 
       if (reader[kState].stream === undefined) {
         throw new ERR_INVALID_STATE.TypeError(
@@ -559,19 +576,19 @@ class ReadableStream {
         // need to investigate if it's a bug in our impl or
         // the spec.
         if (!started) {
-          current = PromiseResolve();
+          state.current = PromiseResolve();
           started = true;
         }
-        current = current !== undefined ?
-          PromisePrototypeThen(current, nextSteps, nextSteps) :
+        state.current = state.current !== undefined ?
+          PromisePrototypeThen(state.current, nextSteps, nextSteps) :
           nextSteps();
-        return current;
+        return state.current;
       },
 
       return(error) {
-        return current ?
+        return state.current ?
           PromisePrototypeThen(
-            current,
+              state.current,
             () => returnSteps(error),
             () => returnSteps(error)) :
           returnSteps(error);


### PR DESCRIPTION
140% Improvement
 
### Benchmark CI
```
                                                                        confidence improvement accuracy (*)    (**)   (***)
 webstreams/creation.js kind='ReadableStream.tee' n=50000                              -0.96 %       ±3.01%  ±4.01%  ±5.22%
 webstreams/creation.js kind='ReadableStream' n=50000                                  -0.15 %       ±3.60%  ±4.79%  ±6.24%
 webstreams/creation.js kind='ReadableStreamBYOBReader' n=50000                        -0.26 %       ±4.59%  ±6.11%  ±7.95%
 webstreams/creation.js kind='ReadableStreamDefaultReader' n=50000                      6.40 %      ±10.81% ±14.40% ±18.76%
 webstreams/creation.js kind='TransformStream' n=50000                                 -1.70 %       ±2.61%  ±3.48%  ±4.52%
 webstreams/creation.js kind='WritableStream' n=50000                                   0.50 %       ±4.24%  ±5.65%  ±7.35%
 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=1024 n=500000                 1.05 %       ±2.32%  ±3.09%  ±4.02%
 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=2048 n=500000                -0.07 %       ±1.67%  ±2.23%  ±2.90%
 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=4096 n=500000                 0.51 %       ±1.99%  ±2.66%  ±3.46%
 webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=512 n=500000                 -1.66 %       ±1.92%  ±2.56%  ±3.33%
 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=1024 n=500000                 1.23 %       ±1.78%  ±2.37%  ±3.08%
 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=2048 n=500000                -0.59 %       ±2.23%  ±2.97%  ±3.87%
 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=4096 n=500000                 1.76 %       ±1.93%  ±2.57%  ±3.35%
 webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=512 n=500000                 -1.05 %       ±2.07%  ±2.76%  ±3.60%
 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=1024 n=500000                -1.31 %       ±2.06%  ±2.74%  ±3.58%
 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=2048 n=500000                 0.71 %       ±1.97%  ±2.62%  ±3.41%
 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=4096 n=500000                 1.58 %       ±1.68%  ±2.24%  ±2.91%
 webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=512 n=500000                 -1.58 %       ±2.00%  ±2.66%  ±3.46%
 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=1024 n=500000                 -1.08 %       ±2.10%  ±2.79%  ±3.64%
 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=2048 n=500000                 -1.20 %       ±2.05%  ±2.72%  ±3.54%
 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=4096 n=500000                 -0.27 %       ±2.23%  ±2.97%  ±3.87%
 webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=512 n=500000                   1.03 %       ±2.07%  ±2.75%  ±3.58%
 webstreams/readable-async-iterator.js n=100000                                ***    140.34 %      ±13.76% ±18.45% ±24.31%
 
 Be aware that when doing many comparisons the risk of a false-positive
 result increases. In this case, there are 23 comparisons, you can thus
 expect the following amount of false-positive results:
   1.15 false positives, when considering a   5% risk acceptance (*, **, ***),
   0.23 false positives, when considering a   1% risk acceptance (**, ***),
   0.02 false positives, when considering a 0.1% risk acceptance (***)
```


### My local tests

```
confidence improvement accuracy (*)   (**)  (***)
webstreams/readable-async-iterator.js n=100000                                ***    136.22 %       ±1.83% ±2.45% ±3.24%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 23 comparisons, you can thus expect the following amount of false-positive results:
  1.15 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.23 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```


