### PR TITLE
wasi: address coverity warning

### DIFF
--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -83,8 +83,8 @@ WASI::WASI(Environment* env,
   int err = uvwasi_init(&uvw_, options);
   if (err != UVWASI_ESUCCESS) {
     Local<Value> exception;
-    if (!WASIException(env->context(), err, "uvwasi_init").ToLocal(&exception))
-      return;
+    CHECK(
+        WASIException(env->context(), err, "uvwasi_init").ToLocal(&exception));
 
     env->isolate()->ThrowException(exception);
   }


### PR DESCRIPTION
- add check for case when trying to provide a better Exception fails
- the code was modified to avoid a CHECK_EQ in all cases in https://github.com/nodejs/node/pull/31076, however, I believe that if we fail to create the exeption to throw instead of simply returning using a CHECK makes more sense. I think it should also address the coverity warning about not initializing in the constructor.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
