### PR TITLE
src, doc: improve documentation and error message for ICU data fallback

### DIFF
--- a/doc/api/intl.md
+++ b/doc/api/intl.md
@@ -113,27 +113,47 @@ This mode provides a balance between features and binary size.
 
 If the `small-icu` option is used, one can still provide additional locale data
 at runtime so that the JS methods would work for all ICU locales. Assuming the
-data file is stored at `/some/directory`, it can be made available to ICU
-through either:
+data file is stored at `/runtime/directory/with/dat/file`, it can be made
+available to ICU through either:
+
+* The `--with-icu-default-data-dir` configure option:
+
+  ```bash
+  ./configure --with-icu-default-data-dir=/runtime/directory/with/dat/file --with-intl=small-icu
+  ```
+
+  This only embeds the default data directory path into the binary.
+  The actual data file is going to be loaded at runtime from this directory
+  path.
 
 * The [`NODE_ICU_DATA`][] environment variable:
 
   ```bash
-  env NODE_ICU_DATA=/some/directory node
+  env NODE_ICU_DATA=/runtime/directory/with/dat/file node
   ```
 
 * The [`--icu-data-dir`][] CLI parameter:
 
   ```bash
-  node --icu-data-dir=/some/directory
+  node --icu-data-dir=/runtime/directory/with/dat/file
   ```
 
-(If both are specified, the `--icu-data-dir` CLI parameter takes precedence.)
+When more than one of them is specified, the `--icu-data-dir` CLI parameter has
+the highest precedence, then the `NODE_ICU_DATA`  environment variable, then
+the `--with-icu-default-data-dir` configure option.
 
 ICU is able to automatically find and load a variety of data formats, but the
 data must be appropriate for the ICU version, and the file correctly named.
-The most common name for the data file is `icudt6X[bl].dat`, where `6X` denotes
+The most common name for the data file is `icudtX[bl].dat`, where `X` denotes
 the intended ICU version, and `b` or `l` indicates the system's endianness.
+Node.js would fail to load if the expected data file cannot be read from the
+specified directory. The name of the data file corresponding to the current
+Node.js version can be computed with:
+
+```js
+`icudt${process.versions.icu.split('.')[0]}${os.endianness()[0].toLowerCase()}.dat`;
+```
+
 Check ["ICU Data"][] article in the ICU User Guide for other supported formats
 and more details on ICU data in general.
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -916,9 +916,14 @@ static ExitCode InitializeNodeWithArgsInternal(
 
     // Initialize ICU.
     // If icu_data_dir is empty here, it will load the 'minimal' data.
-    if (!i18n::InitializeICUDirectory(per_process::cli_options->icu_data_dir)) {
-      errors->push_back("could not initialize ICU "
-                        "(check NODE_ICU_DATA or --icu-data-dir parameters)\n");
+    std::string icu_error;
+    if (!i18n::InitializeICUDirectory(per_process::cli_options->icu_data_dir,
+                                      &icu_error)) {
+      errors->push_back(icu_error +
+                        ": Could not initialize ICU. "
+                        "Check the directory specified by NODE_ICU_DATA or "
+                        "--icu-data-dir contains " U_ICUDATA_NAME ".dat and "
+                        "it's readable\n");
       return ExitCode::kInvalidCommandLineArgument;
     }
     per_process::metadata.versions.InitializeIntlVersions();

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -54,20 +54,21 @@
 #include "util-inl.h"
 #include "v8.h"
 
-#include <unicode/utypes.h>
 #include <unicode/putil.h>
+#include <unicode/timezone.h>
 #include <unicode/uchar.h>
 #include <unicode/uclean.h>
+#include <unicode/ucnv.h>
 #include <unicode/udata.h>
 #include <unicode/uidna.h>
-#include <unicode/ucnv.h>
-#include <unicode/utf8.h>
-#include <unicode/utf16.h>
-#include <unicode/timezone.h>
 #include <unicode/ulocdata.h>
+#include <unicode/urename.h>
+#include <unicode/ustring.h>
+#include <unicode/utf16.h>
+#include <unicode/utf8.h>
+#include <unicode/utypes.h>
 #include <unicode/uvernum.h>
 #include <unicode/uversion.h>
-#include <unicode/ustring.h>
 
 #ifdef NODE_HAVE_SMALL_ICU
 /* if this is defined, we have a 'secondary' entry point.
@@ -569,8 +570,7 @@ ConverterObject::ConverterObject(
   }
 }
 
-
-bool InitializeICUDirectory(const std::string& path) {
+bool InitializeICUDirectory(const std::string& path, std::string* error) {
   UErrorCode status = U_ZERO_ERROR;
   if (path.empty()) {
 #ifdef NODE_HAVE_SMALL_ICU
@@ -583,7 +583,12 @@ bool InitializeICUDirectory(const std::string& path) {
     u_setDataDirectory(path.c_str());
     u_init(&status);
   }
-  return status == U_ZERO_ERROR;
+  if (status == U_ZERO_ERROR) {
+    return true;
+  }
+
+  *error = u_errorName(status);
+  return false;
 }
 
 void SetDefaultTimeZone(const char* tzid) {

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -38,7 +38,7 @@
 namespace node {
 namespace i18n {
 
-bool InitializeICUDirectory(const std::string& path);
+bool InitializeICUDirectory(const std::string& path, std::string* error);
 
 void SetDefaultTimeZone(const char* tzid);
 

--- a/test/parallel/test-icu-data-dir.js
+++ b/test/parallel/test-icu-data-dir.js
@@ -1,27 +1,33 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
+const { spawnSyncAndExit } = require('../common/child_process');
 const { internalBinding } = require('internal/test/binding');
-const os = require('os');
 
 const { hasSmallICU } = internalBinding('config');
 if (!(common.hasIntl && hasSmallICU))
   common.skip('missing Intl');
 
-const assert = require('assert');
-const { spawnSync } = require('child_process');
-
-const expected =
-    'could not initialize ICU (check NODE_ICU_DATA or ' +
-    `--icu-data-dir parameters)${os.EOL}`;
-
 {
-  const child = spawnSync(process.execPath, ['--icu-data-dir=/', '-e', '0']);
-  assert(child.stderr.toString().includes(expected));
+  spawnSyncAndExit(
+    process.execPath,
+    ['--icu-data-dir=/', '-e', '0'],
+    {
+      status: 9,
+      signal: null,
+      stderr: /Could not initialize ICU/
+    });
 }
 
 {
   const env = { ...process.env, NODE_ICU_DATA: '/' };
-  const child = spawnSync(process.execPath, ['-e', '0'], { env });
-  assert(child.stderr.toString().includes(expected));
+  spawnSyncAndExit(
+    process.execPath,
+    ['-e', '0'],
+    { env },
+    {
+      status: 9,
+      signal: null,
+      stderr: /Could not initialize ICU/
+    });
 }


### PR DESCRIPTION
### src: improve error message when ICU data cannot be initialized

Previously when we fail to initialize ICU data, the error message is

```
could not initialize ICU (check NODE_ICU_DATA or --icu-data-dir
parameters)
```

This patch updates it to something similar to:

```
U_FILE_ACCESS_ERROR: Could not initialize ICU. Check the directory
specified by NODE_ICU_DATA or --icu-data-dir contains icudt73l.dat
and it's readable
```

Where the expected data file name is the same as U_ICUDATA_NAME.

### doc: improve documentation about ICU data fallback

This patch:

- Documents `--with-icu-default-data-dir` and its precedence
- Elaborates a bit more about the format of the name of the expected
  data file.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
