### PR TITLE
test_runner: add test location for FileTests

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -29,6 +29,7 @@ const {
 
 const { spawn } = require('child_process');
 const { finished } = require('internal/streams/end-of-stream');
+const { resolve } = require('path');
 const { DefaultDeserializer, DefaultSerializer } = require('v8');
 // TODO(aduh95): switch to internal/readline/interface when backporting to Node.js 16.x is no longer a concern.
 const { createInterface } = require('readline');
@@ -139,6 +140,17 @@ class FileTest extends Test {
   #rawBufferSize = 0;
   #reportedChildren = 0;
   failedSubtests = false;
+
+  constructor(options) {
+    super(options);
+    this.loc ??= {
+      __proto__: null,
+      line: 1,
+      column: 1,
+      file: resolve(this.name),
+    };
+  }
+
   #skipReporting() {
     return this.#reportedChildren > 0 && (!this.error || this.error.failureType === kSubtestsFailed);
   }

--- a/test/parallel/test-runner-filetest-location.js
+++ b/test/parallel/test-runner-filetest-location.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const { strictEqual } = require('node:assert');
+const { relative } = require('node:path');
+const { run } = require('node:test');
+const fixture = fixtures.path('test-runner', 'never_ending_sync.js');
+const relativePath = relative(process.cwd(), fixture);
+const stream = run({
+  files: [relativePath],
+  timeout: common.platformTimeout(100),
+});
+
+stream.on('test:fail', common.mustCall((result) => {
+  strictEqual(result.name, relativePath);
+  strictEqual(result.details.error.failureType, 'testTimeoutFailure');
+  strictEqual(result.line, 1);
+  strictEqual(result.column, 1);
+  strictEqual(result.file, fixture);
+}));


### PR DESCRIPTION
This commit adds the previously missing test location for `FileTest` tests.

Fixes: https://github.com/nodejs/node/issues/49926
Fixes: https://github.com/nodejs/node/issues/49927