### PR TITLE
errors: improve performance of determineSpecificType

### DIFF
--- a/benchmark/error/determine-specific-type.js
+++ b/benchmark/error/determine-specific-type.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const common = require('../common');
+
+const bench = common.createBenchmark(main, {
+  n: [1e6],
+  v: [
+    '() => 1n',
+    '() => true',
+    '() => false',
+    '() => 2',
+    '() => +0',
+    '() => -0',
+    '() => NaN',
+    '() => Infinity',
+    '() => ""',
+    '() => "\'"',
+    '() => Symbol("foo")',
+    '() => function foo() {}',
+    '() => null',
+    '() => undefined',
+    '() => new Array()',
+    '() => new BigInt64Array()',
+    '() => new BigUint64Array()',
+    '() => new Int8Array()',
+    '() => new Int16Array()',
+    '() => new Int32Array()',
+    '() => new Float32Array()',
+    '() => new Float64Array()',
+    '() => new Uint8Array()',
+    '() => new Uint8ClampedArray()',
+    '() => new Uint16Array()',
+    '() => new Uint32Array()',
+    '() => new Date()',
+    '() => new Map()',
+    '() => new WeakMap()',
+    '() => new Object()',
+    '() => Promise.resolve("foo")',
+    '() => new Set()',
+    '() => new WeakSet()',
+    '() => ({ __proto__: null })',
+  ],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function main({ n, v }) {
+  const {
+    determineSpecificType,
+  } = require('internal/errors');
+
+  const value = eval(v)();
+
+  bench.start();
+  for (let i = 0; i < n; ++i)
+    determineSpecificType(value);
+  bench.end(n);
+}

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -48,6 +48,7 @@ const {
   String,
   StringPrototypeEndsWith,
   StringPrototypeIncludes,
+  StringPrototypeIndexOf,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -874,23 +875,53 @@ const genericNodeError = hideStackFrames(function genericNodeError(message, erro
  * @returns {string}
  */
 function determineSpecificType(value) {
-  if (value == null) {
-    return '' + value;
+  if (value === null) {
+    return 'null';
+  } else if (value === undefined) {
+    return 'undefined';
   }
-  if (typeof value === 'function' && value.name) {
-    return `function ${value.name}`;
-  }
-  if (typeof value === 'object') {
-    if (value.constructor?.name) {
-      return `an instance of ${value.constructor.name}`;
-    }
-    return `${lazyInternalUtilInspect().inspect(value, { depth: -1 })}`;
-  }
-  let inspected = lazyInternalUtilInspect()
-    .inspect(value, { colors: false });
-  if (inspected.length > 28) { inspected = `${StringPrototypeSlice(inspected, 0, 25)}...`; }
 
-  return `type ${typeof value} (${inspected})`;
+  const type = typeof value;
+
+  switch (type) {
+    case 'bigint':
+      return `type bigint (${value}n)`;
+    case 'number':
+      if (value === 0) {
+        return 1 / value === -Infinity ? 'type number (-0)' : 'type number (0)';
+      } else if (value !== value) { // eslint-disable-line no-self-compare
+        return 'type number (NaN)';
+      } else if (value === Infinity) {
+        return 'type number (Infinity)';
+      } else if (value === -Infinity) {
+        return 'type number (-Infinity)';
+      }
+      return `type number (${value})`;
+    case 'boolean':
+      return value ? 'type boolean (true)' : 'type boolean (false)';
+    case 'symbol':
+      return `type symbol (${String(value)})`;
+    case 'function':
+      return `function ${value.name}`;
+    case 'object':
+      if (value.constructor && 'name' in value.constructor) {
+        return `an instance of ${value.constructor.name}`;
+      }
+      return `${lazyInternalUtilInspect().inspect(value, { depth: -1 })}`;
+    case 'string':
+      value.length > 28 && (value = `${StringPrototypeSlice(value, 0, 25)}...`);
+      if (StringPrototypeIndexOf(value, "'") === -1) {
+        return `type string ('${value}')`;
+      }
+      return `type string (${JSONStringify(value)})`;
+    default:
+      value = lazyInternalUtilInspect().inspect(value, { colors: false });
+      if (value.length > 28) {
+        value = `${StringPrototypeSlice(value, 0, 25)}...`;
+      }
+
+      return `type ${type} (${value})`;
+  }
 }
 
 /**

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -815,7 +815,7 @@ function invalidArgTypeHelper(input) {
   if (input == null) {
     return ` Received ${input}`;
   }
-  if (typeof input === 'function' && input.name) {
+  if (typeof input === 'function') {
     return ` Received function ${input.name}`;
   }
   if (typeof input === 'object') {

--- a/test/parallel/test-error-value-type-detection.mjs
+++ b/test/parallel/test-error-value-type-detection.mjs
@@ -13,6 +13,10 @@ strictEqual(
 );
 
 strictEqual(
+  determineSpecificType(true),
+  'type boolean (true)',
+);
+strictEqual(
   determineSpecificType(false),
   'type boolean (false)',
 );
@@ -43,6 +47,27 @@ strictEqual(
 );
 
 strictEqual(
+  determineSpecificType(''),
+  "type string ('')",
+);
+strictEqual(
+  determineSpecificType("''"),
+  "type string (\"''\")",
+);
+strictEqual(
+  determineSpecificType('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor'),
+  "type string ('Lorem ipsum dolor sit ame...')",
+);
+strictEqual(
+  determineSpecificType("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor'"),
+  "type string ('Lorem ipsum dolor sit ame...')",
+);
+strictEqual(
+  determineSpecificType("Lorem' ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"),
+  "type string (\"Lorem' ipsum dolor sit am...\")",
+);
+
+strictEqual(
   determineSpecificType(Symbol('foo')),
   'type symbol (Symbol(foo))',
 );
@@ -50,6 +75,38 @@ strictEqual(
 strictEqual(
   determineSpecificType(function foo() {}),
   'function foo',
+);
+
+const implicitlyNamed = function() {}; // eslint-disable-line func-style
+strictEqual(
+  determineSpecificType(implicitlyNamed),
+  'function implicitlyNamed',
+);
+strictEqual(
+  determineSpecificType(() => {}),
+  'function ',
+);
+function noName() {}
+delete noName.name;
+strictEqual(
+  noName.name,
+  '',
+);
+strictEqual(
+  determineSpecificType(noName),
+  'function ',
+);
+
+function * generatorFn() {}
+strictEqual(
+  determineSpecificType(generatorFn),
+  'function generatorFn',
+);
+
+async function asyncFn() {}
+strictEqual(
+  determineSpecificType(asyncFn),
+  'function asyncFn',
 );
 
 strictEqual(
@@ -132,6 +189,10 @@ strictEqual(
 
 strictEqual(
   determineSpecificType({}),
+  'an instance of Object',
+);
+strictEqual(
+  determineSpecificType(new Object()),
   'an instance of Object',
 );
 

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -61,7 +61,7 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     message: 'The "path" argument must be of type string or an instance of ' +
-             'Buffer or URL. Received type function ([Function (anonymous)])',
+             'Buffer or URL. Received function ',
     name: 'TypeError'
   }
 );


### PR DESCRIPTION
This PR improves the function determineSpecificType in errors.js.  

Also fixes a bug, where a string would be sliced without the single tick at the end of the string. 

Added unit tests. Added benchmarks based on unit tests.

main:

```sh
error/determine-specific-type.js v="() => 1n" n=1000000: 6,843,920.840090735
error/determine-specific-type.js v="() => true" n=1000000: 9,456,016.191725645
error/determine-specific-type.js v="() => false" n=1000000: 8,851,588.609212818
error/determine-specific-type.js v="() => 2" n=1000000: 9,901,905.486054687
error/determine-specific-type.js v="() => +0" n=1000000: 8,973,347.793105612
error/determine-specific-type.js v="() => -0" n=1000000: 10,751,000.496169424
error/determine-specific-type.js v="() => NaN" n=1000000: 10,215,963.841045486
error/determine-specific-type.js v="() => Infinity" n=1000000: 10,320,438.148834981
error/determine-specific-type.js v="() => \"\"" n=1000000: 6,254,431.929555482
error/determine-specific-type.js v="() => Symbol(\"foo\")" n=1000000: 5,327,156.757878972
error/determine-specific-type.js v="() => function foo() {}" n=1000000: 28,370,147.240213074
error/determine-specific-type.js v="() => null" n=1000000: 84,447,833.61750029
error/determine-specific-type.js v="() => undefined" n=1000000: 143,308,256.7768683
error/determine-specific-type.js v="() => new Array()" n=1000000: 17,252,357.461324573
error/determine-specific-type.js v="() => new BigInt64Array()" n=1000000: 21,056,043.101214882
error/determine-specific-type.js v="() => new BigUint64Array()" n=1000000: 22,987,115.95138041
error/determine-specific-type.js v="() => new Int8Array()" n=1000000: 22,238,571.03126347
error/determine-specific-type.js v="() => new Int16Array()" n=1000000: 20,920,369.479666267
error/determine-specific-type.js v="() => new Int32Array()" n=1000000: 22,552,915.624017186
error/determine-specific-type.js v="() => new Float32Array()" n=1000000: 22,731,474.433672026
error/determine-specific-type.js v="() => new Float64Array()" n=1000000: 21,389,880.191003073
error/determine-specific-type.js v="() => new Uint8Array()" n=1000000: 22,209,250.046039775
error/determine-specific-type.js v="() => new Uint8ClampedArray()" n=1000000: 21,585,063.757529628
error/determine-specific-type.js v="() => new Uint16Array()" n=1000000: 22,708,905.351735055
error/determine-specific-type.js v="() => new Uint32Array()" n=1000000: 22,544,499.855568662
error/determine-specific-type.js v="() => new Date()" n=1000000: 27,342,526.528744582
error/determine-specific-type.js v="() => new Map()" n=1000000: 26,338,839.423816815
error/determine-specific-type.js v="() => new WeakMap()" n=1000000: 25,778,798.114064377
error/determine-specific-type.js v="() => new Object()" n=1000000: 20,142,102.12766866
error/determine-specific-type.js v="() => Promise.resolve(\"foo\")" n=1000000: 26,109,976.21198397
error/determine-specific-type.js v="() => new Set()" n=1000000: 25,905,614.964326676
error/determine-specific-type.js v="() => new WeakSet()" n=1000000: 25,752,138.193596177
error/determine-specific-type.js v="() => ({ __proto__: null })" n=1000000: 1,271,014.61081246
```

PR:
```js
error/determine-specific-type.js v="() => 1n" n=1000000: 20,725,839.6296707
error/determine-specific-type.js v="() => true" n=1000000: 140,278,463.97326404
error/determine-specific-type.js v="() => false" n=1000000: 146,549,885.94755125
error/determine-specific-type.js v="() => 2" n=1000000: 49,945,631.68263187
error/determine-specific-type.js v="() => +0" n=1000000: 127,743,303.4086129
error/determine-specific-type.js v="() => -0" n=1000000: 123,600,395.47182535
error/determine-specific-type.js v="() => NaN" n=1000000: 153,607,424.2769161
error/determine-specific-type.js v="() => Infinity" n=1000000: 137,883,393.39304143
error/determine-specific-type.js v="() => \"\"" n=1000000: 47,073,709.89790654
error/determine-specific-type.js v="() => \"'\"" n=1000000: 8,823,294.789975893
error/determine-specific-type.js v="() => Symbol(\"foo\")" n=1000000: 11,643,085.227570156
error/determine-specific-type.js v="() => function foo() {}" n=1000000: 24,384,259.05368641
error/determine-specific-type.js v="() => null" n=1000000: 223,003,179.3563281
error/determine-specific-type.js v="() => undefined" n=1000000: 203,319,433.73911148
error/determine-specific-type.js v="() => new Array()" n=1000000: 35,201,357.92758342
error/determine-specific-type.js v="() => new BigInt64Array()" n=1000000: 21,667,733.83867111
error/determine-specific-type.js v="() => new BigUint64Array()" n=1000000: 17,649,319.59755033
error/determine-specific-type.js v="() => new Int8Array()" n=1000000: 22,205,003.47563817
error/determine-specific-type.js v="() => new Int16Array()" n=1000000: 21,894,023.991121184
error/determine-specific-type.js v="() => new Int32Array()" n=1000000: 21,752,199.72382537
error/determine-specific-type.js v="() => new Float32Array()" n=1000000: 20,549,685.59494782
error/determine-specific-type.js v="() => new Float64Array()" n=1000000: 21,237,781.66528292
error/determine-specific-type.js v="() => new Uint8Array()" n=1000000: 21,616,408.912246525
error/determine-specific-type.js v="() => new Uint8ClampedArray()" n=1000000: 20,134,607.096901342
error/determine-specific-type.js v="() => new Uint16Array()" n=1000000: 18,759,458.753596798
error/determine-specific-type.js v="() => new Uint32Array()" n=1000000: 21,513,774.5814237
error/determine-specific-type.js v="() => new Date()" n=1000000: 34,218,765.56419165
error/determine-specific-type.js v="() => new Map()" n=1000000: 31,749,019.17755055
error/determine-specific-type.js v="() => new WeakMap()" n=1000000: 23,849,589.985003855
error/determine-specific-type.js v="() => new Object()" n=1000000: 34,675,541.47851863
error/determine-specific-type.js v="() => Promise.resolve(\"foo\")" n=1000000: 34,478,485.66629363
error/determine-specific-type.js v="() => new Set()" n=1000000: 31,878,517.854217436
error/determine-specific-type.js v="() => new WeakSet()" n=1000000: 34,144,917.037412174
error/determine-specific-type.js v="() => ({ __proto__: null })" n=1000000: 1,280,069.176986435
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
