### PR TITLE
deps: V8: cherry-pick 8ec2651fbdd8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.18',
+    'v8_embedder_string': '-node.19',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-base.cc
+++ b/deps/v8/src/snapshot/embedded/platform-embedded-file-writer-base.cc
@@ -130,7 +130,8 @@ EmbeddedTargetOs ToEmbeddedTargetOs(const char* s) {
   }
 
   std::string string(s);
-  if (string == "aix") {
+  // Python 3.9+ on IBM i returns os400 as sys.platform instead of aix
+  if (string == "aix" || string == "os400") {
     return EmbeddedTargetOs::kAIX;
   } else if (string == "chromeos") {
     return EmbeddedTargetOs::kChromeOS;


### PR DESCRIPTION
Original commit message:

    fix: EmbeddedTargetOs on IBM i with Python 3.9

    For some context, Python 3.9 on IBM i returns "os400" for sys.platform
    instead of "aix". We used to build with Python 3.6 which returned "aix"
    as the platform

    When attempting to build Node.js with python 3.9 on IBM i we run into a
    build error.

    Ref: https://github.com/nodejs/node/pull/48056
    Ref: https://github.com/nodejs/node/pull/48056#issuecomment-1553719508

    I'm not quite sure where target_os is being passed down to the function ToEmbeddedTargetOs.
    It seems as though target_os is being generated from sys.platform or
    similar call from python as we started running into this issue after
    building with Python 3.9.

    This PR supersedes initial changes proposed in:
    https://chromium-review.googlesource.com/c/v8/v8/+/4259330

    This PR contains the minimal changes to successfully build Node.js (builds v8 as an internal dep)
    on IBM i with Python 3.9.

    Change-Id: I32d43197bce994a72a0d85091e91f80eeea4482d
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4846413
    Commit-Queue: Jakob Linke <jgruber@chromium.org>
    Reviewed-by: Michael Achenbach <machenbach@chromium.org>
    Reviewed-by: Jakob Linke <jgruber@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#89981}

Refs: https://github.com/v8/v8/commit/8ec2651fbdd8adf054397ee832031c9ff7aa16ac

CC @nodejs/platform-ibmi 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
