### PR TITLE
module,src: add `--experimental-entry-url` flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -626,7 +626,10 @@ added:
 
 > Stability: 1.0 - Early development
 
-When present, Node.js will interpret the entry point as a URL, rather than a path.
+When present, Node.js will interpret the entry point as a URL, rather than a
+path. The URL must either start with `./` (e.g. `./entry.js`) or be absolute
+(e.g. `file:///home/user/entry.js`). Bare specifier (e.g. `entry.js`) won't
+work.
 
 ### `--experimental-import-meta-resolve`
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -617,6 +617,17 @@ files with no extension will be treated as WebAssembly if they begin with the
 WebAssembly magic number (`\0asm`); otherwise they will be treated as ES module
 JavaScript.
 
+### `--experimental-entry-url`
+
+<!-- YAML
+added:
+  - REPLACEME
+-->
+
+> Stability: 1.0 - Early development
+
+When present, Node.js will interpret the entry point as a URL, rather than a path.
+
 ### `--experimental-import-meta-resolve`
 
 <!-- YAML
@@ -2274,6 +2285,7 @@ Node.js options that are allowed are:
 * `--enable-source-maps`
 * `--experimental-abortcontroller`
 * `--experimental-default-type`
+* `--experimental-entry-url`
 * `--experimental-import-meta-resolve`
 * `--experimental-json-modules`
 * `--experimental-loader`

--- a/lib/internal/main/run_main_module.js
+++ b/lib/internal/main/run_main_module.js
@@ -6,8 +6,9 @@ const {
   prepareMainThreadExecution,
   markBootstrapComplete,
 } = require('internal/process/pre_execution');
+const { getOptionValue } = require('internal/options');
 
-prepareMainThreadExecution(true);
+prepareMainThreadExecution(!getOptionValue('--experimental-entry-url'));
 
 markBootstrapComplete();
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -1028,6 +1028,7 @@ function throwIfInvalidParentURL(parentURL) {
  */
 function defaultResolve(specifier, context = {}) {
   let { parentURL, conditions } = context;
+  const isMain = parentURL === undefined;
   throwIfInvalidParentURL(parentURL);
   if (parentURL && policy?.manifest) {
     const redirects = policy.manifest.getDependencyMapper(parentURL);
@@ -1083,8 +1084,8 @@ function defaultResolve(specifier, context = {}) {
     ) {
       return { __proto__: null, url: parsed.href };
     }
-  } catch {
-    // Ignore exception
+  } catch (err) {
+    if (isMain && !shouldBeTreatedAsRelativeOrAbsolutePath(specifier)) { throw err; }
   }
 
   // There are multiple deep branches that can either throw or return; instead
@@ -1102,7 +1103,6 @@ function defaultResolve(specifier, context = {}) {
   if (parsed && parsed.protocol === 'node:') { return { __proto__: null, url: specifier }; }
 
 
-  const isMain = parentURL === undefined;
   if (isMain) {
     parentURL = getCWDURL().href;
 

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -12,6 +12,9 @@ const path = require('path');
  * @param {string} main Entry point path
  */
 function resolveMainPath(main) {
+  if (getOptionValue('--experimental-default-type') === 'module' || getOptionValue('--experimental-entry-url')) {
+    return;
+  }
   // Note extension resolution for the main entry point can be deprecated in a
   // future major.
   // Module._findPath is monkey-patchable here.
@@ -33,6 +36,7 @@ function resolveMainPath(main) {
  * @param {string} mainPath Absolute path to the main entry point
  */
 function shouldUseESMLoader(mainPath) {
+  if (getOptionValue('--experimental-entry-url')) { return true; }
   /**
    * @type {string[]} userLoaders A list of custom loaders registered by the user
    * (or an empty list when none have been registered).
@@ -64,8 +68,7 @@ function runMainESM(mainPath) {
   const { pathToFileURL } = require('internal/url');
 
   handleMainPromise(loadESM((esmLoader) => {
-    const main = path.isAbsolute(mainPath) ?
-      pathToFileURL(mainPath).href : mainPath;
+    const main = getOptionValue('--experimental-entry-url') ? mainPath : pathToFileURL(mainPath).href;
     return esmLoader.import(main, undefined, { __proto__: null });
   }));
 }

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -52,7 +52,7 @@ const {
 } = require('internal/v8/startup_snapshot');
 
 function prepareMainThreadExecution(expandArgv1 = false, initializeModules = true) {
-  prepareExecution({
+  return prepareExecution({
     expandArgv1,
     initializeModules,
     isMainThread: true,
@@ -60,7 +60,7 @@ function prepareMainThreadExecution(expandArgv1 = false, initializeModules = tru
 }
 
 function prepareWorkerThreadExecution() {
-  prepareExecution({
+  return prepareExecution({
     expandArgv1: false,
     initializeModules: false,  // Will need to initialize it after policy setup
     isMainThread: false,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -657,6 +657,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "set module system to use by default",
             &EnvironmentOptions::type,
             kAllowedInEnvvar);
+  AddOption("--experimental-entry-url",
+            "set module system to use by default",
+            &EnvironmentOptions::entry_is_url,
+            kAllowedInEnvvar);
   AddOption("--extra-info-on-fatal-exception",
             "hide extra information on fatal exception that causes exit",
             &EnvironmentOptions::extra_info_on_fatal_exception,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -119,6 +119,7 @@ class EnvironmentOptions : public Options {
   bool experimental_import_meta_resolve = false;
   std::string input_type;  // Value of --input-type
   std::string type;        // Value of --experimental-default-type
+  bool entry_is_url = false;
   std::string experimental_policy;
   std::string experimental_policy_integrity;
   bool has_policy_integrity_string = false;

--- a/test/es-module/test-esm-loader-entry-is-url.mjs
+++ b/test/es-module/test-esm-loader-entry-is-url.mjs
@@ -1,0 +1,89 @@
+import { spawnPromisified } from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import assert from 'node:assert';
+import { execPath } from 'node:process';
+import { describe, it } from 'node:test';
+
+describe('--entry-url', { concurrency: true }, () => {
+  it('should reject loading absolute path that contains %', async () => {
+    const { code, signal, stderr, stdout } = await spawnPromisified(
+      execPath,
+      [
+        '--experimental-entry-url',
+        fixtures.path('es-modules/test-esm-double-encoding-native%20.mjs'),
+      ]
+    );
+
+    assert.match(stderr, /ERR_MODULE_NOT_FOUND/);
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should support loading absolute URLs', async () => {
+    const { code, signal, stderr, stdout } = await spawnPromisified(
+      execPath,
+      [
+        '--experimental-entry-url',
+        fixtures.fileURL('printA.js'),
+      ]
+    );
+
+    assert.strictEqual(stderr, '');
+    assert.match(stdout, /^A\r?\n$/);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should support loading relative URLs', async () => {
+    const { code, signal, stderr, stdout } = await spawnPromisified(
+      execPath,
+      [
+        '--experimental-entry-url',
+        './printA.js?key=value',
+      ],
+      {
+        cwd: fixtures.fileURL('./'),
+      }
+    );
+
+    assert.strictEqual(stderr, '');
+    assert.match(stdout, /^A\r?\n$/);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should reject loading relative URLs without trailing `./`', async () => {
+    const { code, signal, stderr, stdout } = await spawnPromisified(
+      execPath,
+      [
+        '--experimental-entry-url',
+        'printA.js?key=value',
+      ],
+      {
+        cwd: fixtures.fileURL('./'),
+      }
+    );
+
+    assert.match(stderr, /ERR_MODULE_NOT_FOUND/);
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should support loading `data:` URLs', async () => {
+    const { code, signal, stderr, stdout } = await spawnPromisified(
+      execPath,
+      [
+        '--experimental-entry-url',
+        'data:text/javascript,console.log(0)',
+      ],
+    );
+
+    assert.strictEqual(stderr, '');
+    assert.match(stdout, /^0\r?\n$/);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
+});

--- a/test/es-module/test-esm-loader-entry-is-url.mjs
+++ b/test/es-module/test-esm-loader-entry-is-url.mjs
@@ -20,6 +20,21 @@ describe('--entry-url', { concurrency: true }, () => {
     assert.strictEqual(signal, null);
   });
 
+  it('should support loading absolute Unix path properly encoded', async () => {
+    const { code, signal, stderr, stdout } = await spawnPromisified(
+      execPath,
+      [
+        '--experimental-entry-url',
+        fixtures.fileURL('es-modules/test-esm-double-encoding-native%20.mjs').pathname,
+      ]
+    );
+
+    assert.strictEqual(stderr, '');
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  });
+
   it('should support loading absolute URLs', async () => {
     const { code, signal, stderr, stdout } = await spawnPromisified(
       execPath,
@@ -65,7 +80,25 @@ describe('--entry-url', { concurrency: true }, () => {
       }
     );
 
-    assert.match(stderr, /ERR_MODULE_NOT_FOUND/);
+    assert.match(stderr, /ERR_INVALID_URL/);
+    assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
+  });
+
+  it('should reject loading bare specifiers from node_modules', async () => {
+    const { code, signal, stderr, stdout } = await spawnPromisified(
+      execPath,
+      [
+        '--experimental-entry-url',
+        'explicit-main',
+      ],
+      {
+        cwd: fixtures.fileURL('./es-module-specifiers/'),
+      }
+    );
+
+    assert.match(stderr, /ERR_INVALID_URL/);
     assert.strictEqual(stdout, '');
     assert.strictEqual(code, 1);
     assert.strictEqual(signal, null);


### PR DESCRIPTION
`--experimental-entry-url` is a new boolean flag that causes the entry point string to be parsed as a URL and loaded by the ESM loader: `node --experimental-entry-url --enable-source-maps ./entry.js?foo=bar`

Refs: https://github.com/nodejs/node/issues/49432#issuecomment-1739859702
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
