### PR TITLE
test_runner: disallow array in `run` options

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -423,12 +423,8 @@ function watchFiles(testFiles, opts) {
   return filesWatcher;
 }
 
-function run(options) {
-  if (options != null) {
-    validateObject(options, 'options');
-  }
-
-  options = options ?? kEmptyObject;
+function run(options = kEmptyObject) {
+  validateObject(options, 'options');
 
   let { testNamePatterns, shard } = options;
   const { concurrency, timeout, signal, files, inspectPort, watch, setup, only } = options;

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -424,9 +424,12 @@ function watchFiles(testFiles, opts) {
 }
 
 function run(options) {
-  if (options === null || typeof options !== 'object') {
-    options = kEmptyObject;
+  if (options != null) {
+    validateObject(options, 'options');
   }
+
+  options = options ?? kEmptyObject;
+
   let { testNamePatterns, shard } = options;
   const { concurrency, timeout, signal, files, inspectPort, watch, setup, only } = options;
 

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -8,12 +8,6 @@ import assert from 'node:assert';
 const testFixtures = fixtures.path('test-runner');
 
 describe('require(\'node:test\').run', { concurrency: true }, () => {
-  it('should fail when passing array as options', () => {
-    assert.throws(() => run([]), {
-      code: 'ERR_INVALID_ARG_TYPE'
-    });
-  });
-
   it('should run with no tests', async () => {
     const stream = run({ files: [] });
     stream.on('test:fail', common.mustNotCall());
@@ -68,13 +62,6 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
     stream.on('test:pass', common.mustNotCall());
     // eslint-disable-next-line no-unused-vars
     for await (const _ of stream);
-  });
-
-  it('should validate files', async () => {
-    [Symbol(), {}, () => {}, 0, 1, 0n, 1n, '', '1', Promise.resolve([]), true, false]
-      .forEach((files) => assert.throws(() => run({ files }), {
-        code: 'ERR_INVALID_ARG_TYPE'
-      }));
   });
 
   it('should be piped with dot', async () => {
@@ -440,6 +427,22 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
       }));
 
       assert.deepStrictEqual(executedTestFiles.sort(), [...shardsTestsFiles].sort());
+    });
+  });
+
+  describe('validation', () => {
+    it('should only allow array in options.files', async () => {
+      [Symbol(), {}, () => {}, 0, 1, 0n, 1n, '', '1', Promise.resolve([]), true, false]
+        .forEach((files) => assert.throws(() => run({ files }), {
+          code: 'ERR_INVALID_ARG_TYPE'
+        }));
+    });
+
+    it('should only allow object as options', () => {
+      [Symbol(), [], () => {}, 0, 1, 0n, 1n, '', '1', true, false]
+        .forEach((options) => assert.throws(() => run(options), {
+          code: 'ERR_INVALID_ARG_TYPE'
+        }));
     });
   });
 });

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -8,6 +8,11 @@ import assert from 'node:assert';
 const testFixtures = fixtures.path('test-runner');
 
 describe('require(\'node:test\').run', { concurrency: true }, () => {
+  it('should fail when passing array as options', () => {
+    assert.throws(() => run([]), {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
+  });
 
   it('should run with no tests', async () => {
     const stream = run({ files: [] });


### PR DESCRIPTION
is this a major change (on the surface it looks like it does)?

did this as I accidentally passed array of files as the run argument instead of inside the `files` option