### PR TITLE
watch: fix null `fileName` on windows systems

### DIFF
--- a/lib/internal/watch_mode/files_watcher.js
+++ b/lib/internal/watch_mode/files_watcher.js
@@ -98,7 +98,7 @@ class FilesWatcher extends EventEmitter {
     }
     const watcher = watch(path, { recursive, signal: this.#signal });
     watcher.on('change', (eventType, fileName) => this
-      .#onChange(recursive ? resolve(path, fileName) : path));
+      .#onChange(recursive ? resolve(path, fileName ?? '') : path));
     this.#watchers.set(path, { handle: watcher, recursive });
     if (recursive) {
       this.#removeWatchedChildren(path);


### PR DESCRIPTION
This fixes a Node.js crash when running on Windows with `--watch`.
The issue is that `fs.watch()` sometimes returns `null` for the `filename` as described in the official Node.js [documentation](https://nodejs.org/api/fs.html#filename-argument).

The thrown error:
```
node:internal/validators:162
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "paths[1]" argument must be of type string. Received null
    at __node_internal_captureLargerStackTrace (node:internal/errors:496:5)
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at resolve (node:path:171:9)
    at FSWatcher.<anonymous> (node:internal/watch_mode/files_watcher:99:30)
    at FSWatcher.emit (node:events:514:28)
    at FSWatcher._handle.onchange (node:internal/fs/watchers:215:12) {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v20.5.1
```

There is also a Stack Overflow [question](https://stackoverflow.com/questions/76970212/node-18-17-1-windows-built-in-filesystem-watcher-crashes) related to this issue.