### PR TITLE
fs: use fast api calls for `existsSync`

### DIFF
--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -27,6 +27,10 @@ using CFunctionCallbackWithStrings =
              const v8::FastOneByteString& base);
 using CFunctionWithUint32 = uint32_t (*)(v8::Local<v8::Value>,
                                          const uint32_t input);
+using CFunctionCallbackWithStringOptions =
+    bool (*)(v8::Local<v8::Object>, const v8::FastOneByteString& input,
+             // NOLINTNEXTLINE(runtime/references) This is V8 api.
+             v8::FastApiCallbackOptions& options);
 
 // This class manages the external references from the V8 heap
 // to the C++ addresses in Node.js.
@@ -41,6 +45,7 @@ class ExternalReferenceRegistry {
   V(CFunctionCallbackWithInt64)                                                \
   V(CFunctionCallbackWithBool)                                                 \
   V(CFunctionCallbackWithString)                                               \
+  V(CFunctionCallbackWithStringOptions)                                        \
   V(CFunctionCallbackWithStrings)                                              \
   V(CFunctionWithUint32)                                                       \
   V(const v8::CFunctionInfo*)                                                  \

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -28,7 +28,8 @@ using CFunctionCallbackWithStrings =
 using CFunctionWithUint32 = uint32_t (*)(v8::Local<v8::Value>,
                                          const uint32_t input);
 using CFunctionCallbackWithStringOptions =
-    bool (*)(v8::Local<v8::Object>, const v8::FastOneByteString& input,
+    bool (*)(v8::Local<v8::Object>,
+             const v8::FastOneByteString& input,
              // NOLINTNEXTLINE(runtime/references) This is V8 api.
              v8::FastApiCallbackOptions& options);
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3429,8 +3429,8 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "accessSync", AccessSync);
   SetMethod(isolate, target, "close", Close);
   SetMethod(isolate, target, "closeSync", CloseSync);
-  SetFastMethodNoSideEffect(
-      isolate, target, "existsSync", ExistsSync, &fast_exists_sync_);
+  SetFastMethod(isolate, target, "existsSync",
+                ExistsSync, &fast_exists_sync_);
   SetMethod(isolate, target, "open", Open);
   SetMethod(isolate, target, "openSync", OpenSync);
   SetMethod(isolate, target, "openFileHandle", OpenFileHandle);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3429,8 +3429,7 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "accessSync", AccessSync);
   SetMethod(isolate, target, "close", Close);
   SetMethod(isolate, target, "closeSync", CloseSync);
-  SetFastMethod(isolate, target, "existsSync",
-                ExistsSync, &fast_exists_sync_);
+  SetFastMethod(isolate, target, "existsSync", ExistsSync, &fast_exists_sync_);
   SetMethod(isolate, target, "open", Open);
   SetMethod(isolate, target, "openSync", OpenSync);
   SetMethod(isolate, target, "openFileHandle", OpenFileHandle);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1111,9 +1111,8 @@ bool FastExistsSync(v8::Local<v8::Object> recv,
   memcpy(path.out(), string.data, string.length);
   path.SetLengthAndZeroTerminate(string.length);
 
-  if (UNLIKELY(!env->permission()
-                   ->is_granted(permission::PermissionScope::kFileSystemRead,
-                                path.ToStringView()))) {
+  if (UNLIKELY(!env->permission()->is_granted(
+          permission::PermissionScope::kFileSystemRead, path.ToStringView()))) {
     options.fallback = true;
     return false;
   }
@@ -3409,8 +3408,8 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethodNoSideEffect(isolate, target, "accessSync", AccessSync);
   SetMethod(isolate, target, "close", Close);
   SetMethod(isolate, target, "closeSync", CloseSync);
-  SetFastMethodNoSideEffect(isolate, target, "existsSync",
-                            ExistsSync, &fast_exists_sync_);
+  SetFastMethodNoSideEffect(
+      isolate, target, "existsSync", ExistsSync, &fast_exists_sync_);
   SetMethod(isolate, target, "open", Open);
   SetMethod(isolate, target, "openSync", OpenSync);
   SetMethod(isolate, target, "openFileHandle", OpenFileHandle);

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -54,3 +54,11 @@ assert(!fs.existsSync(`${f}-NO`));
 assert(!fs.existsSync());
 assert(!fs.existsSync({}));
 assert(!fs.existsSync(new URL('https://foo')));
+
+{
+  // This test is to ensure that the v8 fast api works.
+  const oneBytePath = 'hello.txt'
+  for (let i = 0; i < 1e5; i++) {
+    assert(!fs.existsSync(oneBytePath));
+  }
+}

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -57,7 +57,7 @@ assert(!fs.existsSync(new URL('https://foo')));
 
 {
   // This test is to ensure that the v8 fast api works.
-  const oneBytePath = 'hello.txt'
+  const oneBytePath = 'hello.txt';
   for (let i = 0; i < 1e5; i++) {
     assert(!fs.existsSync(oneBytePath));
   }

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -60,5 +60,6 @@ assert(!fs.existsSync(new URL('https://foo')));
   const oneBytePath = 'hello.txt';
   for (let i = 0; i < 1e5; i++) {
     assert(!fs.existsSync(oneBytePath));
+    assert(fs.existsSync(__filename));
   }
 }


### PR DESCRIPTION
Currently, It takes the fast route when `path` string is represented as a OneByteString in V8.

```
                                                          confidence improvement accuracy (*)   (**)  (***)
fs/bench-existsSync.js n=1000000 type='existing'                 ***      2.87 %       ±0.68% ±0.91% ±1.19%
fs/bench-existsSync.js n=1000000 type='non-existing'             ***     43.04 %       ±1.17% ±1.56% ±2.03%
fs/bench-existsSync.js n=1000000 type='non-flat-existing'        ***      2.63 %       ±0.42% ±0.56% ±0.73%
n=1000000 type='non-existing' 836103.841448331                    NA       NaN %           NA     NA     NA

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 4 comparisons, you can thus expect the following amount of false-positive results:
  0.20 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.04 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```