### PR TITLE
fs: add stacktrace to fs/promises

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -131,6 +131,10 @@ function lazyFsStreams() {
   return fsStreams ??= require('internal/fs/streams');
 }
 
+// By the time the C++ land creates an error for a promise rejection (likely from a
+// libuv callback), there is already no JS frames on the stack. So we need to
+// wait until V8 resumes execution back to JS land before we have enough information
+// to re-capture the stack trace.
 function handleErrorFromBinding(error) {
   ErrorCaptureStackTrace(error, handleErrorFromBinding);
   return PromiseReject(error);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -500,8 +500,11 @@ async function readFileHandle(filehandle, options) {
 
   checkAborted(signal);
 
-  const statFields = await binding.fstat(filehandle.fd, false, kUsePromises)
-                                  .catch(handleErrorFromBinding);
+  const statFields = await PromisePrototypeThen(
+    binding.fstat(filehandle.fd, false, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 
   checkAborted(signal);
 
@@ -532,9 +535,11 @@ async function readFileHandle(filehandle, options) {
       length = MathMin(size - totalRead, kReadFileBufferLength);
     }
 
-    const bytesRead = (await binding.read(filehandle.fd, buffer, offset,
-                                          length, -1, kUsePromises)
-                                    .catch(handleErrorFromBinding)) ?? 0;
+    const bytesRead = (await PromisePrototypeThen(
+      binding.read(filehandle.fd, buffer, offset, length, -1, kUsePromises),
+      undefined,
+      handleErrorFromBinding
+    )) ?? 0;
     totalRead += bytesRead;
 
     if (bytesRead === 0 ||
@@ -582,9 +587,11 @@ async function access(path, mode = F_OK) {
   path = getValidatedPath(path);
 
   mode = getValidMode(mode, 'access');
-  return await binding.access(pathModule.toNamespacedPath(path), mode,
-                              kUsePromises)
-                      .catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.access(pathModule.toNamespacedPath(path), mode, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function cp(src, dest, options) {
@@ -598,11 +605,14 @@ async function copyFile(src, dest, mode) {
   src = getValidatedPath(src, 'src');
   dest = getValidatedPath(dest, 'dest');
   mode = getValidMode(mode, 'copyFile');
-  return await binding.copyFile(pathModule.toNamespacedPath(src),
-                                pathModule.toNamespacedPath(dest),
-                                mode,
-                                kUsePromises)
-                      .catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.copyFile(pathModule.toNamespacedPath(src),
+                     pathModule.toNamespacedPath(dest),
+                     mode,
+                     kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 // Note that unlike fs.open() which uses numeric file descriptors,
@@ -611,10 +621,12 @@ async function open(path, flags, mode) {
   path = getValidatedPath(path);
   const flagsNumber = stringToFlags(flags);
   mode = parseFileMode(mode, 'mode', 0o666);
-  return new FileHandle(
-    await binding.openFileHandle(pathModule.toNamespacedPath(path),
-                                 flagsNumber, mode, kUsePromises)
-                 .catch(handleErrorFromBinding));
+  return new FileHandle(await PromisePrototypeThen(
+    binding.openFileHandle(pathModule.toNamespacedPath(path),
+                          flagsNumber, mode, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  ));
 }
 
 async function read(handle, bufferOrParams, offset, length, position) {
@@ -667,9 +679,11 @@ async function read(handle, bufferOrParams, offset, length, position) {
     validatePosition(position, 'position', length);
   }
 
-  const bytesRead = (await binding.read(handle.fd, buffer, offset, length,
-                                        position, kUsePromises)
-                                  .catch(handleErrorFromBinding)) || 0;
+  const bytesRead = (await PromisePrototypeThen(
+    binding.read(handle.fd, buffer, offset, length, position, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  )) || 0;
 
   return { __proto__: null, bytesRead, buffer };
 }
@@ -680,9 +694,11 @@ async function readv(handle, buffers, position) {
   if (typeof position !== 'number')
     position = null;
 
-  const bytesRead = (await binding.readBuffers(handle.fd, buffers, position,
-                                               kUsePromises)
-                                  .catch(handleErrorFromBinding)) || 0;
+  const bytesRead = (await PromisePrototypeThen(
+    binding.readBuffers(handle.fd, buffers, position, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  )) || 0;
   return { __proto__: null, bytesRead, buffers };
 }
 
@@ -711,17 +727,22 @@ async function write(handle, buffer, offsetOrOptions, length, position) {
       position = null;
     validateOffsetLengthWrite(offset, length, buffer.byteLength);
     const bytesWritten =
-      (await binding.writeBuffer(handle.fd, buffer, offset,
-                                 length, position, kUsePromises)
-                    .catch(handleErrorFromBinding)) || 0;
+      (await PromisePrototypeThen(
+        binding.writeBuffer(handle.fd, buffer, offset,
+                            length, position, kUsePromises),
+        undefined,
+        handleErrorFromBinding
+      )) || 0;
     return { __proto__: null, bytesWritten, buffer };
   }
 
   validateStringAfterArrayBufferView(buffer, 'buffer');
   validateEncoding(buffer, length);
-  const bytesWritten = (await binding.writeString(handle.fd, buffer, offset,
-                                                  length, kUsePromises)
-                                     .catch(handleErrorFromBinding)) || 0;
+  const bytesWritten = (await PromisePrototypeThen(
+    binding.writeString(handle.fd, buffer, offset, length, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  )) || 0;
   return { __proto__: null, bytesWritten, buffer };
 }
 
@@ -735,19 +756,24 @@ async function writev(handle, buffers, position) {
     return { __proto__: null, bytesWritten: 0, buffers };
   }
 
-  const bytesWritten = (await binding.writeBuffers(handle.fd, buffers, position,
-                                                   kUsePromises)
-                                     .catch(handleErrorFromBinding)) || 0;
+  const bytesWritten = (await PromisePrototypeThen(
+    binding.writeBuffers(handle.fd, buffers, position, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  )) || 0;
   return { __proto__: null, bytesWritten, buffers };
 }
 
 async function rename(oldPath, newPath) {
   oldPath = getValidatedPath(oldPath, 'oldPath');
   newPath = getValidatedPath(newPath, 'newPath');
-  return await binding.rename(pathModule.toNamespacedPath(oldPath),
-                              pathModule.toNamespacedPath(newPath),
-                              kUsePromises)
-                      .catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.rename(pathModule.toNamespacedPath(oldPath),
+                   pathModule.toNamespacedPath(newPath),
+                   kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function truncate(path, len = 0) {
@@ -758,7 +784,11 @@ async function truncate(path, len = 0) {
 async function ftruncate(handle, len = 0) {
   validateInteger(len, 'len');
   len = MathMax(0, len);
-  return await binding.ftruncate(handle.fd, len, kUsePromises).catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.ftruncate(handle.fd, len, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function rm(path, options) {
@@ -779,15 +809,27 @@ async function rmdir(path, options) {
     }
   }
 
-  return await binding.rmdir(path, kUsePromises).catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.rmdir(path, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function fdatasync(handle) {
-  return await binding.fdatasync(handle.fd, kUsePromises).catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.fdatasync(handle.fd, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function fsync(handle) {
-  return await binding.fsync(handle.fd, kUsePromises).catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.fsync(handle.fd, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function mkdir(path, options) {
@@ -801,10 +843,13 @@ async function mkdir(path, options) {
   path = getValidatedPath(path);
   validateBoolean(recursive, 'options.recursive');
 
-  return await binding.mkdir(pathModule.toNamespacedPath(path),
-                             parseFileMode(mode, 'mode', 0o777), recursive,
-                             kUsePromises)
-                      .catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.mkdir(pathModule.toNamespacedPath(path),
+                  parseFileMode(mode, 'mode', 0o777), recursive,
+                  kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function readdirRecursive(originalPath, options) {
@@ -812,12 +857,16 @@ async function readdirRecursive(originalPath, options) {
   const queue = [
     [
       originalPath,
-      await binding.readdir(
-        pathModule.toNamespacedPath(originalPath),
-        options.encoding,
-        !!options.withFileTypes,
-        kUsePromises,
-      ).catch(handleErrorFromBinding),
+      await PromisePrototypeThen(
+        binding.readdir(
+          pathModule.toNamespacedPath(originalPath),
+          options.encoding,
+          !!options.withFileTypes,
+          kUsePromises,
+        ),
+        undefined,
+        handleErrorFromBinding
+      ),
     ],
   ];
 
@@ -832,12 +881,16 @@ async function readdirRecursive(originalPath, options) {
           const direntPath = pathModule.join(path, dirent.name);
           ArrayPrototypePush(queue, [
             direntPath,
-            await binding.readdir(
-              direntPath,
-              options.encoding,
-              true,
-              kUsePromises,
-            ).catch(handleErrorFromBinding),
+            await PromisePrototypeThen(
+              binding.readdir(
+                direntPath,
+                options.encoding,
+                true,
+                kUsePromises,
+              ),
+              undefined,
+              handleErrorFromBinding
+            ),
           ]);
         }
       }
@@ -855,12 +908,16 @@ async function readdirRecursive(originalPath, options) {
         if (stat === 1) {
           ArrayPrototypePush(queue, [
             direntPath,
-            await binding.readdir(
-              pathModule.toNamespacedPath(direntPath),
-              options.encoding,
-              false,
-              kUsePromises,
-            ).catch(handleErrorFromBinding),
+            await PromisePrototypeThen(
+              binding.readdir(
+                pathModule.toNamespacedPath(direntPath),
+                options.encoding,
+                false,
+                kUsePromises,
+              ),
+              undefined,
+              handleErrorFromBinding
+            ),
           ]);
         }
       }
@@ -876,12 +933,16 @@ async function readdir(path, options) {
   if (options.recursive) {
     return readdirRecursive(path, options);
   }
-  const result = await binding.readdir(
-    pathModule.toNamespacedPath(path),
-    options.encoding,
-    !!options.withFileTypes,
-    kUsePromises,
-  ).catch(handleErrorFromBinding);
+  const result = await PromisePrototypeThen(
+    binding.readdir(
+      pathModule.toNamespacedPath(path),
+      options.encoding,
+      !!options.withFileTypes,
+      kUsePromises,
+    ),
+    undefined,
+    handleErrorFromBinding
+  );
   return options.withFileTypes ?
     getDirectoryEntriesPromise(path, result) :
     result;
@@ -890,9 +951,12 @@ async function readdir(path, options) {
 async function readlink(path, options) {
   options = getOptions(options);
   path = getValidatedPath(path, 'oldPath');
-  return await binding.readlink(pathModule.toNamespacedPath(path),
-                                options.encoding, kUsePromises)
-                      .catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.readlink(pathModule.toNamespacedPath(path),
+                     options.encoding, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function symlink(target, path, type_) {
@@ -908,65 +972,96 @@ async function symlink(target, path, type_) {
   }
   target = getValidatedPath(target, 'target');
   path = getValidatedPath(path);
-  return await binding.symlink(preprocessSymlinkDestination(target, type, path),
-                               pathModule.toNamespacedPath(path),
-                               stringToSymlinkType(type),
-                               kUsePromises)
-                      .catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.symlink(preprocessSymlinkDestination(target, type, path),
+                    pathModule.toNamespacedPath(path),
+                    stringToSymlinkType(type),
+                    kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function fstat(handle, options = { bigint: false }) {
-  const result = await binding.fstat(handle.fd, options.bigint, kUsePromises).catch(handleErrorFromBinding);
+  const result = await PromisePrototypeThen(
+    binding.fstat(handle.fd, options.bigint, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
   return getStatsFromBinding(result);
 }
 
 async function lstat(path, options = { bigint: false }) {
   path = getValidatedPath(path);
-  const result = await binding.lstat(pathModule.toNamespacedPath(path),
-                                     options.bigint, kUsePromises)
-                              .catch(handleErrorFromBinding);
+  const result = await PromisePrototypeThen(
+    binding.lstat(pathModule.toNamespacedPath(path),
+                  options.bigint, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
   return getStatsFromBinding(result);
 }
 
 async function stat(path, options = { bigint: false }) {
   path = getValidatedPath(path);
-  const result = await binding.stat(pathModule.toNamespacedPath(path),
-                                    options.bigint, kUsePromises)
-                              .catch(handleErrorFromBinding);
+  const result = await PromisePrototypeThen(
+    binding.stat(pathModule.toNamespacedPath(path),
+                 options.bigint, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
   return getStatsFromBinding(result);
 }
 
 async function statfs(path, options = { bigint: false }) {
   path = getValidatedPath(path);
-  const result = await binding.statfs(pathModule.toNamespacedPath(path),
-                                      options.bigint, kUsePromises)
-                              .catch(handleErrorFromBinding);
+  const result = await PromisePrototypeThen(
+    binding.statfs(pathModule.toNamespacedPath(path),
+                   options.bigint, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
   return getStatFsFromBinding(result);
 }
 
 async function link(existingPath, newPath) {
   existingPath = getValidatedPath(existingPath, 'existingPath');
   newPath = getValidatedPath(newPath, 'newPath');
-  return await binding.link(pathModule.toNamespacedPath(existingPath),
-                            pathModule.toNamespacedPath(newPath),
-                            kUsePromises)
-                      .catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.link(pathModule.toNamespacedPath(existingPath),
+                 pathModule.toNamespacedPath(newPath),
+                 kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function unlink(path) {
   path = getValidatedPath(path);
-  return await binding.unlink(pathModule.toNamespacedPath(path), kUsePromises).catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.unlink(pathModule.toNamespacedPath(path), kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function fchmod(handle, mode) {
   mode = parseFileMode(mode, 'mode');
-  return await binding.fchmod(handle.fd, mode, kUsePromises).catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.fchmod(handle.fd, mode, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function chmod(path, mode) {
   path = getValidatedPath(path);
   mode = parseFileMode(mode, 'mode');
-  return await binding.chmod(pathModule.toNamespacedPath(path), mode, kUsePromises).catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.chmod(pathModule.toNamespacedPath(path), mode, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function lchmod(path, mode) {
@@ -981,54 +1076,76 @@ async function lchown(path, uid, gid) {
   path = getValidatedPath(path);
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  return await binding.lchown(pathModule.toNamespacedPath(path),
-                              uid, gid, kUsePromises)
-                      .catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.lchown(pathModule.toNamespacedPath(path), uid, gid, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function fchown(handle, uid, gid) {
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  return await binding.fchown(handle.fd, uid, gid, kUsePromises).catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.fchown(handle.fd, uid, gid, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function chown(path, uid, gid) {
   path = getValidatedPath(path);
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  return await binding.chown(pathModule.toNamespacedPath(path),
-                             uid, gid, kUsePromises)
-                       .catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.chown(pathModule.toNamespacedPath(path), uid, gid, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function utimes(path, atime, mtime) {
   path = getValidatedPath(path);
-  return await binding.utimes(pathModule.toNamespacedPath(path),
-                              toUnixTimestamp(atime),
-                              toUnixTimestamp(mtime),
-                              kUsePromises)
-                      .catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.utimes(pathModule.toNamespacedPath(path),
+                   toUnixTimestamp(atime),
+                   toUnixTimestamp(mtime),
+                   kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function futimes(handle, atime, mtime) {
   atime = toUnixTimestamp(atime, 'atime');
   mtime = toUnixTimestamp(mtime, 'mtime');
-  return await binding.futimes(handle.fd, atime, mtime, kUsePromises).catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.futimes(handle.fd, atime, mtime, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function lutimes(path, atime, mtime) {
   path = getValidatedPath(path);
-  return await binding.lutimes(pathModule.toNamespacedPath(path),
-                               toUnixTimestamp(atime),
-                               toUnixTimestamp(mtime),
-                               kUsePromises)
-                       .catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.lutimes(pathModule.toNamespacedPath(path),
+                    toUnixTimestamp(atime),
+                    toUnixTimestamp(mtime),
+                    kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function realpath(path, options) {
   options = getOptions(options);
   path = getValidatedPath(path);
-  return await binding.realpath(path, options.encoding, kUsePromises).catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.realpath(path, options.encoding, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function mkdtemp(prefix, options) {
@@ -1044,7 +1161,11 @@ async function mkdtemp(prefix, options) {
     path = Buffer.concat([prefix, Buffer.from('XXXXXX')]);
   }
 
-  return await binding.mkdtemp(path, options.encoding, kUsePromises).catch(handleErrorFromBinding);
+  return await PromisePrototypeThen(
+    binding.mkdtemp(path, options.encoding, kUsePromises),
+    undefined,
+    handleErrorFromBinding
+  );
 }
 
 async function writeFile(path, data, options) {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -507,7 +507,7 @@ async function readFileHandle(filehandle, options) {
   const statFields = await PromisePrototypeThen(
     binding.fstat(filehandle.fd, false, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 
   checkAborted(signal);
@@ -542,7 +542,7 @@ async function readFileHandle(filehandle, options) {
     const bytesRead = (await PromisePrototypeThen(
       binding.read(filehandle.fd, buffer, offset, length, -1, kUsePromises),
       undefined,
-      handleErrorFromBinding
+      handleErrorFromBinding,
     )) ?? 0;
     totalRead += bytesRead;
 
@@ -594,7 +594,7 @@ async function access(path, mode = F_OK) {
   return await PromisePrototypeThen(
     binding.access(pathModule.toNamespacedPath(path), mode, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -615,7 +615,7 @@ async function copyFile(src, dest, mode) {
                      mode,
                      kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -627,9 +627,9 @@ async function open(path, flags, mode) {
   mode = parseFileMode(mode, 'mode', 0o666);
   return new FileHandle(await PromisePrototypeThen(
     binding.openFileHandle(pathModule.toNamespacedPath(path),
-                          flagsNumber, mode, kUsePromises),
+                           flagsNumber, mode, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   ));
 }
 
@@ -686,7 +686,7 @@ async function read(handle, bufferOrParams, offset, length, position) {
   const bytesRead = (await PromisePrototypeThen(
     binding.read(handle.fd, buffer, offset, length, position, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   )) || 0;
 
   return { __proto__: null, bytesRead, buffer };
@@ -701,7 +701,7 @@ async function readv(handle, buffers, position) {
   const bytesRead = (await PromisePrototypeThen(
     binding.readBuffers(handle.fd, buffers, position, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   )) || 0;
   return { __proto__: null, bytesRead, buffers };
 }
@@ -735,7 +735,7 @@ async function write(handle, buffer, offsetOrOptions, length, position) {
         binding.writeBuffer(handle.fd, buffer, offset,
                             length, position, kUsePromises),
         undefined,
-        handleErrorFromBinding
+        handleErrorFromBinding,
       )) || 0;
     return { __proto__: null, bytesWritten, buffer };
   }
@@ -745,7 +745,7 @@ async function write(handle, buffer, offsetOrOptions, length, position) {
   const bytesWritten = (await PromisePrototypeThen(
     binding.writeString(handle.fd, buffer, offset, length, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   )) || 0;
   return { __proto__: null, bytesWritten, buffer };
 }
@@ -763,7 +763,7 @@ async function writev(handle, buffers, position) {
   const bytesWritten = (await PromisePrototypeThen(
     binding.writeBuffers(handle.fd, buffers, position, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   )) || 0;
   return { __proto__: null, bytesWritten, buffers };
 }
@@ -776,7 +776,7 @@ async function rename(oldPath, newPath) {
                    pathModule.toNamespacedPath(newPath),
                    kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -791,7 +791,7 @@ async function ftruncate(handle, len = 0) {
   return await PromisePrototypeThen(
     binding.ftruncate(handle.fd, len, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -816,7 +816,7 @@ async function rmdir(path, options) {
   return await PromisePrototypeThen(
     binding.rmdir(path, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -824,7 +824,7 @@ async function fdatasync(handle) {
   return await PromisePrototypeThen(
     binding.fdatasync(handle.fd, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -832,7 +832,7 @@ async function fsync(handle) {
   return await PromisePrototypeThen(
     binding.fsync(handle.fd, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -852,7 +852,7 @@ async function mkdir(path, options) {
                   parseFileMode(mode, 'mode', 0o777), recursive,
                   kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -869,7 +869,7 @@ async function readdirRecursive(originalPath, options) {
           kUsePromises,
         ),
         undefined,
-        handleErrorFromBinding
+        handleErrorFromBinding,
       ),
     ],
   ];
@@ -893,7 +893,7 @@ async function readdirRecursive(originalPath, options) {
                 kUsePromises,
               ),
               undefined,
-              handleErrorFromBinding
+              handleErrorFromBinding,
             ),
           ]);
         }
@@ -920,7 +920,7 @@ async function readdirRecursive(originalPath, options) {
                 kUsePromises,
               ),
               undefined,
-              handleErrorFromBinding
+              handleErrorFromBinding,
             ),
           ]);
         }
@@ -945,7 +945,7 @@ async function readdir(path, options) {
       kUsePromises,
     ),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
   return options.withFileTypes ?
     getDirectoryEntriesPromise(path, result) :
@@ -959,7 +959,7 @@ async function readlink(path, options) {
     binding.readlink(pathModule.toNamespacedPath(path),
                      options.encoding, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -982,7 +982,7 @@ async function symlink(target, path, type_) {
                     stringToSymlinkType(type),
                     kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -990,7 +990,7 @@ async function fstat(handle, options = { bigint: false }) {
   const result = await PromisePrototypeThen(
     binding.fstat(handle.fd, options.bigint, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
   return getStatsFromBinding(result);
 }
@@ -1001,7 +1001,7 @@ async function lstat(path, options = { bigint: false }) {
     binding.lstat(pathModule.toNamespacedPath(path),
                   options.bigint, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
   return getStatsFromBinding(result);
 }
@@ -1012,7 +1012,7 @@ async function stat(path, options = { bigint: false }) {
     binding.stat(pathModule.toNamespacedPath(path),
                  options.bigint, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
   return getStatsFromBinding(result);
 }
@@ -1023,7 +1023,7 @@ async function statfs(path, options = { bigint: false }) {
     binding.statfs(pathModule.toNamespacedPath(path),
                    options.bigint, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
   return getStatFsFromBinding(result);
 }
@@ -1036,7 +1036,7 @@ async function link(existingPath, newPath) {
                  pathModule.toNamespacedPath(newPath),
                  kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -1045,7 +1045,7 @@ async function unlink(path) {
   return await PromisePrototypeThen(
     binding.unlink(pathModule.toNamespacedPath(path), kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -1054,7 +1054,7 @@ async function fchmod(handle, mode) {
   return await PromisePrototypeThen(
     binding.fchmod(handle.fd, mode, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -1064,7 +1064,7 @@ async function chmod(path, mode) {
   return await PromisePrototypeThen(
     binding.chmod(pathModule.toNamespacedPath(path), mode, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -1083,7 +1083,7 @@ async function lchown(path, uid, gid) {
   return await PromisePrototypeThen(
     binding.lchown(pathModule.toNamespacedPath(path), uid, gid, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -1093,7 +1093,7 @@ async function fchown(handle, uid, gid) {
   return await PromisePrototypeThen(
     binding.fchown(handle.fd, uid, gid, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -1104,7 +1104,7 @@ async function chown(path, uid, gid) {
   return await PromisePrototypeThen(
     binding.chown(pathModule.toNamespacedPath(path), uid, gid, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -1116,7 +1116,7 @@ async function utimes(path, atime, mtime) {
                    toUnixTimestamp(mtime),
                    kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -1126,7 +1126,7 @@ async function futimes(handle, atime, mtime) {
   return await PromisePrototypeThen(
     binding.futimes(handle.fd, atime, mtime, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -1138,7 +1138,7 @@ async function lutimes(path, atime, mtime) {
                     toUnixTimestamp(mtime),
                     kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -1148,7 +1148,7 @@ async function realpath(path, options) {
   return await PromisePrototypeThen(
     binding.realpath(path, options.encoding, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 
@@ -1168,7 +1168,7 @@ async function mkdtemp(prefix, options) {
   return await PromisePrototypeThen(
     binding.mkdtemp(path, options.encoding, kUsePromises),
     undefined,
-    handleErrorFromBinding
+    handleErrorFromBinding,
   );
 }
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -582,9 +582,9 @@ async function access(path, mode = F_OK) {
   path = getValidatedPath(path);
 
   mode = getValidMode(mode, 'access');
-  return binding.access(pathModule.toNamespacedPath(path), mode,
-                        kUsePromises)
-                .catch(handleErrorFromBinding);
+  return await binding.access(pathModule.toNamespacedPath(path), mode,
+                              kUsePromises)
+                      .catch(handleErrorFromBinding);
 }
 
 async function cp(src, dest, options) {
@@ -598,11 +598,11 @@ async function copyFile(src, dest, mode) {
   src = getValidatedPath(src, 'src');
   dest = getValidatedPath(dest, 'dest');
   mode = getValidMode(mode, 'copyFile');
-  return binding.copyFile(pathModule.toNamespacedPath(src),
-                          pathModule.toNamespacedPath(dest),
-                          mode,
-                          kUsePromises)
-                .catch(handleErrorFromBinding);
+  return await binding.copyFile(pathModule.toNamespacedPath(src),
+                                pathModule.toNamespacedPath(dest),
+                                mode,
+                                kUsePromises)
+                      .catch(handleErrorFromBinding);
 }
 
 // Note that unlike fs.open() which uses numeric file descriptors,
@@ -744,10 +744,10 @@ async function writev(handle, buffers, position) {
 async function rename(oldPath, newPath) {
   oldPath = getValidatedPath(oldPath, 'oldPath');
   newPath = getValidatedPath(newPath, 'newPath');
-  return binding.rename(pathModule.toNamespacedPath(oldPath),
-                        pathModule.toNamespacedPath(newPath),
-                        kUsePromises)
-                .catch(handleErrorFromBinding);
+  return await binding.rename(pathModule.toNamespacedPath(oldPath),
+                              pathModule.toNamespacedPath(newPath),
+                              kUsePromises)
+                      .catch(handleErrorFromBinding);
 }
 
 async function truncate(path, len = 0) {
@@ -758,7 +758,7 @@ async function truncate(path, len = 0) {
 async function ftruncate(handle, len = 0) {
   validateInteger(len, 'len');
   len = MathMax(0, len);
-  return binding.ftruncate(handle.fd, len, kUsePromises).catch(handleErrorFromBinding);
+  return await binding.ftruncate(handle.fd, len, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function rm(path, options) {
@@ -779,15 +779,15 @@ async function rmdir(path, options) {
     }
   }
 
-  return binding.rmdir(path, kUsePromises).catch(handleErrorFromBinding);
+  return await binding.rmdir(path, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function fdatasync(handle) {
-  return binding.fdatasync(handle.fd, kUsePromises).catch(handleErrorFromBinding);
+  return await binding.fdatasync(handle.fd, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function fsync(handle) {
-  return binding.fsync(handle.fd, kUsePromises).catch(handleErrorFromBinding);
+  return await binding.fsync(handle.fd, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function mkdir(path, options) {
@@ -801,10 +801,10 @@ async function mkdir(path, options) {
   path = getValidatedPath(path);
   validateBoolean(recursive, 'options.recursive');
 
-  return binding.mkdir(pathModule.toNamespacedPath(path),
-                       parseFileMode(mode, 'mode', 0o777), recursive,
-                       kUsePromises)
-                .catch(handleErrorFromBinding);
+  return await binding.mkdir(pathModule.toNamespacedPath(path),
+                             parseFileMode(mode, 'mode', 0o777), recursive,
+                             kUsePromises)
+                      .catch(handleErrorFromBinding);
 }
 
 async function readdirRecursive(originalPath, options) {
@@ -890,9 +890,9 @@ async function readdir(path, options) {
 async function readlink(path, options) {
   options = getOptions(options);
   path = getValidatedPath(path, 'oldPath');
-  return binding.readlink(pathModule.toNamespacedPath(path),
-                          options.encoding, kUsePromises)
-                .catch(handleErrorFromBinding);
+  return await binding.readlink(pathModule.toNamespacedPath(path),
+                                options.encoding, kUsePromises)
+                      .catch(handleErrorFromBinding);
 }
 
 async function symlink(target, path, type_) {
@@ -908,11 +908,11 @@ async function symlink(target, path, type_) {
   }
   target = getValidatedPath(target, 'target');
   path = getValidatedPath(path);
-  return binding.symlink(preprocessSymlinkDestination(target, type, path),
-                         pathModule.toNamespacedPath(path),
-                         stringToSymlinkType(type),
-                         kUsePromises)
-                .catch(handleErrorFromBinding);
+  return await binding.symlink(preprocessSymlinkDestination(target, type, path),
+                               pathModule.toNamespacedPath(path),
+                               stringToSymlinkType(type),
+                               kUsePromises)
+                      .catch(handleErrorFromBinding);
 }
 
 async function fstat(handle, options = { bigint: false }) {
@@ -947,26 +947,26 @@ async function statfs(path, options = { bigint: false }) {
 async function link(existingPath, newPath) {
   existingPath = getValidatedPath(existingPath, 'existingPath');
   newPath = getValidatedPath(newPath, 'newPath');
-  return binding.link(pathModule.toNamespacedPath(existingPath),
-                      pathModule.toNamespacedPath(newPath),
-                      kUsePromises)
-                .catch(handleErrorFromBinding);
+  return await binding.link(pathModule.toNamespacedPath(existingPath),
+                            pathModule.toNamespacedPath(newPath),
+                            kUsePromises)
+                      .catch(handleErrorFromBinding);
 }
 
 async function unlink(path) {
   path = getValidatedPath(path);
-  return binding.unlink(pathModule.toNamespacedPath(path), kUsePromises).catch(handleErrorFromBinding);
+  return await binding.unlink(pathModule.toNamespacedPath(path), kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function fchmod(handle, mode) {
   mode = parseFileMode(mode, 'mode');
-  return binding.fchmod(handle.fd, mode, kUsePromises).catch(handleErrorFromBinding);
+  return await binding.fchmod(handle.fd, mode, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function chmod(path, mode) {
   path = getValidatedPath(path);
   mode = parseFileMode(mode, 'mode');
-  return binding.chmod(pathModule.toNamespacedPath(path), mode, kUsePromises).catch(handleErrorFromBinding);
+  return await binding.chmod(pathModule.toNamespacedPath(path), mode, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function lchmod(path, mode) {
@@ -981,54 +981,54 @@ async function lchown(path, uid, gid) {
   path = getValidatedPath(path);
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  return binding.lchown(pathModule.toNamespacedPath(path),
-                        uid, gid, kUsePromises)
-                .catch(handleErrorFromBinding);
+  return await binding.lchown(pathModule.toNamespacedPath(path),
+                              uid, gid, kUsePromises)
+                      .catch(handleErrorFromBinding);
 }
 
 async function fchown(handle, uid, gid) {
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  return binding.fchown(handle.fd, uid, gid, kUsePromises).catch(handleErrorFromBinding);
+  return await binding.fchown(handle.fd, uid, gid, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function chown(path, uid, gid) {
   path = getValidatedPath(path);
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  return binding.chown(pathModule.toNamespacedPath(path),
-                       uid, gid, kUsePromises)
-                .catch(handleErrorFromBinding);
+  return await binding.chown(pathModule.toNamespacedPath(path),
+                             uid, gid, kUsePromises)
+                       .catch(handleErrorFromBinding);
 }
 
 async function utimes(path, atime, mtime) {
   path = getValidatedPath(path);
-  return binding.utimes(pathModule.toNamespacedPath(path),
-                        toUnixTimestamp(atime),
-                        toUnixTimestamp(mtime),
-                        kUsePromises)
-                .catch(handleErrorFromBinding);
+  return await binding.utimes(pathModule.toNamespacedPath(path),
+                              toUnixTimestamp(atime),
+                              toUnixTimestamp(mtime),
+                              kUsePromises)
+                      .catch(handleErrorFromBinding);
 }
 
 async function futimes(handle, atime, mtime) {
   atime = toUnixTimestamp(atime, 'atime');
   mtime = toUnixTimestamp(mtime, 'mtime');
-  return binding.futimes(handle.fd, atime, mtime, kUsePromises).catch(handleErrorFromBinding);
+  return await binding.futimes(handle.fd, atime, mtime, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function lutimes(path, atime, mtime) {
   path = getValidatedPath(path);
-  return binding.lutimes(pathModule.toNamespacedPath(path),
-                         toUnixTimestamp(atime),
-                         toUnixTimestamp(mtime),
-                         kUsePromises)
-                .catch(handleErrorFromBinding);
+  return await binding.lutimes(pathModule.toNamespacedPath(path),
+                               toUnixTimestamp(atime),
+                               toUnixTimestamp(mtime),
+                               kUsePromises)
+                       .catch(handleErrorFromBinding);
 }
 
 async function realpath(path, options) {
   options = getOptions(options);
   path = getValidatedPath(path);
-  return binding.realpath(path, options.encoding, kUsePromises).catch(handleErrorFromBinding);
+  return await binding.realpath(path, options.encoding, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function mkdtemp(prefix, options) {
@@ -1044,7 +1044,7 @@ async function mkdtemp(prefix, options) {
     path = Buffer.concat([prefix, Buffer.from('XXXXXX')]);
   }
 
-  return binding.mkdtemp(path, options.encoding, kUsePromises).catch(handleErrorFromBinding);
+  return await binding.mkdtemp(path, options.encoding, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function writeFile(path, data, options) {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -4,6 +4,7 @@ const {
   ArrayPrototypePush,
   ArrayPrototypePop,
   Error,
+  ErrorCaptureStackTrace,
   MathMax,
   MathMin,
   Promise,
@@ -128,6 +129,11 @@ function lazyLoadCpPromises() {
 let fsStreams;
 function lazyFsStreams() {
   return fsStreams ??= require('internal/fs/streams');
+}
+
+function handleErrorFromBinding(error) {
+  ErrorCaptureStackTrace(error, handleErrorFromBinding);
+  return PromiseReject(error);
 }
 
 class FileHandle extends EventEmitter {
@@ -494,7 +500,8 @@ async function readFileHandle(filehandle, options) {
 
   checkAborted(signal);
 
-  const statFields = await binding.fstat(filehandle.fd, false, kUsePromises);
+  const statFields = await binding.fstat(filehandle.fd, false, kUsePromises)
+                                  .catch(handleErrorFromBinding);
 
   checkAborted(signal);
 
@@ -526,7 +533,8 @@ async function readFileHandle(filehandle, options) {
     }
 
     const bytesRead = (await binding.read(filehandle.fd, buffer, offset,
-                                          length, -1, kUsePromises)) ?? 0;
+                                          length, -1, kUsePromises)
+                                    .catch(handleErrorFromBinding)) ?? 0;
     totalRead += bytesRead;
 
     if (bytesRead === 0 ||
@@ -575,7 +583,8 @@ async function access(path, mode = F_OK) {
 
   mode = getValidMode(mode, 'access');
   return binding.access(pathModule.toNamespacedPath(path), mode,
-                        kUsePromises);
+                        kUsePromises)
+                .catch(handleErrorFromBinding);
 }
 
 async function cp(src, dest, options) {
@@ -592,7 +601,8 @@ async function copyFile(src, dest, mode) {
   return binding.copyFile(pathModule.toNamespacedPath(src),
                           pathModule.toNamespacedPath(dest),
                           mode,
-                          kUsePromises);
+                          kUsePromises)
+                .catch(handleErrorFromBinding);
 }
 
 // Note that unlike fs.open() which uses numeric file descriptors,
@@ -603,7 +613,8 @@ async function open(path, flags, mode) {
   mode = parseFileMode(mode, 'mode', 0o666);
   return new FileHandle(
     await binding.openFileHandle(pathModule.toNamespacedPath(path),
-                                 flagsNumber, mode, kUsePromises));
+                                 flagsNumber, mode, kUsePromises)
+                 .catch(handleErrorFromBinding));
 }
 
 async function read(handle, bufferOrParams, offset, length, position) {
@@ -657,7 +668,8 @@ async function read(handle, bufferOrParams, offset, length, position) {
   }
 
   const bytesRead = (await binding.read(handle.fd, buffer, offset, length,
-                                        position, kUsePromises)) || 0;
+                                        position, kUsePromises)
+                                  .catch(handleErrorFromBinding)) || 0;
 
   return { __proto__: null, bytesRead, buffer };
 }
@@ -669,7 +681,8 @@ async function readv(handle, buffers, position) {
     position = null;
 
   const bytesRead = (await binding.readBuffers(handle.fd, buffers, position,
-                                               kUsePromises)) || 0;
+                                               kUsePromises)
+                                  .catch(handleErrorFromBinding)) || 0;
   return { __proto__: null, bytesRead, buffers };
 }
 
@@ -699,14 +712,16 @@ async function write(handle, buffer, offsetOrOptions, length, position) {
     validateOffsetLengthWrite(offset, length, buffer.byteLength);
     const bytesWritten =
       (await binding.writeBuffer(handle.fd, buffer, offset,
-                                 length, position, kUsePromises)) || 0;
+                                 length, position, kUsePromises)
+                    .catch(handleErrorFromBinding)) || 0;
     return { __proto__: null, bytesWritten, buffer };
   }
 
   validateStringAfterArrayBufferView(buffer, 'buffer');
   validateEncoding(buffer, length);
   const bytesWritten = (await binding.writeString(handle.fd, buffer, offset,
-                                                  length, kUsePromises)) || 0;
+                                                  length, kUsePromises)
+                                     .catch(handleErrorFromBinding)) || 0;
   return { __proto__: null, bytesWritten, buffer };
 }
 
@@ -721,7 +736,8 @@ async function writev(handle, buffers, position) {
   }
 
   const bytesWritten = (await binding.writeBuffers(handle.fd, buffers, position,
-                                                   kUsePromises)) || 0;
+                                                   kUsePromises)
+                                     .catch(handleErrorFromBinding)) || 0;
   return { __proto__: null, bytesWritten, buffers };
 }
 
@@ -730,7 +746,8 @@ async function rename(oldPath, newPath) {
   newPath = getValidatedPath(newPath, 'newPath');
   return binding.rename(pathModule.toNamespacedPath(oldPath),
                         pathModule.toNamespacedPath(newPath),
-                        kUsePromises);
+                        kUsePromises)
+                .catch(handleErrorFromBinding);
 }
 
 async function truncate(path, len = 0) {
@@ -741,7 +758,7 @@ async function truncate(path, len = 0) {
 async function ftruncate(handle, len = 0) {
   validateInteger(len, 'len');
   len = MathMax(0, len);
-  return binding.ftruncate(handle.fd, len, kUsePromises);
+  return binding.ftruncate(handle.fd, len, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function rm(path, options) {
@@ -762,15 +779,15 @@ async function rmdir(path, options) {
     }
   }
 
-  return binding.rmdir(path, kUsePromises);
+  return binding.rmdir(path, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function fdatasync(handle) {
-  return binding.fdatasync(handle.fd, kUsePromises);
+  return binding.fdatasync(handle.fd, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function fsync(handle) {
-  return binding.fsync(handle.fd, kUsePromises);
+  return binding.fsync(handle.fd, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function mkdir(path, options) {
@@ -786,7 +803,8 @@ async function mkdir(path, options) {
 
   return binding.mkdir(pathModule.toNamespacedPath(path),
                        parseFileMode(mode, 'mode', 0o777), recursive,
-                       kUsePromises);
+                       kUsePromises)
+                .catch(handleErrorFromBinding);
 }
 
 async function readdirRecursive(originalPath, options) {
@@ -799,7 +817,7 @@ async function readdirRecursive(originalPath, options) {
         options.encoding,
         !!options.withFileTypes,
         kUsePromises,
-      ),
+      ).catch(handleErrorFromBinding),
     ],
   ];
 
@@ -819,7 +837,7 @@ async function readdirRecursive(originalPath, options) {
               options.encoding,
               true,
               kUsePromises,
-            ),
+            ).catch(handleErrorFromBinding),
           ]);
         }
       }
@@ -842,7 +860,7 @@ async function readdirRecursive(originalPath, options) {
               options.encoding,
               false,
               kUsePromises,
-            ),
+            ).catch(handleErrorFromBinding),
           ]);
         }
       }
@@ -863,7 +881,7 @@ async function readdir(path, options) {
     options.encoding,
     !!options.withFileTypes,
     kUsePromises,
-  );
+  ).catch(handleErrorFromBinding);
   return options.withFileTypes ?
     getDirectoryEntriesPromise(path, result) :
     result;
@@ -873,7 +891,8 @@ async function readlink(path, options) {
   options = getOptions(options);
   path = getValidatedPath(path, 'oldPath');
   return binding.readlink(pathModule.toNamespacedPath(path),
-                          options.encoding, kUsePromises);
+                          options.encoding, kUsePromises)
+                .catch(handleErrorFromBinding);
 }
 
 async function symlink(target, path, type_) {
@@ -892,32 +911,36 @@ async function symlink(target, path, type_) {
   return binding.symlink(preprocessSymlinkDestination(target, type, path),
                          pathModule.toNamespacedPath(path),
                          stringToSymlinkType(type),
-                         kUsePromises);
+                         kUsePromises)
+                .catch(handleErrorFromBinding);
 }
 
 async function fstat(handle, options = { bigint: false }) {
-  const result = await binding.fstat(handle.fd, options.bigint, kUsePromises);
+  const result = await binding.fstat(handle.fd, options.bigint, kUsePromises).catch(handleErrorFromBinding);
   return getStatsFromBinding(result);
 }
 
 async function lstat(path, options = { bigint: false }) {
   path = getValidatedPath(path);
   const result = await binding.lstat(pathModule.toNamespacedPath(path),
-                                     options.bigint, kUsePromises);
+                                     options.bigint, kUsePromises)
+                              .catch(handleErrorFromBinding);
   return getStatsFromBinding(result);
 }
 
 async function stat(path, options = { bigint: false }) {
   path = getValidatedPath(path);
   const result = await binding.stat(pathModule.toNamespacedPath(path),
-                                    options.bigint, kUsePromises);
+                                    options.bigint, kUsePromises)
+                              .catch(handleErrorFromBinding);
   return getStatsFromBinding(result);
 }
 
 async function statfs(path, options = { bigint: false }) {
   path = getValidatedPath(path);
   const result = await binding.statfs(pathModule.toNamespacedPath(path),
-                                      options.bigint, kUsePromises);
+                                      options.bigint, kUsePromises)
+                              .catch(handleErrorFromBinding);
   return getStatFsFromBinding(result);
 }
 
@@ -926,23 +949,24 @@ async function link(existingPath, newPath) {
   newPath = getValidatedPath(newPath, 'newPath');
   return binding.link(pathModule.toNamespacedPath(existingPath),
                       pathModule.toNamespacedPath(newPath),
-                      kUsePromises);
+                      kUsePromises)
+                .catch(handleErrorFromBinding);
 }
 
 async function unlink(path) {
   path = getValidatedPath(path);
-  return binding.unlink(pathModule.toNamespacedPath(path), kUsePromises);
+  return binding.unlink(pathModule.toNamespacedPath(path), kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function fchmod(handle, mode) {
   mode = parseFileMode(mode, 'mode');
-  return binding.fchmod(handle.fd, mode, kUsePromises);
+  return binding.fchmod(handle.fd, mode, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function chmod(path, mode) {
   path = getValidatedPath(path);
   mode = parseFileMode(mode, 'mode');
-  return binding.chmod(pathModule.toNamespacedPath(path), mode, kUsePromises);
+  return binding.chmod(pathModule.toNamespacedPath(path), mode, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function lchmod(path, mode) {
@@ -958,13 +982,14 @@ async function lchown(path, uid, gid) {
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
   return binding.lchown(pathModule.toNamespacedPath(path),
-                        uid, gid, kUsePromises);
+                        uid, gid, kUsePromises)
+                .catch(handleErrorFromBinding);
 }
 
 async function fchown(handle, uid, gid) {
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  return binding.fchown(handle.fd, uid, gid, kUsePromises);
+  return binding.fchown(handle.fd, uid, gid, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function chown(path, uid, gid) {
@@ -972,7 +997,8 @@ async function chown(path, uid, gid) {
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
   return binding.chown(pathModule.toNamespacedPath(path),
-                       uid, gid, kUsePromises);
+                       uid, gid, kUsePromises)
+                .catch(handleErrorFromBinding);
 }
 
 async function utimes(path, atime, mtime) {
@@ -980,13 +1006,14 @@ async function utimes(path, atime, mtime) {
   return binding.utimes(pathModule.toNamespacedPath(path),
                         toUnixTimestamp(atime),
                         toUnixTimestamp(mtime),
-                        kUsePromises);
+                        kUsePromises)
+                .catch(handleErrorFromBinding);
 }
 
 async function futimes(handle, atime, mtime) {
   atime = toUnixTimestamp(atime, 'atime');
   mtime = toUnixTimestamp(mtime, 'mtime');
-  return binding.futimes(handle.fd, atime, mtime, kUsePromises);
+  return binding.futimes(handle.fd, atime, mtime, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function lutimes(path, atime, mtime) {
@@ -994,13 +1021,14 @@ async function lutimes(path, atime, mtime) {
   return binding.lutimes(pathModule.toNamespacedPath(path),
                          toUnixTimestamp(atime),
                          toUnixTimestamp(mtime),
-                         kUsePromises);
+                         kUsePromises)
+                .catch(handleErrorFromBinding);
 }
 
 async function realpath(path, options) {
   options = getOptions(options);
   path = getValidatedPath(path);
-  return binding.realpath(path, options.encoding, kUsePromises);
+  return binding.realpath(path, options.encoding, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function mkdtemp(prefix, options) {
@@ -1016,7 +1044,7 @@ async function mkdtemp(prefix, options) {
     path = Buffer.concat([prefix, Buffer.from('XXXXXX')]);
   }
 
-  return binding.mkdtemp(path, options.encoding, kUsePromises);
+  return binding.mkdtemp(path, options.encoding, kUsePromises).catch(handleErrorFromBinding);
 }
 
 async function writeFile(path, data, options) {

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -95,9 +95,13 @@ fs.promises.access(readOnlyFile, fs.constants.R_OK)
     assert.strictEqual(err.code, 'ENOENT');
     assert.strictEqual(err.path, doesNotExist);
   };
+  const expectedErrorPromise = (err) => {
+    expectedError(err);
+    assert.match(err.stack, /at async Object\.access/);
+  };
   fs.access(doesNotExist, common.mustCall(expectedError));
   fs.promises.access(doesNotExist)
-    .then(common.mustNotCall(), common.mustCall(expectedError))
+    .then(common.mustNotCall(), common.mustCall(expectedErrorPromise))
     .catch(throwNextTick);
 }
 

--- a/test/parallel/test-fs-promises-readfile.js
+++ b/test/parallel/test-fs-promises-readfile.js
@@ -72,7 +72,7 @@ async function validateWrongSignalParam() {
 async function validateZeroByteLiar() {
   const originalFStat = fsBinding.fstat;
   fsBinding.fstat = common.mustCall(
-    () => (/* stat fields */ [0, 1, 2, 3, 4, 5, 6, 7, 0 /* size */])
+    async () => (/* stat fields */ [0, 1, 2, 3, 4, 5, 6, 7, 0 /* size */])
   );
   const readBuffer = await readFile(fn);
   assert.strictEqual(readBuffer.toString(), largeBuffer.toString());

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -57,7 +57,8 @@ assert.strictEqual(
     {
       code: 'ENOENT',
       name: 'Error',
-      message: /^ENOENT: no such file or directory, access/
+      message: /^ENOENT: no such file or directory, access/,
+      stack: /at async Function\.rejects/
     }
   );
 


### PR DESCRIPTION
Sync functions in fs throwed an error with a stacktrace which is helpful for debugging. But functions in fs/promises throwed an error without a stacktrace. This commit adds stacktraces by calling Error.captureStacktrace and re-throwing the error.

Refs: https://github.com/nodejs/node/issues/34817
Fixes: https://github.com/nodejs/node/issues/50160

```js
import fsS from 'node:fs'
fsS.readdirSync('./foo')
/*
node:fs:1515
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, scandir './foo'
    at Object.readdirSync (node:fs:1515:3)
    at file:///mnt/c/users/green/Downloads/foo/index.mjs:6:5
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:328:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:79:12) {
  errno: -2,
  syscall: 'scandir',
  code: 'ENOENT',
  path: './foo'
}

Node.js v21.0.0-pre
*/

import fs from 'node:fs/promises'
await fs.readdir('./foo')
/*
---------- Before ----------

node:internal/process/esm_loader:40
      internalBinding('errors').triggerUncaughtException(
                                ^

[Error: ENOENT: no such file or directory, scandir './foo'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'scandir',
  path: './foo'
}

Node.js v21.0.0-pre

---------- After ----------

node:internal/fs/promises:862
  const result = await binding.readdir(
                 ^

Error: ENOENT: no such file or directory, scandir './foo'
    at async Object.readdir (node:internal/fs/promises:862:18)
    at async file:///mnt/c/users/green/Downloads/foo/index.mjs:5:1 {
  errno: -2,
  code: 'ENOENT',
  syscall: 'scandir',
  path: './foo'
}

Node.js v21.0.0-pre
*/
```

I have some questions.

- Was the stacktrace generation skipped on purpose? For example, in terms of performance. I remember capturing the stacktrace is slow.
- Is there a better way? I guess I can call `Error.captureStackTrace` on C++ land but didn't find the way.
