### PR TITLE
querystring: rebalance the performance of unescape

### DIFF
--- a/benchmark/querystring/querystring-unescape.js
+++ b/benchmark/querystring/querystring-unescape.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common.js');
+const querystring = require('querystring');
+
+const bench = common.createBenchmark(main, {
+  input: [
+    'there is nothing to unescape here',
+    'there+are+spaces+to+unescape+here',
+    'there%20are%20several%20spaces%20that%20need%20to%20be%20unescaped',
+    '%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%30%31%32%33%34%35%36%37',
+    'there%2Qare%0-fake%escaped values in%%%%this%9Hstring',
+    'there%2Qare%0-fake%escaped%20values in%%%%this%9Hstring',
+    '%%2a',
+    '%2sf%2a',
+    '%2%2af%2a',
+  ],
+  n: [10e6],
+  decodeSpaces: [1, 0],
+});
+
+function main({ input, n, decodeSpaces }) {
+  decodeSpaces = !!decodeSpaces;
+  bench.start();
+  for (let i = 0; i < n; i += 1)
+    querystring.unescape(input, decodeSpaces);
+  bench.end(n);
+}

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -28,10 +28,15 @@ const {
   ArrayIsArray,
   Int8Array,
   MathAbs,
+  NumberParseInt,
   NumberIsFinite,
   ObjectKeys,
+  RegExpPrototypeExec,
   String,
+  StringFromCharCode,
   StringPrototypeCharCodeAt,
+  StringPrototypeIndexOf,
+  StringPrototypeReplace,
   StringPrototypeSlice,
   decodeURIComponent,
 } = primordials;
@@ -125,17 +130,40 @@ function unescapeBuffer(s, decodeSpaces) {
 
 /**
  * @param {string} s
- * @param {boolean} decodeSpaces
+ * @param {boolean} [decodeSpaces=false]
  * @returns {string}
  */
-function qsUnescape(s, decodeSpaces) {
-  try {
-    return decodeURIComponent(s);
-  } catch {
-    return QueryString.unescapeBuffer(s, decodeSpaces).toString();
+function qsUnescape(s, decodeSpaces = false) {
+  if (StringPrototypeIndexOf(s, '%') === -1) {
+    return s;
   }
+
+  if (RegExpPrototypeExec(MALFORMED_URI_REGEX, s) !== null) {
+    if (decodeSpaces) {
+      return StringPrototypeReplace(s, decodeSpacesRegexp, decodeSpacesReplacer);
+    }
+    return StringPrototypeReplace(s, baseRegexp, baseReplacer);
+
+  }
+  return decodeURIComponent(s);
+
 }
 
+const MALFORMED_URI_REGEX = /(?:%(?:[^0-9a-fA-F]|[0-9a-fA-F][^0-9a-fA-F]))/u;
+
+const baseRegexp = /(%[\da-fA-F]{2})/gu;
+
+function baseReplacer(match) {
+  return StringFromCharCode(NumberParseInt(match[1] + match[2], 16));
+}
+
+const decodeSpacesRegexp = /(%[\da-fA-F]{2}|[+])/gu;
+
+function decodeSpacesReplacer(match) {
+  return match === '+' ?
+    ' ' :
+    StringFromCharCode(NumberParseInt(match[1] + match[2], 16));
+}
 
 // These characters do not need escaping when generating query strings:
 // ! - . _ ~

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -170,9 +170,13 @@ const qsNoMungeTestCases = [
 const qsUnescapeTestCases = [
   ['there is nothing to unescape here',
    'there is nothing to unescape here'],
+  ['there+is+nothing+to+unescape+here',
+   'there+is+nothing+to+unescape+here'],
   ['there%20are%20several%20spaces%20that%20need%20to%20be%20unescaped',
    'there are several spaces that need to be unescaped'],
   ['there%2Qare%0-fake%escaped values in%%%%this%9Hstring',
+   'there%2Qare%0-fake%escaped values in%%%%this%9Hstring'],
+  ['there%2Qare%0-fake%escaped%20values in%%%%this%9Hstring',
    'there%2Qare%0-fake%escaped values in%%%%this%9Hstring'],
   ['%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%30%31%32%33%34%35%36%37',
    ' !"#$%&\'()*+,-./01234567'],


### PR DESCRIPTION
This is a more subjective change.

Yes, it is better to optimize the performance for the valid values. But we should atleast talk about a potential rebalance, because the invalid cases are by a magnitude to the power of 10 slower.  

Main:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/node$ ./node benchmark/querystring/querystring-unescape
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="there is nothing to unescape here": 4,113,106.929616375
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="there is nothing to unescape here": 4,089,343.3686964614
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="there+are+spaces+to+unescape+here": 4,274,766.056566554
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="there+are+spaces+to+unescape+here": 4,061,408.8115218435
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="there%20are%20several%20spaces%20that%20need%20to%20be%20unescaped": 3,510,995.446936891
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="there%20are%20several%20spaces%20that%20need%20to%20be%20unescaped": 3,460,418.298049153
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%30%31%32%33%34%35%36%37": 3,869,361.695712258
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%30%31%32%33%34%35%36%37": 3,775,579.0810461766
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="there%2Qare%0-fake%escaped values in%%%%this%9Hstring": 215,872.0410033765
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="there%2Qare%0-fake%escaped values in%%%%this%9Hstring": 213,378.59760950686
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="there%2Qare%0-fake%escaped%20values in%%%%this%9Hstring": 207,500.03947543
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="there%2Qare%0-fake%escaped%20values in%%%%this%9Hstring": 205,365.56867032265
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="%%2a": 223,229.9520471313
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="%%2a": 223,690.59260464486
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="%2sf%2a": 227,860.16645240664
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="%2sf%2a": 225,300.9021186388
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="%2%2af%2a": 225,509.4556772351
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="%2%2af%2a": 225,241.08518054444
```

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/node$ ./node benchmark/querystring/querystring-parse.js 
querystring/querystring-parse.js n=1000000 type="noencode": 2,177,571.164212423
querystring/querystring-parse.js n=1000000 type="multicharsep": 1,739,568.2493195976
querystring/querystring-parse.js n=1000000 type="encodefake": 2,085,370.2926235178
querystring/querystring-parse.js n=1000000 type="encodemany": 802,063.171478715
querystring/querystring-parse.js n=1000000 type="encodelast": 1,556,455.2942840066
querystring/querystring-parse.js n=1000000 type="multivalue": 1,571,969.2554190147
querystring/querystring-parse.js n=1000000 type="multivaluemany": 632,386.2968473879
querystring/querystring-parse.js n=1000000 type="manypairs": 482,585.1627748775
querystring/querystring-parse.js n=1000000 type="manyblankpairs": 9,688,510.230044665
querystring/querystring-parse.js n=1000000 type="altspaces": 1,283,259.4807236101
```

PR:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/node$ ./node benchmark/querystring/querystring-unescape
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="there is nothing to unescape here": 100,427,336.39327392
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="there is nothing to unescape here": 97,391,355.97371358
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="there+are+spaces+to+unescape+here": 102,242,459.32212186
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="there+are+spaces+to+unescape+here": 99,328,034.91769794
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="there%20are%20several%20spaces%20that%20need%20to%20be%20unescaped": 2,633,501.5164387757
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="there%20are%20several%20spaces%20that%20need%20to%20be%20unescaped": 2,682,782.847191968
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%30%31%32%33%34%35%36%37": 2,499,892.974581972
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%30%31%32%33%34%35%36%37": 2,480,777.7518877746
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="there%2Qare%0-fake%escaped values in%%%%this%9Hstring": 3,861,793.8289530952
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="there%2Qare%0-fake%escaped values in%%%%this%9Hstring": 3,967,029.210953804
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="there%2Qare%0-fake%escaped%20values in%%%%this%9Hstring": 1,459,010.40988068
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="there%2Qare%0-fake%escaped%20values in%%%%this%9Hstring": 1,502,679.3505376268
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="%%2a": 1,779,846.2099925526
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="%%2a": 1,825,411.7980473512
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="%2sf%2a": 1,774,107.3798485843
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="%2sf%2a": 1,791,908.5580977711
querystring/querystring-unescape.js decodeSpaces=1 n=10000000 input="%2%2af%2a": 1,281,074.3418205427
querystring/querystring-unescape.js decodeSpaces=0 n=10000000 input="%2%2af%2a": 1,292,793.9636541568
```

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/node$ ./node benchmark/querystring/querystring-parse.js 
querystring/querystring-parse.js n=1000000 type="noencode": 2,121,496.3342187502
querystring/querystring-parse.js n=1000000 type="multicharsep": 1,651,250.577514569
querystring/querystring-parse.js n=1000000 type="encodefake": 1,880,046.3216340984
querystring/querystring-parse.js n=1000000 type="encodemany": 686,176.5092676014
querystring/querystring-parse.js n=1000000 type="encodelast": 1,427,965.3511176023
querystring/querystring-parse.js n=1000000 type="multivalue": 1,568,195.285878574
querystring/querystring-parse.js n=1000000 type="multivaluemany": 628,898.464937145
querystring/querystring-parse.js n=1000000 type="manypairs": 509,180.7333122751
querystring/querystring-parse.js n=1000000 type="manyblankpairs": 9,802,497.611694977
querystring/querystring-parse.js n=1000000 type="altspaces": 1,254,499.2616017347
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
