### PR TITLE
src: limit Buffer::kMaxLength to 1TB

### DIFF
--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -30,7 +30,7 @@ namespace node {
 namespace Buffer {
 
 static constexpr size_t kMaxLength =
-    v8::TypedArray::kMaxLength < 0x10000000000ull ? v8::Uint8Array::kMaxLength
+    v8::Uint8Array::kMaxLength < 0x10000000000ull ? v8::Uint8Array::kMaxLength
                                                   : 0x10000000000ull;
 
 typedef void (*FreeCallback)(char* data, void* hint);

--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -29,7 +29,9 @@ namespace node {
 
 namespace Buffer {
 
-static const size_t kMaxLength = v8::TypedArray::kMaxLength;
+static constexpr size_t kMaxLength =
+    v8::TypedArray::kMaxLength < 0x10000000000ull ? v8::Uint8Array::kMaxLength
+                                                  : 0x10000000000ull;
 
 typedef void (*FreeCallback)(char* data, void* hint);
 

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -5,6 +5,7 @@
 
 #include "debug_utils-inl.h"
 #include "env.h"
+#include "node_buffer.h"
 #include "v8.h"
 
 // Use ostringstream to print exact-width integer types
@@ -216,9 +217,10 @@ inline void THROW_ERR_SCRIPT_EXECUTION_TIMEOUT(Environment* env,
 
 inline v8::Local<v8::Value> ERR_BUFFER_TOO_LARGE(v8::Isolate* isolate) {
   char message[128];
-  snprintf(message, sizeof(message),
-      "Cannot create a Buffer larger than 0x%zx bytes",
-      v8::TypedArray::kMaxLength);
+  snprintf(message,
+           sizeof(message),
+           "Cannot create a Buffer larger than 0x%zx bytes",
+           Buffer::kMaxLength);
   return ERR_BUFFER_TOO_LARGE(isolate, message);
 }
 


### PR DESCRIPTION
This change has no real effect for now, as the V8 maximum typed array
length is still `2**32`. When V8 is updated to version 11.9 or later, the
limit will be `2**53-1` on 64-bit architectures, much larger than any
reasonable amount of RAM. This caps the limit at 1TB, which is already
very large and corresponds to the maximum memory that AddressSanitizer
allows to allocate.

Refs: https://github.com/nodejs/node/pull/49876
Refs: https://github.com/nodejs/node-v8/issues/268

