### PR TITLE
lib,test: do not hardcode Buffer.kMaxLength

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -24,6 +24,9 @@ const {
   concat,
   getDataObject,
 } = internalBinding('blob');
+const {
+  kMaxLength,
+} = internalBinding('buffer');
 
 const {
   TextDecoder,
@@ -62,7 +65,6 @@ const {
 } = require('internal/errors');
 
 const {
-  isUint32,
   validateDictionary,
 } = require('internal/validators');
 
@@ -160,8 +162,8 @@ class Blob {
       return src;
     });
 
-    if (!isUint32(length))
-      throw new ERR_BUFFER_TOO_LARGE(0xFFFFFFFF);
+    if (length > kMaxLength)
+      throw new ERR_BUFFER_TOO_LARGE(kMaxLength);
 
     this[kHandle] = _createBlob(sources_, length);
     this[kLength] = length;

--- a/test/parallel/test-blob-buffer-too-large.js
+++ b/test/parallel/test-blob-buffer-too-large.js
@@ -3,17 +3,17 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { Blob } = require('buffer');
+const { Blob, kMaxLength } = require('buffer');
 
 if (common.isFreeBSD)
   common.skip('Oversized buffer make the FreeBSD CI runner crash');
 
 try {
-  new Blob([new Uint8Array(0xffffffff), [1]]);
+  new Blob([new Uint8Array(kMaxLength), [1]]);
 } catch (e) {
   if (
     e.message === 'Array buffer allocation failed' ||
-    e.message === 'Invalid typed array length: 4294967295'
+    e.message === `Invalid typed array length: ${kMaxLength}`
   ) {
     common.skip(
       'Insufficient memory on this platform for oversized buffer test.'

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -4,13 +4,16 @@ const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
-const SlowBuffer = require('buffer').SlowBuffer;
+const {
+  SlowBuffer,
+  kMaxLength,
+} = require('buffer');
 
 // Verify the maximum Uint8Array size. There is no concrete limit by spec. The
 // internal limits should be updated if this fails.
 assert.throws(
-  () => new Uint8Array(2 ** 32 + 1),
-  { message: 'Invalid typed array length: 4294967297' }
+  () => new Uint8Array(kMaxLength + 1),
+  { message: `Invalid typed array length: ${kMaxLength + 1}` },
 );
 
 const b = Buffer.allocUnsafe(1024);

--- a/test/parallel/test-buffer-over-max-length.js
+++ b/test/parallel/test-buffer-over-max-length.js
@@ -12,18 +12,8 @@ const bufferMaxSizeMsg = {
   name: 'RangeError',
 };
 
-assert.throws(() => Buffer((-1 >>> 0) + 2), bufferMaxSizeMsg);
-assert.throws(() => SlowBuffer((-1 >>> 0) + 2), bufferMaxSizeMsg);
-assert.throws(() => Buffer.alloc((-1 >>> 0) + 2), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafe((-1 >>> 0) + 2), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafeSlow((-1 >>> 0) + 2), bufferMaxSizeMsg);
-
 assert.throws(() => Buffer(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => Buffer.alloc(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => Buffer.allocUnsafe(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => Buffer.allocUnsafeSlow(kMaxLength + 1), bufferMaxSizeMsg);
-
-// issue GH-4331
-assert.throws(() => Buffer.allocUnsafe(0x100000001), bufferMaxSizeMsg);
-assert.throws(() => Buffer.allocUnsafe(0xFFFFFFFFF), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-tostring-rangeerror.js
+++ b/test/parallel/test-buffer-tostring-rangeerror.js
@@ -1,17 +1,22 @@
 'use strict';
 require('../common');
 
-// This test ensures that Node.js throws a RangeError when trying to convert a
-// gigantic buffer into a string.
+// This test ensures that Node.js throws an Error when trying to convert a
+// large buffer into a string.
 // Regression test for https://github.com/nodejs/node/issues/649.
 
 const assert = require('assert');
-const SlowBuffer = require('buffer').SlowBuffer;
+const {
+  SlowBuffer,
+  constants: {
+    MAX_STRING_LENGTH,
+  },
+} = require('buffer');
 
-const len = 1422561062959;
+const len = MAX_STRING_LENGTH + 1;
 const message = {
-  code: 'ERR_OUT_OF_RANGE',
-  name: 'RangeError',
+  code: 'ERR_STRING_TOO_LONG',
+  name: 'Error',
 };
 assert.throws(() => Buffer(len).toString('utf8'), message);
 assert.throws(() => SlowBuffer(len).toString('utf8'), message);


### PR DESCRIPTION
V8 will soon support typed arrays as large as the maximum array buffer length. This patch replaces hardcoded values related to Buffer.kMaxLength with the actual constant.
It also fixes a test that was passing by accident.

Refs: https://github.com/v8/v8/commit/44b299590083b888637c79fb5632806e607ab861
