### PR TITLE
fs: move getValidMode to c++ for better performance

### DIFF
--- a/benchmark/fs/bench-accessSync.js
+++ b/benchmark/fs/bench-accessSync.js
@@ -9,12 +9,12 @@ const tmpfile = tmpdir.resolve(`.existing-file-${process.pid}`);
 fs.writeFileSync(tmpfile, 'this-is-for-a-benchmark', 'utf8');
 
 const bench = common.createBenchmark(main, {
-  type: ['existing', 'non-existing', 'non-flat-existing'],
+  type: ['existing', 'non-existing', 'non-flat-existing', 'invalid-mode'],
   n: [1e5],
 });
 
 function main({ n, type }) {
-  let path;
+  let path, mode;
 
   switch (type) {
     case 'existing':
@@ -26,6 +26,10 @@ function main({ n, type }) {
     case 'non-existing':
       path = tmpdir.resolve(`.non-existing-file-${process.pid}`);
       break;
+    case 'invalid-mode':
+      path = __filename;
+      mode = -1;
+      break;
     default:
       new Error('Invalid type');
   }
@@ -33,7 +37,7 @@ function main({ n, type }) {
   bench.start();
   for (let i = 0; i < n; i++) {
     try {
-      fs.accessSync(path);
+      fs.accessSync(path, mode);
     } catch {
       // do nothing
     }

--- a/benchmark/fs/bench-copyFileSync.js
+++ b/benchmark/fs/bench-copyFileSync.js
@@ -6,18 +6,22 @@ const tmpdir = require('../../test/common/tmpdir');
 tmpdir.refresh();
 
 const bench = common.createBenchmark(main, {
-  type: ['invalid', 'valid'],
+  type: ['invalid-mode', 'invalid-path', 'valid'],
   n: [1e4],
 });
 
 function main({ n, type }) {
   tmpdir.refresh();
   const dest = tmpdir.resolve(`copy-file-bench-${process.pid}`);
-  let path;
+  let path, mode;
 
   switch (type) {
-    case 'invalid':
+    case 'invalid-path':
       path = tmpdir.resolve(`.existing-file-${process.pid}`);
+      break;
+    case 'invalid-mode':
+      path = __filename;
+      mode = -1;
       break;
     case 'valid':
       path = __filename;
@@ -28,7 +32,7 @@ function main({ n, type }) {
   bench.start();
   for (let i = 0; i < n; i++) {
     try {
-      fs.copyFileSync(path, dest);
+      fs.copyFileSync(path, dest, mode);
     } catch {
       // do nothing
     }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -103,7 +103,6 @@ const {
   getOptions,
   getValidatedFd,
   getValidatedPath,
-  getValidMode,
   handleErrorFromBinding,
   possiblyTransformPath,
   preprocessSymlinkDestination,
@@ -226,7 +225,6 @@ function access(path, mode, callback) {
   }
 
   path = getValidatedPath(path);
-  mode = getValidMode(mode, 'access');
   callback = makeCallback(callback);
 
   const req = new FSReqCallback();
@@ -243,7 +241,6 @@ function access(path, mode, callback) {
  */
 function accessSync(path, mode) {
   path = getValidatedPath(path);
-  mode = getValidMode(mode, 'access');
 
   binding.access(pathModule.toNamespacedPath(path), mode);
 }
@@ -2962,7 +2959,6 @@ function copyFile(src, dest, mode, callback) {
 
   src = pathModule._makeLong(src);
   dest = pathModule._makeLong(dest);
-  mode = getValidMode(mode, 'copyFile');
   callback = makeCallback(callback);
 
   const req = new FSReqCallback();
@@ -2985,7 +2981,7 @@ function copyFileSync(src, dest, mode) {
   binding.copyFile(
     pathModule.toNamespacedPath(src),
     pathModule.toNamespacedPath(dest),
-    getValidMode(mode, 'copyFile'),
+    mode,
   );
 }
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -57,7 +57,6 @@ const {
   getStatFsFromBinding,
   getStatsFromBinding,
   getValidatedPath,
-  getValidMode,
   preprocessSymlinkDestination,
   stringToFlags,
   stringToSymlinkType,
@@ -559,7 +558,6 @@ async function readFileHandle(filehandle, options) {
 async function access(path, mode = F_OK) {
   path = getValidatedPath(path);
 
-  mode = getValidMode(mode, 'access');
   return binding.access(pathModule.toNamespacedPath(path), mode,
                         kUsePromises);
 }
@@ -574,7 +572,6 @@ async function cp(src, dest, options) {
 async function copyFile(src, dest, mode) {
   src = getValidatedPath(src, 'src');
   dest = getValidatedPath(dest, 'dest');
-  mode = getValidMode(mode, 'copyFile');
   return binding.copyFile(pathModule.toNamespacedPath(src),
                           pathModule.toNamespacedPath(dest),
                           mode,

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -10,7 +10,6 @@ const {
   FunctionPrototypeCall,
   Number,
   NumberIsFinite,
-  MathMin,
   MathRound,
   ObjectIs,
   ObjectSetPrototypeOf,
@@ -62,17 +61,9 @@ const {
 const pathModule = require('path');
 const kType = Symbol('type');
 const kStats = Symbol('stats');
-const assert = require('internal/assert');
 
 const {
   fs: {
-    F_OK = 0,
-    W_OK = 0,
-    R_OK = 0,
-    X_OK = 0,
-    COPYFILE_EXCL,
-    COPYFILE_FICLONE,
-    COPYFILE_FICLONE_FORCE,
     O_APPEND,
     O_CREAT,
     O_EXCL,
@@ -106,26 +97,6 @@ const {
     },
   },
 } = internalBinding('constants');
-
-// The access modes can be any of F_OK, R_OK, W_OK or X_OK. Some might not be
-// available on specific systems. They can be used in combination as well
-// (F_OK | R_OK | W_OK | X_OK).
-const kMinimumAccessMode = MathMin(F_OK, W_OK, R_OK, X_OK);
-const kMaximumAccessMode = F_OK | W_OK | R_OK | X_OK;
-
-const kDefaultCopyMode = 0;
-// The copy modes can be any of COPYFILE_EXCL, COPYFILE_FICLONE or
-// COPYFILE_FICLONE_FORCE. They can be used in combination as well
-// (COPYFILE_EXCL | COPYFILE_FICLONE | COPYFILE_FICLONE_FORCE).
-const kMinimumCopyMode = MathMin(
-  kDefaultCopyMode,
-  COPYFILE_EXCL,
-  COPYFILE_FICLONE,
-  COPYFILE_FICLONE_FORCE,
-);
-const kMaximumCopyMode = COPYFILE_EXCL |
-                         COPYFILE_FICLONE |
-                         COPYFILE_FICLONE_FORCE;
 
 // Most platforms don't allow reads or writes >= 2 GiB.
 // See https://github.com/libuv/libuv/pull/1501.
@@ -795,7 +766,6 @@ const validateCpOptions = hideStackFrames((options) => {
   validateBoolean(options.preserveTimestamps, 'options.preserveTimestamps');
   validateBoolean(options.recursive, 'options.recursive');
   validateBoolean(options.verbatimSymlinks, 'options.verbatimSymlinks');
-  options.mode = getValidMode(options.mode, 'copyFile');
   if (options.dereference === true && options.verbatimSymlinks === true) {
     throw new ERR_INCOMPATIBLE_OPTION_PAIR('dereference', 'verbatimSymlinks');
   }
@@ -888,24 +858,6 @@ const validateRmdirOptions = hideStackFrames(
     return options;
   });
 
-const getValidMode = hideStackFrames((mode, type) => {
-  let min = kMinimumAccessMode;
-  let max = kMaximumAccessMode;
-  let def = F_OK;
-  if (type === 'copyFile') {
-    min = kMinimumCopyMode;
-    max = kMaximumCopyMode;
-    def = mode || kDefaultCopyMode;
-  } else {
-    assert(type === 'access');
-  }
-  if (mode == null) {
-    return def;
-  }
-  validateInteger(mode, 'mode', min, max);
-  return mode;
-});
-
 const validateStringAfterArrayBufferView = hideStackFrames((buffer, name) => {
   if (typeof buffer !== 'string') {
     throw new ERR_INVALID_ARG_TYPE(
@@ -949,7 +901,6 @@ module.exports = {
   getOptions,
   getValidatedFd,
   getValidatedPath,
-  getValidMode,
   handleErrorFromBinding,
   nullCheck,
   possiblyTransformPath,

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -163,6 +163,8 @@ fs.accessSync(readWriteFile, mode);
   { [Symbol.toPrimitive]() { return fs.constants.R_OK; } },
   [1],
   'r',
+  NaN,
+  Infinity,
 ].forEach((mode, i) => {
   console.log(mode, i);
   assert.throws(
@@ -183,8 +185,6 @@ fs.accessSync(readWriteFile, mode);
 [
   -1,
   8,
-  Infinity,
-  NaN,
 ].forEach((mode, i) => {
   console.log(mode, i);
   assert.throws(

--- a/test/parallel/test-fs-cp.mjs
+++ b/test/parallel/test-fs-cp.mjs
@@ -133,8 +133,10 @@ function nextdir() {
 
 // It rejects if options.mode is invalid.
 {
+  const src = './test/fixtures/copy/kitchen-sink';
+  const dest = nextdir();
   assert.throws(
-    () => cpSync('a', 'b', { mode: -1 }),
+    () => cpSync(src, dest, mustNotMutateObjectDeep({ recursive: true, mode: -1 })),
     { code: 'ERR_OUT_OF_RANGE' }
   );
 }
@@ -858,10 +860,11 @@ if (!isWindows) {
 
 // It throws if options is not object.
 {
-  assert.throws(
-    () => cp('a', 'b', { mode: -1 }, () => {}),
-    { code: 'ERR_OUT_OF_RANGE' }
-  );
+  const src = './test/fixtures/copy/kitchen-sink';
+  const dest = nextdir();
+  cp(src, dest, mustNotMutateObjectDeep({ recursive: true, mode: -1 }), (err) => {
+    assert.strictEqual(err.code, 'ERR_OUT_OF_RANGE');
+  });
 }
 
 // Promises implementation of copy.
@@ -943,10 +946,13 @@ if (!isWindows) {
 
 // It rejects if options.mode is invalid.
 {
+  const src = './test/fixtures/copy/kitchen-sink';
+  const dest = nextdir();
   await assert.rejects(
-    fs.promises.cp('a', 'b', {
+    fs.promises.cp(src, dest, mustNotMutateObjectDeep({
+      recursive: true,
       mode: -1,
-    }),
+    })),
     { code: 'ERR_OUT_OF_RANGE' }
   );
 }


### PR DESCRIPTION
```
                                                     confidence improvement accuracy (*)    (**)   (***)
fs/bench-copyFileSync.js n=10000 type='invalid mode'        ***     69.61 %      ±10.49% ±14.01% ±18.33%
fs/bench-copyFileSync.js n=10000 type='invalid path'                 1.58 %       ±6.12%  ±8.14% ±10.59%
fs/bench-copyFileSync.js n=10000 type='valid'                        1.90 %      ±10.90% ±14.50% ±18.88%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 3 comparisons, you can thus expect the following amount of false-positive results:
  0.15 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.03 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

```
                                                         confidence improvement accuracy (*)    (**)   (***)
fs/bench-accessSync.js n=100000 type='existing'                         -2.88 %       ±6.17%  ±8.22% ±10.72%
fs/bench-accessSync.js n=100000 type='invalid-mode'             ***     52.14 %      ±10.53% ±14.03% ±18.30%
fs/bench-accessSync.js n=100000 type='non-existing'                     -0.87 %       ±5.86%  ±7.80% ±10.17%
fs/bench-accessSync.js n=100000 type='non-flat-existing'                 0.83 %       ±6.60%  ±8.78% ±11.43%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 4 comparisons, you can thus expect the following amount of false-positive results:
  0.20 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.04 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

Ref: https://github.com/nodejs/performance/issues/111

The improvements are noticeable for cases where an error related to `mode` is thrown.

Thanks to @anonrig for the idea.