### PR TITLE
`node:fs` error path performance improvements

### DIFF
--- a/benchmark/fs/bench-chownSync.js
+++ b/benchmark/fs/bench-chownSync.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const assert = require('assert');
+const tmpdir = require('../../test/common/tmpdir');
+
+if (process.platform === 'win32') {
+  console.log('Skipping: Windows does not have `getuid` or `getgid`');
+  process.exit(0);
+}
+
+const bench = common.createBenchmark(main, {
+  type: ['existing', 'non-existing'],
+  method: ['chownSync', 'lchownSync'],
+  n: [1e4],
+});
+
+function main({ n, type, method }) {
+  const uid = process.getuid();
+  const gid = process.getgid();
+  const fsMethod = fs[method];
+
+  switch (type) {
+    case 'existing': {
+      tmpdir.refresh();
+      const tmpfile = tmpdir.resolve(`.existing-file-${process.pid}`);
+      fs.writeFileSync(tmpfile, 'this-is-for-a-benchmark', 'utf8');
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        fsMethod(tmpfile, uid, gid);
+      }
+      bench.end(n);
+      break;
+    }
+    case 'non-existing': {
+      const path = tmpdir.resolve(`.non-existing-file-${Date.now()}`);
+      let hasError = false;
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs[method](path, uid, gid);
+        } catch {
+          hasError = true;
+        }
+      }
+      bench.end(n);
+      assert(hasError);
+      break;
+    }
+    default:
+      new Error('Invalid type');
+  }
+}

--- a/benchmark/fs/bench-linkSync.js
+++ b/benchmark/fs/bench-linkSync.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const assert = require('assert');
+const tmpdir = require('../../test/common/tmpdir');
+
+tmpdir.refresh();
+const tmpfile = tmpdir.resolve(`.bench-file-data-${Date.now()}`);
+fs.writeFileSync(tmpfile, 'bench-file', 'utf-8');
+
+const bench = common.createBenchmark(main, {
+  type: ['valid', 'invalid'],
+  n: [1e3],
+});
+
+function main({ n, type }) {
+  switch (type) {
+    case 'valid': {
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        fs.linkSync(tmpfile, tmpdir.resolve(`.valid-${i}`), 'file');
+      }
+      bench.end(n);
+
+      break;
+    }
+
+    case 'invalid': {
+      let hasError = false;
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.linkSync(
+            tmpdir.resolve(`.non-existing-file-for-linkSync-${i}`),
+            __filename,
+            'file',
+          );
+        } catch {
+          hasError = true;
+        }
+      }
+      bench.end(n);
+      assert(hasError);
+      break;
+    }
+    default:
+      new Error('Invalid type');
+  }
+}

--- a/benchmark/fs/bench-readlinkSync.js
+++ b/benchmark/fs/bench-readlinkSync.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const assert = require('assert');
+const tmpdir = require('../../test/common/tmpdir');
+
+if (process.platform === 'win32') {
+  console.log('Skipping: Windows does not play well with `symlinkSync`');
+  process.exit(0);
+}
+
+const bench = common.createBenchmark(main, {
+  type: ['valid', 'invalid'],
+  n: [1e3],
+});
+
+function main({ n, type }) {
+  switch (type) {
+    case 'valid': {
+      tmpdir.refresh();
+      const tmpfile = tmpdir.resolve(`.readlink-file-${process.pid}`);
+      fs.writeFileSync(tmpfile, 'data', 'utf8');
+      let returnValue;
+      for (let i = 0; i < n; i++) {
+        fs.symlinkSync(tmpfile, tmpdir.resolve(`.readlink-sync-${i}`), 'file');
+      }
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        returnValue = fs.readlinkSync(tmpdir.resolve(`.readlink-sync-${i}`), { encoding: 'utf8' });
+      }
+      bench.end(n);
+      assert(returnValue);
+      break;
+    }
+
+    case 'invalid': {
+      let hasError = false;
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.readlinkSync(tmpdir.resolve('.non-existing-file-for-readlinkSync'));
+        } catch {
+          hasError = true;
+        }
+      }
+      bench.end(n);
+      assert(hasError);
+      break;
+    }
+    default:
+      new Error('Invalid type');
+  }
+}

--- a/benchmark/fs/bench-renameSync.js
+++ b/benchmark/fs/bench-renameSync.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const assert = require('assert');
+const tmpdir = require('../../test/common/tmpdir');
+
+const bench = common.createBenchmark(main, {
+  type: ['invalid', 'valid'],
+  n: [2e3],
+});
+
+function main({ n, type }) {
+  switch (type) {
+    case 'invalid': {
+      let hasError = false;
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.renameSync(tmpdir.resolve(`.non-existing-file-${i}`), tmpdir.resolve(`.new-file-${i}`));
+        } catch {
+          hasError = true;
+        }
+      }
+      bench.end(n);
+      assert(hasError);
+      break;
+    }
+    case 'valid': {
+      tmpdir.refresh();
+      for (let i = 0; i < n; i++) {
+        fs.writeFileSync(tmpdir.resolve(`.existing-file-${i}`), 'bench', 'utf8');
+      }
+
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        fs.renameSync(
+          tmpdir.resolve(`.existing-file-${i}`),
+          tmpdir.resolve(`.new-existing-file-${i}`),
+        );
+      }
+
+      bench.end(n);
+      break;
+    }
+    default:
+      throw new Error('Invalid type');
+  }
+}

--- a/benchmark/fs/bench-symlinkSync.js
+++ b/benchmark/fs/bench-symlinkSync.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const assert = require('assert');
+const tmpdir = require('../../test/common/tmpdir');
+
+if (process.platform === 'win32') {
+  console.log('Skipping: Windows does not play well with `symlink`');
+  process.exit(0);
+}
+
+const bench = common.createBenchmark(main, {
+  type: ['valid', 'invalid'],
+  n: [1e3],
+});
+
+function main({ n, type }) {
+  switch (type) {
+    case 'valid': {
+      tmpdir.refresh();
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        fs.symlinkSync(tmpdir.resolve('.non-existent-symlink-file'), tmpdir.resolve(`.valid-${i}`), 'file');
+      }
+      bench.end(n);
+      break;
+    }
+
+    case 'invalid': {
+      let hasError = false;
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.symlinkSync(
+            tmpdir.resolve('.non-existent-symlink-file'),
+            __filename,
+            'file',
+          );
+        } catch {
+          hasError = true;
+        }
+      }
+      bench.end(n);
+      assert(hasError);
+      break;
+    }
+    default:
+      new Error('Invalid type');
+  }
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1034,10 +1034,10 @@ function rename(oldPath, newPath, callback) {
 function renameSync(oldPath, newPath) {
   oldPath = getValidatedPath(oldPath, 'oldPath');
   newPath = getValidatedPath(newPath, 'newPath');
-  const ctx = { path: oldPath, dest: newPath };
-  binding.rename(pathModule.toNamespacedPath(oldPath),
-                 pathModule.toNamespacedPath(newPath), undefined, ctx);
-  handleErrorFromBinding(ctx);
+  binding.rename(
+    pathModule.toNamespacedPath(oldPath),
+    pathModule.toNamespacedPath(newPath),
+  );
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1804,13 +1804,12 @@ function symlinkSync(target, path, type) {
   }
   target = getValidatedPath(target, 'target');
   path = getValidatedPath(path);
-  const flags = stringToSymlinkType(type);
 
-  const ctx = { path: target, dest: path };
-  binding.symlink(preprocessSymlinkDestination(target, type, path),
-                  pathModule.toNamespacedPath(path), flags, undefined, ctx);
-
-  handleErrorFromBinding(ctx);
+  binding.symlink(
+    preprocessSymlinkDestination(target, type, path),
+    pathModule.toNamespacedPath(path),
+    stringToSymlinkType(type),
+  );
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1847,12 +1847,10 @@ function linkSync(existingPath, newPath) {
   existingPath = getValidatedPath(existingPath, 'existingPath');
   newPath = getValidatedPath(newPath, 'newPath');
 
-  const ctx = { path: existingPath, dest: newPath };
-  const result = binding.link(pathModule.toNamespacedPath(existingPath),
-                              pathModule.toNamespacedPath(newPath),
-                              undefined, ctx);
-  handleErrorFromBinding(ctx);
-  return result;
+  binding.link(
+    pathModule.toNamespacedPath(existingPath),
+    pathModule.toNamespacedPath(newPath),
+  );
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2966,11 +2966,7 @@ function mkdtempSync(prefix, options) {
     path = Buffer.concat([prefix, Buffer.from('XXXXXX')]);
   }
 
-  const ctx = { path };
-  const result = binding.mkdtemp(path, options.encoding,
-                                 undefined, ctx);
-  handleErrorFromBinding(ctx);
-  return result;
+  return binding.mkdtemp(path, options.encoding);
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2752,10 +2752,10 @@ function realpathSync(p, options) {
 realpathSync.native = (path, options) => {
   options = getOptions(options);
   path = getValidatedPath(path);
-  const ctx = { path };
-  const result = binding.realpath(pathModule.toNamespacedPath(path), options.encoding, undefined, ctx);
-  handleErrorFromBinding(ctx);
-  return result;
+  return binding.realpath(
+    pathModule.toNamespacedPath(path),
+    options.encoding,
+  );
 };
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2089,9 +2089,11 @@ function chownSync(path, uid, gid) {
   path = getValidatedPath(path);
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  const ctx = { path };
-  binding.chown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
-  handleErrorFromBinding(ctx);
+  binding.chown(
+    pathModule.toNamespacedPath(path),
+    uid,
+    gid,
+  );
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2012,9 +2012,11 @@ function lchownSync(path, uid, gid) {
   path = getValidatedPath(path);
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  const ctx = { path };
-  binding.lchown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
-  handleErrorFromBinding(ctx);
+  binding.lchown(
+    pathModule.toNamespacedPath(path),
+    uid,
+    gid,
+  );
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1728,11 +1728,10 @@ function readlink(path, options, callback) {
 function readlinkSync(path, options) {
   options = getOptions(options);
   path = getValidatedPath(path, 'oldPath');
-  const ctx = { path };
-  const result = binding.readlink(pathModule.toNamespacedPath(path),
-                                  options.encoding, undefined, ctx);
-  handleErrorFromBinding(ctx);
-  return result;
+  return binding.readlink(
+    pathModule.toNamespacedPath(path),
+    options.encoding,
+  );
 }
 
 /**
@@ -2714,10 +2713,8 @@ function realpathSync(p, options) {
         }
       }
       if (linkTarget === null) {
-        const ctx = { path: base };
         binding.stat(baseLong, false, undefined, true);
-        linkTarget = binding.readlink(baseLong, undefined, undefined, ctx);
-        handleErrorFromBinding(ctx);
+        linkTarget = binding.readlink(baseLong, undefined);
       }
       resolvedLink = pathModule.resolve(previous, linkTarget);
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1828,28 +1828,27 @@ static void RealPath(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = env->isolate();
 
   const int argc = args.Length();
-  CHECK_GE(argc, 3);
+  CHECK_GE(argc, 2);
 
   BufferValue path(isolate, args[0]);
   CHECK_NOT_NULL(*path);
 
   const enum encoding encoding = ParseEncoding(isolate, args[1], UTF8);
 
-  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
-  if (req_wrap_async != nullptr) {  // realpath(path, encoding, req)
+  if (argc > 2) {  // realpath(path, encoding, req)
+    FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_REALPATH, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "realpath", encoding, AfterStringPtr,
               uv_fs_realpath, *path);
   } else {  // realpath(path, encoding, undefined, ctx)
-    CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap_sync;
+    FSReqWrapSync req_wrap_sync("realpath", *path);
     FS_SYNC_TRACE_BEGIN(realpath);
-    int err = SyncCall(env, args[3], &req_wrap_sync, "realpath",
-                       uv_fs_realpath, *path);
+    int err =
+        SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_realpath, *path);
     FS_SYNC_TRACE_END(realpath);
     if (err < 0) {
-      return;  // syscall failed, no need to continue, error info is in ctx
+      return;
     }
 
     const char* link_path = static_cast<const char*>(req_wrap_sync.req.ptr);
@@ -1860,8 +1859,7 @@ static void RealPath(const FunctionCallbackInfo<Value>& args) {
                                                encoding,
                                                &error);
     if (rc.IsEmpty()) {
-      Local<Object> ctx = args[3].As<Object>();
-      ctx->Set(env->context(), env->error_string(), error).Check();
+      env->isolate()->ThrowException(error);
       return;
     }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2760,27 +2760,26 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
 
   const enum encoding encoding = ParseEncoding(isolate, args[1], UTF8);
 
-  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
-  if (req_wrap_async != nullptr) {  // mkdtemp(tmpl, encoding, req)
+  if (argc > 2) {  // mkdtemp(tmpl, encoding, req)
+    FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_MKDTEMP, req_wrap_async, "path", TRACE_STR_COPY(*tmpl))
     AsyncCall(env, req_wrap_async, args, "mkdtemp", encoding, AfterStringPath,
               uv_fs_mkdtemp, *tmpl);
-  } else {  // mkdtemp(tmpl, encoding, undefined, ctx)
-    CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap_sync;
+  } else {  // mkdtemp(tmpl, encoding)
+    FSReqWrapSync req_wrap_sync("mkdtemp", *tmpl);
     FS_SYNC_TRACE_BEGIN(mkdtemp);
-    SyncCall(env, args[3], &req_wrap_sync, "mkdtemp",
-             uv_fs_mkdtemp, *tmpl);
+    int result =
+        SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_mkdtemp, *tmpl);
     FS_SYNC_TRACE_END(mkdtemp);
-    const char* path = req_wrap_sync.req.path;
-
+    if (is_uv_error(result)) {
+      return;
+    }
     Local<Value> error;
     MaybeLocal<Value> rc =
-        StringBytes::Encode(isolate, path, encoding, &error);
+        StringBytes::Encode(isolate, req_wrap_sync.req.path, encoding, &error);
     if (rc.IsEmpty()) {
-      Local<Object> ctx = args[3].As<Object>();
-      ctx->Set(env->context(), env->error_string(), error).Check();
+      env->isolate()->ThrowException(error);
       return;
     }
     args.GetReturnValue().Set(rc.ToLocalChecked());

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1342,7 +1342,7 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = env->isolate();
 
   const int argc = args.Length();
-  CHECK_GE(argc, 3);
+  CHECK_GE(argc, 2);
 
   BufferValue src(isolate, args[0]);
   CHECK_NOT_NULL(*src);
@@ -1360,8 +1360,8 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemWrite, dest_view);
 
-  FSReqBase* req_wrap_async = GetReqWrap(args, 2);
-  if (req_wrap_async != nullptr) {  // link(src, dest, req)
+  if (argc > 2) {  // link(src, dest, req)
+    FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     FS_ASYNC_TRACE_BEGIN2(UV_FS_LINK,
                           req_wrap_async,
                           "src",
@@ -1371,11 +1371,9 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
     AsyncDestCall(env, req_wrap_async, args, "link", *dest, dest.length(), UTF8,
                   AfterNoArgs, uv_fs_link, *src, *dest);
   } else {  // link(src, dest)
-    CHECK_EQ(argc, 4);
-    FSReqWrapSync req_wrap_sync;
+    FSReqWrapSync req_wrap_sync("link", *src, *dest);
     FS_SYNC_TRACE_BEGIN(link);
-    SyncCall(env, args[3], &req_wrap_sync, "link",
-             uv_fs_link, *src, *dest);
+    SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_link, *src, *dest);
     FS_SYNC_TRACE_END(link);
   }
 }

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -121,6 +121,7 @@ declare namespace InternalFSBinding {
   function link(existingPath: string, newPath: string, req: FSReqCallback): void;
   function link(existingPath: string, newPath: string, req: undefined, ctx: FSSyncContext): void;
   function link(existingPath: string, newPath: string, usePromises: typeof kUsePromises): Promise<void>;
+  function link(existingPath: string, newPath: string): void;
 
   function lstat(path: StringOrBuffer, useBigint: boolean, req: FSReqCallback<Float64Array | BigUint64Array>): void;
   function lstat(path: StringOrBuffer, useBigint: true, req: FSReqCallback<BigUint64Array>): void;

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -184,6 +184,7 @@ declare namespace InternalFSBinding {
   function realpath(path: StringOrBuffer, encoding: unknown, req: FSReqCallback<string | Buffer>): void;
   function realpath(path: StringOrBuffer, encoding: unknown, req: undefined, ctx: FSSyncContext): string | Buffer;
   function realpath(path: StringOrBuffer, encoding: unknown, usePromises: typeof kUsePromises): Promise<string | Buffer>;
+  function realpath(path: StringOrBuffer, encoding: unknown): StringOrBuffer;
 
   function rename(oldPath: string, newPath: string, req: FSReqCallback): void;
   function rename(oldPath: string, newPath: string, req: undefined, ctx: FSSyncContext): void;

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -117,6 +117,7 @@ declare namespace InternalFSBinding {
   function lchown(path: string, uid: number, gid: number, req: FSReqCallback): void;
   function lchown(path: string, uid: number, gid: number, req: undefined, ctx: FSSyncContext): void;
   function lchown(path: string, uid: number, gid: number, usePromises: typeof kUsePromises): Promise<void>;
+  function lchown(path: string, uid: number, gid: number): void;
 
   function link(existingPath: string, newPath: string, req: FSReqCallback): void;
   function link(existingPath: string, newPath: string, req: undefined, ctx: FSSyncContext): void;

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -67,6 +67,7 @@ declare namespace InternalFSBinding {
   function chown(path: string, uid: number, gid: number, req: FSReqCallback): void;
   function chown(path: string, uid: number, gid: number, req: undefined, ctx: FSSyncContext): void;
   function chown(path: string, uid: number, gid: number, usePromises: typeof kUsePromises): Promise<void>;
+  function chown(path: string, uid: number, gid: number): void;
 
   function close(fd: number, req: FSReqCallback): void;
   function close(fd: number, req: undefined, ctx: FSSyncContext): void;

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -140,6 +140,7 @@ declare namespace InternalFSBinding {
   function mkdtemp(prefix: string, encoding: unknown, req: FSReqCallback<string>): void;
   function mkdtemp(prefix: string, encoding: unknown, req: undefined, ctx: FSSyncContext): string;
   function mkdtemp(prefix: string, encoding: unknown, usePromises: typeof kUsePromises): Promise<string>;
+  function mkdtemp(prefix: string, encoding: unknown): string;
 
   function mkdir(path: string, mode: number, recursive: boolean, req: FSReqCallback<void | string>): void;
   function mkdir(path: string, mode: number, recursive: true, req: FSReqCallback<string>): void;

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -178,6 +178,7 @@ declare namespace InternalFSBinding {
   function readlink(path: StringOrBuffer, encoding: unknown, req: FSReqCallback<string | Buffer>): void;
   function readlink(path: StringOrBuffer, encoding: unknown, req: undefined, ctx: FSSyncContext): string | Buffer;
   function readlink(path: StringOrBuffer, encoding: unknown, usePromises: typeof kUsePromises): Promise<string | Buffer>;
+  function readlink(path: StringOrBuffer, encoding: unknown): StringOrBuffer;
 
   function realpath(path: StringOrBuffer, encoding: unknown, req: FSReqCallback<string | Buffer>): void;
   function realpath(path: StringOrBuffer, encoding: unknown, req: undefined, ctx: FSSyncContext): string | Buffer;

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -183,6 +183,7 @@ declare namespace InternalFSBinding {
   function rename(oldPath: string, newPath: string, req: FSReqCallback): void;
   function rename(oldPath: string, newPath: string, req: undefined, ctx: FSSyncContext): void;
   function rename(oldPath: string, newPath: string, usePromises: typeof kUsePromises): Promise<void>;
+  function rename(oldPath: string, newPath: string): void;
 
   function rmdir(path: string, req: FSReqCallback): void;
   function rmdir(path: string, req: undefined, ctx: FSSyncContext): void;

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -206,6 +206,7 @@ declare namespace InternalFSBinding {
   function symlink(target: StringOrBuffer, path: StringOrBuffer, type: number, req: FSReqCallback): void;
   function symlink(target: StringOrBuffer, path: StringOrBuffer, type: number, req: undefined, ctx: FSSyncContext): void;
   function symlink(target: StringOrBuffer, path: StringOrBuffer, type: number, usePromises: typeof kUsePromises): Promise<void>;
+  function symlink(target: StringOrBuffer, path: StringOrBuffer, type: number): void;
 
   function unlink(path: string, req: FSReqCallback): void;
   function unlink(path: string): void;


### PR DESCRIPTION
Closes https://github.com/nodejs/node/pull/49863
Closes https://github.com/nodejs/node/pull/49750
Closes https://github.com/nodejs/node/pull/49748

## Local benchmarks:

- `readlinkSync`, `linkSync`, `symlinkSync`

```
fs/bench-linkSync.js n=1000 type='invalid'               ***     33.31 %       ±1.38% ±1.84%  ±2.40%
fs/bench-linkSync.js n=1000 type='valid'                         -1.06 %       ±3.29% ±4.40%  ±5.77%
fs/bench-readlinkSync.js n=1000 type='invalid'           ***     25.55 %       ±0.96% ±1.28%  ±1.66%
fs/bench-readlinkSync.js n=1000 type='valid'                      4.01 %       ±6.24% ±8.32% ±10.87%
fs/bench-symlinkSync.js n=1000 type='invalid'            ***     31.08 %       ±1.08% ±1.45%  ±1.90%
fs/bench-symlinkSync.js n=1000 type='valid'                       1.37 %       ±3.34% ±4.45%  ±5.79%
```

- `renameSync`

```
fs/bench-renameSync.js n=2000 type='invalid'        ***     44.88 %       ±4.54% ±6.06% ±7.93%
fs/bench-renameSync.js n=2000 type='valid'                  -1.36 %       ±4.57% ±6.08% ±7.92%
```

- `chownSync` & `lchownSync`

```
fs/bench-chownSync.js n=10000 method='chownSync' type='existing'              **      3.08 %       ±1.93% ±2.58% ±3.39%
fs/bench-chownSync.js n=10000 method='chownSync' type='non-existing'         ***     90.16 %       ±1.57% ±2.09% ±2.72%
fs/bench-chownSync.js n=10000 method='lchownSync' type='existing'                    -0.03 %       ±1.99% ±2.65% ±3.45%
fs/bench-chownSync.js n=10000 method='lchownSync' type='non-existing'        ***     87.50 %       ±1.75% ±2.33% ±3.06%
```

- `mkdtempSync`

```
fs/bench-mkdtempSync.js n=1000 type='invalid'        ***     54.66 %       ±1.72% ±2.30% ±3.01%
fs/bench-mkdtempSync.js n=1000 type='valid'                  -1.20 %       ±3.58% ±4.77% ±6.20%
```

Ref: https://github.com/nodejs/performance/issues/106

cc @nodejs/performance