### PR TITLE
[deps/zlib]: Fixed cpu-features.h not found during building for Android aarch64

### DIFF
--- a/android_configure.py
+++ b/android_configure.py
@@ -70,6 +70,7 @@ GYP_DEFINES = "target_arch=" + arch
 GYP_DEFINES += " v8_target_arch=" + arch
 GYP_DEFINES += " android_target_arch=" + arch
 GYP_DEFINES += " host_os=" + host_os + " OS=android"
+GYP_DEFINES += " android_ndk_path=" + android_ndk_path
 os.environ['GYP_DEFINES'] = GYP_DEFINES
 
 if os.path.exists("./configure"):

--- a/common.gypi
+++ b/common.gypi
@@ -230,7 +230,7 @@
             ],
           },],
           ['OS == "android"', {
-            'cflags': [ '-fPIC' ],
+            'cflags': [ '-fPIC', '-I<(android_ndk_path)/sources/android/cpufeatures' ],
             'ldflags': [ '-fPIC' ]
           }],
         ],


### PR DESCRIPTION
Fixed [#49766](https://github.com/nodejs/node/issues/49766)

I fixed cpu-features.h not found during building for Android aarch64 but now the building problems are:
```

../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:49:21: error: call to undeclared function 'ntohs'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    return (int64_t)ntohs(n.n16);
                    ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:53:21: error: call to undeclared function 'ntohl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    return (int64_t)ntohl(n.n32);
                    ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:69:7: error: call to undeclared function 'ntohl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  n = nghttp3_htonl64(n);
      ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.h:73:32: note: expanded from macro 'nghttp3_htonl64'
#    define nghttp3_htonl64(N) nghttp3_bswap64(N)
                               ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.h:60:17: note: expanded from macro 'nghttp3_bswap64'
    ((uint64_t)(ntohl((uint32_t)(N))) << 32 | ntohl((uint32_t)((N) >> 32)))
                ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:74:7: error: call to undeclared function 'ntohl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  n = nghttp3_htonl64(n);
      ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.h:73:32: note: expanded from macro 'nghttp3_htonl64'
#    define nghttp3_htonl64(N) nghttp3_bswap64(N)
                               ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.h:60:17: note: expanded from macro 'nghttp3_bswap64'
    ((uint64_t)(ntohl((uint32_t)(N))) << 32 | ntohl((uint32_t)((N) >> 32)))
                ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:79:7: error: call to undeclared function 'htonl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  n = htonl(n);
      ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:84:7: error: call to undeclared function 'htonl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  n = htonl(n);
      ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:89:7: error: call to undeclared function 'htons'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  n = htons(n);
      ^
7 errors generated.


```


To solve this problem I created an environment variable called NDK_PATH that points to the ndk installation folder.
In the common.gypi file I added another argument to cflags which contains the path to the cpu-features.h file.

I changed only release configuration.
