### PR TITLE
vm: use default host-defined options when importModuleDynamically is not set

### DIFF
--- a/benchmark/vm/compile-script-in-isolate-cache.js
+++ b/benchmark/vm/compile-script-in-isolate-cache.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// This benchmarks compiling scripts that hit the in-isolate compilation
+// cache (by having the same source).
+const common = require('../common.js');
+const fs = require('fs');
+const vm = require('vm');
+const fixtures = require('../../test/common/fixtures.js');
+const scriptPath = fixtures.path('snapshot', 'typescript.js');
+
+const bench = common.createBenchmark(main, {
+  type: ['with-dynamic-import-callback', 'without-dynamic-import-callback'],
+  n: [100],
+});
+
+const scriptSource = fs.readFileSync(scriptPath, 'utf8');
+
+function main({ n, type }) {
+  let script;
+  bench.start();
+  const options = {};
+  switch (type) {
+    case 'with-dynamic-import-callback':
+      // Use a dummy callback for now until we really need to benchmark it.
+      options.importModuleDynamically = async () => {};
+      break;
+    case 'without-dynamic-import-callback':
+      break;
+  }
+  for (let i = 0; i < n; i++) {
+    script = new vm.Script(scriptSource, options);
+  }
+  bench.end(n);
+  script.runInThisContext();
+}

--- a/lib/internal/modules/esm/utils.js
+++ b/lib/internal/modules/esm/utils.js
@@ -13,6 +13,10 @@ const {
   },
 } = internalBinding('util');
 const {
+  default_host_defined_options,
+} = internalBinding('symbols');
+
+const {
   ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING,
   ERR_INVALID_ARG_VALUE,
 } = require('internal/errors').codes;
@@ -128,6 +132,13 @@ const moduleRegistries = new SafeWeakMap();
  */
 function registerModule(referrer, registry) {
   const idSymbol = referrer[host_defined_option_symbol];
+  if (idSymbol === default_host_defined_options) {
+    // The referrer is compiled without custom callbacks, so there is
+    // no registry to hold on to. We'll throw
+    // ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING when a callback is
+    // needed.
+    return;
+  }
   // To prevent it from being GC'ed.
   registry.callbackReferrer ??= referrer;
   moduleRegistries.set(idSymbol, registry);

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -86,6 +86,12 @@ class Script extends ContextifyScript {
     }
     validateBoolean(produceCachedData, 'options.produceCachedData');
 
+    if (importModuleDynamically !== undefined) {
+      // Check that it's either undefined or a function before we pass
+      // it into the native constructor.
+      validateFunction(importModuleDynamically,
+                       'options.importModuleDynamically');
+    }
     // Calling `ReThrow()` on a native TryCatch does not generate a new
     // abort-on-uncaught-exception check. A dummy try/catch in JS land
     // protects against that.
@@ -96,14 +102,13 @@ class Script extends ContextifyScript {
             columnOffset,
             cachedData,
             produceCachedData,
-            parsingContext);
+            parsingContext,
+            importModuleDynamically !== undefined);
     } catch (e) {
       throw e; /* node-do-not-add-exception-line */
     }
 
     if (importModuleDynamically !== undefined) {
-      validateFunction(importModuleDynamically,
-                       'options.importModuleDynamically');
       const { importModuleDynamicallyWrap } = require('internal/vm/module');
       const { registerModule } = require('internal/modules/esm/utils');
       registerModule(this, {

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -33,6 +33,7 @@
 // Symbols are per-isolate primitives but Environment proxies them
 // for the sake of convenience.
 #define PER_ISOLATE_SYMBOL_PROPERTIES(V)                                       \
+  V(default_host_defined_options, "default_host_defined_options")              \
   V(fs_use_promises_symbol, "fs_use_promises_symbol")                          \
   V(async_id_symbol, "async_id_symbol")                                        \
   V(handle_onclose_symbol, "handle_onclose")                                   \

--- a/test/parallel/test-vm-no-dynamic-import-callback.js
+++ b/test/parallel/test-vm-no-dynamic-import-callback.js
@@ -1,11 +1,10 @@
-
 'use strict';
 
 require('../common');
 const { Script } = require('vm');
 const assert = require('assert');
 
-assert.rejects(async() => {
+assert.rejects(async () => {
   const script = new Script('import("fs")');
   const imported = script.runInThisContext();
   await imported;

--- a/test/parallel/test-vm-no-dynamic-import-callback.js
+++ b/test/parallel/test-vm-no-dynamic-import-callback.js
@@ -1,0 +1,14 @@
+
+'use strict';
+
+require('../common');
+const { Script } = require('vm');
+const assert = require('assert');
+
+assert.rejects(async() => {
+  const script = new Script('import("fs")');
+  const imported = script.runInThisContext();
+  await imported;
+}, {
+  code: 'ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING'
+});


### PR DESCRIPTION
This makes it possile to hit the in-isolate compilation cache when host-defined options are not necessary.

Local benchmark numbers: huge variance because when the cache is missed (in the main branch) it is just toooooo slow, I think we can keep n fairly small for now until we no longer need to compare the cache-miss cases, but the speed up is very visible if you just run the benchmark locally - with cache hit it finishes in a blink of an eye and without cache it gets stuck for a few seconds.

```
                                                                                   confidence improvement accuracy (*)     (**)    (***)
vm/compile-script-in-isolate-cache.js n=100 type='with-dynamic-import-callback'                   -0.33 %       ±0.81%   ±1.08%   ±1.41%
vm/compile-script-in-isolate-cache.js n=100 type='without-dynamic-import-callback'        ***   9132.25 %     ±319.74% ±433.30% ±580.24%
```

Refs: https://github.com/nodejs/node/issues/35375
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
