### PR TITLE
nghttp3_conv: fix call to undeclared functions 'ntohl' and 'htons'

### DIFF
--- a/deps/ngtcp2/ngtcp2.gyp
+++ b/deps/ngtcp2/ngtcp2.gyp
@@ -112,7 +112,7 @@
             },
           },
         }],
-        ['OS=="linux"', {
+        ['OS=="linux" or OS=="android"', {
           'defines': [
             'HAVE_ARPA_INET_H',
             'HAVE_NETINET_IN_H',
@@ -162,7 +162,7 @@
             },
           },
         }],
-        ['OS=="linux"', {
+        ['OS=="linux" or OS=="android"', {
           'defines': [
             'HAVE_ARPA_INET_H',
             'HAVE_NETINET_IN_H',


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

I don't think it's the right method but this solves these errors when compiling for Android arm64:
```

../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:49:21: error: call to undeclared function 'ntohs'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    return (int64_t)ntohs(n.n16);
                    ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:53:21: error: call to undeclared function 'ntohl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    return (int64_t)ntohl(n.n32);
                    ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:69:7: error: call to undeclared function 'ntohl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  n = nghttp3_htonl64(n);
      ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.h:73:32: note: expanded from macro 'nghttp3_htonl64'
#    define nghttp3_htonl64(N) nghttp3_bswap64(N)
                               ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.h:60:17: note: expanded from macro 'nghttp3_bswap64'
    ((uint64_t)(ntohl((uint32_t)(N))) << 32 | ntohl((uint32_t)((N) >> 32)))
                ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:74:7: error: call to undeclared function 'ntohl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  n = nghttp3_htonl64(n);
      ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.h:73:32: note: expanded from macro 'nghttp3_htonl64'
#    define nghttp3_htonl64(N) nghttp3_bswap64(N)
                               ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.h:60:17: note: expanded from macro 'nghttp3_bswap64'
    ((uint64_t)(ntohl((uint32_t)(N))) << 32 | ntohl((uint32_t)((N) >> 32)))
                ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:79:7: error: call to undeclared function 'htonl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  n = htonl(n);
      ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:84:7: error: call to undeclared function 'htonl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  n = htonl(n);
      ^
../deps/ngtcp2/nghttp3/lib/nghttp3_conv.c:89:7: error: call to undeclared function 'htons'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  n = htons(n);
      ^
7 errors generated.


```
I added -Wno-implicit-function-declaration option to cflags
