### PR TITLE
stream: optimize writable fast path

### DIFF
--- a/benchmark/streams/writable-manywrites.js
+++ b/benchmark/streams/writable-manywrites.js
@@ -24,6 +24,7 @@ function main({ n, sync, writev, callback, len }) {
   };
 
   if (writev === 'yes') {
+    s._writev2 = (chunks, encoding, cb) => writecb(cb);
     s._writev = (chunks, cb) => writecb(cb);
   } else {
     s._write = (chunk, encoding, cb) => writecb(cb);

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -479,7 +479,9 @@ function doWrite(stream, state, writev, len, chunk, encoding, cb) {
   state.state |= kWriting | kSync;
   if ((state.state & kDestroyed) !== 0)
     state.onwrite(new ERR_STREAM_DESTROYED('write'));
-  else if (writev)
+  else if (writev && stream._writev2)
+    stream._writev2(chunk, encoding, state.onwrite);
+  else if (writev && stream._writev)
     stream._writev(chunk, state.onwrite);
   else
     stream._write(chunk, encoding, state.onwrite);
@@ -621,8 +623,16 @@ function clearBuffer(stream, state) {
   let i = bufferedIndex;
 
   state.state |= kBufferProcessing;
-  if (bufferedLength > 1 && stream._writev) {
+  if (bufferedLength > 1 && stream._writev2 && (state.state & kSimpleBuffer) !== 0) {
     state.pendingcb -= bufferedLength - 1;
+
+    doWrite(stream, state, true, state.length, state.buffered, 'utf8', nop);
+
+    resetBuffer(state);
+  } else if (bufferedLength > 1 && stream._writev) {
+    state.pendingcb -= bufferedLength - 1;
+
+    const allBuffers = (state.state & kAllBuffers) !== 0;
 
     let chunks;
     let callback;
@@ -638,12 +648,12 @@ function clearBuffer(stream, state) {
       callback = nop;
       chunks = state.buffered.map(chunk => ({
         chunk,
-        encoding: typeof chunk === 'string' ? 'utf8' : 'buffer',
+        encoding: !allBuffers && typeof chunk === 'string' ? 'utf8' : 'buffer',
         callback
       }))
     }
 
-    chunks.allBuffers = (state.state & kAllBuffers) !== 0;
+    chunks.allBuffers = allBuffers
 
     doWrite(stream, state, true, state.length, chunks, '', callback);
 
@@ -678,7 +688,9 @@ function clearBuffer(stream, state) {
 }
 
 Writable.prototype._write = function(chunk, encoding, cb) {
-  if (this._writev) {
+  if (this._writev2) {
+    this._writev2([chunk], encoding, cb);
+  } else if (this._writev) {
     this._writev([{ chunk, encoding }], cb);
   } else {
     throw new ERR_METHOD_NOT_IMPLEMENTED('_write()');
@@ -686,6 +698,7 @@ Writable.prototype._write = function(chunk, encoding, cb) {
 };
 
 Writable.prototype._writev = null;
+Writable.prototype._writev2 = null;
 
 Writable.prototype.end = function(chunk, encoding, cb) {
   const state = this._writableState;

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -93,7 +93,7 @@ const kWriting = 1 << 15;
 const kBufferProcessing = 1 << 16;
 const kPrefinished = 1 << 17;
 const kAllBuffers = 1 << 18;
-const kAllNoop = 1 << 19;
+const kSimpleBuffer = 1 << 19;
 
 // TODO(benjamingr) it is likely slower to do it this way than with free functions
 function makeBitMapDescriptor(bit) {
@@ -174,8 +174,7 @@ ObjectDefineProperties(WritableState.prototype, {
   // depending on emitClose.
   closeEmitted: makeBitMapDescriptor(kCloseEmitted),
 
-  allBuffers: makeBitMapDescriptor(kAllBuffers),
-  allNoop: makeBitMapDescriptor(kAllNoop),
+  allBuffers: makeBitMapDescriptor(kSimpleBuffer),
 });
 
 function WritableState(options, stream, isDuplex) {
@@ -259,11 +258,17 @@ function WritableState(options, stream, isDuplex) {
 function resetBuffer(state) {
   state.buffered = [];
   state.bufferedIndex = 0;
-  state.state |= kAllBuffers | kAllNoop;
+  state.state |= kAllBuffers | kSimpleBuffer;
 }
 
 WritableState.prototype.getBuffer = function getBuffer() {
-  return ArrayPrototypeSlice(this.buffered, this.bufferedIndex);
+  return (this.state & kSimpleBuffer) === 0
+    ? this.buffered.slice(this.bufferedIndex)
+    : this.buffered.map(chunk => ({
+      chunk,
+      encoding: typeof chunk === 'string' ? 'utf8' : 'buffer',
+      callback: nop
+    }));
 };
 
 ObjectDefineProperty(WritableState.prototype, 'bufferedRequestCount', {
@@ -433,12 +438,27 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
     state.state |= kNeedDrain;
 
   if ((state.state & kWriting) !== 0 || state.corked || state.errored || (state.state & kConstructed) === 0) {
-    state.buffered.push({ chunk, encoding, callback });
-    if ((state.state & kAllBuffers) !== 0 && encoding !== 'buffer') {
-      state.state &= ~kAllBuffers;
+    if (
+      (encoding !== 'buffer' && encoding !== 'utf8') ||
+      callback !== nop ||
+      (state.state & kSimpleBuffer) === 0
+    ) {
+      if ((state.state & kSimpleBuffer) !== 0) {
+        state.buffered = state.buffered.length > 0
+          ? state.buffered.map(chunk => ({
+            chunk,
+            encoding: typeof chunk === 'string' ? 'utf8' : 'buffer',
+            callback: nop
+          }))
+          : state.buffered;
+        state.state &= ~kSimpleBuffer;
+      }
+      state.buffered.push({ chunk, encoding, callback });
+    } else {
+      state.buffered.push(chunk);
     }
-    if ((state.state & kAllNoop) !== 0 && callback !== nop) {
-      state.state &= ~kAllNoop;
+    if (encoding !== 'buffer') {
+      state.state &= ~kAllBuffers;
     }
   } else {
     state.writelen = len;
@@ -567,7 +587,8 @@ function errorBuffer(state) {
   }
 
   for (let n = state.bufferedIndex; n < state.buffered.length; ++n) {
-    const { chunk, callback } = state.buffered[n];
+    const { chunk, callback } = (state.state & kSimpleBuffer) === 0 ? state.buffered[n]
+      : { chunk: state.buffered[n], callback: nop };
     const len = (state.state & kObjectMode) !== 0 ? 1 : chunk.length;
     state.length -= len;
     callback(state.errored ?? new ERR_STREAM_DESTROYED('write'));
@@ -603,27 +624,46 @@ function clearBuffer(stream, state) {
   if (bufferedLength > 1 && stream._writev) {
     state.pendingcb -= bufferedLength - 1;
 
-    const callback = (state.state & kAllNoop) !== 0 ? nop : (err) => {
-      for (let n = i; n < buffered.length; ++n) {
-        buffered[n].callback(err);
-      }
-    };
-    // Make a copy of `buffered` if it's going to be used by `callback` above,
-    // since `doWrite` will mutate the array.
-    const chunks = (state.state & kAllNoop) !== 0 && i === 0 ?
-      buffered : ArrayPrototypeSlice(buffered, i);
+    let chunks;
+    let callback;
+
+    if ((state.state & kSimpleBuffer) === 0) {
+      chunks = state.buffered.slice(0);
+      callback = (err) => {
+        for (let n = i; n < chunks.length; ++n) {
+          chunks[n].callback(err);
+        }
+      };
+    } else {
+      callback = nop;
+      chunks = state.buffered.map(chunk => ({
+        chunk,
+        encoding: typeof chunk === 'string' ? 'utf8' : 'buffer',
+        callback
+      }))
+    }
+
     chunks.allBuffers = (state.state & kAllBuffers) !== 0;
 
     doWrite(stream, state, true, state.length, chunks, '', callback);
 
     resetBuffer(state);
   } else {
-    do {
-      const { chunk, encoding, callback } = buffered[i];
-      buffered[i++] = null;
-      const len = objectMode ? 1 : chunk.length;
-      doWrite(stream, state, false, len, chunk, encoding, callback);
-    } while (i < buffered.length && (state.state & kWriting) === 0);
+    if ((state.state & kSimpleBuffer) === 0) {
+      do {
+        const { chunk, encoding, callback } = buffered[i];
+        buffered[i++] = null;
+        const len = objectMode ? 1 : chunk.length;
+        doWrite(stream, state, false, len, chunk, encoding, callback);
+      } while (i < buffered.length && (state.state & kWriting) === 0);
+    } else {
+      do {
+        const chunk= buffered[i];
+        buffered[i++] = null;
+        const len = objectMode ? 1 : chunk.length;
+        doWrite(stream, state, false, len, chunk, typeof chunk === 'string' ? 'utf8' : 'buffer', nop);
+      } while (i < buffered.length && (state.state & kWriting) === 0);
+    }
 
     if (i === buffered.length) {
       resetBuffer(state);

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -628,7 +628,7 @@ function clearBuffer(stream, state) {
     let callback;
 
     if ((state.state & kSimpleBuffer) === 0) {
-      chunks = state.buffered.slice(0);
+      chunks = ArrayPrototypeSlice(state.buffered, 0);
       callback = (err) => {
         for (let n = i; n < chunks.length; ++n) {
           chunks[n].callback(err);


### PR DESCRIPTION
```
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='no' n=2000000            ***      2.98 %       ±1.57% ±2.10% ±2.74%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='yes' n=2000000           ***     -5.68 %       ±1.01% ±1.36% ±1.78%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='no' n=2000000           ***    -23.13 %       ±2.48% ±3.32% ±4.36%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='yes' n=2000000          ***     -2.80 %       ±1.54% ±2.06% ±2.71%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='no' n=2000000             *      1.48 %       ±1.17% ±1.56% ±2.03%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='yes' n=2000000          ***     -2.59 %       ±0.97% ±1.29% ±1.69%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='no' n=2000000          ***     -5.82 %       ±2.42% ±3.24% ±4.24%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='yes' n=2000000                  2.55 %       ±2.77% ±3.69% ±4.80%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='no' n=2000000           ***      7.22 %       ±1.57% ±2.10% ±2.73%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='yes' n=2000000          ***     10.24 %       ±1.12% ±1.49% ±1.94%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='no' n=2000000          ***      4.59 %       ±1.31% ±1.74% ±2.26%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='yes' n=2000000         ***     10.53 %       ±1.62% ±2.15% ±2.81%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='no' n=2000000          ***      9.04 %       ±1.05% ±1.40% ±1.82%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='yes' n=2000000         ***     12.41 %       ±2.44% ±3.25% ±4.23%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='no' n=2000000         ***      5.05 %       ±1.93% ±2.58% ±3.37%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='yes' n=2000000        ***      9.61 %       ±1.70% ±2.27% ±2.96%
```