### PR TITLE
lib: improve performance of validateStringArray and validateBooleanArray

### DIFF
--- a/benchmark/validators/parse-file-mode.js
+++ b/benchmark/validators/parse-file-mode.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e7],
+  value: [
+    "'777'",
+    '0o777',
+  ],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function getParseFactory() {
+  const {
+    parseFileMode,
+  } = require('internal/validators');
+
+  return (n) => parseFileMode(n, 'n');
+}
+
+function main({ n, value }) {
+  const parse = getParseFactory();
+
+  value = value === "'777'" ? '777' : 0o777;
+
+  // Warm up.
+  const length = 1024;
+  const array = [];
+  let errCase = false;
+
+  for (let i = 0; i < length; ++i) {
+    try {
+      array.push(parse(value));
+    } catch (e) {
+      errCase = true;
+      array.push(e);
+    }
+  }
+
+  bench.start();
+
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    try {
+      array[index] = parse(value);
+    } catch (e) {
+      array[index] = e;
+    }
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], errCase ? 'object' : 'number');
+  }
+}

--- a/benchmark/validators/validate-array.js
+++ b/benchmark/validators/validate-array.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e7],
+  value: [
+    '[]',
+    '[1,2,3]',
+  ],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function getValidateFactory() {
+  const {
+    validateArray,
+  } = require('internal/validators');
+
+  return (n) => validateArray(n, 'n');
+}
+
+function main({ n, value }) {
+  const validate = getValidateFactory();
+
+  switch (value) {
+    case '[]':
+      value = [];
+      break;
+    case '[1,2,3]':
+      value = [1, 2, 3];
+      break;
+  }
+
+  // Warm up.
+  const length = 1024;
+  const array = [];
+  let errCase = false;
+
+  for (let i = 0; i < length; ++i) {
+    try {
+      array.push(validate(value));
+    } catch (e) {
+      errCase = true;
+      array.push(e);
+    }
+  }
+
+  bench.start();
+
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    try {
+      array[index] = validate(value);
+    } catch (e) {
+      array[index] = e;
+    }
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], errCase ? 'object' : 'undefined');
+  }
+}

--- a/benchmark/validators/validate-boolean.js
+++ b/benchmark/validators/validate-boolean.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e8],
+  code: [
+    'validateBoolean',
+  ],
+  value: [
+    'true',
+    'false',
+  ],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function getValidateFactory(code) {
+  const {
+    validateBoolean,
+  } = require('internal/validators');
+
+  switch (code) {
+    case 'validateBoolean':
+      return (n) => validateBoolean(n, 'n');
+  }
+}
+
+function main({ n, code, value }) {
+  const validate = getValidateFactory(code);
+  const v = value === 'true';
+
+  // Warm up.
+  const length = 1024;
+  const array = [];
+  for (let i = 0; i < length; ++i) {
+    array.push(validate(v));
+  }
+
+  bench.start();
+
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    array[index] = validate(v);
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], 'undefined');
+  }
+}

--- a/benchmark/validators/validate-encoding.js
+++ b/benchmark/validators/validate-encoding.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e8],
+  encoding: [
+    'ascii',
+    'utf8',
+    'utf-8',
+    'utf16le',
+    'ucs2',
+    'ucs-2',
+    'base64',
+    'latin1',
+    'binary',
+    'hex',
+  ],
+  value: [
+    'test',
+  ],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function getValidateFactory(encoding) {
+  const {
+    validateEncoding,
+  } = require('internal/validators');
+
+  return (n) => validateEncoding(n, encoding);
+}
+
+function main({ n, encoding, value }) {
+  const validate = getValidateFactory(encoding);
+
+  // Warm up.
+  const length = 1024;
+  const array = [];
+  for (let i = 0; i < length; ++i) {
+    array.push(validate(value));
+  }
+
+  bench.start();
+
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    array[index] = validate(value);
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], 'undefined');
+  }
+}

--- a/benchmark/validators/validate-one-of.js
+++ b/benchmark/validators/validate-one-of.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e7],
+  code: [
+    'validateOneOf',
+  ],
+  value: [
+    'fifo',
+    'lifo',
+    'lilo',
+  ],
+  validLength: [
+    1,
+    2,
+    3,
+  ],
+}, {
+  flags: ['--expose-internals'],
+});
+
+const validValues = [
+  'fifo',
+  'lifo',
+  'lilo',
+  'filo',
+];
+
+function getValidateFactory(code, validLength) {
+  const {
+    validateOneOf,
+  } = require('internal/validators');
+
+  switch (code) {
+    case 'validateOneOf':
+      return (n) => validateOneOf(n, 'n', validValues.slice(0, validLength));
+  }
+}
+
+function main({ n, code, validLength }) {
+  const validate = getValidateFactory(code, validLength);
+
+  // Warm up.
+  const length = 1024;
+  const array = [];
+
+  const value = validValues[validLength - 1];
+
+  for (let i = 0; i < length; ++i) {
+    array.push(validate(value));
+  }
+
+  bench.start();
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    array[index] = validate(value);
+  }
+  bench.end(n);
+
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], 'undefined');
+  }
+}

--- a/benchmark/validators/validate-x-array.js
+++ b/benchmark/validators/validate-x-array.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e8],
+  type: [
+    'validateStringArray',
+    'validateBooleanArray',
+  ],
+  arrayLength: [
+    0,
+    1,
+    10,
+    100,
+  ],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function getValidateFactory(type, arrayLength) {
+  const {
+    validateBooleanArray,
+    validateStringArray,
+  } = require('internal/validators');
+
+  switch (type) {
+    case 'validateBooleanArray':
+      return [
+        (n) => validateBooleanArray(n, 'n'),
+        Array.from({ length: arrayLength }, (v, i) => ((i & 1) === 0)),
+      ];
+    case 'validateStringArray':
+      return [
+        (n) => validateStringArray(n, 'n'),
+        Array.from({ length: arrayLength }, (v, i) => `foo${i}`),
+      ];
+  }
+}
+
+function main({ n, type, arrayLength }) {
+  const [validate, value] = getValidateFactory(type, arrayLength);
+
+  // Warm up.
+  const length = 1024;
+  const array = [];
+  for (let i = 0; i < length; ++i) {
+    array.push(validate(value));
+  }
+
+  bench.start();
+
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    array[index] = validate(value);
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], 'undefined');
+  }
+}

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -311,8 +311,12 @@ const validateArray = hideStackFrames((value, name, minLength = 0) => {
 /** @type {validateStringArray} */
 function validateStringArray(value, name) {
   validateArray(value, name);
-  for (let i = 0; i < value.length; i++) {
-    validateString(value[i], `${name}[${i}]`);
+  for (let i = 0; i < value.length; ++i) {
+    // Don't use validateString here for performance reasons, as
+    // we would generate intermediate strings for the name.
+    if (typeof value[i] !== 'string') {
+      throw new ERR_INVALID_ARG_TYPE(`${name}[${i}]`, 'string', value[i]);
+    }
   }
 }
 
@@ -326,8 +330,12 @@ function validateStringArray(value, name) {
 /** @type {validateBooleanArray} */
 function validateBooleanArray(value, name) {
   validateArray(value, name);
-  for (let i = 0; i < value.length; i++) {
-    validateBoolean(value[i], `${name}[${i}]`);
+  for (let i = 0; i < value.length; ++i) {
+    // Don't use validateBoolean here for performance reasons, as
+    // we would generate intermediate strings for the name.
+    if (value[i] !== true && value[i] !== false) {
+      throw new ERR_INVALID_ARG_TYPE(`${name}[${i}]`, 'boolean', value[i]);
+    }
   }
 }
 

--- a/test/benchmark/test-benchmark-validators.js
+++ b/test/benchmark/test-benchmark-validators.js
@@ -4,7 +4,6 @@ require('../common');
 
 // Minimal test for assert benchmarks. This makes sure the benchmarks aren't
 // completely broken but nothing more than that.
-
 const runBenchmark = require('../common/benchmark');
 
 runBenchmark('validators');


### PR DESCRIPTION
instead of calling the validateString/validateBoolean function, where we are forced to create strings, which we potentially dont need, we create the string only when needed.

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1423