### PR TITLE
src: move const variable in `node_file.h` to `node_file.cc`

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2909,11 +2909,18 @@ BindingData::FilePathIsFileReturnType BindingData::FilePathIsFile(
   return BindingData::FilePathIsFileReturnType::kIsNotFile;
 }
 
+namespace {
+// define the final index of the algorithm resolution
+// when packageConfig.main is defined.
+constexpr uint8_t legacy_main_extensions_with_main_end = 7;
+// define the final index of the algorithm resolution
+// when packageConfig.main is NOT defined
+constexpr uint8_t legacy_main_extensions_package_fallback_end = 10;
 // the possible file extensions that should be tested
 // 0-6: when packageConfig.main is defined
 // 7-9: when packageConfig.main is NOT defined,
 //      or when the previous case didn't found the file
-const std::array<std::string, 10> BindingData::legacy_main_extensions = {
+constexpr char* legacy_main_extensions[] = {
     "",
     ".js",
     ".json",
@@ -2924,6 +2931,7 @@ const std::array<std::string, 10> BindingData::legacy_main_extensions = {
     ".js",
     ".json",
     ".node"};
+}
 
 void BindingData::LegacyMainResolve(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(args.Length(), 1);
@@ -2965,9 +2973,9 @@ void BindingData::LegacyMainResolve(const FunctionCallbackInfo<Value>& args) {
 
     FromNamespacedPath(&initial_file_path);
 
-    for (int i = 0; i < BindingData::legacy_main_extensions_with_main_end;
+    for (int i = 0; i < legacy_main_extensions_with_main_end;
          i++) {
-      file_path = initial_file_path + BindingData::legacy_main_extensions[i];
+      file_path = initial_file_path + legacy_main_extensions[i];
 
       switch (FilePathIsFile(env, file_path)) {
         case BindingData::FilePathIsFileReturnType::kIsFile:
@@ -3000,10 +3008,10 @@ void BindingData::LegacyMainResolve(const FunctionCallbackInfo<Value>& args) {
 
   FromNamespacedPath(&initial_file_path);
 
-  for (int i = BindingData::legacy_main_extensions_with_main_end;
-       i < BindingData::legacy_main_extensions_package_fallback_end;
+  for (int i = legacy_main_extensions_with_main_end;
+       i < legacy_main_extensions_package_fallback_end;
        i++) {
-    file_path = initial_file_path + BindingData::legacy_main_extensions[i];
+    file_path = initial_file_path + legacy_main_extensions[i];
 
     switch (FilePathIsFile(env, file_path)) {
       case BindingData::FilePathIsFileReturnType::kIsFile:

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -102,14 +102,6 @@ class BindingData : public SnapshotableObject {
 
   static FilePathIsFileReturnType FilePathIsFile(Environment* env,
                                                  const std::string& file_path);
-
-  static const std::array<std::string, 10> legacy_main_extensions;
-  // define the final index of the algorithm resolution
-  // when packageConfig.main is defined.
-  static const uint8_t legacy_main_extensions_with_main_end = 7;
-  // define the final index of the algorithm resolution
-  // when packageConfig.main is NOT defined
-  static const uint8_t legacy_main_extensions_package_fallback_end = 10;
 };
 
 // structure used to store state during a complex operation, e.g., mkdirp.


### PR DESCRIPTION
After checking the comments in the reference, In my opinion, there is no need to define `const` variables in the header.

It seems efficient to process it by defining it as `constexpr` in the source file so that it can be evaluated at compile time. To this end, I suggest changing it to `char[]` rather than processing it as `std::array`.

Refs: #48325 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
