### PR TITLE
lib: make fetch sync and return a Promise

### DIFF
--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -292,7 +292,8 @@ function setupUndici() {
   }
 
   if (!getOptionValue('--no-experimental-fetch')) {
-    async function fetch(input, init = undefined) {
+    // Fetch is meant to return a Promise, but not be async.
+    function fetch(input, init = undefined) {
       return lazyUndici().fetch(input, init);
     }
 

--- a/test/parallel/test-fetch.mjs
+++ b/test/parallel/test-fetch.mjs
@@ -10,6 +10,14 @@ assert.strictEqual(typeof globalThis.Headers, 'function');
 assert.strictEqual(typeof globalThis.Request, 'function');
 assert.strictEqual(typeof globalThis.Response, 'function');
 
+{
+  const asyncFunction = async function() {}.constructor;
+
+  assert.ok(!(fetch instanceof asyncFunction));
+  assert.notStrictEqual(Reflect.getPrototypeOf(fetch), Reflect.getPrototypeOf(async function() {}));
+  assert.strictEqual(Reflect.getPrototypeOf(fetch), Reflect.getPrototypeOf(function() {}));
+}
+
 const server = http.createServer(common.mustCall((req, res) => {
   res.end('Hello world');
 }));


### PR DESCRIPTION
I haven't tracked down exactly where the webidl spec says this, but every other platform I've tested matches this behavior. This has been nagging at me for a while 😅