### PR TITLE
errors: fix stacktrace of SystemError, add more tests and benchmark

### DIFF
--- a/benchmark/error/system-error-instantiation.js
+++ b/benchmark/error/system-error-instantiation.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e6],
+  code: [
+    'built-in',
+    'ERR_FS_CP_DIR_TO_NON_DIR',
+  ],
+  stackTraceLimit: [0, 10],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function getErrorFactory(code) {
+  const {
+    ERR_FS_CP_DIR_TO_NON_DIR,
+  } = require('internal/errors').codes;
+
+  switch (code) {
+    case 'built-in':
+      return (n) => new Error();
+    case 'ERR_FS_CP_DIR_TO_NON_DIR':
+      return (n) => new ERR_FS_CP_DIR_TO_NON_DIR({
+        message: 'cannot overwrite directory',
+        path: 'dest',
+        syscall: 'cp',
+        errno: 21,
+        code: 'EISDIR',
+      });
+    default:
+      throw new Error(`${code} not supported`);
+  }
+}
+
+function main({ n, code, stackTraceLimit }) {
+  const getError = getErrorFactory(code);
+
+  Error.stackTraceLimit = stackTraceLimit;
+
+  // Warm up.
+  const length = 1024;
+  const array = [];
+  for (let i = 0; i < length; ++i) {
+    array.push(getError(i));
+  }
+
+  bench.start();
+
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    array[index] = getError(index);
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], 'object');
+  }
+}

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -241,11 +241,7 @@ function inspectWithNoCustomRetry(obj, options) {
 // and may have .path and .dest.
 class SystemError extends Error {
   constructor(key, context) {
-    const limit = Error.stackTraceLimit;
-    if (isErrorStackTraceLimitWritable()) Error.stackTraceLimit = 0;
     super();
-    // Reset the limit and setting the name property.
-    if (isErrorStackTraceLimitWritable()) Error.stackTraceLimit = limit;
     const prefix = getMessage(key, [], this);
     let message = `${prefix}: ${context.syscall} returned ` +
                   `${context.code} (${context.message})`;
@@ -254,8 +250,6 @@ class SystemError extends Error {
       message += ` ${context.path}`;
     if (context.dest !== undefined)
       message += ` => ${context.dest}`;
-
-    captureLargerStackTrace(this);
 
     this.code = key;
 

--- a/test/parallel/test-errors-systemerror.js
+++ b/test/parallel/test-errors-systemerror.js
@@ -3,7 +3,8 @@
 
 require('../common');
 const assert = require('assert');
-const { E, SystemError, codes } = require('internal/errors');
+const { E, SystemError, codes, kIsNodeError } = require('internal/errors');
+const { inspect } = require('internal/util/inspect');
 
 assert.throws(
   () => { new SystemError(); },
@@ -31,7 +32,7 @@ const { ERR_TEST } = codes;
       code: 'ERR_TEST',
       name: 'SystemError',
       message: 'custom message: syscall_test returned ETEST (code message)' +
-               ' /str => /str2',
+        ' /str => /str2',
       info: ctx
     }
   );
@@ -51,7 +52,7 @@ const { ERR_TEST } = codes;
       code: 'ERR_TEST',
       name: 'SystemError',
       message: 'custom message: syscall_test returned ETEST (code message)' +
-               ' /buf => /str2',
+        ' /buf => /str2',
       info: ctx
     }
   );
@@ -71,7 +72,7 @@ const { ERR_TEST } = codes;
       code: 'ERR_TEST',
       name: 'SystemError',
       message: 'custom message: syscall_test returned ETEST (code message)' +
-               ' /buf => /buf2',
+        ' /buf => /buf2',
       info: ctx
     }
   );
@@ -110,6 +111,11 @@ const { ERR_TEST } = codes;
   assert.strictEqual(err.syscall, 'test');
   assert.strictEqual(err.path, 'path');
   assert.strictEqual(err.dest, 'path');
+
+  assert.strictEqual(err.info.errno, 321);
+  assert.strictEqual(err.info.dest.toString(), 'path');
+  assert.strictEqual(err.info.path.toString(), 'path');
+  assert.strictEqual(err.info.syscall, 'test');
 }
 
 {
@@ -128,8 +134,277 @@ const { ERR_TEST } = codes;
       code: 'ERR_TEST',
       name: 'Foobar',
       message: 'custom message: syscall_test returned ERR_TEST ' +
-               '(Error occurred)',
+        '(Error occurred)',
       info: ctx
     }
+  );
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // is set to true
+  assert.strictEqual(err[kIsNodeError], true);
+
+  // is not writable
+  assert.throws(
+    () => { err[kIsNodeError] = false; },
+    {
+      name: 'TypeError',
+      message: /Symbol\(kIsNodeError\)/,
+    }
+  );
+
+  // is not enumerable
+  assert.strictEqual(Object.prototype.propertyIsEnumerable.call(err, kIsNodeError), false);
+
+  // is configurable
+  delete err[kIsNodeError];
+  assert.strictEqual(kIsNodeError in err, false);
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // is set to true
+  assert.strictEqual(err.name, 'SystemError');
+
+  // is writable
+  err.name = 'CustomError';
+  assert.strictEqual(err.name, 'CustomError');
+
+  // is not enumerable
+  assert.strictEqual(Object.prototype.propertyIsEnumerable.call(err, 'name'), false);
+
+  // is configurable
+  delete err.name;
+  assert.strictEqual(err.name, 'Error');
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // Is set with the correct message
+  assert.strictEqual(err.message, 'custom message: syscall_test returned ERR (something happened)');
+
+  // is writable
+  err.message = 'custom message';
+  assert.strictEqual(err.message, 'custom message');
+
+  // is not enumerable
+  assert.strictEqual(Object.prototype.propertyIsEnumerable.call(err, 'message'), false);
+
+  // is configurable
+  delete err.message;
+  assert.strictEqual(err.message, '');
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // Is set to the correct syscall
+  assert.strictEqual(err.syscall, 'syscall_test');
+
+  // is writable
+  err.syscall = 'custom syscall';
+  assert.strictEqual(err.syscall, 'custom syscall');
+
+  // is enumerable
+  assert(Object.prototype.propertyIsEnumerable.call(err, 'syscall'));
+
+  // is configurable
+  delete err.syscall;
+  assert.strictEqual('syscall' in err, false);
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // Is set to the correct errno
+  assert.strictEqual(err.errno, 123);
+
+  // is writable
+  err.errno = 'custom errno';
+  assert.strictEqual(err.errno, 'custom errno');
+
+  // is enumerable
+  assert(Object.prototype.propertyIsEnumerable.call(err, 'errno'));
+
+  // is configurable
+  delete err.errno;
+  assert.strictEqual('errno' in err, false);
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // Is set to the correct info
+  assert.strictEqual(Object.keys(err.info).length, 4);
+  assert.strictEqual(err.info.errno, 123);
+  assert.strictEqual(err.info.code, 'ERR');
+  assert.strictEqual(err.info.message, 'something happened');
+  assert.strictEqual(err.info.syscall, 'syscall_test');
+
+  // is not writable
+  assert.throws(
+    () => {
+      err.info = {
+        ...ctx,
+        errno: 124
+      };
+    },
+    {
+      name: 'TypeError',
+      message: /'info'/,
+    }
+  );
+
+  assert.strictEqual(Object.keys(err.info).length, 4);
+  assert.strictEqual(err.info.errno, 123);
+  assert.strictEqual(err.info.code, 'ERR');
+  assert.strictEqual(err.info.message, 'something happened');
+  assert.strictEqual(err.info.syscall, 'syscall_test');
+
+  // is enumerable
+  assert(Object.prototype.propertyIsEnumerable.call(err, 'info'));
+
+  // is configurable
+  delete err.info;
+
+  assert.strictEqual('info' in err, false);
+}
+
+{
+  // Make sure the stack trace does not contain SystemError
+  try {
+    throw new ERR_TEST({
+      code: 'ERR',
+      errno: 123,
+      message: 'something happened',
+      syscall: 'syscall_test',
+    });
+  } catch (e) {
+    assert.doesNotMatch(e.stack, /at new SystemError/);
+    assert.match(e.stack.split('\n')[1], /test-errors-systemerror\.js/);
+  }
+}
+
+{
+  // Make sure the stack trace has the correct number of frames
+  const limit = Error.stackTraceLimit;
+  Error.stackTraceLimit = 3;
+  function a() {
+    b();
+  }
+
+  function b() {
+    c();
+  }
+
+  function c() {
+    throw new ERR_TEST({
+      code: 'ERR',
+      errno: 123,
+      message: 'something happened',
+      syscall: 'syscall_test',
+    });
+  }
+  try {
+    a();
+  } catch (e) {
+    assert.doesNotMatch(e.stack, /at new SystemError/);
+    assert.match(e.stack.split('\n')[1], /test-errors-systemerror\.js/);
+    assert.match(e.stack.split('\n')[1], /at c \(/);
+    assert.match(e.stack.split('\n')[2], /test-errors-systemerror\.js/);
+    assert.match(e.stack.split('\n')[2], /at b \(/);
+    assert.match(e.stack.split('\n')[3], /test-errors-systemerror\.js/);
+    assert.match(e.stack.split('\n')[3], /at a \(/);
+    assert.strictEqual(e.stack.split('\n').length, 4);
+  } finally {
+    Error.stackTraceLimit = limit;
+  }
+}
+
+{
+  // Inspect should return the correct string
+  const err = new ERR_TEST({
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+    custom: 'custom'
+  });
+  let inspectedErr = inspect(err);
+
+  assert.ok(inspectedErr.includes(`info: {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+    custom: 'custom'
+  },`));
+
+  err.syscall = 'custom_syscall';
+
+  inspectedErr = inspect(err);
+
+  assert.ok(inspectedErr.includes(`info: {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'custom_syscall',
+    custom: 'custom'
+  },`));
+}
+
+{
+  // toString should return the correct string
+
+  const err = new ERR_TEST({
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  });
+
+  assert.strictEqual(
+    err.toString(),
+    'SystemError [ERR_TEST]: custom message: syscall_test returned ERR (something happened)'
   );
 }


### PR DESCRIPTION
Before I wanted to tackle the performance of SystemError I wanted better test coverage for SystemError.

While I was working on the tests, I realized that the stacktrace for SystemError is wrong. I fixed it accordingly ;). It also has slightly performance gains. 

So my proposal is:
- Review and merge of this PR.
- Follow Up PR for optimizing the SystemError instanciation

Benefit of this separate PR is, that we can see by the changes in the tests, if the behaviour of SystemError got changed.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
