### PR TITLE
fs: fix `fs.openAsBlob`, add `fs.openAsBlobSync` and `fsPromises.openAsBlob`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1236,6 +1236,44 @@ by [Naming Files, Paths, and Namespaces][]. Under NTFS, if the filename contains
 a colon, Node.js will open a file system stream, as described by
 [this MSDN page][MSDN-Using-Streams].
 
+### `fsPromises.openAsBlob(path[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `path` {string|Buffer|URL}
+* `options` {Object}
+  * `type` {string} An optional mime type for the blob.
+* Return: {Promise} containing {Blob}
+
+Returns a {Blob} whose data is backed by the given file.
+
+The file must not be modified after the {Blob} is created. Any modifications
+will cause reading the {Blob} data to fail with a `DOMException` error.
+Synchronous stat operations on the file when the `Blob` is created, and before
+each read in order to detect whether the file data has been modified on disk.
+
+```mjs
+import { openAsBlob } from 'node:fs/promises';
+
+const blob = await openAsBlob('the.file.txt');
+const ab = await blob.arrayBuffer();
+blob.stream();
+```
+
+```cjs
+const { openAsBlob } = require('node:fs/promises');
+
+(async () => {
+  const blob = await openAsBlob('the.file.txt');
+  const ab = await blob.arrayBuffer();
+  blob.stream();
+})();
+```
+
 ### `fsPromises.opendir(path[, options])`
 
 <!-- YAML
@@ -3401,10 +3439,14 @@ a colon, Node.js will open a file system stream, as described by
 Functions based on `fs.open()` exhibit this behavior as well:
 `fs.writeFile()`, `fs.readFile()`, etc.
 
-### `fs.openAsBlob(path[, options])`
+### `fs.openAsBlob(path[, options], callback)`
 
 <!-- YAML
 added: v19.8.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/49759
+    description: Replaced with callback-based function.
 -->
 
 > Stability: 1 - Experimental
@@ -3412,32 +3454,12 @@ added: v19.8.0
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `type` {string} An optional mime type for the blob.
-* Return: {Promise} containing {Blob}
+* `callback` {Function}
+  * `err` {Error}
+  * `blob` {Blob}
 
-Returns a {Blob} whose data is backed by the given file.
-
-The file must not be modified after the {Blob} is created. Any modifications
-will cause reading the {Blob} data to fail with a `DOMException` error.
-Synchronous stat operations on the file when the `Blob` is created, and before
-each read in order to detect whether the file data has been modified on disk.
-
-```mjs
-import { openAsBlob } from 'node:fs';
-
-const blob = await openAsBlob('the.file.txt');
-const ab = await blob.arrayBuffer();
-blob.stream();
-```
-
-```cjs
-const { openAsBlob } = require('node:fs');
-
-(async () => {
-  const blob = await openAsBlob('the.file.txt');
-  const ab = await blob.arrayBuffer();
-  blob.stream();
-})();
-```
+For detailed information, see the documentation of the Promises version
+of this API: [`fsPromises.openAsBlob()`][].
 
 ### `fs.opendir(path[, options], callback)`
 
@@ -5601,6 +5623,22 @@ this API: [`fs.mkdtemp()`][].
 
 The optional `options` argument can be a string specifying an encoding, or an
 object with an `encoding` property specifying the character encoding to use.
+
+### `fs.openAsBlobSync(path[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `path` {string|Buffer|URL}
+* `options` {Object}
+  * `type` {string} An optional mime type for the blob.
+* Returns: {Blob}
+
+For detailed information, see the documentation of the Promises version
+of this API: [`fsPromises.openAsBlob()`][].
 
 ### `fs.opendirSync(path[, options])`
 
@@ -8149,6 +8187,7 @@ the file contents.
 [`fsPromises.access()`]: #fspromisesaccesspath-mode
 [`fsPromises.copyFile()`]: #fspromisescopyfilesrc-dest-mode
 [`fsPromises.open()`]: #fspromisesopenpath-flags-mode
+[`fsPromises.openAsBlob()`]: #fspromisesopenasblobpath-options
 [`fsPromises.opendir()`]: #fspromisesopendirpath-options
 [`fsPromises.rm()`]: #fspromisesrmpath-options
 [`fsPromises.stat()`]: #fspromisesstatpath-options

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -579,8 +579,8 @@ function openSync(path, flags, mode) {
  */
 function openAsBlob(path, options, callback) {
   if (callback === undefined) {
-    options = kEmptyObject;
     callback = options;
+    options = kEmptyObject;
   } else {
     options ??= kEmptyObject;
   }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -33,7 +33,6 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   Promise,
-  PromiseResolve,
   ReflectApply,
   SafeMap,
   SafeSet,
@@ -572,17 +571,47 @@ function openSync(path, flags, mode) {
  * @param {{
  *   type?: string;
  *   }} [options]
- * @returns {Promise<Blob>}
+ * @param {(
+ *   err?: Error,
+ *   blob?: Blob
+ *   ) => any} callback
+ * @returns {void}
  */
-function openAsBlob(path, options = kEmptyObject) {
+function openAsBlob(path, options, callback) {
+  if (callback === undefined) {
+    options = kEmptyObject;
+    callback = options;
+  } else {
+    options ??= kEmptyObject;
+  }
+
   validateObject(options, 'options');
   const type = options.type || '';
   validateString(type, 'options.type');
-  // The underlying implementation here returns the Blob synchronously for now.
-  // To give ourselves flexibility to maybe return the Blob asynchronously,
-  // this API returns a Promise.
+
+  let blob;
+  let cbError = null;
+  try {
+    blob = createBlobFromFilePath(pathModule.toNamespacedPath(path), { type });
+  } catch (err) {
+    cbError = err;
+  }
+  callback(cbError, blob);
+}
+
+/**
+ * @param {string | Buffer | URL } path
+ * @param {{
+ *   type?: string;
+ *   }} [options]
+ * @returns {Blob}
+ */
+function openAsBlobSync(path, options = kEmptyObject) {
+  validateObject(options, 'options');
+  const type = options.type || '';
+  validateString(type, 'options.type');
   path = getValidatedPath(path);
-  return PromiseResolve(createBlobFromFilePath(pathModule.toNamespacedPath(path), { type }));
+  return createBlobFromFilePath(pathModule.toNamespacedPath(path), { type });
 }
 
 /**
@@ -3093,6 +3122,7 @@ module.exports = fs = {
   open,
   openSync,
   openAsBlob,
+  openAsBlobSync,
   readdir,
   readdirSync,
   read,

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -612,12 +612,8 @@ function openAsBlob(path, options, callback) {
  *   }} [options]
  * @returns {Blob}
  */
-function openAsBlobSync(path, options = kEmptyObject) {
-  validateObject(options, 'options');
-  const type = options.type || '';
-  validateString(type, 'options.type');
-  path = getValidatedPath(path);
-  return createBlobFromFilePath(pathModule.toNamespacedPath(path), { type });
+function openAsBlobSync(path, options) {
+  return syncFs.openAsBlob(path, options);
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -601,7 +601,8 @@ function openAsBlob(path, options, callback) {
     }
     cbError = err;
   }
-  callback(cbError, blob);
+
+  process.nextTick(callback, cbError, blob);
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -588,12 +588,17 @@ function openAsBlob(path, options, callback) {
   validateObject(options, 'options');
   const type = options.type || '';
   validateString(type, 'options.type');
+  validateFunction(callback, 'cb');
 
   let blob;
   let cbError = null;
   try {
     blob = createBlobFromFilePath(pathModule.toNamespacedPath(path), { type });
   } catch (err) {
+    // Permission errors should be thrown instead of being passed to callback
+    if (err.code === 'ERR_ACCESS_DENIED') {
+      throw err;
+    }
     cbError = err;
   }
   callback(cbError, blob);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -95,6 +95,7 @@ const { kFSWatchStart, watch } = require('internal/fs/watchers');
 const nonNativeWatcher = require('internal/fs/recursive_watch');
 const { isIterable } = require('internal/streams/utils');
 const assert = require('internal/assert');
+const { createBlobFromFilePath } = require('internal/blob');
 
 const kHandle = Symbol('kHandle');
 const kFd = Symbol('kFd');
@@ -756,6 +757,14 @@ async function fsync(handle) {
   return binding.fsync(handle.fd, kUsePromises);
 }
 
+async function openAsBlob(path, options = kEmptyObject) {
+  validateObject(options, 'options');
+  const type = options.type || '';
+  validateString(type, 'options.type');
+  path = getValidatedPath(path);
+  return createBlobFromFilePath(pathModule.toNamespacedPath(path), { type });
+}
+
 async function mkdir(path, options) {
   if (typeof options === 'number' || typeof options === 'string') {
     options = { mode: options };
@@ -1075,6 +1084,7 @@ module.exports = {
     opendir: promisify(opendir),
     rename,
     truncate,
+    openAsBlob,
     rm,
     rmdir,
     mkdir,

--- a/lib/internal/fs/sync.js
+++ b/lib/internal/fs/sync.js
@@ -9,7 +9,13 @@ const {
   getStatFsFromBinding,
   getValidatedFd,
 } = require('internal/fs/utils');
-const { parseFileMode } = require('internal/validators');
+const {
+  parseFileMode,
+  validateObject,
+  validateString,
+} = require('internal/validators');
+const { kEmptyObject } = require('internal/util');
+const { createBlobFromFilePath } = require('internal/blob');
 
 const binding = internalBinding('fs');
 
@@ -49,6 +55,14 @@ function copyFile(src, dest, mode) {
     pathModule.toNamespacedPath(dest),
     getValidMode(mode, 'copyFile'),
   );
+}
+
+function openAsBlob(path, options = kEmptyObject) {
+  validateObject(options, 'options');
+  const type = options.type || '';
+  validateString(type, 'options.type');
+  path = getValidatedPath(path);
+  return createBlobFromFilePath(pathModule.toNamespacedPath(path), { type });
 }
 
 function stat(path, options = { bigint: false, throwIfNoEntry: true }) {
@@ -91,6 +105,7 @@ module.exports = {
   exists,
   access,
   copyFile,
+  openAsBlob,
   stat,
   statfs,
   open,

--- a/test/fixtures/permission/fs-read.js
+++ b/test/fixtures/permission/fs-read.js
@@ -253,7 +253,7 @@ const regularFile = __filename;
 // fs.openAsBlob
 {
   assert.throws(() => {
-    fs.openAsBlob(blockedFile);
+    fs.openAsBlob(blockedFile, () => {});
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',

--- a/test/parallel/test-blob-file-backed.js
+++ b/test/parallel/test-blob-file-backed.js
@@ -9,7 +9,7 @@ const {
 const { TextDecoder } = require('util');
 const {
   writeFileSync,
-  openAsBlob,
+  promises: { openAsBlob },
 } = require('fs');
 
 const {

--- a/test/parallel/test-permission-fs-supported.js
+++ b/test/parallel/test-permission-fs-supported.js
@@ -36,7 +36,7 @@ const supportedApis = [
   ...syncAndAsyncAPI('mkdir'),
   ...syncAndAsyncAPI('mkdtemp'),
   ...syncAndAsyncAPI('open'),
-  'openAsBlob',
+  ...syncAndAsyncAPI('openAsBlob'),
   ...syncAndAsyncAPI('mkdtemp'),
   ...syncAndAsyncAPI('readdir'),
   ...syncAndAsyncAPI('readFile'),


### PR DESCRIPTION
`fs.openAsBlob()` was added in https://github.com/nodejs/node/pull/45258 as part of Callback API despite returning Promise instead of calling callback.

I guess it should look more like this?

https://github.com/nodejs/node/labels/semver-minor unless there are objections (`fs.openAsBlob` was marked as experimental).

cc @jasnell 