### PR TITLE
stream: avoid tick in writable hot path

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -612,24 +612,31 @@ function onwrite(stream, er) {
     }
 
     if (sync) {
+      const needDrain = state.length === 0 && (state.state & kNeedDrain) !== 0;
+      const needTick = needDrain || (state.state & kDestroyed !== 0) || cb !== nop;
+
       // It is a common case that the callback passed to .write() is always
       // the same. In that case, we do not schedule a new nextTick(), but
       // rather just increase a counter, to improve performance and avoid
       // memory allocations.
       if (cb === nop) {
-        if ((state.state & kAfterWritePending) === 0) {
+        if ((state.state & kAfterWritePending) === 0 && needTick) {
           process.nextTick(afterWrite, stream, state, 1, cb);
           state.state |= kAfterWritePending;
         } else {
-          state.pendingcb -= 1;
+          state.pendingcb--;
+          finishMaybe(stream, state, true);
         }
-      } else if (state.afterWriteTickInfo !== null &&
-                 state.afterWriteTickInfo.cb === cb) {
-        state.afterWriteTickInfo.count++;
+      } else if ((state.state & kAfterWriteTickInfo) !== 0 &&
+                 state[kAfterWriteTickInfoValue].cb === cb) {
+        state[kAfterWriteTickInfoValue].count++;
+      } else if (needTick) {
+        state[kAfterWriteTickInfoValue] = { count: 1, cb, stream, state };
+        process.nextTick(afterWriteTick, state[kAfterWriteTickInfoValue]);
+        state.state |= (kAfterWritePending | kAfterWriteTickInfo);
       } else {
-        state.afterWriteTickInfo = { count: 1, cb, stream, state };
-        process.nextTick(afterWriteTick, state.afterWriteTickInfo);
-        state.state |= kAfterWritePending;
+        state.pendingcb--;
+        finishMaybe(stream, state, true);
       }
     } else {
       afterWrite(stream, state, 1, cb);
@@ -638,7 +645,8 @@ function onwrite(stream, er) {
 }
 
 function afterWriteTick({ stream, state, count, cb }) {
-  state.afterWriteTickInfo = null;
+  state.state &= ~kAfterWriteTickInfo;
+  state[kAfterWriteTickInfoValue] = null;
   return afterWrite(stream, state, count, cb);
 }
 
@@ -795,6 +803,8 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   if (typeof cb === 'function') {
     if (err) {
       process.nextTick(cb, err);
+    } else if ((state.state & kErrored) !== 0) {
+      process.nextTick(cb, state[kErroredValue]);
     } else if ((state.state & kFinished) !== 0) {
       process.nextTick(cb, null);
     } else {


### PR DESCRIPTION
```
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='no' n=100000            ***      4.11 %       ±1.32% ±1.76% ±2.31%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='yes' n=100000           ***     -2.82 %       ±1.32% ±1.77% ±2.34%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='no' n=100000           ***      4.15 %       ±1.63% ±2.18% ±2.85%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='yes' n=100000          ***      2.74 %       ±1.17% ±1.57% ±2.06%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='no' n=100000           ***      4.59 %       ±1.55% ±2.06% ±2.68%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='yes' n=100000          ***      5.49 %       ±2.10% ±2.80% ±3.65%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='no' n=100000          ***      6.62 %       ±2.87% ±3.82% ±4.98%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='yes' n=100000           *      5.87 %       ±4.72% ±6.34% ±8.37%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='no' n=100000           ***      5.45 %       ±1.31% ±1.74% ±2.27%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='yes' n=100000          ***      7.98 %       ±1.71% ±2.28% ±2.99%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='no' n=100000          ***      5.86 %       ±1.37% ±1.83% ±2.38%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='yes' n=100000         ***      8.15 %       ±1.79% ±2.41% ±3.19%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='no' n=100000          ***      4.93 %       ±0.67% ±0.90% ±1.17%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='yes' n=100000         ***      9.06 %       ±2.03% ±2.71% ±3.54%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='no' n=100000         ***      6.20 %       ±1.85% ±2.47% ±3.23%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='yes' n=100000        ***      8.49 %       ±0.85% ±1.13% ±1.47%
```