### PR TITLE
perf_hooks: reduce overhead of new resource timings

### DIFF
--- a/benchmark/perf_hooks/resourcetiming.js
+++ b/benchmark/perf_hooks/resourcetiming.js
@@ -72,6 +72,6 @@ function main({ n, observe }) {
   obs.observe({ entryTypes: [observe], buffered: true });
 
   bench.start();
-  for (let i = 0; i < 1e5; i++)
+  for (let i = 0; i < n; i++)
     test();
 }

--- a/lib/internal/perf/performance_entry.js
+++ b/lib/internal/perf/performance_entry.js
@@ -31,10 +31,12 @@ function isPerformanceEntry(obj) {
 }
 
 class PerformanceEntry {
-  constructor(skipThrowSymbol = undefined) {
+  constructor(skipThrowSymbol = undefined, name = undefined, type = undefined, start = undefined, duration = undefined) {
     if (skipThrowSymbol !== kSkipThrow) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
+
+    initPerformanceEntry(this, name, type, start, duration);
   }
 
   get name() {
@@ -94,11 +96,7 @@ function initPerformanceEntry(entry, name, type, start, duration) {
 }
 
 function createPerformanceEntry(name, type, start, duration) {
-  const entry = new PerformanceEntry(kSkipThrow);
-
-  initPerformanceEntry(entry, name, type, start, duration);
-
-  return entry;
+  return new PerformanceEntry(kSkipThrow, name, type, start, duration);
 }
 
 /**
@@ -123,9 +121,8 @@ class PerformanceNodeEntry extends PerformanceEntry {
 }
 
 function createPerformanceNodeEntry(name, type, start, duration, detail) {
-  const entry = new PerformanceNodeEntry(kSkipThrow);
+  const entry = new PerformanceNodeEntry(kSkipThrow, name, type, start, duration);
 
-  initPerformanceEntry(entry, name, type, start, duration);
   entry[kDetail] = detail;
 
   return entry;
@@ -138,4 +135,5 @@ module.exports = {
   isPerformanceEntry,
   PerformanceNodeEntry,
   createPerformanceNodeEntry,
+  kSkipThrow,
 };

--- a/lib/internal/perf/performance_entry.js
+++ b/lib/internal/perf/performance_entry.js
@@ -31,7 +31,13 @@ function isPerformanceEntry(obj) {
 }
 
 class PerformanceEntry {
-  constructor(skipThrowSymbol = undefined, name = undefined, type = undefined, start = undefined, duration = undefined) {
+  constructor(
+    skipThrowSymbol = undefined,
+    name = undefined,
+    type = undefined,
+    start = undefined,
+    duration = undefined,
+  ) {
     if (skipThrowSymbol !== kSkipThrow) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }

--- a/lib/internal/perf/resource_timing.js
+++ b/lib/internal/perf/resource_timing.js
@@ -3,19 +3,17 @@
 
 const {
   ObjectDefineProperties,
-  ObjectSetPrototypeOf,
-  ReflectConstruct,
   Symbol,
   SymbolToStringTag,
 } = primordials;
-const { initPerformanceEntry, PerformanceEntry } = require('internal/perf/performance_entry');
-const assert = require('internal/assert');
-const { enqueue, bufferResourceTiming } = require('internal/perf/observe');
 const {
   codes: {
     ERR_ILLEGAL_CONSTRUCTOR,
   },
 } = require('internal/errors');
+const { PerformanceEntry, kSkipThrow } = require('internal/perf/performance_entry');
+const assert = require('internal/assert');
+const { enqueue, bufferResourceTiming } = require('internal/perf/observe');
 const { validateInternalField } = require('internal/validators');
 const { kEnumerableProperty } = require('internal/util');
 
@@ -25,8 +23,12 @@ const kTimingInfo = Symbol('kTimingInfo');
 const kInitiatorType = Symbol('kInitiatorType');
 
 class PerformanceResourceTiming extends PerformanceEntry {
-  constructor() {
-    throw new ERR_ILLEGAL_CONSTRUCTOR();
+  constructor(skipThrowSymbol = undefined, name = undefined, type = undefined) {
+    if (skipThrowSymbol !== kSkipThrow) {
+      throw new ERR_ILLEGAL_CONSTRUCTOR();
+    }
+
+    super(skipThrowSymbol, name, type);
   }
 
   get name() {
@@ -189,16 +191,17 @@ ObjectDefineProperties(PerformanceResourceTiming.prototype, {
 });
 
 function createPerformanceResourceTiming(requestedUrl, initiatorType, timingInfo, cacheMode = '') {
-  return ReflectConstruct(function PerformanceResourceTiming() {
-    initPerformanceEntry(this, requestedUrl, 'resource');
-    this[kInitiatorType] = initiatorType;
-    this[kRequestedUrl] = requestedUrl;
-    // https://fetch.spec.whatwg.org/#fetch-timing-info
-    // This class is using timingInfo assuming it's already validated.
-    // The spec doesn't say to validate it in the class construction.
-    this[kTimingInfo] = timingInfo;
-    this[kCacheMode] = cacheMode;
-  }, [], PerformanceResourceTiming);
+  const resourceTiming = new PerformanceResourceTiming(kSkipThrow, requestedUrl, 'resource');
+
+  resourceTiming[kInitiatorType] = initiatorType;
+  resourceTiming[kRequestedUrl] = requestedUrl;
+  // https://fetch.spec.whatwg.org/#fetch-timing-info
+  // This class is using timingInfo assuming it's already validated.
+  // The spec doesn't say to validate it in the class construction.
+  resourceTiming[kTimingInfo] = timingInfo;
+  resourceTiming[kCacheMode] = cacheMode;
+
+  return resourceTiming;
 }
 
 // https://w3c.github.io/resource-timing/#dfn-mark-resource-timing
@@ -221,7 +224,6 @@ function markResourceTiming(
     cacheMode,
   );
 
-  ObjectSetPrototypeOf(resource, PerformanceResourceTiming.prototype);
   enqueue(resource);
   bufferResourceTiming(resource);
   return resource;


### PR DESCRIPTION
Continuing the work started on https://github.com/nodejs/performance/issues/109.

This PR should be landed after #49803.

```
                                                         confidence improvement accuracy (*)    (**)   (***)
perf_hooks/resourcetiming.js observe='resource' n=100000        ***   1086.23 %      ±40.80% ±54.98% ±72.99%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 1 comparisons, you can thus
expect the following amount of false-positive results:
  0.05 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.01 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

~I want to use the symbol `kSkipThrow` in other classes around the NodeJS codebase, someone had some idea where I should put it? Or create a new symbol and reuse it when possible?~

~Right now, we have this symbol being used on `perf_hooks` but there is also an identical symbol on `webstreams`, so maybe we can put it in a higher module and import it around the node, I initially thought to put it inside `errors`, since we will always use it together with `ERR_ILLEGAL_CONSTRUCTOR`.~

I will reuse the same symbol only when it inherits some class that exports a symbol, otherwise, I will create a new one.

/cc @nodejs/performance