### PR TITLE
console: treat non-strings as separate argument in console.assert()

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -432,7 +432,12 @@ const consoleMethods = {
 
   assert(expression, ...args) {
     if (!expression) {
-      args[0] = `Assertion failed${args.length === 0 ? '' : `: ${args[0]}`}`;
+      // https://console.spec.whatwg.org/#assert step 4.2:
+      if (typeof args[0] === "string") {
+        args[0] = `Assertion failed: ${args[0]}`
+      } else {
+        ArrayPrototypeUnshift(args, "Assertion failed")
+      }
       // The arguments will be formatted in warn() again
       ReflectApply(this.warn, this, args);
     }


### PR DESCRIPTION
fixes #49680 

unsure if i should add more desc text here