### PR TITLE
lib: reduce overhead of validateObject

### DIFF
--- a/benchmark/validators/validate-object.js
+++ b/benchmark/validators/validate-object.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e4],
+  objectToTest: [
+    'object',
+    'null',
+    'array',
+    'function'
+  ],
+  option: [
+    'default',
+    'allowNullable',
+    'allowArray',
+    'allowFunction',
+    'allowAll',
+  ],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function getObjectToTest(objectToTest) {
+  switch (objectToTest) {
+    case 'object':
+      return { foo: 'bar' };
+    case 'null':
+      return null;
+    case 'array':
+      return ['foo', 'bar'];
+    case 'function':
+      return () => 'foo';
+    default:
+      throw new Error(`Value ${objectToTest} is not a valid objectToTest.`);
+  }
+}
+
+function getOptions(option) {
+  const {
+    kValidateObjectAllowNullable,
+    kValidateObjectAllowArray,
+    kValidateObjectAllowFunction,
+  } = require('internal/validators');
+
+  switch(option) {
+    case 'default':
+      return 0;
+    case 'allowNullable':
+      return kValidateObjectAllowNullable;
+    case 'allowArray':
+      return kValidateObjectAllowArray;
+    case 'allowFunction':
+      return kValidateObjectAllowFunction;
+    case 'allowAll':
+      return kValidateObjectAllowNullable | kValidateObjectAllowArray | kValidateObjectAllowFunction;
+    default:
+      throw new Error(`Value ${ option } is not a valid option.`)
+  }
+}
+
+let _validateResult;
+
+function main({ n, objectToTest, option }) {
+  const {
+    validateObject,
+  } = require('internal/validators');
+
+  const value = getObjectToTest(objectToTest);
+  const options = getOptions(option);
+
+  bench.start();
+  for (let i = 0; i < n; ++i) {
+    try {
+      _validateResult = validateObject(value, 'Object', options);
+    } catch (e) {
+      _validateResult = undefined;
+    }
+  }
+  bench.end(n);
+
+  assert.ok(!_validateResult);
+}

--- a/benchmark/validators/validate-object.js
+++ b/benchmark/validators/validate-object.js
@@ -4,19 +4,12 @@ const common = require('../common');
 const assert = require('assert');
 
 const bench = common.createBenchmark(main, {
-  n: [1e4],
+  n: [1e5],
   objectToTest: [
     'object',
     'null',
     'array',
-    'function'
-  ],
-  option: [
-    'default',
-    'allowNullable',
-    'allowArray',
-    'allowFunction',
-    'allowAll',
+    'function',
   ],
 }, {
   flags: ['--expose-internals'],
@@ -37,44 +30,42 @@ function getObjectToTest(objectToTest) {
   }
 }
 
-function getOptions(option) {
+function getOptions(objectToTest) {
   const {
     kValidateObjectAllowNullable,
     kValidateObjectAllowArray,
     kValidateObjectAllowFunction,
   } = require('internal/validators');
 
-  switch(option) {
-    case 'default':
+  switch (objectToTest) {
+    case 'object':
       return 0;
-    case 'allowNullable':
+    case 'null':
       return kValidateObjectAllowNullable;
-    case 'allowArray':
+    case 'array':
       return kValidateObjectAllowArray;
-    case 'allowFunction':
+    case 'function':
       return kValidateObjectAllowFunction;
-    case 'allowAll':
-      return kValidateObjectAllowNullable | kValidateObjectAllowArray | kValidateObjectAllowFunction;
     default:
-      throw new Error(`Value ${ option } is not a valid option.`)
+      throw new Error(`Value ${objectToTest} is not a valid objectToTest.`);
   }
 }
 
 let _validateResult;
 
-function main({ n, objectToTest, option }) {
+function main({ n, objectToTest }) {
   const {
     validateObject,
   } = require('internal/validators');
 
   const value = getObjectToTest(objectToTest);
-  const options = getOptions(option);
+  const options = getOptions(objectToTest);
 
   bench.start();
   for (let i = 0; i < n; ++i) {
     try {
       _validateResult = validateObject(value, 'Object', options);
-    } catch (e) {
+    } catch {
       _validateResult = undefined;
     }
   }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -140,6 +140,7 @@ const {
   validateInteger,
   validateObject,
   validateString,
+  kValidateObjectAllowNullable,
 } = require('internal/validators');
 const syncFs = require('internal/fs/sync');
 
@@ -605,7 +606,7 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
   if (arguments.length <= 4) {
     if (arguments.length === 4) {
       // This is fs.read(fd, buffer, options, callback)
-      validateObject(offsetOrOptions, 'options', { nullable: true });
+      validateObject(offsetOrOptions, 'options', kValidateObjectAllowNullable);
       callback = length;
       params = offsetOrOptions;
     } else if (arguments.length === 3) {
@@ -623,7 +624,7 @@ function read(fd, buffer, offsetOrOptions, length, position, callback) {
     }
 
     if (params !== undefined) {
-      validateObject(params, 'options', { nullable: true });
+      validateObject(params, 'options', kValidateObjectAllowNullable);
     }
     ({
       offset = 0,
@@ -695,7 +696,7 @@ function readSync(fd, buffer, offsetOrOptions, length, position) {
   let offset = offsetOrOptions;
   if (arguments.length <= 3 || typeof offsetOrOptions === 'object') {
     if (offsetOrOptions !== undefined) {
-      validateObject(offsetOrOptions, 'options', { nullable: true });
+      validateObject(offsetOrOptions, 'options', kValidateObjectAllowNullable);
     }
 
     ({

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -46,6 +46,8 @@ const {
   validateAbortSignalArray,
   validateObject,
   validateUint32,
+  kValidateObjectAllowArray,
+  kValidateObjectAllowFunction,
 } = require('internal/validators');
 
 const {
@@ -436,7 +438,7 @@ async function aborted(signal, resource) {
     throw new ERR_INVALID_ARG_TYPE('signal', 'AbortSignal', signal);
   }
   validateAbortSignal(signal, 'signal');
-  validateObject(resource, 'resource', { nullable: false, allowFunction: true, allowArray: true });
+  validateObject(resource, 'resource', kValidateObjectAllowArray | kValidateObjectAllowFunction);
   if (signal.aborted)
     return PromiseResolve();
   const abortPromise = createDeferredPromise();

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -393,7 +393,9 @@ const TextDecoder =
     makeTextDecoderICU() :
     makeTextDecoderJS();
 
-const kValidateObjectAllowObjectsAndNull = kValidateObjectAllowNullable | kValidateObjectAllowArray | kValidateObjectAllowFunction;
+const kValidateObjectAllowObjectsAndNull = kValidateObjectAllowNullable |
+  kValidateObjectAllowArray |
+  kValidateObjectAllowFunction;
 
 function makeTextDecoderICU() {
   const {

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -47,6 +47,9 @@ const {
 const {
   validateString,
   validateObject,
+  kValidateObjectAllowNullable,
+  kValidateObjectAllowArray,
+  kValidateObjectAllowFunction,
 } = require('internal/validators');
 const binding = internalBinding('encoding_binding');
 const {
@@ -390,6 +393,8 @@ const TextDecoder =
     makeTextDecoderICU() :
     makeTextDecoderJS();
 
+const kValidateObjectAllowObjectsAndNull = kValidateObjectAllowNullable | kValidateObjectAllowArray | kValidateObjectAllowFunction;
+
 function makeTextDecoderICU() {
   const {
     decode: _decode,
@@ -399,11 +404,7 @@ function makeTextDecoderICU() {
   class TextDecoder {
     constructor(encoding = 'utf-8', options = kEmptyObject) {
       encoding = `${encoding}`;
-      validateObject(options, 'options', {
-        nullable: true,
-        allowArray: true,
-        allowFunction: true,
-      });
+      validateObject(options, 'options', kValidateObjectAllowObjectsAndNull);
 
       const enc = getEncodingFromLabel(encoding);
       if (enc === undefined)
@@ -448,11 +449,7 @@ function makeTextDecoderICU() {
 
       this.#prepareConverter();
 
-      validateObject(options, 'options', {
-        nullable: true,
-        allowArray: true,
-        allowFunction: true,
-      });
+      validateObject(options, 'options', kValidateObjectAllowObjectsAndNull);
 
       let flags = 0;
       if (options !== null)
@@ -482,11 +479,7 @@ function makeTextDecoderJS() {
   class TextDecoder {
     constructor(encoding = 'utf-8', options = kEmptyObject) {
       encoding = `${encoding}`;
-      validateObject(options, 'options', {
-        nullable: true,
-        allowArray: true,
-        allowFunction: true,
-      });
+      validateObject(options, 'options', kValidateObjectAllowObjectsAndNull);
 
       const enc = getEncodingFromLabel(encoding);
       if (enc === undefined || !hasConverter(enc))
@@ -528,11 +521,7 @@ function makeTextDecoderJS() {
                                        ['ArrayBuffer', 'ArrayBufferView'],
                                        input);
       }
-      validateObject(options, 'options', {
-        nullable: true,
-        allowArray: true,
-        allowFunction: true,
-      });
+      validateObject(options, 'options', kValidateObjectAllowObjectsAndNull);
 
       if (this[kFlags] & CONVERTER_FLAGS_FLUSH) {
         this[kBOMSeen] = false;

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -30,7 +30,14 @@ const {
     ERR_INVALID_THIS,
   },
 } = require('internal/errors');
-const { validateAbortSignal, validateObject, validateString, validateInternalField, kValidateObjectAllowArray, kValidateObjectAllowFunction } = require('internal/validators');
+const {
+  validateAbortSignal,
+  validateObject,
+  validateString,
+  validateInternalField,
+  kValidateObjectAllowArray,
+  kValidateObjectAllowFunction,
+} = require('internal/validators');
 
 const {
   customInspectSymbol,

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -30,7 +30,7 @@ const {
     ERR_INVALID_THIS,
   },
 } = require('internal/errors');
-const { validateAbortSignal, validateObject, validateString, validateInternalField } = require('internal/validators');
+const { validateAbortSignal, validateObject, validateString, validateInternalField, kValidateObjectAllowArray, kValidateObjectAllowFunction } = require('internal/validators');
 
 const {
   customInspectSymbol,
@@ -1037,9 +1037,7 @@ function validateEventListenerOptions(options) {
 
   if (options === null)
     return kEmptyObject;
-  validateObject(options, 'options', {
-    allowArray: true, allowFunction: true,
-  });
+  validateObject(options, 'options', kValidateObjectAllowArray | kValidateObjectAllowFunction);
   return {
     once: Boolean(options.once),
     capture: Boolean(options.capture),

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -82,6 +82,7 @@ const {
   validateInteger,
   validateObject,
   validateString,
+  kValidateObjectAllowNullable,
 } = require('internal/validators');
 const pathModule = require('path');
 const {
@@ -597,7 +598,7 @@ async function read(handle, bufferOrParams, offset, length, position) {
   if (!isArrayBufferView(buffer)) {
     // This is fh.read(params)
     if (bufferOrParams !== undefined) {
-      validateObject(bufferOrParams, 'options', { nullable: true });
+      validateObject(bufferOrParams, 'options', kValidateObjectAllowNullable);
     }
     ({
       buffer = Buffer.alloc(16384),

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -154,6 +154,7 @@ const { BuiltinModule } = require('internal/bootstrap/realm');
 const {
   validateObject,
   validateString,
+  kValidateObjectAllowArray,
 } = require('internal/validators');
 
 let hexSlice;
@@ -2155,7 +2156,7 @@ function format(...args) {
 }
 
 function formatWithOptions(inspectOptions, ...args) {
-  validateObject(inspectOptions, 'inspectOptions', { allowArray: true });
+  validateObject(inspectOptions, 'inspectOptions', kValidateObjectAllowArray);
   return formatWithOptionsInternal(inspectOptions, args);
 }
 

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -361,7 +361,7 @@ function validateSignalName(signal, name = 'signal') {
   if (signals[signal] === undefined) {
     if (signals[StringPrototypeToUpperCase(signal)] !== undefined) {
       throw new ERR_UNKNOWN_SIGNAL(signal +
-        ' (signals must use all capital letters)');
+                                   ' (signals must use all capital letters)');
     }
 
     throw new ERR_UNKNOWN_SIGNAL(signal);
@@ -379,8 +379,8 @@ function validateSignalName(signal, name = 'signal') {
 const validateBuffer = hideStackFrames((buffer, name = 'buffer') => {
   if (!isArrayBufferView(buffer)) {
     throw new ERR_INVALID_ARG_TYPE(name,
-      ['Buffer', 'TypedArray', 'DataView'],
-      buffer);
+                                   ['Buffer', 'TypedArray', 'DataView'],
+                                   buffer);
   }
 });
 
@@ -394,7 +394,7 @@ function validateEncoding(data, encoding) {
 
   if (normalizedEncoding === 'hex' && length % 2 !== 0) {
     throw new ERR_INVALID_ARG_VALUE('encoding', encoding,
-      `is invalid for data of length ${length}`);
+                                    `is invalid for data of length ${length}`);
   }
 }
 
@@ -408,10 +408,10 @@ function validateEncoding(data, encoding) {
  */
 function validatePort(port, name = 'Port', allowZero = true) {
   if ((typeof port !== 'number' && typeof port !== 'string') ||
-    (typeof port === 'string' && StringPrototypeTrim(port).length === 0) ||
-    +port !== (+port >>> 0) ||
-    port > 0xFFFF ||
-    (port === 0 && !allowZero)) {
+      (typeof port === 'string' && StringPrototypeTrim(port).length === 0) ||
+      +port !== (+port >>> 0) ||
+      port > 0xFFFF ||
+      (port === 0 && !allowZero)) {
     throw new ERR_SOCKET_BAD_PORT(name, port, allowZero);
   }
   return port | 0;
@@ -426,9 +426,9 @@ function validatePort(port, name = 'Port', allowZero = true) {
 /** @type {validateAbortSignal} */
 const validateAbortSignal = hideStackFrames((signal, name) => {
   if (signal !== undefined &&
-    (signal === null ||
-      typeof signal !== 'object' ||
-      !('aborted' in signal))) {
+      (signal === null ||
+       typeof signal !== 'object' ||
+       !('aborted' in signal))) {
     throw new ERR_INVALID_ARG_TYPE(name, 'AbortSignal', signal);
   }
 });

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -177,7 +177,7 @@ function validateNumber(value, name, min = undefined, max) {
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
 
   if ((min != null && value < min) || (max != null && value > max) ||
-      ((min != null || max != null) && NumberIsNaN(value))) {
+    ((min != null || max != null) && NumberIsNaN(value))) {
     throw new ERR_OUT_OF_RANGE(
       name,
       `${min != null ? `>= ${min}` : ''}${min != null && max != null ? ' && ' : ''}${max != null ? `<= ${max}` : ''}`,
@@ -218,41 +218,47 @@ function validateBoolean(value, name) {
     throw new ERR_INVALID_ARG_TYPE(name, 'boolean', value);
 }
 
-/**
- * @param {any} options
- * @param {string} key
- * @param {boolean} defaultValue
- * @returns {boolean}
- */
-function getOwnPropertyValueOrDefault(options, key, defaultValue) {
-  return options == null || !ObjectPrototypeHasOwnProperty(options, key) ?
-    defaultValue :
-    options[key];
-}
+const kValidateObjectAllowNullable = 1 << 0;
+const kValidateObjectAllowArray = 1 << 1;
+const kValidateObjectAllowFunction = 1 << 2;
 
 /**
  * @callback validateObject
  * @param {*} value
  * @param {string} name
- * @param {{
- *   allowArray?: boolean,
- *   allowFunction?: boolean,
- *   nullable?: boolean
- * }} [options]
+ * @param {number} [options]
  */
 
 /** @type {validateObject} */
 const validateObject = hideStackFrames(
-  (value, name, options = null) => {
-    const allowArray = getOwnPropertyValueOrDefault(options, 'allowArray', false);
-    const allowFunction = getOwnPropertyValueOrDefault(options, 'allowFunction', false);
-    const nullable = getOwnPropertyValueOrDefault(options, 'nullable', false);
-    if ((!nullable && value === null) ||
-        (!allowArray && ArrayIsArray(value)) ||
-        (typeof value !== 'object' && (
-          !allowFunction || typeof value !== 'function'
-        ))) {
-      throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
+  (value, name, options = 0) => {
+    if (options === 0) {
+      if (value === null || ArrayIsArray(value)) {
+        throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
+      }
+
+      if (typeof value !== 'object') {
+        throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
+      }
+    } else {
+      const throwOnNullable = (kValidateObjectAllowNullable & options) === 0;
+
+      if (throwOnNullable && value === null) {
+        throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
+      }
+
+      const throwOnArray = (kValidateObjectAllowArray & options) === 0;
+
+      if (throwOnArray && ArrayIsArray(value)) {
+        throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
+      }
+
+      const throwOnFunction = (kValidateObjectAllowFunction & options) === 0;
+      const typeofValue = typeof value;
+
+      if (typeofValue !== 'object' && (throwOnFunction || typeofValue !== 'function')) {
+        throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
+      }
     }
   });
 
@@ -355,7 +361,7 @@ function validateSignalName(signal, name = 'signal') {
   if (signals[signal] === undefined) {
     if (signals[StringPrototypeToUpperCase(signal)] !== undefined) {
       throw new ERR_UNKNOWN_SIGNAL(signal +
-                                   ' (signals must use all capital letters)');
+        ' (signals must use all capital letters)');
     }
 
     throw new ERR_UNKNOWN_SIGNAL(signal);
@@ -373,8 +379,8 @@ function validateSignalName(signal, name = 'signal') {
 const validateBuffer = hideStackFrames((buffer, name = 'buffer') => {
   if (!isArrayBufferView(buffer)) {
     throw new ERR_INVALID_ARG_TYPE(name,
-                                   ['Buffer', 'TypedArray', 'DataView'],
-                                   buffer);
+      ['Buffer', 'TypedArray', 'DataView'],
+      buffer);
   }
 });
 
@@ -388,7 +394,7 @@ function validateEncoding(data, encoding) {
 
   if (normalizedEncoding === 'hex' && length % 2 !== 0) {
     throw new ERR_INVALID_ARG_VALUE('encoding', encoding,
-                                    `is invalid for data of length ${length}`);
+      `is invalid for data of length ${length}`);
   }
 }
 
@@ -402,10 +408,10 @@ function validateEncoding(data, encoding) {
  */
 function validatePort(port, name = 'Port', allowZero = true) {
   if ((typeof port !== 'number' && typeof port !== 'string') ||
-      (typeof port === 'string' && StringPrototypeTrim(port).length === 0) ||
-      +port !== (+port >>> 0) ||
-      port > 0xFFFF ||
-      (port === 0 && !allowZero)) {
+    (typeof port === 'string' && StringPrototypeTrim(port).length === 0) ||
+    +port !== (+port >>> 0) ||
+    port > 0xFFFF ||
+    (port === 0 && !allowZero)) {
     throw new ERR_SOCKET_BAD_PORT(name, port, allowZero);
   }
   return port | 0;
@@ -420,9 +426,9 @@ function validatePort(port, name = 'Port', allowZero = true) {
 /** @type {validateAbortSignal} */
 const validateAbortSignal = hideStackFrames((signal, name) => {
   if (signal !== undefined &&
-      (signal === null ||
-       typeof signal !== 'object' ||
-       !('aborted' in signal))) {
+    (signal === null ||
+      typeof signal !== 'object' ||
+      !('aborted' in signal))) {
     throw new ERR_INVALID_ARG_TYPE(name, 'AbortSignal', signal);
   }
 });
@@ -564,6 +570,9 @@ module.exports = {
   validateInteger,
   validateNumber,
   validateObject,
+  kValidateObjectAllowNullable,
+  kValidateObjectAllowArray,
+  kValidateObjectAllowFunction,
   validateOneOf,
   validatePlainFunction,
   validatePort,

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -218,6 +218,7 @@ function validateBoolean(value, name) {
     throw new ERR_INVALID_ARG_TYPE(name, 'boolean', value);
 }
 
+const kValidateObjectNone = 0;
 const kValidateObjectAllowNullable = 1 << 0;
 const kValidateObjectAllowArray = 1 << 1;
 const kValidateObjectAllowFunction = 1 << 2;
@@ -231,8 +232,8 @@ const kValidateObjectAllowFunction = 1 << 2;
 
 /** @type {validateObject} */
 const validateObject = hideStackFrames(
-  (value, name, options = 0) => {
-    if (options === 0) {
+  (value, name, options = kValidateObjectNone) => {
+    if (options === kValidateObjectNone) {
       if (value === null || ArrayIsArray(value)) {
         throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
       }
@@ -570,6 +571,7 @@ module.exports = {
   validateInteger,
   validateNumber,
   validateObject,
+  kValidateObjectNone,
   kValidateObjectAllowNullable,
   kValidateObjectAllowArray,
   kValidateObjectAllowFunction,

--- a/lib/internal/vm.js
+++ b/lib/internal/vm.js
@@ -17,13 +17,15 @@ const {
   validateString,
   validateStringArray,
   validateUint32,
+  kValidateObjectAllowArray,
+  kValidateObjectAllowNullable,
 } = require('internal/validators');
 const {
   ERR_INVALID_ARG_TYPE,
 } = require('internal/errors').codes;
 
 function isContext(object) {
-  validateObject(object, 'object', { __proto__: null, allowArray: true });
+  validateObject(object, 'object', kValidateObjectAllowArray);
 
   return _isContext(object);
 }
@@ -67,7 +69,7 @@ function internalCompileFunction(code, params, options) {
   validateArray(contextExtensions, 'options.contextExtensions');
   ArrayPrototypeForEach(contextExtensions, (extension, i) => {
     const name = `options.contextExtensions[${i}]`;
-    validateObject(extension, name, { __proto__: null, nullable: true });
+    validateObject(extension, name, kValidateObjectAllowNullable);
   });
 
   const result = compileFunction(

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -59,6 +59,8 @@ const {
   validateAbortSignal,
   validateBuffer,
   validateObject,
+  kValidateObjectAllowNullable,
+  kValidateObjectAllowFunction,
 } = require('internal/validators');
 
 const {
@@ -345,7 +347,7 @@ class ReadableStream {
   getReader(options = kEmptyObject) {
     if (!isReadableStream(this))
       throw new ERR_INVALID_THIS('ReadableStream');
-    validateObject(options, 'options', { nullable: true, allowFunction: true });
+    validateObject(options, 'options', kValidateObjectAllowNullable | kValidateObjectAllowFunction);
     const mode = options?.mode;
 
     if (mode === undefined)

--- a/test/benchmark/test-benchmark-validators.js
+++ b/test/benchmark/test-benchmark-validators.js
@@ -1,0 +1,10 @@
+'use strict';
+
+require('../common');
+
+// Minimal test for assert benchmarks. This makes sure the benchmarks aren't
+// completely broken but nothing more than that.
+
+const runBenchmark = require('../common/benchmark');
+
+runBenchmark('validators');

--- a/test/parallel/test-validators.js
+++ b/test/parallel/test-validators.js
@@ -9,6 +9,9 @@ const {
   validateInteger,
   validateNumber,
   validateObject,
+  kValidateObjectAllowNullable,
+  kValidateObjectAllowArray,
+  kValidateObjectAllowFunction,
   validateString,
   validateInt32,
   validateUint32,
@@ -106,10 +109,6 @@ const invalidArgValueError = {
 
 {
   // validateObject tests.
-  Object.prototype.nullable = true;
-  Object.prototype.allowArray = true;
-  Object.prototype.allowFunction = true;
-
   validateObject({}, 'foo');
   validateObject({ a: 42, b: 'foo' }, 'foo');
 
@@ -121,18 +120,14 @@ const invalidArgValueError = {
     });
 
   // validateObject options tests:
-  validateObject(null, 'foo', { nullable: true });
-  validateObject([], 'foo', { allowArray: true });
-  validateObject(() => {}, 'foo', { allowFunction: true });
+  validateObject(null, 'foo', kValidateObjectAllowNullable);
+  validateObject([], 'foo', kValidateObjectAllowArray);
+  validateObject(() => {}, 'foo', kValidateObjectAllowFunction);
 
   // validateObject should not be affected by Object.prototype tampering.
-  assert.throws(() => validateObject(null, 'foo', { allowArray: true }), invalidArgTypeError);
-  assert.throws(() => validateObject([], 'foo', { nullable: true }), invalidArgTypeError);
-  assert.throws(() => validateObject(() => {}, 'foo', { nullable: true }), invalidArgTypeError);
-
-  delete Object.prototype.nullable;
-  delete Object.prototype.allowArray;
-  delete Object.prototype.allowFunction;
+  assert.throws(() => validateObject(null, 'foo', kValidateObjectAllowArray), invalidArgTypeError);
+  assert.throws(() => validateObject([], 'foo', kValidateObjectAllowNullable), invalidArgTypeError);
+  assert.throws(() => validateObject(() => {}, 'foo', kValidateObjectAllowNullable), invalidArgTypeError);
 }
 
 {


### PR DESCRIPTION
Reducing the number of comparisons and allocations when using `validateObject`.

```
                                                               confidence improvement accuracy (*)      (**)     (***)
validators/validate-object.js objectToTest='array' n=100000           ***  28696.95 %    ±1448.43% ±1952.07% ±2591.59%
validators/validate-object.js objectToTest='function' n=100000        ***  28553.34 %    ±1501.99% ±2024.25% ±2687.42%
validators/validate-object.js objectToTest='null' n=100000            ***  25157.86 %    ±1483.43% ±1999.24% ±2654.21%
validators/validate-object.js objectToTest='object' n=100000          ***     60.87 %      ±10.64%   ±14.24%   ±18.70%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 4 comparisons, you can thus
expect the following amount of false-positive results:
  0.20 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.04 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```
