### PR TITLE
fs: improve error performance for `rmdirSync`

### DIFF
--- a/benchmark/fs/bench-rmdirSync.js
+++ b/benchmark/fs/bench-rmdirSync.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const bench = common.createBenchmark(main, {
+  type: ['existing', 'non-existing'],
+  n: [1e4],
+});
+
+function main({ n, type }) {
+  switch (type) {
+    case 'existing': {
+      for (let i = 0; i < n; i++) {
+        fs.mkdirSync(tmpdir.resolve(`rmdirsync-bench-dir-${i}`));
+      }
+
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        fs.rmdirSync(tmpdir.resolve(`rmdirsync-bench-dir-${i}`));
+      }
+      bench.end(n);
+      break;
+    }
+    case 'non-existing': {
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.rmdirSync(tmpdir.resolve(`.non-existent-folder-${i}`));
+        } catch {
+          // do nothing
+        }
+      }
+      bench.end(n);
+      break;
+    }
+    default:
+      new Error('Invalid type');
+  }
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1216,9 +1216,7 @@ function rmdirSync(path, options) {
     validateRmdirOptions(options);
   }
 
-  const ctx = { path };
-  binding.rmdir(pathModule.toNamespacedPath(path), undefined, ctx);
-  return handleErrorFromBinding(ctx);
+  binding.rmdir(pathModule.toNamespacedPath(path));
 }
 
 /**

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1491,25 +1491,23 @@ static void RMDir(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   const int argc = args.Length();
-  CHECK_GE(argc, 2);
+  CHECK_GE(argc, 1);
 
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
 
-  FSReqBase* req_wrap_async = GetReqWrap(args, 1);  // rmdir(path, req)
-  if (req_wrap_async != nullptr) {
+  if (argc > 1) {
+    FSReqBase* req_wrap_async = GetReqWrap(args, 1);  // rmdir(path, req)
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_RMDIR, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "rmdir", UTF8, AfterNoArgs,
               uv_fs_rmdir, *path);
-  } else {  // rmdir(path, undefined, ctx)
-    CHECK_EQ(argc, 3);
-    FSReqWrapSync req_wrap_sync;
+  } else {  // rmdir(path)
+    FSReqWrapSync req_wrap_sync("rmdir", *path);
     FS_SYNC_TRACE_BEGIN(rmdir);
-    SyncCall(env, args[2], &req_wrap_sync, "rmdir",
-             uv_fs_rmdir, *path);
+    SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_rmdir, *path);
     FS_SYNC_TRACE_END(rmdir);
   }
 }

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -191,7 +191,7 @@ declare namespace InternalFSBinding {
   function rename(oldPath: string, newPath: string): void;
 
   function rmdir(path: string, req: FSReqCallback): void;
-  function rmdir(path: string, req: undefined, ctx: FSSyncContext): void;
+  function rmdir(path: string): void;
   function rmdir(path: string, usePromises: typeof kUsePromises): Promise<void>;
 
   function stat(path: StringOrBuffer, useBigint: boolean, req: FSReqCallback<Float64Array | BigUint64Array>): void;


### PR DESCRIPTION
Results from i9/Linux/SSD:
```
                                                   confidence improvement accuracy (*)   (**)  (***)
fs/bench-rmdirSync.js n=10000 type='existing'                     0.54 %       ±1.35% ±1.80% ±2.34%
fs/bench-rmdirSync.js n=10000 type='non-existing'        ***     61.81 %       ±2.15% ±2.88% ±3.77%
```

Ref: https://github.com/nodejs/performance/issues/106

Thanks to and inspiration from @anonrig 🚀