### PR TITLE
deps: remove pthread-fixes.c from uv.gyp

### DIFF
--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -136,7 +136,6 @@
     'uv_sources_android': [
       'src/unix/linux.c',
       'src/unix/procfs-exepath.c',
-      'src/unix/pthread-fixes.c',
       'src/unix/random-getentropy.c',
       'src/unix/random-getrandom.c',
       'src/unix/random-sysctl-linux.c',
@@ -398,7 +397,6 @@
         }],
         ['OS=="zos"', {
           'sources': [
-            'src/unix/pthread-fixes.c',
             'src/unix/os390.c',
             'src/unix/os390-syscalls.c'
           ]


### PR DESCRIPTION
The file was removed in the latest libuv upgrade. Remove it from the build recipe as well.

Fixes: https://github.com/nodejs/node/issues/49739