### PR TITLE
Revert "doc: promote fetch/webstreams from experimental to stable"

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1117,7 +1117,7 @@ Silence deprecation warnings.
 added: v18.0.0
 -->
 
-Disable exposition of [Fetch API][] on the global scope.
+Disable experimental support for the [Fetch API][].
 
 ### `--no-experimental-global-customevent`
 

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -478,16 +478,13 @@ added:
   - v17.5.0
   - v16.15.0
 changes:
-  - version:
-    - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/45684
-    description: No longer experimental.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41811
     description: No longer behind `--experimental-global-fetch` CLI flag.
 -->
 
-> Stability: 2 - Stable
+> Stability: 1 - Experimental. Disable this API with the [`--no-experimental-fetch`][]
+> CLI flag.
 
 A browser-compatible implementation of the [`fetch()`][] function.
 
@@ -508,16 +505,13 @@ added:
   - v17.6.0
   - v16.15.0
 changes:
-  - version:
-    - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/45684
-    description: No longer experimental.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41811
     description: No longer behind `--experimental-global-fetch` CLI flag.
 -->
 
-> Stability: 2 - Stable
+> Stability: 1 - Experimental. Disable this API with the [`--no-experimental-fetch`][]
+> CLI flag.
 
 A browser-compatible implementation of {FormData}.
 
@@ -547,16 +541,13 @@ added:
   - v17.5.0
   - v16.15.0
 changes:
-  - version:
-    - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/45684
-    description: No longer experimental.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41811
     description: No longer behind `--experimental-global-fetch` CLI flag.
 -->
 
-> Stability: 2 - Stable
+> Stability: 1 - Experimental. Disable this API with the [`--no-experimental-fetch`][]
+> CLI flag.
 
 A browser-compatible implementation of {Headers}.
 
@@ -822,16 +813,13 @@ added:
   - v17.5.0
   - v16.15.0
 changes:
-  - version:
-    - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/45684
-    description: No longer experimental.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41811
     description: No longer behind `--experimental-global-fetch` CLI flag.
 -->
 
-> Stability: 2 - Stable
+> Stability: 1 - Experimental. Disable this API with the [`--no-experimental-fetch`][]
+> CLI flag.
 
 A browser-compatible implementation of {Response}.
 
@@ -842,16 +830,13 @@ added:
   - v17.5.0
   - v16.15.0
 changes:
-  - version:
-    - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/45684
-    description: No longer experimental.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41811
     description: No longer behind `--experimental-global-fetch` CLI flag.
 -->
 
-> Stability: 2 - Stable
+> Stability: 1 - Experimental. Disable this API with the [`--no-experimental-fetch`][]
+> CLI flag.
 
 A browser-compatible implementation of {Request}.
 
@@ -1052,6 +1037,7 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 [ECMAScript module]: esm.md
 [Navigator API]: https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
 [Web Crypto API]: webcrypto.md
+[`--no-experimental-fetch`]: cli.md#--no-experimental-fetch
 [`--no-experimental-global-customevent`]: cli.md#--no-experimental-global-customevent
 [`--no-experimental-global-webcrypto`]: cli.md#--no-experimental-global-webcrypto
 [`AbortController`]: https://developer.mozilla.org/en-US/docs/Web/API/AbortController

--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -5,16 +5,12 @@
 <!-- YAML
 added: v16.5.0
 changes:
-  - version:
-    - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/45684
-    description: No longer experimental.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/42225
     description: Use of this API no longer emit a runtime warning.
 -->
 
-> Stability: 2 - Stable
+> Stability: 1 - Experimental.
 
 An implementation of the [WHATWG Streams Standard][].
 


### PR DESCRIPTION
This reverts commit [740ca5423aabc06af48f6dacfb17335bbaa25c0c1](https://github.com/nodejs/node/commit/740ca5423aabc06af48f6dacfb17335bbaa25c0c).

At minimum, this needs more discussion.

Refs: https://github.com/nodejs/undici/issues/1737#issuecomment-1729783598 (discussion starts here)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
