### PR TITLE
esm: identify parent importing a url with invalid host

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -230,7 +230,15 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
       fileURLToPath(base));
   }
 
-  const path = fileURLToPath(resolved);
+  let path;
+  try {
+    path = fileURLToPath(resolved);
+  } catch (err) {
+    const { setOwnProperty } = require('internal/util');
+    setOwnProperty(err, 'input', `${resolved}`);
+    setOwnProperty(err, 'module', `${base}`);
+    throw err;
+  }
 
   const stats = internalModuleStat(toNamespacedPath(StringPrototypeEndsWith(path, '/') ?
     StringPrototypeSlice(path, -1) : path));

--- a/test/es-module/test-esm-loader-default-resolver.mjs
+++ b/test/es-module/test-esm-loader-default-resolver.mjs
@@ -55,12 +55,12 @@ describe('default resolver', () => {
 
     const { code, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
-      fixtures.path('es-modules','invalid-posix-host.mjs'),
+      fixtures.path('es-modules', 'invalid-posix-host.mjs'),
     ]);
 
     assert.match(stderr, /ERR_INVALID_FILE_URL_HOST/);
-    assert.match(stderr, /file\:\/\/hmm.js/);
-    assert.match(stderr, /invalid-posix-host.mjs/);
+    assert.match(stderr, /file:\/\/hmm\.js/);
+    assert.match(stderr, /invalid-posix-host\.mjs/);
     assert.strictEqual(code, 1);
   });
 });

--- a/test/es-module/test-esm-loader-default-resolver.mjs
+++ b/test/es-module/test-esm-loader-default-resolver.mjs
@@ -49,4 +49,18 @@ describe('default resolver', () => {
     assert.strictEqual(stdout.trim(), 'index.byoe!');
     assert.strictEqual(stderr, '');
   });
+
+  it('should identify the parent module of an invalid URL host in import specifier', async () => {
+    if (process.platform === 'win32') return;
+
+    const { code, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      fixtures.path('es-modules','invalid-posix-host.mjs'),
+    ]);
+
+    assert.match(stderr, /ERR_INVALID_FILE_URL_HOST/);
+    assert.match(stderr, /file\:\/\/hmm.js/);
+    assert.match(stderr, /invalid-posix-host.mjs/);
+    assert.strictEqual(code, 1);
+  });
 });

--- a/test/fixtures/es-modules/invalid-posix-host.mjs
+++ b/test/fixtures/es-modules/invalid-posix-host.mjs
@@ -1,0 +1,1 @@
+import "file://hmm.js";


### PR DESCRIPTION
New output:

```
TypeError [ERR_INVALID_FILE_URL_HOST]: File URL host must be "localhost" or empty on darwin
    at new NodeError (node:internal/errors:406:5)
    at getPathFromURLPosix (node:internal/url:1385:11)
    at fileURLToPath (node:internal/url:1408:50)
    at finalizeResolution (node:internal/modules/esm/resolve:210:16)
    …
  code: 'ERR_INVALID_FILE_URL_HOST',
  input: 'file://hmm.js/',
  module: 'file:///…/test.mjs'
```

fixes https://github.com/nodejs/node/issues/49571