### PR TITLE
doc: deprecate `fs.F_OK`, `fs.R_OK`, `fs.W_OK`, `fs.X_OK`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3397,6 +3397,20 @@ Type: Documentation-only
 Calling [`util.promisify`][] on a function that returns a <Promise> will ignore
 the result of said promise, which can lead to unhandled promise rejections.
 
+### DEP0175: `fs.F_OK`, `fs.R_OK`, `fs.W_OK`, `fs.X_OK`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+`F_OK`, `R_OK`, `W_OK` and `X_OK` getters exposed directly on `node:fs` are
+deprecated. Get them from `fs.constants` or `fs.promises.constants` instead.
+
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [RFC 8247 Section 2.4]: https://www.rfc-editor.org/rfc/rfc8247#section-2.4

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3402,7 +3402,7 @@ the result of said promise, which can lead to unhandled promise rejections.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/49683
     description: Documentation-only deprecation.
 -->
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1828,6 +1828,9 @@ concurrent modifications on the same file or data corruption may occur.
 <!-- YAML
 added: v0.11.15
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: `fs.F_OK`, `fs.R_OK`, `fs.W_OK` and `fs.X_OK`are deprecated.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678
     description: Passing an invalid callback to the `callback` argument

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1829,7 +1829,7 @@ concurrent modifications on the same file or data corruption may occur.
 added: v0.11.15
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/49683
     description: `fs.F_OK`, `fs.R_OK`, `fs.W_OK` and `fs.X_OK`are deprecated.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1830,7 +1830,8 @@ added: v0.11.15
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/49683
-    description: `fs.F_OK`, `fs.R_OK`, `fs.W_OK` and `fs.X_OK`are deprecated.
+    description: The constants `fs.F_OK`, `fs.R_OK`, `fs.W_OK` and `fs.X_OK`
+                 which were present directly on `fs` are deprecated.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678
     description: Passing an invalid callback to the `callback` argument


### PR DESCRIPTION
These constants were soft deprecated since [v6.3.0](https://nodejs.org/api/fs.html#fsaccesspath-mode-callback) in favour of `fs.constants`.

Nowadays we also have `fs.promises.constants` without re-exposing those directly on `fs.promises`, so perhaps it's time to get rid of them.

cc @nodejs/fs 