### PR TITLE
test: add and use checkIfCollectable in vm leak tests

### DIFF
--- a/test/common/gc.js
+++ b/test/common/gc.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// TODO(joyeecheung): merge ongc.js and gcUntil from common/index.js
+// into this.
+
+// This function can be used to check if an object factor leaks or not,
+// but it needs to be used with care:
+// 1. The test should be set up with an ideally small
+//   --max-old-space-size or --max-heap-size, which combined with
+//   the maxCount parameter can reproduce a leak of the objects
+//   created by fn().
+// 2. This works under the assumption that if *none* of the objects
+//   created by fn() can be garbage-collected, the test would crash due
+//   to OOM.
+// 3. If *any* of the objects created by fn() can be garbage-collected,
+//   it is considered leak-free. The FinalizationRegistry is used to
+//   terminate the test early once we detect any of the object is
+//   garbage-collected to make the test less prone to false positives.
+//   This may be especially important for memory management relying on
+//   emphemeron GC which can be inefficient to deal with extremely fast
+//   heap growth.
+// Note that this can still produce false positives. When the test using
+// this function still crashes due to OOM, inspect the heap to confirm
+// if a leak is present (e.g. using heap snapshots).
+async function checkIfCollectable(fn, maxCount = 4096, logEvery = 128) {
+  let anyFinalized = false;
+  let count = 0;
+
+  const f = new FinalizationRegistry(() => {
+    anyFinalized = true;
+  });
+
+  async function createObject() {
+    const obj = await fn();
+    f.register(obj);
+    if (count % logEvery === 1) {
+      console.log('Created', count);
+    }
+    if (count++ < maxCount && !anyFinalized) {
+      setImmediate(createObject);
+    }
+  }
+
+  createObject();
+}
+
+module.exports = {
+  checkIfCollectable,
+};

--- a/test/es-module/test-vm-compile-function-leak.js
+++ b/test/es-module/test-vm-compile-function-leak.js
@@ -4,16 +4,13 @@
 // This tests that vm.compileFunction with dynamic import callback does not leak.
 // See https://github.com/nodejs/node/issues/44211
 require('../common');
+const { checkIfCollectable } = require('../common/gc');
 const vm = require('vm');
-let count = 0;
 
-function main() {
-  // Try to reach the maximum old space size.
-  vm.compileFunction(`"${Math.random().toString().repeat(512)}"`, [], {
+async function createCompiledFunction() {
+  return vm.compileFunction(`"${Math.random().toString().repeat(512)}"`, [], {
     async importModuleDynamically() {},
   });
-  if (count++ < 2048) {
-    setTimeout(main, 1);
-  }
 }
-main();
+
+checkIfCollectable(createCompiledFunction, 2048);

--- a/test/es-module/test-vm-contextified-script-leak.js
+++ b/test/es-module/test-vm-contextified-script-leak.js
@@ -4,16 +4,13 @@
 // This tests that vm.Script with dynamic import callback does not leak.
 // See: https://github.com/nodejs/node/issues/33439
 require('../common');
+const { checkIfCollectable } = require('../common/gc');
 const vm = require('vm');
-let count = 0;
 
-function main() {
+async function createContextifyScript() {
   // Try to reach the maximum old space size.
-  new vm.Script(`"${Math.random().toString().repeat(512)}";`, {
+  return new vm.Script(`"${Math.random().toString().repeat(512)}";`, {
     async importModuleDynamically() {},
   });
-  if (count++ < 2 * 1024) {
-    setTimeout(main, 1);
-  }
 }
-main();
+checkIfCollectable(createContextifyScript, 2048);

--- a/test/es-module/test-vm-source-text-module-leak.js
+++ b/test/es-module/test-vm-source-text-module-leak.js
@@ -18,4 +18,4 @@ async function createSourceTextModule() {
   return m;
 }
 
-checkIfCollectable(createSourceTextModule, 4096);
+checkIfCollectable(createSourceTextModule, 4096, 1024);

--- a/test/es-module/test-vm-source-text-module-leak.js
+++ b/test/es-module/test-vm-source-text-module-leak.js
@@ -4,20 +4,18 @@
 // This tests that vm.SourceTextModule() does not leak.
 // See: https://github.com/nodejs/node/issues/33439
 require('../common');
-
+const { checkIfCollectable } = require('../common/gc');
 const vm = require('vm');
-let count = 0;
-async function createModule() {
+
+async function createSourceTextModule() {
   // Try to reach the maximum old space size.
   const m = new vm.SourceTextModule(`
-  const bar = new Array(512).fill("----");
-  export { bar };
-`);
+    const bar = new Array(512).fill("----");
+    export { bar };
+  `);
   await m.link(() => {});
   await m.evaluate();
-  if (count++ < 4096) {
-    setTimeout(createModule, 1);
-  }
   return m;
 }
-createModule();
+
+checkIfCollectable(createSourceTextModule, 4096);

--- a/test/es-module/test-vm-synthetic-module-leak.js
+++ b/test/es-module/test-vm-synthetic-module-leak.js
@@ -4,20 +4,15 @@
 // This tests that vm.SyntheticModule does not leak.
 // See https://github.com/nodejs/node/issues/44211
 require('../common');
+const { checkIfCollectable } = require('../common/gc');
 const vm = require('vm');
 
-let count = 0;
-async function createModule() {
-  // Try to reach the maximum old space size.
+async function createSyntheticModule() {
   const m = new vm.SyntheticModule(['bar'], () => {
     m.setExport('bar', new Array(512).fill('----'));
   });
   await m.link(() => {});
   await m.evaluate();
-  if (count++ < 4 * 1024) {
-    setTimeout(createModule, 1);
-  }
   return m;
 }
-
-createModule();
+checkIfCollectable(createSyntheticModule, 4096);


### PR DESCRIPTION
### test: add checkIfCollectable to test/common/gc.js

### test: use checkIfCollectable in vm leak tests

Previously we simply create a lot of the target objects and check
if the process crash due to OOM. Due to how we use emphemeron GC
to handle memory management, which is inefficient but necessary
for correctness, the tests can produce false positives as
the GC isn't efficient enough to catch up with a very fast
heap growth.

This patch uses a new checkIfCollectable() utility to terminate the
test early once we detect that any of the target object can actually
be garbage collected. This should lower the chance of false positives.
As a drive-by this also allows us to use setImmediate() to grow the
heap even faster to make the tests run faster.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
