### PR TITLE
test: Use seclevel=0 unconditionally on OpenSSL 3

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -59,9 +59,6 @@ const hasCrypto = Boolean(process.versions.openssl) &&
 const hasOpenSSL3 = hasCrypto &&
     require('crypto').constants.OPENSSL_VERSION_NUMBER >= 0x30000000;
 
-const hasOpenSSL31 = hasCrypto &&
-    require('crypto').constants.OPENSSL_VERSION_NUMBER >= 0x30100000;
-
 const hasQuic = hasCrypto && !!process.config.variables.openssl_quic;
 
 function parseTestFlags(filename = process.argv[1]) {
@@ -922,7 +919,6 @@ const common = {
   hasIntl,
   hasCrypto,
   hasOpenSSL3,
-  hasOpenSSL31,
   hasQuic,
   hasMultiLocalhost,
   invalidArgTypeHelper,

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -56,7 +56,7 @@ function faultyServer(port) {
 function second(server, session) {
   const req = https.request({
     port: server.address().port,
-    ciphers: (common.hasOpenSSL31 ? 'DEFAULT:@SECLEVEL=0' : 'DEFAULT'),
+    ciphers: 'DEFAULT:@SECLEVEL=0',
     rejectUnauthorized: false
   }, function(res) {
     res.resume();

--- a/test/parallel/test-tls-alert.js
+++ b/test/parallel/test-tls-alert.js
@@ -42,7 +42,7 @@ const server = tls.Server({
   cert: loadPEM('agent2-cert')
 }, null).listen(0, common.mustCall(() => {
   const args = ['s_client', '-quiet', '-tls1_1',
-                '-cipher', (common.hasOpenSSL31 ? 'DEFAULT:@SECLEVEL=0' : 'DEFAULT'),
+                '-cipher', 'DEFAULT:@SECLEVEL=0',
                 '-connect', `127.0.0.1:${server.address().port}`];
 
   execFile(common.opensslCli, args, common.mustCall((err, _, stderr) => {

--- a/test/parallel/test-tls-getprotocol.js
+++ b/test/parallel/test-tls-getprotocol.js
@@ -14,11 +14,11 @@ const clientConfigs = [
   {
     secureProtocol: 'TLSv1_method',
     version: 'TLSv1',
-    ciphers: (common.hasOpenSSL31 ? 'DEFAULT:@SECLEVEL=0' : 'DEFAULT')
+    ciphers: 'DEFAULT:@SECLEVEL=0'
   }, {
     secureProtocol: 'TLSv1_1_method',
     version: 'TLSv1.1',
-    ciphers: (common.hasOpenSSL31 ? 'DEFAULT:@SECLEVEL=0' : 'DEFAULT')
+    ciphers: 'DEFAULT:@SECLEVEL=0'
   }, {
     secureProtocol: 'TLSv1_2_method',
     version: 'TLSv1.2'

--- a/test/parallel/test-tls-min-max-version.js
+++ b/test/parallel/test-tls-min-max-version.js
@@ -22,8 +22,8 @@ function test(cmin, cmax, cprot, smin, smax, sprot, proto, cerr, serr) {
     if (serr !== 'ERR_SSL_UNSUPPORTED_PROTOCOL')
       ciphers = 'ALL@SECLEVEL=0';
   }
-  if (common.hasOpenSSL31 && cerr === 'ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION') {
-    ciphers = 'DEFAULT@SECLEVEL=0';
+  if (common.hasOpenSSL3 && cerr === 'ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION') {
+    ciphers = 'DEFAULT:@SECLEVEL=0';
   }
   // Report where test was called from. Strip leading garbage from
   //     at Object.<anonymous> (file:line)

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -100,7 +100,7 @@ function doTest(testOptions, callback) {
     const args = [
       's_client',
       '-tls1',
-      '-cipher', (common.hasOpenSSL31 ? 'DEFAULT:@SECLEVEL=0' : 'DEFAULT'),
+      '-cipher', 'DEFAULT:@SECLEVEL=0',
       '-connect', `localhost:${this.address().port}`,
       '-servername', 'ohgod',
       '-key', fixtures.path('keys/rsa_private.pem'),


### PR DESCRIPTION
OpenSSL 3.1 forces TLS v1.1 and less to security level 0 so the security level was lowered in the tests to pass them.
There is no need to conditionally lower the limit on OpenSSL 3.1 since the same can be done on 3.0. Both OpenSSL share the same ABI so it nodejs can be compiled again 3.0 and run the tests against 3.1. The latter is used in Debian CI to ensure smooth transition without recompiling.

Remove 3.1 special case and use it unconditionally on the 3 series.