### PR TITLE
tls: use validateFunction for `options.checkServerIdentity`

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1738,7 +1738,7 @@ exports.connect = function connect(...args) {
   if (!options.keepAlive)
     options.singleUse = true;
 
-  assert(typeof options.checkServerIdentity === 'function');
+  validateFunction(options.checkServerIdentity, 'options.checkServerIdentity');
   assert(typeof options.minDHSize === 'number',
          'options.minDHSize is not a number: ' + options.minDHSize);
   assert(options.minDHSize > 0,

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -135,3 +135,12 @@ assert.throws(() => { tls.createSecureContext({ maxVersion: 'fhqwhgads' }); },
                 code: 'ERR_TLS_INVALID_PROTOCOL_VERSION',
                 name: 'TypeError'
               });
+
+[undefined, null, 1, true].forEach((value) => {
+  assert.throws(() => {
+    tls.connect({ checkServerIdentity: value });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+  });
+});

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -136,11 +136,11 @@ assert.throws(() => { tls.createSecureContext({ maxVersion: 'fhqwhgads' }); },
                 name: 'TypeError'
               });
 
-[undefined, null, 1, true].forEach((value) => {
+for (const checkServerIdentity of [undefined, null, 1, true]) {
   assert.throws(() => {
-    tls.connect({ checkServerIdentity: value });
+    tls.connect({ checkServerIdentity });
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
   });
-});
+}


### PR DESCRIPTION
If user uses invalid type for `options.checkServerIdentity` in tls.connect(), it's not internal issue of Node.js. So validateFunction() is more proper than assert().

Fixes: https://github.com/nodejs/node/issues/49839

Before
```
node:internal/assert:14
    throw new ERR_INTERNAL_ASSERTION(message);
    ^

Error [ERR_INTERNAL_ASSERTION]: This is caused by either a bug in Node.js or incorrect usage of Node.js internals.
Please open an issue with this stack trace at https://github.com/nodejs/node/issues
```

After
```
node:internal/validators:440
    throw new ERR_INVALID_ARG_TYPE(name, 'Function', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "options.checkServerIdentity" property must be of type function. Received undefined
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
