### PR TITLE
fs: improve error performance for `fdatasyncSync`

### DIFF
--- a/benchmark/fs/bench_fdatasyncSync.js
+++ b/benchmark/fs/bench_fdatasyncSync.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const tmpfile = tmpdir.resolve(`.existing-file-${process.pid}`);
+fs.writeFileSync(tmpfile, 'this-is-for-a-benchmark', 'utf8');
+
+const bench = common.createBenchmark(main, {
+  type: ['existing', 'non-existing'],
+  n: [1e4],
+});
+
+function main({ n, type }) {
+  let fd;
+
+  switch (type) {
+    case 'existing':
+      fd = fs.openSync(tmpfile, 'r', 0o666);
+      break;
+    case 'non-existing':
+      fd = 1 << 30;
+      break;
+    default:
+      new Error('Invalid type');
+  }
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    try {
+      fs.fdatasyncSync(fd);
+    } catch {
+      // do nothing
+    }
+  }
+
+  bench.end(n);
+
+  if (type === 'existing') fs.closeSync(fd);
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1303,7 +1303,7 @@ function fdatasync(fd, callback) {
  * @returns {void}
  */
 function fdatasyncSync(fd) {
-  syncFs.fdatasync(fd);
+  return binding.fdatasync(fd);
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1303,6 +1303,7 @@ function fdatasync(fd, callback) {
  * @returns {void}
  */
 function fdatasyncSync(fd) {
+  fd = getValidatedFd(fd);
   return binding.fdatasync(fd);
 }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1303,10 +1303,7 @@ function fdatasync(fd, callback) {
  * @returns {void}
  */
 function fdatasyncSync(fd) {
-  fd = getValidatedFd(fd);
-  const ctx = {};
-  binding.fdatasync(fd, undefined, ctx);
-  handleErrorFromBinding(ctx);
+  syncFs.fdatasync(fd);
 }
 
 /**

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -116,6 +116,24 @@ inline int64_t GetOffset(Local<Value> value) {
   return IsSafeJsInt(value) ? value.As<Integer>()->Value() : -1;
 }
 
+inline int GetValidatedFd(Environment* env, Local<Value> value) {
+  if (!value->IsInt32()) {
+    env->isolate()->ThrowException(ERR_INVALID_ARG_TYPE(
+        env->isolate(), "Invalid argument. The fd must be int32."));
+    return 1 << 30;
+  }
+
+  const int fd = value.As<Int32>()->Value();
+
+  if (fd < 0 || fd > INT32_MAX) {
+    env->isolate()->ThrowException(ERR_OUT_OF_RANGE(
+        env->isolate(), "It must be >= 0 && <= INT32_MAX. Received %d", fd));
+    return 1 << 30;
+  }
+
+  return fd;
+}
+
 static const char* get_fs_func_name_by_type(uv_fs_type req_type) {
   switch (req_type) {
 #define FS_TYPE_TO_NAME(type, name)                                            \
@@ -1517,6 +1535,24 @@ static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
     FS_SYNC_TRACE_BEGIN(fdatasync);
     SyncCall(env, args[2], &req_wrap_sync, "fdatasync", uv_fs_fdatasync, fd);
     FS_SYNC_TRACE_END(fdatasync);
+  }
+}
+
+static void FdatasyncSync(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  CHECK_EQ(args.Length(), 1);
+
+  const int fd = GetValidatedFd(env, args[0]);
+  if (fd == (1 << 30)) return;
+
+  uv_fs_t req;
+  auto make = OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
+  FS_SYNC_TRACE_BEGIN(fdatasync);
+  int err = uv_fs_fdatasync(nullptr, &req, fd, nullptr);
+  FS_SYNC_TRACE_END(fdatasync);
+  if (err < 0) {
+    return env->ThrowUVException(err, "fdatasync");
   }
 }
 
@@ -3218,6 +3254,7 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "readFileUtf8", ReadFileUtf8);
   SetMethod(isolate, target, "readBuffers", ReadBuffers);
   SetMethod(isolate, target, "fdatasync", Fdatasync);
+  SetMethod(isolate, target, "fdatasyncSync", FdatasyncSync);
   SetMethod(isolate, target, "fsync", Fsync);
   SetMethod(isolate, target, "rename", Rename);
   SetMethod(isolate, target, "ftruncate", FTruncate);
@@ -3337,6 +3374,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(ReadFileUtf8);
   registry->Register(ReadBuffers);
   registry->Register(Fdatasync);
+  registry->Register(FdatasyncSync);
   registry->Register(Fsync);
   registry->Register(Rename);
   registry->Register(FTruncate);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1522,6 +1522,7 @@ static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 1);
 
   const int fd = GetValidatedFd(env, args[0]);
+  if (fd == (1 << 30)) return;
 
   if (argc > 1) {  // fdatasync(fd, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 1);

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -84,7 +84,7 @@ declare namespace InternalFSBinding {
   function fdatasync(fd: number, req: FSReqCallback): void;
   function fdatasync(fd: number, req: undefined, ctx: FSSyncContext): void;
   function fdatasync(fd: number, usePromises: typeof kUsePromises): Promise<void>;
-  function fdatasyncSync(fd: number): void;
+  function fdatasync(fd: number): void;
 
   function fstat(fd: number, useBigint: boolean, req: FSReqCallback<Float64Array | BigUint64Array>): void;
   function fstat(fd: number, useBigint: true, req: FSReqCallback<BigUint64Array>): void;

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -84,6 +84,7 @@ declare namespace InternalFSBinding {
   function fdatasync(fd: number, req: FSReqCallback): void;
   function fdatasync(fd: number, req: undefined, ctx: FSSyncContext): void;
   function fdatasync(fd: number, usePromises: typeof kUsePromises): Promise<void>;
+  function fdatasyncSync(fd: number): void;
 
   function fstat(fd: number, useBigint: boolean, req: FSReqCallback<Float64Array | BigUint64Array>): void;
   function fstat(fd: number, useBigint: true, req: FSReqCallback<BigUint64Array>): void;


### PR DESCRIPTION
```
                                                      confidence improvement accuracy (*)   (**)   (***)
fs/bench_fdatasyncSync.js n=10000 type='existing'            ***      6.39 %       ±1.85% ±2.48%  ±3.25%
fs/bench_fdatasyncSync.js n=10000 type='non-existing'        ***    116.11 %       ±6.89% ±9.21% ±12.08%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 2 comparisons, you can thus expect the following amount of false-positive results:
  0.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.02 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

Refs: https://github.com/nodejs/performance/issues/106
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
