### PR TITLE
tools: support updating @reporters/github manually

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -24,6 +24,7 @@ on:
           - doc
           - eslint
           - googletest
+          - github_reporter
           - histogram
           - icu
           - libuv

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -23,8 +23,8 @@ on:
           - corepack
           - doc
           - eslint
-          - googletest
           - github_reporter
+          - googletest
           - histogram
           - icu
           - libuv


### PR DESCRIPTION
refs: https://github.com/nodejs/node/pull/49869/commits/fbe28e2f1da0a66a78164201048c0c60615bd0c8
https://github.com/nodejs/node/pull/49869 requires the [latest release of @reporters/github ](https://github.com/MoLow/reporters/releases/tag/github-v1.5.3) wich cannot be manually updated