### PR TITLE
lib: faster internal createBlob

### DIFF
--- a/benchmark/blob/blob.js
+++ b/benchmark/blob/blob.js
@@ -4,7 +4,7 @@ const { Blob } = require('buffer');
 
 const bench = common.createBenchmark(main, {
   bytes: [128, 1024, 1024 ** 2],
-  n: [1e6],
+  n: [1e3],
   operation: ['text', 'arrayBuffer'],
 });
 

--- a/benchmark/blob/clone.js
+++ b/benchmark/blob/clone.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common.js');
+const {
+  Blob,
+} = require('node:buffer');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [50e3],
+});
+
+let _cloneResult;
+
+function main({ n }) {
+  bench.start();
+  for (let i = 0; i < n; ++i)
+    _cloneResult = structuredClone(new Blob(['hello']));
+  bench.end(n);
+
+  // Avoid V8 deadcode (elimination)
+  assert.ok(_cloneResult);
+}

--- a/benchmark/blob/creation.js
+++ b/benchmark/blob/creation.js
@@ -1,0 +1,48 @@
+'use strict';
+const common = require('../common.js');
+const {
+  Blob,
+} = require('node:buffer');
+const assert = require('assert');
+
+const options = {
+  flags: ['--expose-internals'],
+};
+
+const bench = common.createBenchmark(main, {
+  n: [50e3],
+  kind: [
+    'Blob',
+    'createBlob',
+  ],
+}, options);
+
+let _blob;
+let _createBlob;
+
+function main({ n, kind }) {
+  switch (kind) {
+    case 'Blob': {
+      bench.start();
+      for (let i = 0; i < n; ++i)
+        _blob = new Blob(['hello']);
+      bench.end(n);
+
+      // Avoid V8 deadcode (elimination)
+      assert.ok(_blob);
+      break;
+    } case 'createBlob': {
+      const { createBlob } = require('internal/blob');
+      const reusableBlob = new Blob(['hello']);
+      bench.start();
+      for (let i = 0; i < n; ++i)
+        _createBlob = createBlob(reusableBlob, reusableBlob.size);
+      bench.end(n);
+
+      // Avoid V8 deadcode (elimination)
+      assert.ok(_createBlob);
+      break;
+    } default:
+      throw new Error('Invalid kind');
+  }
+}

--- a/benchmark/blob/file.js
+++ b/benchmark/blob/file.js
@@ -4,7 +4,7 @@ const { File } = require('buffer');
 
 const bench = common.createBenchmark(main, {
   bytes: [128, 1024, 1024 ** 2],
-  n: [1e6],
+  n: [1e3],
   operation: ['text', 'arrayBuffer'],
 });
 

--- a/benchmark/blob/file.js
+++ b/benchmark/blob/file.js
@@ -3,7 +3,7 @@ const common = require('../common.js');
 const { File } = require('buffer');
 
 const bench = common.createBenchmark(main, {
-  bytes: [128, 1024, 1024 ** 2],
+  bytes: [128, 1024],
   n: [1e3],
   operation: ['text', 'arrayBuffer'],
 });

--- a/benchmark/blob/resolveObjectURL.js
+++ b/benchmark/blob/resolveObjectURL.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common.js');
+const {
+  Blob,
+  resolveObjectURL,
+} = require('node:buffer');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [50e3],
+});
+
+let _resolveObjectURL;
+
+function main({ n }) {
+  const blob = new Blob(['hello']);
+  const id = URL.createObjectURL(blob);
+  bench.start();
+  for (let i = 0; i < n; ++i)
+    _resolveObjectURL = resolveObjectURL(id);
+  bench.end(n);
+
+  // Avoid V8 deadcode (elimination)
+  assert.ok(_resolveObjectURL);
+}

--- a/benchmark/blob/resolveObjectURL.js
+++ b/benchmark/blob/resolveObjectURL.js
@@ -1,9 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const {
-  Blob,
-  resolveObjectURL,
-} = require('node:buffer');
+const { Blob, resolveObjectURL } = require('node:buffer');
 const assert = require('assert');
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/blob/slice.js
+++ b/benchmark/blob/slice.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common.js');
+const { Blob } = require('node:buffer');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [50e3],
+  dataSize: [
+    5,
+    30 * 1024,
+  ],
+});
+
+let _sliceResult;
+
+function main({ n, dataSize }) {
+  const data = 'a'.repeat(dataSize);
+  const reusableBlob = new Blob([data]);
+
+  bench.start();
+  for (let i = 0; i < n; ++i)
+    _sliceResult = reusableBlob.slice(0, Math.floor(data.length / 2));
+  bench.end(n);
+
+  // Avoid V8 deadcode (elimination)
+  assert.ok(_sliceResult);
+}

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -407,7 +407,12 @@ ObjectSetPrototypeOf(TransferrableBlob.prototype, Blob.prototype);
 ObjectSetPrototypeOf(TransferrableBlob, Blob);
 
 function createBlob(handle, length, type = '') {
-  return new TransferrableBlob(handle, length, type);
+  var transferredBlob = new TransferrableBlob(handle, length, type);
+
+  // fix issues like: https://github.com/nodejs/node/pull/49730#discussion_r1331720053
+  transferredBlob.constructor = Blob;
+
+  return transferredBlob;
 }
 
 ObjectDefineProperty(Blob.prototype, SymbolToStringTag, {

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -407,9 +407,9 @@ ObjectSetPrototypeOf(TransferrableBlob.prototype, Blob.prototype);
 ObjectSetPrototypeOf(TransferrableBlob, Blob);
 
 function createBlob(handle, length, type = '') {
-  var transferredBlob = new TransferrableBlob(handle, length, type);
+  const transferredBlob = new TransferrableBlob(handle, length, type);
 
-  // fix issues like: https://github.com/nodejs/node/pull/49730#discussion_r1331720053
+  // Fix issues like: https://github.com/nodejs/node/pull/49730#discussion_r1331720053
   transferredBlob.constructor = Blob;
 
   return transferredBlob;

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -6,6 +6,7 @@ const {
   MathMin,
   ObjectDefineProperties,
   ObjectDefineProperty,
+  ObjectSetPrototypeOf,
   PromiseReject,
   ReflectConstruct,
   RegExpPrototypeExec,
@@ -395,13 +396,18 @@ function ClonedBlob() {
 }
 ClonedBlob.prototype[kDeserialize] = () => {};
 
+function TransferrableBlob(handle, length, type = '') {
+  markTransferMode(this, true, false);
+  this[kHandle] = handle;
+  this[kType] = type;
+  this[kLength] = length;
+}
+
+ObjectSetPrototypeOf(TransferrableBlob.prototype, Blob.prototype);
+ObjectSetPrototypeOf(TransferrableBlob, Blob);
+
 function createBlob(handle, length, type = '') {
-  return ReflectConstruct(function() {
-    markTransferMode(this, true, false);
-    this[kHandle] = handle;
-    this[kType] = type;
-    this[kLength] = length;
-  }, [], Blob);
+  return new TransferrableBlob(handle, length, type);
 }
 
 ObjectDefineProperty(Blob.prototype, SymbolToStringTag, {

--- a/test/parallel/test-blob-createobjecturl.js
+++ b/test/parallel/test-blob-createobjecturl.js
@@ -24,6 +24,8 @@ const assert = require('assert');
   const id = URL.createObjectURL(blob);
   assert.strictEqual(typeof id, 'string');
   const otherBlob = resolveObjectURL(id);
+  assert.ok(otherBlob instanceof Blob);
+  assert.strictEqual(otherBlob.constructor, Blob);
   assert.strictEqual(otherBlob.size, 5);
   assert.strictEqual(
     Buffer.from(await otherBlob.arrayBuffer()).toString(),

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -431,3 +431,10 @@ assert.throws(() => new Blob({}), {
 
   await new Blob(chunks).arrayBuffer();
 })().then(common.mustCall());
+
+{
+  const blob = new Blob(['hello']);
+
+  assert.ok(blob.slice(0, 1).constructor === Blob);
+  assert.ok(blob.slice(0, 1) instanceof Blob);
+}


### PR DESCRIPTION
Inspired by https://github.com/nodejs/performance/issues/109, I removed the usage of `ReflectConstruct` which is very heavy to call, and I also added a couple more benchmarks for `blob`.

Improvements:

```
                                           confidence improvement accuracy (*)     (**)    (***)
blob/creation.js kind='Blob' n=50000                       0.02 %       ±1.66%   ±2.21%   ±2.88%
blob/creation.js kind='createBlob' n=50000        ***   2727.18 %     ±138.63% ±186.82% ±248.02%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 2 comparisons, you can thus
expect the following amount of false-positive results:
  0.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.02 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

```
                                 confidence improvement accuracy (*)    (**)   (***)
blob/resolveObjectURL.js n=50000        ***    304.19 %      ±11.73% ±15.80% ±20.95%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 1 comparisons, you can thus
expect the following amount of false-positive results:
  0.05 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.01 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

```
                                    confidence improvement accuracy (*)    (**)   (***)
blob/slice.js dataSize=30720 n=50000        ***    445.71 %      ±32.71% ±44.06% ±58.44%
blob/slice.js dataSize=5 n=50000            ***    456.75 %      ±22.46% ±30.25% ±40.13%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 2 comparisons, you can thus
expect the following amount of false-positive results:
  0.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.02 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***
```

I also think we can improve `ClonedBlob` but I tried using Function and also Class inheritance but I was not able to make it work correctly, but we probably can improve by 50% if we can make a version without `ReflectConstruct`.

cc @nodejs/performance 