### PR TITLE
Fixes: CVE-2023-4807 Update poly1305-x86_64.pl

### DIFF
--- a/deps/openssl/openssl/crypto/poly1305/asm/poly1305-x86_64.pl
+++ b/deps/openssl/openssl/crypto/poly1305/asm/poly1305-x86_64.pl
@@ -190,7 +190,7 @@ $code.=<<___	if ($avx);
 	cmovc	%rax,%r10
 	cmovc	%rcx,%r11
 ___
-$code.=<<___	if ($avx>1);
+$code.=<<___	if ($avx>1 && !$win64);
 	lea	poly1305_blocks_avx2(%rip),%rax
 	bt	\$`5+32`,%r9		# AVX2?
 	cmovc	%rax,%r10
@@ -2724,7 +2724,7 @@ $code.=<<___;
 .cfi_endproc
 .size	poly1305_blocks_avx512,.-poly1305_blocks_avx512
 ___
-if ($avx>3) {
+if ($avx>3 && !$win64) {
 ########################################################################
 # VPMADD52 version using 2^44 radix.
 #


### PR DESCRIPTION
Fixes: CVE-2023-4807 
https://nvd.nist.gov/vuln/detail/CVE-2023-4807
Fix: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-4807