### PR TITLE
Update PipeWrap to use uv_pipe_bind2 and uv_pipe_connect2 to restore ability to connect to abstract domain sockets

### DIFF
--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -62,7 +62,6 @@ MaybeLocal<Object> PipeWrap::Instantiate(Environment* env,
       constructor->NewInstance(env->context(), 1, &type_value));
 }
 
-
 void PipeWrap::Initialize(Local<Object> target,
                           Local<Value> unused,
                           Local<Context> context,
@@ -71,8 +70,7 @@ void PipeWrap::Initialize(Local<Object> target,
   Isolate* isolate = env->isolate();
 
   Local<FunctionTemplate> t = NewFunctionTemplate(isolate, New);
-  t->InstanceTemplate()
-    ->SetInternalFieldCount(StreamBase::kInternalFieldCount);
+  t->InstanceTemplate()->SetInternalFieldCount(StreamBase::kInternalFieldCount);
 
   t->Inherit(LibuvStreamWrap::GetConstructorTemplate(env));
 
@@ -102,9 +100,7 @@ void PipeWrap::Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(constants, IPC);
   NODE_DEFINE_CONSTANT(constants, UV_READABLE);
   NODE_DEFINE_CONSTANT(constants, UV_WRITABLE);
-  target->Set(context,
-              env->constants_string(),
-              constants).Check();
+  target->Set(context, env->constants_string(), constants).Check();
 }
 
 void PipeWrap::RegisterExternalReferences(ExternalReferenceRegistry* registry) {
@@ -152,7 +148,6 @@ void PipeWrap::New(const FunctionCallbackInfo<Value>& args) {
   new PipeWrap(env, args.This(), provider, ipc);
 }
 
-
 PipeWrap::PipeWrap(Environment* env,
                    Local<Object> object,
                    ProviderType provider,
@@ -163,15 +158,13 @@ PipeWrap::PipeWrap(Environment* env,
                    // Suggestion: uv_pipe_init() returns void.
 }
 
-
 void PipeWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
   node::Utf8Value name(args.GetIsolate(), args[0]);
-  int err = uv_pipe_bind(&wrap->handle_, *name);
+  int err = uv_pipe_bind2(&wrap->handle_, *name, name.length(), 0);
   args.GetReturnValue().Set(err);
 }
-
 
 #ifdef _WIN32
 void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
@@ -183,7 +176,6 @@ void PipeWrap::SetPendingInstances(const FunctionCallbackInfo<Value>& args) {
 }
 #endif
 
-
 void PipeWrap::Fchmod(const v8::FunctionCallbackInfo<v8::Value>& args) {
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
@@ -193,19 +185,16 @@ void PipeWrap::Fchmod(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(err);
 }
 
-
 void PipeWrap::Listen(const FunctionCallbackInfo<Value>& args) {
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
   Environment* env = wrap->env();
   int backlog;
   if (!args[0]->Int32Value(env->context()).To(&backlog)) return;
-  int err = uv_listen(reinterpret_cast<uv_stream_t*>(&wrap->handle_),
-                      backlog,
-                      OnConnection);
+  int err = uv_listen(
+      reinterpret_cast<uv_stream_t*>(&wrap->handle_), backlog, OnConnection);
   args.GetReturnValue().Set(err);
 }
-
 
 void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -222,7 +211,6 @@ void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(err);
 }
 
-
 void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -237,10 +225,8 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
   ConnectWrap* req_wrap =
       new ConnectWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_PIPECONNECTWRAP);
-  req_wrap->Dispatch(uv_pipe_connect,
-                     &wrap->handle_,
-                     *name,
-                     AfterConnect);
+  req_wrap->Dispatch(
+      uv_pipe_connect2, &wrap->handle_, *name, name.length(), 0, AfterConnect);
 
   TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(TRACING_CATEGORY_NODE2(net, native),
                                     "connect",
@@ -250,7 +236,6 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
   args.GetReturnValue().Set(0);  // uv_pipe_connect() doesn't return errors.
 }
-
 
 }  // namespace node
 

--- a/test/parallel/test-pipe-abstract-socket-http.js
+++ b/test/parallel/test-pipe-abstract-socket-http.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+if (!common.isLinux) common.skip();
+
+const server = http.createServer(
+  common.mustCall((req, res) => {
+    res.end('ok');
+  })
+);
+
+server.listen(
+  '\0abstract',
+  common.mustCall(() => {
+    http.get(
+      {
+        socketPath: server.address(),
+      },
+      common.mustCall((res) => {
+        assert.strictEqual(res.statusCode, 200);
+        server.close();
+      })
+    );
+  })
+);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR moves `PipeWrap` from the classic `uv_pipe_bind` and `uv_pipe_connect` methods to their newer `uv_pipe_bind2` and `uv_pipe_connect2` counterparts. This restores support for connecting to abstract unix domain sockets. Support was lost due to the refactor in libuv/libuv#4030 where `uv_pipe_bind` and `uv_pipe_connect` now infer the length of the `pathname` using `strlen()`. For an abstract unix socket, this was producing `0`. Moving to `uv_pipe_bind2` and `uv_pipe_connect2` allows us to pass an explicit `size_t` for the socket path based on the length of the v8 string.

Fixes: https://github.com/nodejs/node/issues/49656