### PR TITLE
stream: improve readable webstream `pipeTo`

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1452,9 +1452,7 @@ function readableStreamPipeTo(
 
     const promise = createDeferredPromise();
     // eslint-disable-next-line no-use-before-define
-    const readRequest = new PipeToReadableStreamReadRequest(writer, state, promise);
-
-    readableStreamDefaultReaderRead(reader, readRequest);
+    readableStreamDefaultReaderRead(reader, new PipeToReadableStreamReadRequest(writer, state, promise));
 
     return promise.promise;
   }

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1336,7 +1336,9 @@ function readableStreamPipeTo(
 
   const promise = createDeferredPromise();
 
-  let currentWrite = PromiseResolve();
+  const state = {
+    currentWrite: PromiseResolve(),
+  };
 
   // The error here can be undefined. The rejected arg
   // tells us that the promise must be rejected even
@@ -1353,9 +1355,9 @@ function readableStreamPipeTo(
   }
 
   async function waitForCurrentWrite() {
-    const write = currentWrite;
+    const write = state.currentWrite;
     await write;
-    if (write !== currentWrite)
+    if (write !== state.currentWrite)
       await waitForCurrentWrite();
   }
 
@@ -1446,20 +1448,15 @@ function readableStreamPipeTo(
   async function step() {
     if (shuttingDown)
       return true;
+
     await writer[kState].ready.promise;
-    return new Promise((resolve, reject) => {
-      readableStreamDefaultReaderRead(
-        reader,
-        {
-          [kChunk](chunk) {
-            currentWrite = writableStreamDefaultWriterWrite(writer, chunk);
-            setPromiseHandled(currentWrite);
-            resolve(false);
-          },
-          [kClose]: () => resolve(true),
-          [kError]: reject,
-        });
-    });
+
+    const promise = createDeferredPromise();
+    const readRequest = new PipeToReadableStreamReadRequest(writer, state, promise);
+
+    readableStreamDefaultReaderRead(reader, readRequest);
+
+    return promise.promise;
   }
 
   async function run() {
@@ -1519,6 +1516,28 @@ function readableStreamPipeTo(
   }
 
   return promise.promise;
+}
+
+class PipeToReadableStreamReadRequest {
+  constructor(writer, state, promise) {
+    this.writer = writer;
+    this.state = state;
+    this.promise = promise;
+  }
+
+  [kChunk](chunk) {
+    this.state.currentWrite = writableStreamDefaultWriterWrite(this.writer, chunk);
+    setPromiseHandled(this.state.currentWrite);
+    this.promise.resolve(false);
+  }
+
+  [kClose]() {
+    this.promise.resolve(true)
+  }
+
+  [kError](error) {
+    this.promise.reject(error);
+  }
 }
 
 function readableStreamTee(stream, cloneForBranch2) {

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -14,7 +14,6 @@ const {
   ObjectCreate,
   ObjectDefineProperties,
   ObjectSetPrototypeOf,
-  Promise,
   PromisePrototypeThen,
   PromiseResolve,
   PromiseReject,
@@ -1452,6 +1451,7 @@ function readableStreamPipeTo(
     await writer[kState].ready.promise;
 
     const promise = createDeferredPromise();
+    // eslint-disable-next-line no-use-before-define
     const readRequest = new PipeToReadableStreamReadRequest(writer, state, promise);
 
     readableStreamDefaultReaderRead(reader, readRequest);
@@ -1532,7 +1532,7 @@ class PipeToReadableStreamReadRequest {
   }
 
   [kClose]() {
-    this.promise.resolve(true)
+    this.promise.resolve(true);
   }
 
   [kError](error) {


### PR DESCRIPTION
improvement of ~60%

### benchmark ci:
```
                                                                       confidence improvement accuracy (*)    (**)   (***)
webstreams/creation.js kind='ReadableStream.tee' n=50000                        *     -3.14 %       ±2.61%  ±3.49%  ±4.56%
webstreams/creation.js kind='ReadableStream' n=50000                                   0.82 %       ±3.54%  ±4.71%  ±6.13%
webstreams/creation.js kind='ReadableStreamBYOBReader' n=50000                        -0.03 %       ±4.17%  ±5.55%  ±7.23%
webstreams/creation.js kind='ReadableStreamDefaultReader' n=50000                      3.01 %      ±10.03% ±13.40% ±17.56%
webstreams/creation.js kind='TransformStream' n=50000                                  1.19 %       ±2.14%  ±2.84%  ±3.70%
webstreams/creation.js kind='WritableStream' n=50000                                  -1.15 %       ±3.61%  ±4.81%  ±6.26%
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=1024 n=500000        ***     62.25 %       ±3.69%  ±4.95%  ±6.51%
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=2048 n=500000        ***     66.37 %       ±3.48%  ±4.67%  ±6.15%
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=4096 n=500000        ***     64.58 %       ±4.21%  ±5.65%  ±7.44%
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=512 n=500000         ***     61.06 %       ±3.50%  ±4.69%  ±6.16%
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=1024 n=500000        ***     66.45 %       ±3.90%  ±5.22%  ±6.85%
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=2048 n=500000        ***     65.32 %       ±3.50%  ±4.70%  ±6.20%
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=4096 n=500000        ***     63.26 %       ±3.89%  ±5.21%  ±6.84%
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=512 n=500000         ***     64.78 %       ±3.94%  ±5.27%  ±6.93%
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=1024 n=500000        ***     69.88 %       ±3.30%  ±4.41%  ±5.80%
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=2048 n=500000        ***     65.36 %       ±3.73%  ±5.00%  ±6.58%
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=4096 n=500000        ***     65.94 %       ±3.70%  ±4.96%  ±6.52%
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=512 n=500000         ***     59.84 %       ±4.31%  ±5.78%  ±7.63%
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=1024 n=500000         ***     65.53 %       ±3.91%  ±5.24%  ±6.90%
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=2048 n=500000         ***     66.57 %       ±3.59%  ±4.81%  ±6.33%
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=4096 n=500000         ***     69.25 %       ±3.92%  ±5.27%  ±6.95%
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=512 n=500000          ***     66.25 %       ±3.61%  ±4.83%  ±6.34%
webstreams/readable-async-iterator.js n=100000                                         2.85 %       ±6.90%  ±9.17% ±11.94%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 23 comparisons, you can thus
expect the following amount of false-positive results:
  1.15 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.23 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```


### local tests

```
                                                                       confidence improvement accuracy (*)   (**)  (***)
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=1024 n=500000        ***     60.99 %       ±1.17% ±1.56% ±2.04%
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=2048 n=500000        ***     59.79 %       ±1.08% ±1.44% ±1.88%
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=4096 n=500000        ***     60.23 %       ±1.11% ±1.48% ±1.93%
webstreams/pipe-to.js highWaterMarkW=1024 highWaterMarkR=512 n=500000         ***     59.52 %       ±1.31% ±1.75% ±2.29%
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=1024 n=500000        ***     59.72 %       ±1.27% ±1.69% ±2.20%
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=2048 n=500000        ***     60.98 %       ±1.19% ±1.59% ±2.07%
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=4096 n=500000        ***     58.00 %       ±1.10% ±1.46% ±1.91%
webstreams/pipe-to.js highWaterMarkW=2048 highWaterMarkR=512 n=500000         ***     60.16 %       ±1.25% ±1.66% ±2.18%
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=1024 n=500000        ***     59.35 %       ±1.21% ±1.62% ±2.11%
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=2048 n=500000        ***     59.69 %       ±1.13% ±1.51% ±1.98%
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=4096 n=500000        ***     59.78 %       ±1.02% ±1.36% ±1.78%
webstreams/pipe-to.js highWaterMarkW=4096 highWaterMarkR=512 n=500000         ***     59.84 %       ±1.43% ±1.91% ±2.52%
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=1024 n=500000         ***     60.59 %       ±1.10% ±1.47% ±1.91%
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=2048 n=500000         ***     59.37 %       ±1.17% ±1.57% ±2.05%
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=4096 n=500000         ***     59.87 %       ±1.24% ±1.66% ±2.17%
webstreams/pipe-to.js highWaterMarkW=512 highWaterMarkR=512 n=500000          ***     58.74 %       ±1.48% ±1.98% ±2.59%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 16 comparisons, you can thus expect the following amount of false-positive results:
  0.80 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.16 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```