### PR TITLE
node-api: treat V8 platform symbols same as base

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1436,10 +1436,7 @@
         '<(V8_ROOT)/src/libplatform/worker-thread.h',
       ],
       'conditions': [
-        ['component=="shared_library"', {
-          'direct_dependent_settings': {
-            'defines': ['USING_V8_PLATFORM_SHARED'],
-          },
+        ['is_component_build', {
           'defines': ['BUILDING_V8_PLATFORM_SHARED'],
         }],
         ['v8_use_perfetto==1', {


### PR DESCRIPTION
Export V8 platform symbols in the Node shared library build, in the same way as with V8 base, to allow linking on Windows.

PR-URL: https://github.com/nodejs/node/pull/49596

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
