### PR TITLE
tls: use `validateNumber` for `options.minDHSize`

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1739,11 +1739,7 @@ exports.connect = function connect(...args) {
     options.singleUse = true;
 
   validateFunction(options.checkServerIdentity, 'options.checkServerIdentity');
-  assert(typeof options.minDHSize === 'number',
-         'options.minDHSize is not a number: ' + options.minDHSize);
-  assert(options.minDHSize > 0,
-         'options.minDHSize is not a positive number: ' +
-         options.minDHSize);
+  validateNumber(options.minDHSize, 'options.minDHSize', 1);
 
   const context = options.secureContext || tls.createSecureContext(options);
 

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -74,16 +74,23 @@ testDHE1024();
 assert.throws(() => test(512, true, common.mustNotCall()),
               /DH parameter is less than 1024 bits/);
 
-let errMessage = /minDHSize is not a positive number/;
-[0, -1, -Infinity, NaN].forEach((minDHSize) => {
-  assert.throws(() => tls.connect({ minDHSize }),
-                errMessage);
-});
+for (const minDHSize of [0, -1, -Infinity, NaN]) {
+  assert.throws(() => {
+    tls.connect({ minDHSize });
+  }, {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError',
+  });
+}
 
-errMessage = /minDHSize is not a number/;
-[true, false, null, undefined, {}, [], '', '1'].forEach((minDHSize) => {
-  assert.throws(() => tls.connect({ minDHSize }), errMessage);
-});
+for (const minDHSize of [true, false, null, undefined, {}, [], '', '1']) {
+  assert.throws(() => {
+    tls.connect({ minDHSize });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+  });
+}
 
 process.on('exit', function() {
   assert.strictEqual(nsuccess, 1);


### PR DESCRIPTION
If user sets invalid type for options.minDHSize in tls.connect(), it's not internal issue of Node.js. So validateNumber() is more proper than assert(). Plus, set min of validateNumber() as 1 to check minDHSize is positive.

Refs: https://github.com/nodejs/node/pull/49896

Before
```
node:internal/assert:14
    throw new ERR_INTERNAL_ASSERTION(message);
    ^

Error [ERR_INTERNAL_ASSERTION]: options.minDHSize is not a number: undefined
This is caused by either a bug in Node.js or incorrect usage of Node.js internals.
Please open an issue with this stack trace at https://github.com/nodejs/node/issues
```

After
```
// case#1: undefined is used as minDHSize.
node:internal/validators:177
    throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "options.minDHSize" property must be of type number. Received undefined

// case#2: 0 is used as minDHSize.
node:internal/validators:181
    throw new ERR_OUT_OF_RANGE(
    ^

RangeError [ERR_OUT_OF_RANGE]: The value of "options.minDHSize" is out of range. It must be >= 1. Received 0

```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
