### PR TITLE
fs: improve error performance for `fs.mkdtempSync`

### DIFF
--- a/benchmark/fs/bench-mkdtempSync.js
+++ b/benchmark/fs/bench-mkdtempSync.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const nonexistentDir = tmpdir.resolve('non-existent', 'foo', 'bar');
+const bench = common.createBenchmark(main, {
+  type: ['valid', 'invalid'],
+  n: [1e3],
+});
+
+function main({ n, type }) {
+  let prefix;
+
+  switch (type) {
+    case 'valid':
+      prefix = `${Date.now()}`;
+      break;
+    case 'invalid':
+      prefix = nonexistentDir;
+      break;
+    default:
+      new Error('Invalid type');
+  }
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    try {
+      const folderPath = fs.mkdtempSync(prefix, { encoding: 'utf8' });
+      fs.rmdirSync(folderPath);
+    } catch {
+      // do nothing
+    }
+  }
+  bench.end(n);
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2893,23 +2893,7 @@ function mkdtemp(prefix, options, callback) {
  * @returns {string}
  */
 function mkdtempSync(prefix, options) {
-  options = getOptions(options);
-
-  prefix = getValidatedPath(prefix, 'prefix');
-  warnOnNonPortableTemplate(prefix);
-
-  let path;
-  if (typeof prefix === 'string') {
-    path = `${prefix}XXXXXX`;
-  } else {
-    path = Buffer.concat([prefix, Buffer.from('XXXXXX')]);
-  }
-
-  const ctx = { path };
-  const result = binding.mkdtemp(path, options.encoding,
-                                 undefined, ctx);
-  handleErrorFromBinding(ctx);
-  return result;
+  return syncFs.mkdtemp(prefix, options);
 }
 
 /**

--- a/lib/internal/fs/sync.js
+++ b/lib/internal/fs/sync.js
@@ -8,8 +8,11 @@ const {
   getStatsFromBinding,
   getStatFsFromBinding,
   getValidatedFd,
+  getOptions,
+  warnOnNonPortableTemplate,
 } = require('internal/fs/utils');
 const { parseFileMode, isInt32 } = require('internal/validators');
+const { Buffer } = require('buffer');
 
 const binding = internalBinding('fs');
 
@@ -53,6 +56,25 @@ function copyFile(src, dest, mode) {
   );
 }
 
+function mkdtemp(prefix, options) {
+  options = getOptions(options);
+
+  prefix = getValidatedPath(prefix, 'prefix');
+  warnOnNonPortableTemplate(prefix);
+
+  let path;
+  if (typeof prefix === 'string') {
+    path = `${prefix}XXXXXX`;
+  } else {
+    path = Buffer.concat([prefix, Buffer.from('XXXXXX')]);
+  }
+
+  return binding.mkdtempSync(
+    path,
+    options.encoding,
+  );
+}
+
 function stat(path, options = { bigint: false, throwIfNoEntry: true }) {
   path = getValidatedPath(path);
   const stats = binding.statSync(
@@ -93,6 +115,7 @@ module.exports = {
   exists,
   access,
   copyFile,
+  mkdtemp,
   stat,
   statfs,
   open,

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3441,7 +3441,7 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "lutimes", LUTimes);
 
   SetMethod(isolate, target, "mkdtemp", Mkdtemp);
-  SetMethodNoSideEffect(isolate, target, "mkdtempSync", MkdtempSync);
+  SetMethod(isolate, target, "mkdtempSync", MkdtempSync);
 
   StatWatcher::CreatePerIsolateProperties(isolate_data, target);
   BindingData::CreatePerIsolateProperties(isolate_data, target);


### PR DESCRIPTION
```
                                               confidence improvement accuracy (*)    (**)   (***)
fs/bench-mkdtempSync.js n=1000 type='invalid'        ***     78.55 %      ±18.94% ±25.20% ±32.82%
fs/bench-mkdtempSync.js n=1000 type='valid'                  -0.72 %       ±7.92% ±10.54% ±13.72%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 2 comparisons, you can thus expect the following amount of false-positive results:
  0.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.02 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

Ref: https://github.com/nodejs/performance/issues/106