### PR TITLE
test_runner: replace spurious if with else

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -86,7 +86,7 @@ function stopTest(timeout, signal) {
 
   if (timeout === kDefaultTimeout) {
     disposeFunction = abortListener[SymbolDispose];
-  } if (timeout !== kDefaultTimeout) {
+  } else {
     timer = setTimeout(() => deferred.resolve(), timeout);
     timer.unref();
 


### PR DESCRIPTION
There is an `if` statement that likely should have been an `else` in the original PR.

Refs: https://github.com/nodejs/node/pull/48915