### PR TITLE
fs: improve error performance of `opendirSync`

### DIFF
--- a/benchmark/fs/bench-opendirSync.js
+++ b/benchmark/fs/bench-opendirSync.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const bench = common.createBenchmark(main, {
+  type: ['existing', 'non-existing'],
+  bufferSize: [ 4, 32, 128 ],
+  n: [1e4],
+});
+
+function main({ n, type, bufferSize }) {
+  let path;
+
+  switch (type) {
+    case 'existing':
+      path = 'lib';
+      break;
+    case 'non-existing':
+      path = tmpdir.resolve(`.non-existing-file-${process.pid}`);
+      break;
+    default:
+      new Error('Invalid type');
+  }
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    try {
+      const dir = fs.opendirSync(path, { bufferSize });
+      dir.closeSync();
+    } catch {
+      // do nothing
+    }
+  }
+  bench.end(n);
+}

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -322,18 +322,11 @@ function opendir(path, options, callback) {
 
 function opendirSync(path, options) {
   path = getValidatedPath(path);
-  options = getOptions(options, {
-    encoding: 'utf8',
-  });
+  options = getOptions(options, { encoding: 'utf8' });
 
-  const ctx = { path };
-  const handle = dirBinding.opendir(
+  const handle = dirBinding.opendirSync(
     pathModule.toNamespacedPath(path),
-    options.encoding,
-    undefined,
-    ctx,
   );
-  handleErrorFromBinding(ctx);
 
   return new Dir(handle, path, options);
 }


### PR DESCRIPTION
```
fs/bench-opendirSync.js n=10000 bufferSize=128 type='existing'                    -0.15 %       ±1.56%  ±2.08%  ±2.71%
fs/bench-opendirSync.js n=10000 bufferSize=128 type='non-existing'        ***    109.56 %       ±3.93%  ±5.23%  ±6.81%
fs/bench-opendirSync.js n=10000 bufferSize=32 type='existing'                     -0.34 %       ±1.95%  ±2.60%  ±3.39%
fs/bench-opendirSync.js n=10000 bufferSize=32 type='non-existing'         ***    111.68 %       ±3.03%  ±4.03%  ±5.25%
fs/bench-opendirSync.js n=10000 bufferSize=4 type='existing'                      -1.19 %       ±1.44%  ±1.92%  ±2.51%
fs/bench-opendirSync.js n=10000 bufferSize=4 type='non-existing'          ***    104.85 %       ±8.18% ±11.01% ±14.59%
```

Ref: https://github.com/nodejs/performance/issues/106