### PR TITLE
fs: improve error performance for `fs.renameSync`

### DIFF
--- a/benchmark/fs/bench-renameSync.js
+++ b/benchmark/fs/bench-renameSync.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const bench = common.createBenchmark(main, {
+  type: ['invalid', 'valid'],
+  n: [1e3],
+});
+
+function main({ n, type }) {
+  tmpdir.refresh();
+
+  switch (type) {
+    case 'invalid': {
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.renameSync(tmpdir.resolve(`.non-existing-file-${i}`), tmpdir.resolve(`.new-file-${i}`));
+        } catch {
+          // do nothing
+        }
+      }
+      bench.end(n);
+
+      break;
+    }
+    case 'valid': {
+      for (let i = 0; i < n; i++) {
+        fs.writeFileSync(tmpdir.resolve(`.existing-file-${i}`), 'bench', 'utf8');
+      }
+
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.renameSync(
+            tmpdir.resolve(`.existing-file-${i}`),
+            tmpdir.resolve(`.new-existing-file-${i}`),
+          );
+        } catch {
+          // do nothing
+        }
+      }
+
+      bench.end(n);
+      break;
+    }
+    default:
+      throw new Error('Invalid type');
+  }
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1015,12 +1015,7 @@ function rename(oldPath, newPath, callback) {
  * @returns {void}
  */
 function renameSync(oldPath, newPath) {
-  oldPath = getValidatedPath(oldPath, 'oldPath');
-  newPath = getValidatedPath(newPath, 'newPath');
-  const ctx = { path: oldPath, dest: newPath };
-  binding.rename(pathModule.toNamespacedPath(oldPath),
-                 pathModule.toNamespacedPath(newPath), undefined, ctx);
-  handleErrorFromBinding(ctx);
+  return syncFs.rename(oldPath, newPath);
 }
 
 /**

--- a/lib/internal/fs/sync.js
+++ b/lib/internal/fs/sync.js
@@ -93,6 +93,15 @@ function unlink(path) {
   return binding.unlinkSync(path);
 }
 
+function rename(oldPath, newPath) {
+  oldPath = getValidatedPath(oldPath, 'oldPath');
+  newPath = getValidatedPath(newPath, 'newPath');
+  return binding.renameSync(
+    pathModule.toNamespacedPath(oldPath),
+    pathModule.toNamespacedPath(newPath),
+  );
+}
+
 module.exports = {
   readFileUtf8,
   exists,
@@ -103,4 +112,5 @@ module.exports = {
   open,
   close,
   unlink,
+  rename,
 };

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -180,6 +180,7 @@ declare namespace InternalFSBinding {
   function rename(oldPath: string, newPath: string, req: FSReqCallback): void;
   function rename(oldPath: string, newPath: string, req: undefined, ctx: FSSyncContext): void;
   function rename(oldPath: string, newPath: string, usePromises: typeof kUsePromises): Promise<void>;
+  function renameSync(oldPath: string, newPath: string): void;
 
   function rmdir(path: string, req: FSReqCallback): void;
   function rmdir(path: string, req: undefined, ctx: FSSyncContext): void;
@@ -261,6 +262,7 @@ export interface FsBinding {
   readlink: typeof InternalFSBinding.readlink;
   realpath: typeof InternalFSBinding.realpath;
   rename: typeof InternalFSBinding.rename;
+  renameSync: typeof InternalFSBinding.renameSync;
   rmdir: typeof InternalFSBinding.rmdir;
   stat: typeof InternalFSBinding.stat;
   symlink: typeof InternalFSBinding.symlink;


### PR DESCRIPTION
```
                                              confidence improvement accuracy (*)    (**)   (***)
fs/bench-renameSync.js n=1000 type='invalid'        ***     50.69 %      ±16.74% ±22.31% ±29.10%
fs/bench-renameSync.js n=1000 type='valid'                   1.87 %      ±12.40% ±16.50% ±21.48%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 2 comparisons, you can thus expect the following amount of false-positive results:
  0.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.02 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

Ref: https://github.com/nodejs/performance/issues/106