### PR TITLE
lib: update params in jsdoc for `HTTPRequestOptions`

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -76,6 +76,7 @@ function createServer(opts, requestListener) {
  * @property {string} [host] A domain name or IP address of the server to issue the request to.
  * @property {string} [hostname] Alias for host.
  * @property {boolean} [insecureHTTPParser] Use an insecure HTTP parser that accepts invalid HTTP headers when true.
+ * @property {boolean} [joinDuplicateHeaders] Multiple header that joined with `,` field line values.
  * @property {string} [localAddress] Local interface to bind for network connections.
  * @property {number} [localPort] Local port to connect from.
  * @property {Function} [lookup] Custom lookup function. Default: dns.lookup().
@@ -88,6 +89,7 @@ function createServer(opts, requestListener) {
  * @property {AbortSignal} [signal] An AbortSignal that may be used to abort an ongoing request.
  * @property {string} [socketPath] Unix domain socket.
  * @property {number} [timeout] A number specifying the socket timeout in milliseconds.
+ * @property {Array} [uniqueHeaders] A list of request headers that should be sent only once.
  */
 
 /**

--- a/lib/https.js
+++ b/lib/https.js
@@ -392,6 +392,7 @@ function request(...args) {
  *   host?: string;
  *   hostname?: string;
  *   insecureHTTPParser?: boolean;
+ *   joinDuplicateHeaders?: boolean;
  *   localAddress?: string;
  *   localPort?: number;
  *   lookup?: Function;
@@ -404,6 +405,7 @@ function request(...args) {
  *   socketPath?: string;
  *   timeout?: number;
  *   signal?: AbortSignal;
+ *   uniqueHeaders?: Array;
  *   } | string | URL} [options]
  * @param {Function} [cb]
  * @returns {ClientRequest}


### PR DESCRIPTION
A missing parameter was added to the jsdoc of `HTTPRequestOptions`.

- `joinDuplicateHeaders`
- `uniqueHeaders`

https://github.com/nodejs/node/blob/main/doc/api/http.md#httprequesturl-options-callback

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
