### PR TITLE
test: update skip for moved `test-wasm-web-api`

### DIFF
--- a/test/es-module/es-module.status
+++ b/test/es-module/es-module.status
@@ -9,3 +9,7 @@ prefix es-module
 [$system==linux || $system==freebsd]
 # https://github.com/nodejs/node/issues/47836
 test-esm-loader-http-imports: PASS,FLAKY
+
+[$arch==arm || $arch==arm64]
+# https://github.com/nodejs/node/issues/47297
+test-wasm-web-api: SKIP

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -38,8 +38,6 @@ test-http-server-request-timeouts-mixed: PASS,FLAKY
 # https://github.com/nodejs/node/pull/31178
 test-crypto-dh-stateless: SKIP
 test-crypto-keygen: SKIP
-# https://github.com/nodejs/node/issues/47297
-test-wasm-web-api: SKIP
 
 [$system==solaris] # Also applies to SmartOS
 # https://github.com/nodejs/node/issues/43457


### PR DESCRIPTION
`test-wasm-web-api` was moved from `test/parallel` to `test/es-modules`. Update the status files for parallel and es-modules accordingly.

Refs: https://github.com/nodejs/node/pull/49869
Refs: https://github.com/nodejs/node/pull/47299
Refs: https://github.com/nodejs/node/issues/47297

---

Started seeing `test-wasm-web-api` failing for arm64 debug builds again today. 
e.g. https://ci.nodejs.org/job/node-test-commit-arm-debug/nodes=ubuntu2004_debug-arm64/9557/ seems to be the earliest build that it happened in. 

According to the [reliability repo](https://github.com/search?q=repo%3Anodejs%2Freliability+test-wasm-web-api&type=issues&s=created&o=desc), we saw this test flaking at the beginning of the year. We started skipping it on arm in https://github.com/nodejs/node/pull/47299. https://github.com/nodejs/node/pull/49869 moved the test from `test/parallel` to `test/es-modules` but didn't move the corresponding entry in `test/parallel/parallel.status`.

cc @nodejs/loaders 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
