### PR TITLE
fs: improve error perf of sync `*times`

### DIFF
--- a/benchmark/fs/bench-timesSync.js
+++ b/benchmark/fs/bench-timesSync.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const bench = common.createBenchmark(main, {
+  type: ['existing', 'non-existing'],
+  func: [ 'utimes', 'futimes', 'lutimes' ],
+  n: [1e3],
+});
+
+function main({ n, type, func }) {
+  const useFds = func === 'futimes';
+  const fsFunc = fs[func + 'Sync'];
+
+  switch (type) {
+    case 'existing': {
+      const files = [];
+
+      // Populate tmpdir with mock files
+      for (let i = 0; i < n; i++) {
+        const path = tmpdir.resolve(`timessync-bench-file-${i}`);
+        fs.writeFileSync(path, 'bench');
+        files.push(useFds ? fs.openSync(path, 'r+') : path);
+      }
+
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        fsFunc(files[i], i, i);
+      }
+      bench.end(n);
+
+      if (useFds) files.forEach((x) => {
+        try {
+          fs.closeSync(x);
+        } catch {
+          // do nothing
+        }
+      });
+
+      break;
+    }
+    case 'non-existing': {
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fsFunc(useFds ? (1 << 30) : tmpdir.resolve(`.non-existing-file-${Date.now()}`), i, i);
+        } catch {
+          // do nothing
+        }
+      }
+      bench.end(n);
+
+      break;
+    }
+    default:
+      new Error('Invalid type');
+  }
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2130,11 +2130,11 @@ function utimes(path, atime, mtime, callback) {
  */
 function utimesSync(path, atime, mtime) {
   path = getValidatedPath(path);
-  const ctx = { path };
-  binding.utimes(pathModule.toNamespacedPath(path),
-                 toUnixTimestamp(atime), toUnixTimestamp(mtime),
-                 undefined, ctx);
-  handleErrorFromBinding(ctx);
+  binding.utimes(
+    pathModule.toNamespacedPath(path),
+    toUnixTimestamp(atime),
+    toUnixTimestamp(mtime),
+  );
 }
 
 /**
@@ -2167,12 +2167,11 @@ function futimes(fd, atime, mtime, callback) {
  * @returns {void}
  */
 function futimesSync(fd, atime, mtime) {
-  fd = getValidatedFd(fd);
-  atime = toUnixTimestamp(atime, 'atime');
-  mtime = toUnixTimestamp(mtime, 'mtime');
-  const ctx = {};
-  binding.futimes(fd, atime, mtime, undefined, ctx);
-  handleErrorFromBinding(ctx);
+  binding.futimes(
+    getValidatedFd(fd),
+    toUnixTimestamp(atime, 'atime'),
+    toUnixTimestamp(mtime, 'mtime'),
+  );
 }
 
 /**
@@ -2206,12 +2205,11 @@ function lutimes(path, atime, mtime, callback) {
  */
 function lutimesSync(path, atime, mtime) {
   path = getValidatedPath(path);
-  const ctx = { path };
-  binding.lutimes(pathModule.toNamespacedPath(path),
-                  toUnixTimestamp(atime),
-                  toUnixTimestamp(mtime),
-                  undefined, ctx);
-  handleErrorFromBinding(ctx);
+  binding.lutimes(
+    pathModule.toNamespacedPath(path),
+    toUnixTimestamp(atime),
+    toUnixTimestamp(mtime),
+  );
 }
 
 function writeAll(fd, isUserFd, buffer, offset, length, signal, flush, callback) {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2675,18 +2675,17 @@ static void UTimes(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsNumber());
   const double mtime = args[2].As<Number>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
-  if (req_wrap_async != nullptr) {  // utimes(path, atime, mtime, req)
+  if (argc > 3) {  // utimes(path, atime, mtime, req)
+    FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_UTIME, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "utime", UTF8, AfterNoArgs,
               uv_fs_utime, *path, atime, mtime);
-  } else {  // utimes(path, atime, mtime, undefined, ctx)
-    CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap_sync;
+  } else {  // utimes(path, atime, mtime)
+    FSReqWrapSync req_wrap_sync("utime", *path);
     FS_SYNC_TRACE_BEGIN(utimes);
-    SyncCall(env, args[4], &req_wrap_sync, "utime",
-             uv_fs_utime, *path, atime, mtime);
+    SyncCallAndThrowOnError(
+        env, &req_wrap_sync, uv_fs_utime, *path, atime, mtime);
     FS_SYNC_TRACE_END(utimes);
   }
 }
@@ -2706,17 +2705,16 @@ static void FUTimes(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsNumber());
   const double mtime = args[2].As<Number>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
-  if (req_wrap_async != nullptr) {  // futimes(fd, atime, mtime, req)
+  if (argc > 3) {  // futimes(fd, atime, mtime, req)
+    FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_FUTIME, req_wrap_async)
     AsyncCall(env, req_wrap_async, args, "futime", UTF8, AfterNoArgs,
               uv_fs_futime, fd, atime, mtime);
-  } else {  // futimes(fd, atime, mtime, undefined, ctx)
-    CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap_sync;
+  } else {  // futimes(fd, atime, mtime)
+    FSReqWrapSync req_wrap_sync("futime");
     FS_SYNC_TRACE_BEGIN(futimes);
-    SyncCall(env, args[4], &req_wrap_sync, "futime",
-             uv_fs_futime, fd, atime, mtime);
+    SyncCallAndThrowOnError(
+        env, &req_wrap_sync, uv_fs_futime, fd, atime, mtime);
     FS_SYNC_TRACE_END(futimes);
   }
 }
@@ -2738,18 +2736,17 @@ static void LUTimes(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsNumber());
   const double mtime = args[2].As<Number>()->Value();
 
-  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
-  if (req_wrap_async != nullptr) {  // lutimes(path, atime, mtime, req)
+  if (argc > 3) {  // lutimes(path, atime, mtime, req)
+    FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_LUTIME, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "lutime", UTF8, AfterNoArgs,
               uv_fs_lutime, *path, atime, mtime);
-  } else {  // lutimes(path, atime, mtime, undefined, ctx)
-    CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap_sync;
+  } else {  // lutimes(path, atime, mtime)
+    FSReqWrapSync req_wrap_sync("lutime", *path);
     FS_SYNC_TRACE_BEGIN(lutimes);
-    SyncCall(env, args[4], &req_wrap_sync, "lutime",
-             uv_fs_lutime, *path, atime, mtime);
+    SyncCallAndThrowOnError(
+        env, &req_wrap_sync, uv_fs_lutime, *path, atime, mtime);
     FS_SYNC_TRACE_END(lutimes);
   }
 }

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -107,7 +107,7 @@ declare namespace InternalFSBinding {
   function ftruncate(fd: number, len: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function futimes(fd: number, atime: number, mtime: number, req: FSReqCallback): void;
-  function futimes(fd: number, atime: number, mtime: number, req: undefined, ctx: FSSyncContext): void;
+  function futimes(fd: number, atime: number, mtime: number): void;
   function futimes(fd: number, atime: number, mtime: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function internalModuleReadJSON(path: string): [] | [string, boolean];
@@ -132,7 +132,7 @@ declare namespace InternalFSBinding {
   function lstat(path: StringOrBuffer, useBigint: false, usePromises: typeof kUsePromises): Promise<Float64Array>;
 
   function lutimes(path: string, atime: number, mtime: number, req: FSReqCallback): void;
-  function lutimes(path: string, atime: number, mtime: number, req: undefined, ctx: FSSyncContext): void;
+  function lutimes(path: string, atime: number, mtime: number): void;
   function lutimes(path: string, atime: number, mtime: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function mkdtemp(prefix: string, encoding: unknown, req: FSReqCallback<string>): void;
@@ -207,7 +207,7 @@ declare namespace InternalFSBinding {
   function unlink(path: string, usePromises: typeof kUsePromises): Promise<void>;
 
   function utimes(path: string, atime: number, mtime: number, req: FSReqCallback): void;
-  function utimes(path: string, atime: number, mtime: number, req: undefined, ctx: FSSyncContext): void;
+  function utimes(path: string, atime: number, mtime: number): void;
   function utimes(path: string, atime: number, mtime: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function writeBuffer(fd: number, buffer: ArrayBufferView, offset: number, length: number, position: number | null, req: FSReqCallback<number>): void;


### PR DESCRIPTION
Results from i7 Windows laptop:
```
                                                                confidence improvement accuracy (*)    (**)   (***)
fs\bench-timesSync.js n=1000 func='futimes' type='existing'                     1.30 %       ±8.42% ±11.20% ±14.57%
fs\bench-timesSync.js n=1000 func='futimes' type='non-existing'        ***    105.93 %      ±12.64% ±16.88% ±22.09%
fs\bench-timesSync.js n=1000 func='lutimes' type='existing'                     5.56 %       ±8.48% ±11.29% ±14.73%
fs\bench-timesSync.js n=1000 func='lutimes' type='non-existing'        ***     62.51 %      ±13.07% ±17.43% ±22.75%
fs\bench-timesSync.js n=1000 func='utimes' type='existing'                     -1.04 %       ±5.85%  ±7.78% ±10.13%
fs\bench-timesSync.js n=1000 func='utimes' type='non-existing'         ***     61.88 %       ±8.31% ±11.06% ±14.40%
```

Ref: https://github.com/nodejs/performance/issues/106