### PR TITLE
lib: fix `primordials` typings

### DIFF
--- a/typings/primordials.d.ts
+++ b/typings/primordials.d.ts
@@ -427,8 +427,8 @@ declare namespace primordials {
   export const SymbolFor: typeof Symbol.for
   export const SymbolKeyFor: typeof Symbol.keyFor
   export const SymbolAsyncIterator: typeof Symbol.asyncIterator
-  export const SymbolDispose: typeof Symbol // TODO(MoLow): use typeof Symbol.dispose when it's available
-  export const SymbolAsyncDispose: typeof Symbol // TODO(MoLow): use typeof Symbol.asyncDispose when it's available
+  export const SymbolDispose: symbol // TODO(MoLow): use typeof Symbol.dispose when it's available
+  export const SymbolAsyncDispose: symbol // TODO(MoLow): use typeof Symbol.asyncDispose when it's available
   export const SymbolHasInstance: typeof Symbol.hasInstance
   export const SymbolIsConcatSpreadable: typeof Symbol.isConcatSpreadable
   export const SymbolIterator: typeof Symbol.iterator


### PR DESCRIPTION
Hey 👋 

I noticed that in the [`primordials.js`, SymbolDispose and SymbolAsyncDispose](https://github.com/nodejs/node/blob/main/lib/internal/per_context/primordials.js#L234-L235) are defined as

```ts
primordials.SymbolDispose ??= primordials.SymbolFor('nodejs.dispose');
primordials.SymbolAsyncDispose ??= primordials.SymbolFor('nodejs.asyncDispose');
```

The result of `primordials.SymbolFor` is a `symbol`. Currently these two properties are defined as `SymbolConstructor` (`typeof Symbol`). I think this is incorrect and should be updated to `symbol` instead.