### PR TITLE
fs: improve error performance of `chownSync`

### DIFF
--- a/benchmark/fs/bench-chownSync.js
+++ b/benchmark/fs/bench-chownSync.js
@@ -5,6 +5,11 @@ const fs = require('fs');
 const tmpdir = require('../../test/common/tmpdir');
 tmpdir.refresh();
 
+// Windows does not have `getuid` or `getgid`.
+if (process.platform === 'win32') {
+  return;
+}
+
 const tmpfile = tmpdir.resolve(`.existing-file-${process.pid}`);
 fs.writeFileSync(tmpfile, 'this-is-for-a-benchmark', 'utf8');
 

--- a/benchmark/fs/bench-chownSync.js
+++ b/benchmark/fs/bench-chownSync.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const tmpfile = tmpdir.resolve(`.existing-file-${process.pid}`);
+fs.writeFileSync(tmpfile, 'this-is-for-a-benchmark', 'utf8');
+
+const bench = common.createBenchmark(main, {
+  type: ['existing', 'non-existing'],
+  n: [1e4],
+});
+
+function main({ n, type }) {
+  const uid = process.getuid();
+  const gid = process.getgid();
+  let path;
+
+  switch (type) {
+    case 'existing':
+      path = tmpfile;
+      break;
+    case 'non-existing':
+      path = tmpdir.resolve(`.non-existing-file-${Date.now()}`);
+      break;
+    default:
+      new Error('Invalid type');
+  }
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    try {
+      fs.chownSync(path, uid, gid);
+    } catch {
+      // do nothing
+    }
+  }
+  bench.end(n);
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2063,12 +2063,7 @@ function chown(path, uid, gid, callback) {
  * @returns {void}
  */
 function chownSync(path, uid, gid) {
-  path = getValidatedPath(path);
-  validateInteger(uid, 'uid', -1, kMaxUserId);
-  validateInteger(gid, 'gid', -1, kMaxUserId);
-  const ctx = { path };
-  binding.chown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
-  handleErrorFromBinding(ctx);
+  return syncFs.chown(path, uid, gid);
 }
 
 /**

--- a/lib/internal/fs/sync.js
+++ b/lib/internal/fs/sync.js
@@ -2,6 +2,9 @@
 
 const pathModule = require('path');
 const {
+  constants: {
+    kMaxUserId,
+  },
   getValidatedPath,
   stringToFlags,
   getValidMode,
@@ -9,7 +12,7 @@ const {
   getStatFsFromBinding,
   getValidatedFd,
 } = require('internal/fs/utils');
-const { parseFileMode, isInt32 } = require('internal/validators');
+const { parseFileMode, isInt32, validateInteger } = require('internal/validators');
 
 const binding = internalBinding('fs');
 
@@ -88,6 +91,17 @@ function close(fd) {
   return binding.closeSync(fd);
 }
 
+function chown(path, uid, gid) {
+  path = getValidatedPath(path);
+  validateInteger(uid, 'uid', -1, kMaxUserId);
+  validateInteger(gid, 'gid', -1, kMaxUserId);
+  return binding.chownSync(
+    pathModule.toNamespacedPath(path),
+    uid,
+    gid,
+  );
+}
+
 module.exports = {
   readFileUtf8,
   exists,
@@ -97,4 +111,5 @@ module.exports = {
   statfs,
   open,
   close,
+  chown,
 };

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3426,7 +3426,7 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "fchmod", FChmod);
 
   SetMethod(isolate, target, "chown", Chown);
-  SetMethodNoSideEffect(isolate, target, "chownSync", ChownSync);
+  SetMethod(isolate, target, "chownSync", ChownSync);
   SetMethod(isolate, target, "fchown", FChown);
   SetMethod(isolate, target, "lchown", LChown);
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2768,7 +2768,7 @@ static void ChownSync(const FunctionCallbackInfo<Value>& args) {
   const uv_gid_t gid = static_cast<uv_gid_t>(args[2].As<Integer>()->Value());
 
   uv_fs_t req;
-  auto make = OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
+  auto cleanup = OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
   FS_SYNC_TRACE_BEGIN(chown);
   int err = uv_fs_chown(nullptr, &req, *path, uid, gid, nullptr);
   FS_SYNC_TRACE_END(chown);

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -65,6 +65,7 @@ declare namespace InternalFSBinding {
   function chown(path: string, uid: number, gid: number, req: FSReqCallback): void;
   function chown(path: string, uid: number, gid: number, req: undefined, ctx: FSSyncContext): void;
   function chown(path: string, uid: number, gid: number, usePromises: typeof kUsePromises): Promise<void>;
+  function chownSync(path: string, uid: number, gid: number): void;
 
   function close(fd: number, req: FSReqCallback): void;
   function close(fd: number, req: undefined, ctx: FSSyncContext): void;
@@ -236,6 +237,7 @@ export interface FsBinding {
   access: typeof InternalFSBinding.access;
   chmod: typeof InternalFSBinding.chmod;
   chown: typeof InternalFSBinding.chown;
+  chownSync: typeof InternalFSBinding.chownSync;
   close: typeof InternalFSBinding.close;
   copyFile: typeof InternalFSBinding.copyFile;
   fchmod: typeof InternalFSBinding.fchmod;


### PR DESCRIPTION
```
                                                   confidence improvement accuracy (*)   (**)  (***)
fs/bench-chownSync.js n=10000 type='existing'                     0.24 %       ±2.31% ±3.09% ±4.06%
fs/bench-chownSync.js n=10000 type='non-existing'        ***     83.99 %       ±3.73% ±4.96% ±6.46%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 2 comparisons, you can thus expect the following amount of false-positive results:
  0.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.02 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

Ref: https://github.com/nodejs/performance/issues/106