### PR TITLE
fs: improve error perf of sync `chmod`+`fchmod`

### DIFF
--- a/benchmark/fs/bench-chmodSync.js
+++ b/benchmark/fs/bench-chmodSync.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const bench = common.createBenchmark(main, {
+  type: ['existing', 'non-existing'],
+  n: [1e3],
+});
+
+function main({ n, type }) {
+  switch (type) {
+    case 'existing': {
+      for (let i = 0; i < n; i++) {
+        fs.writeFileSync(tmpdir.resolve(`chmodsync-bench-file-${i}`), 'bench');
+      }
+
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        fs.chmodSync(tmpdir.resolve(`chmodsync-bench-file-${i}`), 0o666);
+      }
+      bench.end(n);
+      break;
+    }
+    case 'non-existing':
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.chmodSync(tmpdir.resolve(`chmod-non-existing-file-${i}`), 0o666);
+        } catch {
+          // do nothing
+        }
+      }
+      bench.end(n);
+      break;
+    default:
+      new Error('Invalid type');
+  }
+}

--- a/benchmark/fs/bench-fchmodSync.js
+++ b/benchmark/fs/bench-fchmodSync.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const bench = common.createBenchmark(main, {
+  type: ['existing', 'non-existing'],
+  n: [1e3],
+});
+
+function main({ n, type }) {
+  let files;
+
+  switch (type) {
+    case 'existing':
+      files = [];
+
+      // Populate tmpdir with mock files
+      for (let i = 0; i < n; i++) {
+        const path = tmpdir.resolve(`fchmodsync-bench-file-${i}`);
+        fs.writeFileSync(path, 'bench');
+        files.push(path);
+      }
+      break;
+    case 'non-existing':
+      files = new Array(n).fill(tmpdir.resolve(`.non-existing-file-${Date.now()}`));
+      break;
+    default:
+      new Error('Invalid type');
+  }
+
+  const fds = files.map((x) => {
+    // Try to open, if not return likely invalid fd (1 << 30)
+    try {
+      return fs.openSync(x, 'r');
+    } catch {
+      return 1 << 30;
+    }
+  });
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    try {
+      fs.fchmodSync(fds[i], 0o666);
+    } catch {
+      // do nothing
+    }
+  }
+  bench.end(n);
+
+  for (const x of fds) {
+    try {
+      fs.closeSync(x);
+    } catch {
+      // do nothing
+    }
+  }
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1908,11 +1908,10 @@ function fchmod(fd, mode, callback) {
  * @returns {void}
  */
 function fchmodSync(fd, mode) {
-  fd = getValidatedFd(fd);
-  mode = parseFileMode(mode, 'mode');
-  const ctx = {};
-  binding.fchmod(fd, mode, undefined, ctx);
-  handleErrorFromBinding(ctx);
+  binding.fchmod(
+    getValidatedFd(fd),
+    parseFileMode(mode, 'mode'),
+  );
 }
 
 /**
@@ -1987,9 +1986,10 @@ function chmodSync(path, mode) {
   path = getValidatedPath(path);
   mode = parseFileMode(mode, 'mode');
 
-  const ctx = { path };
-  binding.chmod(pathModule.toNamespacedPath(path), mode, undefined, ctx);
-  handleErrorFromBinding(ctx);
+  binding.chmod(
+    pathModule.toNamespacedPath(path),
+    mode,
+  );
 }
 
 /**

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2506,18 +2506,16 @@ static void Chmod(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsInt32());
   int mode = args[1].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
-  if (req_wrap_async != nullptr) {  // chmod(path, mode, req)
+  if (argc > 2) {  // chmod(path, mode, req)
+    FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_CHMOD, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "chmod", UTF8, AfterNoArgs,
               uv_fs_chmod, *path, mode);
-  } else {  // chmod(path, mode, undefined, ctx)
-    CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap_sync;
+  } else {  // chmod(path, mode)
+    FSReqWrapSync req_wrap_sync("chmod", *path);
     FS_SYNC_TRACE_BEGIN(chmod);
-    SyncCall(env, args[3], &req_wrap_sync, "chmod",
-             uv_fs_chmod, *path, mode);
+    SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_chmod, *path, mode);
     FS_SYNC_TRACE_END(chmod);
   }
 }
@@ -2538,17 +2536,15 @@ static void FChmod(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsInt32());
   const int mode = args[1].As<Int32>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
-  if (req_wrap_async != nullptr) {  // fchmod(fd, mode, req)
+  if (argc > 2) {  // fchmod(fd, mode, req)
+    FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_FCHMOD, req_wrap_async)
     AsyncCall(env, req_wrap_async, args, "fchmod", UTF8, AfterNoArgs,
               uv_fs_fchmod, fd, mode);
-  } else {  // fchmod(fd, mode, undefined, ctx)
-    CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap_sync;
+  } else {  // fchmod(fd, mode)
+    FSReqWrapSync req_wrap_sync("fchmod");
     FS_SYNC_TRACE_BEGIN(fchmod);
-    SyncCall(env, args[3], &req_wrap_sync, "fchmod",
-             uv_fs_fchmod, fd, mode);
+    SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_fchmod, fd, mode);
     FS_SYNC_TRACE_END(fchmod);
   }
 }

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -203,7 +203,7 @@ declare namespace InternalFSBinding {
   function symlink(target: StringOrBuffer, path: StringOrBuffer, type: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function unlink(path: string, req: FSReqCallback): void;
-  function unlink(path: string, req: undefined, ctx: FSSyncContext): void;
+  function unlink(path: string): void;
   function unlink(path: string, usePromises: typeof kUsePromises): Promise<void>;
 
   function utimes(path: string, atime: number, mtime: number, req: FSReqCallback): void;

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -61,7 +61,7 @@ declare namespace InternalFSBinding {
   function access(path: StringOrBuffer, mode: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function chmod(path: string, mode: number, req: FSReqCallback): void;
-  function chmod(path: string, mode: number, req: undefined, ctx: FSSyncContext): void;
+  function chmod(path: string, mode: number): void;
   function chmod(path: string, mode: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function chown(path: string, uid: number, gid: number, req: FSReqCallback): void;
@@ -76,7 +76,7 @@ declare namespace InternalFSBinding {
   function copyFile(src: StringOrBuffer, dest: StringOrBuffer, mode: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function fchmod(fd: number, mode: number, req: FSReqCallback): void;
-  function fchmod(fd: number, mode: number, req: undefined, ctx: FSSyncContext): void;
+  function fchmod(fd: number, mode: number): void;
   function fchmod(fd: number, mode: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function fchown(fd: number, uid: number, gid: number, req: FSReqCallback): void;


### PR DESCRIPTION
Results from i7 Windows laptop:
```
                                                  confidence improvement accuracy (*)    (**)   (***)
fs\bench-chmodSync.js n=1000 type='existing'                      2.46 %       ±9.77% ±13.01% ±16.95%
fs\bench-chmodSync.js n=1000 type='non-existing'         ***     74.14 %      ±14.58% ±19.42% ±25.32%
fs\bench-fchmodSync.js n=1000 type='existing'                     0.14 %       ±5.61%  ±7.48%  ±9.76%
fs\bench-fchmodSync.js n=1000 type='non-existing'        ***    118.16 %      ±21.27% ±28.52% ±37.58%
```

Ref: https://github.com/nodejs/performance/issues/106