### PR TITLE
esm: allow `--import` to define main entry

### DIFF
--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  ArrayPrototypeAt,
   StringPrototypeEndsWith,
 } = primordials;
 
@@ -53,15 +54,15 @@ function shouldUseESMLoader(mainPath) {
 
 /**
  * Run the main entry point through the ESM Loader.
- * @param {string} mainPath Absolute path to the main entry point
+ * @param {string} mainEntry - Absolute path to the main entry point, or a specifier to be resolved by the ESM Loader
  */
-function runMainESM(mainPath) {
+function runMainESM(mainEntry) {
   const { loadESM } = require('internal/process/esm_loader');
   const { pathToFileURL } = require('internal/url');
 
   handleMainPromise(loadESM((esmLoader) => {
-    const main = path.isAbsolute(mainPath) ?
-      pathToFileURL(mainPath).href : mainPath;
+    const main = path.isAbsolute(mainEntry) ?
+      pathToFileURL(mainEntry).href : mainEntry;
     return esmLoader.import(main, undefined, { __proto__: null });
   }));
 }
@@ -89,6 +90,18 @@ async function handleMainPromise(promise) {
  * @param {string} main CLI main entry point string
  */
 function executeUserEntryPoint(main = process.argv[1]) {
+  if (!main) {
+    const importFlagValues = getOptionValue('--import');
+    if (importFlagValues.length > 0) {
+      // No main entry point was specified, but --import was used, so we'll use the last --import value as the entry.
+      // Because --import takes specifiers that get resolved by the ESM resolution algorithm, we pass it through to be
+      // resolved later.
+      const entry = ArrayPrototypeAt(importFlagValues, -1);
+      runMainESM(entry);
+      return;
+    }
+  }
+
   const resolvedMain = resolveMainPath(main);
   const useESMLoader = shouldUseESMLoader(resolvedMain);
   if (useESMLoader) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -360,7 +360,9 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
     return StartExecution(env, "internal/main/watch_mode");
   }
 
-  if (!first_argv.empty() && first_argv != "-") {
+  if ((!first_argv.empty() && first_argv != "-") ||
+      (first_argv.empty() && !env->options()->force_repl &&
+       !env->options()->preload_esm_modules.empty())) {
     return StartExecution(env, "internal/main/run_main_module");
   }
 


### PR DESCRIPTION
This PR changes the behavior of `node --import ./entry.js` from running `entry.js` and then launching the REPL; to running `entry.js` as the main entry point. **This is a semver-major change**; to preserve the prior behavior, the user must additionally pass `-i` or `--interactive`, so like `node --import ./entry.js --interactive`.

There are a few reasons for this change in behavior:

- It provides a way to run a URL as the main entry point, because the values of `--import` are parsed as URLs. Users can run `node --import ./entry.js?foo=bar` or `node --import data:text/javascript,console.log("Hello")`.

- It provides a way to run a bare specifier as the main entry point, for example `node --import typescript-repl`.

This satisfies the “define the main entry point as a URL” part of https://github.com/nodejs/node/issues/49432.

Since this is a semver-major change, it cannot be backported. `node --import ./entry.js?foo=bar --eval ''` can achieve very similar results in current and past versions of Node. See also https://github.com/nodejs/node/issues/49432#issuecomment-1739626273. @nodejs/loaders 