### PR TITLE
meta: add primordials strategic initiative 

### DIFF
--- a/doc/contributing/strategic-initiatives.md
+++ b/doc/contributing/strategic-initiatives.md
@@ -7,15 +7,16 @@ agenda to ensure they are active and have the support they need.
 ## Current initiatives
 
 | Initiative             | Champion                    | Links                                         |
-| ---------------------- | --------------------------- | --------------------------------------------- |
-| Core Promise APIs      | [Antoine du Hamel][aduh95]  | <https://github.com/nodejs/TSC/issues/1094>   |
-| QUIC / HTTP3           | [James M Snell][jasnell]    | <https://github.com/nodejs/quic>              |
-| Shadow Realm           | [Chengzhong Wu][legendecas] | <https://github.com/nodejs/node/issues/42528> |
-| Startup Snapshot       | [Joyee Cheung][joyeecheung] | <https://github.com/nodejs/node/issues/35711> |
-| V8 Currency            | [Michaël Zasso][targos]     |                                               |
-| Next-10                | [Michael Dawson][mhdawson]  | <https://github.com/nodejs/next-10>           |
-| Single executable apps | [Darshan Sen][RaisinTen]    | <https://github.com/nodejs/node/issues/43432> |
-| Performance            |                             | <https://github.com/nodejs/performance>       |
+| ---------------------- | ------------------------------- | --------------------------------------------- |
+| Core Promise APIs      | [Antoine du Hamel][aduh95]      | <https://github.com/nodejs/TSC/issues/1094>   |
+| QUIC / HTTP3           | [James M Snell][jasnell]        | <https://github.com/nodejs/quic>              |
+| Shadow Realm           | [Chengzhong Wu][legendecas]     | <https://github.com/nodejs/node/issues/42528> |
+| Startup Snapshot       | [Joyee Cheung][joyeecheung]     | <https://github.com/nodejs/node/issues/35711> |
+| V8 Currency            | [Michaël Zasso][targos]         |                                               |
+| Next-10                | [Michael Dawson][mhdawson]      | <https://github.com/nodejs/next-10>           |
+| Single executable apps | [Darshan Sen][RaisinTen]        | <https://github.com/nodejs/node/issues/43432> |
+| Performance            |                                 | <https://github.com/nodejs/performance>       |
+| Primordials            | [Benjamin Gruenbaum][benjamingr]| <https://github.com/nodejs/performance>       |
 
 <details>
 <summary>List of completed initiatives</summary>
@@ -45,3 +46,4 @@ agenda to ensure they are active and have the support they need.
 [legendecas]: https://github.com/legendecas
 [mhdawson]: https://github.com/mhdawson
 [targos]: https://github.com/targos
+[benjamingr]: https://github.com/benjamingr

--- a/doc/contributing/strategic-initiatives.md
+++ b/doc/contributing/strategic-initiatives.md
@@ -6,17 +6,17 @@ agenda to ensure they are active and have the support they need.
 
 ## Current initiatives
 
-| Initiative             | Champion                    | Links                                         |
-| ---------------------- | ------------------------------- | --------------------------------------------- |
-| Core Promise APIs      | [Antoine du Hamel][aduh95]      | <https://github.com/nodejs/TSC/issues/1094>   |
-| QUIC / HTTP3           | [James M Snell][jasnell]        | <https://github.com/nodejs/quic>              |
-| Shadow Realm           | [Chengzhong Wu][legendecas]     | <https://github.com/nodejs/node/issues/42528> |
-| Startup Snapshot       | [Joyee Cheung][joyeecheung]     | <https://github.com/nodejs/node/issues/35711> |
-| V8 Currency            | [Michaël Zasso][targos]         |                                               |
-| Next-10                | [Michael Dawson][mhdawson]      | <https://github.com/nodejs/next-10>           |
-| Single executable apps | [Darshan Sen][RaisinTen]        | <https://github.com/nodejs/node/issues/43432> |
-| Performance            |                                 | <https://github.com/nodejs/performance>       |
-| Primordials            | [Benjamin Gruenbaum][benjamingr]| <https://github.com/nodejs/performance>       |
+| Initiative             | Champion                    | Links                                                 |
+| ---------------------- | ------------------------------- | ------------------------------------------------- |
+| Core Promise APIs      | [Antoine du Hamel][aduh95]      | <https://github.com/nodejs/TSC/issues/1094>       |
+| QUIC / HTTP3           | [James M Snell][jasnell]        | <https://github.com/nodejs/quic>                  |
+| Shadow Realm           | [Chengzhong Wu][legendecas]     | <https://github.com/nodejs/node/issues/42528>     |
+| Startup Snapshot       | [Joyee Cheung][joyeecheung]     | <https://github.com/nodejs/node/issues/35711>     |
+| V8 Currency            | [Michaël Zasso][targos]         |                                                   |
+| Next-10                | [Michael Dawson][mhdawson]      | <https://github.com/nodejs/next-10>               |
+| Single executable apps | [Darshan Sen][RaisinTen]        | <https://github.com/nodejs/node/issues/43432>     |
+| Performance            |                                 | <https://github.com/nodejs/performance>           |
+| Primordials            | [Benjamin Gruenbaum][benjamingr]| <https://github.com/nodejs/primordials-use-cases> |
 
 <details>
 <summary>List of completed initiatives</summary>


### PR DESCRIPTION
This is a pull request to add the strategic initiative outlined in https://github.com/nodejs/TSC/issues/1439 there is a list of tasks here https://github.com/nodejs/TSC/issues/1439#issuecomment-1717016394

Please do not fast-track this as I'd like to give https://github.com/nodejs/TSC/issues/1439#issuecomment-1717016394 a week to make sure everyone had time to see it for lazy consensus