### PR TITLE
util: lazy parse mime parameters

### DIFF
--- a/benchmark/mime/mimetype-instantiation.js
+++ b/benchmark/mime/mimetype-instantiation.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { MIMEType } = require('util');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+  value: [
+    'application/ecmascript; ',
+    'text/html;charset=gbk',
+    `text/html;${'0123456789'.repeat(12)}=x;charset=gbk`,
+    'text/html;test=\u00FF;charset=gbk',
+    'x/x;\n\r\t x=x\n\r\t ;x=y',
+  ],
+}, {
+});
+
+function main({ n, value }) {
+  // Warm up.
+  const length = 1024;
+  const array = [];
+  let errCase = false;
+
+  for (let i = 0; i < length; ++i) {
+    try {
+      array.push(new MIMEType(value));
+    } catch (e) {
+      errCase = true;
+      array.push(e);
+    }
+  }
+
+  // console.log(`errCase: ${errCase}`);
+  bench.start();
+
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    try {
+      array[index] = new MIMEType(value);
+    } catch (e) {
+      array[index] = e;
+    }
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], errCase ? 'object' : 'object');
+  }
+}

--- a/benchmark/mime/mimetype-to-string.js
+++ b/benchmark/mime/mimetype-to-string.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { MIMEType } = require('util');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+  value: [
+    'application/ecmascript; ',
+    'text/html;charset=gbk',
+    `text/html;${'0123456789'.repeat(12)}=x;charset=gbk`,
+    'text/html;test=\u00FF;charset=gbk',
+    'x/x;\n\r\t x=x\n\r\t ;x=y',
+  ],
+}, {
+});
+
+function main({ n, value }) {
+  // Warm up.
+  const length = 1024;
+  const array = [];
+  let errCase = false;
+
+  const mime = new MIMEType(value);
+
+  for (let i = 0; i < length; ++i) {
+    try {
+      array.push(mime.toString());
+    } catch (e) {
+      errCase = true;
+      array.push(e);
+    }
+  }
+
+  // console.log(`errCase: ${errCase}`);
+  bench.start();
+
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    try {
+      array[index] = mime.toString();
+    } catch (e) {
+      array[index] = e;
+    }
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], errCase ? 'object' : 'string');
+  }
+}

--- a/benchmark/mime/parse-type-and-subtype.js
+++ b/benchmark/mime/parse-type-and-subtype.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e7],
+  value: [
+    'application/ecmascript; ',
+    'text/html;charset=gbk',
+    // eslint-disable-next-line max-len
+    'text/html;0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789=x;charset=gbk',
+  ],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function main({ n, value }) {
+
+  const parseTypeAndSubtype = require('internal/mime').parseTypeAndSubtype;
+  // Warm up.
+  const length = 1024;
+  const array = [];
+  let errCase = false;
+
+  for (let i = 0; i < length; ++i) {
+    try {
+      array.push(parseTypeAndSubtype(value));
+    } catch (e) {
+      errCase = true;
+      array.push(e);
+    }
+  }
+
+  // console.log(`errCase: ${errCase}`);
+  bench.start();
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    try {
+      array[index] = parseTypeAndSubtype(value);
+    } catch (e) {
+      array[index] = e;
+    }
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], errCase ? 'object' : 'object');
+  }
+}

--- a/benchmark/mime/to-ascii-lower.js
+++ b/benchmark/mime/to-ascii-lower.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e7],
+  value: [
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    'UPPERCASE',
+    'lowercase',
+    'mixedCase',
+  ],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function main({ n, value }) {
+
+  const toASCIILower = require('internal/mime').toASCIILower;
+  // Warm up.
+  const length = 1024;
+  const array = [];
+  let errCase = false;
+
+  for (let i = 0; i < length; ++i) {
+    try {
+      array.push(toASCIILower(value));
+    } catch (e) {
+      errCase = true;
+      array.push(e);
+    }
+  }
+
+  // console.log(`errCase: ${errCase}`);
+  bench.start();
+
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    try {
+      array[index] = toASCIILower(value);
+    } catch (e) {
+      array[index] = e;
+    }
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], errCase ? 'object' : 'string');
+  }
+}

--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -36,6 +36,7 @@ function toASCIILower(str) {
 
 const SOLIDUS = '/';
 const SEMICOLON = ';';
+
 function parseTypeAndSubtype(str) {
   // Skip only HTTP whitespace from start
   let position = SafeStringPrototypeSearch(str, END_BEGINNING_WHITESPACE);
@@ -72,12 +73,11 @@ function parseTypeAndSubtype(str) {
     throw new ERR_INVALID_MIME_SYNTAX('subtype', str, trimmedSubtype);
   }
   const subtype = toASCIILower(trimmedSubtype);
-  return {
-    __proto__: null,
+  return [
     type,
     subtype,
-    parametersStringIndex: position,
-  };
+    position,
+  ];
 }
 
 const EQUALS_SEMICOLON_OR_END = /[;=]|$/;
@@ -123,12 +123,29 @@ const encode = (value) => {
 
 class MIMEParams {
   #data = new SafeMap();
+  // We set the flag the MIMEParams instance as processed on initialization
+  // to defer the parsing of a potentially large string.
+  #processed = true;
+  #string = null;
+
+  /**
+   * Used to instantiate a MIMEParams object within the MIMEType class and
+   * to allow it to be parsed lazily.
+   */
+  static instantiateMimeParams(str) {
+    const instance = new MIMEParams();
+    instance.#string = str;
+    instance.#processed = false;
+    return instance;
+  }
 
   delete(name) {
+    this.#parse();
     this.#data.delete(name);
   }
 
   get(name) {
+    this.#parse();
     const data = this.#data;
     if (data.has(name)) {
       return data.get(name);
@@ -137,10 +154,12 @@ class MIMEParams {
   }
 
   has(name) {
+    this.#parse();
     return this.#data.has(name);
   }
 
   set(name, value) {
+    this.#parse();
     const data = this.#data;
     name = `${name}`;
     value = `${value}`;
@@ -166,18 +185,22 @@ class MIMEParams {
   }
 
   *entries() {
+    this.#parse();
     yield* this.#data.entries();
   }
 
   *keys() {
+    this.#parse();
     yield* this.#data.keys();
   }
 
   *values() {
+    this.#parse();
     yield* this.#data.values();
   }
 
   toString() {
+    this.#parse();
     let ret = '';
     for (const { 0: key, 1: value } of this.#data) {
       const encoded = encode(value);
@@ -190,8 +213,11 @@ class MIMEParams {
 
   // Used to act as a friendly class to stringifying stuff
   // not meant to be exposed to users, could inject invalid values
-  static parseParametersString(str, position, params) {
-    const paramsMap = params.#data;
+  #parse() {
+    if (this.#processed) return;  // already parsed
+    const paramsMap = this.#data;
+    let position = 0;
+    const str = this.#string;
     const endOfSource = SafeStringPrototypeSearch(
       StringPrototypeSlice(str, position),
       START_ENDING_WHITESPACE,
@@ -270,13 +296,14 @@ class MIMEParams {
                                   NOT_HTTP_TOKEN_CODE_POINT) === -1 &&
         SafeStringPrototypeSearch(parameterValue,
                                   NOT_HTTP_QUOTED_STRING_CODE_POINT) === -1 &&
-        params.has(parameterString) === false
+        paramsMap.has(parameterString) === false
       ) {
         paramsMap.set(parameterString, parameterValue);
       }
       position++;
     }
-    return paramsMap;
+    this.#data = paramsMap;
+    this.#processed = true;
   }
 }
 const MIMEParamsStringify = MIMEParams.prototype.toString;
@@ -293,8 +320,8 @@ ObjectDefineProperty(MIMEParams.prototype, 'toJSON', {
   writable: true,
 });
 
-const { parseParametersString } = MIMEParams;
-delete MIMEParams.parseParametersString;
+const { instantiateMimeParams } = MIMEParams;
+delete MIMEParams.instantiateMimeParams;
 
 class MIMEType {
   #type;
@@ -303,14 +330,9 @@ class MIMEType {
   constructor(string) {
     string = `${string}`;
     const data = parseTypeAndSubtype(string);
-    this.#type = data.type;
-    this.#subtype = data.subtype;
-    this.#parameters = new MIMEParams();
-    parseParametersString(
-      string,
-      data.parametersStringIndex,
-      this.#parameters,
-    );
+    this.#type = data[0];
+    this.#subtype = data[1];
+    this.#parameters = instantiateMimeParams(StringPrototypeSlice(string, data[2]));
   }
 
   get type() {
@@ -362,6 +384,8 @@ ObjectDefineProperty(MIMEType.prototype, 'toJSON', {
 });
 
 module.exports = {
+  toASCIILower,
+  parseTypeAndSubtype,
   MIMEParams,
   MIMEType,
 };

--- a/test/benchmark/test-benchmark-mime.js
+++ b/test/benchmark/test-benchmark-mime.js
@@ -1,0 +1,7 @@
+'use strict';
+
+require('../common');
+
+const runBenchmark = require('../common/benchmark');
+
+runBenchmark('mime', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/parallel/test-mime-api.js
+++ b/test/parallel/test-mime-api.js
@@ -1,8 +1,10 @@
+// Flags: --expose-internals
 'use strict';
 
 require('../common');
 const assert = require('assert');
 const { MIMEType, MIMEParams } = require('util');
+const { toASCIILower } = require('internal/mime');
 
 
 const WHITESPACES = '\t\n\f\r ';
@@ -158,3 +160,8 @@ assert.throws(() => params.set(`x${NOT_HTTP_TOKEN_CODE_POINT}`, 'x'), /parameter
 assert.throws(() => params.set('x', `${NOT_HTTP_QUOTED_STRING_CODE_POINT};`), /parameter value/i);
 assert.throws(() => params.set('x', `${NOT_HTTP_QUOTED_STRING_CODE_POINT}x`), /parameter value/i);
 assert.throws(() => params.set('x', `x${NOT_HTTP_QUOTED_STRING_CODE_POINT}`), /parameter value/i);
+
+assert.strictEqual(toASCIILower('someThing'), 'something');
+assert.strictEqual(toASCIILower('SomeThing'), 'something');
+assert.strictEqual(toASCIILower('SomeThing3'), 'something3');
+assert.strictEqual(toASCIILower('ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.toLowerCase());

--- a/test/parallel/test-mime-api.js
+++ b/test/parallel/test-mime-api.js
@@ -164,4 +164,4 @@ assert.throws(() => params.set('x', `x${NOT_HTTP_QUOTED_STRING_CODE_POINT}`), /p
 assert.strictEqual(toASCIILower('someThing'), 'something');
 assert.strictEqual(toASCIILower('SomeThing'), 'something');
 assert.strictEqual(toASCIILower('SomeThing3'), 'something3');
-assert.strictEqual(toASCIILower('ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.toLowerCase());
+assert.strictEqual(toASCIILower('ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 'abcdefghijklmnopqrstuvwxyz');


### PR DESCRIPTION
This PR improves the instantiation speed of MimeType by parsing the MimeParams lazily.

MimeParams accepts now a string of the parameter rest. 

```sh
 confidence improvement accuracy (*)    (**)   (***)
mime/mimetype-instantiation.js value='application/ecmascript; ' n=100000                                                                                                                                ***     43.18 %       ±3.42%  ±4.58%  ±6.02%
mime/mimetype-instantiation.js value='text/html;012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789=x;charset=gbk' n=100000        ***    656.71 %      ±21.51% ±28.99% ±38.48%
mime/mimetype-instantiation.js value='text/html;charset=gbk' n=100000                                                                                                                                   ***    151.06 %       ±4.03%  ±5.40%  ±7.13%
mime/mimetype-instantiation.js value='text/html;test=ÿ;charset=gbk' n=100000                                                                                                                            ***    241.04 %       ±4.72%  ±6.33%  ±8.36%
mime/mimetype-instantiation.js value='x/x;\n\r\t x=x\n\r\t ;x=y' n=100000                                                                                                                               ***    267.60 %       ±8.31% ±11.20% ±14.85%
mime/mimetype-to-string.js value='application/ecmascript; ' n=100000                                                                                                                                      *     -5.74 %       ±5.34%  ±7.15%  ±9.41%
mime/mimetype-to-string.js value='text/html;012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789=x;charset=gbk' n=100000              *     -3.68 %       ±2.79%  ±3.72%  ±4.84%
mime/mimetype-to-string.js value='text/html;charset=gbk' n=100000                                                                                                                                       ***     -5.62 %       ±2.67%  ±3.55%  ±4.62%
mime/mimetype-to-string.js value='text/html;test=ÿ;charset=gbk' n=100000                                                                                                                                        -2.71 %       ±3.55%  ±4.75%  ±6.24%
mime/mimetype-to-string.js value='x/x;\n\r\t x=x\n\r\t ;x=y' n=100000                                                                                                                                           -1.44 %       ±5.78%  ±7.74% ±10.18%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 10 comparisons, you can thus expect the following amount of false-positive results:
  0.50 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.10 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
