### PR TITLE
fs: improve `readFileSync` with file descriptors

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -131,7 +131,7 @@ const {
   CHAR_BACKWARD_SLASH,
 } = require('internal/constants');
 const {
-  isUint32,
+  isInt32,
   parseFileMode,
   validateBoolean,
   validateBuffer,
@@ -201,7 +201,7 @@ function makeStatsCallback(cb) {
   };
 }
 
-const isFd = isUint32;
+const isFd = isInt32;
 
 function isFileType(stats, fileType) {
   // Use stats array directly to avoid creating an fs.Stats instance just for
@@ -437,13 +437,11 @@ function tryReadSync(fd, isUserFd, buffer, pos, len) {
 function readFileSync(path, options) {
   options = getOptions(options, { flag: 'r' });
 
-  const isUserFd = isFd(path); // File descriptor ownership
-
-  // TODO(@anonrig): Do not handle file descriptor ownership for now.
-  if (!isUserFd && (options.encoding === 'utf8' || options.encoding === 'utf-8')) {
+  if (options.encoding === 'utf8' || options.encoding === 'utf-8') {
     return syncFs.readFileUtf8(path, options.flag);
   }
 
+  const isUserFd = isFd(path); // File descriptor ownership
   const fd = isUserFd ? path : fs.openSync(path, options.flag, 0o666);
 
   const stats = tryStatSync(fd, isUserFd);

--- a/lib/internal/fs/sync.js
+++ b/lib/internal/fs/sync.js
@@ -9,7 +9,7 @@ const {
   getStatFsFromBinding,
   getValidatedFd,
 } = require('internal/fs/utils');
-const { parseFileMode } = require('internal/validators');
+const { parseFileMode, isInt32 } = require('internal/validators');
 
 const binding = internalBinding('fs');
 
@@ -19,7 +19,9 @@ const binding = internalBinding('fs');
  * @return {string}
  */
 function readFileUtf8(path, flag) {
-  path = pathModule.toNamespacedPath(getValidatedPath(path));
+  if (!isInt32(path)) {
+    path = pathModule.toNamespacedPath(getValidatedPath(path));
+  }
   return binding.readFileUtf8(path, stringToFlags(flag));
 }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2155,7 +2155,7 @@ static void OpenSync(const FunctionCallbackInfo<Value>& args) {
   uv_fs_t req;
   auto make = OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
   FS_SYNC_TRACE_BEGIN(open);
-  int err = uv_fs_open(nullptr, &req, *path, flags, mode, nullptr);
+  auto err = uv_fs_open(nullptr, &req, *path, flags, mode, nullptr);
   FS_SYNC_TRACE_END(open);
   if (err < 0) {
     return env->ThrowUVException(err, "open", nullptr, path.out());
@@ -2546,30 +2546,40 @@ static void ReadFileUtf8(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_GE(args.Length(), 2);
 
-  BufferValue path(env->isolate(), args[0]);
-  CHECK_NOT_NULL(*path);
-
   CHECK(args[1]->IsInt32());
   const int flags = args[1].As<Int32>()->Value();
 
-  if (CheckOpenPermissions(env, path, flags).IsNothing()) return;
-
+  uv_file file;
   uv_fs_t req;
   auto defer_req_cleanup = OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
 
-  FS_SYNC_TRACE_BEGIN(open);
-  uv_file file = uv_fs_open(nullptr, &req, *path, flags, 438, nullptr);
-  FS_SYNC_TRACE_END(open);
-  if (req.result < 0) {
-    // req will be cleaned up by scope leave.
-    return env->ThrowUVException(req.result, "open", nullptr, path.out());
+  bool is_fd = args[0]->IsInt32();
+
+  // Check for file descriptor
+  if (is_fd) {
+    file = args[0].As<Int32>()->Value();
+  } else {
+    BufferValue path(env->isolate(), args[0]);
+    CHECK_NOT_NULL(*path);
+    if (CheckOpenPermissions(env, path, flags).IsNothing()) return;
+
+    FS_SYNC_TRACE_BEGIN(open);
+    file = uv_fs_open(nullptr, &req, *path, flags, O_RDONLY, nullptr);
+    FS_SYNC_TRACE_END(open);
+    if (req.result < 0) {
+      // req will be cleaned up by scope leave.
+      return env->ThrowUVException(req.result, "open", nullptr, path.out());
+    }
   }
 
-  auto defer_close = OnScopeLeave([file]() {
-    uv_fs_t close_req;
-    CHECK_EQ(0, uv_fs_close(nullptr, &close_req, file, nullptr));
-    uv_fs_req_cleanup(&close_req);
+  auto defer_close = OnScopeLeave([file, is_fd]() {
+    if (!is_fd) {
+      uv_fs_t close_req;
+      CHECK_EQ(0, uv_fs_close(nullptr, &close_req, file, nullptr));
+      uv_fs_req_cleanup(&close_req);
+    }
   });
+
   std::string result{};
   char buffer[8192];
   uv_buf_t buf = uv_buf_init(buffer, sizeof(buffer));
@@ -2580,7 +2590,7 @@ static void ReadFileUtf8(const FunctionCallbackInfo<Value>& args) {
     if (req.result < 0) {
       FS_SYNC_TRACE_END(read);
       // req will be cleaned up by scope leave.
-      return env->ThrowUVException(req.result, "read", nullptr, path.out());
+      return env->ThrowUVException(req.result, "read", nullptr);
     }
     if (r <= 0) {
       break;


### PR DESCRIPTION
This particular change applies to: `fs.readFileSync(fs.openSync(__filename), 'utf8')`

My local benchmarks are as follows:

```
fs/readFileSync.js n=10000 hasFileDescriptor='false' path='existing' encoding='undefined'                     0.73 %       ±1.65% ±2.20% ±2.86%
fs/readFileSync.js n=10000 hasFileDescriptor='false' path='existing' encoding='utf8'                          0.05 %       ±1.74% ±2.32% ±3.02%
fs/readFileSync.js n=10000 hasFileDescriptor='false' path='non-existing' encoding='undefined'        ***     62.27 %       ±2.82% ±3.77% ±4.95%
fs/readFileSync.js n=10000 hasFileDescriptor='false' path='non-existing' encoding='utf8'             ***     60.93 %       ±2.72% ±3.64% ±4.78%
fs/readFileSync.js n=10000 hasFileDescriptor='true' path='existing' encoding='undefined'                      0.22 %       ±1.47% ±1.96% ±2.56%
fs/readFileSync.js n=10000 hasFileDescriptor='true' path='existing' encoding='utf8'                  ***     88.18 %       ±2.56% ±3.43% ±4.49%
fs/readFileSync.js n=10000 hasFileDescriptor='true' path='non-existing' encoding='undefined'                 -3.31 %       ±4.32% ±5.80% ±7.65%
fs/readFileSync.js n=10000 hasFileDescriptor='true' path='non-existing' encoding='utf8'                      -3.18 %       ±3.58% ±4.79% ±6.30%
```

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1413