### PR TITLE
inspector: simplify dispatchProtocolMessage

### DIFF
--- a/src/inspector/node_string.cc
+++ b/src/inspector/node_string.cc
@@ -97,16 +97,6 @@ double toDouble(const char* buffer, size_t length, bool* ok) {
   return d;
 }
 
-std::unique_ptr<Value> parseMessage(const std::string_view message,
-                                    bool binary) {
-  if (binary) {
-    return Value::parseBinary(
-        reinterpret_cast<const uint8_t*>(message.data()),
-        message.length());
-  }
-  return parseJSON(message);
-}
-
 ProtocolMessage jsonToMessage(String message) {
   return message;
 }

--- a/src/inspector/node_string.h
+++ b/src/inspector/node_string.h
@@ -68,8 +68,6 @@ void builderAppendQuotedString(StringBuilder& builder, const std::string_view);
 std::unique_ptr<Value> parseJSON(const std::string_view);
 std::unique_ptr<Value> parseJSON(v8_inspector::StringView view);
 
-std::unique_ptr<Value> parseMessage(const std::string_view message,
-                                    bool binary);
 ProtocolMessage jsonToMessage(String message);
 ProtocolMessage binaryToMessage(std::vector<uint8_t> message);
 String fromUTF8(const uint8_t* data, size_t length);

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -253,8 +253,8 @@ class ChannelImpl final : public v8_inspector::V8Inspector::Channel,
                        "[inspector received] %s\n",
                        raw_message);
     std::unique_ptr<protocol::DictionaryValue> value =
-        protocol::DictionaryValue::cast(protocol::StringUtil::parseMessage(
-            raw_message, false));
+        protocol::DictionaryValue::cast(
+            protocol::StringUtil::parseJSON(message));
     int call_id;
     std::string method;
     node_dispatcher_->parseCommand(value.get(), &call_id, &method);

--- a/tools/inspector_protocol/lib/base_string_adapter_cc.template
+++ b/tools/inspector_protocol/lib/base_string_adapter_cc.template
@@ -129,18 +129,6 @@ std::unique_ptr<base::Value> toBaseValue(Value* value, int depth) {
 }
 
 // static
-std::unique_ptr<Value> StringUtil::parseMessage(
-    const std::string& message, bool binary) {
-  if (binary) {
-    return Value::parseBinary(
-        reinterpret_cast<const uint8_t*>(message.data()),
-        message.length());
-  }
-  std::unique_ptr<base::Value> value = base::JSONReader::ReadDeprecated(message);
-  return toProtocolValue(value.get(), 1000);
-}
-
-// static
 ProtocolMessage StringUtil::jsonToMessage(String message) {
   return message;
 }

--- a/tools/inspector_protocol/lib/base_string_adapter_h.template
+++ b/tools/inspector_protocol/lib/base_string_adapter_h.template
@@ -92,7 +92,6 @@ class {{config.lib.export_macro}} StringUtil {
     return builder.toString();
   }
 
-  static std::unique_ptr<Value> parseMessage(const std::string& message, bool binary);
   static ProtocolMessage jsonToMessage(String message);
   static ProtocolMessage binaryToMessage(std::vector<uint8_t> message);
 


### PR DESCRIPTION
This is in relation with bug https://github.com/nodejs/node/issues/47457 where we found that under Windows, there seems to be a problem when converting from UTF-8 to UTF-16 a JSON message generated by key presses in the REPL.

Tracing it back, I found evidence that in common cases, each time you hit a key in the Node REPL, a call to `dispatchProtocolMessage` is made, passing an UTF-16 JSON message. The message is converted to UTF-8 into the local variable `raw_message`, and then we call `parseMessage` which converts back `raw_message` into UTF-16 and calls `parseJSON` on it.

This PR avoids the conversion from UTF-8 back into UTF-16. This should save some processing that is currently done with each key press.

It is possible that it is a [Chesterton's fence](https://fs.blog/chestertons-fence/) and that the complexity is somehow necessary. Nevertheless, if this PR is correct, it would be an interesting optimization for the REPL. 