### PR TITLE
perf_hooks: reduce overhead of new performance_entries

### DIFF
--- a/benchmark/perf_hooks/timerfied.js
+++ b/benchmark/perf_hooks/timerfied.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const assert = require('assert');
+const common = require('../common.js');
+
+const {
+  PerformanceObserver,
+  performance,
+} = require('perf_hooks');
+
+function randomFn() {
+  return Math.random();
+}
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+  observe: ['function'],
+});
+
+let _result;
+
+function main({ n, observe }) {
+  const obs = new PerformanceObserver(() => {
+    bench.end(n);
+  });
+  obs.observe({ entryTypes: [observe], buffered: true });
+
+  const timerfied = performance.timerify(randomFn);
+
+  bench.start();
+  for (let i = 0; i < n; i++)
+    _result = timerfied();
+
+  // Avoid V8 deadcode (elimination)
+  assert.ok(_result);
+}

--- a/lib/internal/perf/performance_entry.js
+++ b/lib/internal/perf/performance_entry.js
@@ -2,7 +2,6 @@
 
 const {
   ObjectDefineProperties,
-  ReflectConstruct,
   Symbol,
 } = primordials;
 
@@ -25,14 +24,17 @@ const kEntryType = Symbol('PerformanceEntry.EntryType');
 const kStartTime = Symbol('PerformanceEntry.StartTime');
 const kDuration = Symbol('PerformanceEntry.Duration');
 const kDetail = Symbol('NodePerformanceEntry.Detail');
+const kSkipThrow = Symbol('kSkipThrow');
 
 function isPerformanceEntry(obj) {
   return obj?.[kName] !== undefined;
 }
 
 class PerformanceEntry {
-  constructor() {
-    throw new ERR_ILLEGAL_CONSTRUCTOR();
+  constructor(skipThrowSymbol = undefined) {
+    if (skipThrowSymbol !== kSkipThrow) {
+      throw new ERR_ILLEGAL_CONSTRUCTOR();
+    }
   }
 
   get name() {
@@ -92,9 +94,11 @@ function initPerformanceEntry(entry, name, type, start, duration) {
 }
 
 function createPerformanceEntry(name, type, start, duration) {
-  return ReflectConstruct(function PerformanceEntry() {
-    initPerformanceEntry(this, name, type, start, duration);
-  }, [], PerformanceEntry);
+  const entry = new PerformanceEntry(kSkipThrow);
+
+  initPerformanceEntry(entry, name, type, start, duration);
+
+  return entry;
 }
 
 /**
@@ -119,10 +123,12 @@ class PerformanceNodeEntry extends PerformanceEntry {
 }
 
 function createPerformanceNodeEntry(name, type, start, duration, detail) {
-  return ReflectConstruct(function PerformanceNodeEntry() {
-    initPerformanceEntry(this, name, type, start, duration);
-    this[kDetail] = detail;
-  }, [], PerformanceNodeEntry);
+  const entry = new PerformanceNodeEntry(kSkipThrow);
+
+  initPerformanceEntry(entry, name, type, start, duration);
+  entry[kDetail] = detail;
+
+  return entry;
 }
 
 module.exports = {


### PR DESCRIPTION
Continuing the work started on https://github.com/nodejs/performance/issues/109

Removed two references for `ReflectConstruct`, the improvements for `createPerformanceNodeEntry` can be seen using the `timerfied` function:

```
                                                    confidence improvement accuracy (*)    (**)   (***)
perf_hooks/timerfied.js observe='function' n=100000        ***    872.44 %      ±22.56% ±30.40% ±40.36%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 1 comparisons, you can thus
expect the following amount of false-positive results:
  0.05 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.01 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

The `createPerformanceEntry` is not used, should I remove it?

/cc @nodejs/performance